### PR TITLE
Improve zebra-state logging and metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3212,6 +3212,7 @@ dependencies = [
  "futures",
  "hex",
  "lazy_static",
+ "metrics",
  "once_cell",
  "serde",
  "sled",

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1", features = ["serde_derive"] }
 sled = "0.34.3"
 
 futures = "0.3.5"
+metrics = "0.12"
 tower = "0.3.1"
 tracing = "0.1"
 tracing-error = "0.1.2"

--- a/zebra-state/src/on_disk.rs
+++ b/zebra-state/src/on_disk.rs
@@ -57,6 +57,10 @@ impl SledState {
             Ok(())
         })?;
 
+        tracing::trace!(?height, ?hash, "Committed block");
+        metrics::gauge!("state.committed.block.height", height.0 as _);
+        metrics::counter!("state.committed.block.count", 1);
+
         Ok(hash)
     }
 


### PR DESCRIPTION
This change makes the state logging and metrics consistent with downloads and verifies.

It can help us work out where blocks are getting stuck.