### PR TITLE
Update to sha2@0.9.0 and try to fix usage, but Digest trait issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,19 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbcf92448676f82bb7a334c58bbce8b0d43580fb5362a9d608b18879d12a3d31"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.14.1",
 ]
 
 [[package]]
@@ -206,7 +218,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 dependencies = [
- "sha2",
+ "sha2 0.8.2",
 ]
 
 [[package]]
@@ -353,7 +365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.8.1",
  "rand_core",
  "subtle",
  "zeroize",
@@ -400,7 +412,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.1",
 ]
 
 [[package]]
@@ -418,7 +439,7 @@ dependencies = [
  "curve25519-dalek",
  "rand_core",
  "serde",
- "sha2",
+ "sha2 0.8.2",
  "thiserror",
 ]
 
@@ -568,6 +589,15 @@ name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2664c2cf08049036f31015b04c6ac3671379a1d86f52ed2416893f16022deb"
 dependencies = [
  "typenum",
 ]
@@ -1339,8 +1369,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "opaque-debug",
 ]
 
@@ -1486,8 +1516,20 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72377440080fd008550fe9b441e854e43318db116f90181eef92e9ae9aedab48"
+dependencies = [
+ "block-buffer 0.8.0",
+ "digest 0.9.0",
  "fake-simd",
  "opaque-debug",
 ]
@@ -2111,7 +2153,7 @@ dependencies = [
  "ripemd160",
  "secp256k1",
  "serde",
- "sha2",
+ "sha2 0.9.0",
  "thiserror",
  "x25519-dalek",
  "zebra-test-vectors",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -22,7 +22,7 @@ rand_core = "0.5.1"
 ripemd160 = "0.8.0"
 secp256k1 = { version = "0.17.2", features = ["serde"] }
 serde = { version = "1", features = ["serde_derive"] }
-sha2 = { version = "0.8.2", features=["compress"] }
+sha2 = { version = "0.9.0", features=["compress"] }
 thiserror = "1"
 x25519-dalek = "0.6"
 # ZF deps

--- a/zebra-chain/src/addresses/transparent.rs
+++ b/zebra-chain/src/addresses/transparent.rs
@@ -194,7 +194,7 @@ impl TransparentAddress {
     /// bytes.
     /// https://en.bitcoin.it/Base58Check_encoding#Encoding_a_Bitcoin_address
     fn hash_payload(bytes: &[u8]) -> [u8; 20] {
-        let sha_hash = Sha256::digest(bytes);
+        let sha_hash = sha2::Sha256::digest(bytes);
         let ripe_hash = Ripemd160::digest(&sha_hash);
         let mut payload = [0u8; 20];
         payload[..].copy_from_slice(&ripe_hash[..]);

--- a/zebra-chain/src/sha256d_writer.rs
+++ b/zebra-chain/src/sha256d_writer.rs
@@ -13,7 +13,7 @@ pub struct Sha256dWriter {
 impl Sha256dWriter {
     /// Consume the Writer and produce the hash result.
     pub fn finish(self) -> [u8; 32] {
-        let result1 = self.hash.result();
+        let result1 = self.hash.finalize();
         let result2 = Sha256::digest(&result1);
         let mut buffer = [0u8; 32];
         buffer[0..32].copy_from_slice(&result2[0..32]);
@@ -23,7 +23,7 @@ impl Sha256dWriter {
 
 impl Write for Sha256dWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.hash.input(buf);
+        self.hash.update(buf);
         Ok(buf.len())
     }
 


### PR DESCRIPTION
Resolves #462 
