### PR TITLE
Remove version fields from Block, Tx messages.

### DIFF
--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -27,7 +27,6 @@
 //! when it is overloaded.
 
 #![deny(missing_docs)]
-
 // Tracing causes false positives on this lint:
 // https://github.com/tokio-rs/tracing/issues/553
 #![allow(clippy::cognitive_complexity)]

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -222,9 +222,6 @@ pub enum Message {
     /// `getblocks`.
     ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#inv)
-    // XXX the bitcoin reference above suggests this can be 1.8 MB in bitcoin -- maybe
-    // larger in Zcash, since Zcash objects could be bigger (?) -- does this tilt towards
-    // having serialization be async?
     Inv(Vec<InventoryHash>),
 
     /// A `getdata` message.

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -132,14 +132,7 @@ pub enum Message {
     /// A `block` message.
     ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#block)
-    Block {
-        /// Transaction data format version (note, this is signed).
-        // XXX does this get folded into the Block struct?
-        version: Version,
-
-        /// The block itself.
-        block: Box<Block>,
-    },
+    Block(Box<Block>),
 
     /// A `getblocks` message.
     ///
@@ -252,16 +245,7 @@ pub enum Message {
     /// A `tx` message.
     ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#tx)
-    // `flag` is not included (it's optional), and therefore
-    // `tx_witnesses` aren't either, as they go if `flag` goes.
-    Tx {
-        /// Transaction data format version (note, this is signed).
-        // XXX do we still need this with the transaction data handling?
-        version: Version,
-
-        /// The `Transaction` type itself.
-        transaction: Box<Transaction>,
-    },
+    Tx(Box<Transaction>),
 
     /// A `mempool` message.
     ///


### PR DESCRIPTION
These are serialized as part of the Block and Transaction structs, so the version fields that we added at the beginning aren't necessary any more (and would cause the codec to try reading two version fields).

Closes #226. 