### PR TITLE
Handle error conversions properly.

### DIFF
--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -9,6 +9,13 @@ extern crate tracing;
 #[macro_use]
 extern crate bitflags;
 
+/// Type alias to make working with tower traits easier.
+///
+/// Note: the 'static lifetime bound means that the *type* cannot have any
+/// non-'static lifetimes, (e.g., when a type contains a borrow and is
+/// parameterized by 'a), *not* that the object itself has 'static lifetime.
+pub(crate) type BoxedStdError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
 mod network;
 pub use network::Network;
 

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -18,7 +18,7 @@ use crate::{
     constants,
     protocol::{codec::*, internal::*, message::*, types::*},
     timestamp_collector::{PeerLastSeen, TimestampCollector},
-    Network,
+    BoxedStdError, Network,
 };
 
 use super::{
@@ -37,7 +37,7 @@ impl<S> PeerConnector<S>
 where
     S: Service<Request, Response = Response> + Clone + Send + 'static,
     S::Future: Send,
-    //S::Error: Into<Error>,
+    S::Error: Into<BoxedStdError>,
 {
     /// XXX replace with a builder
     pub fn new(network: Network, internal_service: S, collector: &TimestampCollector) -> Self {
@@ -54,8 +54,7 @@ impl<S> Service<SocketAddr> for PeerConnector<S>
 where
     S: Service<Request, Response = Response> + Clone + Send + 'static,
     S::Future: Send,
-    S::Error: Send,
-    //S::Error: Into<Error>,
+    S::Error: Send + Into<BoxedStdError>,
 {
     type Response = PeerClient;
     type Error = Error;


### PR DESCRIPTION
This adds a type alias, BoxedStdError, for a boxed std::error::Error
trait object, and uses it in the where bounds for the generic service
code.  In the future, we may want to standardize on using
std::error::Error exclusively, but we would then possibly lose out on
backtrace information.

Closes #50 