### PR TITLE
Change `Services` to a `PeerServices` bitflag.

### DIFF
--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bitflags = "1.2"
 bytes = "0.4"
 rand = "0.7"
 byteorder = "1.3"

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -6,6 +6,8 @@
 extern crate failure;
 #[macro_use]
 extern crate tracing;
+#[macro_use]
+extern crate bitflags;
 
 mod network;
 pub use network::Network;

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -31,7 +31,7 @@ pub struct MetaAddr {
 impl ZcashSerialize for MetaAddr {
     fn zcash_serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
         writer.write_u32::<LittleEndian>(self.last_seen.timestamp() as u32)?;
-        writer.write_u64::<LittleEndian>(self.services.0)?;
+        writer.write_u64::<LittleEndian>(self.services.bits())?;
         writer.write_socket_addr(self.addr)?;
         Ok(())
     }
@@ -41,7 +41,8 @@ impl ZcashDeserialize for MetaAddr {
     fn zcash_deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         Ok(MetaAddr {
             last_seen: Utc.timestamp(reader.read_u32::<LittleEndian>()? as i64, 0),
-            services: PeerServices(reader.read_u64::<LittleEndian>()?),
+            // Discard unknown service bits.
+            services: PeerServices::from_bits_truncate(reader.read_u64::<LittleEndian>()?),
             addr: reader.read_socket_addr()?,
         })
     }

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -10,7 +10,7 @@ use zebra_chain::serialization::{
     ReadZcashExt, SerializationError, WriteZcashExt, ZcashDeserialize, ZcashSerialize,
 };
 
-use crate::protocol::types::Services;
+use crate::protocol::types::PeerServices;
 
 /// An address with metadata on its advertised services and last-seen time.
 ///
@@ -23,7 +23,7 @@ pub struct MetaAddr {
     /// The peer's address.
     pub addr: SocketAddr,
     /// The services advertised by the peer.
-    pub services: Services,
+    pub services: PeerServices,
     /// When the peer was last seen.
     pub last_seen: DateTime<Utc>,
 }
@@ -41,7 +41,7 @@ impl ZcashDeserialize for MetaAddr {
     fn zcash_deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         Ok(MetaAddr {
             last_seen: Utc.timestamp(reader.read_u32::<LittleEndian>()? as i64, 0),
-            services: Services(reader.read_u64::<LittleEndian>()?),
+            services: PeerServices(reader.read_u64::<LittleEndian>()?),
             addr: reader.read_socket_addr()?,
         })
     }

--- a/zebra-network/src/protocol/codec.rs
+++ b/zebra-network/src/protocol/codec.rs
@@ -341,14 +341,14 @@ impl Codec {
     fn read_version<R: Read>(&self, mut reader: R) -> Result<Message, Error> {
         Ok(Message::Version {
             version: Version(reader.read_u32::<LittleEndian>()?),
-            services: Services(reader.read_u64::<LittleEndian>()?),
+            services: PeerServices(reader.read_u64::<LittleEndian>()?),
             timestamp: Utc.timestamp(reader.read_i64::<LittleEndian>()?, 0),
             address_recv: (
-                Services(reader.read_u64::<LittleEndian>()?),
+                PeerServices(reader.read_u64::<LittleEndian>()?),
                 reader.read_socket_addr()?,
             ),
             address_from: (
-                Services(reader.read_u64::<LittleEndian>()?),
+                PeerServices(reader.read_u64::<LittleEndian>()?),
                 reader.read_socket_addr()?,
             ),
             nonce: Nonce(reader.read_u64::<LittleEndian>()?),
@@ -505,7 +505,7 @@ mod tests {
     #[test]
     fn version_message_round_trip() {
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-        let services = Services(0x1);
+        let services = PeerServices(0x1);
         let timestamp = Utc.timestamp(1568000000, 0);
 
         let rt = Runtime::new().unwrap();

--- a/zebra-network/src/protocol/message.rs
+++ b/zebra-network/src/protocol/message.rs
@@ -48,7 +48,7 @@ pub enum Message {
         version: Version,
 
         /// The network services advertised by the sender.
-        services: Services,
+        services: PeerServices,
 
         /// The time when the version message was sent.
         timestamp: DateTime<Utc>,
@@ -57,11 +57,11 @@ pub enum Message {
         /// advertised network services.
         ///
         /// Q: how does the handshake know the remote peer's services already?
-        address_recv: (Services, net::SocketAddr),
+        address_recv: (PeerServices, net::SocketAddr),
 
         /// The network address of the node sending this message, and its
         /// advertised network services.
-        address_from: (Services, net::SocketAddr),
+        address_from: (PeerServices, net::SocketAddr),
 
         /// Node random nonce, randomly generated every time a version
         /// packet is sent. This nonce is used to detect connections

--- a/zebra-network/src/protocol/types.rs
+++ b/zebra-network/src/protocol/types.rs
@@ -12,7 +12,7 @@ pub struct Version(pub u32);
 // Tower provides utilities for service discovery, so this might go
 // away in the future in favor of that.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct Services(pub u64);
+pub struct PeerServices(pub u64);
 
 /// A nonce used in the networking layer to identify messages.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/zebra-network/src/protocol/types.rs
+++ b/zebra-network/src/protocol/types.rs
@@ -8,11 +8,21 @@ pub struct Magic(pub [u8; 4]);
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Version(pub u32);
 
-/// Bitfield of features to be enabled for this connection.
-// Tower provides utilities for service discovery, so this might go
-// away in the future in favor of that.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct PeerServices(pub u64);
+bitflags! {
+    /// A bitflag describing services advertised by a node in the network.
+    ///
+    /// Note that bits 24-31 are reserved for temporary experiments; other
+    /// service bits should be allocated via the ZIP process.
+    #[derive(Default)]
+    pub struct PeerServices: u64 {
+        /// NODE_NETWORK means that the node is a full node capable of serving
+        /// blocks, as opposed to a light client that makes network requests but
+        /// does not provide network services.
+        const NODE_NETWORK = (1 << 0);
+        /// NODE_BLOOM means that the node supports bloom-filtered connections.
+        const NODE_BLOOM = (1 << 2);
+    }
+}
 
 /// A nonce used in the networking layer to identify messages.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -70,13 +70,16 @@ impl ConnectCmd {
 
         let version = Message::Version {
             version: constants::CURRENT_VERSION,
-            services: PeerServices(1),
+            services: PeerServices::NODE_NETWORK,
             timestamp: Utc::now(),
-            address_recv: (PeerServices(1), self.addr),
+            address_recv: (PeerServices::NODE_NETWORK, self.addr),
             // We just make something up because at this stage the `connect` command
             // doesn't run a server or anything -- will the zcashd respond on the
             // same tcp connection or try to open one to the bogus address below?
-            address_from: (PeerServices(1), "127.0.0.1:9000".parse().unwrap()),
+            address_from: (
+                PeerServices::NODE_NETWORK,
+                "127.0.0.1:9000".parse().unwrap(),
+            ),
             nonce: Nonce(1),
             user_agent: "Zebra Connect".to_owned(),
             start_height: BlockHeight(0),

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -70,13 +70,13 @@ impl ConnectCmd {
 
         let version = Message::Version {
             version: constants::CURRENT_VERSION,
-            services: Services(1),
+            services: PeerServices(1),
             timestamp: Utc::now(),
-            address_recv: (Services(1), self.addr),
+            address_recv: (PeerServices(1), self.addr),
             // We just make something up because at this stage the `connect` command
             // doesn't run a server or anything -- will the zcashd respond on the
             // same tcp connection or try to open one to the bogus address below?
-            address_from: (Services(1), "127.0.0.1:9000".parse().unwrap()),
+            address_from: (PeerServices(1), "127.0.0.1:9000".parse().unwrap()),
             nonce: Nonce(1),
             user_agent: "Zebra Connect".to_owned(),
             start_height: BlockHeight(0),


### PR DESCRIPTION
This field is called `services` in Bitcoin and Zcash, but because we use
that word internally for other purposes, calling it `PeerServices`
disambiguates the meaning to "the services advertised by the peer",
rather than, e.g., a `tower::Service`.

This PR renames it and replaces it with a bitflags struct.

Closes #29 