### PR TITLE
Update list of DNS seeders

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -72,16 +72,21 @@ impl Default for Config {
         let mainnet_peers = [
             "dnsseed.z.cash:8233",
             "dnsseed.str4d.xyz:8233",
-            "dnsseed.znodes.org:8233",
+            "mainnet.seeder.zfnd.org:8233",
+            "mainnet.seeder.yolo.money:8233",
         ]
         .iter()
         .map(|&s| String::from(s))
         .collect();
 
-        let testnet_peers = ["dnsseed.testnet.z.cash:18233"]
-            .iter()
-            .map(|&s| String::from(s))
-            .collect();
+        let testnet_peers = [
+            "dnsseed.testnet.z.cash:18233",
+            "testnet.seeder.zfnd.org:18233",
+            "testnet.seeder.yolo.money:18233",
+        ]
+        .iter()
+        .map(|&s| String::from(s))
+        .collect();
 
         Config {
             listen_addr: "127.0.0.1:8233"


### PR DESCRIPTION
First, this removes Simon's old seeder. It's been dead since he left ECC, and zcashd [removed it](https://github.com/zcash/zcash/issues/4153) a while ago.

But primarily this adds our new DNS seeders to the list. They're running [CoreDNS](https://coredns.io) with a [Zcash crawler plugin](https://github.com/ZcashFoundation/dnsseeder), the result of a Zcash Foundation in-house development effort to replace zcash-seeder with something memory safe and easier to maintain.

These are validly operated seeders per the existing policy (https://zcash.readthedocs.io/en/latest/rtd_pages/dnsseed_policy.html):

> A DNS seed operating organization or person is expected to follow good host security practices, maintain control of applicable infrastructure, and not sell or transfer control of the DNS seed. Any hosting services contracted by the operator are equally expected to uphold these expectations.

In both cases the code is running on well-operated public cloud infrastructure in either a container or the most sandboxing appropriate to the environment. The DNS records pointing to the seeders are controlled by reputable third-party DNS providers under accounts with 2FA enabled.

> The DNS seed results must consist exclusively of fairly selected and functioning Zcash nodes from the public network to the best of the operator’s understanding and capability.

The crawler attempts to connect to all discoverable Zcash peers and ensures their continued uptime on a regular basis. The results are always a uniformly randomized subset of all known live peers.

> For the avoidance of doubt, the results may be randomized but must not single out any group of hosts to receive different results unless due to an urgent technical necessity and disclosed.

See above. However, we reserve the right to begin offering [NU-targeted results](https://github.com/ZcashFoundation/dnsseeder/issues/3) based on opt-in client queries.

> The results may not be served with a DNS TTL of less than one minute.

Mainnet results are served with a TTL of 600 seconds, and Testnet results with a TTL of 300 seconds to account for greater flux on that network.

> Any logging of DNS queries should be only that which is necessary for the operation of the service or urgent health of the Zcash network and must not be retained longer than necessary nor disclosed to any third party.

There is no logging of DNS queries in either production configuration, which can be somewhat confirmed by examining the Corefile(s) [[1]](https://github.com/ZcashFoundation/coredns-zcash/blob/master/coredns/Corefile)[[2]](https://github.com/ZcashFoundation/coredns-zcash/blob/master/scripts/gcp-start.sh#L9-L27) we use.

> Information gathered as a result of the operators node-spidering (not from DNS queries) may be freely published or retained, but only if this data was not made more complete by biasing node connectivity (a violation of expectation (1)).

The seeder currently has no persistence outside of its static config file, so this data is neither retained nor shared by the operators.

> Operators are encouraged, but not required, to publicly document the details of their operating practices.

Our deployments are described in detail by the [coredns-zcash](https://github.com/ZcashFoundation/coredns-zcash) repo. Reader, you could run one too!

> A reachable email contact address must be published for inquiries related to the DNS seed operation.

For general questions related to either seeder, contact george@zfnd.org or mention @gtank in the Foundation's Discord. For bug reports, open an issue on the [dnsseeder](https://github.com/ZcashFoundation/dnsseeder) repo.