### PR TITLE
[WIP] Transaction verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3186,6 +3186,7 @@ dependencies = [
  "displaydoc",
  "futures",
  "futures-util",
+ "jubjub 0.5.1",
  "metrics",
  "once_cell",
  "rand 0.7.3",

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -1,5 +1,7 @@
 //! Transactions and transaction-related structures.
 
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 
 mod hash;
@@ -185,5 +187,20 @@ impl Transaction {
         input: Option<(u32, transparent::Output)>,
     ) -> blake2b_simd::Hash {
         sighash::SigHasher::new(self, hash_type, network_upgrade, input).sighash()
+    }
+}
+
+impl fmt::Display for Transaction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let hash = self.hash();
+
+        let name = match self {
+            Transaction::V1 { .. } => "Transaction::V1",
+            Transaction::V2 { .. } => "Transaction::V2",
+            Transaction::V3 { .. } => "Transaction::V3",
+            Transaction::V4 { .. } => "Transaction::V4",
+        };
+
+        write!(f, "{} {{ hash: {}, .. }}", name, hash)
     }
 }

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -20,6 +20,7 @@ pub use joinsplit::JoinSplitData;
 pub use lock_time::LockTime;
 pub use memo::Memo;
 pub use shielded_data::ShieldedData;
+pub use sighash::HashType;
 
 use crate::{
     amount::Amount,

--- a/zebra-chain/src/transaction/shielded_data.rs
+++ b/zebra-chain/src/transaction/shielded_data.rs
@@ -75,41 +75,6 @@ impl ShieldedData {
     pub fn note_commitments(&self) -> Vec<jubjub::Fq> {
         self.outputs().map(|output| output.cm_u).collect()
     }
-
-    /// Calculate the transaction binding signature validating key.
-    ///
-    /// Getting the binding signature validating key from the Spend and Output
-    /// description value commitments and the balancing value implicitly checks
-    /// that the balancing value is consistent with the value transfered in the
-    /// Spend and Output descriptions but also proves that the signer knew the
-    /// randomness used for the Spend and Output value commitments, which
-    /// prevents replays of Output descriptions.
-    ///
-    /// The net value of Spend transfers minus Output transfers in a transaction
-    /// is called the balancing value, measured in zatoshi as a signed integer
-    /// v_balance.
-    ///
-    /// Consistency of v_balance with the value commitments in Spend
-    /// descriptions and Output descriptions is enforced by the binding
-    /// signature.
-    ///
-    /// Instead of generating a key pair at random, we generate it as a function
-    /// of the value commitments in the Spend descriptions and Output
-    /// descriptions of the transaction, and the balancing value.
-    ///
-    /// https://zips.z.cash/protocol/canopy.pdf#saplingbalance
-    pub fn binding_validating_key(
-        &self,
-        value_balance: Amount,
-    ) -> Result<VerificationKey<Binding>, redjubjub::Error> {
-        let cv_old: ValueCommitment = self.spends().map(|spend| spend.cv).sum();
-        let cv_new: ValueCommitment = self.outputs().map(|output| output.cv).sum();
-        let cv_balance: ValueCommitment = ValueCommitment::new(jubjub::Fr::zero(), value_balance);
-
-        let key_bytes: [u8; 32] = (cv_old - cv_new - cv_balance).into();
-
-        VerificationKey::<Binding>::try_from(key_bytes)
-    }
 }
 
 // Technically, it's possible to construct two equivalent representations

--- a/zebra-chain/src/transaction/shielded_data.rs
+++ b/zebra-chain/src/transaction/shielded_data.rs
@@ -1,11 +1,8 @@
-use std::convert::TryFrom;
-
 use futures::future::Either;
 
 use crate::{
-    amount::Amount,
-    primitives::redjubjub::{Binding, Signature, VerificationKey},
-    sapling::{Nullifier, Output, Spend, ValueCommitment},
+    primitives::redjubjub::{Binding, Signature},
+    sapling::{Nullifier, Output, Spend},
     serialization::serde_helpers,
 };
 

--- a/zebra-chain/src/transaction/shielded_data.rs
+++ b/zebra-chain/src/transaction/shielded_data.rs
@@ -76,8 +76,28 @@ impl ShieldedData {
         self.outputs().map(|output| output.cm_u).collect()
     }
 
-    /// Calculate the transaction binding validating key from the spend and
-    /// output value commitments and the value_balance.
+    /// Calculate the transaction binding signature validating key.
+    ///
+    /// Getting the binding signature validating key from the Spend and Output
+    /// description value commitments and the balancing value implicitly checks
+    /// that the balancing value is consistent with the value transfered in the
+    /// Spend and Output descriptions but also proves that the signer knew the
+    /// randomness used for the Spend and Output value commitments, which
+    /// prevents replays of Output descriptions.
+    ///
+    /// The net value of Spend transfers minus Output transfers in a transaction
+    /// is called the balancing value, measured in zatoshi as a signed integer
+    /// v_balance.
+    ///
+    /// Consistency of v_balance with the value commitments in Spend
+    /// descriptions and Output descriptions is enforced by the binding
+    /// signature.
+    ///
+    /// Instead of generating a key pair at random, we generate it as a function
+    /// of the value commitments in the Spend descriptions and Output
+    /// descriptions of the transaction, and the balancing value.
+    ///
+    /// https://zips.z.cash/protocol/canopy.pdf#saplingbalance
     pub fn binding_validating_key(
         &self,
         value_balance: Amount,

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -24,10 +24,15 @@ const ZCASH_SHIELDED_SPENDS_HASH_PERSONALIZATION: &[u8; 16] = b"ZcashSSpendsHash
 const ZCASH_SHIELDED_OUTPUTS_HASH_PERSONALIZATION: &[u8; 16] = b"ZcashSOutputHash";
 
 bitflags::bitflags! {
+    /// The different SigHash types, as defined in https://zips.z.cash/zip-0143
     pub struct HashType: u32 {
+        ///
         const ALL = 0b0000_0001;
+        ///
         const NONE = 0b0000_0010;
+        ///
         const SINGLE = Self::ALL.bits | Self::NONE.bits;
+        ///
         const ANYONECANPAY = 0b1000_0000;
     }
 }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.19"
 color-eyre = "0.5"
+displaydoc = "0.1.7"
+jubjub = "0.5.1"
 once_cell = "1.4"
 rand = "0.7"
 redjubjub = "0.2"
@@ -28,7 +30,6 @@ tower-batch = { path = "../tower-batch/" }
 zebra-chain = { path = "../zebra-chain" }
 zebra-state = { path = "../zebra-state" }
 zebra-script = { path = "../zebra-script" }
-displaydoc = "0.1.7"
 
 [dev-dependencies]
 rand = "0.7"

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -48,9 +48,9 @@ where
 #[derive(Debug, Display, Error)]
 pub enum VerifyChainError {
     /// block could not be checkpointed
-    Checkpoint(VerifyCheckpointError),
+    Checkpoint(#[source] VerifyCheckpointError),
     /// block could not be verified
-    Block(VerifyBlockError),
+    Block(#[source] VerifyBlockError),
 }
 
 impl<S> Service<Arc<Block>> for ChainVerifier<S>

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -14,7 +14,7 @@
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_consensus")]
 // Re-enable this after cleaning the API surface.
 //#![deny(missing_docs)]
-#![allow(clippy::try_err)]
+#![allow(clippy::try_err, unused_imports, dead_code, unused_variables)]
 
 pub mod block;
 pub mod chain;

--- a/zebra-consensus/src/primitives.rs
+++ b/zebra-consensus/src/primitives.rs
@@ -1,5 +1,6 @@
 //! Asynchronous verification of cryptographic primitives.
 
+pub mod groth16;
 pub mod redjubjub;
 
 /// The maximum batch size for any of the batch verifiers.

--- a/zebra-consensus/src/primitives/groth16.rs
+++ b/zebra-consensus/src/primitives/groth16.rs
@@ -1,0 +1,58 @@
+use std::{
+    future::Future,
+    mem,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use jubjub;
+
+use tower::Service;
+
+use zebra_chain::primitives::Groth16Proof;
+
+use crate::BoxError;
+
+/// Provides verification of Groth16 proofs for a specific statement.
+///
+/// Groth16 proofs require a proof verification key; the [`Verifier`] type is
+/// responsible for ownership of the PVK.
+pub struct Verifier {
+    // XXX this needs to hold on to a verification key
+}
+
+impl Verifier {
+    /// Create a new Groth16 verifier, supplying the encoding of the
+    pub fn new(encoded_verification_key: &[u8]) -> Result<Self, BoxError> {
+        // parse and turn into a bellman type,
+        // so that users don't have to have the entire bellman api
+        unimplemented!();
+    }
+}
+
+// XXX this is copied from the WIP batch bellman impl,
+// in the future, replace with a re export
+
+pub struct Item {
+    pub proof: Groth16Proof,
+    pub public_inputs: Vec<jubjub::Fr>,
+}
+
+// XXX in the future, Verifier will implement
+// Service<BatchControl<Item>>> and be wrapped in a Batch
+// to get a Service<Item>
+// but for now, just implement Service<Item> and do unbatched verif.
+//impl Service<BatchControl<Item>> for Verifier {
+impl Service<Item> for Verifier {
+    type Response = ();
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<(), BoxError>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Item) -> Self::Future {
+        unimplemented!()
+    }
+}

--- a/zebra-consensus/src/primitives/groth16.rs
+++ b/zebra-consensus/src/primitives/groth16.rs
@@ -5,7 +5,6 @@ use std::{
     task::{Context, Poll},
 };
 
-use jubjub;
 
 use tower::Service;
 

--- a/zebra-consensus/src/primitives/redjubjub.rs
+++ b/zebra-consensus/src/primitives/redjubjub.rs
@@ -13,11 +13,12 @@ use std::{
 use futures::future::{ready, Ready};
 use once_cell::sync::Lazy;
 use rand::thread_rng;
-use redjubjub::{batch, *};
+
 use tokio::sync::broadcast::{channel, RecvError, Sender};
 use tower::{util::ServiceFn, Service};
 use tower_batch::{Batch, BatchControl};
 use tower_fallback::Fallback;
+use zebra_chain::primitives::redjubjub::{batch, *};
 
 /// Global batch verification context for RedJubjub signatures.
 ///

--- a/zebra-consensus/src/script.rs
+++ b/zebra-consensus/src/script.rs
@@ -26,6 +26,7 @@ use crate::BoxError;
 ///
 /// After verification, the script future completes. State changes are handled by
 /// `BlockVerifier` or `MempoolTransactionVerifier`.
+#[derive(Debug, Clone)]
 pub struct Verifier<ZS> {
     state: ZS,
     branch: ConsensusBranchId,
@@ -38,9 +39,9 @@ impl<ZS> Verifier<ZS> {
 }
 
 #[derive(Debug)]
-struct Request {
-    transaction: Arc<Transaction>,
-    input_index: usize,
+pub struct Request {
+    pub transaction: Arc<Transaction>,
+    pub input_index: usize,
 }
 
 impl<ZS> tower::Service<Request> for Verifier<ZS>

--- a/zebra-consensus/src/script.rs
+++ b/zebra-consensus/src/script.rs
@@ -12,10 +12,13 @@
 //! This is an internal module. Use `verify::BlockVerifier` for blocks and their
 //! transactions, or `mempool::MempoolTransactionVerifier` for mempool transactions.
 
+use std::future::Future;
 use std::{pin::Pin, sync::Arc};
 
-use std::future::Future;
+use tower::{Service, ServiceExt};
+
 use zebra_chain::{parameters::ConsensusBranchId, transaction::Transaction, transparent};
+use zebra_state as zs;
 
 use crate::BoxError;
 

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -63,6 +63,8 @@ pub enum VerifyTransactionError {
     NoTransfer,
     /// The balance of money moving around doesn't compute.
     BadBalance,
+    /// Violation of coinbase rules.
+    Coinbase,
     /// Could not verify a transparent script
     Script(#[from] zebra_script::Error),
     /// Could not verify a Groth16 proof of a JoinSplit/Spend/Output description
@@ -136,7 +138,7 @@ where
                     // of the async script RFC.
                     if tx.is_coinbase() {
                         // do something special for coinbase transactions
-                        unimplemented!();
+                        check::coinbase_tx_does_not_spend_shielded(&tx)?;
                     } else {
                         // otherwise, check no coinbase inputs
                         // feed all of the inputs to the script verifier

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -12,21 +12,22 @@
 //! This is an internal module. Use `verify::BlockVerifier` for blocks and their
 //! transactions, or `mempool::MempoolTransactionVerifier` for mempool transactions.
 
-use displaydoc::Display;
-use futures::{FutureExt, TryFutureExt};
 use std::{
     future::Future,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
 };
+
+use displaydoc::Display;
+use futures::{FutureExt, TryFutureExt};
 use thiserror::Error;
 use tower::{buffer::Buffer, util::BoxService, Service, ServiceExt};
 use tracing::instrument;
 
 use zebra_chain::{
     parameters::{Network, NetworkUpgrade::Sapling},
-    primitives::{ed25519, redjubjub::Error as RedjubjubError},
+    primitives::{ed25519, groth16, redjubjub},
     sapling,
     sighash::HashType,
     sprout,
@@ -40,10 +41,8 @@ use crate::{primitives::redjubjub, BoxError, Config};
 
 /// Internal transaction verification service.
 ///
-/// After verification, the transaction future completes. State changes are handled by
-/// `BlockVerifier` or `MempoolTransactionVerifier`.
-///
-/// `TransactionVerifier` is not yet implemented.
+/// After verification, the transaction future completes. State changes are
+/// handled by `BlockVerifier` or `MempoolTransactionVerifier`.
 #[derive(Default)]
 pub(crate) struct TransactionVerifier<S>
 where
@@ -51,28 +50,20 @@ where
     S::Future: Send + 'static,
 {
     script: ScriptVerifier<S>,
-    joinsplit: JoinSplitVerifier<S>,
-    spend: SpendVerifier<S>,
-    output: OutputVerifier<S>,
-    redjubjub: redjubjub::Verifier<S>,
-    ed25519: ed25519::batch::Verifier<S>,
+    groth16: groth16::Verifier<S>,
 }
 
 #[non_exhaustive]
 #[derive(Debug, Display, Error)]
 pub enum VerifyTransactionError {
-    ///
+    /// Could not verify a transparent script
     Script(VerifyScriptError),
-    ///
-    JoinSplit(VerifyJoinSplitError),
-    ///
+    /// Could not verify a Groth16 proof of a JoinSplit/Spend/Output description
+    Groth16(VerifyGroth16Error),
+    /// Could not verify a Ed25519 signature with JoinSplitData
     Ed25519(ed25519::Error),
-    ///
-    Spend(VerifySpendError),
-    ///
-    Output(VerifyOutputError),
-    ///
-    Redjubjub(RedjubjubError),
+    /// Could not verify a RedJubjub signature with ShieldedData
+    RedJubjub(redjubjub::Error),
 }
 
 impl<S> Service<Arc<Transaction>> for TransactionVerifier<S>
@@ -86,21 +77,13 @@ where
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // TODO: This lorge and must be busted up
-        match (
-            self.script.poll_ready(cx),
-            self.joinsplit.poll_ready(cx),
-            self.ed25519.poll_ready(cx),
-            self.spend.poll_ready(cx),
-            self.output.poll_ready(cx),
-            self.redjubjub.poll_ready(cx),
-        ) {
-            (Poll::Ready(Err(e)), _) => Poll::Ready(Err(VerifyTransactionError::Checkpoint(e))),
-
-            (_, Poll::Ready(Err(e))) => Poll::Ready(Err(VerifyTransactionError::Block(e))),
-
+        match (self.script.poll_ready(cx), self.groth16.poll_ready(cx)) {
+            // First, fail if either service fails.
+            (Poll::Ready(Err(e)), _) => Poll::Ready(Err(VerifyTransactionError::Script(e))),
+            (_, Poll::Ready(Err(e))) => Poll::Ready(Err(VerifyTransactionError::Groth16(e))),
+            // Second, we're unready if either service is unready.
             (Poll::Pending, _) | (_, Poll::Pending) => Poll::Pending,
-
+            // Finally, we're ready if both services are ready and OK.
             (Poll::Ready(Ok(())), Poll::Ready(Ok(()))) => Poll::Ready(Ok(())),
         }
     }
@@ -151,25 +134,44 @@ where
                 sig,
             } = joinsplit_d;
 
-            let msg = tx.data_to_be_signed();
-            self.ed25519
-                .call((pub_key.into(), sig.into(), msg.into()))
+            ed25519::VerificationKey::try_From(pub_key)
+                .and_then(|vk| vk.verify(sig, tx.data_to_be_signed()))
                 .map_err(VerifyTransactionError::Ed25519)
-                .boxed();
         }
 
         if let Some(shielded_data_d) = shielded_data {
+            let sighash = tx.sighash(
+                Network::Sapling, // TODO: pass this in
+                HashType::ALL,    // TODO: check these
+                None,             // TODO: check these
+            );
+
             shielded_data_d.spends().for_each(|spend| {
-                self.spend
-                    .call(spend)
-                    .map_err(VerifyTransactionError::VerifySpendError)
+                // TODO: check that spend.cv and spend.rk are NOT of small
+                // order.
+                // https://zips.z.cash/protocol/canopy.pdf#spenddesc
+
+                // Verify the spend authorization signature for each Spend
+                // description.
+                spend
+                    .rk
+                    .verify(sighash, spend.spend_auth_sig)
+                    .map_err(VerifyTransactionError::Redjubjub);
+
+                self.groth16
+                    .call(spend.into())
+                    .map_err(VerifyTransactionError::VerifyGroth16Error)
                     .boxed()
             });
 
             shielded_data_d.outputs().for_each(|output| {
-                self.output
-                    .call(output)
-                    .map_err(VerifyTransactionError::VerifyOutputError)
+                // TODO: check that output.cv and output.epk are NOT of small
+                // order.
+                // https://zips.z.cash/protocol/canopy.pdf#outputdesc
+
+                self.groth16
+                    .call(output.into())
+                    .map_err(VerifyTransactionError::VerifyGroth16Error)
                     .boxed()
             });
 
@@ -179,12 +181,6 @@ where
                 rest_outputs,
                 binding_sig,
             } = shielded_data_d;
-
-            let sighash = tx.sighash(
-                Network::Sapling, // TODO: pass this in
-                HashType::ALL,    // TODO: check these
-                None,             // TODO: check these
-            );
 
             // Checks the balance.
             //
@@ -202,7 +198,8 @@ where
             //
             // https://zips.z.cash/protocol/canopy.pdf#saplingbalance
             let bsk = shielded_data_d.binding_validating_key(value_balance);
-            bsk.verify(sighash, &binding_sig);
+            bsk.verify(sighash, &binding_sig)
+                .map_err(VerifyTransactionError::Redjubjub);
         }
     }
 }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -12,6 +12,32 @@
 //! This is an internal module. Use `verify::BlockVerifier` for blocks and their
 //! transactions, or `mempool::MempoolTransactionVerifier` for mempool transactions.
 
+use displaydoc::Display;
+use futures::{FutureExt, TryFutureExt};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use thiserror::Error;
+use tower::{buffer::Buffer, util::BoxService, Service, ServiceExt};
+use tracing::instrument;
+
+use zebra_chain::{
+    parameters::{Network, NetworkUpgrade::Sapling},
+    primitives::{ed25519, redjubjub::Error as RedjubjubError},
+    sapling,
+    sighash::HashType,
+    sprout,
+    transaction::{self, HashType, JoinSplitData, ShieldedData, Transaction},
+    transparent::{self, Script},
+};
+
+use zebra_state as zs;
+
+use crate::{primitives::redjubjub, BoxError, Config};
+
 /// Internal transaction verification service.
 ///
 /// After verification, the transaction future completes. State changes are handled by
@@ -19,4 +45,153 @@
 ///
 /// `TransactionVerifier` is not yet implemented.
 #[derive(Default)]
-pub(crate) struct TransactionVerifier {}
+pub(crate) struct TransactionVerifier<S>
+where
+    S: Service<zs::Request, Response = zs::Response, Error = BoxError> + Send + Clone + 'static,
+    S::Future: Send + 'static,
+{
+    script: ScriptVerifier<S>,
+    joinsplit: JoinSplitVerifier<S>,
+    spend: SpendVerifier<S>,
+    output: OutputVerifier<S>,
+    redjubjub: redjubjub::Verifier<S>,
+    ed25519: ed25519::batch::Verifier<S>,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Display, Error)]
+pub enum VerifyTransactionError {
+    ///
+    Script(VerifyScriptError),
+    ///
+    JoinSplit(VerifyJoinSplitError),
+    ///
+    Ed25519(ed25519::Error),
+    ///
+    Spend(VerifySpendError),
+    ///
+    Output(VerifyOutputError),
+    ///
+    Redjubjub(RedjubjubError),
+}
+
+impl<S> Service<Arc<Transaction>> for TransactionVerifier<S>
+where
+    S: Service<zs::Request, Response = zs::Response, Error = BoxError> + Send + Clone + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = transaction::Hash;
+    type Error = VerifyTransactionError;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // TODO: This lorge and must be busted up
+        match (
+            self.script.poll_ready(cx),
+            self.joinsplit.poll_ready(cx),
+            self.ed25519.poll_ready(cx),
+            self.spend.poll_ready(cx),
+            self.output.poll_ready(cx),
+            self.redjubjub.poll_ready(cx),
+        ) {
+            (Poll::Ready(Err(e)), _) => Poll::Ready(Err(VerifyTransactionError::Checkpoint(e))),
+
+            (_, Poll::Ready(Err(e))) => Poll::Ready(Err(VerifyTransactionError::Block(e))),
+
+            (Poll::Pending, _) | (_, Poll::Pending) => Poll::Pending,
+
+            (Poll::Ready(Ok(())), Poll::Ready(Ok(()))) => Poll::Ready(Ok(())),
+        }
+    }
+
+    // TODO: break up each chunk into its own method
+    fn call(&mut self, tx: Arc<Transaction>) -> Self::Future {
+        let Transaction::V4 {
+            inputs,
+            outputs,
+            lock_time,
+            expiry_height,
+            value_balance,
+            joinsplit_data,
+            shielded_data,
+        } = tx;
+
+        if !tx.is_coinbase() && (!inputs.isEmpty() || !outputs.isEmpty()) {
+            let scripts = inputs
+                .iter()
+                .chain(outputs.iter())
+                .filter_map(|input| match input {
+                    transparent::Input::PrevOut { unlock_script, .. } => Some(unlock_script),
+                    transparent::Output { lock_script, .. } => Some(lock_script),
+                    _ => None,
+                })
+                .collect();
+
+            scripts.iter().for_each(|script| {
+                self.script
+                    .call(script)
+                    .map_err(VerifyTransactionError::VerifyScriptError)
+                    .boxed()
+            });
+        }
+
+        if let Some(joinsplit_d) = joinsplit_data {
+            joinsplit_d.joinsplits().for_each(|joinsplit| {
+                self.joinsplit
+                    .call(joinsplit)
+                    .map_err(VerifyTransactionError::VerifyJoinSplitError)
+                    .boxed()
+            });
+
+            let JoinSplitData {
+                first,
+                rest,
+                pub_key,
+                sig,
+            } = joinsplit_d;
+
+            let msg = tx.data_to_be_signed();
+            self.ed25519
+                .call((pub_key.into(), sig.into(), msg.into()))
+                .map_err(VerifyTransactionError::Ed25519)
+                .boxed();
+        }
+
+        if let Some(shielded_data_d) = shielded_data {
+            shielded_data_d.spends().for_each(|spend| {
+                self.spend
+                    .call(spend)
+                    .map_err(VerifyTransactionError::VerifySpendError)
+                    .boxed()
+            });
+
+            shielded_data_d.outputs().for_each(|output| {
+                self.output
+                    .call(output)
+                    .map_err(VerifyTransactionError::VerifyOutputError)
+                    .boxed()
+            });
+
+            let ShieldedData {
+                first,
+                rest_spends,
+                rest_outputs,
+                binding_sig,
+            } = shielded_data_d;
+
+            self.redjubjub
+                .call((
+                    pub_key.into(),
+                    binding_sig.into(),
+                    tx.sighash(
+                        Network::Sapling, // TODO: pass this in
+                        HashType::ALL,    // TODO: check these
+                        None,             // TODO: check these
+                    ),
+                ))
+                .map_err(VerifyTransactionError::Redjubjub)
+                .boxed();
+        }
+    }
+}

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -98,7 +98,7 @@ where
             shielded_data,
         } = tx;
 
-        if !tx.is_coinbase() && (!inputs.isEmpty() || !outputs.isEmpty()) {
+        if !tx.is_coinbase() && (!inputs.is_empty() || !outputs.is_empty()) {
             let scripts = inputs
                 .iter()
                 .chain(outputs.iter())

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -1,0 +1,62 @@
+use std::convert::TryFrom;
+
+use zebra_chain::{
+    amount::Amount,
+    primitives::{
+        ed25519,
+        redjubjub::{self, Binding},
+        Groth16Proof,
+    },
+    sapling::ValueCommitment,
+    transaction::{JoinSplitData, ShieldedData},
+};
+
+use crate::transaction::VerifyTransactionError;
+
+/// Validate the JoinSplit binding signature.
+///
+/// https://zips.z.cash/protocol/canopy.pdf#sproutnonmalleability
+/// https://zips.z.cash/protocol/canopy.pdf#txnencodingandconsensus
+pub fn validate_joinsplit_sig(
+    joinsplit_data: JoinSplitData<Groth16Proof>,
+    sighash: &[u8],
+) -> Result<(), VerifyTransactionError> {
+    ed25519::VerificationKey::try_from(joinsplit_data.pub_key)
+        .and_then(|vk| vk.verify(&joinsplit_data.sig, sighash))
+        .map_err(VerifyTransactionError::Ed25519)
+}
+
+/// Calculate the Spend/Output binding signature validating key.
+///
+/// Getting the binding signature validating key from the Spend and Output
+/// description value commitments and the balancing value implicitly checks
+/// that the balancing value is consistent with the value transfered in the
+/// Spend and Output descriptions but also proves that the signer knew the
+/// randomness used for the Spend and Output value commitments, which
+/// prevents replays of Output descriptions.
+///
+/// The net value of Spend transfers minus Output transfers in a transaction
+/// is called the balancing value, measured in zatoshi as a signed integer
+/// v_balance.
+///
+/// Consistency of v_balance with the value commitments in Spend
+/// descriptions and Output descriptions is enforced by the binding
+/// signature.
+///
+/// Instead of generating a key pair at random, we generate it as a function
+/// of the value commitments in the Spend descriptions and Output
+/// descriptions of the transaction, and the balancing value.
+///
+/// https://zips.z.cash/protocol/canopy.pdf#saplingbalance
+pub fn balancing_value_balances(
+    shielded_data: ShieldedData,
+    value_balance: Amount,
+) -> Result<redjubjub::VerificationKey<Binding>, redjubjub::Error> {
+    let cv_old: ValueCommitment = shielded_data.spends().map(|spend| spend.cv).sum();
+    let cv_new: ValueCommitment = shielded_data.outputs().map(|output| output.cv).sum();
+    let cv_balance: ValueCommitment = ValueCommitment::new(jubjub::Fr::zero(), value_balance);
+
+    let key_bytes: [u8; 32] = (cv_old - cv_new - cv_balance).into();
+
+    redjubjub::VerificationKey::<Binding>::try_from(key_bytes)
+}

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -18,7 +18,7 @@ use crate::transaction::VerifyTransactionError;
 /// https://zips.z.cash/protocol/canopy.pdf#sproutnonmalleability
 /// https://zips.z.cash/protocol/canopy.pdf#txnencodingandconsensus
 pub fn validate_joinsplit_sig(
-    joinsplit_data: JoinSplitData<Groth16Proof>,
+    joinsplit_data: &JoinSplitData<Groth16Proof>,
     sighash: &[u8],
 ) -> Result<(), VerifyTransactionError> {
     ed25519::VerificationKey::try_from(joinsplit_data.pub_key)
@@ -49,16 +49,16 @@ pub fn validate_joinsplit_sig(
 ///
 /// https://zips.z.cash/protocol/canopy.pdf#saplingbalance
 pub fn balancing_value_balances(
-    shielded_data: ShieldedData,
+    shielded_data: &ShieldedData,
     value_balance: Amount,
-) -> Result<redjubjub::VerificationKey<Binding>, redjubjub::Error> {
+) -> redjubjub::VerificationKeyBytes<Binding> {
     let cv_old: ValueCommitment = shielded_data.spends().map(|spend| spend.cv).sum();
     let cv_new: ValueCommitment = shielded_data.outputs().map(|output| output.cv).sum();
     let cv_balance: ValueCommitment = ValueCommitment::new(jubjub::Fr::zero(), value_balance);
 
     let key_bytes: [u8; 32] = (cv_old - cv_new - cv_balance).into();
 
-    redjubjub::VerificationKey::<Binding>::try_from(key_bytes)
+    key_bytes.into()
 }
 
 /// Check that at least one of tx_in_count, nShieldedSpend, and nJoinSplit MUST
@@ -116,7 +116,7 @@ pub fn any_coinbase_inputs_no_transparent_outputs(
 ///
 /// https://zips.z.cash/protocol/canopy.pdf#consensusfrombitcoin
 pub fn shielded_balances_match(
-    shielded_data: ShieldedData,
+    shielded_data: &ShieldedData,
     value_balance: Amount,
 ) -> Result<(), VerifyTransactionError> {
     if shielded_data.spends().count() + shielded_data.outputs().count() != 0 {


### PR DESCRIPTION
This is a high-level sketch of what our `TransactionVerifier` should do. Right now it's calling signature batch verifiers that we may not want to use anymore, and `(Spend|Output|JoinSplit)Verifier`s that don't exist yet, and is incomplete in all its checks and outputs, but you get the idea.