### PR TITLE
Disable CodeCov annotations via GitHub Checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,3 @@
-
 coverage:
   range: "50...100"
   status:
@@ -25,3 +24,6 @@ parsers:
 # This turns off the extra comment; the coverage %'s are still
 # reported on the main PR page as check results
 comment: false
+
+github_checks:
+    annotations: false


### PR DESCRIPTION
They just decided to turn this on by default for all their GitHub users ...

![image](https://user-images.githubusercontent.com/552961/92782134-b95e2e80-f372-11ea-868c-2e3647771653.png)

https://docs.codecov.io/docs/github-checks-beta

Unfortunately our most reliable Rust code coverage tool (Tarpaulin) can be a little noisy so some of the inline coverage annotations are spurious, so let's turn this off. The patch and absolute metrics are still useful on each push, etc.