### PR TITLE
feature: Use zstd compression with sled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,9 +279,12 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cc"
-version = "1.0.41"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
+checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -601,6 +604,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+
+[[package]]
 name = "equihash"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "gumdrop"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,10 +1013,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+
+[[package]]
+name = "jobserver"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "jubjub"
@@ -1765,8 +1798,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "secp256k1"
 version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2932dc07acd2066ff2e3921a4419606b220ba6cd03a9935123856cc534877056"
+source = "git+https://github.com/rust-bitcoin/rust-secp256k1.git?rev=fd8b3ff572354ecb30cf1c783d393fbb404a5a9c#fd8b3ff572354ecb30cf1c783d393fbb404a5a9c"
 dependencies = [
  "secp256k1-sys",
  "serde",
@@ -1775,8 +1807,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-sys"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2c26f0d3552a0f12e639ae8a64afc2e3db9c52fe32f5fc6c289d38519f220"
+source = "git+https://github.com/rust-bitcoin/rust-secp256k1.git?rev=fd8b3ff572354ecb30cf1c783d393fbb404a5a9c#fd8b3ff572354ecb30cf1c783d393fbb404a5a9c"
 dependencies = [
  "cc",
 ]
@@ -1919,9 +1950,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "sled"
-version = "0.34.0"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2aed3832b6d0c828efe6bcb6c309a18cf487dffc5cc0787da2ce140f0fb0ce"
+checksum = "9e6a1b592011d7eb727a261d2f80608db11d7f02972c7016e8d4e74e67fe0daf"
 dependencies = [
  "crc32fast",
  "crossbeam-epoch",
@@ -1931,6 +1962,7 @@ dependencies = [
  "libc",
  "log",
  "parking_lot 0.11.0",
+ "zstd",
 ]
 
 [[package]]
@@ -2817,4 +2849,35 @@ dependencies = [
  "quote 1.0.7",
  "syn 1.0.35",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.5.3+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b32eaf771efa709e8308605bbf9319bf485dc1503179ec0469b611937c0cd8"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "2.0.5+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfb642e0d27f64729a639c52db457e0ae906e7bc6f5fe8f5c453230400f1055"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.4.17+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89249644df056b522696b1bb9e7c18c87e8ffa3e2f0dc3b0155875d6498f01b"
+dependencies = [
+ "cc",
+ "glob",
+ "itertools",
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ panic = "abort"
 
 [patch.crates-io]
 abscissa_core = { git = "https://github.com/yaahc/abscissa.git", rev = "41d342a9344e38442b2211b07f28a89505892a21" }
+# Resolve a cc dependency conflict with sled's compression feature (on sled 0.3.0 and later)
+# Remove when secp256k1 is on 0.17.3 or later
+secp256k1 = { git = "https://github.com/rust-bitcoin/rust-secp256k1.git", rev = "fd8b3ff572354ecb30cf1c783d393fbb404a5a9c" }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -15,7 +15,7 @@ dirs = "3.0.1"
 hex = "0.4.2"
 lazy_static = "1.4.0"
 serde = { version = "1", features = ["serde_derive"] }
-sled = "0.34.0"
+sled = { version = "0.34.0", features = ["compression"] }
 
 futures = "0.3.5"
 tower = "0.3.1"

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -64,7 +64,18 @@ impl Config {
             .join(net_dir)
             .join("state");
 
-        sled::Config::default().path(path)
+        // Use fast Zstd compression for the on-disk cache.
+        //
+        // We expect that long runs of zero bytes in blocks will compress well.
+        // But blocks are mainly distinct hashes, so they won't compress much
+        // more. Since Zebra is CPU-bound, we don't want to use much CPU for the
+        // block cache, so we choose the lowest compression level. (Zstd has
+        // negative compression levels, but they only give a minor increase in
+        // speed, in exchange for a major loss of compression ratio.)
+        sled::Config::default()
+            .path(path)
+            .use_compression(true)
+            .compression_factor(1)
     }
 }
 


### PR DESCRIPTION
Using compression could save a lot of disk space, without much impact on
CPU usage, as long as we set a low compression level.

Overrides the secp256k1 version with a later commit on their master branch,
to resolve a "cc" crate version conflict with zstd (used by sled).

Closes #776.

I'm not sure if we want to do an override, or just wait for the next secp256k1
release.