### PR TITLE
Refactor acceptance serialized_tests

### DIFF
--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -39,7 +39,6 @@ pub fn tempdir(create_config: bool) -> Result<(PathBuf, impl Drop)> {
     Ok((dir.path().to_path_buf(), dir))
 }
 
-
 pub trait CommandExt {
     /// wrapper for `status` fn on `Command` that constructs informative error
     /// reports

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -17,33 +17,28 @@ pub fn test_cmd(command_path: &str, tempdir: &PathBuf) -> Result<Command> {
     Ok(cmd)
 }
 
-/// Create a temp directory and optional default config file with optional additional options
-pub fn tempdir(
-    create_config: bool,
-    additional_config: Option<String>,
-) -> Result<(PathBuf, impl Drop)> {
+/// Create a temp directory and optional config file
+pub fn tempdir(create_config: bool) -> Result<(PathBuf, impl Drop)> {
     let dir = TempDir::new("zebrad_tests")?;
 
     if create_config {
         let cache_dir = dir.path().join("state");
         fs::create_dir(&cache_dir)?;
-
-        let mut content: String = format!(
-            "[state]\ncache_dir = '{}'\nmemory_cache_bytes = 256000000\n",
-            cache_dir
-                .into_os_string()
-                .into_string()
-                .map_err(|_| eyre!("tmp dir path cannot be encoded as UTF8"))?
-        );
-        if additional_config.is_some() {
-            content = format!("{}{}", content, additional_config.unwrap());
-        }
-
-        fs::File::create(dir.path().join("zebrad.toml"))?.write_all(content.as_bytes())?;
+        fs::File::create(dir.path().join("zebrad.toml"))?.write_all(
+            format!(
+                "[state]\ncache_dir = '{}'\nmemory_cache_bytes = 256000000\n[network]\nlisten_addr = '127.0.0.1:0'\n",
+                cache_dir
+                    .into_os_string()
+                    .into_string()
+                    .map_err(|_| eyre!("tmp dir path cannot be encoded as UTF8"))?
+            )
+            .as_bytes(),
+        )?;
     }
 
     Ok((dir.path().to_path_buf(), dir))
 }
+
 
 pub trait CommandExt {
     /// wrapper for `status` fn on `Command` that constructs informative error

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -22,7 +22,7 @@ pub fn get_child(args: &[&str], tempdir: &PathBuf) -> Result<TestChild> {
 #[test]
 fn generate_no_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true)?;
+    let (tempdir, _guard) = tempdir(true, None)?;
 
     let child = get_child(&["generate"], &tempdir)?;
     let output = child.wait_with_output()?;
@@ -37,7 +37,7 @@ fn generate_no_args() -> Result<()> {
 #[test]
 fn generate_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(false)?;
+    let (tempdir, _guard) = tempdir(false, None)?;
 
     // unexpected free argument `argument`
     let child = get_child(&["generate", "argument"], &tempdir)?;
@@ -79,7 +79,7 @@ fn generate_args() -> Result<()> {
 #[test]
 fn help_no_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true)?;
+    let (tempdir, _guard) = tempdir(true, None)?;
 
     let child = get_child(&["help"], &tempdir)?;
     let output = child.wait_with_output()?;
@@ -97,7 +97,7 @@ fn help_no_args() -> Result<()> {
 #[test]
 fn help_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true)?;
+    let (tempdir, _guard) = tempdir(true, None)?;
 
     // The subcommand "argument" wasn't recognized.
     let child = get_child(&["help", "argument"], &tempdir)?;
@@ -115,7 +115,7 @@ fn help_args() -> Result<()> {
 #[test]
 fn revhex_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true)?;
+    let (tempdir, _guard) = tempdir(true, None)?;
 
     // Valid
     let child = get_child(&["revhex", "33eeff55"], &tempdir)?;
@@ -127,9 +127,13 @@ fn revhex_args() -> Result<()> {
     Ok(())
 }
 
+#[test]
 fn seed_no_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true)?;
+    let (tempdir, _guard) = tempdir(
+        true,
+        Some("[network]\nlisten_addr = '127.0.0.1:0'\n".to_string()),
+    )?;
 
     let mut child = get_child(&["-v", "seed"], &tempdir)?;
 
@@ -151,7 +155,7 @@ fn seed_no_args() -> Result<()> {
 #[test]
 fn seed_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true)?;
+    let (tempdir, _guard) = tempdir(true, None)?;
 
     // unexpected free argument `argument`
     let child = get_child(&["seed", "argument"], &tempdir)?;
@@ -171,9 +175,13 @@ fn seed_args() -> Result<()> {
     Ok(())
 }
 
+#[test]
 fn start_no_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true)?;
+    let (tempdir, _guard) = tempdir(
+        true,
+        Some("[network]\nlisten_addr = '127.0.0.1:0'\n".to_string()),
+    )?;
 
     let mut child = get_child(&["-v", "start"], &tempdir)?;
 
@@ -192,9 +200,13 @@ fn start_no_args() -> Result<()> {
     Ok(())
 }
 
+#[test]
 fn start_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true)?;
+    let (tempdir, _guard) = tempdir(
+        true,
+        Some("[network]\nlisten_addr = '127.0.0.1:0'\n".to_string()),
+    )?;
 
     // Any free argument is valid
     let mut child = get_child(&["start", "argument"], &tempdir)?;
@@ -219,7 +231,7 @@ fn start_args() -> Result<()> {
 #[test]
 fn app_no_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true)?;
+    let (tempdir, _guard) = tempdir(true, None)?;
 
     let child = get_child(&[], &tempdir)?;
     let output = child.wait_with_output()?;
@@ -233,7 +245,7 @@ fn app_no_args() -> Result<()> {
 #[test]
 fn version_no_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true)?;
+    let (tempdir, _guard) = tempdir(true, None)?;
 
     let child = get_child(&["version"], &tempdir)?;
     let output = child.wait_with_output()?;
@@ -247,7 +259,7 @@ fn version_no_args() -> Result<()> {
 #[test]
 fn version_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true)?;
+    let (tempdir, _guard) = tempdir(true, None)?;
 
     // unexpected free argument `argument`
     let child = get_child(&["version", "argument"], &tempdir)?;
@@ -263,18 +275,12 @@ fn version_args() -> Result<()> {
 }
 
 #[test]
-fn serialized_tests() -> Result<()> {
-    start_no_args()?;
-    start_args()?;
-    seed_no_args()?;
-    valid_generated_config()?;
-
-    Ok(())
-}
-
 fn valid_generated_config() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(false)?;
+    let (tempdir, _guard) = tempdir(
+        false,
+        Some("[network]\nlisten_addr = '127.0.0.1:0'\n".to_string()),
+    )?;
 
     // Add a config file name to tempdir path
     let mut generated_config_path = tempdir.clone();

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -22,7 +22,7 @@ pub fn get_child(args: &[&str], tempdir: &PathBuf) -> Result<TestChild> {
 #[test]
 fn generate_no_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true, None)?;
+    let (tempdir, _guard) = tempdir(true)?;
 
     let child = get_child(&["generate"], &tempdir)?;
     let output = child.wait_with_output()?;
@@ -37,7 +37,7 @@ fn generate_no_args() -> Result<()> {
 #[test]
 fn generate_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(false, None)?;
+    let (tempdir, _guard) = tempdir(false)?;
 
     // unexpected free argument `argument`
     let child = get_child(&["generate", "argument"], &tempdir)?;
@@ -79,7 +79,7 @@ fn generate_args() -> Result<()> {
 #[test]
 fn help_no_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true, None)?;
+    let (tempdir, _guard) = tempdir(true)?;
 
     let child = get_child(&["help"], &tempdir)?;
     let output = child.wait_with_output()?;
@@ -97,7 +97,7 @@ fn help_no_args() -> Result<()> {
 #[test]
 fn help_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true, None)?;
+    let (tempdir, _guard) = tempdir(true)?;
 
     // The subcommand "argument" wasn't recognized.
     let child = get_child(&["help", "argument"], &tempdir)?;
@@ -115,7 +115,7 @@ fn help_args() -> Result<()> {
 #[test]
 fn revhex_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true, None)?;
+    let (tempdir, _guard) = tempdir(true)?;
 
     // Valid
     let child = get_child(&["revhex", "33eeff55"], &tempdir)?;
@@ -130,10 +130,7 @@ fn revhex_args() -> Result<()> {
 #[test]
 fn seed_no_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(
-        true,
-        Some("[network]\nlisten_addr = '127.0.0.1:0'\n".to_string()),
-    )?;
+    let (tempdir, _guard) = tempdir(true)?;
 
     let mut child = get_child(&["-v", "seed"], &tempdir)?;
 
@@ -155,7 +152,7 @@ fn seed_no_args() -> Result<()> {
 #[test]
 fn seed_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true, None)?;
+    let (tempdir, _guard) = tempdir(true)?;
 
     // unexpected free argument `argument`
     let child = get_child(&["seed", "argument"], &tempdir)?;
@@ -178,10 +175,7 @@ fn seed_args() -> Result<()> {
 #[test]
 fn start_no_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(
-        true,
-        Some("[network]\nlisten_addr = '127.0.0.1:0'\n".to_string()),
-    )?;
+    let (tempdir, _guard) = tempdir(true)?;
 
     let mut child = get_child(&["-v", "start"], &tempdir)?;
 
@@ -203,10 +197,7 @@ fn start_no_args() -> Result<()> {
 #[test]
 fn start_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(
-        true,
-        Some("[network]\nlisten_addr = '127.0.0.1:0'\n".to_string()),
-    )?;
+    let (tempdir, _guard) = tempdir(true)?;
 
     // Any free argument is valid
     let mut child = get_child(&["start", "argument"], &tempdir)?;
@@ -231,7 +222,7 @@ fn start_args() -> Result<()> {
 #[test]
 fn app_no_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true, None)?;
+    let (tempdir, _guard) = tempdir(true)?;
 
     let child = get_child(&[], &tempdir)?;
     let output = child.wait_with_output()?;
@@ -245,7 +236,7 @@ fn app_no_args() -> Result<()> {
 #[test]
 fn version_no_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true, None)?;
+    let (tempdir, _guard) = tempdir(true)?;
 
     let child = get_child(&["version"], &tempdir)?;
     let output = child.wait_with_output()?;
@@ -259,7 +250,7 @@ fn version_no_args() -> Result<()> {
 #[test]
 fn version_args() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(true, None)?;
+    let (tempdir, _guard) = tempdir(true)?;
 
     // unexpected free argument `argument`
     let child = get_child(&["version", "argument"], &tempdir)?;
@@ -277,7 +268,7 @@ fn version_args() -> Result<()> {
 #[test]
 fn valid_generated_config() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(false, None)?;
+    let (tempdir, _guard) = tempdir(false)?;
 
     // Add a config file name to tempdir path
     let mut generated_config_path = tempdir.clone();

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -277,10 +277,7 @@ fn version_args() -> Result<()> {
 #[test]
 fn valid_generated_config() -> Result<()> {
     zebra_test::init();
-    let (tempdir, _guard) = tempdir(
-        false,
-        Some("[network]\nlisten_addr = '127.0.0.1:0'\n".to_string()),
-    )?;
+    let (tempdir, _guard) = tempdir(false, None)?;
 
     // Add a config file name to tempdir path
     let mut generated_config_path = tempdir.clone();


### PR DESCRIPTION
The serialized tests were added because of port conflicts between the tests. This PR adds a configuration option in the tests that were serialized that allows the OS to take a free port on each of them avoiding conflict and covering the requested test at https://github.com/ZcashFoundation/zebra/issues/807#issuecomment-672439063

Need to check the CI to make sure the changes are actually working as expected so pushing initially as a draft PR.