### PR TITLE
Remove connect loop

### DIFF
--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -111,10 +111,8 @@ impl ConnectCmd {
         tail.extend_from_slice(&addrs[addrs.len() - 5..]);
         info!(addrs.first = ?head, addrs.last = ?tail);
 
-        loop {
-            // empty loop ensures we don't exit the application,
-            // and this is throwaway code
-        }
+        let eternity = tokio::future::pending::<()>();
+        eternity.await;
 
         Ok(())
     }


### PR DESCRIPTION
Replace the `loop` in `connect` with a pending future, dropping CPU use from 100% to 0% (my bad)