### PR TITLE
Use ok_or instead of ok_or_else with unnecessary closure

### DIFF
--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -119,7 +119,7 @@ where
             // height for parsed blocks when we deserialize them.
             let height = block
                 .coinbase_height()
-                .ok_or_else(|| BlockError::MissingHeight(hash))?;
+                .ok_or(BlockError::MissingHeight(hash))?;
             if height > block::Height::MAX {
                 Err(BlockError::MaxHeight(height, hash, block::Height::MAX))?;
             }
@@ -130,7 +130,7 @@ where
                 .header
                 .difficulty_threshold
                 .to_expanded()
-                .ok_or_else(|| BlockError::InvalidDifficulty(height, hash))?;
+                .ok_or(BlockError::InvalidDifficulty(height, hash))?;
             if hash > difficulty_threshold {
                 Err(BlockError::DifficultyFilter(
                     height,


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations