### PR TITLE
Remove tracing-subscriber.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,7 +1791,6 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-log",
- "tracing-subscriber",
  "zebra-chain",
  "zebra-network",
 ]

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -19,7 +19,6 @@ futures = "0.3"
 
 tracing = "0.1"
 tracing-futures = "0.2"
-tracing-subscriber = "0.1"
 tracing-log = "0.1"
 
 hyper = "0.13.2"


### PR DESCRIPTION
We don't need to handle the subscriber directly since we upstreamed this
functionality into Abscissa.