### PR TITLE
feature: Use the Canopy testnet network protocol version

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -44,7 +44,7 @@ pub const USER_AGENT: &str = "/🦓Zebra🦓:3.0.0-alpha.0/";
 ///
 /// This protocol version might be the current version on Mainnet or Testnet,
 /// based on where we are in the network upgrade cycle.
-pub const CURRENT_VERSION: Version = Version(170_011);
+pub const CURRENT_VERSION: Version = Version(170_012);
 
 /// The most recent bilateral consensus upgrade implemented by this crate.
 ///


### PR DESCRIPTION
Canopy will activate on testnet within the next 24 hours. To continue to
use testnet, we need to upgrade the Zebra network protocol version.

For details, see:
https://zips.z.cash/zip-0251#support-in-zcashd