### PR TITLE
Impl Display/FromStr/ZcashSerialize/ZcashDeserialize for Sprout keys

### DIFF
--- a/zebra-chain/proptest-regressions/keys/sprout.txt
+++ b/zebra-chain/proptest-regressions/keys/sprout.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 62e2e4683c730eed75125459da772456b5a6722bb681d5a7369ee074f0491df0 # shrinks to sk = SpendingKey { bytes: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], network: Mainnet }
+cc 60b90e63a54bf680d37693716d493b302dae7b88fb4b2101b0d20cf28df25489 # shrinks to sk = SpendingKey { bytes: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], network: Mainnet }

--- a/zebra-chain/src/keys/sprout.rs
+++ b/zebra-chain/src/keys/sprout.rs
@@ -36,9 +36,9 @@ mod sk_magics {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct SpendingKey {
-    ///
+    /// What would normally be the value inside a tuple struct.
     pub bytes: [u8; 32],
-    ///
+    /// The Zcash network with which this key is associated.
     pub network: Network,
 }
 

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -35,3 +35,9 @@ pub enum Network {
     /// The testnet.
     Testnet,
 }
+
+impl Default for Network {
+    fn default() -> Self {
+        Network::Mainnet
+    }
+}


### PR DESCRIPTION
To match the raw and Base58Check encodings as in
https://zips.z.cash/protocol/protocol.pdf#sproutinviewingkeyencoding
https://zips.z.cash/protocol/protocol.pdf#sproutspendingkeyencoding