### PR TITLE
Refactor `TimestampCollector` into `AddressBook`

### DIFF
--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -1,0 +1,76 @@
+//! The addressbook manages information about what peers exist, when they were
+//! seen, and what services they provide.
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+
+use chrono::{DateTime, Utc};
+use futures::channel::mpsc;
+use tokio::prelude::*;
+
+use crate::{
+    constants,
+    types::{MetaAddr, PeerServices},
+};
+
+/// A database of peers, their advertised services, and information on when they
+/// were last seen.
+#[derive(Default, Debug)]
+pub struct AddressBook {
+    by_addr: HashMap<SocketAddr, (DateTime<Utc>, PeerServices)>,
+    by_time: BTreeMap<DateTime<Utc>, (SocketAddr, PeerServices)>,
+}
+
+impl AddressBook {
+    /// Update the address book with `event`, a [`MetaAddr`] representing
+    /// observation of a peer.
+    pub fn update(&mut self, event: MetaAddr) {
+        use chrono::Duration as CD;
+        use std::collections::hash_map::Entry;
+
+        trace!(
+            ?event,
+            data.total = self.by_time.len(),
+            // This would be cleaner if it used "variables" but keeping
+            // it inside the trace! invocation prevents running the range
+            // query unless the output will actually be used.
+            data.recent = self
+                .by_time
+                .range(
+                    (Utc::now() - CD::from_std(constants::LIVE_PEER_DURATION).unwrap())..Utc::now()
+                )
+                .count()
+        );
+
+        let MetaAddr {
+            addr,
+            services,
+            last_seen,
+        } = event;
+
+        match self.by_addr.entry(addr) {
+            Entry::Occupied(mut entry) => {
+                let (prev_last_seen, _) = entry.get();
+                // If the new timestamp event is older than the current
+                // one, discard it.  This is irrelevant for the timestamp
+                // collector but is important for combining address
+                // information from different peers.
+                if *prev_last_seen > last_seen {
+                    return;
+                }
+                self.by_time
+                    .remove(prev_last_seen)
+                    .expect("cannot have by_addr entry without by_time entry");
+                entry.insert((last_seen, services));
+                self.by_time.insert(last_seen, (addr, services));
+            }
+            Entry::Vacant(entry) => {
+                entry.insert((last_seen, services));
+                self.by_time.insert(last_seen, (addr, services));
+            }
+        }
+    }
+}

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -2,7 +2,7 @@
 //! seen, and what services they provide.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeSet, HashMap},
     iter::Extend,
     net::SocketAddr,
     sync::{Arc, Mutex},
@@ -22,20 +22,31 @@ use crate::{
 #[derive(Default, Debug)]
 pub struct AddressBook {
     by_addr: HashMap<SocketAddr, (DateTime<Utc>, PeerServices)>,
-    by_time: BTreeMap<DateTime<Utc>, (SocketAddr, PeerServices)>,
+    by_time: BTreeSet<MetaAddr>,
 }
 
 impl AddressBook {
+    fn assert_consistency(&self) {
+        for (a, (t, s)) in self.by_addr.iter() {
+            for meta in self.by_time.iter().filter(|meta| meta.addr == *a) {
+                if meta.last_seen != *t || meta.services != *s {
+                    panic!("meta {:?} is not {:?}, {:?}, {:?}", meta, a, t, s);
+                }
+            }
+        }
+    }
+
     /// Update the address book with `event`, a [`MetaAddr`] representing
     /// observation of a peer.
     pub fn update(&mut self, event: MetaAddr) {
         use std::collections::hash_map::Entry;
 
-        debug!(
+        trace!(
             ?event,
             data.total = self.by_time.len(),
             data.recent = (self.by_time.len() - self.disconnected_peers().count()),
         );
+        //self.assert_consistency();
 
         let MetaAddr {
             addr,
@@ -45,37 +56,40 @@ impl AddressBook {
 
         match self.by_addr.entry(addr) {
             Entry::Occupied(mut entry) => {
-                let (prev_last_seen, _) = entry.get();
-                // If the new timestamp event is older than the current
-                // one, discard it.  This is irrelevant for the timestamp
-                // collector but is important for combining address
-                // information from different peers.
-                if *prev_last_seen > last_seen {
+                let (prev_last_seen, prev_services) = entry.get().clone();
+                // Ignore stale entries.
+                if prev_last_seen > last_seen {
                     return;
                 }
                 self.by_time
-                    .remove(prev_last_seen)
+                    .take(&MetaAddr {
+                        addr,
+                        services: prev_services,
+                        last_seen: prev_last_seen,
+                    })
                     .expect("cannot have by_addr entry without by_time entry");
                 entry.insert((last_seen, services));
-                self.by_time.insert(last_seen, (addr, services));
+                self.by_time.insert(event);
             }
             Entry::Vacant(entry) => {
                 entry.insert((last_seen, services));
-                self.by_time.insert(last_seen, (addr, services));
+                self.by_time.insert(event);
             }
         }
+        //self.assert_consistency();
     }
 
     /// Return an iterator over all peers, ordered from most recently seen to
     /// least recently seen.
     pub fn peers<'a>(&'a self) -> impl Iterator<Item = MetaAddr> + 'a {
-        self.by_time.iter().rev().map(from_by_time_kv)
+        self.by_time.iter().rev().cloned()
     }
 
     /// Return an iterator over peers known to be disconnected, ordered from most
     /// recently seen to least recently seen.
     pub fn disconnected_peers<'a>(&'a self) -> impl Iterator<Item = MetaAddr> + 'a {
         use chrono::Duration as CD;
+        use std::net::{IpAddr, Ipv4Addr};
         use std::ops::Bound::{Excluded, Unbounded};
 
         // LIVE_PEER_DURATION represents the time interval in which we are
@@ -83,28 +97,24 @@ impl AddressBook {
         // connection. Therefore, if the last-seen timestamp is older than
         // LIVE_PEER_DURATION ago, we know we must have disconnected from it.
         let cutoff = Utc::now() - CD::from_std(constants::LIVE_PEER_DURATION).unwrap();
+        let cutoff_meta = MetaAddr {
+            last_seen: cutoff,
+            // The ordering on MetaAddrs is newest-first, then arbitrary,
+            // so any fields will do here.
+            addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0),
+            services: PeerServices::default(),
+        };
 
         self.by_time
-            .range((Unbounded, Excluded(cutoff)))
+            .range((Excluded(cutoff_meta), Unbounded))
             .rev()
-            .map(from_by_time_kv)
+            .cloned()
     }
 
     /// Returns an iterator that drains entries from the address book, removing
     /// them in order from most recent to least recent.
     pub fn drain_recent<'a>(&'a mut self) -> impl Iterator<Item = MetaAddr> + 'a {
         Drain { book: self }
-    }
-}
-
-// Helper impl to convert by_time Iterator Items back to MetaAddrs
-// This could easily be a From impl, but trait impls are public, and this shouldn't be.
-fn from_by_time_kv(by_time_kv: (&DateTime<Utc>, &(SocketAddr, PeerServices))) -> MetaAddr {
-    let (last_seen, (addr, services)) = by_time_kv;
-    MetaAddr {
-        last_seen: last_seen.clone(),
-        addr: addr.clone(),
-        services: services.clone(),
     }
 }
 
@@ -127,17 +137,12 @@ impl<'a> Iterator for Drain<'a> {
     type Item = MetaAddr;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let most_recent = self.book.by_time.keys().rev().next()?.clone();
-        let (addr, services) = self
-            .book
-            .by_time
-            .remove(&most_recent)
-            .expect("key from keys() must be present in btreemap");
-        self.book.by_addr.remove(&addr);
-        Some(MetaAddr {
-            addr,
-            services,
-            last_seen: most_recent,
-        })
+        let most_recent = self.book.by_time.iter().next()?.clone();
+        self.book.by_time.remove(&most_recent);
+        self.book
+            .by_addr
+            .remove(&most_recent.addr)
+            .expect("cannot have by_time entry without by_addr entry");
+        Some(most_recent)
     }
 }

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -143,7 +143,7 @@ impl AddressBook {
     }
 
     /// Returns an iterator that drains entries from the address book, removing
-    /// them in order from most recent to least recent.
+    /// them in order from least recent to most recent.
     pub fn drain_oldest<'a>(&'a mut self) -> impl Iterator<Item = MetaAddr> + 'a {
         Drain {
             book: self,

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -44,6 +44,7 @@ extern crate bitflags;
 /// parameterized by 'a), *not* that the object itself has 'static lifetime.
 pub type BoxedStdError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+mod address_book;
 mod config;
 mod constants;
 mod meta_addr;
@@ -54,11 +55,10 @@ mod protocol;
 mod timestamp_collector;
 
 pub use crate::{
+    address_book::AddressBook,
     config::Config,
     peer_set::{init, BoxedZebraService},
     protocol::internal::{Request, Response},
-    // XXX replace with `AddressBook`
-    timestamp_collector::TimestampCollector,
 };
 
 /// Types used in the definition of [`Request`] and [`Response`] messages.
@@ -68,5 +68,5 @@ pub mod types {
 
 /// This will be removed when we finish encapsulation
 pub mod should_be_private {
-    pub use crate::peer::PeerConnector;
+    pub use crate::{peer::PeerConnector, timestamp_collector::TimestampCollector};
 }

--- a/zebra-network/src/peer_set.rs
+++ b/zebra-network/src/peer_set.rs
@@ -57,9 +57,9 @@ where
     S: Service<Request, Response = Response, Error = BoxedStdError> + Clone + Send + 'static,
     S::Future: Send + 'static,
 {
-    let timestamp_collector = TimestampCollector::new();
+    let (address_book, timestamp_collector) = TimestampCollector::spawn();
     let peer_connector = Buffer::new(
-        PeerConnector::new(config.clone(), inbound_service, &timestamp_collector),
+        PeerConnector::new(config.clone(), inbound_service, timestamp_collector),
         1,
     );
 
@@ -98,7 +98,7 @@ where
 
     // 3. Outgoing peers we connect to in response to load.
 
-    (Box::new(peer_set), timestamp_collector.address_book())
+    (Box::new(peer_set), address_book)
 }
 
 /// Use the provided `peer_connector` to connect to `initial_peers`, then send

--- a/zebra-network/src/timestamp_collector.rs
+++ b/zebra-network/src/timestamp_collector.rs
@@ -1,95 +1,36 @@
 //! The timestamp collector collects liveness information from peers.
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    net::SocketAddr,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
-use chrono::{DateTime, Utc};
 use futures::channel::mpsc;
 use tokio::prelude::*;
 
-use crate::{
-    constants,
-    types::{MetaAddr, PeerServices},
-    AddressBook,
-};
+use crate::{types::MetaAddr, AddressBook};
 
 /// The timestamp collector hooks into incoming message streams for each peer and
 /// records per-connection last-seen timestamps into an [`AddressBook`].
-///
-/// On creation, the `TimestampCollector` spawns a worker task to process new
-/// timestamp events. The resulting `TimestampCollector` can be cloned, and the
-/// worker task and state are shared among all of the clones.
-///
-/// XXX add functionality for querying the timestamp data
-#[derive(Clone, Debug)]
-pub struct TimestampCollector {
-    // We do not expect mutex contention to be a problem, because
-    // the dominant accessor is the collector worker, and it has a long
-    // event buffer to hide latency if other tasks block it temporarily.
-    data: Arc<Mutex<AddressBook>>,
-    shutdown: Arc<ShutdownSignal>,
-    worker_tx: mpsc::Sender<MetaAddr>,
-}
+pub struct TimestampCollector {}
 
 impl TimestampCollector {
-    /// Constructs a new `TimestampCollector`, spawning a worker task to process updates.
-    pub fn new() -> TimestampCollector {
-        let data = Arc::new(Mutex::new(AddressBook::default()));
-        // We need to make a copy now so we can move data into the async block.
-        let data2 = data.clone();
-
+    /// Spawn a new [`TimestampCollector`] task, and return handles for the
+    /// transmission channel for timestamp events and for the [`AddressBook`] it
+    /// updates.
+    pub fn spawn() -> (Arc<Mutex<AddressBook>>, mpsc::Sender<MetaAddr>) {
         const TIMESTAMP_WORKER_BUFFER_SIZE: usize = 100;
         let (worker_tx, mut worker_rx) = mpsc::channel(TIMESTAMP_WORKER_BUFFER_SIZE);
-        let (shutdown_tx, mut shutdown_rx) = mpsc::channel(0);
+        let address_book = Arc::new(Mutex::new(AddressBook::default()));
+        let worker_address_book = address_book.clone();
 
-        // Construct and then spawn a worker.
         let worker = async move {
-            use futures::future::{self, Either};
-            loop {
-                match future::select(shutdown_rx.next(), worker_rx.next()).await {
-                    Either::Left((_, _)) => return,     // shutdown signal
-                    Either::Right((None, _)) => return, // all workers are gone
-                    Either::Right((Some(event), _)) => data2
-                        .lock()
-                        .expect("mutex should be unpoisoned")
-                        .update(event),
-                }
+            while let Some(event) = worker_rx.next().await {
+                worker_address_book
+                    .lock()
+                    .expect("mutex should be unpoisoned")
+                    .update(event);
             }
         };
         tokio::spawn(worker.boxed());
 
-        TimestampCollector {
-            data,
-            worker_tx,
-            shutdown: Arc::new(ShutdownSignal { tx: shutdown_tx }),
-        }
-    }
-
-    /// Return a shared reference to the [`AddressBook`] this collector updates.
-    pub fn address_book(&self) -> Arc<Mutex<AddressBook>> {
-        self.data.clone()
-    }
-
-    pub(crate) fn sender_handle(&self) -> mpsc::Sender<MetaAddr> {
-        self.worker_tx.clone()
-    }
-}
-
-/// Sends a signal when dropped.
-#[derive(Debug)]
-struct ShutdownSignal {
-    /// Sending () signals that the task holding the rx end should terminate.
-    ///
-    /// This should really be a oneshot but calling a oneshot consumes it,
-    /// and we can't move out of self in Drop.
-    tx: mpsc::Sender<()>,
-}
-
-impl Drop for ShutdownSignal {
-    fn drop(&mut self) {
-        self.tx.try_send(()).expect("tx is only used in drop");
+        (address_book, worker_tx)
     }
 }

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -139,7 +139,7 @@ impl ConnectCmd {
             );
         }
 
-        let addrs = all_addrs.drain_recent().collect::<Vec<_>>();
+        let addrs = all_addrs.drain_newest().collect::<Vec<_>>();
 
         info!(addrs.len = addrs.len(), ab.len = all_addrs.peers().count());
         let mut head = Vec::new();

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -79,9 +79,9 @@ impl ConnectCmd {
             use tokio::net::TcpStream;
             use zebra_network::should_be_private::{PeerConnector, TimestampCollector};
 
-            let collector = TimestampCollector::new();
+            let (_, collector) = TimestampCollector::spawn();
             let mut pc = Buffer::new(
-                PeerConnector::new(config.clone(), node.clone(), &collector),
+                PeerConnector::new(config.clone(), node.clone(), collector),
                 1,
             );
 

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -142,6 +142,11 @@ impl ConnectCmd {
         let addrs = all_addrs.drain_recent().collect::<Vec<_>>();
 
         info!(addrs.len = addrs.len(), ab.len = all_addrs.peers().count());
+        let mut head = Vec::new();
+        head.extend_from_slice(&addrs[0..5]);
+        let mut tail = Vec::new();
+        tail.extend_from_slice(&addrs[addrs.len() - 5..]);
+        info!(addrs.first = ?head, addrs.last = ?tail);
 
         loop {
             // empty loop ensures we don't exit the application,

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -51,7 +51,7 @@ impl Runnable for ConnectCmd {
 
 impl ConnectCmd {
     async fn connect(&self) -> Result<(), failure::Error> {
-        use zebra_network::{Request, Response, TimestampCollector};
+        use zebra_network::{Request, Response};
 
         info!("begin tower-based peer handling test stub");
         use tower::{buffer::Buffer, service_fn, Service, ServiceExt};
@@ -77,7 +77,7 @@ impl ConnectCmd {
         // Later, this should turn into initial_peers = vec![self.addr];
         config.initial_peers = {
             use tokio::net::TcpStream;
-            use zebra_network::should_be_private::PeerConnector;
+            use zebra_network::should_be_private::{PeerConnector, TimestampCollector};
 
             let collector = TimestampCollector::new();
             let mut pc = Buffer::new(
@@ -108,7 +108,7 @@ impl ConnectCmd {
             addrs.into_iter().map(|meta| meta.addr).collect::<Vec<_>>()
         };
 
-        let (mut peer_set, _tc) = zebra_network::init(config, node);
+        let (mut peer_set, _address_book) = zebra_network::init(config, node);
 
         info!("waiting for peer_set ready");
         peer_set.ready().await.map_err(Error::from_boxed_compat)?;

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -108,7 +108,7 @@ impl ConnectCmd {
             addrs.into_iter().map(|meta| meta.addr).collect::<Vec<_>>()
         };
 
-        let (mut peer_set, _address_book) = zebra_network::init(config, node);
+        let (mut peer_set, address_book) = zebra_network::init(config, node);
 
         info!("waiting for peer_set ready");
         peer_set.ready().await.map_err(Error::from_boxed_compat)?;


### PR DESCRIPTION
This follows on #71 but is a different concept so it's in a different PR.

This splits the previous, internal-only `TimestampData` struct into a public `AddressBook`, a data structure for managing address entries with timestamps, and makes the `TimestampCollector` internal to `zebra_network`.

The `AddressBook` is rewritten to use a `BTreeSet<MetaAddr>` internally. This requires implementing `Ord` for `MetaAddr`; the order chosen is recent-first and then arbitrary (but deterministic) tiebreaking, which ensures that we handle distinct addresses with identical timestamps correctly.

The `AddressBook` has a number of useful methods for working with addresses:

- `contains_addr(&self, addr: &SocketAddr) -> bool` checks membership.

- `get_by_addr(&self, addr, SocketAddr) -> Option<MetaAddr>` does lookup.

- `update(&mut self, new: MetaAddr)` adds or updates an entry.  If the timestamp in the supplied `event` is older than an existing record, it is discarded.

- `is_potentially_connected(&self, addr: &SocketAddr)` uses `constants::LIVE_PEER_DURATION` to check whether `addr` could be connected to a node feeding timestamps into `self`, and can be used to prevent duplicate connections.

- `impl Extend<MetaAddr>` allows merging any `Iterator<Item=MetaAddr>` (e.g., a `Vec<MetaAddr>` from `GetPeers`) into an existing address book, using `update` to deduplicate and discard stale entries.

- `peers()`, `disconnected_peers()` return read-only iterators over all entries or known-disconnected entries, sorting by recent-first.

- `drain_newest()`, `drain_oldest()` return draining iterators that remove and return entries in either order.

The goal is to be able to structure next-connection-candidate decisions as flows of addresses between different address books (e.g., disconnected peers, gossiped peers, failed peers, etc.).