### PR TITLE
Separate testnet state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+
+[[package]]
 name = "bech32"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +519,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.3",
+]
+
+[[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1606,6 +1632,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_users"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1688,18 @@ dependencies = [
  "block-buffer",
  "digest 0.8.1",
  "opaque-debug",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
+dependencies = [
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2638,6 +2687,7 @@ name = "zebra-state"
 version = "0.1.0"
 dependencies = [
  "color-eyre",
+ "dirs",
  "futures",
  "hex",
  "lazy_static",

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -133,10 +133,8 @@ where
 /// them to `init_from_verifiers`.
 //
 // TODO: revise this interface when we generate our own blocks, or validate
-//       mempool transactions.
-//
-// Only used by tests and other modules
-#[allow(dead_code)]
+//       mempool transactions. We might want to share the BlockVerifier, and we
+//       might not want to add generated blocks to the state.
 pub fn init<S>(
     network: Network,
     state_service: S,
@@ -176,9 +174,6 @@ where
 /// verifiers (and the result be shared, cloning if needed). Constructing
 /// multiple services from the same underlying state might cause synchronisation
 /// bugs.
-//
-// Only used by tests and other modules
-#[allow(dead_code)]
 pub fn init_from_verifiers<BV, S>(
     block_verifier: BV,
     // We use an explcit type, so callers can't accidentally swap the verifiers

--- a/zebra-consensus/src/chain/tests.rs
+++ b/zebra-consensus/src/chain/tests.rs
@@ -64,7 +64,8 @@ fn verifiers_from_checkpoint_list(
     let block_verifier = crate::block::init(state_service.clone());
     let checkpoint_verifier =
         crate::checkpoint::CheckpointVerifier::from_checkpoint_list(checkpoint_list);
-    let chain_verifier = super::init(block_verifier, checkpoint_verifier, state_service.clone());
+    let chain_verifier =
+        super::init_from_verifiers(block_verifier, checkpoint_verifier, state_service.clone());
 
     (chain_verifier, state_service)
 }
@@ -153,7 +154,9 @@ async fn verify_checkpoint_test() -> Result<(), Report> {
     verify_checkpoint().await
 }
 
-/// Test that checkpoint verifies work
+/// Test that checkpoint verifies work.
+///
+/// Also tests the `chain::init` function.
 #[spandoc::spandoc]
 async fn verify_checkpoint() -> Result<(), Report> {
     zebra_test::init();
@@ -162,7 +165,9 @@ async fn verify_checkpoint() -> Result<(), Report> {
         Arc::<Block>::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..])?;
     let hash: BlockHeaderHash = block.as_ref().into();
 
-    let (mut chain_verifier, _) = verifiers_from_network(Mainnet);
+    // Test that the chain::init function works. Most of the other tests use
+    // init_from_verifiers.
+    let mut chain_verifier = super::init(Mainnet, zebra_state::in_memory::init());
 
     /// SPANDOC: Make sure the verifier service is ready
     let ready_verifier_service = chain_verifier.ready_and().await.map_err(|e| eyre!(e))?;

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -117,11 +117,6 @@ impl CheckpointVerifier {
     /// than constructing multiple verification services for the same network. To
     /// Clone a CheckpointVerifier, you might need to wrap it in a
     /// `tower::Buffer` service.
-    //
-    // Avoid some dead code lints.
-    // Until we implement the overall verifier in #516, this function, and some of the
-    // functions and enum variants it uses, are only used in the tests.
-    #[allow(dead_code)]
     pub fn new(network: Network) -> Self {
         Self::from_checkpoint_list(CheckpointList::new(network))
     }
@@ -130,12 +125,11 @@ impl CheckpointVerifier {
     ///
     /// Assumes that the provided genesis checkpoint is correct.
     ///
-    /// See `CheckpointVerifier::new` and `CheckpointList::from_list` for more
-    /// details.
+    /// Callers should prefer `CheckpointVerifier::new`, which uses the
+    /// hard-coded checkpoint lists. See `CheckpointVerifier::new` and
+    /// `CheckpointList::from_list` for more details.
     //
-    // Avoid some dead code lints.
-    // Until we implement the overall verifier in #516, this function, and some of the
-    // functions and enum variants it uses, are only used in the tests.
+    // This function is designed for use in tests.
     #[allow(dead_code)]
     pub(crate) fn from_list(
         list: impl IntoIterator<Item = (BlockHeight, BlockHeaderHash)>,
@@ -145,8 +139,9 @@ impl CheckpointVerifier {
 
     /// Return a checkpoint verification service using `checkpoint_list`.
     ///
-    /// See `CheckpointVerifier::new` and `CheckpointList::from_list` for more
-    /// details.
+    /// Callers should prefer `CheckpointVerifier::new`, which uses the
+    /// hard-coded checkpoint lists. See `CheckpointVerifier::new` and
+    /// `CheckpointList::from_list` for more details.
     pub(crate) fn from_checkpoint_list(checkpoint_list: CheckpointList) -> Self {
         // All the initialisers should call this function, so we only have to
         // change fields or default values in one place.

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -333,10 +333,7 @@ impl CheckpointVerifier {
 
         let height = block.coinbase_height();
         // Report each 1000th block at info level
-        let info_log = match height {
-            Some(BlockHeight(height)) if (height % 1000 == 0) => true,
-            _ => false,
-        };
+        let info_log = matches!(height, Some(BlockHeight(height)) if (height % 1000 == 0));
         if info_log {
             tracing::info!(?height, "queue_block received block");
         } else {
@@ -647,10 +644,7 @@ impl Service<Arc<Block>> for CheckpointVerifier {
 
         let height = block.coinbase_height();
         // Report each 1000th block at info level
-        let info_log = match height {
-            Some(BlockHeight(height)) if (height % 1000 == 0) => true,
-            _ => false,
-        };
+        let info_log = matches!(height, Some(BlockHeight(height)) if (height % 1000 == 0));
 
         if info_log {
             tracing::info!(?height, "CheckpointVerifier received block");

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -8,20 +8,25 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" }
-tower = "0.3.1"
-futures = "0.3.5"
-lazy_static = "1.4.0"
+dirs = "3.0.1"
 hex = "0.4.2"
+lazy_static = "1.4.0"
 sled = "0.33.0"
 serde = { version = "1", features = ["serde_derive"] }
 
+futures = "0.3.5"
+tower = "0.3.1"
+
+zebra-chain = { path = "../zebra-chain" }
+
 [dev-dependencies]
-tokio = { version = "0.2.21", features = ["full"] }
-zebra-test = { path = "../zebra-test/" }
+once_cell = "1.4"
+tempdir = "0.3.7"
+
+color-eyre = "0.5"
 spandoc = "0.2"
+tokio = { version = "0.2.21", features = ["full"] }
 tracing = "0.1.16"
 tracing-futures = "0.2.4"
-tempdir = "0.3.7"
-color-eyre = "0.5"
-once_cell = "1.4"
+
+zebra-test = { path = "../zebra-test/" }

--- a/zebrad/src/commands/generate.rs
+++ b/zebrad/src/commands/generate.rs
@@ -15,9 +15,10 @@ impl Runnable for GenerateCmd {
     /// Start the application.
     fn run(&self) {
         let default_config = ZebradConfig {
-            tracing: crate::config::TracingSection::populated(),
-            network: Default::default(),
             metrics: Default::default(),
+            network: Default::default(),
+            state: Default::default(),
+            tracing: crate::config::TracingSection::populated(),
         };
         let mut output = r"# Default configuration for zebrad.
 #

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -47,7 +47,7 @@ pub struct StartCmd {
 
 impl StartCmd {
     async fn start(&self) -> Result<(), Report> {
-        info!(?self, "begin tower-based peer handling test stub");
+        info!(?self, "starting to connect to the network");
 
         // The service that our node uses to respond to requests by peers
         let node = Buffer::new(
@@ -57,9 +57,9 @@ impl StartCmd {
             }),
             1,
         );
-        let config = app_config().network.clone();
-        let state = zebra_state::on_disk::init(zebra_state::Config::default());
-        let (peer_set, _address_book) = zebra_network::init(config, node).await;
+        let config = app_config();
+        let state = zebra_state::on_disk::init(config.state.clone());
+        let (peer_set, _address_book) = zebra_network::init(config.network.clone(), node).await;
         let verifier = zebra_consensus::chain::init(Mainnet, state.clone());
 
         let mut syncer = sync::Syncer::new(peer_set, state, verifier);

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -57,7 +57,7 @@ impl StartCmd {
             1,
         );
         let config = app_config();
-        let state = zebra_state::on_disk::init(config.state.clone());
+        let state = zebra_state::on_disk::init(config.state.clone(), config.network.network);
         let (peer_set, _address_book) = zebra_network::init(config.network.clone(), node).await;
         let verifier = zebra_consensus::chain::init(config.network.network, state.clone());
 

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -18,12 +18,16 @@
 //!  * Sync Task
 //!    * This task runs in the background and continuously queries the network for
 //!    new blocks to be verified and added to the local state
+
 use crate::config::ZebradConfig;
 use crate::{components::tokio::TokioComponent, prelude::*};
+
 use abscissa_core::{config, Command, FrameworkError, Options, Runnable};
 use color_eyre::eyre::Report;
 use tower::{buffer::Buffer, service_fn};
+
 use zebra_chain::block::BlockHeaderHash;
+use zebra_chain::Network::*;
 
 mod sync;
 
@@ -56,7 +60,7 @@ impl StartCmd {
         let config = app_config().network.clone();
         let state = zebra_state::on_disk::init(zebra_state::Config::default());
         let (peer_set, _address_book) = zebra_network::init(config, node).await;
-        let verifier = zebra_consensus::block::init(state.clone());
+        let verifier = zebra_consensus::chain::init(Mainnet, state.clone());
 
         let mut syncer = sync::Syncer::new(peer_set, state, verifier);
 

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -27,7 +27,6 @@ use color_eyre::eyre::Report;
 use tower::{buffer::Buffer, service_fn};
 
 use zebra_chain::block::BlockHeaderHash;
-use zebra_chain::Network::*;
 
 mod sync;
 
@@ -60,7 +59,7 @@ impl StartCmd {
         let config = app_config();
         let state = zebra_state::on_disk::init(config.state.clone());
         let (peer_set, _address_book) = zebra_network::init(config.network.clone(), node).await;
-        let verifier = zebra_consensus::chain::init(Mainnet, state.clone());
+        let verifier = zebra_consensus::chain::init(config.network.network, state.clone());
 
         let mut syncer = sync::Syncer::new(peer_set, state, verifier);
 

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -9,6 +9,7 @@ use std::net::SocketAddr;
 use serde::{Deserialize, Serialize};
 
 use zebra_network::Config as NetworkSection;
+use zebra_state::Config as StateSection;
 
 /// Configuration for `zebrad`.
 ///
@@ -18,12 +19,17 @@ use zebra_network::Config as NetworkSection;
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct ZebradConfig {
-    /// Tracing configuration
-    pub tracing: TracingSection,
-    /// Networking configuration
-    pub network: NetworkSection,
     /// Metrics configuration
     pub metrics: MetricsSection,
+
+    /// Networking configuration
+    pub network: NetworkSection,
+
+    /// State configuration
+    pub state: StateSection,
+
+    /// Tracing configuration
+    pub tracing: TracingSection,
 }
 
 /// Tracing configuration section.


### PR DESCRIPTION
* Separate testnet state from mainnet state
* Use the standard cache directory by default

Based on #699, the first new commit is 287d463d153f99531f14e6b482f73c003fefda9d.

Closes #715.
Implements part of #694.

TODO:

This PR:
- [x] make the path `zebra/mainnet/state`
- [x] fix compilation issues

Dependencies:
- [x] rebase this PR on main
  - [x] remove the cache dir code, it has already been implemented in #714
- [x] get PR #699 merged
- [x] get PR #714 merged
- [x] get PR #718 merged

Testing:
- [x] fix the checkpoint verifier / sync hang (#725)
- [ ] test mainnet syncing
- [ ] test testnet syncing