### PR TITLE
fix: Stop revhex on EOF

### DIFF
--- a/zebrad/src/commands/revhex.rs
+++ b/zebrad/src/commands/revhex.rs
@@ -36,7 +36,10 @@ impl Runnable for RevhexCmd {
         if self.input.is_empty() || self.input == "-" {
             // "-" is a typical command-line argument for "read standard input"
             let mut input = String::new();
-            while stdin().read_line(&mut input).is_ok() {
+            // Unlike similar C APIs, read_line returns Ok(0) on EOF.
+            // We can distinguish EOF from an empty line, because the newline is
+            // included in the buffer, so empty lines return Ok(1).
+            while stdin().read_line(&mut input).unwrap_or(0) > 0 {
                 println!("{}", byte_reverse_hex(&input.trim()));
             }
         } else {


### PR DESCRIPTION
Turns out that the Rust file API works differently from the C file API.

Oops!