### PR TITLE
fix: Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,7 +3126,6 @@ dependencies = [
  "tracing-error",
  "tracing-futures",
  "zebra-chain",
- "zebra-consensus",
  "zebra-test",
 ]
 
@@ -3166,7 +3165,6 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-error",
- "tracing-futures",
  "zebra-chain",
  "zebra-test",
 ]
@@ -3194,7 +3192,6 @@ dependencies = [
 name = "zebra-utils"
 version = "3.0.0-alpha.0"
 dependencies = [
- "abscissa_core",
  "color-eyre",
  "hex",
  "serde_json",

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -33,7 +33,6 @@ tracing-futures = "0.2"
 tracing-error = { version = "0.1.2", features = ["traced-error"] }
 
 zebra-chain = { path = "../zebra-chain" }
-zebra-consensus = { path = "../zebra-consensus" }
 
 [dev-dependencies]
 proptest = "0.10"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -20,7 +20,6 @@ sled = "0.34.2"
 futures = "0.3.5"
 tower = "0.3.1"
 tracing = "0.1"
-tracing-futures = "0.2"
 tracing-error = "0.1.2"
 thiserror = "1.0.20"
 
@@ -29,6 +28,5 @@ zebra-test = { path = "../zebra-test/" }
 
 once_cell = "1.4"
 spandoc = "0.2"
-tracing-futures = "0.2.4"
 tempdir = "0.3.7"
 tokio = { version = "0.2.22", features = ["full"] }

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-abscissa_core = "0.5"
 structopt = "0.3.16"
 color-eyre = "0.5.1"
 hex = "0.4"


### PR DESCRIPTION
After recent refactors, we have a few unused dependencies.

Found using `cargo-udeps`.