### PR TITLE
Add a timeout to the `PeerServer` event loop.

### DIFF
--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -21,7 +21,7 @@ pin-project = "0.4"
 indexmap = { version = "1.2", default-features = false }
 
 tokio = "=0.2.0-alpha.6"
-futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"] }
+futures-preview = "=0.3.0-alpha.19"
 
 tracing = "0.1"
 tracing-futures = { version = "0.1", features = ["tokio-alpha"], default-features = false }

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -5,6 +5,9 @@ use std::time::Duration;
 // XXX should these constants be split into protocol also?
 use crate::protocol::types::*;
 
+/// The timeout for requests made to a remote peer.
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// We expect to receive a message from a live peer at least once in this time duration.
 /// XXX this needs to be synchronized with the ping transmission times.
 pub const LIVE_PEER_DURATION: Duration = Duration::from_secs(12);

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -164,6 +164,7 @@ where
                 client_rx: rx,
                 error_slot: slot,
                 peer_tx,
+                request_timer: None,
             };
 
             let hooked_peer_rx = peer_rx

--- a/zebra-network/src/peer/server.rs
+++ b/zebra-network/src/peer/server.rs
@@ -127,14 +127,14 @@ where
                         }
                         // XXX switch back to hard failure when we parse all message types
                         //Either::Left((Some(Err(e)), _)) => self.fail_with(e.into()),
-                        Either::Left((Some(Err(e)), _)) => error!(%e),
-                        Either::Left((Some(Ok(msg)), _)) => {
-                            match self.handle_message_as_response(msg) {
+                        Either::Left((Some(Err(peer_err)), _timer)) => error!(%peer_err),
+                        Either::Left((Some(Ok(peer_msg)), _timer)) => {
+                            match self.handle_message_as_response(peer_msg) {
                                 None => continue,
                                 Some(msg) => self.handle_message_as_request(msg).await,
                             }
                         }
-                        Either::Right(((), _)) => {
+                        Either::Right(((), _peer_fut)) => {
                             trace!("client request timed out");
                             // Re-matching lets us take ownership of tx
                             self.state = match self.state {

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1", features = ["serde_derive"] }
 toml = "0.5"
 
 tokio = "=0.2.0-alpha.6"
-futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"] }
+futures-preview = "=0.3.0-alpha.19"
 
 tracing = "0.1"
 tracing-futures = { version = "0.1", features = ["tokio-alpha"], default-features = false }


### PR DESCRIPTION
I think this code could be cleaned up significantly (e.g., removing the
other use of select!) but that's potentially a larger change than this
PR.