### PR TITLE
Exclude zebra-utils, zebra-checkpoint from rendered docs.

### DIFF
--- a/.github/workflows/firebase.yml
+++ b/.github/workflows/firebase.yml
@@ -42,7 +42,8 @@ jobs:
 
     - name: Build external docs
       run: |
-        cargo doc --no-deps
+        # Exclude zebra-utils, it is not for library or app users
+        cargo doc --no-deps --workspace --exclude zebra-utils
       env:
         RUSTDOCFLAGS: "--html-in-header katex-header.html"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,20 +669,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-zebra"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a045d3ca7d15222d578515dc6b54fea6c3591763b8fe2f67a45bbd56d5f1989b"
-dependencies = [
- "curve25519-dalek",
- "hex",
- "rand_core 0.5.1",
- "serde",
- "sha2",
- "thiserror",
-]
-
-[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -4,6 +4,8 @@ authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 version = "3.0.0-alpha.0"
 edition = "2018"
+# Prevent accidental publication of this utility crate.
+publish = false
 
 [dependencies]
 abscissa_core = "0.5"

--- a/zebra-utils/src/lib.rs
+++ b/zebra-utils/src/lib.rs
@@ -1,14 +1,3 @@
-//! A Zebra utilities crate.
-
-// TODO: split this crate up into crates with meaningful names.
-
-#![deny(missing_docs)]
-#![allow(clippy::try_err)]
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+//! Utilities for Zebra development, not for library or application users.
+//!
+//! Currently this consists only of the zebra-checkpoints binary.


### PR DESCRIPTION
These are only development utilities, so they shouldn't be part of the public API docs (and we should not publish them).