### PR TITLE
Feedback Wanted: Explicitly type byte vectors using 0u8

### DIFF
--- a/zebra-chain/src/addresses/sapling.rs
+++ b/zebra-chain/src/addresses/sapling.rs
@@ -69,7 +69,7 @@ impl std::str::FromStr for SaplingShieldedAddress {
             Ok((hrp, bytes)) => {
                 let mut decoded_bytes = io::Cursor::new(Vec::<u8>::from_base32(&bytes).unwrap());
 
-                let mut diversifier_bytes = [0; 11];
+                let mut diversifier_bytes = [0u8; 11];
                 decoded_bytes.read_exact(&mut diversifier_bytes)?;
 
                 let transmission_key_bytes = decoded_bytes.read_32_bytes()?;

--- a/zebra-chain/src/addresses/sprout.rs
+++ b/zebra-chain/src/addresses/sprout.rs
@@ -67,7 +67,7 @@ impl ZcashSerialize for SproutShieldedAddress {
 
 impl ZcashDeserialize for SproutShieldedAddress {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let mut version_bytes = [0; 2];
+        let mut version_bytes = [0u8; 2];
         reader.read_exact(&mut version_bytes)?;
 
         let network = match version_bytes {

--- a/zebra-chain/src/addresses/transparent.rs
+++ b/zebra-chain/src/addresses/transparent.rs
@@ -157,10 +157,10 @@ impl ZcashSerialize for TransparentAddress {
 
 impl ZcashDeserialize for TransparentAddress {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let mut version_bytes = [0; 2];
+        let mut version_bytes = [0u8; 2];
         reader.read_exact(&mut version_bytes)?;
 
-        let mut hash_bytes = [0; 20];
+        let mut hash_bytes = [0u8; 20];
         reader.read_exact(&mut hash_bytes)?;
 
         match version_bytes {
@@ -207,7 +207,7 @@ impl TransparentAddress {
     fn p2pkh_strategy() -> impl Strategy<Value = Self> {
         (any::<Network>(), vec(any::<u8>(), 20))
             .prop_map(|(network, payload_bytes)| {
-                let mut bytes = [0; 20];
+                let mut bytes = [0u8; 20];
                 bytes.copy_from_slice(payload_bytes.as_slice());
                 Self::PayToPublicKeyHash {
                     network,
@@ -220,7 +220,7 @@ impl TransparentAddress {
     fn p2sh_strategy() -> impl Strategy<Value = Self> {
         (any::<Network>(), vec(any::<u8>(), 20))
             .prop_map(|(network, payload_bytes)| {
-                let mut bytes = [0; 20];
+                let mut bytes = [0u8; 20];
                 bytes.copy_from_slice(payload_bytes.as_slice());
                 Self::PayToScriptHash {
                     network,
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn empty_script() {
-        let script = Script(vec![0; 20]);
+        let script = Script(vec![0u8; 20]);
 
         let t_addr = TransparentAddress::from(script);
 

--- a/zebra-chain/src/block/difficulty.rs
+++ b/zebra-chain/src/block/difficulty.rs
@@ -84,7 +84,7 @@ pub struct ExpandedDifficulty(U256);
 
 impl fmt::Debug for ExpandedDifficulty {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut buf = [0; 32];
+        let mut buf = [0u8; 32];
         // Use the same byte order as BlockHeaderHash
         self.0.to_little_endian(&mut buf);
         f.debug_tuple("ExpandedDifficulty")
@@ -447,7 +447,7 @@ mod tests {
         let ex_zero = ExpandedDifficulty(U256::zero());
         let ex_one = ExpandedDifficulty(U256::one());
         let ex_max = ExpandedDifficulty(U256::MAX);
-        let hash_zero = BlockHeaderHash([0; 32]);
+        let hash_zero = BlockHeaderHash([0u8; 32]);
         let hash_max = BlockHeaderHash([0xff; 32]);
 
         assert_eq!(hash_zero, ex_zero);
@@ -477,7 +477,7 @@ mod tests {
             // TODO: round-trip test, once we have ExpandedDifficulty::to_compact()
             let expanded = compact.to_expanded();
 
-            let hash_zero = BlockHeaderHash([0; 32]);
+            let hash_zero = BlockHeaderHash([0u8; 32]);
             let hash_max = BlockHeaderHash([0xff; 32]);
 
             if let Some(expanded) = expanded {
@@ -490,7 +490,7 @@ mod tests {
         #[test]
         fn prop_expanded_order(expanded in any::<ExpandedDifficulty>()) {
             // TODO: round-trip test, once we have ExpandedDifficulty::to_compact()
-            let hash_zero = BlockHeaderHash([0; 32]);
+            let hash_zero = BlockHeaderHash([0u8; 32]);
             let hash_max = BlockHeaderHash([0xff; 32]);
 
             prop_assert!(expanded >= hash_zero);

--- a/zebra-chain/src/block/hash.rs
+++ b/zebra-chain/src/block/hash.rs
@@ -61,7 +61,7 @@ impl ZcashDeserialize for BlockHeaderHash {
 impl std::str::FromStr for BlockHeaderHash {
     type Err = SerializationError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut bytes = [0; 32];
+        let mut bytes = [0u8; 32];
         if hex::decode_to_slice(s, &mut bytes[..]).is_err() {
             Err(SerializationError::Parse("hex decoding error"))
         } else {

--- a/zebra-chain/src/equihash_solution.rs
+++ b/zebra-chain/src/equihash_solution.rs
@@ -50,7 +50,7 @@ impl Copy for EquihashSolution {}
 
 impl Clone for EquihashSolution {
     fn clone(&self) -> Self {
-        let mut bytes = [0; EQUIHASH_SOLUTION_SIZE];
+        let mut bytes = [0u8; EQUIHASH_SOLUTION_SIZE];
         bytes[..].copy_from_slice(&self.0[..]);
         Self(bytes)
     }
@@ -74,7 +74,7 @@ impl ZcashDeserialize for EquihashSolution {
                 "incorrect equihash solution size",
             ));
         }
-        let mut bytes = [0; EQUIHASH_SOLUTION_SIZE];
+        let mut bytes = [0u8; EQUIHASH_SOLUTION_SIZE];
         reader.read_exact(&mut bytes[..])?;
         Ok(Self(bytes))
     }
@@ -93,7 +93,7 @@ mod tests {
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             (vec(any::<u8>(), EQUIHASH_SOLUTION_SIZE))
                 .prop_map(|v| {
-                    let mut bytes = [0; EQUIHASH_SOLUTION_SIZE];
+                    let mut bytes = [0u8; EQUIHASH_SOLUTION_SIZE];
                     bytes.copy_from_slice(v.as_slice());
                     Self(bytes)
                 })

--- a/zebra-chain/src/keys/sprout.rs
+++ b/zebra-chain/src/keys/sprout.rs
@@ -79,7 +79,7 @@ impl ZcashSerialize for SpendingKey {
 
 impl ZcashDeserialize for SpendingKey {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let mut version_bytes = [0; 2];
+        let mut version_bytes = [0u8; 2];
         reader.read_exact(&mut version_bytes)?;
 
         let network = match version_bytes {
@@ -245,7 +245,7 @@ impl ZcashSerialize for IncomingViewingKey {
 
 impl ZcashDeserialize for IncomingViewingKey {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let mut version_bytes = [0; 3];
+        let mut version_bytes = [0u8; 3];
         reader.read_exact(&mut version_bytes)?;
 
         let network = match version_bytes {

--- a/zebra-chain/src/keys/transparent.rs
+++ b/zebra-chain/src/keys/transparent.rs
@@ -18,7 +18,7 @@ impl ZcashSerialize for PublicKey {
 
 impl ZcashDeserialize for PublicKey {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let mut bytes = [0; 33];
+        let mut bytes = [0u8; 33];
         reader.read_exact(&mut bytes[..])?;
         Self::from_slice(&bytes[..])
             .map_err(|_| SerializationError::Parse("invalid secp256k1 compressed public key"))

--- a/zebra-chain/src/notes/memo.rs
+++ b/zebra-chain/src/notes/memo.rs
@@ -16,7 +16,7 @@ impl<'a> TryFrom<&'a [u8]> for Memo {
     type Error = &'static str;
 
     fn try_from(input: &'a [u8]) -> Result<Self, Self::Error> {
-        let mut full_bytes = [0; 512];
+        let mut full_bytes = [0u8; 512];
 
         match input.len().cmp(&512) {
             cmp::Ordering::Less => {
@@ -76,7 +76,7 @@ fn memo_fmt() {
 fn memo_from_string() {
     let memo = Memo::try_from("foo bar baz".as_ref()).unwrap();
 
-    let mut bytes = [0; 512];
+    let mut bytes = [0u8; 512];
     bytes[0..11].copy_from_slice(&[102, 111, 111, 32, 98, 97, 114, 32, 98, 97, 122]);
 
     assert!(memo.0.iter().eq(bytes.iter()));

--- a/zebra-chain/src/notes/sapling.rs
+++ b/zebra-chain/src/notes/sapling.rs
@@ -57,7 +57,7 @@ impl Copy for EncryptedCiphertext {}
 
 impl Clone for EncryptedCiphertext {
     fn clone(&self) -> Self {
-        let mut bytes = [0; 580];
+        let mut bytes = [0u8; 580];
         bytes[..].copy_from_slice(&self.0[..]);
         Self(bytes)
     }
@@ -80,7 +80,7 @@ impl ZcashSerialize for EncryptedCiphertext {
 
 impl ZcashDeserialize for EncryptedCiphertext {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let mut bytes = [0; 580];
+        let mut bytes = [0u8; 580];
         reader.read_exact(&mut bytes[..])?;
         Ok(Self(bytes))
     }
@@ -93,7 +93,7 @@ impl Arbitrary for EncryptedCiphertext {
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         (vec(any::<u8>(), 580))
             .prop_map(|v| {
-                let mut bytes = [0; 580];
+                let mut bytes = [0u8; 580];
                 bytes.copy_from_slice(v.as_slice());
                 Self(bytes)
             })
@@ -121,7 +121,7 @@ impl Copy for OutCiphertext {}
 
 impl Clone for OutCiphertext {
     fn clone(&self) -> Self {
-        let mut bytes = [0; 80];
+        let mut bytes = [0u8; 80];
         bytes[..].copy_from_slice(&self.0[..]);
         Self(bytes)
     }
@@ -144,7 +144,7 @@ impl ZcashSerialize for OutCiphertext {
 
 impl ZcashDeserialize for OutCiphertext {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let mut bytes = [0; 80];
+        let mut bytes = [0u8; 80];
         reader.read_exact(&mut bytes[..])?;
         Ok(Self(bytes))
     }
@@ -157,7 +157,7 @@ impl Arbitrary for OutCiphertext {
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         (vec(any::<u8>(), 80))
             .prop_map(|v| {
-                let mut bytes = [0; 80];
+                let mut bytes = [0u8; 80];
                 bytes.copy_from_slice(v.as_slice());
                 Self(bytes)
             })

--- a/zebra-chain/src/notes/sprout.rs
+++ b/zebra-chain/src/notes/sprout.rs
@@ -53,7 +53,7 @@ impl Copy for EncryptedCiphertext {}
 
 impl Clone for EncryptedCiphertext {
     fn clone(&self) -> Self {
-        let mut bytes = [0; 601];
+        let mut bytes = [0u8; 601];
         bytes[..].copy_from_slice(&self.0[..]);
         Self(bytes)
     }
@@ -76,7 +76,7 @@ impl ZcashSerialize for EncryptedCiphertext {
 
 impl ZcashDeserialize for EncryptedCiphertext {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let mut bytes = [0; 601];
+        let mut bytes = [0u8; 601];
         reader.read_exact(&mut bytes[..])?;
         Ok(Self(bytes))
     }
@@ -89,7 +89,7 @@ impl Arbitrary for EncryptedCiphertext {
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         (vec(any::<u8>(), 601))
             .prop_map(|v| {
-                let mut bytes = [0; 601];
+                let mut bytes = [0u8; 601];
                 bytes.copy_from_slice(v.as_slice());
                 Self(bytes)
             })

--- a/zebra-chain/src/proofs/bctv14.rs
+++ b/zebra-chain/src/proofs/bctv14.rs
@@ -23,7 +23,7 @@ impl Copy for Bctv14Proof {}
 
 impl Clone for Bctv14Proof {
     fn clone(&self) -> Self {
-        let mut bytes = [0; 296];
+        let mut bytes = [0u8; 296];
         bytes[..].copy_from_slice(&self.0[..]);
         Self(bytes)
     }
@@ -46,7 +46,7 @@ impl ZcashSerialize for Bctv14Proof {
 
 impl ZcashDeserialize for Bctv14Proof {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let mut bytes = [0; 296];
+        let mut bytes = [0u8; 296];
         reader.read_exact(&mut bytes[..])?;
         Ok(Self(bytes))
     }
@@ -62,7 +62,7 @@ impl Arbitrary for Bctv14Proof {
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         (vec(any::<u8>(), 296))
             .prop_map(|v| {
-                let mut bytes = [0; 296];
+                let mut bytes = [0u8; 296];
                 bytes.copy_from_slice(v.as_slice());
                 Self(bytes)
             })

--- a/zebra-chain/src/proofs/groth16.rs
+++ b/zebra-chain/src/proofs/groth16.rs
@@ -22,7 +22,7 @@ impl Copy for Groth16Proof {}
 
 impl Clone for Groth16Proof {
     fn clone(&self) -> Self {
-        let mut bytes = [0; 192];
+        let mut bytes = [0u8; 192];
         bytes[..].copy_from_slice(&self.0[..]);
         Self(bytes)
     }
@@ -45,7 +45,7 @@ impl ZcashSerialize for Groth16Proof {
 
 impl ZcashDeserialize for Groth16Proof {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let mut bytes = [0; 192];
+        let mut bytes = [0u8; 192];
         reader.read_exact(&mut bytes[..])?;
         Ok(Self(bytes))
     }
@@ -61,7 +61,7 @@ impl Arbitrary for Groth16Proof {
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         (vec(any::<u8>(), 192))
             .prop_map(|v| {
-                let mut bytes = [0; 192];
+                let mut bytes = [0u8; 192];
                 bytes.copy_from_slice(v.as_slice());
                 Self(bytes)
             })

--- a/zebra-chain/src/serialization.rs
+++ b/zebra-chain/src/serialization.rs
@@ -265,7 +265,7 @@ pub trait ReadZcashExt: io::Read {
     #[inline]
     fn read_string(&mut self) -> Result<String, SerializationError> {
         let len = self.read_compactsize()?;
-        let mut buf = vec![0; len as usize];
+        let mut buf = vec![0u8; len as usize];
         self.read_exact(&mut buf)?;
         String::from_utf8(buf).map_err(|_| SerializationError::Parse("invalid utf-8"))
     }
@@ -273,7 +273,7 @@ pub trait ReadZcashExt: io::Read {
     /// Convenience method to read a `[u8; 4]`.
     #[inline]
     fn read_4_bytes(&mut self) -> io::Result<[u8; 4]> {
-        let mut bytes = [0; 4];
+        let mut bytes = [0u8; 4];
         self.read_exact(&mut bytes)?;
         Ok(bytes)
     }
@@ -281,7 +281,7 @@ pub trait ReadZcashExt: io::Read {
     /// Convenience method to read a `[u8; 12]`.
     #[inline]
     fn read_12_bytes(&mut self) -> io::Result<[u8; 12]> {
-        let mut bytes = [0; 12];
+        let mut bytes = [0u8; 12];
         self.read_exact(&mut bytes)?;
         Ok(bytes)
     }
@@ -289,7 +289,7 @@ pub trait ReadZcashExt: io::Read {
     /// Convenience method to read a `[u8; 32]`.
     #[inline]
     fn read_32_bytes(&mut self) -> io::Result<[u8; 32]> {
-        let mut bytes = [0; 32];
+        let mut bytes = [0u8; 32];
         self.read_exact(&mut bytes)?;
         Ok(bytes)
     }
@@ -297,7 +297,7 @@ pub trait ReadZcashExt: io::Read {
     /// Convenience method to read a `[u8; 64]`.
     #[inline]
     fn read_64_bytes(&mut self) -> io::Result<[u8; 64]> {
-        let mut bytes = [0; 64];
+        let mut bytes = [0u8; 64];
         self.read_exact(&mut bytes)?;
         Ok(bytes)
     }

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -42,7 +42,7 @@ impl std::str::FromStr for TransactionHash {
     type Err = SerializationError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut bytes = [0; 32];
+        let mut bytes = [0u8; 32];
         if hex::decode_to_slice(s, &mut bytes[..]).is_err() {
             Err(SerializationError::Parse("hex decoding error"))
         } else {

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -169,7 +169,7 @@ impl ZcashSerialize for TransparentInput {
                 data,
                 sequence,
             } => {
-                writer.write_all(&[0; 32][..])?;
+                writer.write_all(&[0u8; 32][..])?;
                 writer.write_u32::<LittleEndian>(0xffff_ffff)?;
                 let height_len = coinbase_height_len(*height);
                 let total_len = height_len + data.as_ref().len();
@@ -188,7 +188,7 @@ impl ZcashDeserialize for TransparentInput {
         // This inlines the OutPoint deserialization to peek at the hash value
         // and detect whether we have a coinbase input.
         let bytes = reader.read_32_bytes()?;
-        if bytes == [0; 32] {
+        if bytes == [0u8; 32] {
             if reader.read_u32::<LittleEndian>()? != 0xffff_ffff {
                 return Err(SerializationError::Parse("wrong index in coinbase"));
             }

--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -104,7 +104,7 @@ async fn header_solution() -> Result<(), Report> {
         .map_err(|e| eyre!(e))?;
 
     // Change nonce to something invalid
-    block.header.nonce = [0; 32];
+    block.header.nonce = [0u8; 32];
 
     let ready_verifier_service = block_verifier.ready_and().await.map_err(|e| eyre!(e))?;
 

--- a/zebra-consensus/src/checkpoint/list.rs
+++ b/zebra-consensus/src/checkpoint/list.rs
@@ -128,9 +128,9 @@ impl CheckpointList {
             Err("checkpoint hashes must be unique")?;
         }
 
-        // Make sure all the hashes are valid. In Bitcoin, [0; 32] is the null
+        // Make sure all the hashes are valid. In Bitcoin, [0u8; 32] is the null
         // hash. It is also used as the parent hash of genesis blocks.
-        if block_hashes.contains(&BlockHeaderHash([0; 32])) {
+        if block_hashes.contains(&BlockHeaderHash([0u8; 32])) {
             Err("checkpoint list contains invalid checkpoint hash: found null hash")?;
         }
 

--- a/zebra-consensus/src/checkpoint/list/tests.rs
+++ b/zebra-consensus/src/checkpoint/list/tests.rs
@@ -98,7 +98,7 @@ fn checkpoint_list_no_genesis_fail() -> Result<(), Error> {
 fn checkpoint_list_null_hash_fail() -> Result<(), Error> {
     zebra_test::init();
 
-    let checkpoint_data = vec![(BlockHeight(0), BlockHeaderHash([0; 32]))];
+    let checkpoint_data = vec![(BlockHeight(0), BlockHeaderHash([0u8; 32]))];
 
     // Make a checkpoint list containing the non-genesis block
     let checkpoint_list: BTreeMap<BlockHeight, BlockHeaderHash> =

--- a/zebra-consensus/src/parameters/genesis.rs
+++ b/zebra-consensus/src/parameters/genesis.rs
@@ -6,8 +6,8 @@ use zebra_chain::{Network, Network::*};
 /// The previous block hash for the genesis block.
 ///
 /// All known networks use the Bitcoin `null` value for the parent of the
-/// genesis block. (In Bitcoin, `null` is `[0; 32]`.)
-pub const GENESIS_PREVIOUS_BLOCK_HASH: BlockHeaderHash = BlockHeaderHash([0; 32]);
+/// genesis block. (In Bitcoin, `null` is `[0u8; 32]`.)
+pub const GENESIS_PREVIOUS_BLOCK_HASH: BlockHeaderHash = BlockHeaderHash([0u8; 32]);
 
 /// Returns the hash for the genesis block in `network`.
 pub fn genesis_hash(network: Network) -> BlockHeaderHash {

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -385,7 +385,7 @@ where
                 .peer_tx
                 .send(Message::GetBlocks {
                     block_locator_hashes: known_blocks,
-                    hash_stop: stop.unwrap_or(BlockHeaderHash([0; 32])),
+                    hash_stop: stop.unwrap_or(BlockHeaderHash([0u8; 32])),
                 })
                 .await
                 .map_err(|e| e.into())

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -527,7 +527,7 @@ impl Codec {
 
         let filter_length: usize = body_len - FILTERLOAD_REMAINDER_LENGTH;
 
-        let mut filter_bytes = vec![0; filter_length];
+        let mut filter_bytes = vec![0u8; filter_length];
         reader.read_exact(&mut filter_bytes)?;
 
         Ok(Message::FilterLoad {
@@ -613,7 +613,7 @@ mod tests {
         let mut rt = Runtime::new().unwrap();
 
         let v = Message::FilterLoad {
-            filter: Filter(vec![0; 35999]),
+            filter: Filter(vec![0u8; 35999]),
             hash_functions_count: 0,
             tweak: Tweak(0),
             flags: 0,
@@ -647,7 +647,7 @@ mod tests {
         let mut rt = Runtime::new().unwrap();
 
         let v = Message::FilterLoad {
-            filter: Filter(vec![0; 40000]),
+            filter: Filter(vec![0u8; 40000]),
             hash_functions_count: 0,
             tweak: Tweak(0),
             flags: 0,

--- a/zebra-network/src/protocol/external/inv.rs
+++ b/zebra-network/src/protocol/external/inv.rs
@@ -57,7 +57,7 @@ impl From<BlockHeaderHash> for InventoryHash {
 impl ZcashSerialize for InventoryHash {
     fn zcash_serialize<W: Write>(&self, mut writer: W) -> Result<(), std::io::Error> {
         let (code, bytes) = match *self {
-            InventoryHash::Error => (0, [0; 32]),
+            InventoryHash::Error => (0, [0u8; 32]),
             InventoryHash::Tx(hash) => (1, hash.0),
             InventoryHash::Block(hash) => (2, hash.0),
             InventoryHash::FilteredBlock(hash) => (3, hash.0),


### PR DESCRIPTION
In https://github.com/ZcashFoundation/zebra/pull/809#discussion_r464699425, @dconnolly suggested we use `[0u8; N]` for byte arrays, rather than `[0; N]`.

This change makes sure that the array is a byte array, rather than risking type inference choosing another integer size. (Or defaulting to `i32`.)

However, it comes with a readability cost, so I'm looking for feedback before we merge.

This is an automatic search and replace, using this script:
sed -i -e "s/\[0;/\[0u8;/g" `find zebra* -name '*.rs'`