### PR TITLE
Sanitize outbound address responses.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,6 +1539,7 @@ dependencies = [
  "gumdrop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -25,6 +25,12 @@ pub const LIVE_PEER_DURATION: Duration = Duration::from_secs(60 + 10 + 10 + 10);
 /// connected peer.
 pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 
+/// Truncate timestamps in outbound address messages to this time interval.
+///
+/// This is intended to prevent a peer from learning exactly when we recieved
+/// messages from each of our peers.
+pub const TIMESTAMP_TRUNCATION_SECONDS: i64 = 30 * 60;
+
 /// The User-Agent string provided by the node.
 pub const USER_AGENT: &'static str = "🦓Zebra v2.0.0-alpha.0🦓";
 

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -18,9 +18,6 @@ use crate::protocol::types::PeerServices;
 /// An address with metadata on its advertised services and last-seen time.
 ///
 /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#Network_address)
-// XXX determine whether we will use this struct in *our* networking handling
-// code, or just in the definitions of the networking protocol (in which case
-// it should live in the protocol submodule)
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct MetaAddr {
     /// The peer's address.

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -54,6 +54,6 @@ where
             let client = hs.call((stream, addr)).await?;
             Ok(Change::Insert(addr, client))
         }
-            .boxed()
+        .boxed()
     }
 }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+rand = "0.7"
 chrono = "0.4"
 abscissa_core = "0.3.0"
 failure = "0.1"


### PR DESCRIPTION
This aims to prevent a remote peer from inspecting timings of all messages received by this node.

Closes #18.