### PR TITLE
restore Zebras to part of the name, not a comment

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -38,7 +38,7 @@ pub const TIMESTAMP_TRUNCATION_SECONDS: i64 = 30 * 60;
 /// This must be a valid [BIP 14] user agent.
 ///
 /// [BIP 14]: https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki
-pub const USER_AGENT: &str = "/Zebra:3.0.0-alpha.0(🦓)/";
+pub const USER_AGENT: &str = "/🦓Zebra🦓:3.0.0-alpha.0/";
 
 /// The Zcash network protocol version implemented by this crate.
 ///


### PR DESCRIPTION
The Zebras were supposed to be part of the software name, to encourage ecosystem software to handle unicode correctly.