### PR TITLE
Use try_bind when building tracing endpoint.

### DIFF
--- a/zebrad/src/components/tracing.rs
+++ b/zebrad/src/components/tracing.rs
@@ -77,9 +77,19 @@ impl TracingEndpoint {
         });
 
         // XXX load tracing addr from config
-        let addr = "127.0.0.1:3000".parse().unwrap();
+        let addr = "127.0.0.1:3000"
+            .parse()
+            .expect("Hardcoded address should be parseable");
 
-        let server = Server::bind(&addr).serve(service);
+        let server = match Server::try_bind(&addr) {
+            Ok(s) => s,
+            Err(e) => {
+                error!("Could not open tracing endpoint listener");
+                error!("Error: {}", e);
+                return Ok(());
+            }
+        }
+        .serve(service);
 
         tokio_component.rt.spawn(async {
             if let Err(e) = server.await {


### PR DESCRIPTION
Prior to this commit, the tracing endpoint would attempt to bind the
given address or panic; now, if it is unable to bind the given address
it displays an error but continues running the rest of the application.
This means that we can spin up multiple Zebra instances for load
testing.