### PR TITLE
fix spandoc instrumentation for await expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,12 +927,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-
-[[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,15 +1786,33 @@ dependencies = [
 
 [[package]]
 name = "spandoc"
-version = "0.1.3"
-source = "git+https://github.com/yaahc/spandoc.git?rev=554358be632b156a6f0af963b0b244e2665b4767#554358be632b156a6f0af963b0b244e2665b4767"
+version = "0.2.0"
 dependencies = [
- "matches",
+ "spandoc-attribute",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "spandoc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c287699b5fa467d5286a2be14bff499f684133c223cf79c46c6251d5920badb"
+dependencies = [
+ "spandoc-attribute",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "spandoc-attribute"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5254766110c377a921c002ca0775d4e384ba69af951fc4329d9dd77af2c25763"
+dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
  "syn 1.0.33",
- "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -2410,7 +2422,7 @@ dependencies = [
  "futures-util",
  "rand 0.7.3",
  "redjubjub 0.1.1 (git+https://github.com/ZcashFoundation/redjubjub.git?branch=main)",
- "spandoc",
+ "spandoc 0.2.0",
  "tokio",
  "tower",
  "tower-batch",
@@ -2470,7 +2482,7 @@ dependencies = [
  "once_cell",
  "serde",
  "sled",
- "spandoc",
+ "spandoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir",
  "tokio",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,24 +42,24 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
+checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler32"
-version = "1.1.0"
+name = "adler"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
+checksum = "ccc9a9dd069569f212bc4330af9f17c4afb5e8ce185e83dbb14f1349dda18b10"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c259a748ac706ba73d609b73fc13469e128337f9a6b2fb3cc82d100f8dd8d511"
+checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
  "memchr",
 ]
@@ -70,7 +70,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -105,7 +105,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -116,9 +116,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c"
+checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -501,7 +501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -649,7 +649,7 @@ dependencies = [
  "libc",
  "log",
  "rustc_version",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -684,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "gumdrop"
@@ -739,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
@@ -878,9 +878,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
 
 [[package]]
 name = "linked-hash-map"
@@ -940,9 +940,9 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
 dependencies = [
  "autocfg",
 ]
@@ -1052,11 +1052,11 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
 dependencies = [
- "adler32",
+ "adler",
 ]
 
 [[package]]
@@ -1080,14 +1080,14 @@ dependencies = [
 
 [[package]]
 name = "mio-named-pipes"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
  "mio",
  "miow 0.3.5",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1120,7 +1120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
 dependencies = [
  "socket2",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1131,7 +1131,7 @@ checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1214,7 +1214,7 @@ dependencies = [
  "redox_syscall",
  "rustc_version",
  "smallvec 0.6.13",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1227,8 +1227,8 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall",
- "smallvec 1.4.0",
- "winapi 0.3.8",
+ "smallvec 1.4.1",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1296,7 +1296,7 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
- "unicode-xid 0.2.0",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
@@ -1337,7 +1337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7a1905379198075914bc93d32a5465c40474f90a078bb13439cb00c547bcc"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1374,7 +1374,7 @@ dependencies = [
  "libc",
  "rand_core 0.3.1",
  "rdrand",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1453,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "redjubjub"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9717635678eabb203f6806561c7aa976610a9f6f0bfaadf1ca14dca35957741"
+checksum = "a07921b44f102eef69b63546f25927c9ed0efe561de73d40d3c4b86e5e127f63"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -1506,7 +1506,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1651,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
+checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1756,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 
 [[package]]
 name = "socket2"
@@ -1769,16 +1769,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "spandoc"
-version = "0.2.0"
-dependencies = [
- "spandoc-attribute",
- "tracing",
- "tracing-futures",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1834,7 +1825,7 @@ checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "unicode-xid 0.2.0",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
@@ -1846,7 +1837,7 @@ dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
  "syn 1.0.33",
- "unicode-xid 0.2.0",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
@@ -1870,7 +1861,7 @@ dependencies = [
  "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1918,7 +1909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1942,7 +1933,7 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "tokio-macros",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2229,7 +2220,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
@@ -2255,9 +2246,9 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "version_check"
@@ -2298,9 +2289,9 @@ checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -2324,7 +2315,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2409,13 +2400,8 @@ dependencies = [
  "futures",
  "futures-util",
  "rand 0.7.3",
-<<<<<<< HEAD
- "redjubjub 0.1.1 (git+https://github.com/ZcashFoundation/redjubjub.git?branch=main)",
- "spandoc 0.2.0",
-=======
  "redjubjub",
  "spandoc",
->>>>>>> main
  "tokio",
  "tower",
  "tower-batch",
@@ -2475,7 +2461,7 @@ dependencies = [
  "once_cell",
  "serde",
  "sled",
- "spandoc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spandoc",
  "tempdir",
  "tokio",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,5 @@ panic = "abort"
 
 [patch.crates-io]
 abscissa_core = { git = "https://github.com/yaahc/abscissa.git", rev = "41d342a9344e38442b2211b07f28a89505892a21" }
-spandoc = { git = "https://github.com/yaahc/spandoc.git", rev = "554358be632b156a6f0af963b0b244e2665b4767" }
+# spandoc = { git = "https://github.com/yaahc/spandoc.git", rev = "554358be632b156a6f0af963b0b244e2665b4767" }
+# spandoc = { path = "/home/jlusby/git/yaahc/spandoc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,3 @@ panic = "abort"
 
 [patch.crates-io]
 abscissa_core = { git = "https://github.com/yaahc/abscissa.git", rev = "41d342a9344e38442b2211b07f28a89505892a21" }
-# spandoc = { git = "https://github.com/yaahc/spandoc.git", rev = "554358be632b156a6f0af963b0b244e2665b4767" }
-# spandoc = { path = "/home/jlusby/git/yaahc/spandoc" }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -23,8 +23,7 @@ zebra-state = { path = "../zebra-state" }
 [dev-dependencies]
 color-eyre = "0.5"
 rand = "0.7"
-# spandoc = "0.1"
-spandoc = { path = "/home/jlusby/git/yaahc/spandoc" }
+spandoc = "0.2"
 tokio = { version = "0.2", features = ["full"] }
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.7"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -23,7 +23,8 @@ zebra-state = { path = "../zebra-state" }
 [dev-dependencies]
 color-eyre = "0.5"
 rand = "0.7"
-spandoc = "0.1"
+# spandoc = "0.1"
+spandoc = { path = "/home/jlusby/git/yaahc/spandoc" }
 tokio = { version = "0.2", features = ["full"] }
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.7"

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -750,6 +750,10 @@ mod tests {
     const VERIFY_TIMEOUT_SECONDS: u64 = 10;
 
     #[tokio::test]
+    async fn single_item_checkpoint_list_test() -> Result<(), Report> {
+        single_item_checkpoint_list().await
+    }
+
     #[spandoc::spandoc]
     async fn single_item_checkpoint_list() -> Result<(), Report> {
         zebra_test::init();
@@ -781,17 +785,17 @@ mod tests {
             BlockHeight(0)
         );
 
-        /// Make sure the verifier service is ready
+        /// SPANDOC: Make sure the verifier service is ready
         let ready_verifier_service = checkpoint_verifier
             .ready_and()
             .map_err(|e| eyre!(e))
             .await?;
-        /// Set up the future for block 0
+        /// SPANDOC: Set up the future for block 0
         let verify_future = timeout(
             Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
             ready_verifier_service.call(block0.clone()),
         );
-        /// Wait for the response for block 0
+        /// SPANDOC: Wait for the response for block 0
         // TODO(teor || jlusby): check error kind
         let verify_response = verify_future
             .map_err(|e| eyre!(e))
@@ -818,6 +822,10 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn multi_item_checkpoint_list_test() -> Result<(), Report> {
+        multi_item_checkpoint_list().await
+    }
+
     #[spandoc::spandoc]
     async fn multi_item_checkpoint_list() -> Result<(), Report> {
         zebra_test::init();
@@ -860,18 +868,18 @@ mod tests {
 
         // Now verify each block
         for (block, height, hash) in checkpoint_data {
-            /// Make sure the verifier service is ready
+            /// SPANDOC: Make sure the verifier service is ready
             let ready_verifier_service = checkpoint_verifier
                 .ready_and()
                 .map_err(|e| eyre!(e))
                 .await?;
 
-            /// Set up the future for block {?height}
+            /// SPANDOC: Set up the future for block {?height}
             let verify_future = timeout(
                 Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
                 ready_verifier_service.call(block.clone()),
             );
-            /// Wait for the response for block {?height}
+            /// SPANDOC: Wait for the response for block {?height}
             // TODO(teor || jlusby): check error kind
             let verify_response = verify_future
                 .map_err(|e| eyre!(e))
@@ -923,6 +931,10 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn block_higher_than_max_checkpoint_fail_test() -> Result<(), Report> {
+        block_higher_than_max_checkpoint_fail().await
+    }
+
     #[spandoc::spandoc]
     async fn block_higher_than_max_checkpoint_fail() -> Result<(), Report> {
         zebra_test::init();
@@ -955,17 +967,17 @@ mod tests {
             BlockHeight(0)
         );
 
-        /// Make sure the verifier service is ready
+        /// SPANDOC: Make sure the verifier service is ready
         let ready_verifier_service = checkpoint_verifier
             .ready_and()
             .map_err(|e| eyre!(e))
             .await?;
-        /// Set up the future for block 415000
+        /// SPANDOC: Set up the future for block 415000
         let verify_future = timeout(
             Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
             ready_verifier_service.call(block415000.clone()),
         );
-        /// Wait for the response for block 415000, and expect failure
+        /// SPANDOC: Wait for the response for block 415000, and expect failure
         // TODO(teor || jlusby): check error kind
         let _ = verify_future
             .map_err(|e| eyre!(e))
@@ -990,6 +1002,10 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn wrong_checkpoint_hash_fail_test() -> Result<(), Report> {
+        wrong_checkpoint_hash_fail().await
+    }
+
     #[spandoc::spandoc]
     async fn wrong_checkpoint_hash_fail() -> Result<(), Report> {
         zebra_test::init();
@@ -1026,12 +1042,12 @@ mod tests {
             BlockHeight(0)
         );
 
-        /// Make sure the verifier service is ready (1/3)
+        /// SPANDOC: Make sure the verifier service is ready (1/3)
         let ready_verifier_service = checkpoint_verifier
             .ready_and()
             .map_err(|e| eyre!(e))
             .await?;
-        /// Set up the future for bad block 0 (1/3)
+        /// SPANDOC: Set up the future for bad block 0 (1/3)
         // TODO(teor || jlusby): check error kind
         let bad_verify_future_1 = timeout(
             Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
@@ -1053,12 +1069,12 @@ mod tests {
             BlockHeight(0)
         );
 
-        /// Make sure the verifier service is ready (2/3)
+        /// SPANDOC: Make sure the verifier service is ready (2/3)
         let ready_verifier_service = checkpoint_verifier
             .ready_and()
             .map_err(|e| eyre!(e))
             .await?;
-        /// Set up the future for bad block 0 again (2/3)
+        /// SPANDOC: Set up the future for bad block 0 again (2/3)
         // TODO(teor || jlusby): check error kind
         let bad_verify_future_2 = timeout(
             Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
@@ -1080,17 +1096,17 @@ mod tests {
             BlockHeight(0)
         );
 
-        /// Make sure the verifier service is ready (3/3)
+        /// SPANDOC: Make sure the verifier service is ready (3/3)
         let ready_verifier_service = checkpoint_verifier
             .ready_and()
             .map_err(|e| eyre!(e))
             .await?;
-        /// Set up the future for good block 0 (3/3)
+        /// SPANDOC: Set up the future for good block 0 (3/3)
         let good_verify_future = timeout(
             Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
             ready_verifier_service.call(good_block0.clone()),
         );
-        /// Wait for the response for good block 0, and expect success (3/3)
+        /// SPANDOC: Wait for the response for good block 0, and expect success (3/3)
         // TODO(teor || jlusby): check error kind
         let verify_response = good_verify_future
             .map_err(|e| eyre!(e))
@@ -1115,7 +1131,7 @@ mod tests {
 
         // Now, await the bad futures, which should have completed
 
-        /// Wait for the response for block 0, and expect failure (1/3)
+        /// SPANDOC: Wait for the response for block 0, and expect failure (1/3)
         // TODO(teor || jlusby): check error kind
         let _ = bad_verify_future_1
             .map_err(|e| eyre!(e))
@@ -1136,7 +1152,7 @@ mod tests {
             BlockHeight(0)
         );
 
-        /// Wait for the response for block 0, and expect failure again (2/3)
+        /// SPANDOC: Wait for the response for block 0, and expect failure again (2/3)
         // TODO(teor || jlusby): check error kind
         let _ = bad_verify_future_2
             .map_err(|e| eyre!(e))
@@ -1161,6 +1177,10 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn checkpoint_drop_cancel_test() -> Result<(), Report> {
+        checkpoint_drop_cancel().await
+    }
+
     #[spandoc::spandoc]
     async fn checkpoint_drop_cancel() -> Result<(), Report> {
         zebra_test::init();
@@ -1203,13 +1223,13 @@ mod tests {
         let mut futures = Vec::new();
         // Now collect verify futures for each block
         for (block, height, hash) in checkpoint_data {
-            /// Make sure the verifier service is ready
+            /// SPANDOC: Make sure the verifier service is ready
             let ready_verifier_service = checkpoint_verifier
                 .ready_and()
                 .map_err(|e| eyre!(e))
                 .await?;
 
-            /// Set up the future for block {?height}
+            /// SPANDOC: Set up the future for block {?height}
             let verify_future = timeout(
                 Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
                 ready_verifier_service.call(block.clone()),
@@ -1236,7 +1256,7 @@ mod tests {
         drop(checkpoint_verifier);
 
         for (verify_future, height, hash) in futures {
-            /// Check the response for block {?height}
+            /// SPANDOC: Check the response for block {?height}
             let verify_response = verify_future
                 .map_err(|e| eyre!(e))
                 .await

--- a/zebra-consensus/src/verify/block.rs
+++ b/zebra-consensus/src/verify/block.rs
@@ -291,6 +291,10 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn verify_test() -> Result<(), Report> {
+        verify().await
+    }
+
     #[spandoc::spandoc]
     async fn verify() -> Result<(), Report> {
         zebra_test::init();
@@ -302,9 +306,9 @@ mod tests {
         let state_service = Box::new(zebra_state::in_memory::init());
         let mut block_verifier = super::init(state_service);
 
-        /// Make sure the verifier service is ready
+        /// SPANDOC: Make sure the verifier service is ready
         let ready_verifier_service = block_verifier.ready_and().await.map_err(|e| eyre!(e))?;
-        /// Verify the block
+        /// SPANDOC: Verify the block
         let verify_response = ready_verifier_service
             .call(block.clone())
             .await
@@ -316,6 +320,10 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn round_trip_test() -> Result<(), Report> {
+        round_trip().await
+    }
+
     #[spandoc::spandoc]
     async fn round_trip() -> Result<(), Report> {
         zebra_test::init();
@@ -327,9 +335,9 @@ mod tests {
         let mut state_service = zebra_state::in_memory::init();
         let mut block_verifier = super::init(state_service.clone());
 
-        /// Make sure the verifier service is ready
+        /// SPANDOC: Make sure the verifier service is ready
         let ready_verifier_service = block_verifier.ready_and().await.map_err(|e| eyre!(e))?;
-        /// Verify the block
+        /// SPANDOC: Verify the block
         let verify_response = ready_verifier_service
             .call(block.clone())
             .await
@@ -337,9 +345,9 @@ mod tests {
 
         assert_eq!(verify_response, hash);
 
-        /// Make sure the state service is ready
+        /// SPANDOC: Make sure the state service is ready
         let ready_state_service = state_service.ready_and().await.map_err(|e| eyre!(e))?;
-        /// Make sure the block was added to the state
+        /// SPANDOC: Make sure the block was added to the state
         let state_response = ready_state_service
             .call(zebra_state::Request::GetBlock { hash })
             .await
@@ -358,6 +366,10 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn verify_fail_add_block_test() -> Result<(), Report> {
+        verify_fail_add_block().await
+    }
+
     #[spandoc::spandoc]
     async fn verify_fail_add_block() -> Result<(), Report> {
         zebra_test::init();
@@ -369,9 +381,9 @@ mod tests {
         let mut state_service = zebra_state::in_memory::init();
         let mut block_verifier = super::init(state_service.clone());
 
-        /// Make sure the verifier service is ready (1/2)
+        /// SPANDOC: Make sure the verifier service is ready (1/2)
         let ready_verifier_service = block_verifier.ready_and().await.map_err(|e| eyre!(e))?;
-        /// Verify the block for the first time
+        /// SPANDOC: Verify the block for the first time
         let verify_response = ready_verifier_service
             .call(block.clone())
             .await
@@ -379,9 +391,9 @@ mod tests {
 
         assert_eq!(verify_response, hash);
 
-        /// Make sure the state service is ready (1/2)
+        /// SPANDOC: Make sure the state service is ready (1/2)
         let ready_state_service = state_service.ready_and().await.map_err(|e| eyre!(e))?;
-        /// Make sure the block was added to the state
+        /// SPANDOC: Make sure the block was added to the state
         let state_response = ready_state_service
             .call(zebra_state::Request::GetBlock { hash })
             .await
@@ -396,9 +408,9 @@ mod tests {
             bail!("unexpected response kind: {:?}", state_response);
         }
 
-        /// Make sure the verifier service is ready (2/2)
+        /// SPANDOC: Make sure the verifier service is ready (2/2)
         let ready_verifier_service = block_verifier.ready_and().await.map_err(|e| eyre!(e))?;
-        /// Now try to add the block again, verify should fail
+        /// SPANDOC: Now try to add the block again, verify should fail
         // TODO(teor): ignore duplicate block verifies?
         // TODO(teor || jlusby): check error kind
         ready_verifier_service
@@ -406,9 +418,9 @@ mod tests {
             .await
             .unwrap_err();
 
-        /// Make sure the state service is ready (2/2)
+        /// SPANDOC: Make sure the state service is ready (2/2)
         let ready_state_service = state_service.ready_and().await.map_err(|e| eyre!(e))?;
-        /// But the state should still return the original block we added
+        /// SPANDOC: But the state should still return the original block we added
         let state_response = ready_state_service
             .call(zebra_state::Request::GetBlock { hash })
             .await
@@ -427,6 +439,10 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn verify_fail_future_time_test() -> Result<(), Report> {
+        verify_fail_future_time().await
+    }
+
     #[spandoc::spandoc]
     async fn verify_fail_future_time() -> Result<(), Report> {
         zebra_test::init();
@@ -449,18 +465,18 @@ mod tests {
 
         let arc_block: Arc<Block> = block.into();
 
-        /// Make sure the verifier service is ready
+        /// SPANDOC: Make sure the verifier service is ready
         let ready_verifier_service = block_verifier.ready_and().await.map_err(|e| eyre!(e))?;
-        /// Try to add the block, and expect failure
+        /// SPANDOC: Try to add the block, and expect failure
         // TODO(teor || jlusby): check error kind
         ready_verifier_service
             .call(arc_block.clone())
             .await
             .unwrap_err();
 
-        /// Make sure the state service is ready (2/2)
+        /// SPANDOC: Make sure the state service is ready (2/2)
         let ready_state_service = state_service.ready_and().await.map_err(|e| eyre!(e))?;
-        /// Now make sure the block isn't in the state
+        /// SPANDOC: Now make sure the block isn't in the state
         // TODO(teor || jlusby): check error kind
         ready_state_service
             .call(zebra_state::Request::GetBlock {
@@ -473,6 +489,10 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn header_solution_test() -> Result<(), Report> {
+        header_solution().await
+    }
+
     #[spandoc::spandoc]
     async fn header_solution() -> Result<(), Report> {
         zebra_test::init();

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -19,8 +19,7 @@ serde = { version = "1", features = ["serde_derive"] }
 [dev-dependencies]
 tokio = { version = "0.2.21", features = ["full"] }
 zebra-test = { path = "../zebra-test/" }
-# spandoc = "0.1"
-spandoc = { path = "/home/jlusby/git/yaahc/spandoc" }
+spandoc = "0.2"
 tracing = "0.1.15"
 tracing-futures = "0.2.4"
 tempdir = "0.3.7"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -19,13 +19,8 @@ serde = { version = "1", features = ["serde_derive"] }
 [dev-dependencies]
 tokio = { version = "0.2.21", features = ["full"] }
 zebra-test = { path = "../zebra-test/" }
-<<<<<<< HEAD
 spandoc = "0.2"
-tracing = "0.1.15"
-=======
-spandoc = "0.1"
 tracing = "0.1.16"
->>>>>>> main
 tracing-futures = "0.2.4"
 tempdir = "0.3.7"
 color-eyre = "0.5"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -19,7 +19,8 @@ serde = { version = "1", features = ["serde_derive"] }
 [dev-dependencies]
 tokio = { version = "0.2.21", features = ["full"] }
 zebra-test = { path = "../zebra-test/" }
-spandoc = "0.1"
+# spandoc = "0.1"
+spandoc = { path = "/home/jlusby/git/yaahc/spandoc" }
 tracing = "0.1.15"
 tracing-futures = "0.2.4"
 tempdir = "0.3.7"


### PR DESCRIPTION
This PR and the associated changes upstream in `spandoc` fix the issues in https://github.com/ZcashFoundation/zebra/issues/609 and make it so either ordering of `map_err` and `await` is valid and correctly instrumented :partying_face: 