### PR TITLE
Add peer count data to TimestampData::update trace

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -1,7 +1,13 @@
 //! Definitions of constants.
 
+use std::time::Duration;
+
 // XXX should these constants be split into protocol also?
 use crate::protocol::types::*;
+
+/// We expect to recieve a message from a live peer at least once in this time duration.
+/// XXX this needs to be synchronized with the ping transmission times.
+pub const LIVE_PEER_DURATION: Duration = Duration::from_secs(12);
 
 /// The User-Agent string provided by the node.
 pub const USER_AGENT: &'static str = "🦓Zebra v2.0.0-alpha.0🦓";

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 // XXX should these constants be split into protocol also?
 use crate::protocol::types::*;
 
-/// We expect to recieve a message from a live peer at least once in this time duration.
+/// We expect to receive a message from a live peer at least once in this time duration.
 /// XXX this needs to be synchronized with the ping transmission times.
 pub const LIVE_PEER_DURATION: Duration = Duration::from_secs(12);
 


### PR DESCRIPTION
The trace from updates now looks like
```
Oct 11 XXX.649 TRACE zebra_network::timestamp_collector: addr=V4(XXXXXX:8233) timestamp=XXXXX.649153588Z data.total=6 data.recent=6
```
(This might cause a merge conflict with #65 but it should be easy to resolve and this change is conceptually separate)