### PR TITLE
chain: ensure impl Deserialize for Amount validates data.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
 
 [[package]]
+name = "bincode"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+dependencies = [
+ "byteorder",
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,6 +2621,7 @@ name = "zebra-chain"
 version = "3.0.0-alpha.0"
 dependencies = [
  "bech32",
+ "bincode",
  "blake2b_simd",
  "blake2s_simd",
  "bs58",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -37,3 +37,4 @@ proptest = "0.10"
 proptest-derive = "0.2.0"
 zebra-test = { path = "../zebra-test/" }
 color-eyre = "0.5"
+bincode = "1"


### PR DESCRIPTION
This uses serde's try_from attribute to run deserialized values through the
TryFrom impl.  Also adds a test to make sure that validation actually does
happen.