### PR TITLE
update panic hook for zebra-test to supress confusing output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "color-eyre"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6799fa22451e23a9ebf735955c0aab5a4e772b1bcb2dbc4b791e43337015beae"
+checksum = "1ac5c105065fcb0c002304ae32147ba52df86e07cea7de11c88c62d24972d683"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -3282,6 +3282,7 @@ dependencies = [
  "futures",
  "hex",
  "lazy_static",
+ "owo-colors",
  "pretty_assertions",
  "regex",
  "spandoc",

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -12,7 +12,7 @@ hex = "0.4.2"
 lazy_static = "1.4.0"
 tower = "0.3.1"
 futures = "0.3.5"
-color-eyre = "0.5.2"
+color-eyre = "0.5.3"
 tracing = "0.1.19"
 tracing-subscriber = "0.2.12"
 tracing-error = "0.1.2"
@@ -21,6 +21,7 @@ regex = "1.3.9"
 thiserror = "1.0.20"
 tempdir = "0.3.7"
 pretty_assertions = "0.6.1"
+owo-colors = "1.1.3"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }

--- a/zebra-test/src/lib.rs
+++ b/zebra-test/src/lib.rs
@@ -1,7 +1,10 @@
 //! Miscellaneous test code for Zebra.
-use std::sync::Once;
+use color_eyre::section::PanicMessage;
+use owo_colors::OwoColorize;
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+use std::sync::Once;
 
 pub mod command;
 pub mod prelude;
@@ -76,8 +79,49 @@ pub fn init() {
             // when the message is the exact one created by panics in tests that
             // returned an Err. It will still print the content of the Err in
             // the case where an error is returned.
-            // .panic_message(SkipTestReturnedErrPanicMessages)
+            .panic_message(SkipTestReturnedErrPanicMessages)
             .install()
             .unwrap();
     })
+}
+
+struct SkipTestReturnedErrPanicMessages;
+
+impl PanicMessage for SkipTestReturnedErrPanicMessages {
+    fn display(
+        &self,
+        pi: &std::panic::PanicInfo<'_>,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        let payload = pi
+            .payload()
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| pi.payload().downcast_ref::<&str>().cloned())
+            .unwrap_or("<non string panic payload>");
+
+        // skip panic output that is clearly from tests that returned an `Err`
+        // and assume that the test handler has already printed the value inside
+        // of the `Err`.
+        if payload.contains("the test returned a termination value with a non-zero status code") {
+            return write!(f, "---- end of test output ----");
+        }
+
+        writeln!(f, "{}", "\nThe application panicked (crashed).".red())?;
+
+        write!(f, "Message:  ")?;
+        writeln!(f, "{}", payload.cyan())?;
+
+        // If known, print panic location.
+        write!(f, "Location: ")?;
+        if let Some(loc) = pi.location() {
+            write!(f, "{}", loc.file().purple())?;
+            write!(f, ":")?;
+            write!(f, "{}", loc.line().purple())?;
+        } else {
+            write!(f, "<unknown>")?;
+        }
+
+        Ok(())
+    }
 }

--- a/zebra-test/src/lib.rs
+++ b/zebra-test/src/lib.rs
@@ -73,12 +73,6 @@ pub fn init() {
                 });
             }))
             .display_env_section(false)
-            // Once I make a release with
-            // https://github.com/yaahc/color-eyre/pull/57 I'm going to add a
-            // custom PanicMessage handler for skipping the message in panics
-            // when the message is the exact one created by panics in tests that
-            // returned an Err. It will still print the content of the Err in
-            // the case where an error is returned.
             .panic_message(SkipTestReturnedErrPanicMessages)
             .install()
             .unwrap();


### PR DESCRIPTION
this prevents tests that return an `Err(Report)` from printing the content of the report followed by a verbose panic message explaining that the test returned an `Err`