### PR TITLE
Add a CoinbaseData field, replacing Vec<u8>.

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -14,7 +14,7 @@ mod tests;
 pub use hash::TransactionHash;
 pub use joinsplit::{JoinSplit, JoinSplitData};
 pub use shielded_data::{OutputDescription, ShieldedData, SpendDescription};
-pub use transparent::{OutPoint, TransparentInput, TransparentOutput};
+pub use transparent::{CoinbaseData, OutPoint, TransparentInput, TransparentOutput};
 
 use crate::proofs::{Bctv14Proof, Groth16Proof};
 use crate::types::{BlockHeight, LockTime};

--- a/zebra-chain/src/transaction/tests.rs
+++ b/zebra-chain/src/transaction/tests.rs
@@ -135,7 +135,7 @@ impl Arbitrary for TransparentInput {
                 .prop_map(|(height, data, sequence)| {
                     TransparentInput::Coinbase {
                         height,
-                        data,
+                        data: CoinbaseData(data),
                         sequence,
                     }
                 })

--- a/zebra-chain/src/transaction/transparent.rs
+++ b/zebra-chain/src/transaction/transparent.rs
@@ -7,6 +7,24 @@ use crate::types::{BlockHeight, Script};
 
 use super::TransactionHash;
 
+/// Arbitrary data inserted by miners into a coinbase transaction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CoinbaseData(
+    /// Invariant: this vec, together with the coinbase height, must be less than
+    /// 100 bytes. We enforce this by only constructing CoinbaseData fields by
+    /// parsing blocks with 100-byte data fields. When we implement block
+    /// creation, we should provide a constructor for the coinbase data field
+    /// that restricts it to 95 = 100 -1 -4 bytes (safe for any block height up
+    /// to 500_000_000).
+    pub(super) Vec<u8>,
+);
+
+impl AsRef<[u8]> for CoinbaseData {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 /// OutPoint
 ///
 /// A particular transaction output reference.
@@ -37,9 +55,8 @@ pub enum TransparentInput {
     Coinbase {
         /// The height of this block.
         height: BlockHeight,
-        /// Approximately 100 bytes of data (95 to be safe).
-        /// XXX refine this type.
-        data: Vec<u8>,
+        /// Free data inserted by miners after the block height.
+        data: CoinbaseData,
         /// The sequence number for the output.
         sequence: u32,
     },


### PR DESCRIPTION
The CoinbaseData field can only be constructed by the transaction parser, so we
can ensure that a coinbase input is always serializable, as CoinbaseData
instances can't be constructed outside of the parser that maintains the data
size invariant.