### PR TITLE
reorder workspace crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-        "tower-batch",
+        "zebrad",
         "zebra-chain",
         "zebra-network",
         "zebra-state",
@@ -10,7 +10,7 @@ members = [
         "zebra-client",
         "zebra-test",
         "zebra-utils",
-        "zebrad",
+        "tower-batch",
 ]
 
 [profile.dev]


### PR DESCRIPTION
The order of the workspace crates determines which crate ends up being opened when you run `cargo doc --open` in the root. Right now we're defaulting to displaying the docs for `tower-batch`. This at least changes the default to `zebrad`'s docs which can act as a landing page for the docs of the entire project.

Down the road I'd like to add some sort of Table of Contents to easily jump to the other major workspace crates from `zebrad`.