### PR TITLE
Move all git dependencies to published crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,3 @@ members = [
         "zebra-reactor",
         "zebrad",
 ]
-
-[patch.crates-io]
-tracing-attributes = { git = "https://github.com/tokio-rs/tracing" }
-tracing = { git = "https://github.com/tokio-rs/tracing" }

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -14,11 +14,13 @@ rand = "0.7"
 byteorder = "1.3"
 chrono = "0.4"
 failure = "0.1"
+
 tokio = "=0.2.0-alpha.6"
-tower = { git = "https://github.com/tower-rs/tower", branch = "v0.3.x" }
-tracing = { git = "https://github.com/tokio-rs/tracing" }
-tracing-futures = { git = "https://github.com/tokio-rs/tracing", features = ["tokio-alpha"], default-features = false }
 futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"] }
 
+tracing = "0.1"
+tracing-futures = { version = "0.1", features = ["tokio-alpha"], default-features = false }
+
+tower = "=0.3.0-alpha.2"
 
 zebra-chain = { path = "../zebra-chain" }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -13,16 +13,18 @@ gumdrop = "0.6"
 lazy_static = "1"
 serde = { version = "1", features = ["serde_derive"] }
 toml = "0.5"
+
 tokio = "=0.2.0-alpha.6"
-# Replace with git to pick up instrument derive changes, revert on release.
-#tracing = "0.1"
-tracing = { git = "https://github.com/tokio-rs/tracing" }
-tracing-futures = { git = "https://github.com/tokio-rs/tracing", features = ["tokio-alpha"], default-features = false }
-tracing-subscriber = { git = "https://github.com/tokio-rs/tracing" }
-tracing-log = { git = "https://github.com/tokio-rs/tracing" }
-hyper = { git = "https://github.com/hyperium/hyper"}
-tower = { git = "https://github.com/tower-rs/tower", branch = "v0.3.x" }
 futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"] }
+
+tracing = "0.1"
+tracing-futures = { version = "0.1", features = ["tokio-alpha"], default-features = false }
+tracing-subscriber = "0.1"
+tracing-log = "0.1"
+
+hyper = "=0.13.0-alpha.4"
+
+tower = "=0.3.0-alpha.2"
 
 zebra-chain = { path = "../zebra-chain" }
 zebra-network = { path = "../zebra-network" }


### PR DESCRIPTION
The earlier issues with version resolution incompatibilities are now
resolved, and all the upstream changes we made to tracing are released.

Closes #33 