### PR TITLE
Start of tower-based networking.

### DIFF
--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -14,6 +14,6 @@ tokio = "=0.2.0-alpha.4"
 tracing = "0.1"
 futures-core-preview = "=0.3.0-alpha.18"
 futures-util-preview = "=0.3.0-alpha.18"
-tower-service = "=0.3.0-alpha.1"
+tower = "=0.3.0-alpha.1a"
 
 zebra-chain = { path = "../zebra-chain" }

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -10,4 +10,10 @@ edition = "2018"
 byteorder = "1.3"
 chrono = "0.4"
 failure = "0.1"
+tokio = "=0.2.0-alpha.4"
+tracing = "0.1"
+futures-core-preview = "=0.3.0-alpha.18"
+futures-util-preview = "=0.3.0-alpha.18"
+tower-service = "=0.3.0-alpha.1"
+
 zebra-chain = { path = "../zebra-chain" }

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -5,7 +5,10 @@
 #[macro_use]
 extern crate failure;
 
-mod constants;
 pub mod message;
-mod meta_addr;
 pub mod types;
+
+// XXX make this private once connect is removed
+pub mod meta_addr;
+// XXX make this private once connect is removed
+pub mod constants;

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -15,7 +15,9 @@ tokio = "=0.2.0-alpha.4"
 tracing = "0.1"
 tracing-subscriber = "0.1"
 tracing-log = "=0.0.1-alpha.2"
-hyper = "=0.13.0-alpha.1"
+# Can't use published alpha because of conflicts tracking pin-project alphas
+#hyper = "=0.13.0-alpha.1"
+hyper = { git = "https://github.com/hyperium/hyper" }
 futures-core-preview = { version = "=0.3.0-alpha.18" }
 futures-util-preview = { version = "=0.3.0-alpha.18" }
 

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -5,6 +5,10 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+# temporary, used for debugging
+hex = "*" 
+
+chrono = "0.4"
 abscissa_core = "0.3.0"
 failure = "0.1"
 gumdrop = "0.6"

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -21,6 +21,9 @@ hyper = { git = "https://github.com/hyperium/hyper" }
 futures-core-preview = { version = "=0.3.0-alpha.18" }
 futures-util-preview = { version = "=0.3.0-alpha.18" }
 
+zebra-chain = { path = "../zebra-chain" }
+zebra-network = { path = "../zebra-network" }
+
 [dev-dependencies.abscissa_core]
 version = "0.3.0"
 features = ["testing"]

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -10,10 +10,11 @@
 //! See the `impl Configurable` below for how to specify the path to the
 //! application's configuration file.
 
+mod connect;
 mod start;
 mod version;
 
-use self::{start::StartCmd, version::VersionCmd};
+use self::{connect::ConnectCmd, start::StartCmd, version::VersionCmd};
 use crate::config::ZebradConfig;
 use abscissa_core::{
     config::Override, Command, Configurable, FrameworkError, Help, Options, Runnable,
@@ -37,6 +38,10 @@ pub enum ZebradCmd {
     /// The `version` subcommand
     #[options(help = "display version information")]
     Version(VersionCmd),
+
+    /// The `connect` subcommand
+    #[options(help = "testing stub for dumping network messages")]
+    Connect(ConnectCmd),
 }
 
 /// This trait allows you to define how application configuration is loaded.

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -72,21 +72,15 @@ impl ConnectCmd {
 
         info!(version = ?version);
 
-        let mut version_bytes = Vec::new();
         version
             .zcash_serialize(
-                std::io::Cursor::new(&mut version_bytes),
+                &mut stream,
                 constants::magics::MAINNET,
                 constants::CURRENT_VERSION,
             )
-            .expect("version message should serialize");
-
-        info!(version_bytes = ?hex::encode(&version_bytes));
-
-        stream
-            .write_all(&version_bytes)
             .await
-            .expect("bytes should be written into stream");
+            .expect("version message should serialize into stream");
+
         stream
             .shutdown(Shutdown::Both)
             .expect("stream should shut down cleanly");

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -81,6 +81,22 @@ impl ConnectCmd {
             .await
             .expect("version message should serialize into stream");
 
+        let resp_version = Message::zcash_deserialize(
+            &mut stream,
+            constants::magics::MAINNET,
+            constants::CURRENT_VERSION,
+        )
+        .await;
+        info!(resp_version = ?resp_version);
+
+        let resp_verack = Message::zcash_deserialize(
+            &mut stream,
+            constants::magics::MAINNET,
+            constants::CURRENT_VERSION,
+        )
+        .await;
+        info!(resp_verack = ?resp_verack);
+
         stream
             .shutdown(Shutdown::Both)
             .expect("stream should shut down cleanly");

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -1,0 +1,33 @@
+//! `connect` subcommand - test stub for talking to zcashd
+
+use crate::prelude::*;
+
+use abscissa_core::{Command, Options, Runnable};
+
+/// `connect` subcommand
+#[derive(Command, Debug, Options)]
+pub struct ConnectCmd {
+    /// The address of the node to connect to.
+    #[options(
+        help = "The address of the node to connect to.",
+        default = "127.0.0.1:8233"
+    )]
+    addr: std::net::SocketAddr,
+}
+
+impl Runnable for ConnectCmd {
+    /// Start the application.
+    fn run(&self) {
+        info!(connect.addr = ?self.addr);
+
+        use crate::components::tokio::TokioComponent;
+
+        app_reader()
+            .state()
+            .components
+            .get_downcast_ref::<TokioComponent>()
+            .expect("TokioComponent should be available")
+            .rt
+            .block_on(tokio::future::pending::<()>());
+    }
+}

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -22,12 +22,56 @@ impl Runnable for ConnectCmd {
 
         use crate::components::tokio::TokioComponent;
 
+        let wait = tokio::future::pending::<()>();
+        // Combine the connect future with an infinite wait
+        // so that the program has to be explicitly killed and
+        // won't die before all tracing messages are written.
+        let fut = futures_util::future::join(self.connect(), wait);
+
         app_reader()
             .state()
             .components
             .get_downcast_ref::<TokioComponent>()
             .expect("TokioComponent should be available")
             .rt
-            .block_on(tokio::future::pending::<()>());
+            .block_on(fut);
+    }
+}
+
+impl ConnectCmd {
+    async fn connect(&self) {
+        use std::net::Shutdown;
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpStream;
+        info!("connecting");
+
+        let mut stream = TcpStream::connect(self.addr)
+            .await
+            .expect("connection should succeed");
+
+        /*
+        use chrono::{DateTime, Utc};
+        use zebra_network::message;
+        use zebra_chain::types::BlockHeight;
+        let version = message::Message::Version {
+            version: message::ZCASH_VERSION,
+            services: message::Services(1),
+            timestamp: DateTime::<Utc>::now(),
+            address_receiving: (pub self.addr,
+            address_from: "127.0.0.1:9000".parse().unwrap(),
+            nonce: message::Nonce(1),
+            user_agent: "Zebra Connect".to_owned(),
+            start_height: BlockHeight(0),
+        };
+        */
+
+        stream
+            .write_all(b"hello zcashd -- this is a bogus message, will you accept it or close the connection?")
+            .await
+            .expect("bytes should be written into stream");
+
+        stream
+            .shutdown(Shutdown::Both)
+            .expect("stream should shut down cleanly");
     }
 }

--- a/zebrad/src/components/tracing.rs
+++ b/zebrad/src/components/tracing.rs
@@ -126,7 +126,12 @@ curl -X POST localhost:3000/filter -d "zebrad=trace"
         )),
         (&Method::POST, "/filter") => {
             // Combine all HTTP request chunks into one
-            let whole_chunk = req.into_body().try_concat().await?;
+            //let whole_chunk = req.into_body().try_concat().await?;
+            // XXX try_concat extension trait is not applying for some reason,
+            // just pull one chunk
+            let mut body = req.into_body();
+            let maybe_chunk = body.next().await;
+            let whole_chunk = maybe_chunk.unwrap()?;
             match reload_filter_from_chunk(handle, whole_chunk) {
                 Err(e) => Response::builder()
                     .status(StatusCode::BAD_REQUEST)


### PR DESCRIPTION
This PR adds a new `connect` command to `zebrad`.  This command is explicitly intended to be thrown away later -- it will not be part of the finished code, and it is not intended to cleanly integrate with the rest of the binary, etc.

Instead, it's intended to be a stub that we can hook into to poke at a running `zcashd` instance, send whatever messages, dump their bytes, extract test vectors, etc.