### PR TITLE
Change config module name to generate

### DIFF
--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -1,14 +1,14 @@
 //! Zebrad Subcommands
 
-mod config;
 mod connect;
+mod generate;
 mod revhex;
 mod seed;
 mod start;
 mod version;
 
 use self::{
-    config::ConfigCmd, connect::ConnectCmd, revhex::RevhexCmd, seed::SeedCmd, start::StartCmd,
+    connect::ConnectCmd, generate::GenerateCmd, revhex::RevhexCmd, seed::SeedCmd, start::StartCmd,
     version::VersionCmd,
 };
 use crate::config::ZebradConfig;
@@ -23,9 +23,9 @@ pub const CONFIG_FILE: &str = "zebrad.toml";
 /// Zebrad Subcommands
 #[derive(Command, Debug, Options, Runnable)]
 pub enum ZebradCmd {
-    /// The `config` subcommand
+    /// The `generate` subcommand
     #[options(help = "generate a skeleton configuration")]
-    Config(ConfigCmd),
+    Generate(GenerateCmd),
 
     /// The `connect` subcommand
     #[options(help = "testing stub for dumping network messages")]

--- a/zebrad/src/commands/generate.rs
+++ b/zebrad/src/commands/generate.rs
@@ -1,17 +1,17 @@
-//! `config` subcommand - generates a skeleton config.
+//! `generate` subcommand - generates a skeleton config.
 
 use crate::config::ZebradConfig;
 use abscissa_core::{Command, Options, Runnable};
 
-/// `config` subcommand
+/// `generate` subcommand
 #[derive(Command, Debug, Options)]
-pub struct ConfigCmd {
+pub struct GenerateCmd {
     /// The file to write the generated config to.
     #[options(help = "The file to write the generated config to (stdout if unspecified)")]
     output_file: Option<String>,
 }
 
-impl Runnable for ConfigCmd {
+impl Runnable for GenerateCmd {
     /// Start the application.
     fn run(&self) {
         let default_config = ZebradConfig {


### PR DESCRIPTION
Mentioned in https://github.com/ZcashFoundation/zebra/issues/400#issuecomment-646212238

As we have a flag `-c|--config` to specify the global configuration file to be used in all subdommands and we also have `config` as a subcomand to generate a configuration file i think we can gain some clearness if we rename the last one to `generate`. This PR do that.