### PR TITLE
Suppress warnings from stub functions.

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -89,13 +89,13 @@ pub struct BlockHeader {
 }
 
 impl ZcashSerialize for BlockHeader {
-    fn zcash_serialize<W: io::Write>(&self, writer: W) -> Result<(), SerializationError> {
+    fn zcash_serialize<W: io::Write>(&self, _writer: W) -> Result<(), SerializationError> {
         unimplemented!();
     }
 }
 
 impl ZcashDeserialize for BlockHeader {
-    fn zcash_deserialize<R: io::Read>(reader: R) -> Result<Self, SerializationError> {
+    fn zcash_deserialize<R: io::Read>(_reader: R) -> Result<Self, SerializationError> {
         unimplemented!();
     }
 }
@@ -117,13 +117,13 @@ pub struct Block {
 }
 
 impl ZcashSerialize for Block {
-    fn zcash_serialize<W: io::Write>(&self, writer: W) -> Result<(), SerializationError> {
+    fn zcash_serialize<W: io::Write>(&self, _writer: W) -> Result<(), SerializationError> {
         unimplemented!();
     }
 }
 
 impl ZcashDeserialize for Block {
-    fn zcash_deserialize<R: io::Read>(reader: R) -> Result<Self, SerializationError> {
+    fn zcash_deserialize<R: io::Read>(_reader: R) -> Result<Self, SerializationError> {
         unimplemented!();
     }
 }

--- a/zebra-chain/src/merkle_tree.rs
+++ b/zebra-chain/src/merkle_tree.rs
@@ -3,8 +3,6 @@
 
 use std::io;
 
-use sha2::Sha256;
-
 use crate::serialization::{SerializationError, ZcashDeserialize, ZcashSerialize};
 use crate::sha256d_writer::Sha256dWriter;
 use crate::transaction::Transaction;
@@ -13,17 +11,17 @@ use crate::transaction::Transaction;
 /// node values.
 #[derive(Default)]
 pub struct MerkleTree<T> {
-    leaves: Vec<T>,
+    _leaves: Vec<T>,
 }
 
 impl<Transaction> ZcashSerialize for MerkleTree<Transaction> {
-    fn zcash_serialize<W: io::Write>(&self, writer: W) -> Result<(), SerializationError> {
+    fn zcash_serialize<W: io::Write>(&self, _writer: W) -> Result<(), SerializationError> {
         unimplemented!();
     }
 }
 
 impl<Transaction> ZcashDeserialize for MerkleTree<Transaction> {
-    fn zcash_deserialize<R: io::Read>(reader: R) -> Result<Self, SerializationError> {
+    fn zcash_deserialize<R: io::Read>(_reader: R) -> Result<Self, SerializationError> {
         unimplemented!();
     }
 }

--- a/zebra-chain/src/note_commitment_tree.rs
+++ b/zebra-chain/src/note_commitment_tree.rs
@@ -31,7 +31,7 @@ pub struct SaplingNoteCommitmentTree;
 pub struct SaplingNoteTreeRootHash([u8; 32]);
 
 impl From<SaplingNoteCommitmentTree> for SaplingNoteTreeRootHash {
-    fn from(sapling_note_commitment_tree: SaplingNoteCommitmentTree) -> Self {
+    fn from(_tree: SaplingNoteCommitmentTree) -> Self {
         // TODO: The Sapling note commitment tree requires a Pedersen
         // hash function, not SHA256.
 
@@ -54,13 +54,13 @@ impl SaplingNoteCommitmentTree {
 }
 
 impl ZcashSerialize for SaplingNoteCommitmentTree {
-    fn zcash_serialize<W: io::Write>(&self, writer: W) -> Result<(), SerializationError> {
+    fn zcash_serialize<W: io::Write>(&self, _writer: W) -> Result<(), SerializationError> {
         unimplemented!();
     }
 }
 
 impl ZcashDeserialize for SaplingNoteCommitmentTree {
-    fn zcash_deserialize<R: io::Read>(reader: R) -> Result<Self, SerializationError> {
+    fn zcash_deserialize<R: io::Read>(_reader: R) -> Result<Self, SerializationError> {
         unimplemented!();
     }
 }

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -112,13 +112,13 @@ pub struct Transaction {
 }
 
 impl ZcashSerialize for Transaction {
-    fn zcash_serialize<W: io::Write>(&self, writer: W) -> Result<(), SerializationError> {
+    fn zcash_serialize<W: io::Write>(&self, _writer: W) -> Result<(), SerializationError> {
         unimplemented!();
     }
 }
 
 impl ZcashDeserialize for Transaction {
-    fn zcash_deserialize<R: io::Read>(reader: R) -> Result<Self, SerializationError> {
+    fn zcash_deserialize<R: io::Read>(_reader: R) -> Result<Self, SerializationError> {
         unimplemented!();
     }
 }


### PR DESCRIPTION
This just replaces a bunch of variable names with underscored variants
while the function bodies are still `unimplemented!()`.