### PR TITLE
Support Mempool messages

### DIFF
--- a/zebra-network/src/protocol/codec.rs
+++ b/zebra-network/src/protocol/codec.rs
@@ -258,7 +258,7 @@ impl Codec {
                 writer.write_u32::<LittleEndian>(version.0)?;
                 transaction.zcash_serialize(&mut writer)?
             }
-            // Mempool => {}
+            Mempool => { /* Empty payload -- no-op */ }
             // FilterLoad => {}
             // FilterAdd => {}
             // FilterClear => {}
@@ -557,7 +557,7 @@ impl Codec {
     }
 
     fn read_mempool<R: Read>(&self, mut _reader: R) -> Result<Message, Error> {
-        return Err(Error::Parse("mempool messages are not implemented"));
+        Ok(Message::Mempool)
     }
 
     fn read_filterload<R: Read>(&self, mut _reader: R) -> Result<Message, Error> {

--- a/zebra-network/src/protocol/internal.rs
+++ b/zebra-network/src/protocol/internal.rs
@@ -4,6 +4,8 @@
 //! responses, so that we have unified types to pass around. No serialization
 //! is performed as these are only internal types.
 
+use zebra_chain::transaction::Transaction;
+
 use crate::meta_addr::MetaAddr;
 
 use super::types::Nonce;
@@ -20,6 +22,9 @@ pub enum Request {
     // internally for connection management. You should not expect to
     // be firing or handling `Ping` requests or `Pong` responses.
     Ping(Nonce),
+    /// Requests the transactions the remote server has verified but
+    /// not yet confirmed.
+    GetMempool,
 }
 
 /// A response to a network request, represented in internal format.
@@ -29,4 +34,6 @@ pub enum Response {
     Ok,
     /// A list of peers, used to respond to `GetPeers`.
     Peers(Vec<MetaAddr>),
+    /// A list of transactions, such as in response to `GetMempool`.
+    Transactions(Vec<Transaction>),
 }

--- a/zebra-network/src/protocol/message.rs
+++ b/zebra-network/src/protocol/message.rs
@@ -272,7 +272,7 @@ pub enum Message {
     ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#mempool)
     /// [BIP35]: https://github.com/bitcoin/bips/blob/master/bip-0035.mediawiki
-    Mempool {/* XXX add fields */},
+    Mempool,
 
     /// A `filterload` message.
     ///

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -54,7 +54,7 @@ impl ConnectCmd {
         // Connect only to the specified peer.
         config.initial_mainnet_peers = vec![self.addr.to_string()];
 
-        let (mut peer_set, address_book) = zebra_network::init(config, node).await;
+        let (mut peer_set, _address_book) = zebra_network::init(config, node).await;
 
         info!("waiting for peer_set ready");
         peer_set.ready().await.map_err(Error::from_boxed_compat)?;


### PR DESCRIPTION
This does not yet push requests into services that actually respond with transaction
hashes in our node's mempool, which doesn't exist yet.

Pertains to #26