### PR TITLE
Add a network config struct.

### DIFF
--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -14,6 +14,7 @@ rand = "0.7"
 byteorder = "1.3"
 chrono = "0.4"
 failure = "0.1"
+serde = { version = "1", features = ["serde_derive"] }
 tokio = "=0.2.0-alpha.6"
 tower = { git = "https://github.com/tower-rs/tower", branch = "v0.3.x" }
 tracing = { git = "https://github.com/tokio-rs/tracing" }

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -1,0 +1,15 @@
+/// Configuration for networking code.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// The user-agent to advertise.
+    pub user_agent: String,
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            user_agent: crate::constants::USER_AGENT.to_owned(),
+        }
+    }
+}

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -4,7 +4,7 @@
 use crate::protocol::types::*;
 
 /// The User-Agent string provided by the node.
-pub const USER_AGENT: &'static str = "Zebra v2.0.0-alpha.0";
+pub const USER_AGENT: &'static str = "🦓Zebra v2.0.0-alpha.0🦓";
 
 /// The Zcash network protocol version used on mainnet.
 pub const CURRENT_VERSION: Version = Version(170_007);

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -3,6 +3,8 @@
 #![deny(missing_docs)]
 
 #[macro_use]
+extern crate serde;
+#[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate tracing;
@@ -18,6 +20,9 @@ pub(crate) type BoxedStdError = Box<dyn std::error::Error + Send + Sync + 'stati
 
 mod network;
 pub use network::Network;
+
+mod config;
+pub use config::Config;
 
 pub mod protocol;
 

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -72,9 +72,9 @@ impl ConnectCmd {
             1,
         );
 
+        let config = app_config().network.clone();
         let collector = TimestampCollector::new();
-
-        let mut pc = PeerConnector::new(Network::Mainnet, node, &collector);
+        let mut pc = PeerConnector::new(config, Network::Mainnet, node, &collector);
         // no need to call ready because pc is always ready
         let mut client = pc.call(self.addr.clone()).await?;
 

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -7,24 +7,16 @@
 use abscissa_core::Config;
 use serde::{Deserialize, Serialize};
 
+use zebra_network::Config as NetworkSection;
+
 /// Zebrad Configuration
-#[derive(Clone, Config, Debug, Deserialize, Serialize)]
+#[derive(Clone, Config, Default, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ZebradConfig {
     /// Tracing configuration
     pub tracing: TracingSection,
-}
-
-/// Default configuration settings.
-///
-/// Note: if your needs are as simple as below, you can
-/// use `#[derive(Default)]` on ZebradConfig instead.
-impl Default for ZebradConfig {
-    fn default() -> Self {
-        Self {
-            tracing: TracingSection::default(),
-        }
-    }
+    /// Networking configuration,
+    pub network: NetworkSection,
 }
 
 /// Tracing configuration section.


### PR DESCRIPTION
Closes #53 

At the moment this only has one field (the user-agent), which we may not want to be configurable anyways, but having the struct means that we have an easy place to hook into for other fields we may need.