### PR TITLE
fix: Speed up the block round trip proptest

### DIFF
--- a/zebra-chain/src/block/tests.rs
+++ b/zebra-chain/src/block/tests.rs
@@ -13,6 +13,7 @@ use chrono::{DateTime, Duration, LocalResult, TimeZone, Utc};
 use proptest::{
     arbitrary::{any, Arbitrary},
     prelude::*,
+    test_runner::Config,
 };
 use std::io::{Cursor, ErrorKind, Write};
 
@@ -210,6 +211,11 @@ proptest! {
 
         prop_assert_eq![header, other_header];
     }
+}
+
+proptest! {
+    // The block roundtrip test can be really slow
+    #![proptest_config(Config::with_cases(16))]
 
     #[test]
     fn block_roundtrip(block in any::<Block>()) {


### PR DESCRIPTION
Reduce the number of cases run by the block round trip proptest, to
speed up the Zebra tests.

Closes #803.