### PR TITLE
Handle inbound connections with `PeerConnector`.

### DIFF
--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -11,5 +11,5 @@ mod server;
 
 pub use client::PeerClient;
 pub use connector::PeerConnector;
-pub use error::{PeerError, SharedPeerError};
+pub use error::{HandshakeError, PeerError, SharedPeerError};
 pub use server::PeerServer;

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -69,8 +69,6 @@ where
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // XXX when this asks a second service for
-        // an address to connect to, it should call inner.ready
         Poll::Ready(Ok(()))
     }
 

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -68,7 +68,8 @@ where
 {
     type Response = PeerClient;
     type Error = HandshakeError;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -51,3 +51,20 @@ impl ErrorSlot {
             .map(|e| e.clone())
     }
 }
+
+/// An error during a handshake with a remote peer.
+#[derive(Error, Debug)]
+pub enum HandshakeError {
+    /// The remote peer sent an unexpected message during the handshake.
+    #[error("The remote peer sent an unexpected message: {0:?}")]
+    UnexpectedMessage(crate::protocol::message::Message),
+    /// The peer connector detected handshake nonce reuse, possibly indicating self-connection.
+    #[error("Detected nonce reuse, possible self-connection")]
+    NonceReuse,
+    /// The remote peer closed the connection.
+    #[error("Peer closed connection")]
+    ConnectionClosed,
+    /// A serialization error occurred while reading or writing a message.
+    #[error("Serialization error")]
+    Serialization(#[from] SerializationError),
+}

--- a/zebra-network/src/protocol/codec.rs
+++ b/zebra-network/src/protocol/codec.rs
@@ -450,7 +450,7 @@ impl Codec {
     }
 
     fn read_getaddr<R: Read>(&self, mut _reader: R) -> Result<Message, Error> {
-        Ok(Message::Verack)
+        Ok(Message::GetAddr)
     }
 
     fn read_block<R: Read>(&self, mut reader: R) -> Result<Message, Error> {

--- a/zebra-network/src/protocol/types.rs
+++ b/zebra-network/src/protocol/types.rs
@@ -25,7 +25,7 @@ bitflags! {
 }
 
 /// A nonce used in the networking layer to identify messages.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Nonce(pub u64);
 
 impl Default for Nonce {

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -11,10 +11,11 @@
 //! application's configuration file.
 
 mod connect;
+mod listen;
 mod start;
 mod version;
 
-use self::{connect::ConnectCmd, start::StartCmd, version::VersionCmd};
+use self::{connect::ConnectCmd, listen::ListenCmd, start::StartCmd, version::VersionCmd};
 use crate::config::ZebradConfig;
 use abscissa_core::{
     config::Override, Command, Configurable, FrameworkError, Help, Options, Runnable,
@@ -42,6 +43,10 @@ pub enum ZebradCmd {
     /// The `connect` subcommand
     #[options(help = "testing stub for dumping network messages")]
     Connect(ConnectCmd),
+
+    /// The `listen` subcommand
+    #[options(help = "testing stub for dumping network messages")]
+    Listen(ListenCmd),
 }
 
 /// This trait allows you to define how application configuration is loaded.

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -80,8 +80,11 @@ impl ConnectCmd {
         let mut pc = PeerConnector::new(config, Network::Mainnet, node, &collector);
 
         let tcp_stream = TcpStream::connect(self.addr).await?;
-        pc.ready().await?;
-        let mut client = pc.call((tcp_stream, self.addr)).await?;
+        pc.ready()
+            .await?;
+        let mut client = pc
+            .call((tcp_stream, self.addr))
+            .await?;
 
         client.ready().await?;
 

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -73,11 +73,15 @@ impl ConnectCmd {
             1,
         );
 
+        use tokio::net::TcpStream;
+
         let config = app_config().network.clone();
         let collector = TimestampCollector::new();
         let mut pc = PeerConnector::new(config, Network::Mainnet, node, &collector);
-        // no need to call ready because pc is always ready
-        let mut client = pc.call(self.addr.clone()).await?;
+
+        let tcp_stream = TcpStream::connect(self.addr).await?;
+        pc.ready().await?;
+        let mut client = pc.call((tcp_stream, self.addr)).await?;
 
         client.ready().await?;
 
@@ -90,6 +94,7 @@ impl ConnectCmd {
             "got addresses from first connected peer"
         );
 
+/*
         use failure::Error;
         use futures::{
             future,
@@ -148,6 +153,7 @@ impl ConnectCmd {
             // empty loop ensures we don't exit the application,
             // and this is throwaway code
         }
+        */
 
         Ok(())
     }

--- a/zebrad/src/commands/listen.rs
+++ b/zebrad/src/commands/listen.rs
@@ -1,0 +1,98 @@
+//! `listen` subcommand - test stub for talking to zcashd
+
+use crate::prelude::*;
+
+use abscissa_core::{Command, Options, Runnable};
+
+/// `listen` subcommand
+#[derive(Command, Debug, Options)]
+pub struct ListenCmd {
+    /// The address of the node to connect to.
+    #[options(help = "The address to listen on.", default = "127.0.0.1:28233")]
+    addr: std::net::SocketAddr,
+}
+
+impl Runnable for ListenCmd {
+    /// Start the application.
+    fn run(&self) {
+        info!(connect.addr = ?self.addr);
+
+        use crate::components::tokio::TokioComponent;
+
+        let wait = tokio::future::pending::<()>();
+        // Combine the connect future with an infinite wait
+        // so that the program has to be explicitly killed and
+        // won't die before all tracing messages are written.
+        let fut = futures::future::join(
+            async {
+                match self.listen().await {
+                    Ok(()) => {}
+                    Err(e) => {
+                        // Print any error that occurs.
+                        error!(?e);
+                    }
+                }
+            },
+            wait,
+        );
+
+        let _ = app_reader()
+            .state()
+            .components
+            .get_downcast_ref::<TokioComponent>()
+            .expect("TokioComponent should be available")
+            .rt
+            .block_on(fut);
+    }
+}
+
+impl ListenCmd {
+    async fn listen(&self) -> Result<(), failure::Error> {
+        use zebra_network::{
+            peer::PeerConnector,
+            peer_set::PeerSet,
+            protocol::internal::{Request, Response},
+            timestamp_collector::TimestampCollector,
+            Network,
+        };
+
+        info!("begin tower-based peer handling test stub");
+
+        use tower::{buffer::Buffer, service_fn, Service, ServiceExt};
+
+        let node = Buffer::new(
+            service_fn(|req| {
+                async move {
+                    info!(?req);
+                    Ok::<Response, failure::Error>(Response::Ok)
+                }
+            }),
+            1,
+        );
+
+        use tokio::net::{TcpListener, TcpStream};
+
+        let config = app_config().network.clone();
+        let collector = TimestampCollector::new();
+        let mut pc = PeerConnector::new(config, Network::Mainnet, node, &collector);
+
+        let mut listener = TcpListener::bind(self.addr).await?;
+
+        loop {
+            let (tcp_stream, addr) = listener.accept().await?;
+
+            pc.ready().await?;
+            let mut client = pc.call((tcp_stream, addr)).await?;
+
+            let addrs = match client.call(Request::GetPeers).await? {
+                Response::Peers(addrs) => addrs,
+                _ => bail!("Got wrong response type"),
+            };
+            info!(
+                addrs.len = addrs.len(),
+                "asked for addresses from remote peer"
+            );
+        }
+        Ok(())
+    }
+}

--- a/zebrad/src/prelude.rs
+++ b/zebrad/src/prelude.rs
@@ -10,3 +10,10 @@ pub use abscissa_core::{Application, Command, Runnable};
 // These are disabled because we use tracing.
 // Logging macros
 //pub use abscissa_core::log::{debug, error, info, log, log_enabled, trace, warn};
+
+/// Type alias to make working with tower traits easier.
+///
+/// Note: the 'static lifetime bound means that the *type* cannot have any
+/// non-'static lifetimes, (e.g., when a type contains a borrow and is
+/// parameterized by 'a), *not* that the object itself has 'static lifetime.
+pub(crate) type BoxedStdError = Box<dyn std::error::Error + Send + Sync + 'static>;


### PR DESCRIPTION
Because the Bitcoin handshake is symmetric, we can reuse the same logic for both incoming and outgoing connections.  By using a single `PeerConnector` service for both inbound and outbound connections, we can maintain shared state -- an `Arc<Mutex<HashSet<Nonce>>>` -- between the connector and all of its live connection futures, preventing self-connections.

This is progress towards #46, and in fact almost completely finishes it, but so far leaves off encapsulating the `TcpListener` stub into a `PeerListener`.