### PR TITLE
Avoid testnet listener conflicts

### DIFF
--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -172,6 +172,7 @@ impl ZebradApp {
             tracing:
                 crate::config::TracingSection {
                     filter: Some(filter),
+                    endpoint_addr: _,
                 },
             ..
         }) = &self.config

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -126,6 +126,10 @@ impl Application for ZebradApp {
         config: Self::Cfg,
         command: &Self::Cmd,
     ) -> Result<(), FrameworkError> {
+        use crate::components::{
+            metrics::MetricsEndpoint, tokio::TokioComponent, tracing::TracingEndpoint,
+        };
+
         // Configure components
         self.state.components.after_config(&config)?;
         self.config = Some(config);
@@ -137,6 +141,30 @@ impl Application for ZebradApp {
                 .get_downcast_mut::<Tracing>()
                 .expect("Tracing component should be available")
                 .reload_filter(level);
+
+            // Work around some issues with dependency injection and configs
+            let config = self
+                .config
+                .clone()
+                .expect("config was set to Some earlier in this function");
+
+            let tokio_component = self
+                .state
+                .components
+                .get_downcast_ref::<TokioComponent>()
+                .expect("Tokio component should be available");
+
+            self.state
+                .components
+                .get_downcast_ref::<TracingEndpoint>()
+                .expect("Tracing endpoint should be available")
+                .open_endpoint(&config.tracing, tokio_component);
+
+            self.state
+                .components
+                .get_downcast_ref::<MetricsEndpoint>()
+                .expect("Metrics endpoint should be available")
+                .open_endpoint(&config.metrics, tokio_component);
         }
 
         Ok(())

--- a/zebrad/src/components/metrics.rs
+++ b/zebrad/src/components/metrics.rs
@@ -1,10 +1,10 @@
 //! An HTTP endpoint for metrics collection.
 
-use metrics_runtime::{exporters::HttpExporter, observers::PrometheusBuilder, Receiver};
+use crate::{components::tokio::TokioComponent, prelude::*};
 
 use abscissa_core::{Component, FrameworkError};
 
-use crate::components::tokio::TokioComponent;
+use metrics_runtime::{exporters::HttpExporter, observers::PrometheusBuilder, Receiver};
 
 /// Abscissa component which runs a metrics endpoint.
 #[derive(Debug, Component)]
@@ -21,10 +21,7 @@ impl MetricsEndpoint {
     pub fn init_tokio(&mut self, tokio_component: &TokioComponent) -> Result<(), FrameworkError> {
         info!("Initializing metrics endpoint");
 
-        // XXX load metrics addr from config
-        let addr = "0.0.0.0:9999"
-            .parse()
-            .expect("Hardcoded address should be parseable");
+        let addr = app_config().metrics.endpoint_addr;
 
         // XXX do we need to hold on to the receiver?
         let receiver = Receiver::builder()

--- a/zebrad/src/components/tracing.rs
+++ b/zebrad/src/components/tracing.rs
@@ -35,10 +35,7 @@ impl TracingEndpoint {
         let service =
             make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(request_handler)) });
 
-        // XXX load tracing addr from config
-        let addr = "0.0.0.0:3000"
-            .parse()
-            .expect("Hardcoded address should be parseable");
+        let addr = app_config().tracing.endpoint_addr;
 
         tokio_component
             .rt

--- a/zebrad/src/components/tracing.rs
+++ b/zebrad/src/components/tracing.rs
@@ -1,6 +1,6 @@
 //! An HTTP endpoint for dynamically setting tracing filters.
 
-use crate::{components::tokio::TokioComponent, prelude::*};
+use crate::{components::tokio::TokioComponent, config::TracingSection, prelude::*};
 
 use abscissa_core::{Component, FrameworkError};
 
@@ -28,14 +28,25 @@ impl TracingEndpoint {
         Ok(Self {})
     }
 
-    /// Do setup after receiving a tokio runtime.
-    pub fn init_tokio(&mut self, tokio_component: &TokioComponent) -> Result<(), FrameworkError> {
+    /// Tokio endpoint dependency stub.
+    ///
+    /// We can't open the endpoint here, because the config has not been loaded.
+    pub fn init_tokio(&mut self, _tokio_component: &TokioComponent) -> Result<(), FrameworkError> {
+        Ok(())
+    }
+
+    /// Open the tracing endpoint.
+    ///
+    /// We can't implement `after_config`, because we use `derive(Component)`.
+    /// And the ownership rules might make it hard to access the TokioComponent
+    /// from `after_config`.
+    pub fn open_endpoint(&self, tracing_config: &TracingSection, tokio_component: &TokioComponent) {
         info!("Initializing tracing endpoint");
 
         let service =
             make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(request_handler)) });
 
-        let addr = app_config().tracing.endpoint_addr;
+        let addr = tracing_config.endpoint_addr;
 
         tokio_component
             .rt
@@ -58,8 +69,6 @@ impl TracingEndpoint {
                     error!("Server error: {}", e);
                 }
             });
-
-        Ok(())
     }
 }
 

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -33,17 +33,27 @@ pub struct ZebradConfig {
 }
 
 /// Tracing configuration section.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct TracingSection {
     /// The filter used for tracing events.
     pub filter: Option<String>,
+
+    /// The endpoint address used for tracing.
+    pub endpoint_addr: SocketAddr,
+}
+
+impl Default for TracingSection {
+    fn default() -> Self {
+        Self::populated()
+    }
 }
 
 impl TracingSection {
     pub fn populated() -> Self {
         Self {
             filter: Some("info".to_owned()),
+            endpoint_addr: "0.0.0.0:3000".parse().unwrap(),
         }
     }
 }
@@ -52,6 +62,7 @@ impl TracingSection {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct MetricsSection {
+    /// The endpoint address used for metrics.
     pub endpoint_addr: SocketAddr,
 }
 


### PR DESCRIPTION
* set the metrics and tracing listeners from the config
* warn if the zcash listener is configured with the other network's default port
* open the endpoints after the config is loaded