### PR TITLE
WIP: Resolve deadlocks between the sync service backpressure and the checkpoint verifier

### DIFF
--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -78,7 +78,6 @@ where
     /// Used for debugging.
     ///
     /// Updated before verification: the block at this height might not be valid.
-    /// Not updated for unexpected high blocks.
     last_block_height: Option<BlockHeight>,
 }
 
@@ -130,10 +129,10 @@ where
             (Some(BlockHeight(block_height)), Some(BlockHeight(last_block_height)))
                 if (block_height > last_block_height + MAX_EXPECTED_BLOCK_GAP) =>
             {
+                self.last_block_height = Some(BlockHeight(block_height));
                 true
             }
             (Some(block_height), _) => {
-                // Update the last height if the block height was expected
                 self.last_block_height = Some(block_height);
                 false
             }
@@ -147,11 +146,15 @@ where
 
             // Call a verifier based on the block height and checkpoints.
             if is_higher_than_max_checkpoint(block_height, max_checkpoint_height) {
-                // Log an info-level message on early high blocks.
+                // Log a message on early high blocks.
                 // The sync service rejects most of these blocks, but we
                 // still want to know if a large number get through.
+                //
+                // This message can also happen if we keep getting unexpected
+                // low blocks. (We can't distinguish between these cases, until
+                // we've verified the blocks.)
                 if is_unexpected_high_block {
-                    tracing::info!(?block_height, "unexpected high block");
+                    tracing::debug!(?block_height, "unexpected high block, or recent unexpected low blocks");
                 }
 
                 block_verifier

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -330,7 +330,7 @@ impl CheckpointVerifier {
             InitialTip(previous_height) | PreviousCheckpoint(previous_height)
                 if (height <= previous_height) =>
             {
-                Err("block height has already been verified")?
+                Err(format!("Block has already been verified. {:?}", height))?
             }
             InitialTip(_) | PreviousCheckpoint(_) => {}
             // We're finished, so no checkpoint height is valid
@@ -394,7 +394,9 @@ impl CheckpointVerifier {
         let height = match self.check_block(&block) {
             Ok(height) => height,
             Err(error) => {
-                tracing::warn!(?error);
+                // Block errors happen frequently on mainnet, due to bad peers.
+                tracing::debug!(?error);
+
                 // Sending might fail, depending on what the caller does with rx,
                 // but there's nothing we can do about it.
                 let _ = tx.send(Err(error));
@@ -573,7 +575,7 @@ impl CheckpointVerifier {
             } else {
                 // The last block height we processed did not have any blocks
                 // with a matching hash, so chain verification has failed.
-                tracing::warn!(
+                tracing::info!(
                     ?current_height,
                     ?current_range,
                     "No valid blocks at height in CheckpointVerifier"

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -141,9 +141,12 @@ pub enum Response {
 
 /// Get the heights of the blocks for constructing a block_locator list
 fn block_locator_heights(tip_height: BlockHeight) -> impl Iterator<Item = BlockHeight> {
-    iter::successors(Some(1u32), |h| h.checked_mul(2))
+    let locators = iter::successors(Some(1u32), |h| h.checked_mul(2))
         .flat_map(move |step| tip_height.0.checked_sub(step))
-        .map(BlockHeight)
+        .filter(|&height| height != 0)
+        .map(BlockHeight);
+    iter::once(tip_height)
+        .chain(locators)
         .chain(iter::once(BlockHeight(0)))
 }
 

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -22,6 +22,7 @@
 // Tracing causes false positives on this lint:
 // https://github.com/tokio-rs/tracing/issues/553
 #![allow(clippy::cognitive_complexity)]
+#![allow(clippy::try_err)]
 
 #[macro_use]
 extern crate tracing;


### PR DESCRIPTION
I think there's a deadlock between the sync service lookahead limit, and the checkpoint verifier waiting for failed blocks.

In #819, I temporarily resolved the issue by increasing the retry limit. (Before #819, the issue was usually hidden by duplicate downloads.)

I tried adding a timeout in this PR, but the way I implemented it doesn't resolve the deadlock.

Based on #819, the first new commit is 0b6519a.

TODO:
- [ ] Revise after splitting #819 

