### PR TITLE
Update zebrad docs and README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # zebra 🦓
 
-
 Hello! I am Zebra, an ongoing Rust implementation of a Zcash node.
 
 Zebra is a work in progress.  It is developed as a collection of `zebra-*`
 libraries implementing the different components of a Zcash node (networking,
 chain structures, consensus rules, etc), and a `zebrad` binary which uses them.
 
+Most of our work so far has gone into `zebra-network`, building a new
+networking stack for Zcash, and `zebra-chain`, building foundational data
+structures.
+
 [Rendered docs from the `main` branch](https://doc.zebra.zfnd.org).
+
+[Join us on Discord](https://discord.gg/na6QZNd).
 
 ## License
 

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -1,8 +1,16 @@
-//! Zebrad
+//! Hello! I am Zebra, an ongoing Rust implementation of a Zcash node.
 //!
-//! Application based on the [Abscissa] framework.
+//! Zebra is a work in progress.  It is developed as a collection of `zebra-*`
+//! libraries implementing the different components of a Zcash node (networking,
+//! chain structures, consensus rules, etc), and a `zebrad` binary which uses them.
 //!
-//! [Abscissa]: https://github.com/iqlusioninc/abscissa
+//! Most of our work so far has gone into `zebra-network`, building a new
+//! networking stack for Zcash, and `zebra-chain`, building foundational data
+//! structures.
+//!
+//! [Rendered docs from the `main` branch](https://doc.zebra.zfnd.org).
+//!
+//! [Join us on Discord](https://discord.gg/na6QZNd).
 
 //#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
Ideally we would use `doc(include ...)` to put the README.md directly into the docs for `zebrad`, but that feature is nightly-only, so we would need to gate our use of the rust feature by a feature in our crate, and feature selection doesn't work in workspaces.  So for now it's just copy-pasted.