### PR TITLE
Fix healthcheck (tracing) endpoint

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         gcloud compute instance-templates create-with-container "zebrad-$BRANCH_NAME-$SHORT_SHA" \
           --container-image "gcr.io/$PROJECT_ID/$REPOSITORY/$BRANCH_NAME:$SHORT_SHA" \
-          --machine-type n1-standard-2 \
+          --machine-type n1-highcpu-2 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
           --tags zebrad \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN rustc -V; cargo -V; rustup -V; cargo test --all && cargo build --release
 
 FROM debian:buster-slim
 COPY --from=builder /zebra/target/release/zebrad /
-RUN echo -e "[tracing]\nendpoint_addr = '0.0.0.0:3000'" > /zebrad.toml
+RUN echo "[tracing]\nendpoint_addr = '0.0.0.0:3000'" > /zebrad.toml
 EXPOSE 3000 8233 18233
 CMD [ "/zebrad", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,6 @@ RUN rustc -V; cargo -V; rustup -V; cargo test --all && cargo build --release
 
 FROM debian:buster-slim
 COPY --from=builder /zebra/target/release/zebrad /
+RUN echo -e "[tracing]\nendpoint_addr = '0.0.0.0:3000'" > /zebrad.toml
 EXPOSE 3000 8233 18233
 CMD [ "/zebrad", "start" ]


### PR DESCRIPTION
And bump vm type to n1-highcpu-2

The tracing endpoint was disabled by default in #834