### PR TITLE
tower-batch: test fallback verification example.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-zebra"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a045d3ca7d15222d578515dc6b54fea6c3591763b8fe2f67a45bbd56d5f1989b"
+dependencies = [
+ "curve25519-dalek",
+ "hex",
+ "rand_core 0.5.1",
+ "serde",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "equihash"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,13 +2226,15 @@ dependencies = [
 name = "tower-batch"
 version = "0.1.0"
 dependencies = [
- "ed25519-zebra",
+ "color-eyre",
+ "ed25519-zebra 2.1.0",
  "futures",
  "futures-core",
  "pin-project",
  "rand 0.7.3",
  "tokio",
  "tower",
+ "tower-fallback",
  "tracing",
  "tracing-futures",
  "zebra-test",
@@ -2602,7 +2618,7 @@ dependencies = [
  "chrono",
  "color-eyre",
  "displaydoc",
- "ed25519-zebra",
+ "ed25519-zebra 1.0.0",
  "equihash",
  "futures",
  "hex",

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -15,8 +15,10 @@ tracing-futures = "0.2.4"
 futures = "0.3.5"
 
 [dev-dependencies]
-ed25519-zebra = "1.0"
+ed25519-zebra = "2.1.0"
 rand = "0.7"
 tokio = { version = "0.2", features = ["full"]}
 tracing = "0.1.17"
 zebra-test = { path = "../zebra-test/" }
+tower-fallback = { path = "../tower-fallback/" }
+color-eyre = "0.5"


### PR DESCRIPTION
This exposes an awkward part of the tower-batch API that I think should be fixed before making further changes.