### PR TITLE
Fix sync algorithm.

### DIFF
--- a/zebra-network/src/policies.rs
+++ b/zebra-network/src/policies.rs
@@ -18,11 +18,12 @@ impl RetryLimit {
     }
 }
 
-impl<Req: Clone, Res, E> Policy<Req, Res, E> for RetryLimit {
+impl<Req: Clone + std::fmt::Debug, Res, E: std::fmt::Debug> Policy<Req, Res, E> for RetryLimit {
     type Future = future::Ready<Self>;
-    fn retry(&self, _: &Req, result: Result<&Res, &E>) -> Option<Self::Future> {
-        if result.is_err() {
+    fn retry(&self, req: &Req, result: Result<&Res, &E>) -> Option<Self::Future> {
+        if let Err(e) = result {
             if self.remaining_tries > 0 {
+                tracing::debug!(?req, ?e, remaining_tries = self.remaining_tries, "retrying");
                 Some(future::ready(RetryLimit {
                     remaining_tries: self.remaining_tries - 1,
                 }))

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -68,6 +68,9 @@ pub struct Config {
     /// | Windows | `{FOLDERID_LocalAppData}\zebra`                 | C:\Users\Alice\AppData\Local\zebra |
     /// | Other   | `std::env::current_dir()/cache`                 |                                    |
     pub cache_dir: PathBuf,
+
+    /// The maximum number of bytes to use caching data in memory.
+    pub memory_cache_bytes: u64,
 }
 
 impl Config {
@@ -80,7 +83,10 @@ impl Config {
         };
         let path = self.cache_dir.join(net_dir).join("state");
 
-        sled::Config::default().path(path)
+        sled::Config::default()
+            .path(path)
+            .cache_capacity(self.memory_cache_bytes)
+            .mode(sled::Mode::LowSpace)
     }
 }
 
@@ -89,7 +95,10 @@ impl Default for Config {
         let cache_dir = dirs::cache_dir()
             .unwrap_or_else(|| std::env::current_dir().unwrap().join("cache"))
             .join("zebra");
-        Self { cache_dir }
+        Self {
+            cache_dir,
+            memory_cache_bytes: 512 * 1024 * 1024,
+        }
     }
 }
 

--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -123,7 +123,13 @@ async fn check_transcripts(network: Network) -> Result<(), Report> {
 
         let storage_guard = TempDir::new("")?;
         let cache_dir = storage_guard.path().to_owned();
-        let service = on_disk::init(Config { cache_dir }, network);
+        let service = on_disk::init(
+            Config {
+                cache_dir,
+                ..Config::default()
+            },
+            network,
+        );
         let transcript = Transcript::from(transcript_data.iter().cloned());
         /// SPANDOC: check the on disk service against the transcript
         transcript.check(service).await?;

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -20,7 +20,7 @@ pub fn test_cmd(path: &str) -> Result<(Command, impl Drop)> {
 
     fs::File::create(dir.path().join("zebrad.toml"))?.write_all(
         format!(
-            "[state]\ncache_dir = '{}'",
+            "[state]\ncache_dir = '{}'\nmemory_cache_bytes = 256000000",
             cache_dir
                 .into_os_string()
                 .into_string()

--- a/zebrad/src/commands/start/sync.rs
+++ b/zebrad/src/commands/start/sync.rs
@@ -303,7 +303,16 @@ where
                         match (hashes.first(), hashes.len()) {
                             (None, _) => continue,
                             (_, 1) => {
+                                // zcashd might respond with a length-1 inv message if a broadcast of new inventory
+                                // is sent while we're sending our request.
                                 tracing::debug!("skipping length-1 response, in case it's an unsolicited inv message");
+                                continue;
+                            }
+                            (_, 501) => {
+                                // zcashd has an ad-hoc buffering mechanism for inv items that can result in a broadcast
+                                // of new inventory getting mixed in to the *body* of a response to a getblocks message,
+                                // but only at the front or rear.
+                                tracing::debug!("skipping length-501 response, in case it's an unsolicited inv message");
                                 continue;
                             }
                             (Some(hash), _) if (hash == &self.genesis_hash) => {

--- a/zebrad/src/commands/start/sync.rs
+++ b/zebrad/src/commands/start/sync.rs
@@ -23,7 +23,7 @@ const FANOUT: usize = checkpoint::MAX_QUEUED_BLOCKS_PER_HEIGHT;
 /// checkpoint distance.
 pub const LOOKAHEAD_LIMIT: usize = checkpoint::MAX_CHECKPOINT_HEIGHT_GAP * 2;
 /// Controls how long we wait for a block download request to complete.
-pub const BLOCK_TIMEOUT: Duration = Duration::from_secs(9);
+pub const BLOCK_TIMEOUT: Duration = Duration::from_secs(6);
 
 /// Helps work around defects in the bitcoin protocol by checking whether
 /// the returned hashes actually extend a chain tip.

--- a/zebrad/src/commands/start/sync.rs
+++ b/zebrad/src/commands/start/sync.rs
@@ -269,10 +269,10 @@ where
         //
         // remove all prospective tips and iterate over them individually
         let tips = std::mem::take(&mut self.prospective_tips);
-        tracing::debug!(?tips, "extending tip set");
 
         let mut download_set = HashSet::new();
         for tip in tips {
+            tracing::debug!(?tip, "extending tip");
             // ExtendTips Step 2
             //
             // Create a FindBlocksByHash request consisting of just the

--- a/zebrad/src/commands/start/sync.rs
+++ b/zebrad/src/commands/start/sync.rs
@@ -21,9 +21,9 @@ const FANOUT: usize = checkpoint::MAX_QUEUED_BLOCKS_PER_HEIGHT;
 /// Controls how far ahead of the chain tip the syncer tries to download before
 /// waiting for queued verifications to complete. Set to twice the maximum
 /// checkpoint distance.
-pub const LOOKAHEAD_LIMIT: usize = checkpoint::MAX_CHECKPOINT_HEIGHT_GAP * 2;
+const LOOKAHEAD_LIMIT: usize = checkpoint::MAX_CHECKPOINT_HEIGHT_GAP * 2;
 /// Controls how long we wait for a block download request to complete.
-pub const BLOCK_TIMEOUT: Duration = Duration::from_secs(6);
+const BLOCK_TIMEOUT: Duration = Duration::from_secs(6);
 /// Controls how long we wait to restart syncing after finishing a sync run.
 const SYNC_RESTART_TIMEOUT: Duration = Duration::from_secs(20);
 

--- a/zebrad/src/commands/start/sync.rs
+++ b/zebrad/src/commands/start/sync.rs
@@ -108,6 +108,11 @@ where
 
                 // Check whether we need to wait for existing block download tasks to finish
                 while self.pending_blocks.len() > LOOKAHEAD_LIMIT {
+                    tracing::debug!(
+                        tips.len = self.prospective_tips.len(),
+                        pending.len = self.pending_blocks.len(),
+                        pending.limit = LOOKAHEAD_LIMIT,
+                    );
                     match self
                         .pending_blocks
                         .next()
@@ -440,6 +445,7 @@ where
                 .await
                 .map_err(|e| eyre!(e))?
                 .call(zn::Request::BlocksByHash(iter::once(hash).collect()));
+            tracing::debug!(?hash, "requested block");
             let span = tracing::info_span!("block_fetch_verify", ?hash);
             let mut verifier = self.verifier.clone();
             let task = tokio::spawn(async move {


### PR DESCRIPTION
Changes the sync algorithm in a few ways:

1.  We handle errors by discarding all of the prospective tips and restarting from the current verified state.  This discards the joinhandles for all of the spawned tasks, letting them run to completion and ignoring the results.

2.  This means that we have to handle cancelations in the checkpoint verifier, which we do by rejecting the *older* of duplicate verification results.  When a duplicate verification request arrives in the checkpoint verifier, we replace the old sender handle with the new one and send an error to the old handle.  If there are orphaned tasks waiting on verification, they'll error out and terminate when this happens.

3.  The sync algorithm now treats a tip as a *pair* of hashes rather than a single hash.  Rather than taking the last hash in the returned list as the new tip, we take the last two, treat the second-to-last as the new tip, and the last hash as an expected next hash. This lets us detect when a peer is extending our tip or when they're feeding us garbage.  (If they feed us *crafted* garbage, they can of course lead us in the wrong direction.  But because we don't rely on a single peer, we'll start working on both the bad and good tips, and hopefully get further along on the good tips before we restart on error).

Also closes #888 to add a memory limit to sled.

The sync algorithm is now different from the one described in the design document, so it should be updated, but I think that that could be a follow-on PR after this one is merged and we don't think we'll be making further changes to it.

With these changes I'm able to get Zebra to successfully checkpoint-sync up to at least 850,000 blocks in about an hour:
![Screenshot from 2020-08-12 14-11-34](https://user-images.githubusercontent.com/44879/90068651-da652e00-dca5-11ea-9215-b8bd159a858f.png)

Looking at the metrics from the connection pool, it looks like for a lot of that period we're not fully saturating the connection pool, so we could potentially be going faster:
![Screenshot from 2020-08-12 14-14-09](https://user-images.githubusercontent.com/44879/90068840-30d26c80-dca6-11ea-8145-e4678b015490.png)

Zooming in on part of the sync metrics, we can see that there are some periods where no new blocks are being fed into the checkpointer and new blocks are not being downloaded.  I believe that this is caused by a situation where an early block failed to download, we're waiting for it to time out to retry, and we've hit the lookahead limit so we can't start fetching new blocks.  Increasing the lookahead limit might help improve speed here by letting the rest of the block downloads continue:
![Screenshot from 2020-08-12 14-15-38](https://user-images.githubusercontent.com/44879/90068935-5b242a00-dca6-11ea-884a-e651afff5cae.png)
