### PR TITLE
Downgrade inbound peer requests to debug

### DIFF
--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -53,7 +53,7 @@ impl StartCmd {
         // The service that our node uses to respond to requests by peers
         let node = Buffer::new(
             service_fn(|req| async move {
-                info!(?req);
+                debug!(?req, "inbound peer request");
                 Ok::<zebra_network::Response, Report>(zebra_network::Response::Nil)
             }),
             1,


### PR DESCRIPTION
Logging at info was a bit too verbose.

Also add a short log message.