### PR TITLE
Revert #500 (generic errors in tower-batch).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,7 +2105,6 @@ dependencies = [
 name = "tower-batch"
 version = "0.1.0"
 dependencies = [
- "color-eyre",
  "ed25519-zebra",
  "futures",
  "futures-core",

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -19,5 +19,4 @@ ed25519-zebra = "1.0"
 rand = "0.7"
 tokio = { version = "0.2", features = ["full"]}
 tracing = "0.1.16"
-color-eyre = "0.5"
 zebra-test = { path = "../zebra-test/" }

--- a/tower-batch/src/error.rs
+++ b/tower-batch/src/error.rs
@@ -1,10 +1,45 @@
 //! Error types for the `Batch` middleware.
 
-use std::fmt;
+use crate::BoxError;
+use std::{fmt, sync::Arc};
+
+/// An error produced by a `Service` wrapped by a `Batch`.
+#[derive(Debug)]
+pub struct ServiceError {
+    inner: Arc<BoxError>,
+}
 
 /// An error produced when the batch worker closes unexpectedly.
 pub struct Closed {
     _p: (),
+}
+
+// ===== impl ServiceError =====
+
+impl ServiceError {
+    pub(crate) fn new(inner: BoxError) -> ServiceError {
+        let inner = Arc::new(inner);
+        ServiceError { inner }
+    }
+
+    // Private to avoid exposing `Clone` trait as part of the public API
+    pub(crate) fn clone(&self) -> ServiceError {
+        ServiceError {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl fmt::Display for ServiceError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "batching service failed: {}", self.inner)
+    }
+}
+
+impl std::error::Error for ServiceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&**self.inner)
+    }
 }
 
 // ===== impl Closed =====

--- a/tower-batch/src/layer.rs
+++ b/tower-batch/src/layer.rs
@@ -9,14 +9,13 @@ use tower::Service;
 /// which means that this layer can only be used on the Tokio runtime.
 ///
 /// See the module documentation for more details.
-pub struct BatchLayer<Request, E2> {
+pub struct BatchLayer<Request> {
     max_items: usize,
     max_latency: std::time::Duration,
     _p: PhantomData<fn(Request)>,
-    _e: PhantomData<E2>,
 }
 
-impl<Request, E2> BatchLayer<Request, E2> {
+impl<Request> BatchLayer<Request> {
     /// Creates a new `BatchLayer`.
     ///
     /// The wrapper is responsible for telling the inner service when to flush a
@@ -29,28 +28,25 @@ impl<Request, E2> BatchLayer<Request, E2> {
             max_items,
             max_latency,
             _p: PhantomData,
-            _e: PhantomData,
         }
     }
 }
 
-impl<S, Request, E2> Layer<S> for BatchLayer<Request, E2>
+impl<S, Request> Layer<S> for BatchLayer<Request>
 where
     S: Service<BatchControl<Request>> + Send + 'static,
     S::Future: Send,
-    S::Error: Clone + Into<E2> + Send + Sync,
+    S::Error: Into<crate::BoxError> + Send + Sync,
     Request: Send + 'static,
-    E2: Send + 'static,
-    crate::error::Closed: Into<E2>,
 {
-    type Service = Batch<S, Request, E2>;
+    type Service = Batch<S, Request>;
 
     fn layer(&self, service: S) -> Self::Service {
         Batch::new(service, self.max_items, self.max_latency)
     }
 }
 
-impl<Request, E2> fmt::Debug for BatchLayer<Request, E2> {
+impl<Request> fmt::Debug for BatchLayer<Request> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("BufferLayer")
             .field("max_items", &self.max_items)

--- a/tower-batch/src/message.rs
+++ b/tower-batch/src/message.rs
@@ -1,15 +1,16 @@
+use super::error::ServiceError;
 use tokio::sync::oneshot;
 
 /// Message sent to the batch worker
 #[derive(Debug)]
-pub(crate) struct Message<Request, Fut, E> {
+pub(crate) struct Message<Request, Fut> {
     pub(crate) request: Request,
-    pub(crate) tx: Tx<Fut, E>,
+    pub(crate) tx: Tx<Fut>,
     pub(crate) span: tracing::Span,
 }
 
 /// Response sender
-pub(crate) type Tx<Fut, E> = oneshot::Sender<Result<Fut, E>>;
+pub(crate) type Tx<Fut> = oneshot::Sender<Result<Fut, ServiceError>>;
 
 /// Response receiver
-pub(crate) type Rx<Fut, E> = oneshot::Receiver<Result<Fut, E>>;
+pub(crate) type Rx<Fut> = oneshot::Receiver<Result<Fut, ServiceError>>;

--- a/tower-batch/tests/ed25519.rs
+++ b/tower-batch/tests/ed25519.rs
@@ -6,7 +6,6 @@ use std::{
     time::Duration,
 };
 
-use color_eyre::eyre::Result;
 use ed25519_zebra::*;
 use futures::stream::{FuturesUnordered, StreamExt};
 use rand::thread_rng;
@@ -109,23 +108,31 @@ where
 }
 
 #[tokio::test]
-async fn batch_flushes_on_max_items() -> Result<()> {
+async fn batch_flushes_on_max_items() {
     use tokio::time::timeout;
     zebra_test::init();
 
     // Use a very long max_latency and a short timeout to check that
     // flushing is happening based on hitting max_items.
     let verifier = Batch::new(Ed25519Verifier::new(), 10, Duration::from_secs(1000));
-    timeout(Duration::from_secs(1), sign_and_verify(verifier, 100)).await?
+    assert!(
+        timeout(Duration::from_secs(1), sign_and_verify(verifier, 100))
+            .await
+            .is_ok()
+    );
 }
 
 #[tokio::test]
-async fn batch_flushes_on_max_latency() -> Result<()> {
+async fn batch_flushes_on_max_latency() {
     use tokio::time::timeout;
     zebra_test::init();
 
     // Use a very high max_items and a short timeout to check that
     // flushing is happening based on hitting max_latency.
     let verifier = Batch::new(Ed25519Verifier::new(), 100, Duration::from_millis(500));
-    timeout(Duration::from_secs(1), sign_and_verify(verifier, 10)).await?
+    assert!(
+        timeout(Duration::from_secs(1), sign_and_verify(verifier, 10))
+            .await
+            .is_ok()
+    );
 }

--- a/zebra-consensus/src/redjubjub/tests.rs
+++ b/zebra-consensus/src/redjubjub/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 
 use std::time::Duration;
 
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{eyre, Result};
 use futures::stream::{FuturesUnordered, StreamExt};
 use tower::ServiceExt;
 use tower_batch::Batch;
@@ -53,7 +53,11 @@ async fn batch_flushes_on_max_items() -> Result<()> {
     // Use a very long max_latency and a short timeout to check that
     // flushing is happening based on hitting max_items.
     let verifier = Batch::new(Verifier::new(), 10, Duration::from_secs(1000));
-    timeout(Duration::from_secs(5), sign_and_verify(verifier, 100)).await?
+    timeout(Duration::from_secs(5), sign_and_verify(verifier, 100))
+        .await
+        .map_err(|e| eyre!(e))?;
+
+    Ok(())
 }
 
 #[tokio::test]
@@ -64,5 +68,9 @@ async fn batch_flushes_on_max_latency() -> Result<()> {
     // Use a very high max_items and a short timeout to check that
     // flushing is happening based on hitting max_latency.
     let verifier = Batch::new(Verifier::new(), 100, Duration::from_millis(500));
-    timeout(Duration::from_secs(5), sign_and_verify(verifier, 10)).await?
+    timeout(Duration::from_secs(5), sign_and_verify(verifier, 10))
+        .await
+        .map_err(|e| eyre!(e))?;
+
+    Ok(())
 }


### PR DESCRIPTION
Unfortunately, since the Batch wrapper was changed to have a generic error
type, when wrapping it in another Service, nothing constrains the error type,
so we have to specify it explicitly to avoid an inference hole.  This is pretty
unergonomic -- from the compiler error message it's very unintuitive that the
right fix is to change `Batch::new` to `Batch::<_, _, SomeError>::new`.

The options are:

1. roll back the changes that make the error type generic, so that the error
   type is a concrete type;

2. keep the error type generic but hardcode the error in the default
   constructor and add an additional code path that allows overriding the
   error.

However, there's a further issue with generic errors: the error type must be
Clone.  This problem comes from the fact that there can be multiple Batch
handles that have to share access to errors generated by the inner Batch
worker, so there's not a way to work around this.  However, almost all error
types aren't Clone, so there are fairly few error types that we would be
swapping in.

This suggests that in case (2) we would be maintaining extra code to allow
generic errors, but with restrictive enough generic bounds to make it
impractical to use generic error types.  For this reason I think that (1) is a
better option.