### PR TITLE
Rename script fields to lock/unlock scripts.

### DIFF
--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -157,11 +157,11 @@ impl ZcashSerialize for TransparentInput {
         match self {
             TransparentInput::PrevOut {
                 outpoint,
-                script,
+                unlock_script,
                 sequence,
             } => {
                 outpoint.zcash_serialize(&mut writer)?;
-                script.zcash_serialize(&mut writer)?;
+                unlock_script.zcash_serialize(&mut writer)?;
                 writer.write_u32::<LittleEndian>(*sequence)?;
             }
             TransparentInput::Coinbase {
@@ -211,7 +211,7 @@ impl ZcashDeserialize for TransparentInput {
                     hash: TransactionHash(bytes),
                     index: reader.read_u32::<LittleEndian>()?,
                 },
-                script: Script::zcash_deserialize(&mut reader)?,
+                unlock_script: Script::zcash_deserialize(&mut reader)?,
                 sequence: reader.read_u32::<LittleEndian>()?,
             })
         }
@@ -221,7 +221,7 @@ impl ZcashDeserialize for TransparentInput {
 impl ZcashSerialize for TransparentOutput {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         writer.write_u64::<LittleEndian>(self.value.into())?;
-        self.pk_script.zcash_serialize(&mut writer)?;
+        self.lock_script.zcash_serialize(&mut writer)?;
         Ok(())
     }
 }
@@ -230,7 +230,7 @@ impl ZcashDeserialize for TransparentOutput {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
         Ok(TransparentOutput {
             value: reader.read_u64::<LittleEndian>()?.try_into()?,
-            pk_script: Script::zcash_deserialize(&mut reader)?,
+            lock_script: Script::zcash_deserialize(&mut reader)?,
         })
     }
 }

--- a/zebra-chain/src/transaction/tests/arbitrary.rs
+++ b/zebra-chain/src/transaction/tests/arbitrary.rs
@@ -202,10 +202,10 @@ impl Arbitrary for TransparentInput {
     fn arbitrary_with(_args: ()) -> Self::Strategy {
         prop_oneof![
             (any::<OutPoint>(), any::<Script>(), any::<u32>())
-                .prop_map(|(outpoint, script, sequence)| {
+                .prop_map(|(outpoint, unlock_script, sequence)| {
                     TransparentInput::PrevOut {
                         outpoint,
-                        script,
+                        unlock_script,
                         sequence,
                     }
                 })

--- a/zebra-chain/src/transaction/transparent.rs
+++ b/zebra-chain/src/transaction/transparent.rs
@@ -51,7 +51,7 @@ pub enum TransparentInput {
         /// The previous output transaction reference.
         outpoint: OutPoint,
         /// The script that authorizes spending `outpoint`.
-        script: Script,
+        unlock_script: Script,
         /// The sequence number for the output.
         sequence: u32,
     },
@@ -85,7 +85,6 @@ pub struct TransparentOutput {
     // At https://en.bitcoin.it/wiki/Protocol_documentation#tx, this is an i64.
     pub value: Amount<NonNegative>,
 
-    /// Usually contains the public key as a Bitcoin script setting up
-    /// conditions to claim this output.
-    pub pk_script: Script,
+    /// The lock script defines the conditions under which this output can be spent.
+    pub lock_script: Script,
 }


### PR DESCRIPTION
This is slightly clearer and more correct than the previous pk_script.

Submitting this in advance of an RFC for async script verification so that the links in the RFC can be to the nicely named script field docs.