### PR TITLE
Update the BlockHeader fields for Heartwood

### DIFF
--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -35,9 +35,18 @@ pub struct BlockHeader {
     /// header.
     pub merkle_root_hash: MerkleTreeRootHash,
 
-    /// [Sapling onward] The root LEBS2OSP256(rt) of the Sapling note
+    /// [Pre-Sapling] Reserved. All zeroes.
+    /// [Sapling and Blossom] The root LEBS2OSP256(rt) of the Sapling note
     /// commitment tree corresponding to the final Sapling treestate of
     /// this block.
+    /// [Heartwood onward] The root of a Merkle Mountain Range tree, which
+    /// commits to various features of the chain's history, including the
+    /// Sapling commitment tree. This commitment supports the FlyClient
+    /// protocol. See ZIP-221 for details.
+    // TODO:
+    //   - replace with an unspecified HistoryRootHash type?
+    // Note that the NetworkUpgrade list is in zebra-consensus, so we can't
+    // parse this field into a HistoryRootHash enum in zebra-chain.
     pub final_sapling_root_hash: SaplingNoteTreeRootHash,
 
     /// The block timestamp is a Unix epoch time (UTC) when the miner
@@ -52,8 +61,7 @@ pub struct BlockHeader {
     /// `ThresholdBits(height)`.
     ///
     /// [Bitcoin-nBits](https://bitcoin.org/en/developer-reference#target-nbits)
-    // parity-zcash has their own wrapper around u32 for this field, see #572 and:
-    // https://github.com/paritytech/parity-zcash/blob/master/primitives/src/compact.rs
+    // See #572 for details.
     pub bits: u32,
 
     /// An arbitrary field that miners can change to modify the header

--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -1,7 +1,6 @@
 use super::{BlockHeaderHash, Error};
 use crate::equihash_solution::EquihashSolution;
 use crate::merkle_tree::MerkleTreeRootHash;
-use crate::note_commitment_tree::SaplingNoteTreeRootHash;
 use crate::serialization::ZcashSerialize;
 use chrono::{DateTime, Duration, Utc};
 
@@ -47,7 +46,7 @@ pub struct BlockHeader {
     //   - replace with an unspecified HistoryRootHash type?
     // Note that the NetworkUpgrade list is in zebra-consensus, so we can't
     // parse this field into a HistoryRootHash enum in zebra-chain.
-    pub final_sapling_root_hash: SaplingNoteTreeRootHash,
+    pub history_root_hash: [u8; 32],
 
     /// The block timestamp is a Unix epoch time (UTC) when the miner
     /// started hashing the header (according to the miner).

--- a/zebra-chain/src/block/serialize.rs
+++ b/zebra-chain/src/block/serialize.rs
@@ -4,7 +4,6 @@ use std::io;
 
 use crate::equihash_solution::EquihashSolution;
 use crate::merkle_tree::MerkleTreeRootHash;
-use crate::note_commitment_tree::SaplingNoteTreeRootHash;
 use crate::serialization::ZcashDeserializeInto;
 use crate::serialization::{ReadZcashExt, SerializationError, ZcashDeserialize, ZcashSerialize};
 
@@ -18,7 +17,7 @@ impl ZcashSerialize for BlockHeader {
         writer.write_u32::<LittleEndian>(self.version)?;
         self.previous_block_hash.zcash_serialize(&mut writer)?;
         writer.write_all(&self.merkle_root_hash.0[..])?;
-        writer.write_all(&self.final_sapling_root_hash.0[..])?;
+        writer.write_all(&self.history_root_hash[..])?;
         // this is a truncating cast, rather than a saturating cast
         // but u32 times are valid until 2106, and our block verification time
         // checks should detect any truncation.
@@ -66,7 +65,7 @@ impl ZcashDeserialize for BlockHeader {
             version,
             previous_block_hash: BlockHeaderHash::zcash_deserialize(&mut reader)?,
             merkle_root_hash: MerkleTreeRootHash(reader.read_32_bytes()?),
-            final_sapling_root_hash: SaplingNoteTreeRootHash(reader.read_32_bytes()?),
+            history_root_hash: reader.read_32_bytes()?,
             // This can't panic, because all u32 values are valid `Utc.timestamp`s
             time: Utc.timestamp(reader.read_u32::<LittleEndian>()? as i64, 0),
             bits: reader.read_u32::<LittleEndian>()?,

--- a/zebra-chain/src/block/tests.rs
+++ b/zebra-chain/src/block/tests.rs
@@ -2,7 +2,6 @@ use super::*;
 
 use crate::equihash_solution::EquihashSolution;
 use crate::merkle_tree::MerkleTreeRootHash;
-use crate::note_commitment_tree::SaplingNoteTreeRootHash;
 use crate::serialization::{
     SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
 };
@@ -25,7 +24,7 @@ impl Arbitrary for BlockHeader {
             (4u32..(i32::MAX as u32)),
             any::<BlockHeaderHash>(),
             any::<MerkleTreeRootHash>(),
-            any::<SaplingNoteTreeRootHash>(),
+            any::<[u8; 32]>(),
             // time is interpreted as u32 in the spec, but rust timestamps are i64
             (0i64..(u32::MAX as i64)),
             any::<u32>(),
@@ -37,7 +36,7 @@ impl Arbitrary for BlockHeader {
                     version,
                     previous_block_hash,
                     merkle_root_hash,
-                    final_sapling_root_hash,
+                    history_root_hash,
                     timestamp,
                     bits,
                     nonce,
@@ -46,7 +45,7 @@ impl Arbitrary for BlockHeader {
                     version,
                     previous_block_hash,
                     merkle_root_hash,
-                    final_sapling_root_hash,
+                    history_root_hash,
                     time: Utc.timestamp(timestamp, 0),
                     bits,
                     nonce,


### PR DESCRIPTION
This PR is based on #766. I made a separate PR, because I wasn't sure if we
would want these changes.

The Heartwood upgrade changes the meaning of the hashFinalSaplingRoot to
hashLightClientRoot. Since we don't know the network upgrade heights in
zebra-chain, we just use [u8; 32] for now.