### PR TITLE
Print endpoint addresses at startup

### DIFF
--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -191,6 +191,8 @@ where
     S::Future: Send + 'static,
 {
     let mut listener = TcpListener::bind(addr).await?;
+    let local_addr = listener.local_addr()?;
+    info!("Network listening at {}", local_addr);
     loop {
         if let Ok((tcp_stream, addr)) = listener.accept().await {
             debug!(?addr, "got incoming connection");

--- a/zebrad/src/components/metrics.rs
+++ b/zebrad/src/components/metrics.rs
@@ -30,7 +30,7 @@ impl MetricsEndpoint {
             return Ok(());
         };
 
-        info!("Initializing metrics endpoint");
+        info!("Initializing metrics endpoint at {}", addr);
 
         // XXX do we need to hold on to the receiver?
         let receiver = Receiver::builder()

--- a/zebrad/src/components/tracing/endpoint.rs
+++ b/zebrad/src/components/tracing/endpoint.rs
@@ -41,7 +41,7 @@ impl TracingEndpoint {
         } else {
             return Ok(());
         };
-        info!("Initializing tracing endpoint");
+        info!("Initializing tracing endpoint at {}", addr);
 
         let service =
             make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(request_handler)) });


### PR DESCRIPTION
I think this will finally close https://github.com/ZcashFoundation/zebra/issues/807 as the rest of the tasks were done in other PRs but i may have something missing.

This PR will print the listener network port using `local_addr()` as suggested in https://github.com/ZcashFoundation/zebra/issues/807#issuecomment-670202728. This will work even when the user use port `0` in the config.

Metrics and Tracing endpoints are printed only if the defaults are changed to make them active, in this case just the user provided string is displayed(will show port `0` if the user use it however this is unlikely - https://github.com/ZcashFoundation/zebra/issues/807#issuecomment-671212500).