### PR TITLE
Reject future blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,6 +2327,7 @@ version = "0.1.0"
 name = "zebra-consensus"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "color-eyre",
  "futures-util",
  "spandoc",

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -145,6 +145,8 @@ impl ZcashSerialize for BlockHeader {
         self.previous_block_hash.zcash_serialize(&mut writer)?;
         writer.write_all(&self.merkle_root_hash.0[..])?;
         writer.write_all(&self.final_sapling_root_hash.0[..])?;
+        // this is a truncating cast, rather than a saturating cast
+        // but u32 times are valid until 2106
         writer.write_u32::<LittleEndian>(self.time.timestamp() as u32)?;
         writer.write_u32::<LittleEndian>(self.bits)?;
         writer.write_all(&self.nonce[..])?;
@@ -190,6 +192,7 @@ impl ZcashDeserialize for BlockHeader {
             previous_block_hash: BlockHeaderHash::zcash_deserialize(&mut reader)?,
             merkle_root_hash: MerkleTreeRootHash(reader.read_32_bytes()?),
             final_sapling_root_hash: SaplingNoteTreeRootHash(reader.read_32_bytes()?),
+            // This can't panic, because all u32 values are valid `Utc.timestamp`s
             time: Utc.timestamp(reader.read_u32::<LittleEndian>()? as i64, 0),
             bits: reader.read_u32::<LittleEndian>()?,
             nonce: reader.read_32_bytes()?,

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -146,7 +146,8 @@ impl ZcashSerialize for BlockHeader {
         writer.write_all(&self.merkle_root_hash.0[..])?;
         writer.write_all(&self.final_sapling_root_hash.0[..])?;
         // this is a truncating cast, rather than a saturating cast
-        // but u32 times are valid until 2106
+        // but u32 times are valid until 2106, and our block verification time
+        // checks should detect any truncation.
         writer.write_u32::<LittleEndian>(self.time.timestamp() as u32)?;
         writer.write_u32::<LittleEndian>(self.bits)?;
         writer.write_all(&self.nonce[..])?;

--- a/zebra-chain/src/block/tests.rs
+++ b/zebra-chain/src/block/tests.rs
@@ -16,11 +16,13 @@ impl Arbitrary for BlockHeader {
 
     fn arbitrary_with(_args: ()) -> Self::Strategy {
         (
-            (4u32..2_147_483_647u32),
+            // version is interpreted as i32 in the spec, so we are limited to i32::MAX here
+            (4u32..(i32::MAX as u32)),
             any::<BlockHeaderHash>(),
             any::<MerkleTreeRootHash>(),
             any::<SaplingNoteTreeRootHash>(),
-            (0i64..4_294_967_296i64),
+            // time is interpreted as u32 in the spec, but rust timestamps are i64
+            (0i64..(u32::MAX as i64)),
             any::<u32>(),
             any::<[u8; 32]>(),
             any::<EquihashSolution>(),

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -359,6 +359,17 @@ impl ZcashDeserialize for Output {
 
 impl ZcashSerialize for Transaction {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        // Post-Sapling, transaction size is limited to MAX_BLOCK_BYTES.
+        // (Strictly, the maximum transaction size is about 1.5 kB less,
+        // because blocks also include a block header.)
+        //
+        // Currently, all transaction structs are parsed as part of a
+        // block. So we don't need to check transaction size here, until
+        // we start parsing mempool transactions, or generating our own
+        // transactions (see #483).
+        //
+        // Since we checkpoint on Sapling activation, we won't ever need
+        // to check the smaller pre-Sapling transaction size limit.
         match self {
             Transaction::V1 {
                 inputs,

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 [dependencies]
 zebra-chain = { path = "../zebra-chain" }
 zebra-state = { path = "../zebra-state" }
+chrono = "0.4.11"
 futures-util = "0.3.5"
 tower = "0.3.1"
 

--- a/zebra-consensus/src/verify.rs
+++ b/zebra-consensus/src/verify.rs
@@ -88,16 +88,35 @@ where
     fn call(&mut self, block: Arc<Block>) -> Self::Future {
         // TODO(jlusby): Error = Report, handle errors from state_service.
         // TODO(teor):
-        //   - handle chain reorgs, adjust state_service "unique block height" conditions
-        //   - handle block validation errors (including errors in the block's transactions)
+        //   - handle chain reorgs
+        //   - adjust state_service "unique block height" conditions
+        //   - move expensive checks into the async block
 
+        // Create an AddBlock Future, but don't run it yet.
+        //
         // `state_service.call` is OK here because we already called
         // `state_service.poll_ready` in our `poll_ready`.
-        let add_block = self
-            .state_service
-            .call(zebra_state::Request::AddBlock { block });
+        //
+        // `tower::Buffer` expects exactly one `call` for each
+        // `poll_ready`. So we unconditionally create the AddBlock
+        // Future using `state_service.call`. If verification fails,
+        // we return an error, and implicitly cancel the future.
+        let add_block = self.state_service.call(zebra_state::Request::AddBlock {
+            block: block.clone(),
+        });
 
         async move {
+            // If verification fails, return an error result.
+            // The AddBlock Future is implicitly cancelled by the
+            // error return in `?`.
+
+            // Since errors cause an early exit, try to do the
+            // quick checks first.
+            block::node_time_check(block)?;
+
+            // Verification was successful.
+            // Add the block to the state by awaiting the AddBlock
+            // Future, and return its result.
             match add_block.await? {
                 zebra_state::Response::Added { hash } => Ok(hash),
                 _ => Err("adding block to zebra-state failed".into()),

--- a/zebra-consensus/src/verify.rs
+++ b/zebra-consensus/src/verify.rs
@@ -8,6 +8,7 @@
 //! Verification is provided via a `tower::Service`, to support backpressure and batch
 //! verification.
 
+use chrono::Utc;
 use futures_util::FutureExt;
 use std::{
     error,
@@ -64,7 +65,9 @@ where
         async move {
             // Since errors cause an early exit, try to do the
             // quick checks first.
-            block::node_time_check(block.clone())?;
+
+            let now = Utc::now();
+            block::node_time_check(block.header.time, now)?;
 
             // `Tower::Buffer` requires a 1:1 relationship between `poll()`s
             // and `call()`s, because it reserves a buffer slot in each

--- a/zebra-consensus/src/verify.rs
+++ b/zebra-consensus/src/verify.rs
@@ -267,11 +267,8 @@ mod tests {
             .await;
 
         ensure!(
-            match verify_result {
-                Ok(_) => false,
-                // TODO(teor || jlusby): check error string
-                _ => true,
-            },
+            // TODO(teor || jlusby): check error string
+            verify_result.is_err(),
             "unexpected result kind: {:?}",
             verify_result
         );

--- a/zebra-consensus/src/verify.rs
+++ b/zebra-consensus/src/verify.rs
@@ -20,6 +20,7 @@ use tower::{buffer::Buffer, Service};
 
 use zebra_chain::block::{Block, BlockHeaderHash};
 
+mod block;
 mod script;
 mod transaction;
 
@@ -30,50 +31,6 @@ struct BlockVerifier<S> {
 /// The error type for the BlockVerifier Service.
 // TODO(jlusby): Error = Report ?
 type Error = Box<dyn error::Error + Send + Sync + 'static>;
-
-/// Block validity checks
-mod block {
-    use super::Error;
-
-    use chrono::{DateTime, Duration, Utc};
-    use std::sync::Arc;
-
-    use zebra_chain::block::Block;
-
-    /// Helper function for `node_time_check()`, see that function for details.
-    fn node_time_check_helper(
-        block_header_time: DateTime<Utc>,
-        now: DateTime<Utc>,
-    ) -> Result<(), Error> {
-        let two_hours_in_the_future = now
-            .checked_add_signed(Duration::hours(2))
-            .ok_or("overflow when calculating 2 hours in the future")?;
-
-        if block_header_time <= two_hours_in_the_future {
-            Ok(())
-        } else {
-            Err("block header time is more than 2 hours in the future".into())
-        }
-    }
-
-    /// Check if the block header time is less than or equal to
-    /// 2 hours in the future, according to the node's local clock.
-    ///
-    /// This is a non-deterministic rule, as clocks vary over time, and
-    /// between different nodes.
-    ///
-    /// "In addition, a full validator MUST NOT accept blocks with nTime
-    /// more than two hours in the future according to its clock. This
-    /// is not strictly a consensus rule because it is nondeterministic,
-    /// and clock time varies between nodes. Also note that a block that
-    /// is rejected by this rule at a given point in time may later be
-    /// accepted."[S 7.5][7.5]
-    ///
-    /// [7.5]: https://zips.z.cash/protocol/protocol.pdf#blockheader
-    pub(super) fn node_time_check(block: Arc<Block>) -> Result<(), Error> {
-        node_time_check_helper(block.header.time, Utc::now())
-    }
-}
 
 /// The BlockVerifier service implementation.
 ///

--- a/zebra-consensus/src/verify.rs
+++ b/zebra-consensus/src/verify.rs
@@ -31,6 +31,43 @@ struct BlockVerifier<S> {
 // TODO(jlusby): Error = Report ?
 type Error = Box<dyn error::Error + Send + Sync + 'static>;
 
+/// Block validity checks
+mod block {
+    use super::Error;
+
+    use chrono::{Duration, Utc};
+    use std::sync::Arc;
+
+    use zebra_chain::block::Block;
+
+    /// Check if the block header time is less than or equal to
+    /// 2 hours in the future, according to the node's local clock.
+    ///
+    /// This is a non-deterministic rule, as clocks vary over time, and
+    /// between different nodes.
+    ///
+    /// "In addition, a full validator MUST NOT accept blocks with nTime
+    /// more than two hours in the future according to its clock. This
+    /// is not strictly a consensus rule because it is nondeterministic,
+    /// and clock time varies between nodes. Also note that a block that
+    /// is rejected by this rule at a given point in time may later be
+    /// accepted."[S 7.5][7.5]
+    ///
+    /// [7.5]: https://zips.z.cash/protocol/protocol.pdf#blockheader
+    pub(super) fn node_time_check(block: Arc<Block>) -> Result<(), Error> {
+        let now = Utc::now();
+        let two_hours_in_the_future = now
+            .checked_add_signed(Duration::hours(2))
+            .ok_or("overflow when calculating 2 hours in the future")?;
+
+        if block.header.time <= two_hours_in_the_future {
+            Ok(())
+        } else {
+            Err("block header time is more than 2 hours in the future".into())
+        }
+    }
+}
+
 /// The BlockVerifier service implementation.
 ///
 /// After verification, blocks are added to the underlying state service.

--- a/zebra-consensus/src/verify/block.rs
+++ b/zebra-consensus/src/verify/block.rs
@@ -1,0 +1,42 @@
+//! Block validity checks
+
+use super::Error;
+
+use chrono::{DateTime, Duration, Utc};
+use std::sync::Arc;
+
+use zebra_chain::block::Block;
+
+/// Helper function for `node_time_check()`, see that function for details.
+fn node_time_check_helper(
+    block_header_time: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> Result<(), Error> {
+    let two_hours_in_the_future = now
+        .checked_add_signed(Duration::hours(2))
+        .ok_or("overflow when calculating 2 hours in the future")?;
+
+    if block_header_time <= two_hours_in_the_future {
+        Ok(())
+    } else {
+        Err("block header time is more than 2 hours in the future".into())
+    }
+}
+
+/// Check if the block header time is less than or equal to
+/// 2 hours in the future, according to the node's local clock.
+///
+/// This is a non-deterministic rule, as clocks vary over time, and
+/// between different nodes.
+///
+/// "In addition, a full validator MUST NOT accept blocks with nTime
+/// more than two hours in the future according to its clock. This
+/// is not strictly a consensus rule because it is nondeterministic,
+/// and clock time varies between nodes. Also note that a block that
+/// is rejected by this rule at a given point in time may later be
+/// accepted."[S 7.5][7.5]
+///
+/// [7.5]: https://zips.z.cash/protocol/protocol.pdf#blockheader
+pub(super) fn node_time_check(block: Arc<Block>) -> Result<(), Error> {
+    node_time_check_helper(block.header.time, Utc::now())
+}

--- a/zebra-consensus/src/verify/block.rs
+++ b/zebra-consensus/src/verify/block.rs
@@ -40,3 +40,139 @@ fn node_time_check_helper(
 pub(super) fn node_time_check(block: Arc<Block>) -> Result<(), Error> {
     node_time_check_helper(block.header.time, Utc::now())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::offset::{LocalResult, TimeZone};
+    use zebra_chain::serialization::ZcashDeserialize;
+
+    #[test]
+    fn time_check_past_block() {
+        // This block is also verified as part of the BlockVerifier service
+        // tests.
+        let block =
+            Arc::<Block>::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_415000_BYTES[..])
+                .expect("block should deserialize");
+
+        // This check is non-deterministic, but BLOCK_MAINNET_415000 is
+        // a long time in the past. So it's unlikely that the test machine
+        // will have a clock that's far enough in the past for the test to
+        // fail.
+        node_time_check(block).expect("the header time from a mainnet block should be valid");
+    }
+
+    #[test]
+    fn time_check_now() {
+        // These checks are deteministic, because all the times are offset
+        // from the current time.
+        let now = Utc::now();
+        let three_hours_in_the_past = now - Duration::hours(3);
+        let two_hours_in_the_future = now + Duration::hours(2);
+        let two_hours_and_one_second_in_the_future =
+            now + Duration::hours(2) + Duration::seconds(1);
+
+        node_time_check_helper(now, now)
+            .expect("the current time should be valid as a block header time");
+        node_time_check_helper(three_hours_in_the_past, now)
+            .expect("a past time should be valid as a block header time");
+        node_time_check_helper(two_hours_in_the_future, now)
+            .expect("2 hours in the future should be valid as a block header time");
+        node_time_check_helper(two_hours_and_one_second_in_the_future, now).expect_err(
+            "2 hours and 1 second in the future should be invalid as a block header time",
+        );
+
+        // Now invert the tests
+        // 3 hours in the future should fail
+        node_time_check_helper(now, three_hours_in_the_past)
+            .expect_err("3 hours in the future should be invalid as a block header time");
+        // The past should succeed
+        node_time_check_helper(now, two_hours_in_the_future)
+            .expect("2 hours in the past should be valid as a block header time");
+        node_time_check_helper(now, two_hours_and_one_second_in_the_future)
+            .expect("2 hours and 1 second in the past should be valid as a block header time");
+    }
+
+    /// Valid unix epoch timestamps for blocks, in seconds
+    static BLOCK_HEADER_VALID_TIMESTAMPS: &[i64] = &[
+        // These times are currently invalid DateTimes, but they could
+        // become valid in future chrono versions
+        i64::MIN,
+        i64::MIN + 1,
+        // These times are valid DateTimes
+        (u32::MIN as i64) - 1,
+        (u32::MIN as i64),
+        (u32::MIN as i64) + 1,
+        (i32::MIN as i64) - 1,
+        (i32::MIN as i64),
+        (i32::MIN as i64) + 1,
+        -1,
+        0,
+        1,
+        // maximum nExpiryHeight or lock_time, in blocks
+        499_999_999,
+        // minimum lock_time, in seconds
+        500_000_000,
+        500_000_001,
+    ];
+
+    /// Invalid unix epoch timestamps for blocks, in seconds
+    static BLOCK_HEADER_INVALID_TIMESTAMPS: &[i64] = &[
+        (i32::MAX as i64) - 1,
+        (i32::MAX as i64),
+        (i32::MAX as i64) + 1,
+        (u32::MAX as i64) - 1,
+        (u32::MAX as i64),
+        (u32::MAX as i64) + 1,
+        // These times are currently invalid DateTimes, but they could
+        // become valid in future chrono versions
+        i64::MAX - 1,
+        i64::MAX,
+    ];
+
+    #[test]
+    fn time_check_fixed() {
+        // These checks are non-deterministic, but the times are all in the
+        // distant past or far future. So it's unlikely that the test
+        // machine will have a clock that makes these tests fail.
+        let now = Utc::now();
+
+        for valid_timestamp in BLOCK_HEADER_VALID_TIMESTAMPS {
+            let block_header_time = match Utc.timestamp_opt(*valid_timestamp, 0) {
+                LocalResult::Single(time) => time,
+                LocalResult::None => {
+                    // Skip the test if the timestamp is invalid
+                    continue;
+                }
+                LocalResult::Ambiguous(_, _) => {
+                    // Utc doesn't have ambiguous times
+                    unreachable!();
+                }
+            };
+            node_time_check_helper(block_header_time, now)
+                .expect("the time should be valid as a block header time");
+            // Invert the check, leading to an invalid time
+            node_time_check_helper(now, block_header_time)
+                .expect_err("the inverse comparison should be invalid");
+        }
+
+        for invalid_timestamp in BLOCK_HEADER_INVALID_TIMESTAMPS {
+            let block_header_time = match Utc.timestamp_opt(*invalid_timestamp, 0) {
+                LocalResult::Single(time) => time,
+                LocalResult::None => {
+                    // Skip the test if the timestamp is invalid
+                    continue;
+                }
+                LocalResult::Ambiguous(_, _) => {
+                    // Utc doesn't have ambiguous times
+                    unreachable!();
+                }
+            };
+            node_time_check_helper(block_header_time, now)
+                .expect_err("the time should be invalid as a block header time");
+            // Invert the check, leading to a valid time
+            node_time_check_helper(now, block_header_time)
+                .expect("the inverse comparison should be valid");
+        }
+    }
+}


### PR DESCRIPTION
Reject blocks that are more than 2 hours in the future, according to the node's clock.

~~I'll be able to complete this PR, once we've finished the async `AddBlock()` changes in PR #491.~~

Edit: PR #491 wasn't actually needed.