### PR TITLE
Make acceptance test failures clearer

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -299,8 +299,15 @@ fn valid_generated_config() -> Result<()> {
 
     output.stdout_contains(r"Starting zebrad")?;
 
-    // Make sure the command was killed
-    assert!(output.was_killed());
+    // If the test child has a cache or port conflict with another test, or a
+    // running zebrad or zcashd, then it will panic. But the acceptance tests
+    // expect it to run until it is killed.
+    //
+    // If these conflicts cause test failures:
+    //   - run the tests in an isolated environment,
+    //   - run zebrad on a custom cache path and port,
+    //   - run zcashd on a custom port.
+    assert!(output.was_killed(), "Expected zebrad with generated config to succeed. Are there other acceptance test, zebrad, or zcashd processes running?");
 
     // Run seed using temp dir and kill it at 1 second
     let mut child = get_child(

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -186,7 +186,9 @@ fn start_no_args() -> Result<()> {
     let output = child.wait_with_output()?;
     let output = output.assert_failure()?;
 
-    output.stdout_contains(r"Starting zebrad")?;
+    // start is the default mode, so we check for end of line, to distinguish it
+    // from seed
+    output.stdout_contains(r"Starting zebrad$")?;
 
     // Make sure the command was killed
     assert!(output.was_killed());
@@ -270,7 +272,7 @@ fn valid_generated_config_test() -> Result<()> {
     // Unlike the other tests, these tests can not be run in parallel, because
     // they use the generated config. So parallel execution can cause port and
     // cache conflicts.
-    valid_generated_config("start", r"Starting zebrad")?;
+    valid_generated_config("start", r"Starting zebrad$")?;
     valid_generated_config("seed", r"Starting zebrad in seed mode")?;
 
     Ok(())


### PR DESCRIPTION
The generate and run acceptance test can fail due to conflicts with a local zcashd, zebrad, or another test run.

Add an explanation to the assert which fails due to these conflicts.

Also cleanup some duplicate code.