### PR TITLE
Adjust coverage job to only trigger on changes to *.rs files

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,27 @@
+name: Coverage
+
+on:
+  pull_request:
+    paths:
+    - '**.rs'
+  push:
+    paths:
+    - '**.rs'
+
+jobs:
+
+  codecov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          version: 'latest'
+          timeout: 300
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v1.0.10

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,23 +35,6 @@ jobs:
           command: build
           args: --verbose --release
 
-  grcov:
-    name: Code Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.12.3'
-          timeout: 300
-      - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v1.0.10
-
   clippy:
     name: Clippy
     runs-on: ubuntu-latest


### PR DESCRIPTION
Moves it to its own workflow. 
Also pulls in latest tarpaulin release every time. 🤞