### PR TITLE
Use ok_or for constants in zebra-network

### DIFF
--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -15,7 +15,7 @@ pub fn is_coinbase_first(block: &Block) -> Result<(), Error> {
     let first = block
         .transactions
         .get(0)
-        .ok_or_else(|| "block has no transactions")?;
+        .ok_or("block has no transactions")?;
     let mut rest = block.transactions.iter().skip(1);
     if !first.is_coinbase() {
         return Err("first transaction must be coinbase".into());

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -262,7 +262,7 @@ where
             let remote_msg = stream
                 .next()
                 .await
-                .ok_or_else(|| HandshakeError::ConnectionClosed)??;
+                .ok_or(HandshakeError::ConnectionClosed)??;
 
             // Check that we got a Version and destructure its fields into the local scope.
             debug!(?remote_msg, "got message from remote peer");
@@ -295,7 +295,7 @@ where
             let remote_msg = stream
                 .next()
                 .await
-                .ok_or_else(|| HandshakeError::ConnectionClosed)??;
+                .ok_or(HandshakeError::ConnectionClosed)??;
             if let Message::Verack = remote_msg {
                 debug!("got verack from remote peer");
             } else {


### PR DESCRIPTION
I can't see these clippy warnings locally, but they happen in CI.