### PR TITLE
ci: only run cargo test for PRs, not cargo build --release.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,11 +29,6 @@ jobs:
         with:
           command: test
           args: --verbose --all
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --release
 
   clippy:
     name: Clippy


### PR DESCRIPTION
We already built everything in debug mode to run tests, so running a release
build doesn't give us extra information, but it does double the length of every
CI run.