### PR TITLE
Remove vestigial should_be_private module.

### DIFF
--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -65,8 +65,3 @@ pub use crate::{
 pub mod types {
     pub use crate::{meta_addr::MetaAddr, network::Network, protocol::types::PeerServices};
 }
-
-/// This will be removed when we finish encapsulation
-pub mod should_be_private {
-    pub use crate::{peer::Handshake, timestamp_collector::TimestampCollector};
-}


### PR DESCRIPTION
The encapsulation was already finished but we forgot to remove the stub re-export module.