### PR TITLE
Try to make CodeCov bot comment on PRs quieter

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,5 +18,5 @@ parsers:
       macro: yes
 
 comment:
-  layout: "files"
+  layout: "diff"
   require_changes: true  # if true: only post the comment if coverage changes

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,3 +16,7 @@ parsers:
       loop: yes
       method: yes
       macro: yes
+
+comment:
+  layout: "" # "reach, diff, flags, files"
+  require_changes: true  # if true: only post the comment if coverage changes

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,5 +18,5 @@ parsers:
       macro: yes
 
 comment:
-  layout: "" # "reach, diff, flags, files"
+  layout: "files"
   require_changes: true  # if true: only post the comment if coverage changes


### PR DESCRIPTION
require_changes: true - "Comments will now only post when coverage
changes. Furthermore, if a comment already exists, and a newer commit
results in no coverage change for the entire pull, the comment will be
deleted."

See what "no layout at all" looks like.

Resolves #570 