### PR TITLE
Remove failure from zebra-chain, zebra-network.

### DIFF
--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+thiserror = "1"
 byteorder = "1.3"
 chrono = "0.4"
-failure = "0.1"
 #hex = "0.4" This conflicts with tracing-subscriber?
 sha2 = "0.8"

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -1,9 +1,6 @@
 //! Blockchain-related datastructures for Zebra. 🦓
 #![deny(missing_docs)]
 
-#[macro_use]
-extern crate failure;
-
 mod merkle_tree;
 mod sha256d_writer;
 

--- a/zebra-chain/src/serialization.rs
+++ b/zebra-chain/src/serialization.rs
@@ -10,25 +10,19 @@ use std::io;
 use std::net::{IpAddr, SocketAddr};
 
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
+use thiserror::Error;
 
 /// A serialization error.
 // XXX refine error types -- better to use boxed errors?
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum SerializationError {
     /// An underlying IO error.
-    #[fail(display = "io error {}", _0)]
-    IoError(io::Error),
+    #[error("io error")]
+    Io(#[from] io::Error),
     /// The data to be deserialized was malformed.
     // XXX refine errors
-    #[fail(display = "parse error: {}", _0)]
-    ParseError(&'static str),
-}
-
-// Allow upcasting io::Error to SerializationError
-impl From<io::Error> for SerializationError {
-    fn from(e: io::Error) -> Self {
-        Self::IoError(e)
-    }
+    #[error("parse error: {0}")]
+    Parse(&'static str),
 }
 
 /// Consensus-critical serialization for Zcash.

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -13,7 +13,7 @@ bytes = "0.4"
 rand = "0.7"
 byteorder = "1.3"
 chrono = "0.4"
-failure = "0.1"
+thiserror = "1"
 serde = { version = "1", features = ["serde_derive"] }
 pin-project = "0.4"
 # indexmap has rayon support for parallel iteration, 

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -7,8 +7,6 @@ extern crate pin_project;
 #[macro_use]
 extern crate serde;
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate tracing;
 #[macro_use]
 extern crate bitflags;

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -4,30 +4,12 @@
 mod client;
 /// Asynchronously connects to peers.
 mod connector;
+/// Peer-related errors.
+mod error;
 /// Handles inbound requests from the network to our node.
 mod server;
 
 pub use client::PeerClient;
 pub use connector::PeerConnector;
+pub use error::{PeerError, SharedPeerError};
 pub use server::PeerServer;
-
-/// An error related to a peer connection.
-#[derive(Fail, Debug, Clone)]
-pub enum PeerError {
-    /// Wrapper around `failure::Error` that can be `Clone`.
-    #[fail(display = "{}", _0)]
-    Inner(std::sync::Arc<failure::Error>),
-}
-
-impl From<failure::Error> for PeerError {
-    fn from(e: failure::Error) -> PeerError {
-        PeerError::Inner(std::sync::Arc::new(e))
-    }
-}
-
-// XXX hack
-impl Into<crate::BoxedStdError> for PeerError {
-    fn into(self) -> crate::BoxedStdError {
-        Box::new(format_err!("dropped error info").compat())
-    }
-}

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -1,0 +1,53 @@
+use std::sync::{Arc, Mutex};
+
+use thiserror::Error;
+
+use zebra_chain::serialization::SerializationError;
+
+/// A wrapper around `Arc<PeerError>` that implements `Error`.
+#[derive(Error, Debug, Clone)]
+#[error("{0}")]
+pub struct SharedPeerError(#[from] Arc<PeerError>);
+
+/// An error related to peer connection handling.
+#[derive(Error, Debug)]
+pub enum PeerError {
+    /// The remote peer closed the connection.
+    #[error("Peer closed connection")]
+    ConnectionClosed,
+    /// The [`PeerClient`] half of the [`PeerClient`]/[`PeerServer`] pair died before
+    /// the [`PeerServer`] half did.
+    #[error("PeerClient instance died")]
+    DeadPeerClient,
+    /// The [`PeerServer`] half of the [`PeerServer`]/[`PeerClient`] pair died before
+    /// the [`PeerClient`] half did.
+    #[error("PeerServer instance died")]
+    DeadPeerServer,
+    /// The remote peer did not respond to a [`PeerClient`] request in time.
+    #[error("Client request timed out")]
+    ClientRequestTimeout,
+    /// A serialization error occurred while reading or writing a message.
+    #[error("Serialization error")]
+    Serialization(#[from] SerializationError),
+    /// A badly-behaved remote peer sent a handshake message after the handshake was
+    /// already complete.
+    #[error("Remote peer sent handshake messages after handshake")]
+    DuplicateHandshake,
+    /// This node's internal services were overloaded, so the connection was dropped
+    /// to shed load.
+    #[error("Internal services over capacity")]
+    Overloaded,
+}
+
+#[derive(Default, Clone)]
+pub(super) struct ErrorSlot(pub(super) Arc<Mutex<Option<SharedPeerError>>>);
+
+impl ErrorSlot {
+    pub fn try_get_error(&self) -> Option<SharedPeerError> {
+        self.0
+            .lock()
+            .expect("error mutex should be unpoisoned")
+            .as_ref()
+            .map(|e| e.clone())
+    }
+}

--- a/zebra-network/src/peer_set/discover.rs
+++ b/zebra-network/src/peer_set/discover.rs
@@ -4,11 +4,10 @@ use std::{
     task::{Context, Poll},
 };
 
-use failure::Error;
 use tokio::prelude::*;
 use tower::discover::{Change, Discover};
 
-use crate::peer::PeerClient;
+use crate::peer::{PeerClient, PeerError};
 
 /// A [`tower::discover::Discover`] implementation to report new `PeerClient`s.
 ///
@@ -22,7 +21,7 @@ pub struct PeerDiscover {
 impl Discover for PeerDiscover {
     type Key = SocketAddr;
     type Service = PeerClient;
-    type Error = Error;
+    type Error = PeerError;
 
     fn poll_discover(
         self: Pin<&mut Self>,

--- a/zebra-network/src/protocol/inv.rs
+++ b/zebra-network/src/protocol/inv.rs
@@ -63,7 +63,7 @@ impl ZcashDeserialize for InventoryHash {
             1 => Ok(InventoryHash::Tx(TransactionHash(bytes))),
             2 => Ok(InventoryHash::Block(BlockHeaderHash(bytes))),
             3 => Ok(InventoryHash::FilteredBlock(BlockHeaderHash(bytes))),
-            _ => Err(SerializationError::ParseError("invalid inventory code")),
+            _ => Err(SerializationError::Parse("invalid inventory code")),
         }
     }
 }


### PR DESCRIPTION
Failure uses a distinct Fail trait rather than the standard library's
Error trait, which causes a lot of interoperability problems with tower
and other Error-using crates.  Since failure was created, the standard
library's Error trait was improved, and its conveniences are now
available without the custom Fail trait using `thiserror` (for easy
error derives) and `anyhow` (for a better boxed Error).