### PR TITLE
Rename peer structs

### DIFF
--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -68,5 +68,5 @@ pub mod types {
 
 /// This will be removed when we finish encapsulation
 pub mod should_be_private {
-    pub use crate::{peer::PeerHandshake, timestamp_collector::TimestampCollector};
+    pub use crate::{peer::Handshake, timestamp_collector::TimestampCollector};
 }

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -14,5 +14,5 @@ mod server;
 pub use client::Client;
 pub use connector::PeerConnector;
 pub use error::{HandshakeError, PeerError, SharedPeerError};
-pub use handshake::PeerHandshake;
+pub use handshake::Handshake;
 pub use server::Server;

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -11,8 +11,8 @@ mod handshake;
 /// Handles inbound requests from the network to our node.
 mod server;
 
-use error::ErrorSlot;
 use client::ClientRequest;
+use error::ErrorSlot;
 
 pub use client::Client;
 pub use connector::Connector;

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -15,4 +15,4 @@ pub use client::Client;
 pub use connector::PeerConnector;
 pub use error::{HandshakeError, PeerError, SharedPeerError};
 pub use handshake::PeerHandshake;
-pub use server::PeerServer;
+pub use server::Server;

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -11,7 +11,7 @@ mod handshake;
 /// Handles inbound requests from the network to our node.
 mod server;
 
-pub use client::PeerClient;
+pub use client::Client;
 pub use connector::PeerConnector;
 pub use error::{HandshakeError, PeerError, SharedPeerError};
 pub use handshake::PeerHandshake;

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -12,7 +12,7 @@ mod handshake;
 mod server;
 
 pub use client::Client;
-pub use connector::PeerConnector;
+pub use connector::Connector;
 pub use error::{HandshakeError, PeerError, SharedPeerError};
 pub use handshake::Handshake;
 pub use server::Server;

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -11,6 +11,9 @@ mod handshake;
 /// Handles inbound requests from the network to our node.
 mod server;
 
+use error::ErrorSlot;
+use client::ClientRequest;
+
 pub use client::Client;
 pub use connector::Connector;
 pub use error::{HandshakeError, PeerError, SharedPeerError};

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -12,7 +12,7 @@ use tower::Service;
 
 use crate::protocol::internal::{Request, Response};
 
-use super::{error::ErrorSlot, SharedPeerError};
+use super::{ErrorSlot, SharedPeerError};
 
 /// The "client" duplex half of a peer connection.
 pub struct Client {

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -21,7 +21,7 @@ pub struct Client {
     pub(super) error_slot: ErrorSlot,
 }
 
-/// A message from the `peer::Client` to the `PeerServer`, containing both a
+/// A message from the `peer::Client` to the `peer::Server`, containing both a
 /// request and a return message channel. The reason the return channel is
 /// included is because `peer::Client::call` returns a future that may be moved
 /// around before it resolves, so the future must have ownership of the channel
@@ -43,7 +43,7 @@ impl Service<Request> for Client {
             Poll::Ready(Err(self
                 .error_slot
                 .try_get_error()
-                .expect("failed PeerServers must set their error slot")))
+                .expect("failed servers must set their error slot")))
         } else {
             Poll::Ready(Ok(()))
         }
@@ -60,7 +60,7 @@ impl Service<Request> for Client {
                     future::ready(Err(self
                         .error_slot
                         .try_get_error()
-                        .expect("failed PeerServers must set their error slot")))
+                        .expect("failed servers must set their error slot")))
                     .instrument(self.span.clone())
                     .boxed()
                 } else {

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -15,15 +15,15 @@ use crate::protocol::internal::{Request, Response};
 use super::{error::ErrorSlot, SharedPeerError};
 
 /// The "client" duplex half of a peer connection.
-pub struct PeerClient {
+pub struct Client {
     pub(super) span: tracing::Span,
     pub(super) server_tx: mpsc::Sender<ClientRequest>,
     pub(super) error_slot: ErrorSlot,
 }
 
-/// A message from the `PeerClient` to the `PeerServer`, containing both a
+/// A message from the `peer::Client` to the `PeerServer`, containing both a
 /// request and a return message channel. The reason the return channel is
-/// included is because `PeerClient::call` returns a future that may be moved
+/// included is because `peer::Client::call` returns a future that may be moved
 /// around before it resolves, so the future must have ownership of the channel
 /// on which it receives the response.
 #[derive(Debug)]
@@ -32,7 +32,7 @@ pub(super) struct ClientRequest(
     pub(super) oneshot::Sender<Result<Response, SharedPeerError>>,
 );
 
-impl Service<Request> for PeerClient {
+impl Service<Request> for Client {
     type Response = Response;
     type Error = SharedPeerError;
     type Future =

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -9,13 +9,13 @@ use tower::{discover::Change, Service, ServiceExt};
 
 use crate::{BoxedStdError, Request, Response};
 
-use super::{HandshakeError, Client, PeerHandshake};
+use super::{HandshakeError, Client, Handshake};
 
-/// A wrapper around [`PeerHandshake`] that opens a TCP connection before
+/// A wrapper around [`peer::Handshake`] that opens a TCP connection before
 /// forwarding to the inner handshake service. Writing this as its own
 /// [`tower::Service`] lets us apply unified timeout policies, etc.
 pub struct PeerConnector<S> {
-    handshaker: PeerHandshake<S>,
+    handshaker: Handshake<S>,
 }
 
 impl<S: Clone> Clone for PeerConnector<S> {
@@ -27,7 +27,7 @@ impl<S: Clone> Clone for PeerConnector<S> {
 }
 
 impl<S> PeerConnector<S> {
-    pub fn new(handshaker: PeerHandshake<S>) -> Self {
+    pub fn new(handshaker: Handshake<S>) -> Self {
         Self { handshaker }
     }
 }

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -9,7 +9,7 @@ use tower::{discover::Change, Service, ServiceExt};
 
 use crate::{BoxedStdError, Request, Response};
 
-use super::{HandshakeError, PeerClient, PeerHandshake};
+use super::{HandshakeError, Client, PeerHandshake};
 
 /// A wrapper around [`PeerHandshake`] that opens a TCP connection before
 /// forwarding to the inner handshake service. Writing this as its own
@@ -37,7 +37,7 @@ where
     S: Service<Request, Response = Response, Error = BoxedStdError> + Clone + Send + 'static,
     S::Future: Send,
 {
-    type Response = Change<SocketAddr, PeerClient>;
+    type Response = Change<SocketAddr, Client>;
     type Error = HandshakeError;
     type Future =
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -14,25 +14,25 @@ use super::{HandshakeError, Client, Handshake};
 /// A wrapper around [`peer::Handshake`] that opens a TCP connection before
 /// forwarding to the inner handshake service. Writing this as its own
 /// [`tower::Service`] lets us apply unified timeout policies, etc.
-pub struct PeerConnector<S> {
+pub struct Connector<S> {
     handshaker: Handshake<S>,
 }
 
-impl<S: Clone> Clone for PeerConnector<S> {
+impl<S: Clone> Clone for Connector<S> {
     fn clone(&self) -> Self {
-        Self {
+        Connector {
             handshaker: self.handshaker.clone(),
         }
     }
 }
 
-impl<S> PeerConnector<S> {
+impl<S> Connector<S> {
     pub fn new(handshaker: Handshake<S>) -> Self {
-        Self { handshaker }
+        Connector { handshaker }
     }
 }
 
-impl<S> Service<SocketAddr> for PeerConnector<S>
+impl<S> Service<SocketAddr> for Connector<S>
 where
     S: Service<Request, Response = Response, Error = BoxedStdError> + Clone + Send + 'static,
     S::Future: Send,

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -9,7 +9,7 @@ use tower::{discover::Change, Service, ServiceExt};
 
 use crate::{BoxedStdError, Request, Response};
 
-use super::{HandshakeError, Client, Handshake};
+use super::{Client, Handshake, HandshakeError};
 
 /// A wrapper around [`peer::Handshake`] that opens a TCP connection before
 /// forwarding to the inner handshake service. Writing this as its own

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -15,14 +15,14 @@ pub enum PeerError {
     /// The remote peer closed the connection.
     #[error("Peer closed connection")]
     ConnectionClosed,
-    /// The [`peer::Client`] half of the [`peer::Client`]/[`PeerServer`] pair died before
+    /// The [`peer::Client`] half of the [`peer::Client`]/[`peer::Server`] pair died before
     /// the [`Server`] half did.
     #[error("peer::Client instance died")]
     DeadClient,
-    /// The [`PeerServer`] half of the [`PeerServer`]/[`peer::Client`] pair died before
+    /// The [`peer::Server`] half of the [`peer::Server`]/[`peer::Client`] pair died before
     /// the [`peer::Client`] half did.
-    #[error("PeerServer instance died")]
-    DeadPeerServer,
+    #[error("peer::Server instance died")]
+    DeadServer,
     /// The remote peer did not respond to a [`peer::Client`] request in time.
     #[error("Client request timed out")]
     ClientRequestTimeout,

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -15,15 +15,15 @@ pub enum PeerError {
     /// The remote peer closed the connection.
     #[error("Peer closed connection")]
     ConnectionClosed,
-    /// The [`PeerClient`] half of the [`PeerClient`]/[`PeerServer`] pair died before
-    /// the [`PeerServer`] half did.
-    #[error("PeerClient instance died")]
-    DeadPeerClient,
-    /// The [`PeerServer`] half of the [`PeerServer`]/[`PeerClient`] pair died before
-    /// the [`PeerClient`] half did.
+    /// The [`peer::Client`] half of the [`peer::Client`]/[`PeerServer`] pair died before
+    /// the [`Server`] half did.
+    #[error("peer::Client instance died")]
+    DeadClient,
+    /// The [`PeerServer`] half of the [`PeerServer`]/[`peer::Client`] pair died before
+    /// the [`peer::Client`] half did.
     #[error("PeerServer instance died")]
     DeadPeerServer,
-    /// The remote peer did not respond to a [`PeerClient`] request in time.
+    /// The remote peer did not respond to a [`peer::Client`] request in time.
     #[error("Client request timed out")]
     ClientRequestTimeout,
     /// A serialization error occurred while reading or writing a message.

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -25,7 +25,7 @@ use crate::{
     BoxedStdError, Config,
 };
 
-use super::{error::ErrorSlot, server::ServerState, HandshakeError, Client, PeerServer};
+use super::{error::ErrorSlot, server::ServerState, HandshakeError, Client, Server};
 
 /// A [`Service`] that handshakes with a remote peer and constructs a
 /// client/server pair.
@@ -192,7 +192,7 @@ where
 
             let (peer_tx, peer_rx) = stream.split();
 
-            let server = PeerServer {
+            let server = Server {
                 state: ServerState::AwaitingRequest,
                 svc: internal_service,
                 client_rx: server_rx,

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -25,7 +25,7 @@ use crate::{
     BoxedStdError, Config,
 };
 
-use super::{error::ErrorSlot, HandshakeError, Client, Server};
+use super::{ErrorSlot, HandshakeError, Client, Server};
 
 /// A [`Service`] that handshakes with a remote peer and constructs a
 /// client/server pair.

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -25,7 +25,7 @@ use crate::{
     BoxedStdError, Config,
 };
 
-use super::{error::ErrorSlot, server::ServerState, HandshakeError, PeerClient, PeerServer};
+use super::{error::ErrorSlot, server::ServerState, HandshakeError, Client, PeerServer};
 
 /// A [`Service`] that handshakes with a remote peer and constructs a
 /// client/server pair.
@@ -77,7 +77,7 @@ where
     S: Service<Request, Response = Response, Error = BoxedStdError> + Clone + Send + 'static,
     S::Future: Send,
 {
-    type Response = PeerClient;
+    type Response = Client;
     type Error = HandshakeError;
     type Future =
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
@@ -177,14 +177,14 @@ where
             // two versions, etc. -- actually is it possible to edit the `Codec`
             // after using it to make a framed adapter?
 
-            debug!("constructing PeerClient, spawning PeerServer");
+            debug!("constructing client, spawning server");
 
             // These channels should not be cloned more than they are
             // in this block, see constants.rs for more.
             let (server_tx, server_rx) = mpsc::channel(0);
             let slot = ErrorSlot::default();
 
-            let client = PeerClient {
+            let client = Client {
                 span: connection_span.clone(),
                 server_tx: server_tx.clone(),
                 error_slot: slot.clone(),

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -29,16 +29,16 @@ use super::{error::ErrorSlot, HandshakeError, Client, Server};
 
 /// A [`Service`] that handshakes with a remote peer and constructs a
 /// client/server pair.
-pub struct PeerHandshake<S> {
+pub struct Handshake<S> {
     config: Config,
     internal_service: S,
     timestamp_collector: mpsc::Sender<MetaAddr>,
     nonces: Arc<Mutex<HashSet<Nonce>>>,
 }
 
-impl<S: Clone> Clone for PeerHandshake<S> {
+impl<S: Clone> Clone for Handshake<S> {
     fn clone(&self) -> Self {
-        Self {
+        Handshake {
             config: self.config.clone(),
             internal_service: self.internal_service.clone(),
             timestamp_collector: self.timestamp_collector.clone(),
@@ -47,7 +47,7 @@ impl<S: Clone> Clone for PeerHandshake<S> {
     }
 }
 
-impl<S> PeerHandshake<S>
+impl<S> Handshake<S>
 where
     S: Service<Request, Response = Response, Error = BoxedStdError> + Clone + Send + 'static,
     S::Future: Send,
@@ -63,7 +63,7 @@ where
         // Builder2, ..., with Builder1::with_config() -> Builder2;
         // Builder2::with_internal_service() -> ... or use Options in a single
         // Builder type or use the derive_builder crate.
-        PeerHandshake {
+        Handshake {
             config,
             internal_service,
             timestamp_collector,
@@ -72,7 +72,7 @@ where
     }
 }
 
-impl<S> Service<(TcpStream, SocketAddr)> for PeerHandshake<S>
+impl<S> Service<(TcpStream, SocketAddr)> for Handshake<S>
 where
     S: Service<Request, Response = Response, Error = BoxedStdError> + Clone + Send + 'static,
     S::Future: Send,

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -25,7 +25,7 @@ use crate::{
     BoxedStdError, Config,
 };
 
-use super::{error::ErrorSlot, server::ServerState, HandshakeError, Client, Server};
+use super::{error::ErrorSlot, HandshakeError, Client, Server};
 
 /// A [`Service`] that handshakes with a remote peer and constructs a
 /// client/server pair.
@@ -192,8 +192,9 @@ where
 
             let (peer_tx, peer_rx) = stream.split();
 
+            use super::server;
             let server = Server {
-                state: ServerState::AwaitingRequest,
+                state: server::State::AwaitingRequest,
                 svc: internal_service,
                 client_rx: server_rx,
                 error_slot: slot,

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -25,7 +25,7 @@ use crate::{
     BoxedStdError, Config,
 };
 
-use super::{ErrorSlot, HandshakeError, Client, Server};
+use super::{Client, ErrorSlot, HandshakeError, Server};
 
 /// A [`Service`] that handshakes with a remote peer and constructs a
 /// client/server pair.

--- a/zebra-network/src/peer/server.rs
+++ b/zebra-network/src/peer/server.rs
@@ -24,7 +24,7 @@ use crate::{
 
 use super::{client::ClientRequest, error::ErrorSlot, PeerError, SharedPeerError};
 
-pub(super) enum ServerState {
+pub(super) enum State {
     /// Awaiting a client request or a peer message.
     AwaitingRequest,
     /// Awaiting a peer message we can interpret as a client request.
@@ -35,9 +35,9 @@ pub(super) enum ServerState {
 
 /// The "server" duplex half of a peer connection.
 pub struct Server<S, Tx> {
-    pub(super) state: ServerState,
+    pub(super) state: State,
     /// A timeout for a client request. This is stored separately from
-    /// ServerState so that we can move the future out of it independently of
+    /// State so that we can move the future out of it independently of
     /// other state handling.
     pub(super) request_timer: Option<Delay>,
     pub(super) svc: S,
@@ -80,7 +80,7 @@ where
         // check whether it can be interpreted as a response to the pending request.
         loop {
             match self.state {
-                ServerState::AwaitingRequest => {
+                State::AwaitingRequest => {
                     trace!("awaiting client request or peer message");
                     match future::select(peer_rx.next(), self.client_rx.next()).await {
                         Either::Left((None, _)) => {
@@ -100,7 +100,7 @@ where
                 }
                 // We're awaiting a response to a client request,
                 // so wait on either a peer message, or on a request timeout.
-                ServerState::AwaitingResponse { .. } => {
+                State::AwaitingResponse { .. } => {
                     trace!("awaiting response to client request");
                     let timer_ref = self
                         .request_timer
@@ -121,14 +121,14 @@ where
                             trace!("client request timed out");
                             // Re-matching lets us take ownership of tx
                             self.state = match self.state {
-                                ServerState::AwaitingResponse(Request::Ping(_), _) => {
+                                State::AwaitingResponse(Request::Ping(_), _) => {
                                     self.fail_with(PeerError::ClientRequestTimeout);
-                                    ServerState::Failed
+                                    State::Failed
                                 }
-                                ServerState::AwaitingResponse(_, tx) => {
+                                State::AwaitingResponse(_, tx) => {
                                     let e = PeerError::ClientRequestTimeout;
                                     let _ = tx.send(Err(Arc::new(e).into()));
-                                    ServerState::AwaitingRequest
+                                    State::AwaitingRequest
                                 }
                                 _ => panic!("unreachable"),
                             };
@@ -137,7 +137,7 @@ where
                 }
                 // We've failed, but we need to flush all pending client
                 // requests before we can return and complete the future.
-                ServerState::Failed => {
+                State::Failed => {
                     match self.client_rx.next().await {
                         Some(ClientRequest(_, tx)) => {
                             let e = self
@@ -172,13 +172,13 @@ where
         // Drop the guard immediately to release the mutex.
         std::mem::drop(guard);
 
-        // We want to close the client channel and set ServerState::Failed so
+        // We want to close the client channel and set State::Failed so
         // that we can flush any pending client requests. However, we may have
-        // an outstanding client request in ServerState::AwaitingResponse, so
+        // an outstanding client request in State::AwaitingResponse, so
         // we need to deal with it first if it exists.
         self.client_rx.close();
-        let old_state = std::mem::replace(&mut self.state, ServerState::Failed);
-        if let ServerState::AwaitingResponse(_, tx) = old_state {
+        let old_state = std::mem::replace(&mut self.state, State::Failed);
+        if let State::AwaitingResponse(_, tx) = old_state {
             // We know the slot has Some(e) because we just set it above,
             // and the error slot is never unset.
             let e = self.error_slot.try_get_error().unwrap();
@@ -191,7 +191,7 @@ where
     async fn handle_client_request(&mut self, msg: ClientRequest) {
         trace!(?msg);
         use Request::*;
-        use ServerState::*;
+        use State::*;
         let ClientRequest(req, tx) = msg;
 
         // Inner match returns Result with the new state or an error.
@@ -254,7 +254,7 @@ where
         // This conversion is done by a sequence of (request, message) match arms,
         // each of which contains the conversion logic for that pair.
         use Request::*;
-        use ServerState::*;
+        use State::*;
         let mut ignored_msg = None;
         // We want to be able to consume the state, but it's behind a mutable
         // reference, so we can't move it out of self without swapping in a

--- a/zebra-network/src/peer/server.rs
+++ b/zebra-network/src/peer/server.rs
@@ -42,7 +42,7 @@ pub struct PeerServer<S, Tx> {
     pub(super) request_timer: Option<Delay>,
     pub(super) svc: S,
     pub(super) client_rx: mpsc::Receiver<ClientRequest>,
-    /// A slot shared between the PeerServer and PeerClient for storing an error.
+    /// A slot shared between the client and server for storing an error.
     pub(super) error_slot: ErrorSlot,
     //pub(super) peer_rx: Rx,
     pub(super) peer_tx: Tx,
@@ -65,7 +65,7 @@ where
         // request from the remote peer to our node.
         //
         // We also need to handle those client requests in the first place. The client
-        // requests are received from the corresponding `PeerClient` over a bounded
+        // requests are received from the corresponding `peer::Client` over a bounded
         // channel (with bound 1, to minimize buffering), but there is no relationship
         // between the stream of client requests and the stream of peer messages, so we
         // cannot ignore one kind while waiting on the other. Moreover, we cannot accept
@@ -93,7 +93,7 @@ where
                             self.handle_message_as_request(msg).await
                         }
                         Either::Right((None, _)) => {
-                            self.fail_with(PeerError::DeadPeerClient);
+                            self.fail_with(PeerError::DeadClient);
                         }
                         Either::Right((Some(req), _)) => self.handle_client_request(req).await,
                     }

--- a/zebra-network/src/peer/server.rs
+++ b/zebra-network/src/peer/server.rs
@@ -22,7 +22,7 @@ use crate::{
     BoxedStdError,
 };
 
-use super::{client::ClientRequest, error::ErrorSlot, PeerError, SharedPeerError};
+use super::{ClientRequest, ErrorSlot, PeerError, SharedPeerError};
 
 pub(super) enum State {
     /// Awaiting a client request or a peer message.

--- a/zebra-network/src/peer/server.rs
+++ b/zebra-network/src/peer/server.rs
@@ -34,7 +34,7 @@ pub(super) enum ServerState {
 }
 
 /// The "server" duplex half of a peer connection.
-pub struct PeerServer<S, Tx> {
+pub struct Server<S, Tx> {
     pub(super) state: ServerState,
     /// A timeout for a client request. This is stored separately from
     /// ServerState so that we can move the future out of it independently of
@@ -48,7 +48,7 @@ pub struct PeerServer<S, Tx> {
     pub(super) peer_tx: Tx,
 }
 
-impl<S, Tx> PeerServer<S, Tx>
+impl<S, Tx> Server<S, Tx>
 where
     S: Service<Request, Response = Response, Error = BoxedStdError>,
     S::Error: Into<BoxedStdError>,

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -70,7 +70,7 @@ use crate::{types::MetaAddr, AddressBook, BoxedStdError, Request, Response};
 ///           ▼
 ///    ┌────────────┐
 ///    │    send    │
-///    │ PeerClient │
+///    │peer::Client│
 ///    │to Discover │
 ///    └────────────┘
 /// ```

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -3,8 +3,6 @@
 // Portions of this submodule were adapted from tower-balance,
 // which is (c) 2019 Tower Contributors (MIT licensed).
 
-// XXX these imports should go in a peer_set::initialize submodule
-
 use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -27,7 +27,8 @@ use tower::{
 use tower_load::{peak_ewma::PeakEwmaDiscover, NoInstrument};
 
 use crate::{
-    peer::{PeerClient, PeerConnector, PeerHandshake},
+    peer,
+    peer::{PeerConnector, PeerHandshake},
     timestamp_collector::TimestampCollector,
     AddressBook, BoxedStdError, Config, Request, Response,
 };
@@ -35,7 +36,7 @@ use crate::{
 use super::CandidateSet;
 use super::PeerSet;
 
-type PeerChange = Result<Change<SocketAddr, PeerClient>, BoxedStdError>;
+type PeerChange = Result<Change<SocketAddr, peer::Client>, BoxedStdError>;
 
 /// Initialize a peer set with the given `config`, forwarding peer requests to the `inbound_service`.
 pub async fn init<S>(
@@ -150,7 +151,7 @@ async fn add_initial_peers<S>(
     connector: S,
     mut tx: mpsc::Sender<PeerChange>,
 ) where
-    S: Service<SocketAddr, Response = Change<SocketAddr, PeerClient>, Error = BoxedStdError>
+    S: Service<SocketAddr, Response = Change<SocketAddr, peer::Client>, Error = BoxedStdError>
         + Clone,
     S::Future: Send + 'static,
 {
@@ -172,7 +173,7 @@ async fn listen<S>(
     tx: mpsc::Sender<PeerChange>,
 ) -> Result<(), BoxedStdError>
 where
-    S: Service<(TcpStream, SocketAddr), Response = PeerClient, Error = BoxedStdError> + Clone,
+    S: Service<(TcpStream, SocketAddr), Response = peer::Client, Error = BoxedStdError> + Clone,
     S::Future: Send + 'static,
 {
     let mut listener = TcpListener::bind(addr).await?;
@@ -194,7 +195,7 @@ where
 }
 
 /// Given a channel that signals a need for new peers, try to connect to a peer
-/// and send the resulting `PeerClient` through a channel.
+/// and send the resulting `peer::Client` through a channel.
 ///
 #[instrument(skip(new_peer_interval, demand_signal, candidates, connector, success_tx))]
 async fn crawl_and_dial<C, S>(
@@ -205,7 +206,7 @@ async fn crawl_and_dial<C, S>(
     mut success_tx: mpsc::Sender<PeerChange>,
 ) -> Result<(), BoxedStdError>
 where
-    C: Service<SocketAddr, Response = Change<SocketAddr, PeerClient>, Error = BoxedStdError>
+    C: Service<SocketAddr, Response = Change<SocketAddr, peer::Client>, Error = BoxedStdError>
         + Clone,
     C::Future: Send + 'static,
     S: Service<Request, Response = Response, Error = BoxedStdError>,

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -26,7 +26,7 @@ use tower_load::{peak_ewma::PeakEwmaDiscover, NoInstrument};
 
 use crate::{
     peer,
-    peer::{PeerConnector, PeerHandshake},
+    peer::{PeerConnector},
     timestamp_collector::TimestampCollector,
     AddressBook, BoxedStdError, Config, Request, Response,
 };
@@ -64,7 +64,7 @@ where
     let (listener, connector) = {
         use tower::timeout::TimeoutLayer;
         let hs_timeout = TimeoutLayer::new(config.handshake_timeout);
-        let hs = PeerHandshake::new(config.clone(), inbound_service, timestamp_collector);
+        let hs = peer::Handshake::new(config.clone(), inbound_service, timestamp_collector);
         (
             hs_timeout.layer(hs.clone()),
             hs_timeout.layer(PeerConnector::new(hs)),

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -26,7 +26,6 @@ use tower_load::{peak_ewma::PeakEwmaDiscover, NoInstrument};
 
 use crate::{
     peer,
-    peer::{PeerConnector},
     timestamp_collector::TimestampCollector,
     AddressBook, BoxedStdError, Config, Request, Response,
 };
@@ -67,7 +66,7 @@ where
         let hs = peer::Handshake::new(config.clone(), inbound_service, timestamp_collector);
         (
             hs_timeout.layer(hs.clone()),
-            hs_timeout.layer(PeerConnector::new(hs)),
+            hs_timeout.layer(peer::Connector::new(hs)),
         )
     };
 

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -25,9 +25,8 @@ use tower::{
 use tower_load::{peak_ewma::PeakEwmaDiscover, NoInstrument};
 
 use crate::{
-    peer,
-    timestamp_collector::TimestampCollector,
-    AddressBook, BoxedStdError, Config, Request, Response,
+    peer, timestamp_collector::TimestampCollector, AddressBook, BoxedStdError, Config, Request,
+    Response,
 };
 
 use super::CandidateSet;


### PR DESCRIPTION
This does the renaming in https://github.com/ZcashFoundation/zebra/issues/37#issuecomment-545240042 and cleans up some import statements.

Now inside of the `peer` module, all of the components can be used un-prefixed, and the submodules of `peer` don't need to know about the structure of their sibling modules.  Outside of the `peer` module, the components can be used with the `peer` prefix, which also shortens the import preludes.