### PR TITLE
Explicitly set zebra-chain's ed25519-zebra to 1.0.* until Canopy

### DIFF
--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -31,7 +31,7 @@ x25519-dalek = { version = "1", features = ["serde"] }
 
 # ZF deps
 displaydoc = "0.1.7"
-ed25519-zebra = "1"
+ed25519-zebra = "1.0"
 equihash = "0.1"
 redjubjub = "0.2"
 


### PR DESCRIPTION
vs the dep in tower-batch which uses it for an example. 