### PR TITLE
tower-batch middleware.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,19 @@ checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 [[package]]
 name = "ed25519-zebra"
 version = "0.3.0"
+source = "git+https://github.com/zcashfoundation/ed25519-zebra?branch=batch2#e12a4cb32230512856bb7d1ccac51248ce2b180c"
+dependencies = [
+ "curve25519-dalek",
+ "hex",
+ "rand_core 0.5.1",
+ "serde",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "ed25519-zebra"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "802a065ae2171664a2bf607c0571d21c267a0ad2c6c8dad4a5668f09bf34f661"
 dependencies = [
@@ -1927,7 +1940,7 @@ dependencies = [
 name = "tower-batch"
 version = "0.1.0"
 dependencies = [
- "ed25519-zebra",
+ "ed25519-zebra 0.3.0 (git+https://github.com/zcashfoundation/ed25519-zebra?branch=batch2)",
  "futures",
  "futures-core",
  "pin-project",
@@ -1935,7 +1948,9 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "tracing-error",
  "tracing-futures",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2278,7 +2293,7 @@ dependencies = [
  "bs58",
  "byteorder",
  "chrono",
- "ed25519-zebra",
+ "ed25519-zebra 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "hex",
  "jubjub",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,22 +428,9 @@ checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 
 [[package]]
 name = "ed25519-zebra"
-version = "0.3.0"
-source = "git+https://github.com/zcashfoundation/ed25519-zebra?branch=batch2#e12a4cb32230512856bb7d1ccac51248ce2b180c"
-dependencies = [
- "curve25519-dalek",
- "hex",
- "rand_core 0.5.1",
- "serde",
- "sha2",
- "thiserror",
-]
-
-[[package]]
-name = "ed25519-zebra"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802a065ae2171664a2bf607c0571d21c267a0ad2c6c8dad4a5668f09bf34f661"
+checksum = "4da934dd0d7d7d16676ad3d01a73ea64dede46a908128ae7db851ee99e7c8598"
 dependencies = [
  "curve25519-dalek",
  "hex",
@@ -1940,7 +1927,7 @@ dependencies = [
 name = "tower-batch"
 version = "0.1.0"
 dependencies = [
- "ed25519-zebra 0.3.0 (git+https://github.com/zcashfoundation/ed25519-zebra?branch=batch2)",
+ "ed25519-zebra",
  "futures",
  "futures-core",
  "pin-project",
@@ -2293,7 +2280,7 @@ dependencies = [
  "bs58",
  "byteorder",
  "chrono",
- "ed25519-zebra 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-zebra",
  "futures",
  "hex",
  "jubjub",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,11 +1927,13 @@ dependencies = [
 name = "tower-batch"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "futures-core",
  "pin-project",
  "tokio",
  "tower",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,6 +1924,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-batch"
+version = "0.1.0"
+dependencies = [
+ "futures-core",
+ "pin-project",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "tower-buffer"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,9 +1927,11 @@ dependencies = [
 name = "tower-batch"
 version = "0.1.0"
 dependencies = [
+ "ed25519-zebra",
  "futures",
  "futures-core",
  "pin-project",
+ "rand 0.7.3",
  "tokio",
  "tower",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+        "tower-batch",
         "zebra-chain",
         "zebra-network",
         "zebra-state",

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -6,8 +6,10 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-tokio = { version = "0.2", features = ["time"] }
+tokio = { version = "0.2", features = ["time", "sync", "stream"] }
 tower = "0.3"
 futures-core = "0.3.5"
 pin-project = "0.4.20"
 tracing = "0.1.15"
+tracing-futures = "0.2.4"
+futures = "0.3.5"

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tower-batch"
+version = "0.1.0"
+authors = ["Zcash Foundation <zebra@zfnd.org>"]
+license = "MIT"
+edition = "2018"
+
+[dependencies]
+tokio = { version = "0.2", features = ["time"] }
+tower = "0.3"
+futures-core = "0.3.5"
+pin-project = "0.4.20"
+tracing = "0.1.15"

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -15,7 +15,7 @@ tracing-futures = "0.2.4"
 futures = "0.3.5"
 
 [dev-dependencies]
-ed25519-zebra = { git = "https://github.com/zcashfoundation/ed25519-zebra", branch = "batch2" }
+ed25519-zebra = "0.4"
 rand = "0.7"
 tokio = { version = "0.2", features = ["full"]}
 tracing-error = "0.1.2"

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -13,3 +13,8 @@ pin-project = "0.4.20"
 tracing = "0.1.15"
 tracing-futures = "0.2.4"
 futures = "0.3.5"
+
+[dev-dependencies]
+ed25519-zebra = "0.3"
+rand = "0.7"
+tokio = { version = "0.2", features = ["full"]}

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -15,6 +15,9 @@ tracing-futures = "0.2.4"
 futures = "0.3.5"
 
 [dev-dependencies]
-ed25519-zebra = "0.3"
+ed25519-zebra = { git = "https://github.com/zcashfoundation/ed25519-zebra", branch = "batch2" }
 rand = "0.7"
 tokio = { version = "0.2", features = ["full"]}
+tracing-error = "0.1.2"
+tracing-subscriber = "0.2.5"
+tracing = "0.1.15"

--- a/tower-batch/src/error.rs
+++ b/tower-batch/src/error.rs
@@ -1,0 +1,65 @@
+//! Error types for the `Buffer` middleware.
+
+use crate::BoxError;
+use std::{fmt, sync::Arc};
+
+/// An error produced by a `Service` wrapped by a `Buffer`
+#[derive(Debug)]
+pub struct ServiceError {
+    inner: Arc<BoxError>,
+}
+
+/// An error produced when the a buffer's worker closes unexpectedly.
+pub struct Closed {
+    _p: (),
+}
+
+// ===== impl ServiceError =====
+
+impl ServiceError {
+    pub(crate) fn new(inner: BoxError) -> ServiceError {
+        let inner = Arc::new(inner);
+        ServiceError { inner }
+    }
+
+    // Private to avoid exposing `Clone` trait as part of the public API
+    pub(crate) fn clone(&self) -> ServiceError {
+        ServiceError {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl fmt::Display for ServiceError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "buffered service failed: {}", self.inner)
+    }
+}
+
+impl std::error::Error for ServiceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&**self.inner)
+    }
+}
+
+// ===== impl Closed =====
+
+impl Closed {
+    pub(crate) fn new() -> Self {
+        Closed { _p: () }
+    }
+}
+
+impl fmt::Debug for Closed {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_tuple("Closed").finish()
+    }
+}
+
+impl fmt::Display for Closed {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("buffer's worker closed unexpectedly")
+    }
+}
+
+impl std::error::Error for Closed {}

--- a/tower-batch/src/error.rs
+++ b/tower-batch/src/error.rs
@@ -1,15 +1,15 @@
-//! Error types for the `Buffer` middleware.
+//! Error types for the `Batch` middleware.
 
 use crate::BoxError;
 use std::{fmt, sync::Arc};
 
-/// An error produced by a `Service` wrapped by a `Buffer`
+/// An error produced by a `Service` wrapped by a `Batch`.
 #[derive(Debug)]
 pub struct ServiceError {
     inner: Arc<BoxError>,
 }
 
-/// An error produced when the a buffer's worker closes unexpectedly.
+/// An error produced when the batch worker closes unexpectedly.
 pub struct Closed {
     _p: (),
 }
@@ -32,7 +32,7 @@ impl ServiceError {
 
 impl fmt::Display for ServiceError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "buffered service failed: {}", self.inner)
+        write!(fmt, "batching service failed: {}", self.inner)
     }
 }
 
@@ -58,7 +58,7 @@ impl fmt::Debug for Closed {
 
 impl fmt::Display for Closed {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("buffer's worker closed unexpectedly")
+        fmt.write_str("batch worker closed unexpectedly")
     }
 }
 

--- a/tower-batch/src/future.rs
+++ b/tower-batch/src/future.rs
@@ -1,0 +1,68 @@
+//! Future types for the `Buffer` middleware.
+
+use super::{error::Closed, message};
+use futures_core::ready;
+use pin_project::{pin_project, project};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// Future that completes when the buffered service eventually services the submitted request.
+#[pin_project]
+#[derive(Debug)]
+pub struct ResponseFuture<T> {
+    #[pin]
+    state: ResponseState<T>,
+}
+
+#[pin_project]
+#[derive(Debug)]
+enum ResponseState<T> {
+    Failed(Option<crate::BoxError>),
+    Rx(#[pin] message::Rx<T>),
+    Poll(#[pin] T),
+}
+
+impl<T> ResponseFuture<T> {
+    pub(crate) fn new(rx: message::Rx<T>) -> Self {
+        ResponseFuture {
+            state: ResponseState::Rx(rx),
+        }
+    }
+
+    pub(crate) fn failed(err: crate::BoxError) -> Self {
+        ResponseFuture {
+            state: ResponseState::Failed(Some(err)),
+        }
+    }
+}
+
+impl<F, T, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<T, E>>,
+    E: Into<crate::BoxError>,
+{
+    type Output = Result<T, crate::BoxError>;
+
+    #[project]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        loop {
+            #[project]
+            match this.state.as_mut().project() {
+                ResponseState::Failed(e) => {
+                    return Poll::Ready(Err(e.take().expect("polled after error")));
+                }
+                ResponseState::Rx(rx) => match ready!(rx.poll(cx)) {
+                    Ok(Ok(f)) => this.state.set(ResponseState::Poll(f)),
+                    Ok(Err(e)) => return Poll::Ready(Err(e.into())),
+                    Err(_) => return Poll::Ready(Err(Closed::new().into())),
+                },
+                ResponseState::Poll(fut) => return fut.poll(cx).map_err(Into::into),
+            }
+        }
+    }
+}

--- a/tower-batch/src/future.rs
+++ b/tower-batch/src/future.rs
@@ -1,4 +1,4 @@
-//! Future types for the `Buffer` middleware.
+//! Future types for the `Batch` middleware.
 
 use super::{error::Closed, message};
 use futures_core::ready;
@@ -9,7 +9,7 @@ use std::{
     task::{Context, Poll},
 };
 
-/// Future that completes when the buffered service eventually services the submitted request.
+/// Future that completes when the batch processing is complete.
 #[pin_project]
 #[derive(Debug)]
 pub struct ResponseFuture<T> {

--- a/tower-batch/src/layer.rs
+++ b/tower-batch/src/layer.rs
@@ -1,0 +1,60 @@
+use super::service::Buffer;
+use std::{fmt, marker::PhantomData};
+use tower_layer::Layer;
+use tower_service::Service;
+
+/// Adds an mpsc buffer in front of an inner service.
+///
+/// The default Tokio executor is used to run the given service,
+/// which means that this layer can only be used on the Tokio runtime.
+///
+/// See the module documentation for more details.
+pub struct BufferLayer<Request> {
+    bound: usize,
+    _p: PhantomData<fn(Request)>,
+}
+
+impl<Request> BufferLayer<Request> {
+    /// Creates a new `BufferLayer` with the provided `bound`.
+    ///
+    /// `bound` gives the maximal number of requests that can be queued for the service before
+    /// backpressure is applied to callers.
+    ///
+    /// # A note on choosing a `bound`
+    ///
+    /// When `Buffer`'s implementation of `poll_ready` returns `Poll::Ready`, it reserves a
+    /// slot in the channel for the forthcoming `call()`. However, if this call doesn't arrive,
+    /// this reserved slot may be held up for a long time. As a result, it's advisable to set
+    /// `bound` to be at least the maximum number of concurrent requests the `Buffer` will see.
+    /// If you do not, all the slots in the buffer may be held up by futures that have just called
+    /// `poll_ready` but will not issue a `call`, which prevents other senders from issuing new
+    /// requests.
+    pub fn new(bound: usize) -> Self {
+        BufferLayer {
+            bound,
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<S, Request> Layer<S> for BufferLayer<Request>
+where
+    S: Service<Request> + Send + 'static,
+    S::Future: Send,
+    S::Error: Into<crate::BoxError> + Send + Sync,
+    Request: Send + 'static,
+{
+    type Service = Buffer<S, Request>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        Buffer::new(service, self.bound)
+    }
+}
+
+impl<Request> fmt::Debug for BufferLayer<Request> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("BufferLayer")
+            .field("bound", &self.bound)
+            .finish()
+    }
+}

--- a/tower-batch/src/layer.rs
+++ b/tower-batch/src/layer.rs
@@ -1,60 +1,56 @@
-use super::service::Buffer;
+use super::{service::Batch, BatchControl};
 use std::{fmt, marker::PhantomData};
-use tower_layer::Layer;
-use tower_service::Service;
+use tower::layer::Layer;
+use tower::Service;
 
-/// Adds an mpsc buffer in front of an inner service.
+/// Adds a layer performing batch processing of requests.
 ///
 /// The default Tokio executor is used to run the given service,
 /// which means that this layer can only be used on the Tokio runtime.
 ///
 /// See the module documentation for more details.
-pub struct BufferLayer<Request> {
-    bound: usize,
+pub struct BatchLayer<Request> {
+    max_items: usize,
+    max_latency: std::time::Duration,
     _p: PhantomData<fn(Request)>,
 }
 
-impl<Request> BufferLayer<Request> {
-    /// Creates a new `BufferLayer` with the provided `bound`.
+impl<Request> BatchLayer<Request> {
+    /// Creates a new `BatchLayer`.
     ///
-    /// `bound` gives the maximal number of requests that can be queued for the service before
-    /// backpressure is applied to callers.
+    /// The wrapper is responsible for telling the inner service when to flush a
+    /// batch of requests.  Two parameters control this policy:
     ///
-    /// # A note on choosing a `bound`
-    ///
-    /// When `Buffer`'s implementation of `poll_ready` returns `Poll::Ready`, it reserves a
-    /// slot in the channel for the forthcoming `call()`. However, if this call doesn't arrive,
-    /// this reserved slot may be held up for a long time. As a result, it's advisable to set
-    /// `bound` to be at least the maximum number of concurrent requests the `Buffer` will see.
-    /// If you do not, all the slots in the buffer may be held up by futures that have just called
-    /// `poll_ready` but will not issue a `call`, which prevents other senders from issuing new
-    /// requests.
-    pub fn new(bound: usize) -> Self {
-        BufferLayer {
-            bound,
+    /// * `max_items` gives the maximum number of items per batch.
+    /// * `max_latency` gives the maximum latency for a batch item.
+    pub fn new(max_items: usize, max_latency: std::time::Duration) -> Self {
+        BatchLayer {
+            max_items,
+            max_latency,
             _p: PhantomData,
         }
     }
 }
 
-impl<S, Request> Layer<S> for BufferLayer<Request>
+impl<S, Request> Layer<S> for BatchLayer<Request>
 where
-    S: Service<Request> + Send + 'static,
+    S: Service<BatchControl<Request>> + Send + 'static,
     S::Future: Send,
     S::Error: Into<crate::BoxError> + Send + Sync,
     Request: Send + 'static,
 {
-    type Service = Buffer<S, Request>;
+    type Service = Batch<S, Request>;
 
     fn layer(&self, service: S) -> Self::Service {
-        Buffer::new(service, self.bound)
+        Batch::new(service, self.max_items, self.max_latency)
     }
 }
 
-impl<Request> fmt::Debug for BufferLayer<Request> {
+impl<Request> fmt::Debug for BatchLayer<Request> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("BufferLayer")
-            .field("bound", &self.bound)
+            .field("max_items", &self.max_items)
+            .field("max_latency", &self.max_latency)
             .finish()
     }
 }

--- a/tower-batch/src/lib.rs
+++ b/tower-batch/src/lib.rs
@@ -1,3 +1,90 @@
+//! Tower middleware for batch request processing
+//!
+//! This crate provides generic middleware for handling management of
+//! latency/throughput tradeoffs for batch processing. It provides a
+//! [`BatchControl<R>`](BatchControl) enum with [`Item(R)`](BatchControl::Item)
+//! and [`Flush`](BatchControl::Flush) variants, and provides a
+//! [`Batch<S>`](Batch) wrapper that wraps `S: Service<BatchControl<R>>` to
+//! provide a `Service<R>`, managing maximum request latency and batch size.
+//!
+//! ## Example: batch verification
+//!
+//! In cryptography, batch verification asks whether *all* items in some set are
+//! valid, rather than asking whether *each* of them is valid. This increases
+//! throughput by allowing computation to be shared across each item. However, it
+//! comes at the cost of higher latency (the entire batch must complete),
+//! complexity of caller code (which must assemble a batch of items to verify),
+//! and loss of the ability to easily pinpoint failing items (requiring either a
+//! retry or more sophisticated techniques).
+//!
+//! The latency-throughput tradeoff is manageable, but the second aspect poses
+//! serious practical difficulties. Conventional batch verification APIs require
+//! choosing in advance how much data to batch, and then processing the entire
+//! batch simultaneously. But for applications which require verification of
+//! heterogeneous data, this is cumbersome and difficult.
+//!
+//! For example, Zcash uses four different kinds of signatures (ECDSA signatures
+//! from Bitcoin, Ed25519 signatures for Sprout, and RedJubjub spendauth and
+//! binding signatures for Sapling) as well as three different kinds of
+//! zero-knowledge proofs (Sprout-on-BCTV14, Sprout-on-Groth16, and
+//! Sapling-on-Groth16). A single transaction can have multiple proofs or
+//! signatures of different kinds, depending on the transaction version and its
+//! structure. Verification of a transaction conventionally proceeds
+//! “depth-first”, checking that the structure is appropriate and then that all
+//! the component signatures and proofs are valid.
+//!
+//! Now consider the problem of implementing batch verification in this context,
+//! using conventional batch verification APIs that require passing a list of
+//! signatures or proofs. This is quite complicated, requiring implementing a
+//! second transposed set of validation logic that proceeds “breadth-first”,
+//! checking that the structure of each transaction is appropriate while
+//! assembling collections of signatures and proofs to verify. This transposed
+//! validation logic must match the untransposed logic, but there is another
+//! problem, which is that the set of transactions must be decided in advance.
+//! This is difficult because different levels of batching are required in
+//! different contexts. For instance, batching within a transaction is
+//! appropriate on receipt of a gossiped transaction, batching within a block is
+//! appropriate for block verification, and batching across blocks is appropriate
+//! when syncing the chain.
+//!
+//! ## Asynchronous batch verification
+//!
+//! To address this problem, we move from a synchronous model for signature
+//! verification to an asynchronous model. Rather than immediately returning a
+//! verification result, verification returns a future which will eventually
+//! resolve to a verification result. Verification futures can be combined with
+//! various futures combinators, expressing the logical semantics of the combined
+//! verification checks. This allows writing checks generic over the choice of
+//! singleton or batched verification. And because the batch context is distinct
+//! from the verification logic itself, the same verification logic can be reused
+//! in different batching contexts - batching within a transaction, within a
+//! block, within a chain, etc.
+//!
+//! ## Batch processing middleware
+//!
+//! Tower's [`Service`](tower::Service) interface is an an attractive choice for
+//! implementing this model for two reasons. First, it makes it easy to express
+//! generic bounds on [`Service`](tower::Service)s, allowing higher-level
+//! verification services to be written generically with respect to the
+//! verification of each lower-level component.
+//!
+//! Second, Tower's design allows service combinators to easily compose
+//! behaviors. For instance, the third drawback mentioned above (failure
+//! pinpointing) can addressed fairly straightforwardly by composing a batch
+//! verification [`Service`](tower::Service) with a retry
+//! [`Layer`](tower::layer::Layer) that retries verification of that item without
+//! batching.
+//!
+//! The remaining problem to address is the latency-throughput tradeoff. The
+//! logic to manage this tradeoff is independent of the specific batching
+//! procedure, and this crate provides a generic `Batch` wrapper that does so.
+//! The wrapper makes use of a [`BatchControl<R>`](BatchControl) enum with
+//! [`Item(R)`](BatchControl::Item) and [`Flush`](BatchControl::Flush) variants.
+//! Given `S: Service<BatchControl<R>>`, the [`Batch<S>`](Batch) wrapper provides
+//! a `Service<R>`. The wrapped service does not need to implement any batch
+//! control logic, as it will receive explicit [`Flush`](BatchControl::Flush)
+//! requests from the wrapper.
+
 pub mod error;
 pub mod future;
 mod layer;
@@ -7,8 +94,11 @@ mod worker;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+/// Signaling mechanism for batchable services that allows explicit flushing.
 pub enum BatchControl<R> {
+    /// A new batch item.
     Item(R),
+    /// The current batch should be flushed.
     Flush,
 }
 

--- a/tower-batch/src/lib.rs
+++ b/tower-batch/src/lib.rs
@@ -7,5 +7,16 @@ mod worker;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-pub use self::layer::BufferLayer;
-pub use self::service::Buffer;
+pub enum BatchControl<R> {
+    Item(R),
+    Flush,
+}
+
+impl<R> From<R> for BatchControl<R> {
+    fn from(req: R) -> BatchControl<R> {
+        BatchControl::Item(req)
+    }
+}
+
+pub use self::layer::BatchLayer;
+pub use self::service::Batch;

--- a/tower-batch/src/lib.rs
+++ b/tower-batch/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod error;
+pub mod future;
+mod layer;
+mod message;
+mod service;
+mod worker;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+pub use self::layer::BufferLayer;
+pub use self::service::Buffer;

--- a/tower-batch/src/message.rs
+++ b/tower-batch/src/message.rs
@@ -1,0 +1,16 @@
+use super::error::ServiceError;
+use tokio::sync::oneshot;
+
+/// Message sent over buffer
+#[derive(Debug)]
+pub(crate) struct Message<Request, Fut> {
+    pub(crate) request: Request,
+    pub(crate) tx: Tx<Fut>,
+    pub(crate) span: tracing::Span,
+}
+
+/// Response sender
+pub(crate) type Tx<Fut> = oneshot::Sender<Result<Fut, ServiceError>>;
+
+/// Response receiver
+pub(crate) type Rx<Fut> = oneshot::Receiver<Result<Fut, ServiceError>>;

--- a/tower-batch/src/message.rs
+++ b/tower-batch/src/message.rs
@@ -1,7 +1,7 @@
 use super::error::ServiceError;
 use tokio::sync::oneshot;
 
-/// Message sent over buffer
+/// Message sent to the batch worker
 #[derive(Debug)]
 pub(crate) struct Message<Request, Fut> {
     pub(crate) request: Request,

--- a/tower-batch/src/service.rs
+++ b/tower-batch/src/service.rs
@@ -1,0 +1,139 @@
+use super::{
+    future::ResponseFuture,
+    message::Message,
+    worker::{Handle, Worker},
+};
+
+use futures_core::ready;
+use std::task::{Context, Poll};
+use tokio::sync::{mpsc, oneshot};
+use tower::Service;
+
+/// Adds an mpsc buffer in front of an inner service.
+///
+/// See the module documentation for more details.
+#[derive(Debug)]
+pub struct Buffer<T, Request>
+where
+    T: Service<Request>,
+{
+    tx: mpsc::Sender<Message<Request, T::Future>>,
+    handle: Handle,
+}
+
+impl<T, Request> Buffer<T, Request>
+where
+    T: Service<Request>,
+    T::Error: Into<crate::BoxError>,
+{
+    /// Creates a new `Buffer` wrapping `service`.
+    ///
+    /// `bound` gives the maximal number of requests that can be queued for the service before
+    /// backpressure is applied to callers.
+    ///
+    /// The default Tokio executor is used to run the given service, which means that this method
+    /// must be called while on the Tokio runtime.
+    ///
+    /// # A note on choosing a `bound`
+    ///
+    /// When `Buffer`'s implementation of `poll_ready` returns `Poll::Ready`, it reserves a
+    /// slot in the channel for the forthcoming `call()`. However, if this call doesn't arrive,
+    /// this reserved slot may be held up for a long time. As a result, it's advisable to set
+    /// `bound` to be at least the maximum number of concurrent requests the `Buffer` will see.
+    /// If you do not, all the slots in the buffer may be held up by futures that have just called
+    /// `poll_ready` but will not issue a `call`, which prevents other senders from issuing new
+    /// requests.
+    pub fn new(service: T, bound: usize) -> Self
+    where
+        T: Send + 'static,
+        T::Future: Send,
+        T::Error: Send + Sync,
+        Request: Send + 'static,
+    {
+        let (tx, rx) = mpsc::channel(bound);
+        let (handle, worker) = Worker::new(service, rx);
+        tokio::spawn(worker);
+        Buffer { tx, handle }
+    }
+
+    /// Creates a new `Buffer` wrapping `service`, but returns the background worker.
+    ///
+    /// This is useful if you do not want to spawn directly onto the `tokio` runtime
+    /// but instead want to use your own executor. This will return the `Buffer` and
+    /// the background `Worker` that you can then spawn.
+    pub fn pair(service: T, bound: usize) -> (Buffer<T, Request>, Worker<T, Request>)
+    where
+        T: Send + 'static,
+        T::Error: Send + Sync,
+        Request: Send + 'static,
+    {
+        let (tx, rx) = mpsc::channel(bound);
+        let (handle, worker) = Worker::new(service, rx);
+        (Buffer { tx, handle }, worker)
+    }
+
+    fn get_worker_error(&self) -> crate::BoxError {
+        self.handle.get_error_on_closed()
+    }
+}
+
+impl<T, Request> Service<Request> for Buffer<T, Request>
+where
+    T: Service<Request>,
+    T::Error: Into<crate::BoxError>,
+{
+    type Response = T::Response;
+    type Error = crate::BoxError;
+    type Future = ResponseFuture<T::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // If the inner service has errored, then we error here.
+        if let Err(_) = ready!(self.tx.poll_ready(cx)) {
+            Poll::Ready(Err(self.get_worker_error()))
+        } else {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        // TODO:
+        // ideally we'd poll_ready again here so we don't allocate the oneshot
+        // if the try_send is about to fail, but sadly we can't call poll_ready
+        // outside of task context.
+        let (tx, rx) = oneshot::channel();
+
+        // get the current Span so that we can explicitly propagate it to the worker
+        // if we didn't do this, events on the worker related to this span wouldn't be counted
+        // towards that span since the worker would have no way of entering it.
+        let span = tracing::Span::current();
+        tracing::trace!(parent: &span, "sending request to buffer worker");
+        match self.tx.try_send(Message { request, span, tx }) {
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                ResponseFuture::failed(self.get_worker_error())
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                // When `mpsc::Sender::poll_ready` returns `Ready`, a slot
+                // in the channel is reserved for the handle. Other `Sender`
+                // handles may not send a message using that slot. This
+                // guarantees capacity for `request`.
+                //
+                // Given this, the only way to hit this code path is if
+                // `poll_ready` has not been called & `Ready` returned.
+                panic!("buffer full; poll_ready must be called first");
+            }
+            Ok(_) => ResponseFuture::new(rx),
+        }
+    }
+}
+
+impl<T, Request> Clone for Buffer<T, Request>
+where
+    T: Service<Request>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+            handle: self.handle.clone(),
+        }
+    }
+}

--- a/tower-batch/src/service.rs
+++ b/tower-batch/src/service.rs
@@ -2,6 +2,7 @@ use super::{
     future::ResponseFuture,
     message::Message,
     worker::{Handle, Worker},
+    BatchControl,
 };
 
 use futures_core::ready;
@@ -9,67 +10,45 @@ use std::task::{Context, Poll};
 use tokio::sync::{mpsc, oneshot};
 use tower::Service;
 
-/// Adds an mpsc buffer in front of an inner service.
+/// Allows batch processing of requests.
 ///
 /// See the module documentation for more details.
 #[derive(Debug)]
-pub struct Buffer<T, Request>
+pub struct Batch<T, Request>
 where
-    T: Service<Request>,
+    T: Service<BatchControl<Request>>,
 {
     tx: mpsc::Sender<Message<Request, T::Future>>,
     handle: Handle,
 }
 
-impl<T, Request> Buffer<T, Request>
+impl<T, Request> Batch<T, Request>
 where
-    T: Service<Request>,
+    T: Service<BatchControl<Request>>,
     T::Error: Into<crate::BoxError>,
 {
-    /// Creates a new `Buffer` wrapping `service`.
+    /// Creates a new `Batch` wrapping `service`.
     ///
-    /// `bound` gives the maximal number of requests that can be queued for the service before
-    /// backpressure is applied to callers.
+    /// The wrapper is responsible for telling the inner service when to flush a
+    /// batch of requests.  Two parameters control this policy:
     ///
-    /// The default Tokio executor is used to run the given service, which means that this method
-    /// must be called while on the Tokio runtime.
+    /// * `max_items` gives the maximum number of items per batch.
+    /// * `max_latency` gives the maximum latency for a batch item.
     ///
-    /// # A note on choosing a `bound`
-    ///
-    /// When `Buffer`'s implementation of `poll_ready` returns `Poll::Ready`, it reserves a
-    /// slot in the channel for the forthcoming `call()`. However, if this call doesn't arrive,
-    /// this reserved slot may be held up for a long time. As a result, it's advisable to set
-    /// `bound` to be at least the maximum number of concurrent requests the `Buffer` will see.
-    /// If you do not, all the slots in the buffer may be held up by futures that have just called
-    /// `poll_ready` but will not issue a `call`, which prevents other senders from issuing new
-    /// requests.
-    pub fn new(service: T, bound: usize) -> Self
+    /// The default Tokio executor is used to run the given service, which means
+    /// that this method must be called while on the Tokio runtime.
+    pub fn new(service: T, max_items: usize, max_latency: std::time::Duration) -> Self
     where
         T: Send + 'static,
         T::Future: Send,
         T::Error: Send + Sync,
         Request: Send + 'static,
     {
-        let (tx, rx) = mpsc::channel(bound);
-        let (handle, worker) = Worker::new(service, rx);
-        tokio::spawn(worker);
-        Buffer { tx, handle }
-    }
-
-    /// Creates a new `Buffer` wrapping `service`, but returns the background worker.
-    ///
-    /// This is useful if you do not want to spawn directly onto the `tokio` runtime
-    /// but instead want to use your own executor. This will return the `Buffer` and
-    /// the background `Worker` that you can then spawn.
-    pub fn pair(service: T, bound: usize) -> (Buffer<T, Request>, Worker<T, Request>)
-    where
-        T: Send + 'static,
-        T::Error: Send + Sync,
-        Request: Send + 'static,
-    {
-        let (tx, rx) = mpsc::channel(bound);
-        let (handle, worker) = Worker::new(service, rx);
-        (Buffer { tx, handle }, worker)
+        // XXX(hdevalence): is this bound good
+        let (tx, rx) = mpsc::channel(1);
+        let (handle, worker) = Worker::new(service, rx, max_items, max_latency);
+        tokio::spawn(worker.run());
+        Batch { tx, handle }
     }
 
     fn get_worker_error(&self) -> crate::BoxError {
@@ -77,9 +56,9 @@ where
     }
 }
 
-impl<T, Request> Service<Request> for Buffer<T, Request>
+impl<T, Request> Service<Request> for Batch<T, Request>
 where
-    T: Service<Request>,
+    T: Service<BatchControl<Request>>,
     T::Error: Into<crate::BoxError>,
 {
     type Response = T::Response;
@@ -106,7 +85,7 @@ where
         // if we didn't do this, events on the worker related to this span wouldn't be counted
         // towards that span since the worker would have no way of entering it.
         let span = tracing::Span::current();
-        tracing::trace!(parent: &span, "sending request to buffer worker");
+        tracing::trace!(parent: &span, "sending request to batch worker");
         match self.tx.try_send(Message { request, span, tx }) {
             Err(mpsc::error::TrySendError::Closed(_)) => {
                 ResponseFuture::failed(self.get_worker_error())
@@ -126,9 +105,9 @@ where
     }
 }
 
-impl<T, Request> Clone for Buffer<T, Request>
+impl<T, Request> Clone for Batch<T, Request>
 where
-    T: Service<Request>,
+    T: Service<BatchControl<Request>>,
 {
     fn clone(&self) -> Self {
         Self {

--- a/tower-batch/src/worker.rs
+++ b/tower-batch/src/worker.rs
@@ -1,0 +1,228 @@
+use super::{
+    error::{Closed, ServiceError},
+    message::Message,
+};
+use futures_core::ready;
+use pin_project::pin_project;
+use std::sync::{Arc, Mutex};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::sync::mpsc;
+use tower::Service;
+
+/// Task that handles processing the buffer. This type should not be used
+/// directly, instead `Buffer` requires an `Executor` that can accept this task.
+///
+/// The struct is `pub` in the private module and the type is *not* re-exported
+/// as part of the public API. This is the "sealed" pattern to include "private"
+/// types in public traits that are not meant for consumers of the library to
+/// implement (only call).
+#[pin_project]
+#[derive(Debug)]
+pub struct Worker<T, Request>
+where
+    T: Service<Request>,
+    T::Error: Into<crate::BoxError>,
+{
+    current_message: Option<Message<Request, T::Future>>,
+    rx: mpsc::Receiver<Message<Request, T::Future>>,
+    service: T,
+    finish: bool,
+    failed: Option<ServiceError>,
+    handle: Handle,
+}
+
+/// Get the error out
+#[derive(Debug)]
+pub(crate) struct Handle {
+    inner: Arc<Mutex<Option<ServiceError>>>,
+}
+
+impl<T, Request> Worker<T, Request>
+where
+    T: Service<Request>,
+    T::Error: Into<crate::BoxError>,
+{
+    pub(crate) fn new(
+        service: T,
+        rx: mpsc::Receiver<Message<Request, T::Future>>,
+    ) -> (Handle, Worker<T, Request>) {
+        let handle = Handle {
+            inner: Arc::new(Mutex::new(None)),
+        };
+
+        let worker = Worker {
+            current_message: None,
+            finish: false,
+            failed: None,
+            rx,
+            service,
+            handle: handle.clone(),
+        };
+
+        (handle, worker)
+    }
+
+    /// Return the next queued Message that hasn't been canceled.
+    ///
+    /// If a `Message` is returned, the `bool` is true if this is the first time we received this
+    /// message, and false otherwise (i.e., we tried to forward it to the backing service before).
+    fn poll_next_msg(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<(Message<Request, T::Future>, bool)>> {
+        if self.finish {
+            // We've already received None and are shutting down
+            return Poll::Ready(None);
+        }
+
+        tracing::trace!("worker polling for next message");
+        if let Some(mut msg) = self.current_message.take() {
+            // poll_closed returns Poll::Ready is the receiver is dropped.
+            // Returning Pending means it is still alive, so we should still
+            // use it.
+            if msg.tx.poll_closed(cx).is_pending() {
+                tracing::trace!("resuming buffered request");
+                return Poll::Ready(Some((msg, false)));
+            }
+
+            tracing::trace!("dropping cancelled buffered request");
+        }
+
+        // Get the next request
+        while let Some(mut msg) = ready!(Pin::new(&mut self.rx).poll_recv(cx)) {
+            if msg.tx.poll_closed(cx).is_pending() {
+                tracing::trace!("processing new request");
+                return Poll::Ready(Some((msg, true)));
+            }
+            // Otherwise, request is canceled, so pop the next one.
+            tracing::trace!("dropping cancelled request");
+        }
+
+        Poll::Ready(None)
+    }
+
+    fn failed(&mut self, error: crate::BoxError) {
+        // The underlying service failed when we called `poll_ready` on it with the given `error`. We
+        // need to communicate this to all the `Buffer` handles. To do so, we wrap up the error in
+        // an `Arc`, send that `Arc<E>` to all pending requests, and store it so that subsequent
+        // requests will also fail with the same error.
+
+        // Note that we need to handle the case where some handle is concurrently trying to send us
+        // a request. We need to make sure that *either* the send of the request fails *or* it
+        // receives an error on the `oneshot` it constructed. Specifically, we want to avoid the
+        // case where we send errors to all outstanding requests, and *then* the caller sends its
+        // request. We do this by *first* exposing the error, *then* closing the channel used to
+        // send more requests (so the client will see the error when the send fails), and *then*
+        // sending the error to all outstanding requests.
+        let error = ServiceError::new(error);
+
+        let mut inner = self.handle.inner.lock().unwrap();
+
+        if inner.is_some() {
+            // Future::poll was called after we've already errored out!
+            return;
+        }
+
+        *inner = Some(error.clone());
+        drop(inner);
+
+        self.rx.close();
+
+        // By closing the mpsc::Receiver, we know that poll_next_msg will soon return Ready(None),
+        // which will trigger the `self.finish == true` phase. We just need to make sure that any
+        // requests that we receive before we've exhausted the receiver receive the error:
+        self.failed = Some(error);
+    }
+}
+
+impl<T, Request> Future for Worker<T, Request>
+where
+    T: Service<Request>,
+    T::Error: Into<crate::BoxError>,
+{
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.finish {
+            return Poll::Ready(());
+        }
+
+        loop {
+            match ready!(self.poll_next_msg(cx)) {
+                Some((msg, first)) => {
+                    let _guard = msg.span.enter();
+                    if let Some(ref failed) = self.failed {
+                        tracing::trace!("notifying caller about worker failure");
+                        let _ = msg.tx.send(Err(failed.clone()));
+                        continue;
+                    }
+
+                    // Wait for the service to be ready
+                    tracing::trace!(
+                        resumed = !first,
+                        message = "worker received request; waiting for service readiness"
+                    );
+                    match self.service.poll_ready(cx) {
+                        Poll::Ready(Ok(())) => {
+                            tracing::debug!(service.ready = true, message = "processing request");
+                            let response = self.service.call(msg.request);
+
+                            // Send the response future back to the sender.
+                            //
+                            // An error means the request had been canceled in-between
+                            // our calls, the response future will just be dropped.
+                            tracing::trace!("returning response future");
+                            let _ = msg.tx.send(Ok(response));
+                        }
+                        Poll::Pending => {
+                            tracing::trace!(service.ready = false, message = "delay");
+                            // Put out current message back in its slot.
+                            drop(_guard);
+                            self.current_message = Some(msg);
+                            return Poll::Pending;
+                        }
+                        Poll::Ready(Err(e)) => {
+                            let error = e.into();
+                            tracing::debug!({ %error }, "service failed");
+                            drop(_guard);
+                            self.failed(error);
+                            let _ = msg.tx.send(Err(self
+                                .failed
+                                .as_ref()
+                                .expect("Worker::failed did not set self.failed?")
+                                .clone()));
+                        }
+                    }
+                }
+                None => {
+                    // No more more requests _ever_.
+                    self.finish = true;
+                    return Poll::Ready(());
+                }
+            }
+        }
+    }
+}
+
+impl Handle {
+    pub(crate) fn get_error_on_closed(&self) -> crate::BoxError {
+        self.inner
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|svc_err| svc_err.clone().into())
+            .unwrap_or_else(|| Closed::new().into())
+    }
+}
+
+impl Clone for Handle {
+    fn clone(&self) -> Handle {
+        Handle {
+            inner: self.inner.clone(),
+        }
+    }
+}

--- a/tower-batch/tests/ed25519.rs
+++ b/tower-batch/tests/ed25519.rs
@@ -1,0 +1,142 @@
+use std::{
+    convert::TryFrom,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use ed25519_zebra::*;
+use futures::stream::{FuturesUnordered, StreamExt};
+use rand::thread_rng;
+use tokio::sync::broadcast::{channel, RecvError, Sender};
+use tower::{Service, ServiceExt};
+use tower_batch::{Batch, BatchControl};
+
+// ============ service impl ============
+
+pub struct Ed25519Verifier {
+    batch: BatchVerifier,
+    // This uses a "broadcast" channel, which is an mpmc channel. Tokio also
+    // provides a spmc channel, "watch", but it only keeps the latest value, so
+    // using it would require thinking through whether it was possible for
+    // results from one batch to be mixed with another.
+    tx: Sender<Result<(), Error>>,
+}
+
+impl Ed25519Verifier {
+    pub fn new() -> Self {
+        let batch = BatchVerifier::default();
+        let (tx, _) = channel(1);
+        Self { tx, batch }
+    }
+}
+
+type Request<'msg> = (VerificationKeyBytes, Signature, &'msg [u8]);
+
+impl<'msg> Service<BatchControl<Request<'msg>>> for Ed25519Verifier {
+    type Response = ();
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: BatchControl<Request<'msg>>) -> Self::Future {
+        match req {
+            BatchControl::Item((vk_bytes, sig, msg)) => {
+                self.batch.queue(vk_bytes, sig, msg);
+                let mut rx = self.tx.subscribe();
+                Box::pin(async move {
+                    match rx.recv().await {
+                        Ok(result) => result,
+                        // this would be bad
+                        Err(RecvError::Lagged(_)) => Err(Error::InvalidSignature),
+                        Err(RecvError::Closed) => panic!("verifier was dropped without flushing"),
+                    }
+                })
+            }
+            BatchControl::Flush => {
+                let batch = std::mem::replace(&mut self.batch, BatchVerifier::default());
+                let _ = self.tx.send(batch.verify(thread_rng()));
+                Box::pin(async { Ok(()) })
+            }
+        }
+    }
+}
+
+impl Drop for Ed25519Verifier {
+    fn drop(&mut self) {
+        // We need to flush the current batch in case there are still any pending futures.
+        let batch = std::mem::replace(&mut self.batch, BatchVerifier::default());
+        let _ = self.tx.send(batch.verify(thread_rng()));
+    }
+}
+
+// =============== testing code ========
+
+async fn sign_and_verify<V>(mut verifier: V, n: usize)
+where
+    for<'msg> V: Service<Request<'msg>>,
+    for<'msg> <V as Service<Request<'msg>>>::Error:
+        Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+{
+    let mut results = FuturesUnordered::new();
+    for _ in 0..n {
+        let sk = SigningKey::new(thread_rng());
+        let vk_bytes = VerificationKeyBytes::from(&sk);
+        let msg = b"BatchVerifyTest";
+        let sig = sk.sign(&msg[..]);
+        results.push(
+            verifier
+                .ready_and()
+                .await
+                .map_err(|e| e.into())
+                .unwrap()
+                .call((vk_bytes, sig, &msg[..])),
+        )
+    }
+
+    while let Some(result) = results.next().await {
+        assert!(result.is_ok());
+    }
+}
+
+#[tokio::test]
+async fn individual_verification_with_service_fn() {
+    let verifier = tower::service_fn(|(vk_bytes, sig, msg): Request| {
+        let result = VerificationKey::try_from(vk_bytes).and_then(|vk| vk.verify(&sig, msg));
+        async move { result }
+    });
+
+    sign_and_verify(verifier, 100).await;
+}
+
+#[tokio::test]
+async fn batch_flushes_on_max_items() {
+    use tokio::time::timeout;
+
+    // Use a very long max_latency and a short timeout to check that
+    // flushing is happening based on hitting max_items.
+    let verifier = Batch::new(Ed25519Verifier::new(), 10, Duration::from_secs(1000));
+    assert!(
+        timeout(Duration::from_secs(1), sign_and_verify(verifier, 100))
+            .await
+            .is_ok()
+    )
+}
+
+#[tokio::test]
+async fn batch_flushes_on_max_latency() {
+    use tokio::time::timeout;
+
+    // Use a very high max_items and a short timeout to check that
+    // flushing is happening based on hitting max_latency.
+    let verifier = Batch::new(Ed25519Verifier::new(), 100, Duration::from_millis(500));
+    assert!(
+        timeout(Duration::from_secs(1), sign_and_verify(verifier, 10))
+            .await
+            .is_ok()
+    )
+}

--- a/tower-batch/tests/ed25519.rs
+++ b/tower-batch/tests/ed25519.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryFrom,
     future::Future,
     pin::Pin,
     sync::Once,
@@ -128,19 +127,6 @@ where
         assert!(result.is_ok());
     }
 }
-
-/*
-#[tokio::test]
-async fn individual_verification_with_service_fn() {
-    let verifier = tower::service_fn(|item: Ed25519Item| {
-        // now this is actually impossible to write, oops
-        let result = VerificationKey::try_from(vk_bytes).and_then(|vk| vk.verify(&sig, msg));
-        async move { result }
-    });
-
-    sign_and_verify(verifier, 100).await;
-}
-*/
 
 #[tokio::test]
 async fn batch_flushes_on_max_items() {

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1"
 x25519-dalek = { version = "0.6", features = ["serde"] }
 serde-big-array = "0.3.0"
 # ZF deps
-ed25519-zebra = "0.3"
+ed25519-zebra = "0.4"
 redjubjub = "0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
First attempt at implementing #470. This is split into two commits, one that vendors the tower-buffer source code, and one that modifies it to provide a `tower-batch`.

I didn't test it yet because that requires writing services against its interface but I believe that it should work correctly.