### PR TITLE
Stop the block locator at the reorg limit

### DIFF
--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -142,9 +142,12 @@ pub enum Response {
 
 /// Get the heights of the blocks for constructing a block_locator list
 fn block_locator_heights(tip_height: BlockHeight) -> impl Iterator<Item = BlockHeight> {
-    iter::successors(Some(1u32), |h| h.checked_mul(2))
+    let locators = iter::successors(Some(1u32), |h| h.checked_mul(2))
         .flat_map(move |step| tip_height.0.checked_sub(step))
-        .map(BlockHeight)
+        .filter(|&height| height != 0)
+        .map(BlockHeight);
+    iter::once(tip_height)
+        .chain(locators)
         .chain(iter::once(BlockHeight(0)))
 }
 

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -156,18 +156,15 @@ pub enum Response {
 /// Get the heights of the blocks for constructing a block_locator list
 fn block_locator_heights(tip_height: BlockHeight) -> impl Iterator<Item = BlockHeight> {
     // Stop at the reorg limit, or the genesis block.
-    let min_locator_height = tip_height
-        .0
-        .checked_sub(MAX_BLOCK_REORG_HEIGHT.0)
-        .map(BlockHeight)
-        .unwrap_or(BlockHeight(0));
+    let min_locator_height = tip_height.0.saturating_sub(MAX_BLOCK_REORG_HEIGHT.0);
     let locators = iter::successors(Some(1u32), |h| h.checked_mul(2))
-        .flat_map(move |step| tip_height.0.checked_sub(step))
-        .filter(move |&height| height > min_locator_height.0)
-        .map(BlockHeight);
-    let locators = iter::once(tip_height)
+        .flat_map(move |step| tip_height.0.checked_sub(step));
+    let locators = iter::once(tip_height.0)
         .chain(locators)
-        .chain(iter::once(min_locator_height));
+        .take_while(move |&height| height > min_locator_height)
+        .chain(iter::once(min_locator_height))
+        .map(BlockHeight);
+
     let locators: Vec<_> = locators.collect();
     tracing::info!(
         ?tip_height,
@@ -175,6 +172,7 @@ fn block_locator_heights(tip_height: BlockHeight) -> impl Iterator<Item = BlockH
         ?locators,
         "created block locator"
     );
+
     locators.into_iter()
 }
 
@@ -253,6 +251,61 @@ mod tests {
         match network {
             Mainnet => assert_eq!(path.file_name(), Some(OsStr::new("mainnet"))),
             Testnet => assert_eq!(path.file_name(), Some(OsStr::new("testnet"))),
+        }
+    }
+
+    /// Block heights, and the expected minimum block locator height
+    static BLOCK_LOCATOR_CASES: &[(u32, u32)] = &[
+        (0, 0),
+        (1, 0),
+        (10, 0),
+        (98, 0),
+        (99, 0),
+        (100, 1),
+        (101, 2),
+        (1000, 901),
+        (10000, 9901),
+    ];
+
+    /// Check that the block locator heights are sensible.
+    #[test]
+    fn test_block_locator_heights() {
+        for (height, min_height) in BLOCK_LOCATOR_CASES.iter().cloned() {
+            let locator = block_locator_heights(BlockHeight(height)).collect::<Vec<_>>();
+
+            assert!(!locator.is_empty(), "locators must not be empty");
+            if (height - min_height) > 1 {
+                assert!(
+                    locator.len() > 2,
+                    "non-trivial locators must have some intermediate heights"
+                );
+            }
+
+            assert_eq!(
+                locator[0],
+                BlockHeight(height),
+                "locators must start with the tip height"
+            );
+
+            // Check that the locator is sorted, and that it has no duplicates
+            // TODO: replace with dedup() and is_sorted_by() when sorting stabilises.
+            assert!(locator.windows(2).all(|v| match v {
+                [a, b] => a.0 > b.0,
+                _ => unreachable!("windows returns exact sized slices"),
+            }));
+
+            let final_height = locator[locator.len() - 1];
+            assert_eq!(
+                final_height,
+                BlockHeight(min_height),
+                "locators must end with the specified final height"
+            );
+            assert!(height - final_height.0 <= MAX_BLOCK_REORG_HEIGHT.0,
+                    format!("locator for {} must not be more than the maximum reorg height {} below the tip, but {} is {} blocks below the tip",
+                         height,
+                         MAX_BLOCK_REORG_HEIGHT.0,
+                         final_height.0,
+                         height - final_height.0));
         }
     }
 }

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -31,6 +31,19 @@ use zebra_chain::{
 pub mod in_memory;
 pub mod on_disk;
 
+/// The maturity threshold for transparent coinbase outputs.
+///
+/// A transaction MUST NOT spend a transparent output of a coinbase transaction
+/// from a block less than 100 blocks prior to the spend. Note that transparent
+/// outputs of coinbase transactions include Founders' Reward outputs.
+const MIN_TRASPARENT_COINBASE_MATURITY: BlockHeight = BlockHeight(100);
+
+/// The maximum chain reorganisation height.
+///
+/// Allowing reorganisations past this height could allow double-spends of
+/// coinbase transactions.
+const MAX_BLOCK_REORG_HEIGHT: BlockHeight = BlockHeight(MIN_TRASPARENT_COINBASE_MATURITY.0 - 1);
+
 /// Configuration for the state service.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -142,13 +155,27 @@ pub enum Response {
 
 /// Get the heights of the blocks for constructing a block_locator list
 fn block_locator_heights(tip_height: BlockHeight) -> impl Iterator<Item = BlockHeight> {
+    // Stop at the reorg limit, or the genesis block.
+    let min_locator_height = tip_height
+        .0
+        .checked_sub(MAX_BLOCK_REORG_HEIGHT.0)
+        .map(BlockHeight)
+        .unwrap_or(BlockHeight(0));
     let locators = iter::successors(Some(1u32), |h| h.checked_mul(2))
         .flat_map(move |step| tip_height.0.checked_sub(step))
-        .filter(|&height| height != 0)
+        .filter(move |&height| height > min_locator_height.0)
         .map(BlockHeight);
-    iter::once(tip_height)
+    let locators = iter::once(tip_height)
         .chain(locators)
-        .chain(iter::once(BlockHeight(0)))
+        .chain(iter::once(min_locator_height));
+    let locators: Vec<_> = locators.collect();
+    tracing::info!(
+        ?tip_height,
+        ?min_locator_height,
+        ?locators,
+        "created block locator"
+    );
+    locators.into_iter()
 }
 
 /// The error type for the State Service.

--- a/zebrad/src/commands/start/sync.rs
+++ b/zebrad/src/commands/start/sync.rs
@@ -59,7 +59,7 @@ where
     ///  - state: the zebra-state that stores the chain
     ///  - verifier: the zebra-consensus verifier that checks the chain
     pub fn new(chain: Network, peers: ZN, state: ZS, verifier: ZV) -> Self {
-        let retry_peers = Retry::new(RetryLimit::new(3), peers.clone());
+        let retry_peers = Retry::new(RetryLimit::new(10), peers.clone());
         Self {
             tip_network: peers,
             block_network: retry_peers,


### PR DESCRIPTION
Don't request blocks that are past the reorg limit, because we won't accept forks
beyond that limit anyway.

This change reduces the number of duplicate blocks, particularly from low-height side
chains.