### PR TITLE
Remove straggler install_tracing()

### DIFF
--- a/zebra-consensus/src/verify/block.rs
+++ b/zebra-consensus/src/verify/block.rs
@@ -475,7 +475,7 @@ mod tests {
     #[tokio::test]
     #[spandoc::spandoc]
     async fn header_solution() -> Result<(), Report> {
-        install_tracing();
+        zebra_test::init();
 
         // Service variables
         let state_service = Box::new(zebra_state::in_memory::init());


### PR DESCRIPTION
This was removed in the PR but the actual squashed commit still had it. 🤔