### PR TITLE
Add utility methods to zebra-network.

### DIFF
--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -11,6 +11,16 @@ pub enum Network {
     Testnet,
 }
 
+impl Network {
+    /// Get the default port associated to this network.
+    pub fn default_port(&self) -> u16 {
+        match self {
+            Network::Mainnet => 8233,
+            Network::Testnet => 18233,
+        }
+    }
+}
+
 impl Default for Network {
     fn default() -> Self {
         Network::Mainnet


### PR DESCRIPTION
This adds two utility methods to zebra-network items:

- `AddressBook::potentially_connected_peers()`: the complement of the existing `AddressBook::disconnected_peers()`;
- `Network::default_port()`: gets the default port for a network type.

Extracted from #1008.