### PR TITLE
network: do not export Builder

### DIFF
--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -69,7 +69,6 @@ pub use crate::{
     config::Config,
     peer_set::init,
     policies::{RetryErrors, RetryLimit},
-    protocol::external::codec::Builder,
     protocol::internal::{Request, Response},
 };
 


### PR DESCRIPTION
This is used to construct the Codec, which is an internal type.  The
export was added in 4dc307f2.