### PR TITLE
Move coverage step to common workflow for PRs and pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,20 +91,3 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: 'latest'
-          timeout: 600
-      - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v1.0.13

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          version: 'latest'
+          timeout: 600
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v1.0.13


### PR DESCRIPTION
So we can consistently collect coverage data on the default branch, which CodeCov needs
to compare branch coverage and line data against.

This should get rid of some of the spurious 'new line not covered' annotations on PRs that have popped up with the introduction of CodeCov's Github Checks Patch Annotations that were rolled out and enabled by default.