### PR TITLE
Clean up options in network config section.

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -17,9 +17,6 @@ pub struct Config {
     /// The network to connect to.
     pub network: Network,
 
-    /// The user-agent to advertise.
-    pub user_agent: String,
-
     /// A list of initial peers for the peerset when operating on
     /// mainnet.
     pub initial_mainnet_peers: HashSet<String>,
@@ -28,22 +25,8 @@ pub struct Config {
     /// testnet.
     pub initial_testnet_peers: HashSet<String>,
 
-    /// The outgoing request buffer size for the peer set.
-    pub peerset_request_buffer_size: usize,
-
     /// The initial target size for the peer set.
     pub peerset_initial_target_size: usize,
-
-    // Note: due to the way this is rendered by the toml
-    // serializer, the Duration fields should come last.
-    /// The default RTT estimate for peer responses, used in load-balancing.
-    pub ewma_default_rtt: Duration,
-
-    /// The decay time for the exponentially-weighted moving average response time.
-    pub ewma_decay_time: Duration,
-
-    /// The timeout for peer handshakes.
-    pub handshake_timeout: Duration,
 
     /// How frequently we attempt to connect to a new peer.
     pub new_peer_interval: Duration,
@@ -92,14 +75,9 @@ impl Default for Config {
             listen_addr: "0.0.0.0:8233"
                 .parse()
                 .expect("Hardcoded address should be parseable"),
-            user_agent: crate::constants::USER_AGENT.to_owned(),
             network: Network::Mainnet,
             initial_mainnet_peers: mainnet_peers,
             initial_testnet_peers: testnet_peers,
-            ewma_default_rtt: Duration::from_secs(1),
-            ewma_decay_time: Duration::from_secs(60),
-            peerset_request_buffer_size: 10,
-            handshake_timeout: Duration::from_secs(4),
             new_peer_interval: Duration::from_secs(60),
             peerset_initial_target_size: 50,
         }

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -7,8 +7,14 @@ use crate::protocol::external::types::*;
 
 use zebra_consensus::parameters::NetworkUpgrade::{self, *};
 
+/// The buffer size for the peer set.
+pub const PEERSET_BUFFER_SIZE: usize = 10;
+
 /// The timeout for requests made to a remote peer.
 pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The timeout for handshakes when connecting to new peers.
+pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(4);
 
 /// We expect to receive a message from a live peer at least once in this time duration.
 ///
@@ -58,6 +64,12 @@ pub const CURRENT_VERSION: Version = Version(170_012);
 // TODO: replace with NetworkUpgrade::current(network, height).
 //       See the detailed comment in handshake.rs, where this constant is used.
 pub const MIN_NETWORK_UPGRADE: NetworkUpgrade = Heartwood;
+
+/// The default RTT estimate for peer responses.
+pub const EWMA_DEFAULT_RTT: Duration = Duration::from_secs(1);
+
+/// The decay time for the EWMA response time metric used for load balancing.
+pub const EWMA_DECAY_TIME: Duration = Duration::from_secs(60);
 
 /// Magic numbers used to identify different Zcash networks.
 pub mod magics {

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -104,7 +104,6 @@ where
         let nonces = self.nonces.clone();
         let internal_service = self.internal_service.clone();
         let timestamp_collector = self.timestamp_collector.clone();
-        let user_agent = self.config.user_agent.clone();
         let network = self.config.network;
 
         let fut = async move {
@@ -128,7 +127,7 @@ where
                 //       send our configured address to the peer
                 address_from: (PeerServices::NODE_NETWORK, "0.0.0.0:8233".parse().unwrap()),
                 nonce: local_nonce,
-                user_agent,
+                user_agent: constants::USER_AGENT.to_string(),
                 // XXX eventually the `PeerConnector` will need to have a handle
                 // for a service that gets the current block height. Among other
                 // things we need it to reject peers who don't know about the

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -24,8 +24,8 @@ use tower::{
 use tower_load::{peak_ewma::PeakEwmaDiscover, NoInstrument};
 
 use crate::{
-    peer, timestamp_collector::TimestampCollector, AddressBook, BoxedStdError, Config, Request,
-    Response,
+    constants, peer, timestamp_collector::TimestampCollector, AddressBook, BoxedStdError, Config,
+    Request, Response,
 };
 
 use zebra_chain::Network::*;
@@ -62,7 +62,7 @@ where
     // enforce timeouts as specified in the Config.
     let (listener, connector) = {
         use tower::timeout::TimeoutLayer;
-        let hs_timeout = TimeoutLayer::new(config.handshake_timeout);
+        let hs_timeout = TimeoutLayer::new(constants::HANDSHAKE_TIMEOUT);
         let hs = peer::Handshake::new(config.clone(), inbound_service, timestamp_collector);
         (
             hs_timeout.layer(hs.clone()),
@@ -84,14 +84,14 @@ where
                 // so discard any errored connections...
                 peerset_rx.filter(|result| future::ready(result.is_ok())),
             ),
-            config.ewma_default_rtt,
-            config.ewma_decay_time,
+            constants::EWMA_DEFAULT_RTT,
+            constants::EWMA_DECAY_TIME,
             NoInstrument,
         ),
         demand_tx.clone(),
         handle_rx,
     );
-    let peer_set = Buffer::new(peer_set, config.peerset_request_buffer_size);
+    let peer_set = Buffer::new(peer_set, constants::PEERSET_BUFFER_SIZE);
 
     // Connect the tx end to the 3 peer sources:
 


### PR DESCRIPTION
Closes #536.

This removes:

- the user-agent (we can add a mechanism to specify extra BIP14 components later, if any users ask us for that feature);
- the EWMA parameters (these were put in the config just to avoid making a choice);
- the peer connection timeout (we can change the default value if anyone ever has a problem with it);
- the peer set request buffer size (setting this too low can make the application deadlock);

The new peer interval is left in.