### PR TITLE
chain: Check the maximum block size when parsing

### DIFF
--- a/zebra-chain/src/serialization.rs
+++ b/zebra-chain/src/serialization.rs
@@ -76,7 +76,8 @@ impl<T: ZcashDeserialize> ZcashDeserialize for Vec<T> {
         // We're given len, so we could preallocate. But blindly preallocating
         // without a size bound can allow DOS attacks, and there's no way to
         // pass a size bound in a ZcashDeserialize impl, so instead we allocate
-        // as we read from the reader.
+        // as we read from the reader. (The maximum block and transaction sizes
+        // limit the eventual size of these allocations.)
         let mut vec = Vec::new();
         for _ in 0..len {
             vec.push(T::zcash_deserialize(&mut reader)?);


### PR DESCRIPTION
The maximum block size is 2,000,000 bytes. This commit also limits the
maximum transaction size in parsed blocks. (See #484 for the
corresponding limit on mempool transactions.)

The proptests might test the maximum block size, but they are
randomised. So we also want to explicitly test large block sizes.
(See #482 for these test cases and tests.)

Part of #477.