### PR TITLE
Add Network Upgrade Heights and Branch IDs

### DIFF
--- a/zebra-consensus/src/checkpoint/list.rs
+++ b/zebra-consensus/src/checkpoint/list.rs
@@ -25,12 +25,15 @@ const TESTNET_CHECKPOINTS: &str = include_str!("test-checkpoints.txt");
 // TODO(jlusby): Error = Report ?
 type Error = Box<dyn error::Error + Send + Sync + 'static>;
 
-/// Checkpoint lists are implemented using a BTreeMap.
+/// A list of block height and hash checkpoints.
 ///
 /// Checkpoints should be chosen to avoid forks or chain reorganizations,
 /// which only happen in the last few hundred blocks in the chain.
 /// (zcashd allows chain reorganizations up to 99 blocks, and prunes
 /// orphaned side-chains after 288 blocks.)
+///
+/// This is actually a bijective map, but since it is read-only, we use a
+/// BTreeMap, and do the value uniqueness check on initialisation.
 #[derive(Debug)]
 pub(crate) struct CheckpointList(BTreeMap<BlockHeight, BlockHeaderHash>);
 

--- a/zebra-consensus/src/parameters.rs
+++ b/zebra-consensus/src/parameters.rs
@@ -9,45 +9,11 @@
 //! Typically, consensus parameters are accessed via a function that takes a
 //! `Network` and `BlockHeight`.
 
-use zebra_chain::block::BlockHeaderHash;
-use zebra_chain::{Network, Network::*};
+pub mod genesis;
+pub mod network_upgrade;
 
-/// A Zcash network protocol upgrade.
-//
-// TODO: are new network upgrades a breaking change, or should we make this
-//       enum non-exhaustive?
-pub enum NetworkUpgrade {
-    /// The Zcash protocol before the Overwinter upgrade.
-    ///
-    /// We avoid using `Sprout`, because the specification says that Sprout
-    /// is the name of the pre-Sapling protocol, before and after Overwinter.
-    BeforeOverwinter,
-    /// The Zcash protocol after the Overwinter upgrade.
-    Overwinter,
-    /// The Zcash protocol after the Sapling upgrade.
-    Sapling,
-    /// The Zcash protocol after the Blossom upgrade.
-    Blossom,
-    /// The Zcash protocol after the Heartwood upgrade.
-    Heartwood,
-    /// The Zcash protocol after the Canopy upgrade.
-    Canopy,
-}
+pub use genesis::*;
+pub use network_upgrade::*;
 
-/// The previous block hash for the genesis block.
-///
-/// All known networks use the Bitcoin `null` value for the parent of the
-/// genesis block. (In Bitcoin, `null` is `[0; 32]`.)
-pub const GENESIS_PREVIOUS_BLOCK_HASH: BlockHeaderHash = BlockHeaderHash([0; 32]);
-
-/// Returns the hash for the genesis block in `network`.
-pub fn genesis_hash(network: Network) -> BlockHeaderHash {
-    match network {
-        // zcash-cli getblockhash 0 | zebrad revhex
-        Mainnet => "08ce3d9731b000c08338455c8a4a6bd05da16e26b11daa1b917184ece80f0400",
-        // zcash-cli -testnet getblockhash 0 | zebrad revhex
-        Testnet => "382c4a332661c7ed0671f32a34d724619f086c61873bce7c99859dd9920aa605",
-    }
-    .parse()
-    .expect("hard-coded hash parses")
-}
+#[cfg(test)]
+mod tests;

--- a/zebra-consensus/src/parameters/genesis.rs
+++ b/zebra-consensus/src/parameters/genesis.rs
@@ -1,0 +1,22 @@
+//! Genesis consensus parameters for each Zcash network.
+
+use zebra_chain::block::BlockHeaderHash;
+use zebra_chain::{Network, Network::*};
+
+/// The previous block hash for the genesis block.
+///
+/// All known networks use the Bitcoin `null` value for the parent of the
+/// genesis block. (In Bitcoin, `null` is `[0; 32]`.)
+pub const GENESIS_PREVIOUS_BLOCK_HASH: BlockHeaderHash = BlockHeaderHash([0; 32]);
+
+/// Returns the hash for the genesis block in `network`.
+pub fn genesis_hash(network: Network) -> BlockHeaderHash {
+    match network {
+        // zcash-cli getblockhash 0 | zebrad revhex
+        Mainnet => "08ce3d9731b000c08338455c8a4a6bd05da16e26b11daa1b917184ece80f0400",
+        // zcash-cli -testnet getblockhash 0 | zebrad revhex
+        Testnet => "382c4a332661c7ed0671f32a34d724619f086c61873bce7c99859dd9920aa605",
+    }
+    .parse()
+    .expect("hard-coded hash parses")
+}

--- a/zebra-consensus/src/parameters/network_upgrade.rs
+++ b/zebra-consensus/src/parameters/network_upgrade.rs
@@ -1,0 +1,109 @@
+//! Network upgrade consensus parameters for Zcash.
+
+use NetworkUpgrade::*;
+
+use std::collections::BTreeMap;
+use std::ops::Bound::*;
+
+use zebra_chain::types::BlockHeight;
+use zebra_chain::{Network, Network::*};
+
+/// A Zcash network protocol upgrade.
+//
+// TODO: are new network upgrades a breaking change, or should we make this
+//       enum non-exhaustive?
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum NetworkUpgrade {
+    /// The Zcash protocol before the Overwinter upgrade.
+    ///
+    /// We avoid using `Sprout`, because the specification says that Sprout
+    /// is the name of the pre-Sapling protocol, before and after Overwinter.
+    BeforeOverwinter,
+    /// The Zcash protocol after the Overwinter upgrade.
+    Overwinter,
+    /// The Zcash protocol after the Sapling upgrade.
+    Sapling,
+    /// The Zcash protocol after the Blossom upgrade.
+    Blossom,
+    /// The Zcash protocol after the Heartwood upgrade.
+    Heartwood,
+    /// The Zcash protocol after the Canopy upgrade.
+    Canopy,
+}
+
+/// Mainnet network upgrade activation heights.
+///
+/// This is actually a bijective map, but it is const, so we use a vector, and
+/// do the uniqueness check in the unit tests.
+pub(crate) const MAINNET_ACTIVATION_HEIGHTS: &[(BlockHeight, NetworkUpgrade)] = &[
+    (BlockHeight(0), BeforeOverwinter),
+    (BlockHeight(347_500), Overwinter),
+    (BlockHeight(419_200), Sapling),
+    (BlockHeight(653_600), Blossom),
+    (BlockHeight(903_000), Heartwood),
+    (BlockHeight(1_046_400), Canopy),
+];
+
+/// Testnet network upgrade activation heights.
+///
+/// This is actually a bijective map, but it is const, so we use a vector, and
+/// do the uniqueness check in the unit tests.
+pub(crate) const TESTNET_ACTIVATION_HEIGHTS: &[(BlockHeight, NetworkUpgrade)] = &[
+    (BlockHeight(0), BeforeOverwinter),
+    (BlockHeight(207_500), Overwinter),
+    (BlockHeight(280_000), Sapling),
+    (BlockHeight(584_000), Blossom),
+    (BlockHeight(903_800), Heartwood),
+    // As of 21 July 2020, the Canopy testnet height has not been decided.
+    // See ZIP 251 for updates.
+];
+
+impl NetworkUpgrade {
+    /// Returns a BTreeMap of activation heights and network upgrades for
+    /// `network`.
+    ///
+    /// If the activation height of a future upgrade is not known, that
+    /// network upgrade does not appear in the list.
+    ///
+    /// This is actually a bijective map.
+    pub(crate) fn activation_list(network: Network) -> BTreeMap<BlockHeight, NetworkUpgrade> {
+        match network {
+            Mainnet => MAINNET_ACTIVATION_HEIGHTS,
+            Testnet => TESTNET_ACTIVATION_HEIGHTS,
+        }
+        .iter()
+        .cloned()
+        .collect()
+    }
+
+    /// Returns the current network upgrade for `network` and `height`.
+    pub fn current(network: Network, height: BlockHeight) -> NetworkUpgrade {
+        NetworkUpgrade::activation_list(network)
+            .range(..=height)
+            .map(|(_, nu)| *nu)
+            .next_back()
+            .expect("every height has a current network upgrade")
+    }
+
+    /// Returns the next network upgrade for `network` and `height`.
+    ///
+    /// Returns None if the name of the next upgrade has not been decided yet.
+    pub fn next(network: Network, height: BlockHeight) -> Option<NetworkUpgrade> {
+        NetworkUpgrade::activation_list(network)
+            .range((Excluded(height), Unbounded))
+            .map(|(_, nu)| *nu)
+            .next()
+    }
+
+    /// Returns the activation height for this network upgrade on `network`.
+    ///
+    /// Returns None if this network upgrade is a future upgrade, and its
+    /// activation height has not been set yet.
+    pub fn activation_height(&self, network: Network) -> Option<BlockHeight> {
+        NetworkUpgrade::activation_list(network)
+            .iter()
+            .filter(|(_, nu)| nu == &self)
+            .map(|(height, _)| *height)
+            .next()
+    }
+}

--- a/zebra-consensus/src/parameters/tests.rs
+++ b/zebra-consensus/src/parameters/tests.rs
@@ -1,0 +1,105 @@
+//! Consensus parameter tests for Zebra.
+
+use super::*;
+use NetworkUpgrade::*;
+
+use std::collections::HashSet;
+
+use zebra_chain::types::BlockHeight;
+use zebra_chain::{Network, Network::*};
+
+/// Check that the activation heights and network upgrades are unique.
+#[test]
+fn activation_bijective() {
+    let mainnet_activations = NetworkUpgrade::activation_list(Mainnet);
+    let mainnet_heights: HashSet<&BlockHeight> = mainnet_activations.keys().collect();
+    assert_eq!(MAINNET_ACTIVATION_HEIGHTS.len(), mainnet_heights.len());
+
+    let mainnet_nus: HashSet<&NetworkUpgrade> = mainnet_activations.values().collect();
+    assert_eq!(MAINNET_ACTIVATION_HEIGHTS.len(), mainnet_nus.len());
+
+    let testnet_activations = NetworkUpgrade::activation_list(Testnet);
+    let testnet_heights: HashSet<&BlockHeight> = testnet_activations.keys().collect();
+    assert_eq!(TESTNET_ACTIVATION_HEIGHTS.len(), testnet_heights.len());
+
+    let testnet_nus: HashSet<&NetworkUpgrade> = testnet_activations.values().collect();
+    assert_eq!(TESTNET_ACTIVATION_HEIGHTS.len(), testnet_nus.len());
+}
+
+#[test]
+fn activation_extremes_mainnet() {
+    activation_extremes(Mainnet)
+}
+
+#[test]
+fn activation_extremes_testnet() {
+    activation_extremes(Testnet)
+}
+
+/// Test the activation_list, activation_height, current, and next functions
+/// for `network` with extreme values.
+fn activation_extremes(network: Network) {
+    // The first two upgrades are BeforeOverwinter and Overwinter
+    assert_eq!(
+        NetworkUpgrade::activation_list(network).get(&BlockHeight(0)),
+        Some(&BeforeOverwinter)
+    );
+    assert_eq!(
+        BeforeOverwinter.activation_height(network),
+        Some(BlockHeight(0))
+    );
+    assert_eq!(
+        NetworkUpgrade::current(network, BlockHeight(0)),
+        BeforeOverwinter
+    );
+    assert_eq!(
+        NetworkUpgrade::next(network, BlockHeight(0)),
+        Some(Overwinter)
+    );
+
+    // We assume that the last upgrade we know about continues forever
+    // (even if we suspect that won't be true)
+    assert_ne!(
+        NetworkUpgrade::activation_list(network).get(&BlockHeight::MAX),
+        Some(&BeforeOverwinter)
+    );
+    assert_ne!(
+        NetworkUpgrade::current(network, BlockHeight::MAX),
+        BeforeOverwinter
+    );
+    assert_eq!(NetworkUpgrade::next(network, BlockHeight::MAX), None);
+}
+
+#[test]
+fn activation_consistent_mainnet() {
+    activation_consistent(Mainnet)
+}
+
+#[test]
+fn activation_consistent_testnet() {
+    activation_consistent(Testnet)
+}
+
+/// Check that the activation_height, current, and next functions are
+/// consistent for `network`.
+fn activation_consistent(network: Network) {
+    let activation_list = NetworkUpgrade::activation_list(network);
+    let network_upgrades: HashSet<&NetworkUpgrade> = activation_list.values().collect();
+
+    for &network_upgrade in network_upgrades {
+        let height = network_upgrade
+            .activation_height(network)
+            .expect("activations must have a height");
+        assert_eq!(NetworkUpgrade::current(network, height), network_upgrade);
+        // Network upgrades don't repeat
+        assert_ne!(NetworkUpgrade::next(network, height), Some(network_upgrade));
+        assert_ne!(
+            NetworkUpgrade::next(network, BlockHeight(height.0 + 1)),
+            Some(network_upgrade)
+        );
+        assert_ne!(
+            NetworkUpgrade::next(network, BlockHeight::MAX),
+            Some(network_upgrade)
+        );
+    }
+}

--- a/zebra-consensus/src/parameters/tests.rs
+++ b/zebra-consensus/src/parameters/tests.rs
@@ -80,8 +80,8 @@ fn activation_consistent_testnet() {
     activation_consistent(Testnet)
 }
 
-/// Check that the activation_height, current, and next functions are
-/// consistent for `network`.
+/// Check that the activation_height, current, and next functions are consistent
+/// for `network`.
 fn activation_consistent(network: Network) {
     let activation_list = NetworkUpgrade::activation_list(network);
     let network_upgrades: HashSet<&NetworkUpgrade> = activation_list.values().collect();

--- a/zebra-consensus/src/parameters/tests.rs
+++ b/zebra-consensus/src/parameters/tests.rs
@@ -103,3 +103,75 @@ fn activation_consistent(network: Network) {
         );
     }
 }
+
+/// Check that the network upgrades and branch ids are unique.
+#[test]
+fn branch_id_bijective() {
+    let branch_id_list = NetworkUpgrade::branch_id_list();
+    let nus: HashSet<&NetworkUpgrade> = branch_id_list.keys().collect();
+    assert_eq!(CONSENSUS_BRANCH_IDS.len(), nus.len());
+
+    let branch_ids: HashSet<&ConsensusBranchId> = branch_id_list.values().collect();
+    assert_eq!(CONSENSUS_BRANCH_IDS.len(), branch_ids.len());
+}
+
+#[test]
+fn branch_id_extremes_mainnet() {
+    branch_id_extremes(Mainnet)
+}
+
+#[test]
+fn branch_id_extremes_testnet() {
+    branch_id_extremes(Testnet)
+}
+
+/// Test the branch_id_list, branch_id, and current functions for `network` with
+/// extreme values.
+fn branch_id_extremes(network: Network) {
+    // Branch ids were introduced in Overwinter
+    assert_eq!(
+        NetworkUpgrade::branch_id_list().get(&BeforeOverwinter),
+        None
+    );
+    assert_eq!(ConsensusBranchId::current(network, BlockHeight(0)), None);
+    assert_eq!(
+        NetworkUpgrade::branch_id_list().get(&Overwinter).cloned(),
+        Overwinter.branch_id()
+    );
+
+    // We assume that the last upgrade we know about continues forever
+    // (even if we suspect that won't be true)
+    assert_ne!(
+        NetworkUpgrade::branch_id_list().get(&NetworkUpgrade::current(network, BlockHeight::MAX)),
+        None
+    );
+    assert_ne!(ConsensusBranchId::current(network, BlockHeight::MAX), None);
+}
+
+#[test]
+fn branch_id_consistent_mainnet() {
+    branch_id_consistent(Mainnet)
+}
+
+#[test]
+fn branch_id_consistent_testnet() {
+    branch_id_consistent(Testnet)
+}
+
+/// Check that the branch_id and current functions are consistent for `network`.
+fn branch_id_consistent(network: Network) {
+    let branch_id_list = NetworkUpgrade::branch_id_list();
+    let network_upgrades: HashSet<&NetworkUpgrade> = branch_id_list.keys().collect();
+
+    for &network_upgrade in network_upgrades {
+        let height = network_upgrade.activation_height(network);
+
+        // Skip network upgrades that don't have activation heights yet
+        if let Some(height) = height {
+            assert_eq!(
+                ConsensusBranchId::current(network, height),
+                network_upgrade.branch_id()
+            );
+        }
+    }
+}

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -46,7 +46,7 @@ pub const CURRENT_VERSION: Version = Version(170_011);
 ///
 /// Used to select the minimum supported version for peer connections.
 //
-// TODO: dynamically choose the minimum network upgrade based on block height.
+// TODO: replace with NetworkUpgrade::current(network, height).
 //       See the detailed comment in handshake.rs, where this constant is used.
 pub const MIN_NETWORK_UPGRADE: NetworkUpgrade = Heartwood;
 

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -199,12 +199,12 @@ where
             // For example, we could reject old peers with probability 0.5.
             //
             // At the network upgrade, we also need to disconnect from old peers.
-            // TODO: replace MIN_NETWORK_UPGRADE with
-            //       NetworkUpgrade::current(network, height) where network is
-            //       the configured network, and height is the best tip's block
+            // TODO: replace min_for_upgrade(network, MIN_NETWORK_UPGRADE) with
+            //       current_min(network, height) where network is the
+            //       configured network, and height is the best tip's block
             //       height.
 
-            if remote_version < Version::min_version(network, constants::MIN_NETWORK_UPGRADE) {
+            if remote_version < Version::min_for_upgrade(network, constants::MIN_NETWORK_UPGRADE) {
                 // Disconnect if peer is using an obsolete version.
                 return Err(HandshakeError::ObsoleteVersion(remote_version));
             }

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -194,8 +194,15 @@ where
             //  if (pfrom->nVersion < consensusParams.vUpgrades[currentEpoch].nProtocolVersion)
             //
             // For approximately 1.5 days before a network upgrade, we also need to:
-            //  - prefer evicting pre-upgrade peers from the peer set, and
-            //  - prefer choosing post-upgrade ready peers for queries
+            //  - avoid old peers, and
+            //  - prefer updated peers.
+            // For example, we could reject old peers with probability 0.5.
+            //
+            // At the network upgrade, we also need to disconnect from old peers.
+            // TODO: replace MIN_NETWORK_UPGRADE with
+            //       NetworkUpgrade::current(network, height) where network is
+            //       the configured network, and height is the best tip's block
+            //       height.
 
             if remote_version < Version::min_version(network, constants::MIN_NETWORK_UPGRADE) {
                 // Disconnect if peer is using an obsolete version.

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -4,6 +4,7 @@ use crate::constants::magics;
 
 use std::fmt;
 
+use zebra_chain::types::BlockHeight;
 use zebra_chain::Network::{self, *};
 use zebra_consensus::parameters::NetworkUpgrade::{self, *};
 
@@ -38,7 +39,7 @@ pub struct Version(pub u32);
 impl Version {
     /// Returns the minimum network protocol version for `network` and
     /// `network_upgrade`.
-    pub fn min_version(network: Network, network_upgrade: NetworkUpgrade) -> Self {
+    pub fn min_for_upgrade(network: Network, network_upgrade: NetworkUpgrade) -> Self {
         // TODO: Should we reject earlier protocol versions during our initial
         //       sync? zcashd accepts 170_002 or later during its initial sync.
         Version(match (network, network_upgrade) {
@@ -53,6 +54,14 @@ impl Version {
             (Testnet, Canopy) => 170_012,
             (Mainnet, Canopy) => 170_013,
         })
+    }
+
+    /// Returns the current minimum protocol version for `network` and `height`.
+    ///
+    /// Returns None if the network has no branch id at this height.
+    pub fn current_min(network: Network, height: BlockHeight) -> Version {
+        let network_upgrade = NetworkUpgrade::current(network, height);
+        Version::min_for_upgrade(network, network_upgrade)
     }
 }
 
@@ -117,6 +126,72 @@ mod proptest {
         #[test]
         fn proptest_magic_from_array(data in any::<[u8; 4]>()) {
             assert_eq!(format!("{:?}", Magic(data)), format!("Magic({:x?})", hex::encode(data)));
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn version_extremes_mainnet() {
+        version_extremes(Mainnet)
+    }
+
+    #[test]
+    fn version_extremes_testnet() {
+        version_extremes(Testnet)
+    }
+
+    /// Test the min_for_upgrade and current_min functions for `network` with
+    /// extreme values.
+    fn version_extremes(network: Network) {
+        assert_eq!(
+            Version::current_min(network, BlockHeight(0)),
+            Version::min_for_upgrade(network, BeforeOverwinter),
+        );
+
+        // We assume that the last version we know about continues forever
+        // (even if we suspect that won't be true)
+        assert_ne!(
+            Version::current_min(network, BlockHeight::MAX),
+            Version::min_for_upgrade(network, BeforeOverwinter),
+        );
+    }
+
+    #[test]
+    fn version_consistent_mainnet() {
+        version_consistent(Mainnet)
+    }
+
+    #[test]
+    fn version_consistent_testnet() {
+        version_consistent(Testnet)
+    }
+
+    /// Check that the min_for_upgrade and current_min functions
+    /// are consistent for `network`.
+    fn version_consistent(network: Network) {
+        let highest_network_upgrade = NetworkUpgrade::current(network, BlockHeight::MAX);
+        assert!(highest_network_upgrade == Canopy || highest_network_upgrade == Heartwood,
+                "expected coverage of all network upgrades: add the new network upgrade to the list in this test");
+
+        for &network_upgrade in &[
+            BeforeOverwinter,
+            Overwinter,
+            Sapling,
+            Blossom,
+            Heartwood,
+            Canopy,
+        ] {
+            let height = network_upgrade.activation_height(network);
+            if let Some(height) = height {
+                assert_eq!(
+                    Version::min_for_upgrade(network, network_upgrade),
+                    Version::current_min(network, height)
+                );
+            }
         }
     }
 }

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -39,7 +39,8 @@ impl Version {
     /// Returns the minimum network protocol version for `network` and
     /// `network_upgrade`.
     pub fn min_version(network: Network, network_upgrade: NetworkUpgrade) -> Self {
-        // We might not ever use these older versions.
+        // TODO: Should we reject earlier protocol versions during our initial
+        //       sync? zcashd accepts 170_002 or later during its initial sync.
         Version(match (network, network_upgrade) {
             (_, BeforeOverwinter) => 170_002,
             (Testnet, Overwinter) => 170_003,


### PR DESCRIPTION
For each network upgrade, add:
- [x] an activation height for mainnet and testnet
- [x] a consensus branch ID
- [x] the current network protocol version (by height)

Closes #716.