### PR TITLE
Remove 'self-DoS'ing tokio task for testing 'zebra seed' command.

### DIFF
--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -39,3 +39,6 @@ tracing-error = "0.1.2"
 [dev-dependencies]
 abscissa_core = { version = "0.5", features = ["testing"] }
 once_cell = "1.4"
+
+[features]
+dos = []

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -39,6 +39,3 @@ tracing-error = "0.1.2"
 [dev-dependencies]
 abscissa_core = { version = "0.5", features = ["testing"] }
 once_cell = "1.4"
-
-[features]
-dos = []

--- a/zebrad/src/commands/seed.rs
+++ b/zebrad/src/commands/seed.rs
@@ -131,7 +131,7 @@ impl SeedCmd {
         info!("begin tower-based peer handling test stub");
 
         let (addressbook_tx, addressbook_rx) = oneshot::channel();
-        let seed_service = SeedService {
+        let mut seed_service = SeedService {
             state: SeederState::AwaitingAddressBook(addressbook_rx),
         };
         let node = Buffer::new(seed_service, 1);
@@ -147,10 +147,10 @@ impl SeedCmd {
 
         info!("peer_set became ready");
 
-        #[cfg(dos)]
+        #[cfg(feature = "dos")]
         use std::time::Duration;
 
-        #[cfg(dos)]
+        #[cfg(feature = "dos")]
         // Fire GetPeers requests at ourselves, for testing.
         tokio::spawn(async move {
             let mut interval_stream = tokio::time::interval(Duration::from_secs(1));
@@ -158,7 +158,7 @@ impl SeedCmd {
             loop {
                 interval_stream.next().await;
 
-                let _ = seed_service.call(Request::GetPeers);
+                let _ = seed_service.call(Request::Peers);
             }
         });
 

--- a/zebrad/src/commands/seed.rs
+++ b/zebrad/src/commands/seed.rs
@@ -147,22 +147,6 @@ impl SeedCmd {
 
         info!("peer_set became ready");
 
-        #[cfg(feature = "dos")]
-        use std::time::Duration;
-
-        #[cfg(feature = "dos")]
-        // Fire GetPeers requests at ourselves, for testing.
-        tokio::spawn(async move {
-            let mut interval_stream = tokio::time::interval(Duration::from_secs(1));
-            let mut svc = buffered_svc.clone();
-
-            loop {
-                interval_stream.next().await;
-
-                let _ = svc.call(Request::Peers);
-            }
-        });
-
         let eternity = future::pending::<()>();
         eternity.await;
 

--- a/zebrad/src/commands/seed.rs
+++ b/zebrad/src/commands/seed.rs
@@ -131,14 +131,14 @@ impl SeedCmd {
         info!("begin tower-based peer handling test stub");
 
         let (addressbook_tx, addressbook_rx) = oneshot::channel();
-        let mut seed_service = SeedService {
+        let seed_service = SeedService {
             state: SeederState::AwaitingAddressBook(addressbook_rx),
         };
-        let node = Buffer::new(seed_service, 1);
+        let buffered_svc = Buffer::new(seed_service, 1);
 
         let config = app_config().network.clone();
 
-        let (mut peer_set, address_book) = zebra_network::init(config, node).await;
+        let (mut peer_set, address_book) = zebra_network::init(config, buffered_svc.clone()).await;
 
         let _ = addressbook_tx.send(address_book);
 
@@ -154,11 +154,12 @@ impl SeedCmd {
         // Fire GetPeers requests at ourselves, for testing.
         tokio::spawn(async move {
             let mut interval_stream = tokio::time::interval(Duration::from_secs(1));
+            let mut svc = buffered_svc.clone();
 
             loop {
                 interval_stream.next().await;
 
-                let _ = seed_service.call(Request::Peers);
+                let _ = svc.call(Request::Peers);
             }
         });
 


### PR DESCRIPTION
Request::Peers not GetPeers

Fix 'dos' feature for seed command, and Buffer the seed service