### PR TITLE
fix: Remove redundant ConsensusBranchId constants

### DIFF
--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -72,23 +72,6 @@ pub(crate) const TESTNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ConsensusBranchId(u32);
 
-impl ConsensusBranchId {
-    /// Consensus branch ID for the overwinter network branch
-    pub const OVERWINTER: ConsensusBranchId = ConsensusBranchId(0x5ba81b19);
-
-    /// Consensus branch ID for the sapling network branch
-    pub const SAPLING: ConsensusBranchId = ConsensusBranchId(0x76b809bb);
-
-    /// Consensus branch ID for the blossom network branch
-    pub const BLOSSOM: ConsensusBranchId = ConsensusBranchId(0x2bb40e60);
-
-    /// Consensus branch ID for the heartwood network branch
-    pub const HEARTWOOD: ConsensusBranchId = ConsensusBranchId(0xf5b9230b);
-
-    /// Consensus branch ID for the canopy network branch
-    pub const CANOPY: ConsensusBranchId = ConsensusBranchId(0xe9ff75a6);
-}
-
 impl From<ConsensusBranchId> for u32 {
     fn from(branch: ConsensusBranchId) -> u32 {
         branch.0
@@ -106,14 +89,13 @@ impl From<ConsensusBranchId> for u32 {
 /// This is actually a bijective map, but it is const, so we use a vector, and
 /// do the uniqueness check in the unit tests.
 pub(crate) const CONSENSUS_BRANCH_IDS: &[(NetworkUpgrade, ConsensusBranchId)] = &[
-    // TODO(teor): byte order?
-    (Overwinter, ConsensusBranchId::OVERWINTER),
-    (Sapling, ConsensusBranchId::SAPLING),
-    (Blossom, ConsensusBranchId::BLOSSOM),
-    (Heartwood, ConsensusBranchId::HEARTWOOD),
+    (Overwinter, ConsensusBranchId(0x5ba81b19)),
+    (Sapling, ConsensusBranchId(0x76b809bb)),
+    (Blossom, ConsensusBranchId(0x2bb40e60)),
+    (Heartwood, ConsensusBranchId(0xf5b9230b)),
     // As of 21 July 2020. Could change before mainnet activation.
     // See ZIP 251 for updates.
-    (Canopy, ConsensusBranchId::CANOPY),
+    (Canopy, ConsensusBranchId(0xe9ff75a6)),
 ];
 
 impl NetworkUpgrade {

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -135,7 +135,9 @@ mod tests {
     use hex::FromHex;
     use std::convert::TryInto;
     use std::sync::Arc;
-    use zebra_chain::{serialization::ZcashDeserializeInto, transparent};
+    use zebra_chain::{
+        parameters::NetworkUpgrade::*, serialization::ZcashDeserializeInto, transparent,
+    };
     use zebra_test::prelude::*;
 
     lazy_static::lazy_static! {
@@ -156,7 +158,9 @@ mod tests {
             lock_script: transparent::Script(SCRIPT_PUBKEY.clone()),
         };
         let input_index = 0;
-        let branch_id = ConsensusBranchId::BLOSSOM;
+        let branch_id = Blossom
+            .branch_id()
+            .expect("Blossom has a ConsensusBranchId");
 
         is_valid(transaction, branch_id, (input_index, output))?;
 


### PR DESCRIPTION
Reverts a change in #749 

For details, see https://github.com/ZcashFoundation/zebra/pull/708#discussion_r471052627.