### PR TITLE
Bind internal services to localhost

### DIFF
--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -121,7 +121,9 @@ where
                 services: PeerServices::NODE_NETWORK,
                 timestamp: Utc::now(),
                 address_recv: (PeerServices::NODE_NETWORK, addr),
-                address_from: (PeerServices::NODE_NETWORK, "0.0.0.0:9000".parse().unwrap()),
+                // TODO: when we've implemented block and transaction relaying,
+                //       send our configured address to the peer
+                address_from: (PeerServices::NODE_NETWORK, "0.0.0.0:8233".parse().unwrap()),
                 nonce: local_nonce,
                 user_agent,
                 // XXX eventually the `PeerConnector` will need to have a handle

--- a/zebrad/src/components/metrics.rs
+++ b/zebrad/src/components/metrics.rs
@@ -21,8 +21,16 @@ impl MetricsEndpoint {
     pub fn init_tokio(&mut self, tokio_component: &TokioComponent) -> Result<(), FrameworkError> {
         info!("Initializing metrics endpoint");
 
-        // XXX load metrics addr from config
-        let addr = "0.0.0.0:9999"
+        // TODO:
+        //  - load metrics addr from config
+        //  - security: disable service by default
+        //    Binding to localhost by default is insecure, because other
+        //    applications on the machine (such as a web browser) can access
+        //    the endpoint.
+        //
+        // The `ToSocketAddrs` trait docs say that host names are supported,
+        // but "localhost" does not work here
+        let addr = "127.0.0.1:9999"
             .parse()
             .expect("Hardcoded address should be parseable");
 

--- a/zebrad/src/components/tracing.rs
+++ b/zebrad/src/components/tracing.rs
@@ -35,8 +35,16 @@ impl TracingEndpoint {
         let service =
             make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(request_handler)) });
 
-        // XXX load tracing addr from config
-        let addr = "0.0.0.0:3000"
+        // TODO:
+        //  - load tracing addr from config
+        //  - security: disable service by default
+        //    Binding to localhost by default is insecure, because other
+        //    applications on the machine (such as a web browser) can access
+        //    the endpoint.
+        //
+        // The `ToSocketAddrs` trait docs say that host names are supported,
+        // but "localhost" does not work here
+        let addr = "127.0.0.1:3000"
             .parse()
             .expect("Hardcoded address should be parseable");
 

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -52,7 +52,9 @@ pub struct MetricsSection {
 impl Default for MetricsSection {
     fn default() -> Self {
         Self {
-            endpoint_addr: "0.0.0.0:9999".parse().unwrap(),
+            // The `ToSocketAddrs` trait docs say that host names are supported,
+            // but "localhost" does not work here
+            endpoint_addr: "127.0.0.1:9999".parse().unwrap(),
         }
     }
 }


### PR DESCRIPTION
Let's bind internal services like tracing and metrics to localhost by default, for security reasons.