### PR TITLE
Align crate versions and user-agent with NU numbers.

### DIFF
--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "0.1.0"
+version = "3.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-client/Cargo.toml
+++ b/zebra-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-client"
-version = "0.1.0"
+version = "3.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "0.1.0"
+version = "3.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "0.1.0"
+version = "3.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -34,7 +34,7 @@ pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 pub const TIMESTAMP_TRUNCATION_SECONDS: i64 = 30 * 60;
 
 /// The User-Agent string provided by the node.
-pub const USER_AGENT: &str = "🦓Zebra v2.0.0-alpha.0🦓";
+pub const USER_AGENT: &str = "🦓 Zebra 3.0.0-alpha.0 🦓";
 
 /// The Zcash network protocol version implemented by this crate.
 ///

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "0.1.0"
+version = "3.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "0.1.0"
+version = "3.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "0.1.0"
+version = "3.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-test"
-version = "0.1.0"
+version = "3.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zebra-utils"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-version = "0.1.0"
+version = "3.0.0-alpha.0"
 edition = "2018"
 
 [dependencies]

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zebrad"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-version = "0.1.0"
+version = "3.0.0-alpha.0"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
We had a brief discussion on discord and it seemed like we had consensus on the
following versioning policy:

* zebrad: match major version to NU version, so we will start by releasing
  zebrad 3.0.0;

* zebra-* libraries: start by matching zebrad's version, then increment major
  versions of each library as we need to make breaking changes (potentially
  faster than the zebrad version, always respecting semver but making no
  guarantees about the longevity of major releases).

This commit sets all of the crate versions to 3.0.0-alpha.0 -- the -alpha.0
marks it as a prerelease not subject to perfect adherence to compatibility
guarantees.

Closes #693 