### PR TITLE
fix: Reduce the previous block waiting time

### DIFF
--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -185,7 +185,7 @@ where
                 //   - Replace with AddBlock constraints
                 None => {
                     tracing::debug!(?height, ?hash, "Waiting for state to have block");
-                    time::delay_for(Duration::from_secs(2)).await
+                    time::delay_for(Duration::from_millis(50)).await
                 }
             };
         }


### PR DESCRIPTION
Reduce the amount of time that the block verifier waits for the previous
block, before polling again. (Waiting for 2 seconds results in some
apparent block verifier hangs.)

This is a temporary fix, until the state layer handles context checks.
