### PR TITLE
Create zebrad debian package

### DIFF
--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -5,6 +5,16 @@ license = "MIT OR Apache-2.0"
 version = "3.0.0-alpha.0"
 edition = "2018"
 
+[package.metadata.deb]
+extended-description = "Zebra Node"
+assets = [
+    ["../target/release/zebrad", "/usr/bin/zebrad", "755"],
+    ["debian/zebrad.service", "/lib/systemd/system/zebrad.service", "644"],
+]
+maintainer-scripts = "debian/scripts"
+
+[package.metadata.deb.systemd-units]
+
 [dependencies]
 zebra-chain = { path = "../zebra-chain" }
 zebra-consensus = { path = "../zebra-consensus/" }

--- a/zebrad/debian/zebrad.service
+++ b/zebrad/debian/zebrad.service
@@ -1,0 +1,13 @@
+[Unit]
+AssertPathExists=/usr/bin/zebrad
+
+[Service]
+WorkingDirectory=~
+ExecStart=/usr/bin/zebrad start
+Restart=always
+PrivateTmp=true
+NoNewPrivileges=true
+
+[Install]
+Alias=zebrad
+WantedBy=default.target


### PR DESCRIPTION
The following will use [cargo deb](https://github.com/mmstick/cargo-deb) to build a debian package.

If your system dont have `cargo deb` please first do:

`cargo install cargo-deb`

In a zebra directory build the  dpkg with:

`cargo build && cargo deb -p zebrad`

Install:

`sudo dpkg -i target/debian/zebrad_3.0.0~alpha.0_amd64.deb`

Manage:

```
systemctl status zebrad
sudo systemctl stop zebrad
```

Logs:

`journalctl -u zebrad.service`

Uninstall:

` sudo dpkg --purge zebrad`

References:

- https://github.com/vasilakisfil/hello.service
- https://github.com/mmstick/cargo-deb/blob/HEAD/systemd.md

If merged will close https://github.com/ZcashFoundation/zebra/issues/562