### PR TITLE
Try naively parallelizing test and build jobs on our platform matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   test:
-    name: Build & test on ${{ matrix.os }}
+    name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -29,6 +29,24 @@ jobs:
         with:
           command: test
           args: --verbose --all
+
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: cargo fetch
+        uses: actions-rs/cargo@v1
+        with:
+          command: fetch
       - name: Build
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
I want there to be a better way to define the OS matrix once and refer to it in both 'test' and 'build' jobs but I'm not sure there is one.