### PR TITLE
move block downloads to background tasks

### DIFF
--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -63,8 +63,6 @@ impl StartCmd {
             peer_set,
             state,
             block_requests: FuturesUnordered::new(),
-            downloading: HashSet::new(),
-            downloaded: HashSet::new(),
             fanout: 4,
             prospective_tips: HashSet::new(),
         };


### PR DESCRIPTION
This just parallelizes block downloads, currently we alternate between extending tips and downloading blocks, this cleans that up and hopefully gets us some perf wins but thats not really the main goal. This doesn't address the retry policy or error propagation. For error propagation we need to store the join handles and check them for errors, but for right now I'm gonna punt on that.