### PR TITLE
Test sync on testnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,6 +3291,7 @@ dependencies = [
  "proptest",
  "regex",
  "spandoc",
+ "tempdir",
  "thiserror",
  "tokio",
  "tower",

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = "1.0.21"
 pretty_assertions = "0.6.1"
 owo-colors = "1.1.3"
 proptest = "0.10.1"
+tempdir = "0.3.7"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -93,6 +93,9 @@ impl CommandExt for Command {
 
 /// Extension trait for methods on `tempdir::TempDir` for using it as a test
 /// directory with an arbitrary command.
+///
+/// This trait is separate from `ZebradTestDirExt`, so that we can test
+/// `zebra_test::command` without running `zebrad`.
 pub trait TestDirExt
 where
     Self: Borrow<TempDir> + Sized,

--- a/zebra-test/tests/command.rs
+++ b/zebra-test/tests/command.rs
@@ -1,0 +1,169 @@
+#![allow(clippy::try_err)]
+
+use std::{process::Command, time::Duration};
+
+use color_eyre::eyre::Result;
+use tempdir::TempDir;
+
+use zebra_test::{command::TestDirExt, prelude::Stdio};
+
+/// Returns true if `cmd` with `args` runs successfully.
+///
+/// On failure, prints an error message to stderr.
+/// (This message is captured by the test runner, use `cargo test -- --nocapture` to see it.)
+///
+/// The command's stdout and stderr are ignored.
+fn is_command_available(cmd: &str, args: &[&str]) -> bool {
+    let status = Command::new(cmd)
+        .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    match status {
+        Err(e) => {
+            eprintln!(
+                "Skipping test because '{} {:?}' returned error {:?}",
+                cmd, args, e
+            );
+            false
+        }
+        Ok(status) if !status.success() => {
+            eprintln!(
+                "Skipping test because '{} {:?}' returned status {:?}",
+                cmd, args, status
+            );
+            false
+        }
+        _ => true,
+    }
+}
+
+/// Test if a process that keeps on producing lines of output is killed after the timeout.
+#[test]
+fn kill_on_timeout_output_continuous_lines() -> Result<()> {
+    zebra_test::init();
+
+    // Ideally, we'd want to use the 'yes' command here, but BSD yes treats
+    // every string as an argument to repeat - so we can't test if it is
+    // present on the system.
+    const TEST_CMD: &str = "hexdump";
+    // Skip the test if the test system does not have the command
+    if !is_command_available(TEST_CMD, &["/dev/null"]) {
+        return Ok(());
+    }
+
+    // Without '-v', hexdump hides duplicate lines. But we want duplicate lines
+    // in this test.
+    let mut child = TempDir::new("zebra_test")?
+        .spawn_child_with_command(TEST_CMD, &["-v", "/dev/zero"])?
+        .with_timeout(Duration::from_secs(2));
+
+    // We need to use expect_stdout, because wait_with_output ignores timeouts.
+    // We use a non-matching regex, to trigger the timeout.
+    assert!(child.expect_stdout("this regex should not match").is_err());
+
+    Ok(())
+}
+
+/// Test if the tests pass for a process that produces a single line of output,
+/// then exits before the timeout.
+//
+// TODO: create a similar test that pauses after output
+#[test]
+fn finish_before_timeout_output_single_line() -> Result<()> {
+    zebra_test::init();
+
+    const TEST_CMD: &str = "echo";
+    // Skip the test if the test system does not have the command
+    if !is_command_available(TEST_CMD, &[]) {
+        return Ok(());
+    }
+
+    let mut child = TempDir::new("zebra_test")?
+        .spawn_child_with_command(TEST_CMD, &["zebra_test_output"])?
+        .with_timeout(Duration::from_secs(2));
+
+    // We need to use expect_stdout, because wait_with_output ignores timeouts.
+    // We use a non-matching regex, to trigger the timeout.
+    assert!(child.expect_stdout("this regex should not match").is_err());
+
+    Ok(())
+}
+
+/// Test if a process that keeps on producing output, but doesn't produce any newlines,
+/// is killed after the timeout.
+///
+/// This test fails due to bugs in TestDirExt, see #1140 for details.
+#[test]
+#[ignore]
+fn kill_on_timeout_continuous_output_no_newlines() -> Result<()> {
+    zebra_test::init();
+
+    const TEST_CMD: &str = "cat";
+    // Skip the test if the test system does not have the command
+    if !is_command_available(TEST_CMD, &["/dev/null"]) {
+        return Ok(());
+    }
+
+    let mut child = TempDir::new("zebra_test")?
+        .spawn_child_with_command(TEST_CMD, &["/dev/zero"])?
+        .with_timeout(Duration::from_secs(2));
+
+    // We need to use expect_stdout, because wait_with_output ignores timeouts.
+    // We use a non-matching regex, to trigger the timeout.
+    assert!(child.expect_stdout("this regex should not match").is_err());
+
+    Ok(())
+}
+
+/// Test if tests pass for a process that produces a small amount of output,
+/// with no newlines, then exits before the timeout.
+//
+// TODO: create a similar test that pauses after output
+#[test]
+fn finish_before_timeout_short_output_no_newlines() -> Result<()> {
+    zebra_test::init();
+
+    const TEST_CMD: &str = "printf";
+    // Skip the test if the test system does not have the command
+    // The empty argument is required, because printf expects at least one argument.
+    if !is_command_available(TEST_CMD, &[""]) {
+        return Ok(());
+    }
+
+    let mut child = TempDir::new("zebra_test")?
+        .spawn_child_with_command(TEST_CMD, &["zebra_test_output"])?
+        .with_timeout(Duration::from_secs(2));
+
+    // We need to use expect_stdout, because wait_with_output ignores timeouts.
+    // We use a non-matching regex, to trigger the timeout.
+    assert!(child.expect_stdout("this regex should not match").is_err());
+
+    Ok(())
+}
+
+/// Test if the timeout works for a process that produces no output.
+///
+/// This test fails due to bugs in TestDirExt, see #1140 for details.
+#[test]
+#[ignore]
+fn kill_on_timeout_no_output() -> Result<()> {
+    zebra_test::init();
+
+    const TEST_CMD: &str = "sleep";
+    // Skip the test if the test system does not have the command
+    if !is_command_available(TEST_CMD, &["0"]) {
+        return Ok(());
+    }
+
+    let mut child = TempDir::new("zebra_test")?
+        .spawn_child_with_command(TEST_CMD, &["120"])?
+        .with_timeout(Duration::from_secs(2));
+
+    // We need to use expect_stdout, because wait_with_output ignores timeouts.
+    // We use a non-matching regex, to trigger the timeout.
+    assert!(child.expect_stdout("this regex should not match").is_err());
+
+    Ok(())
+}

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -44,13 +44,14 @@ fn testdir() -> Result<TempDir> {
 }
 
 /// Extension trait for methods on `tempdir::TempDir` for using it as a test
-/// directory.
-trait TestDirExt
+/// directory for `zebrad`.
+trait ZebradTestDirExt
 where
     Self: Borrow<TempDir> + Sized,
 {
-    /// Spawn the zebrad as a child process in this test directory, potentially
-    /// taking ownership of the tempdir for the duration of the child process.
+    /// Spawn `zebrad` with `args` as a child process in this test directory,
+    /// potentially taking ownership of the tempdir for the duration of the
+    /// child process.
     fn spawn_child(self, args: &[&str]) -> Result<TestChild<Self>>;
 
     /// Add the given config to the test directory and use it for all
@@ -58,7 +59,7 @@ where
     fn with_config(self, config: ZebradConfig) -> Result<Self>;
 }
 
-impl<T> TestDirExt for T
+impl<T> ZebradTestDirExt for T
 where
     Self: Borrow<TempDir> + Sized,
 {

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -20,6 +20,7 @@ use tempdir::TempDir;
 
 use std::{borrow::Borrow, fs, io::Write, time::Duration};
 
+use zebra_chain::parameters::Network::{self, *};
 use zebra_test::prelude::*;
 use zebrad::config::ZebradConfig;
 
@@ -453,14 +454,30 @@ fn valid_generated_config(command: &str, expected_output: &str) -> Result<()> {
 
 #[test]
 #[ignore]
-fn sync_one_checkpoint() -> Result<()> {
+fn sync_one_checkpoint_mainnet() -> Result<()> {
+    sync_one_checkpoint(Mainnet)
+}
+
+#[test]
+#[ignore]
+fn sync_one_checkpoint_testnet() -> Result<()> {
+    sync_one_checkpoint(Testnet)
+}
+
+fn sync_one_checkpoint(network: Network) -> Result<()> {
     zebra_test::init();
 
+    let mut config = persistent_test_config()?;
+    // TODO: add a convenience method?
+    config.network.network = network;
+
     let mut child = testdir()?
-        .with_config(persistent_test_config()?)?
+        .with_config(config)?
         .spawn_child(&["start"])?
         .with_timeout(Duration::from_secs(20));
 
+    // TODO: is there a way to check for testnet or mainnet here?
+    // For example: "network=Mainnet" or "network=Testnet"
     child.expect_stdout("verified checkpoint range")?;
     child.kill()?;
 


### PR DESCRIPTION
These tests aren't enabled by default yet, because we need network access for sync tests in CI:
  - we have network on macOS, but not on Linux (and Windows was terminated due to the Linux failure, so we don't know if it has network access)
  - see #1141 for follow-up

TODO:
- [x]  rebase on main
- [x] fix a `TestDirExt` timeout bug
- [x] add tests for `TestDirExt`