### PR TITLE
Use an n1-standard-2 machine for node deployments

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         gcloud compute instance-templates create-with-container "zebrad-$BRANCH_NAME-$SHORT_SHA" \
           --container-image "gcr.io/$PROJECT_ID/$REPOSITORY/$BRANCH_NAME:$SHORT_SHA" \
-          --machine-type n1-highmem-8 \
+          --machine-type n1-standard-2 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
           --tags zebrad \


### PR DESCRIPTION
We don't load the entire blockchain into memory anymore. 😂

Resolves #892