### PR TITLE
Add log filters which provide block info

### DIFF
--- a/zebra-utils/zebrad-hash-lookup
+++ b/zebra-utils/zebrad-hash-lookup
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Reads stdin or the file $1, looks lines up as hashes, then outputs block info
+# for each hash. Uses the zcash-cli command for block lookups.
+
+ZEBRAD="${ZEBRAD:-zebrad}"
+ZCASH_CLI="${ZCASH_CLI:-zcash-cli}"
+
+while read hash; do
+    zcashd_hash=$($ZEBRAD revhex "$hash")
+    header=$($ZCASH_CLI getblockheader "$zcashd_hash" 2>&1 || true)
+
+    if echo "$header" | jq . > /dev/null 2> /dev/null; then
+        high=$(echo "$header" | jq -r '"\(.height)"')
+        time=$(echo "$header" | jq -r '"\(.time|todate)"')
+        prev=$(echo "$header" | jq -r '"\(.previousblockhash)"')
+        next=$(echo "$header" | jq -r '"\(.nextblockhash)"')
+
+        # use Zebra hash order
+        if [ "$prev" != 'null' ]; then
+            prev=$($ZEBRAD revhex "$prev")
+        fi
+        if [ "$next" != 'null' ]; then
+            next=$($ZEBRAD revhex "$next")
+        fi
+
+        printf 'high: %s\ntime: %s\nhash: %s\nprev: %s\nnext: %s\n' \
+               "$high" "$time" "$hash" "$prev" "$next"
+    else
+        # Handle lookup errors
+        printf 'hash: %s\n%s\n' \
+               "$hash" "$header"
+    fi
+done < "${1:-/dev/stdin}"

--- a/zebra-utils/zebrad-log-filter
+++ b/zebra-utils/zebrad-log-filter
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Reads stdin or the file $1, replacing hashes with block info
+#
+# Uses zebrad-hash-lookup, which uses zcash-cli.
+#
+# Usage:
+#   zebrad start | zebrad-log-filter
+#   ZCASH_CLI="zcash-cli -testnet" zebrad start | zebrad-log-filter
+
+# Find GNU sed
+if command -v gsed > /dev/null; then
+    GNU_SED=${GNU_SED:-gsed}
+else
+    # Just assume it's GNU sed
+    GNU_SED=${GNU_SED:-sed}
+fi
+
+while read line; do
+    # Put each hash on a separate line, then expand them
+    echo "$line" | \
+        $GNU_SED -r \
+            's/([0-9a-f]{64})/\n\1/g' | \
+        $GNU_SED -r \
+            's/(.*)([0-9a-f]{64})(.*)/ \
+                echo -n '\''\1'\''; \
+                echo '\''\2'\'' | zebrad-hash-lookup; \
+                echo -n '\''\3'\''; /e'
+done < "${1:-/dev/stdin}"


### PR DESCRIPTION
These filters use zcash-cli to annotate hashes with the corresponding
block info.

They are useful when the local zebrad instance hasn't downloaded or
parsed the blocks in its logs, or when the zebrad logs just provide a
hash. The filter provides the height, time, previous, and next blocks.