### PR TITLE
chain: Add Transaction::hash() method.

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -50,7 +50,7 @@ impl Block {
             })
     }
 
-    /// Get the hash for the current block
+    /// Compute the hash of this block.
     pub fn hash(&self) -> Hash {
         Hash::from(self)
     }

--- a/zebra-chain/src/block/hash.rs
+++ b/zebra-chain/src/block/hash.rs
@@ -22,6 +22,12 @@ use super::Header;
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct Hash(pub [u8; 32]);
 
+impl fmt::Display for Hash {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&hex::encode(&self.0))
+    }
+}
+
 impl fmt::Debug for Hash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("BlockHeaderHash")

--- a/zebra-chain/src/block/hash.rs
+++ b/zebra-chain/src/block/hash.rs
@@ -15,6 +15,9 @@ use super::Header;
 /// Technically, this is the (SHA256d) hash of a block *header*, but since the
 /// block header includes the Merkle root of the transaction Merkle tree, it
 /// binds the entire contents of the block and is used to identify entire blocks.
+///
+/// Note: Zebra displays transaction and block hashes in their actual byte-order,
+/// not in reversed byte-order.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct Hash(pub [u8; 32]);

--- a/zebra-chain/src/block/tests/prop.rs
+++ b/zebra-chain/src/block/tests/prop.rs
@@ -10,7 +10,7 @@ use super::super::{serialize::MAX_BLOCK_BYTES, *};
 
 proptest! {
     #[test]
-    fn blockheaderhash_roundtrip(hash in any::<Hash>()) {
+    fn block_hash_roundtrip(hash in any::<Hash>()) {
         let bytes = hash.zcash_serialize_to_vec()?;
         let other_hash: Hash = bytes.zcash_deserialize_into()?;
 

--- a/zebra-chain/src/block/tests/prop.rs
+++ b/zebra-chain/src/block/tests/prop.rs
@@ -18,6 +18,13 @@ proptest! {
     }
 
     #[test]
+    fn block_hash_display_fromstr_roundtrip(hash in any::<Hash>()) {
+        let display = format!("{}", hash);
+        let parsed = display.parse::<Hash>().expect("hash should parse");
+        prop_assert_eq!(hash, parsed);
+    }
+
+    #[test]
     fn blockheader_roundtrip(header in any::<Header>()) {
         let bytes = header.zcash_serialize_to_vec()?;
         let other_header = bytes.zcash_deserialize_into()?;

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -97,6 +97,11 @@ pub enum Transaction {
 }
 
 impl Transaction {
+    /// Compute the hash of this transaction.
+    pub fn hash(&self) -> Hash {
+        Hash::from(self)
+    }
+
     /// Access the transparent inputs of this transaction, regardless of version.
     pub fn inputs(&self) -> &[transparent::Input] {
         match self {

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -17,8 +17,8 @@ use super::Transaction;
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct Hash(pub [u8; 32]);
 
-impl From<Transaction> for Hash {
-    fn from(transaction: Transaction) -> Self {
+impl<'a> From<&'a Transaction> for Hash {
+    fn from(transaction: &'a Transaction) -> Self {
         let mut hash_writer = sha256d::Writer::default();
         transaction
             .zcash_serialize(&mut hash_writer)

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -10,6 +10,9 @@ use crate::serialization::{sha256d, SerializationError, ZcashSerialize};
 use super::Transaction;
 
 /// A transaction hash.
+///
+/// Note: Zebra displays transaction and block hashes in their actual byte-order,
+/// not in reversed byte-order.
 #[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct Hash(pub [u8; 32]);

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -27,6 +27,12 @@ impl<'a> From<&'a Transaction> for Hash {
     }
 }
 
+impl fmt::Display for Hash {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&hex::encode(&self.0))
+    }
+}
+
 impl fmt::Debug for Hash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("TransactionHash")

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -9,10 +9,7 @@ use crate::serialization::{sha256d, SerializationError, ZcashSerialize};
 
 use super::Transaction;
 
-/// A hash of a `Transaction`
-///
-/// TODO: I'm pretty sure this is also a SHA256d hash but I haven't
-/// confirmed it yet.
+/// A transaction hash.
 #[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct Hash(pub [u8; 32]);

--- a/zebra-chain/src/transaction/tests/prop.rs
+++ b/zebra-chain/src/transaction/tests/prop.rs
@@ -15,6 +15,13 @@ proptest! {
     }
 
     #[test]
+    fn transaction_hash_display_fromstr_roundtrip(hash in any::<Hash>()) {
+        let display = format!("{}", hash);
+        let parsed = display.parse::<Hash>().expect("hash should parse");
+        prop_assert_eq!(hash, parsed);
+    }
+
+    #[test]
     fn locktime_roundtrip(locktime in any::<LockTime>()) {
         let mut bytes = Cursor::new(Vec::new());
         locktime.zcash_serialize(&mut bytes)?;

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -14,6 +14,20 @@ fn librustzcash_tx_deserialize_and_round_trip() {
 }
 
 #[test]
+fn librustzcash_tx_hash() {
+    let tx = Transaction::zcash_deserialize(&zebra_test::vectors::GENERIC_TESTNET_TX[..])
+        .expect("transaction test vector from librustzcash should deserialize");
+
+    // TxID taken from comment in zebra_test::vectors
+    let hash = tx.hash();
+    let expected = "3956b54c11736f4ac5e2c474029cba8f5b83dca2e38f355337e20ce37fbdf064"
+        .parse::<Hash>()
+        .expect("hash should parse correctly");
+
+    assert_eq!(hash, expected);
+}
+
+#[test]
 fn zip143_deserialize_and_round_trip() {
     let tx1 = Transaction::zcash_deserialize(&zebra_test::vectors::ZIP143_1[..])
         .expect("transaction test vector from ZIP143 should deserialize");


### PR DESCRIPTION
This makes Transaction and Block have a consistent API.

Extracted from #1008. 