### PR TITLE
Increase sync timeouts

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -26,6 +26,10 @@ pub struct Config {
     pub initial_testnet_peers: HashSet<String>,
 
     /// The initial target size for the peer set.
+    ///
+    /// If you have a slow network connection, and Zebra is having trouble
+    /// syncing, try reducing the peer set size. You can also reduce the peer
+    /// set size to reduce Zebra's bandwidth usage.
     pub peerset_initial_target_size: usize,
 
     /// How frequently we attempt to connect to a new peer.
@@ -79,6 +83,20 @@ impl Default for Config {
             initial_mainnet_peers: mainnet_peers,
             initial_testnet_peers: testnet_peers,
             new_peer_interval: Duration::from_secs(60),
+
+            // The default peerset target size should be large enough to ensure
+            // nodes have a reliable set of peers. But it should also be limited
+            // to a reasonable size, to avoid queueing too many in-flight block
+            // downloads. A large queue of in-flight block downloads can choke a
+            // constrained local network connection.
+            //
+            // We assume that Zebra nodes have at least 10 Mbps bandwidth.
+            // Therefore, a maximum-sized block can take up to 2 seconds to
+            // download. So a full default peer set adds up to 100 seconds worth
+            // of blocks to the queue.
+            //
+            // But the peer set for slow nodes is typically much smaller, due to
+            // the handshake RTT timeout.
             peerset_initial_target_size: 50,
         }
     }

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -9,15 +9,24 @@ use zebra_chain::parameters::NetworkUpgrade;
 
 /// The buffer size for the peer set.
 ///
+/// This should be greater than 1 to avoid sender contention, but also reasonably
+/// small, to avoid queueing too many in-flight block downloads. (A large queue
+/// of in-flight block downloads can choke a constrained local network
+/// connection, or a small peer set on testnet.)
+///
 /// We assume that Zebra nodes have at least 10 Mbps bandwidth. Therefore, a
-/// maximum-sized block will take 2 seconds to download. Based on the current
-/// `BLOCK_DOWNLOAD_TIMEOUT`, this is the largest buffer size we can support.
-pub const PEERSET_BUFFER_SIZE: usize = 10;
+/// maximum-sized block can take up to 2 seconds to download. So the peer set
+/// buffer adds up to 6 seconds worth of blocks to the queue.
+pub const PEERSET_BUFFER_SIZE: usize = 3;
 
 /// The timeout for requests made to a remote peer.
 pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// The timeout for handshakes when connecting to new peers.
+///
+/// This timeout should remain small, because it helps stop slow peers getting
+/// into the peer set. This is particularly important for network-constrained
+/// nodes, and on testnet.
 pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(4);
 
 /// We expect to receive a message from a live peer at least once in this time duration.

--- a/zebrad/src/commands/start/sync.rs
+++ b/zebrad/src/commands/start/sync.rs
@@ -229,24 +229,21 @@ where
                 //
                 // Starting to wait is interesting, but logging each wait can be
                 // very verbose.
-                let mut first_wait = true;
+                if self.pending_blocks.len() > LOOKAHEAD_LIMIT {
+                    tracing::info!(
+                        tips.len = self.prospective_tips.len(),
+                        pending.len = self.pending_blocks.len(),
+                        pending.limit = LOOKAHEAD_LIMIT,
+                        "waiting for pending blocks",
+                    );
+                }
                 while self.pending_blocks.len() > LOOKAHEAD_LIMIT {
-                    if first_wait {
-                        tracing::info!(
-                            tips.len = self.prospective_tips.len(),
-                            pending.len = self.pending_blocks.len(),
-                            pending.limit = LOOKAHEAD_LIMIT,
-                            "waiting for pending blocks",
-                        );
-                        first_wait = false;
-                    } else {
-                        tracing::trace!(
-                            tips.len = self.prospective_tips.len(),
-                            pending.len = self.pending_blocks.len(),
-                            pending.limit = LOOKAHEAD_LIMIT,
-                            "continuing to wait for pending blocks",
-                        );
-                    }
+                    tracing::trace!(
+                        tips.len = self.prospective_tips.len(),
+                        pending.len = self.pending_blocks.len(),
+                        pending.limit = LOOKAHEAD_LIMIT,
+                        "continuing to wait for pending blocks",
+                    );
                     match self
                         .pending_blocks
                         .next()

--- a/zebrad/src/commands/start/sync.rs
+++ b/zebrad/src/commands/start/sync.rs
@@ -76,18 +76,24 @@ const TIPS_RETRY_TIMEOUT: Duration = Duration::from_secs(60);
 ///   - allow pending downloads and verifies to complete or time out.
 ///     Sync restarts don't cancel downloads, so quick restarts can overload
 ///     network-bound nodes with lots of peers, leading to further failures.
-///     (The total number of requests being processed by peers is only
-///     constrained by the number of peers.)
+///     (The total number of requests being processed by peers is the sum of
+///     the number of peers, and the peer request buffer size.)
+///
+///     We assume that Zebra nodes have at least 10 Mbps bandwidth. So a
+///     maximum-sized block can take up to 2 seconds to download. Therefore, we
+///     set this timeout to twice the default number of peers. (The peer request
+///     buffer size is small enough that any buffered requests will overlap with
+///     the post-restart ObtainTips.)
+///
 ///   - allow zcashd peers to process pending requests. If the node only has a
 ///     few peers, we want to clear as much peer state as possible. In
 ///     particular, zcashd sends "next block range" hints, based on zcashd's
 ///     internal model of our sync progress. But we want to discard these hints,
 ///     so they don't get confused with ObtainTips and ExtendTips responses.
 ///
-/// Make sure each sync run can download an entire checkpoint, even on instances
-/// with slow or unreliable networks. This is particularly important on testnet,
-/// which has a small number of slow peers.
-const SYNC_RESTART_TIMEOUT: Duration = Duration::from_secs(60);
+/// This timeout is particularly important on instances with slow or unreliable
+/// networks, and on testnet, which has a small number of slow peers.
+const SYNC_RESTART_TIMEOUT: Duration = Duration::from_secs(100);
 
 /// Helps work around defects in the bitcoin protocol by checking whether
 /// the returned hashes actually extend a chain tip.


### PR DESCRIPTION
Increase the sync timeouts, to support slower mainnet and testnet nodes.

This PR is based on #980, because it modifies nearby code.

These longer timeouts are not triggered very often, because of the fixes in:
* #980: Ignore sync errors when the block is already verified
* #978: Make tips independent of response order
* #991: Always drop the final hash in peer responses
* #992: If the first ExtendTips hash is bad, discard it and re-check
* e5a6aa4c in this PR: Retry obtain and extend tips on failure

We might be able to reduce these timeouts in future, once we implement a peer reputation service.

In the meantime, users can further reduce the timeout rate by configuring the number of peers:
* fewer peers if the node is network-bound
* fewer peers to reduce the number of peers providing incorrect responses
* more peers if the node has too many slow peers
* more peers if verification is timing out before all the blocks are downloaded

As a side-effect, the longer timeouts in this PR also reduce the load on the network from zebrad instances which constantly fail to sync. (Because their network connections are slow or unreliable.)

TODO:
- [x] get PR #980 merged
- [x] rebase on main