### PR TITLE
Revert "Create attestations on our container image builds"

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,7 +50,8 @@ jobs:
         ARTIFACT_URL=$(gcloud container images describe "gcr.io/$PROJECT_ID/$BRANCH_NAME:$SHA7" \
           --format="value(image_summary.fully_qualified_digest)");
 
-        gcloud --quiet alpha container binauthz attestations sign-and-create \
+        gcloud alpha container binauthz attestations sign-and-create \
+          --quiet \
           --artifact-url="${ARTIFACT_URL}" \
           --attestor="projects/zealous-zebra/attestors/zebrad-attestor" \
           --keyversion="projects/zealous-zebra/locations/global/keyRings/binary-authorization/cryptoKeys/zebrad-attestor/cryptoKeyVersions/1";

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Set up gcloud Cloud SDK environment
       uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
       with:
+        version: '295.0.0'
         project_id: ${{ env.PROJECT_ID }}
         service_account_key: ${{ secrets.GCLOUD_AUTH }}
 
@@ -51,7 +52,6 @@ jobs:
           --format="value(image_summary.fully_qualified_digest)");
 
         gcloud alpha container binauthz attestations sign-and-create \
-          --quiet \
           --artifact-url="${ARTIFACT_URL}" \
           --attestor="projects/zealous-zebra/attestors/zebrad-attestor" \
           --keyversion="projects/zealous-zebra/locations/global/keyRings/binary-authorization/cryptoKeys/zebrad-attestor/cryptoKeyVersions/1";

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,9 +55,6 @@ jobs:
           --attestor="projects/zealous-zebra/attestors/zebrad-attestor" \
           --keyversion="projects/zealous-zebra/locations/global/keyRings/binary-authorization/cryptoKeys/zebrad-attestor/cryptoKeyVersions/1";
 
-        gcloud container binauthz attestations list \
-          --attestor="projects/zealous-zebra/attestors/zebrad-attestor" | grep $ARTIFACT_URL;
-
     # Create instance template from container image
     - name: Create instance template
       run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,17 +45,6 @@ jobs:
           --machine-type n1-highcpu-32 \
           --timeout 3600s \
 
-    # Create an attestation on the new image with our existing attestor
-    - name: Create attestation
-      run: |
-        ARTIFACT_URL=$(gcloud container images describe "gcr.io/$PROJECT_ID/$BRANCH_NAME:$SHA7" \
-          --format="value(image_summary.fully_qualified_digest)");
-
-        gcloud alpha container binauthz attestations sign-and-create \
-          --artifact-url="${ARTIFACT_URL}" \
-          --attestor="projects/zealous-zebra/attestors/zebrad-attestor" \
-          --keyversion="projects/zealous-zebra/locations/global/keyRings/binary-authorization/cryptoKeys/zebrad-attestor/cryptoKeyVersions/1";
-
     # Create instance template from container image
     - name: Create instance template
       run: |


### PR DESCRIPTION
Reverts ZcashFoundation/zebra#544

We need to check is this container image (id'd by its sha256) has already been built and attested to (like on a branch build), else the attempt to sign-and-attest will fail.