### PR TITLE
feature: Use the Heartwood protocol version in zebra-network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,6 +2569,7 @@ dependencies = [
  "tracing-error",
  "tracing-futures",
  "zebra-chain",
+ "zebra-consensus",
  "zebra-test",
 ]
 

--- a/zebra-consensus/src/parameters.rs
+++ b/zebra-consensus/src/parameters.rs
@@ -12,6 +12,28 @@
 use zebra_chain::block::BlockHeaderHash;
 use zebra_chain::{Network, Network::*};
 
+/// A Zcash network protocol upgrade.
+//
+// TODO: are new network upgrades a breaking change, or should we make this
+//       enum non-exhaustive?
+pub enum NetworkUpgrade {
+    /// The Zcash protocol before the Overwinter upgrade.
+    ///
+    /// We avoid using `Sprout`, because the specification says that Sprout
+    /// is the name of the pre-Sapling protocol, before and after Overwinter.
+    BeforeOverwinter,
+    /// The Zcash protocol after the Overwinter upgrade.
+    Overwinter,
+    /// The Zcash protocol after the Sapling upgrade.
+    Sapling,
+    /// The Zcash protocol after the Blossom upgrade.
+    Blossom,
+    /// The Zcash protocol after the Heartwood upgrade.
+    Heartwood,
+    /// The Zcash protocol after the Canopy upgrade.
+    Canopy,
+}
+
 /// The previous block hash for the genesis block.
 ///
 /// All known networks use the Bitcoin `null` value for the parent of the

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -17,25 +17,26 @@ hex = "0.4"
 # which we don't use, so disable it to drop the dependencies.
 indexmap = { version = "1.4", default-features = false }
 pin-project = "0.4"
-proptest = "0.10"
-proptest-derive = "0.2.0"
 rand = "0.7"
 serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"
 
+futures = "0.3"
 tokio = { version = "0.2", features = ["net", "time", "stream"] }
 tokio-util = { version = "0.2", features = ["codec"] }
-futures = "0.3"
-
-tracing = "0.1"
-tracing-futures = "0.2"
-
 tower = "0.3"
 tower-load = "0.3"
 
 metrics = "0.12"
+tracing = "0.1"
+tracing-futures = "0.2"
+tracing-error = { version = "0.1.2", features = ["traced-error"] }
 
 zebra-chain = { path = "../zebra-chain" }
-tracing-error = { version = "0.1.2", features = ["traced-error"] }
+zebra-consensus = { path = "../zebra-consensus" }
+
+[dev-dependencies]
+proptest = "0.10"
+proptest-derive = "0.2.0"
 
 zebra-test = { path = "../zebra-test/" }

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 // XXX should these constants be split into protocol also?
 use crate::protocol::external::types::*;
 
+use zebra_consensus::parameters::NetworkUpgrade::{self, *};
+
 /// The timeout for requests made to a remote peer.
 pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -34,11 +36,19 @@ pub const TIMESTAMP_TRUNCATION_SECONDS: i64 = 30 * 60;
 /// The User-Agent string provided by the node.
 pub const USER_AGENT: &str = "🦓Zebra v2.0.0-alpha.0🦓";
 
-/// The Zcash network protocol version used on mainnet.
-pub const CURRENT_VERSION: Version = Version(170_009);
+/// The Zcash network protocol version implemented by this crate.
+///
+/// This protocol version might be the current version on Mainnet or Testnet,
+/// based on where we are in the network upgrade cycle.
+pub const CURRENT_VERSION: Version = Version(170_011);
 
-/// The minimum version supported for peer connections.
-pub const MIN_VERSION: Version = Version(170_009);
+/// The most recent bilateral consensus upgrade implemented by this crate.
+///
+/// Used to select the minimum supported version for peer connections.
+//
+// TODO: dynamically choose the minimum network upgrade based on block height.
+//       See the detailed comment in handshake.rs, where this constant is used.
+pub const MIN_NETWORK_UPGRADE: NetworkUpgrade = Heartwood;
 
 /// Magic numbers used to identify different Zcash networks.
 pub mod magics {

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -1,12 +1,14 @@
 #![allow(clippy::unit_arg)]
+
+use crate::constants::magics;
+
 use std::fmt;
+
+use zebra_chain::Network::{self, *};
+use zebra_consensus::parameters::NetworkUpgrade::{self, *};
 
 #[cfg(test)]
 use proptest_derive::Arbitrary;
-
-use zebra_chain::Network;
-
-use crate::constants::magics;
 
 /// A magic number identifying the network.
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32,6 +34,26 @@ impl From<Network> for Magic {
 /// A protocol version number.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Version(pub u32);
+
+impl Version {
+    /// Returns the minimum network protocol version for `network` and
+    /// `network_upgrade`.
+    pub fn min_version(network: Network, network_upgrade: NetworkUpgrade) -> Self {
+        // We might not ever use these older versions.
+        Version(match (network, network_upgrade) {
+            (_, BeforeOverwinter) => 170_002,
+            (Testnet, Overwinter) => 170_003,
+            (Mainnet, Overwinter) => 170_005,
+            (_, Sapling) => 170_007,
+            (Testnet, Blossom) => 170_008,
+            (Mainnet, Blossom) => 170_009,
+            (Testnet, Heartwood) => 170_010,
+            (Mainnet, Heartwood) => 170_011,
+            (Testnet, Canopy) => 170_012,
+            (Mainnet, Canopy) => 170_013,
+        })
+    }
+}
 
 bitflags! {
     /// A bitflag describing services advertised by a node in the network.


### PR DESCRIPTION
We're currently advertising the blossom protocol version, so peers automatically disconnect us.