### PR TITLE
Add a config command.

### DIFF
--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -10,11 +10,12 @@
 //! See the `impl Configurable` below for how to specify the path to the
 //! application's configuration file.
 
+mod config;
 mod connect;
 mod start;
 mod version;
 
-use self::{connect::ConnectCmd, start::StartCmd, version::VersionCmd};
+use self::{config::ConfigCmd, connect::ConnectCmd, start::StartCmd, version::VersionCmd};
 use crate::config::ZebradConfig;
 use abscissa_core::{
     config::Override, Command, Configurable, FrameworkError, Help, Options, Runnable,
@@ -34,6 +35,10 @@ pub enum ZebradCmd {
     /// The `start` subcommand
     #[options(help = "start the application")]
     Start(StartCmd),
+
+    /// The `config` subcommand
+    #[options(help = "generate a skeleton configuration")]
+    Config(ConfigCmd),
 
     /// The `version` subcommand
     #[options(help = "display version information")]

--- a/zebrad/src/commands/config.rs
+++ b/zebrad/src/commands/config.rs
@@ -1,0 +1,46 @@
+//! `config` subcommand - generates a skeleton config.
+
+use crate::config::ZebradConfig;
+use abscissa_core::{Command, Options, Runnable};
+
+/// `config` subcommand
+#[derive(Command, Debug, Options)]
+pub struct ConfigCmd {
+    /// The file to write the generated config to.
+    #[options(help = "The file to write the generated config to (stdout if unspecified)")]
+    output_file: Option<String>,
+}
+
+impl Runnable for ConfigCmd {
+    /// Start the application.
+    fn run(&self) {
+        let default_config = ZebradConfig::default();
+        let mut output = r"# Default configuration values for zebrad.
+#
+# This file is intended as a skeleton for custom configs.
+#
+# Because this contains default values, and the default
+# values may change, you should delete all entries except
+# for the ones you wish to change.
+#
+# Documentation on the meanings of each config option
+# can be found in Rustdoc. XXX add link to rendered docs.
+
+"
+        .to_owned();
+        output += &toml::to_string_pretty(&default_config)
+            .expect("default config should be serializable");
+        match self.output_file {
+            Some(ref output_file) => {
+                use std::{fs::File, io::Write};
+                File::create(output_file)
+                    .expect("must be able to open output file")
+                    .write_all(output.as_bytes())
+                    .expect("must be able to write output");
+            }
+            None => {
+                println!("{}", output);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This runs with
```
zebrad config
```
to get stdout, or 
```
zebrad config -o filename
```
to write it to a file.

Some of the fields are a bit weirdly formatted in the toml file but at least it's autogenerated & guaranteed to stay in sync with the docs.

When we do #73 we should update the help string to point to whatever URL hosts docs.