### PR TITLE
tower-fallback: add implementation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,6 +2570,7 @@ dependencies = [
  "tracing-error",
  "tracing-futures",
  "zebra-chain",
+ "zebra-test",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+
+[[package]]
 name = "equihash"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,6 +2148,19 @@ dependencies = [
  "futures-core",
  "pin-project",
  "tower-service",
+]
+
+[[package]]
+name = "tower-fallback"
+version = "0.1.0"
+dependencies = [
+ "either",
+ "futures-core",
+ "pin-project",
+ "tokio",
+ "tower",
+ "tracing",
+ "zebra-test",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
  "ident_case",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
  "synstructure",
 ]
 
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc9a9dd069569f212bc4330af9f17c4afb5e8ce185e83dbb14f1349dda18b10"
+checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aho-corasick"
@@ -426,7 +426,7 @@ dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
  "strsim 0.9.3",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -437,7 +437,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -455,7 +455,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.2",
+ "generic-array 0.14.3",
 ]
 
 [[package]]
@@ -466,7 +466,7 @@ checksum = "e6269d127174b18c665e683e23c2c55d3735fadbec4181c7c70b0450b764bfa5"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -488,12 +488,6 @@ dependencies = [
  "sha2",
  "thiserror",
 ]
-
-[[package]]
-name = "either"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "equihash"
@@ -616,7 +610,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -683,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac746a5f3bbfdadd6106868134545e684693d54d9d44f6e9588a7d54af0bf980"
+checksum = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
 dependencies = [
  "typenum",
  "version_check",
@@ -725,14 +719,14 @@ checksum = "90454ce4de40b7ca6a8968b5ef367bdab48413962588d0d2b1638d60090c35d7"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
 name = "h2"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
+checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
 dependencies = [
  "bytes",
  "fnv",
@@ -741,10 +735,10 @@ dependencies = [
  "futures-util",
  "http",
  "indexmap",
- "log",
  "slab",
  "tokio",
  "tokio-util 0.3.1",
+ "tracing",
 ]
 
 [[package]]
@@ -1283,7 +1277,7 @@ checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -1313,7 +1307,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
  "version_check",
 ]
 
@@ -1325,7 +1319,7 @@ checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
  "syn-mid",
  "version_check",
 ]
@@ -1529,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "regex"
@@ -1701,7 +1695,7 @@ checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -1847,7 +1841,7 @@ checksum = "5254766110c377a921c002ca0775d4e384ba69af951fc4329d9dd77af2c25763"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -1883,7 +1877,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -1905,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
+checksum = "936cae2873c940d92e697597c5eee105fb570cd5689c695806f672883653349b"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -1922,7 +1916,7 @@ checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -1933,7 +1927,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
  "unicode-xid 0.2.1",
 ]
 
@@ -1996,7 +1990,7 @@ checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -2050,7 +2044,7 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -2154,7 +2148,6 @@ dependencies = [
 name = "tower-fallback"
 version = "0.1.0"
 dependencies = [
- "either",
  "futures-core",
  "pin-project",
  "tokio",
@@ -2272,7 +2265,7 @@ checksum = "f0693bf8d6f2bf22c690fc61a9d21ac69efdbb894a17ed596b9af0f01e64b84b"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
 ]
 
 [[package]]
@@ -2347,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
@@ -2678,6 +2671,6 @@ checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.34",
  "synstructure",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
         "zebra-test",
         "zebra-utils",
         "tower-batch",
+        "tower-fallback",
 ]
 
 [profile.dev]

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -6,7 +6,6 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-either = "1.5"
 tower = "0.3"
 futures-core = "0.3.5"
 pin-project = "0.4.20"

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tower-fallback"
+version = "0.1.0"
+authors = ["Zcash Foundation <zebra@zfnd.org>"]
+license = "MIT"
+edition = "2018"
+
+[dependencies]
+either = "1.5"
+tower = "0.3"
+futures-core = "0.3.5"
+pin-project = "0.4.20"
+tracing = "0.1"
+
+[dev-dependencies]
+zebra-test = { path = "../zebra-test/" }
+tokio = { version = "0.2", features = ["full"]}

--- a/tower-fallback/src/future.rs
+++ b/tower-fallback/src/future.rs
@@ -1,0 +1,158 @@
+//! Future types for the `Fallback` middleware.
+
+use std::{
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use either::Either;
+use futures_core::ready;
+use pin_project::pin_project;
+use tower::Service;
+
+/// Future that completes either with the first service's successful response, or
+/// with the second service's response.
+#[pin_project]
+pub struct ResponseFuture<S1, S2, Request>
+where
+    S1: Service<Request>,
+    S2: Service<Request, Response = <S1 as Service<Request>>::Response>,
+{
+    #[pin]
+    state: ResponseState<S1, S2, Request>,
+}
+
+#[pin_project(project_replace, project = ResponseStateProj)]
+enum ResponseState<S1, S2, Request>
+where
+    S1: Service<Request>,
+    S2: Service<Request>,
+{
+    PollResponse1 {
+        #[pin]
+        fut: S1::Future,
+        req: Request,
+        svc2: S2,
+    },
+    PollReady2 {
+        req: Request,
+        svc2: S2,
+    },
+    PollResponse2 {
+        #[pin]
+        fut: S2::Future,
+    },
+    // Placeholder value to swap into the pin projection of the enum so we can take ownership of the fields.
+    Tmp,
+}
+
+impl<S1, S2, Request> ResponseFuture<S1, S2, Request>
+where
+    S1: Service<Request>,
+    S2: Service<Request, Response = <S1 as Service<Request>>::Response>,
+{
+    pub(crate) fn new(fut: S1::Future, req: Request, svc2: S2) -> Self {
+        ResponseFuture {
+            state: ResponseState::PollResponse1 { fut, req, svc2 },
+        }
+    }
+}
+
+impl<S1, S2, Request> Future for ResponseFuture<S1, S2, Request>
+where
+    S1: Service<Request>,
+    S2: Service<Request, Response = <S1 as Service<Request>>::Response>,
+{
+    type Output = Result<
+        <S1 as Service<Request>>::Response,
+        Either<<S1 as Service<Request>>::Error, <S2 as Service<Request>>::Error>,
+    >;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+        loop {
+            match this.state.as_mut().project() {
+                ResponseStateProj::PollResponse1 { fut, .. } => match ready!(fut.poll(cx)) {
+                    Ok(rsp) => return Poll::Ready(Ok(rsp)),
+                    Err(_) => {
+                        tracing::debug!("got error from svc1, retrying on svc2");
+                        if let __ResponseStateProjectionOwned::PollResponse1 { req, svc2, .. } =
+                            this.state.as_mut().project_replace(ResponseState::Tmp)
+                        {
+                            this.state.set(ResponseState::PollReady2 { req, svc2 });
+                        } else {
+                            unreachable!();
+                        }
+                    }
+                },
+                ResponseStateProj::PollReady2 { svc2, .. } => match ready!(svc2.poll_ready(cx)) {
+                    Err(e) => return Poll::Ready(Err(Either::Right(e))),
+                    Ok(()) => {
+                        if let __ResponseStateProjectionOwned::PollReady2 { mut svc2, req } =
+                            this.state.as_mut().project_replace(ResponseState::Tmp)
+                        {
+                            this.state.set(ResponseState::PollResponse2 {
+                                fut: svc2.call(req),
+                            });
+                        } else {
+                            unreachable!();
+                        }
+                    }
+                },
+                ResponseStateProj::PollResponse2 { fut } => {
+                    return fut.poll(cx).map_err(Either::Right)
+                }
+                ResponseStateProj::Tmp => unreachable!(),
+            }
+        }
+    }
+}
+
+impl<S1, S2, Request> Debug for ResponseFuture<S1, S2, Request>
+where
+    S1: Service<Request>,
+    S2: Service<Request, Response = <S1 as Service<Request>>::Response>,
+    Request: Debug,
+    S1::Future: Debug,
+    S2: Debug,
+    S2::Future: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResponseFuture")
+            .field("state", &self.state)
+            .finish()
+    }
+}
+
+impl<S1, S2, Request> Debug for ResponseState<S1, S2, Request>
+where
+    S1: Service<Request>,
+    S2: Service<Request, Response = <S1 as Service<Request>>::Response>,
+    Request: Debug,
+    S1::Future: Debug,
+    S2: Debug,
+    S2::Future: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResponseState::PollResponse1 { fut, req, svc2 } => f
+                .debug_struct("ResponseState::PollResponse1")
+                .field("fut", fut)
+                .field("req", req)
+                .field("svc2", svc2)
+                .finish(),
+            ResponseState::PollReady2 { req, svc2 } => f
+                .debug_struct("ResponseState::PollReady2")
+                .field("req", req)
+                .field("svc2", svc2)
+                .finish(),
+            ResponseState::PollResponse2 { fut } => f
+                .debug_struct("ResponseState::PollResponse2")
+                .field("fut", fut)
+                .finish(),
+            ResponseState::Tmp => unreachable!(),
+        }
+    }
+}

--- a/tower-fallback/src/lib.rs
+++ b/tower-fallback/src/lib.rs
@@ -6,4 +6,5 @@ pub mod future;
 mod service;
 
 pub use self::service::Fallback;
-pub use either::Either;
+
+pub type BoxedError = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/tower-fallback/src/lib.rs
+++ b/tower-fallback/src/lib.rs
@@ -1,0 +1,9 @@
+/// A service combinator that sends requests to a first service, then retries
+/// processing on a second fallback service if the first service errors.
+///
+/// TODO: similar code exists in linkerd and could be upstreamed into tower
+pub mod future;
+mod service;
+
+pub use self::service::Fallback;
+pub use either::Either;

--- a/tower-fallback/src/lib.rs
+++ b/tower-fallback/src/lib.rs
@@ -1,7 +1,15 @@
-/// A service combinator that sends requests to a first service, then retries
-/// processing on a second fallback service if the first service errors.
-///
-/// TODO: similar code exists in linkerd and could be upstreamed into tower
+//! A service combinator that sends requests to a first service, then retries
+//! processing on a second fallback service if the first service errors.
+//!
+//! Fallback designs have [a number of downsides][aws-fallback] but may be useful
+//! in some cases. For instance, when using batch verification, the `Fallback`
+//! wrapper can be used to fall back to individual verification of each item when
+//! a batch fails to verify.
+//!
+//! TODO: compare with similar code in linkerd.
+//!
+//! [aws-fallback]: https://aws.amazon.com/builders-library/avoiding-fallback-in-distributed-systems/
+
 pub mod future;
 mod service;
 

--- a/tower-fallback/src/service.rs
+++ b/tower-fallback/src/service.rs
@@ -1,0 +1,54 @@
+use super::future::ResponseFuture;
+
+use either::Either;
+use std::task::{Context, Poll};
+use tower::Service;
+
+/// Provides fallback processing on a second service if the first service returned an error.
+#[derive(Debug)]
+pub struct Fallback<S1, S2>
+where
+    S2: Clone,
+{
+    svc1: S1,
+    svc2: S2,
+}
+
+impl<S1: Clone, S2: Clone> Clone for Fallback<S1, S2> {
+    fn clone(&self) -> Self {
+        Self {
+            svc1: self.svc1.clone(),
+            svc2: self.svc2.clone(),
+        }
+    }
+}
+
+impl<S1, S2: Clone> Fallback<S1, S2> {
+    /// Creates a new `Fallback` wrapping a pair of services.
+    ///
+    /// Requests are processed on `svc1`, and retried on `svc2` if `svc1` errored.
+    pub fn new(svc1: S1, svc2: S2) -> Self {
+        Self { svc1, svc2 }
+    }
+}
+
+impl<S1, S2, Request> Service<Request> for Fallback<S1, S2>
+where
+    S1: Service<Request>,
+    S2: Service<Request, Response = <S1 as Service<Request>>::Response>,
+    S2: Clone,
+    Request: Clone,
+{
+    type Response = <S1 as Service<Request>>::Response;
+    type Error = Either<<S1 as Service<Request>>::Error, <S2 as Service<Request>>::Error>;
+    type Future = ResponseFuture<S1, S2, Request>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.svc1.poll_ready(cx).map_err(Either::Left)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let request2 = request.clone();
+        ResponseFuture::new(self.svc1.call(request), request2, self.svc2.clone())
+    }
+}

--- a/tower-fallback/tests/fallback.rs
+++ b/tower-fallback/tests/fallback.rs
@@ -1,0 +1,33 @@
+use tower::{service_fn, Service, ServiceExt};
+use tower_fallback::{Either, Fallback};
+
+#[tokio::test]
+async fn fallback() {
+    zebra_test::init();
+
+    // we'd like to use Transcript here but it can't handle errors :(
+
+    let svc1 = service_fn(|val: u64| async move {
+        if val < 10 {
+            Ok(val)
+        } else {
+            Err("too big value on svc1")
+        }
+    });
+    let svc2 = service_fn(|val: u64| async move {
+        if val < 20 {
+            Ok(100 + val)
+        } else {
+            Err("too big value on svc2")
+        }
+    });
+
+    let mut svc = Fallback::new(svc1, svc2);
+
+    assert_eq!(svc.ready_and().await.unwrap().call(1).await, Ok(1));
+    assert_eq!(svc.ready_and().await.unwrap().call(11).await, Ok(111));
+    assert_eq!(
+        svc.ready_and().await.unwrap().call(21).await,
+        Err(Either::Right("too big value on svc2"))
+    );
+}

--- a/tower-fallback/tests/fallback.rs
+++ b/tower-fallback/tests/fallback.rs
@@ -1,5 +1,5 @@
 use tower::{service_fn, Service, ServiceExt};
-use tower_fallback::{Either, Fallback};
+use tower_fallback::Fallback;
 
 #[tokio::test]
 async fn fallback() {
@@ -24,10 +24,7 @@ async fn fallback() {
 
     let mut svc = Fallback::new(svc1, svc2);
 
-    assert_eq!(svc.ready_and().await.unwrap().call(1).await, Ok(1));
-    assert_eq!(svc.ready_and().await.unwrap().call(11).await, Ok(111));
-    assert_eq!(
-        svc.ready_and().await.unwrap().call(21).await,
-        Err(Either::Right("too big value on svc2"))
-    );
+    assert_eq!(svc.ready_and().await.unwrap().call(1).await.unwrap(), 1);
+    assert_eq!(svc.ready_and().await.unwrap().call(11).await.unwrap(), 111);
+    assert!(svc.ready_and().await.unwrap().call(21).await.is_err());
 }


### PR DESCRIPTION
We'll need this in order to pinpoint errors in batch verification.  Another version of the same idea exists in the linkerd source tree somewhere, and it might be better to upstream that one rather than this one.  But this one will work for now.  It has a manually implemented future that avoids having to add an extra layer of boxing for every request.

Trying to use this for Redjubjub or Ed25519 (not included in this PR) reveals some gaps in the upstream APIs: the `batch::Item`s need to be `Clone` (this is a real blocker) and there should be an `Item::verify_alone()` that does individual verification (rather than forcing the caller to create a batch of size 1).