### PR TITLE
Linkify the reference to the Rust RFC process for background.

### DIFF
--- a/book/src/dev/rfcs.md
+++ b/book/src/dev/rfcs.md
@@ -1,4 +1,5 @@
 # Zebra RFCs
 
-We are experimenting with using a process similar to the Rust RFC process to
-document design decisions for Zebra.
+We are experimenting with using a process similar to [the Rust RFC
+process](https://github.com/ZcashFoundation/zebr://rust-lang.github.io/rfcs/0002-rfc-process.html)
+to document design decisions for Zebra.

--- a/book/src/dev/rfcs.md
+++ b/book/src/dev/rfcs.md
@@ -1,5 +1,5 @@
 # Zebra RFCs
 
 We are experimenting with using a process similar to [the Rust RFC
-process](https://github.com/ZcashFoundation/zebr://rust-lang.github.io/rfcs/0002-rfc-process.html)
+process](https://github.com/rust-lang/rfcs/)
 to document design decisions for Zebra.


### PR DESCRIPTION
*Caution:* I didn't perform any rendering or proof reading of this patch! If it's relatively simple for me to do locally, I can do that first. (I also didn't notice any instructions for how to render, btw, so maybe that'll be another PR.)

This just links to the Rust RFC process, since I thought users like myself who aren't familiar with it might want to get caught up on that. I don't know if that's the best link, but I thought it'd be more productive to "ask via PR" than ask in a chat channel.

I also wonder if linking to [the Zebra template RFC](https://github.com/ZcashFoundation/zebra/blob/stolon/book/src/dev/rfcs/0000-template.md) would be more direct. I don't know how to do cross-file links because I'm not sure what the rendering framework is, but as soon as I learn that I'll submit another "streamlining" PR.