### PR TITLE
fix: Only launch network endpoints for server commands

### DIFF
--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -101,10 +101,19 @@ impl Application for ZebradApp {
             metrics::MetricsEndpoint, tokio::TokioComponent, tracing::TracingEndpoint,
         };
 
+        // `None` outputs zebrad usage information and exits
+        let command_is_server = match &command.command {
+            None => false,
+            Some(c) => c.is_server(),
+        };
+
         let mut components = self.framework_components(command)?;
         components.push(Box::new(TokioComponent::new()?));
-        components.push(Box::new(TracingEndpoint::new()?));
-        components.push(Box::new(MetricsEndpoint::new()?));
+        // Launch network endpoints for long-running commands
+        if command_is_server {
+            components.push(Box::new(TracingEndpoint::new()?));
+            components.push(Box::new(MetricsEndpoint::new()?));
+        }
 
         self.state.components.register(components)
     }

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -7,11 +7,14 @@ mod seed;
 mod start;
 mod version;
 
+use self::ZebradCmd::*;
 use self::{
     connect::ConnectCmd, generate::GenerateCmd, revhex::RevhexCmd, seed::SeedCmd, start::StartCmd,
     version::VersionCmd,
 };
+
 use crate::config::ZebradConfig;
+
 use abscissa_core::{
     config::Override, Command, Configurable, FrameworkError, Help, Options, Runnable,
 };
@@ -61,11 +64,25 @@ impl ZebradCmd {
     /// If the command is `None`, then abscissa writes zebrad usage information
     /// to stdout.
     pub(crate) fn uses_stdout(&self) -> bool {
-        use ZebradCmd::*;
         match self {
             // List all the commands, so new commands have to make a choice here
             Generate(_) | Help(_) | Revhex(_) | Version(_) => true,
             Connect(_) | Seed(_) | Start(_) => false,
+        }
+    }
+
+    /// Returns true if this command is a server command.
+    ///
+    /// For example, `Start` acts as a Zcash node.
+    ///
+    /// Usage note: `abscissa_core::EntryPoint` stores an `Option<ZerbradCmd>`.
+    /// If the command is `None`, then abscissa prints zebrad's usage
+    /// information, then exits.
+    pub(crate) fn is_server(&self) -> bool {
+        match self {
+            // List all the commands, so new commands have to make a choice here
+            Connect(_) | Seed(_) | Start(_) => true,
+            Generate(_) | Help(_) | Revhex(_) | Version(_) => false,
         }
     }
 }


### PR DESCRIPTION
Fixes #669.

I have a few questions about this change:
- [x] Do we want metrics and tracing for Connect, Seed, and Start? (yes)
- [x] Can we disable the tokio component for Generate, Help, Revhex, and Version? (not in this PR, maybe in future, if it's worth the effort)
- [x] Are there any other listeners or components we should disable? (no)