### PR TITLE
Refine Output description ephemeral_key to jubjub::AffinePoint

### DIFF
--- a/zebra-chain/src/transaction/joinsplit.rs
+++ b/zebra-chain/src/transaction/joinsplit.rs
@@ -41,8 +41,6 @@ pub struct JoinSplit<P: ZkSnarkProof> {
     /// XXX refine type to [T; 2] -- there are two commitments
     pub commitments: [[u8; 32]; 2],
     /// An X25519 public key.
-    ///
-    /// XXX refine to an x25519-dalek type?
     pub ephemeral_key: x25519_dalek::PublicKey,
     /// A 256-bit seed that must be chosen independently at random for each
     /// JoinSplit description.

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -332,7 +332,7 @@ impl ZcashSerialize for Output {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         writer.write_all(&self.cv[..])?;
         writer.write_all(&self.cmu[..])?;
-        writer.write_all(&self.ephemeral_key[..])?;
+        writer.write_all(&self.ephemeral_key.to_bytes())?;
         self.enc_ciphertext.zcash_serialize(&mut writer)?;
         self.out_ciphertext.zcash_serialize(&mut writer)?;
         self.zkproof.zcash_serialize(&mut writer)?;
@@ -345,7 +345,7 @@ impl ZcashDeserialize for Output {
         Ok(Output {
             cv: reader.read_32_bytes()?,
             cmu: reader.read_32_bytes()?,
-            ephemeral_key: reader.read_32_bytes()?,
+            ephemeral_key: jubjub::AffinePoint::from_bytes(reader.read_32_bytes()?).unwrap(),
             enc_ciphertext: shielded_data::EncryptedCiphertext::zcash_deserialize(&mut reader)?,
             out_ciphertext: shielded_data::OutCiphertext::zcash_deserialize(&mut reader)?,
             zkproof: Groth16Proof::zcash_deserialize(&mut reader)?,


### PR DESCRIPTION
And impl Arbitrary for Output to support better generation of those points in proptests.

Related to #123 