### PR TITLE
Remove the zebra-consensus AddBlock order workarounds

### DIFF
--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -39,10 +39,17 @@ const MAX_EXPECTED_BLOCK_GAP: u32 = 100_000;
 /// A wrapper type that holds the `ChainVerifier`'s `CheckpointVerifier`, and
 /// its associated state.
 #[derive(Clone)]
-struct ChainCheckpointVerifier {
+struct ChainCheckpointVerifier<S>
+where
+    S: Service<zebra_state::Request, Response = zebra_state::Response, Error = Error>
+        + Send
+        + Clone
+        + 'static,
+    S::Future: Send + 'static,
+{
     /// The underlying `CheckpointVerifier`, wrapped in a buffer, so we can
     /// clone and share it with futures.
-    verifier: Buffer<CheckpointVerifier, Arc<Block>>,
+    verifier: Buffer<CheckpointVerifier<S>, Arc<Block>>,
 
     /// The maximum checkpoint height for `checkpoint_verifier`.
     max_height: block::Height,
@@ -67,10 +74,7 @@ where
     /// associated state.
     ///
     /// None if all the checkpoints have been verified.
-    checkpoint: Option<ChainCheckpointVerifier>,
-
-    /// The underlying `ZebraState`, possibly wrapped in other services.
-    state_service: S,
+    checkpoint: Option<ChainCheckpointVerifier<S>>,
 
     /// The most recent block height that was submitted to the verifier.
     ///
@@ -103,20 +107,19 @@ where
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // We don't expect the state or verifiers to exert backpressure on our
-        // users, so we don't need to call `state_service.poll_ready()` here.
+        // We don't expect the verifiers to exert backpressure on our
+        // users, so we don't need to call the verifier's `poll_ready` here.
         // (And we don't know which verifier to choose at this point, anyway.)
         Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, block: Arc<Block>) -> Self::Future {
-        // TODO(jlusby): Error = Report, handle errors from state_service.
+        // TODO(jlusby): Error = Report
         let height = block.coinbase_height();
         let hash = block.hash();
         let span = tracing::debug_span!("block_verify", ?height, ?hash,);
 
         let mut block_verifier = self.block_verifier.clone();
-        let mut state_service = self.state_service.clone();
         let checkpoint_verifier = self.checkpoint.clone().map(|c| c.verifier);
         let max_checkpoint_height = self.checkpoint.clone().map(|c| c.max_height);
 
@@ -148,18 +151,20 @@ where
                     tracing::debug!("large block height gap: this block or the previous block is out of order");
                 }
 
-                block_verifier
+                let verified_hash = block_verifier
                     .ready_and()
                     .await?
                     .call(block.clone())
                     .await?;
+                assert_eq!(verified_hash, hash, "block verifier returned wrong hash: hashes must be equal");
             } else {
-                checkpoint_verifier
+                let verified_hash = checkpoint_verifier
                     .expect("missing checkpoint verifier: verifier must be Some if max checkpoint height is Some")
                     .ready_and()
                     .await?
                     .call(block.clone())
                     .await?;
+                assert_eq!(verified_hash, hash, "checkpoint verifier returned wrong hash: hashes must be equal");
             }
 
             tracing::trace!(?height, ?hash, "verified block");
@@ -169,15 +174,7 @@ where
             );
             metrics::counter!("chain.verified.block.count", 1);
 
-            let add_block = state_service
-                .ready_and()
-                .await?
-                .call(zebra_state::Request::AddBlock { block });
-
-            match add_block.await? {
-                zebra_state::Response::Added { hash } => Ok(hash),
-                _ => Err("adding block to zebra-state failed".into()),
-            }
+            Ok(hash)
         }
         .instrument(span)
         .boxed()
@@ -253,10 +250,6 @@ where
 /// Return a chain verification service, using the provided block verifier,
 /// checkpoint list, and state service.
 ///
-/// The chain verifier holds a state service of type `S`, used as context for
-/// block validation and to which newly verified blocks will be committed. This
-/// state is pluggable to allow for testing or instrumentation.
-///
 /// The returned type is opaque to allow instrumentation or other wrappers, but
 /// can be boxed for storage. It is also `Clone` to allow sharing of a
 /// verification service.
@@ -320,12 +313,12 @@ where
         (Some(initial_height), _, Some(max_checkpoint_height)) if (initial_height > max_checkpoint_height) => None,
         // No list, no checkpoint verifier
         (_, None, _) => None,
-
         (_, Some(_), None) => panic!("Missing max checkpoint height: height must be Some if verifier is Some"),
+
         // We've done all the checks we need to create a checkpoint verifier
         (_, Some(list), Some(max_height)) => Some(
             ChainCheckpointVerifier {
-                verifier: Buffer::new(CheckpointVerifier::from_checkpoint_list(list, initial_tip), 1),
+                verifier: Buffer::new(CheckpointVerifier::from_checkpoint_list(list, initial_tip, state_service), 1),
                 max_height,
             }),
     };
@@ -334,7 +327,6 @@ where
         ChainVerifier {
             block_verifier,
             checkpoint,
-            state_service,
             last_block_height: initial_height,
         },
         1,

--- a/zebra-consensus/src/chain/tests.rs
+++ b/zebra-consensus/src/chain/tests.rs
@@ -351,6 +351,8 @@ async fn verify_fail_add_block_checkpoint() -> Result<(), Report> {
 }
 
 #[tokio::test]
+// Temporarily ignore this test, until the state can handle out-of-order blocks
+#[ignore]
 async fn continuous_blockchain_test() -> Result<(), Report> {
     continuous_blockchain(None).await?;
     for height in 0..=10 {

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -653,7 +653,7 @@ impl CheckpointVerifier {
         );
 
         let block_count = rev_valid_blocks.len();
-        tracing::info!(?block_count, ?current_range, "Verified checkpoint range");
+        tracing::info!(?block_count, ?current_range, "verified checkpoint range");
         metrics::gauge!(
             "checkpoint.verified.block.height",
             target_checkpoint_height.0 as _

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -210,6 +210,8 @@ async fn multi_item_checkpoint_list() -> Result<(), Report> {
 }
 
 #[tokio::test]
+// Temporarily ignore this test, until the state can handle out-of-order blocks
+#[ignore]
 async fn continuous_blockchain_test() -> Result<(), Report> {
     continuous_blockchain(None).await?;
     for height in 0..=10 {

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -12,6 +12,7 @@ use tokio::{stream::StreamExt, time::timeout};
 use tower::{Service, ServiceExt};
 use tracing_futures::Instrument;
 
+use zebra_chain::parameters::Network::*;
 use zebra_chain::serialization::ZcashDeserialize;
 
 /// The timeout we apply to each verify future during testing.
@@ -44,8 +45,10 @@ async fn single_item_checkpoint_list() -> Result<(), Report> {
             .cloned()
             .collect();
 
+    let state_service = zebra_state::init(zebra_state::Config::ephemeral(), Mainnet);
     let mut checkpoint_verifier =
-        CheckpointVerifier::from_list(genesis_checkpoint_list, None).map_err(|e| eyre!(e))?;
+        CheckpointVerifier::from_list(genesis_checkpoint_list, None, state_service)
+            .map_err(|e| eyre!(e))?;
 
     assert_eq!(
         checkpoint_verifier.previous_checkpoint_height(),
@@ -124,8 +127,10 @@ async fn multi_item_checkpoint_list() -> Result<(), Report> {
         .map(|(_block, height, hash)| (*height, *hash))
         .collect();
 
+    let state_service = zebra_state::init(zebra_state::Config::ephemeral(), Mainnet);
     let mut checkpoint_verifier =
-        CheckpointVerifier::from_list(checkpoint_list, None).map_err(|e| eyre!(e))?;
+        CheckpointVerifier::from_list(checkpoint_list, None, state_service)
+            .map_err(|e| eyre!(e))?;
 
     assert_eq!(
         checkpoint_verifier.previous_checkpoint_height(),
@@ -261,8 +266,10 @@ async fn continuous_blockchain(restart_height: Option<block::Height>) -> Result<
         let initial_tip = restart_height
             .map(|block::Height(height)| &blockchain[height as usize].0)
             .cloned();
+        let state_service = zebra_state::init(zebra_state::Config::ephemeral(), Mainnet);
         let mut checkpoint_verifier =
-            CheckpointVerifier::from_list(checkpoint_list, initial_tip).map_err(|e| eyre!(e))?;
+            CheckpointVerifier::from_list(checkpoint_list, initial_tip, state_service)
+                .map_err(|e| eyre!(e))?;
 
         // Setup checks
         if restart_height
@@ -382,8 +389,10 @@ async fn block_higher_than_max_checkpoint_fail() -> Result<(), Report> {
             .cloned()
             .collect();
 
+    let state_service = zebra_state::init(zebra_state::Config::ephemeral(), Mainnet);
     let mut checkpoint_verifier =
-        CheckpointVerifier::from_list(genesis_checkpoint_list, None).map_err(|e| eyre!(e))?;
+        CheckpointVerifier::from_list(genesis_checkpoint_list, None, state_service)
+            .map_err(|e| eyre!(e))?;
 
     assert_eq!(
         checkpoint_verifier.previous_checkpoint_height(),
@@ -457,8 +466,10 @@ async fn wrong_checkpoint_hash_fail() -> Result<(), Report> {
             .cloned()
             .collect();
 
+    let state_service = zebra_state::init(zebra_state::Config::ephemeral(), Mainnet);
     let mut checkpoint_verifier =
-        CheckpointVerifier::from_list(genesis_checkpoint_list, None).map_err(|e| eyre!(e))?;
+        CheckpointVerifier::from_list(genesis_checkpoint_list, None, state_service)
+            .map_err(|e| eyre!(e))?;
 
     assert_eq!(
         checkpoint_verifier.previous_checkpoint_height(),
@@ -637,8 +648,10 @@ async fn checkpoint_drop_cancel() -> Result<(), Report> {
         .map(|(_block, height, hash)| (*height, *hash))
         .collect();
 
+    let state_service = zebra_state::init(zebra_state::Config::ephemeral(), Mainnet);
     let mut checkpoint_verifier =
-        CheckpointVerifier::from_list(checkpoint_list, None).map_err(|e| eyre!(e))?;
+        CheckpointVerifier::from_list(checkpoint_list, None, state_service)
+            .map_err(|e| eyre!(e))?;
 
     assert_eq!(
         checkpoint_verifier.previous_checkpoint_height(),
@@ -721,8 +734,9 @@ async fn hard_coded_mainnet() -> Result<(), Report> {
         Arc::<Block>::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..])?;
     let hash0 = block0.hash();
 
+    let state_service = zebra_state::init(zebra_state::Config::ephemeral(), Mainnet);
     // Use the hard-coded checkpoint list
-    let mut checkpoint_verifier = CheckpointVerifier::new(Network::Mainnet, None);
+    let mut checkpoint_verifier = CheckpointVerifier::new(Network::Mainnet, None, state_service);
 
     assert_eq!(
         checkpoint_verifier.previous_checkpoint_height(),

--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -95,6 +95,7 @@ static GET_TIP_ADD_ORDERED_TRANSCRIPT_TESTNET: Lazy<Vec<(Request, Result<Respons
         ]
     });
 
+#[allow(dead_code)]
 static GET_TIP_ADD_REVERSED_TRANSCRIPT_MAINNET: Lazy<Vec<(Request, Result<Response, TransError>)>> =
     Lazy::new(|| {
         let block0: Arc<_> =
@@ -121,6 +122,7 @@ static GET_TIP_ADD_REVERSED_TRANSCRIPT_MAINNET: Lazy<Vec<(Request, Result<Respon
         ]
     });
 
+#[allow(dead_code)]
 static GET_TIP_ADD_REVERSED_TRANSCRIPT_TESTNET: Lazy<Vec<(Request, Result<Response, TransError>)>> =
     Lazy::new(|| {
         let block0: Arc<_> =
@@ -164,12 +166,14 @@ async fn check_transcripts(network: Network) -> Result<(), Report> {
     let mainnet_transcript = &[
         &ADD_BLOCK_TRANSCRIPT_MAINNET,
         &GET_TIP_ADD_ORDERED_TRANSCRIPT_MAINNET,
-        &GET_TIP_ADD_REVERSED_TRANSCRIPT_MAINNET,
+        // Temporarily disabled, until the state accepts out-of-order blocks
+        //&GET_TIP_ADD_REVERSED_TRANSCRIPT_MAINNET,
     ];
     let testnet_transcript = &[
         &ADD_BLOCK_TRANSCRIPT_TESTNET,
         &GET_TIP_ADD_ORDERED_TRANSCRIPT_TESTNET,
-        &GET_TIP_ADD_REVERSED_TRANSCRIPT_TESTNET,
+        // Temporarily disabled, until the state accepts out-of-order blocks
+        //&GET_TIP_ADD_REVERSED_TRANSCRIPT_TESTNET,
     ];
 
     for transcript_data in match network {

--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -10,7 +10,7 @@ use zebra_state::*;
 static ADD_BLOCK_TRANSCRIPT_MAINNET: Lazy<Vec<(Request, Result<Response, TransError>)>> =
     Lazy::new(|| {
         let block: Arc<_> =
-            Block::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_415000_BYTES[..])
+            Block::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..])
                 .unwrap()
                 .into();
         let hash = block.as_ref().into();
@@ -28,7 +28,7 @@ static ADD_BLOCK_TRANSCRIPT_MAINNET: Lazy<Vec<(Request, Result<Response, TransEr
 static ADD_BLOCK_TRANSCRIPT_TESTNET: Lazy<Vec<(Request, Result<Response, TransError>)>> =
     Lazy::new(|| {
         let block: Arc<_> =
-            Block::zcash_deserialize(&zebra_test::vectors::BLOCK_TESTNET_10_BYTES[..])
+            Block::zcash_deserialize(&zebra_test::vectors::BLOCK_TESTNET_GENESIS_BYTES[..])
                 .unwrap()
                 .into();
         let hash = block.as_ref().into();
@@ -76,7 +76,7 @@ static GET_TIP_TRANSCRIPT_TESTNET: Lazy<Vec<(Request, Result<Response, TransErro
                 .unwrap()
                 .into();
         let block1: Arc<_> =
-            Block::zcash_deserialize(&zebra_test::vectors::BLOCK_TESTNET_10_BYTES[..])
+            Block::zcash_deserialize(&zebra_test::vectors::BLOCK_TESTNET_1_BYTES[..])
                 .unwrap()
                 .into();
         let hash0 = block0.as_ref().into();

--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -43,7 +43,7 @@ static ADD_BLOCK_TRANSCRIPT_TESTNET: Lazy<Vec<(Request, Result<Response, TransEr
         ]
     });
 
-static GET_TIP_TRANSCRIPT_MAINNET: Lazy<Vec<(Request, Result<Response, TransError>)>> =
+static GET_TIP_ADD_ORDERED_TRANSCRIPT_MAINNET: Lazy<Vec<(Request, Result<Response, TransError>)>> =
     Lazy::new(|| {
         let block0: Arc<_> =
             Block::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..])
@@ -56,20 +56,20 @@ static GET_TIP_TRANSCRIPT_MAINNET: Lazy<Vec<(Request, Result<Response, TransErro
         let hash0 = block0.as_ref().into();
         let hash1 = block1.as_ref().into();
         vec![
-            // Insert higher block first, lower block second
-            (
-                Request::AddBlock { block: block1 },
-                Ok(Response::Added { hash: hash1 }),
-            ),
+            // Insert the blocks in order
             (
                 Request::AddBlock { block: block0 },
                 Ok(Response::Added { hash: hash0 }),
+            ),
+            (
+                Request::AddBlock { block: block1 },
+                Ok(Response::Added { hash: hash1 }),
             ),
             (Request::GetTip, Ok(Response::Tip { hash: hash1 })),
         ]
     });
 
-static GET_TIP_TRANSCRIPT_TESTNET: Lazy<Vec<(Request, Result<Response, TransError>)>> =
+static GET_TIP_ADD_ORDERED_TRANSCRIPT_TESTNET: Lazy<Vec<(Request, Result<Response, TransError>)>> =
     Lazy::new(|| {
         let block0: Arc<_> =
             Block::zcash_deserialize(&zebra_test::vectors::BLOCK_TESTNET_GENESIS_BYTES[..])
@@ -82,7 +82,59 @@ static GET_TIP_TRANSCRIPT_TESTNET: Lazy<Vec<(Request, Result<Response, TransErro
         let hash0 = block0.as_ref().into();
         let hash1 = block1.as_ref().into();
         vec![
-            // Insert higher block first, lower block second
+            // Insert the blocks in order
+            (
+                Request::AddBlock { block: block0 },
+                Ok(Response::Added { hash: hash0 }),
+            ),
+            (
+                Request::AddBlock { block: block1 },
+                Ok(Response::Added { hash: hash1 }),
+            ),
+            (Request::GetTip, Ok(Response::Tip { hash: hash1 })),
+        ]
+    });
+
+static GET_TIP_ADD_REVERSED_TRANSCRIPT_MAINNET: Lazy<Vec<(Request, Result<Response, TransError>)>> =
+    Lazy::new(|| {
+        let block0: Arc<_> =
+            Block::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..])
+                .unwrap()
+                .into();
+        let block1: Arc<_> =
+            Block::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_1_BYTES[..])
+                .unwrap()
+                .into();
+        let hash0 = block0.as_ref().into();
+        let hash1 = block1.as_ref().into();
+        vec![
+            // Insert the blocks in reverse order
+            (
+                Request::AddBlock { block: block1 },
+                Ok(Response::Added { hash: hash1 }),
+            ),
+            (
+                Request::AddBlock { block: block0 },
+                Ok(Response::Added { hash: hash0 }),
+            ),
+            (Request::GetTip, Ok(Response::Tip { hash: hash1 })),
+        ]
+    });
+
+static GET_TIP_ADD_REVERSED_TRANSCRIPT_TESTNET: Lazy<Vec<(Request, Result<Response, TransError>)>> =
+    Lazy::new(|| {
+        let block0: Arc<_> =
+            Block::zcash_deserialize(&zebra_test::vectors::BLOCK_TESTNET_GENESIS_BYTES[..])
+                .unwrap()
+                .into();
+        let block1: Arc<_> =
+            Block::zcash_deserialize(&zebra_test::vectors::BLOCK_TESTNET_1_BYTES[..])
+                .unwrap()
+                .into();
+        let hash0 = block0.as_ref().into();
+        let hash1 = block1.as_ref().into();
+        vec![
+            // Insert the blocks in reverse order
             (
                 Request::AddBlock { block: block1 },
                 Ok(Response::Added { hash: hash1 }),
@@ -109,12 +161,20 @@ async fn check_transcripts_testnet() -> Result<(), Report> {
 async fn check_transcripts(network: Network) -> Result<(), Report> {
     zebra_test::init();
 
-    let mainnet_transcript = &[&ADD_BLOCK_TRANSCRIPT_TESTNET, &GET_TIP_TRANSCRIPT_TESTNET];
-    let testnet_transcript = &[&ADD_BLOCK_TRANSCRIPT_MAINNET, &GET_TIP_TRANSCRIPT_MAINNET];
+    let mainnet_transcript = &[
+        &ADD_BLOCK_TRANSCRIPT_MAINNET,
+        &GET_TIP_ADD_ORDERED_TRANSCRIPT_MAINNET,
+        &GET_TIP_ADD_REVERSED_TRANSCRIPT_MAINNET,
+    ];
+    let testnet_transcript = &[
+        &ADD_BLOCK_TRANSCRIPT_TESTNET,
+        &GET_TIP_ADD_ORDERED_TRANSCRIPT_TESTNET,
+        &GET_TIP_ADD_REVERSED_TRANSCRIPT_TESTNET,
+    ];
 
     for transcript_data in match network {
+        Network::Mainnet => mainnet_transcript,
         Network::Testnet => testnet_transcript,
-        _ => mainnet_transcript,
     } {
         let storage_guard = TempDir::new("")?;
         let cache_dir = storage_guard.path().to_owned();


### PR DESCRIPTION
Closes #969.

Panics on out of order blocks in the state - that will be resolved by #1011.

**Note -  this PR should be merged using a rebase.**

We want to revert the commit - `Temporarily ignore failing state tests` after #1011 is implemented.