### PR TITLE
bug cleanup related to error handling

### DIFF
--- a/zebra-state/src/on_disk.rs
+++ b/zebra-state/src/on_disk.rs
@@ -108,7 +108,7 @@ impl Service<Request> for SledState {
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
+        Poll::Ready(Err("haha".into()))
     }
 
     fn call(&mut self, req: Request) -> Self::Future {

--- a/zebra-state/src/on_disk.rs
+++ b/zebra-state/src/on_disk.rs
@@ -108,7 +108,7 @@ impl Service<Request> for SledState {
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Err("haha".into()))
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, req: Request) -> Self::Future {

--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -49,12 +49,14 @@ static GET_TIP_TRANSCRIPT: Lazy<Vec<(Request, Response)>> = Lazy::new(|| {
 });
 
 #[tokio::test]
+#[spandoc::spandoc]
 async fn check_transcripts() -> Result<(), Report> {
     zebra_test::init();
 
     for transcript_data in &[&ADD_BLOCK_TRANSCRIPT, &GET_TIP_TRANSCRIPT] {
         let service = in_memory::init();
         let transcript = Transcript::from(transcript_data.iter().cloned());
+        /// SPANDOC: check the in memory service against the transcript
         transcript.check(service).await?;
 
         let storage_guard = TempDir::new("")?;
@@ -62,6 +64,7 @@ async fn check_transcripts() -> Result<(), Report> {
             path: storage_guard.path().to_owned(),
         });
         let transcript = Transcript::from(transcript_data.iter().cloned());
+        /// SPANDOC: check the on disk service against the transcript
         transcript.check(service).await?;
         // Delete the contents of the temp directory before going to the next case.
         std::mem::drop(storage_guard);

--- a/zebra-test/src/lib.rs
+++ b/zebra-test/src/lib.rs
@@ -20,7 +20,47 @@ pub fn init() {
             .with(ErrorLayer::default())
             .init();
 
-        color_eyre::install().unwrap();
+        color_eyre::config::HookBuilder::default()
+            .add_frame_filter(Box::new(|frames| {
+                let mut displayed = std::collections::HashSet::new();
+                let filters = &[
+                    "tokio::",
+                    "<futures_util::",
+                    "std::panic",
+                    "test::run_test_in_process",
+                    "core::ops::function::FnOnce::call_once",
+                    "std::thread::local",
+                    "<core::future::",
+                    "<alloc::boxed::Box",
+                    "<std::panic::AssertUnwindSafe",
+                    "core::result::Result",
+                    "<T as futures_util",
+                    "<tracing_futures::Instrumented",
+                    "test::assert_test_result",
+                    "spandoc::",
+                ];
+
+                frames.retain(|frame| {
+                    let loc = (frame.lineno, &frame.filename);
+                    let inserted = displayed.insert(loc);
+
+                    if !inserted {
+                        return false;
+                    }
+
+                    !filters.iter().any(|f| {
+                        let name = if let Some(name) = frame.name.as_ref() {
+                            name.as_str()
+                        } else {
+                            return true;
+                        };
+
+                        name.starts_with(f)
+                    })
+                });
+            }))
+            .install()
+            .unwrap();
     })
 }
 


### PR DESCRIPTION
My hope is that this will eventually grow to include fixes related to the new versions of eyre and color-eyre, spandoc, and tower error handling so that its hard to make mistakes when using the error handling, rn there are a few critical bugs that make it annoyingly verbose and easy to accidentally construct a span that isn't active when your errors are captured.