### PR TITLE
Start testing out new version of `eyre` and `color-eyre` in zebra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,29 +289,14 @@ dependencies = [
 
 [[package]]
 name = "color-eyre"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aaa5f071a62a9c06ebab653ec2e2ba76cb936548a83e7af7f0c5dac525067ff"
+version = "0.5.0"
+source = "git+https://github.com/yaahc/color-eyre.git?branch=hooked#f882a88a7037aa621a42c3719d06a2286aa0f8de"
 dependencies = [
  "ansi_term",
  "backtrace",
- "color-backtrace",
- "color-spantrace",
  "eyre",
  "indenter",
  "once_cell",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058b1bb1ea9b128049d3aa4cfbf166c6c8e53f3eade5f40ebb2d2a51cef65058"
-dependencies = [
- "ansi_term",
- "tracing-core",
- "tracing-error",
 ]
 
 [[package]]
@@ -445,11 +430,11 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e412cbea04ea7af520b2f4d4ac1677ce546027a7237d8a40b494e34e1e0e31"
+version = "0.6.0"
+source = "git+https://github.com/yaahc/eyre.git?branch=hooked#48e8006298651b3640ba7214f1b3b129b3babe67"
 dependencies = [
  "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -2343,7 +2328,6 @@ name = "zebra-consensus"
 version = "0.1.0"
 dependencies = [
  "color-eyre",
- "eyre",
  "futures-util",
  "spandoc",
  "tokio",
@@ -2397,7 +2381,6 @@ name = "zebra-state"
 version = "0.1.0"
 dependencies = [
  "color-eyre",
- "eyre",
  "futures",
  "hex",
  "lazy_static",
@@ -2430,7 +2413,6 @@ dependencies = [
  "abscissa_core",
  "chrono",
  "color-eyre",
- "eyre",
  "futures",
  "gumdrop",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,9 +294,22 @@ source = "git+https://github.com/yaahc/color-eyre.git?branch=hooked#f882a88a7037
 dependencies = [
  "ansi_term",
  "backtrace",
+ "color-spantrace",
  "eyre",
  "indenter",
  "once_cell",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058b1bb1ea9b128049d3aa4cfbf166c6c8e53f3eade5f40ebb2d2a51cef65058"
+dependencies = [
+ "ansi_term",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -21,4 +21,4 @@ tokio = { version = "0.2", features = ["full"]}
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.6"
 tracing = "0.1.15"
-color-eyre = "0.3.4"
+color-eyre = { git = "https://github.com/yaahc/color-eyre.git", branch = "hooked" }

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -21,4 +21,4 @@ tokio = { version = "0.2", features = ["full"]}
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.6"
 tracing = "0.1.15"
-color-eyre = { git = "https://github.com/yaahc/color-eyre.git", branch = "hooked" }
+color-eyre = { git = "https://github.com/yaahc/color-eyre.git", branch = "hooked", features = ["capture-spantrace"] }

--- a/tower-batch/tests/ed25519.rs
+++ b/tower-batch/tests/ed25519.rs
@@ -7,6 +7,7 @@ use std::{
     time::Duration,
 };
 
+use color_eyre::eyre::Result;
 use ed25519_zebra::*;
 use futures::stream::{FuturesUnordered, StreamExt};
 use rand::thread_rng;
@@ -130,7 +131,7 @@ where
 }
 
 #[tokio::test]
-async fn batch_flushes_on_max_items() -> color_eyre::Result<()> {
+async fn batch_flushes_on_max_items() -> Result<()> {
     use tokio::time::timeout;
     install_tracing();
 
@@ -141,7 +142,7 @@ async fn batch_flushes_on_max_items() -> color_eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn batch_flushes_on_max_latency() -> color_eyre::Result<()> {
+async fn batch_flushes_on_max_latency() -> Result<()> {
     use tokio::time::timeout;
     install_tracing();
 

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -20,4 +20,4 @@ tokio = { version = "0.2.21", features = ["full"] }
 tracing = "0.1.15"
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.6"
-color-eyre = { git = "https://github.com/yaahc/color-eyre.git", branch = "hooked" }
+color-eyre = { git = "https://github.com/yaahc/color-eyre.git", branch = "hooked", features = ["capture-spantrace"] }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -15,10 +15,9 @@ tower = "0.3.1"
 
 [dev-dependencies]
 zebra-test-vectors = { path = "../zebra-test-vectors/" }
-color-eyre = "0.3.4"
-eyre = "0.4.2"
 spandoc = { git = "https://github.com/yaahc/spandoc.git" }
 tokio = { version = "0.2.21", features = ["full"] }
 tracing = "0.1.15"
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.6"
+color-eyre = { git = "https://github.com/yaahc/color-eyre.git", branch = "hooked" }

--- a/zebra-consensus/src/verify.rs
+++ b/zebra-consensus/src/verify.rs
@@ -105,8 +105,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use color_eyre::Report;
-    use eyre::{bail, ensure, eyre};
+    use color_eyre::eyre::Report;
+    use color_eyre::eyre::{bail, ensure, eyre};
     use tower::{util::ServiceExt, Service};
     use zebra_chain::serialization::ZcashDeserialize;
 

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -25,4 +25,4 @@ tracing-futures = "0.2.4"
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.6"
 tempdir = "0.3.7"
-color-eyre = { git = "https://github.com/yaahc/color-eyre.git", branch = "hooked" }
+color-eyre = { git = "https://github.com/yaahc/color-eyre.git", branch = "hooked", features = ["capture-spantrace"] }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 [dependencies]
 zebra-chain = { path = "../zebra-chain" }
 tower = "0.3.1"
-eyre = "0.4.2"
 futures = "0.3.5"
 lazy_static = "1.4.0"
 hex = "0.4.2"
@@ -18,8 +17,6 @@ sled = "0.32.0"
 serde = { version = "1", features = ["serde_derive"] }
 
 [dev-dependencies]
-color-eyre = "0.3.4"
-eyre = "0.4.2"
 tokio = { version = "0.2.21", features = ["full"] }
 zebra-test-vectors = { path = "../zebra-test-vectors/" }
 spandoc = { git = "https://github.com/yaahc/spandoc.git" }
@@ -28,3 +25,4 @@ tracing-futures = "0.2.4"
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.6"
 tempdir = "0.3.7"
+color-eyre = { git = "https://github.com/yaahc/color-eyre.git", branch = "hooked" }

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -84,8 +84,8 @@ pub enum Response {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use color_eyre::Report;
-    use eyre::{bail, ensure, eyre};
+    use color_eyre::eyre::Report;
+    use color_eyre::eyre::{bail, ensure, eyre};
     use std::sync::Once;
     use tower::Service;
     use tracing_error::ErrorLayer;

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -30,11 +30,10 @@ metrics = "0.12"
 
 zebra-chain = { path = "../zebra-chain" }
 zebra-network = { path = "../zebra-network" }
-eyre = "0.4.3"
-color-eyre = "0.3.4"
 zebra-state = { path = "../zebra-state" }
 tracing-subscriber = { version = "0.2.6", features = ["tracing-log"] }
 tracing-error = "0.1.2"
+color-eyre = { git = "https://github.com/yaahc/color-eyre.git", branch = "hooked" }
 
 [dev-dependencies]
 abscissa_core = { version = "0.5", features = ["testing"] }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -33,7 +33,7 @@ zebra-network = { path = "../zebra-network" }
 zebra-state = { path = "../zebra-state" }
 tracing-subscriber = { version = "0.2.6", features = ["tracing-log"] }
 tracing-error = "0.1.2"
-color-eyre = { git = "https://github.com/yaahc/color-eyre.git", branch = "hooked" }
+color-eyre = { git = "https://github.com/yaahc/color-eyre.git", branch = "hooked", features = ["capture-spantrace"] }
 
 [dev-dependencies]
 abscissa_core = { version = "0.5", features = ["testing"] }

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -85,6 +85,7 @@ impl Application for ZebradApp {
     ) -> Result<Vec<Box<dyn Component<Self>>>, FrameworkError> {
         let terminal = Terminal::new(self.term_colors(command));
         let tracing = self.tracing_component(command);
+        color_eyre::install().unwrap();
 
         Ok(vec![Box::new(terminal), Box::new(tracing)])
     }

--- a/zebrad/src/commands/connect.rs
+++ b/zebrad/src/commands/connect.rs
@@ -2,8 +2,7 @@
 
 use crate::{components::tokio::TokioComponent, prelude::*};
 use abscissa_core::{Command, Options, Runnable};
-use color_eyre::Report;
-use eyre::{eyre, WrapErr};
+use color_eyre::eyre::{eyre, Report, WrapErr};
 use futures::{
     prelude::*,
     stream::{FuturesUnordered, StreamExt},

--- a/zebrad/src/commands/seed.rs
+++ b/zebrad/src/commands/seed.rs
@@ -14,8 +14,7 @@ use tower::{buffer::Buffer, Service, ServiceExt};
 use zebra_network::{AddressBook, BoxedStdError, Request, Response};
 
 use crate::prelude::*;
-use color_eyre::Report;
-use eyre::eyre;
+use color_eyre::eyre::{eyre, Report};
 
 /// Whether our `SeedService` is poll_ready or not.
 #[derive(Debug)]

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -21,8 +21,8 @@
 use crate::config::ZebradConfig;
 use crate::{components::tokio::TokioComponent, prelude::*};
 use abscissa_core::{config, Command, FrameworkError, Options, Runnable};
-use color_eyre::Report;
-use eyre::{eyre, WrapErr};
+use color_eyre::eyre::Report;
+use color_eyre::eyre::{eyre, WrapErr};
 use futures::{
     prelude::*,
     stream::{FuturesUnordered, StreamExt},

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -59,8 +59,10 @@ impl Default for MetricsSection {
 
 #[cfg(test)]
 mod test {
+    use color_eyre::eyre::Result;
+
     #[test]
-    fn test_toml_ser() -> color_eyre::Result<()> {
+    fn test_toml_ser() -> Result<()> {
         let default_config = super::ZebradConfig::default();
         println!("Default config: {:?}", default_config);
 


### PR DESCRIPTION
This change is also going to put a greatly increased pressure to centralize our test setup code such as `install_tracing` into one single place, where we can then add the `color_eyre::install().unwrap()` fn call for setting up the panic and error reporting hooks for each test. With the new `eyre` design if you don't manually call the `install` fn it will continue to use the default err reporting logic provided by `eyre` which is non colored reports and just a `std::backtrace::Backtrace` when compiled on nightly.