### PR TITLE
Make tips independent of the response order

### DIFF
--- a/zebrad/src/commands/start/sync.rs
+++ b/zebrad/src/commands/start/sync.rs
@@ -226,8 +226,13 @@ where
                         continue;
                     };
 
+                    // Make sure we get the same tips, regardless of the
+                    // order of peer responses
                     if !download_set.contains(&new_tip.expected_next) {
-                        tracing::debug!(?new_tip, "adding new prospective tip");
+                        tracing::debug!(?new_tip,
+                                        "adding new prospective tip, and removing existing tips in the new block hash list");
+                        self.prospective_tips
+                            .retain(|t| !unknown_hashes.contains(&t.expected_next));
                         self.prospective_tips.insert(new_tip);
                     } else {
                         tracing::debug!(?new_tip, "discarding tip already queued for download");
@@ -305,8 +310,13 @@ where
 
                         tracing::trace!(?hashes);
 
+                        // Make sure we get the same tips, regardless of the
+                        // order of peer responses
                         if !download_set.contains(&new_tip.expected_next) {
-                            tracing::debug!(?new_tip, "adding new prospective tip");
+                            tracing::debug!(?new_tip,
+                                            "adding new prospective tip, and removing any existing tips in the new block hash list");
+                            self.prospective_tips
+                                .retain(|t| !unknown_hashes.contains(&t.expected_next));
                             self.prospective_tips.insert(new_tip);
                         } else {
                             tracing::debug!(?new_tip, "discarding tip already queued for download");


### PR DESCRIPTION
This change makes sync less reliant on the exact order of ObtainTips and
ExtendTips responses, by removing any old tips which are contained in
new responses.

This change is part of a set of related changes which increase sync
reliability.