### PR TITLE
WIP: Re-enable some verifier and state service tests

### DIFF
--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -16,14 +16,13 @@ use zebra_chain::{
 };
 use zebra_test::transcript::{TransError, Transcript};
 
-static VALID_BLOCK_TRANSCRIPT: Lazy<Vec<(Arc<Block>, Result<block::Hash, TransError>)>> =
+static INVALID_GENESIS_BLOCK_TRANSCRIPT: Lazy<Vec<(Arc<Block>, Result<block::Hash, TransError>)>> =
     Lazy::new(|| {
         let block: Arc<_> =
             Block::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..])
                 .unwrap()
                 .into();
-        let hash = Ok(block.as_ref().into());
-        vec![(block, hash)]
+        vec![(block, Err(TransError::Any))]
     });
 
 static INVALID_TIME_BLOCK_TRANSCRIPT: Lazy<Vec<(Arc<Block>, Result<block::Hash, TransError>)>> =
@@ -100,8 +99,6 @@ static INVALID_COINBASE_TRANSCRIPT: Lazy<Vec<(Arc<Block>, Result<block::Hash, Tr
     });
 
 #[tokio::test]
-// TODO: enable this test after implementing contextual verification
-#[ignore]
 async fn check_transcripts_test() -> Result<(), Report> {
     check_transcripts().await
 }
@@ -116,7 +113,7 @@ async fn check_transcripts() -> Result<(), Report> {
     let block_verifier = Buffer::new(BlockVerifier::new(state_service.clone()), 1);
 
     for transcript_data in &[
-        &VALID_BLOCK_TRANSCRIPT,
+        &INVALID_GENESIS_BLOCK_TRANSCRIPT,
         &INVALID_TIME_BLOCK_TRANSCRIPT,
         &INVALID_HEADER_SOLUTION_TRANSCRIPT,
         &INVALID_COINBASE_TRANSCRIPT,

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -77,6 +77,9 @@ where
 
     fn call(&mut self, block: Arc<Block>) -> Self::Future {
         let height = block.coinbase_height();
+        let span = tracing::info_span!("chain_call", ?height);
+        let _entered = span.enter();
+        tracing::debug!("verifying new block");
 
         // TODO: do we still need this logging?
         // Log an info-level message on unexpected out of order blocks

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -27,6 +27,7 @@ use thiserror::Error;
 use tokio::sync::oneshot;
 use tower::{Service, ServiceExt};
 
+use tracing::instrument;
 use zebra_chain::{
     block::{self, Block},
     parameters::Network,
@@ -784,6 +785,7 @@ where
         Poll::Ready(Ok(()))
     }
 
+    #[instrument(name = "checkpoint_call", skip(self, block))]
     fn call(&mut self, block: Arc<Block>) -> Self::Future {
         // Immediately reject all incoming blocks that arrive after we've finished.
         if let FinalCheckpoint = self.previous_checkpoint_height() {

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -210,8 +210,6 @@ async fn multi_item_checkpoint_list() -> Result<(), Report> {
 }
 
 #[tokio::test]
-// Temporarily ignore this test, until the state can handle out-of-order blocks
-#[ignore]
 async fn continuous_blockchain_test() -> Result<(), Report> {
     continuous_blockchain(None).await?;
     for height in 0..=10 {
@@ -323,6 +321,11 @@ async fn continuous_blockchain(restart_height: Option<block::Height>) -> Result<
             }
             if height > checkpoint_verifier.checkpoint_list.max_height() {
                 break;
+            }
+
+            if height == block::Height(0) {
+                // don't try to verify the genesis block
+                continue;
             }
 
             /// SPANDOC: Make sure the verifier service is ready for block {?height}

--- a/zebra-state/src/service/memory_state.rs
+++ b/zebra-state/src/service/memory_state.rs
@@ -37,10 +37,13 @@ struct Chain {
 
 impl Chain {
     /// Push a contextually valid non-finalized block into a chain as the new tip.
+    #[instrument(skip(self), fields(%block))]
     pub fn push(&mut self, block: Arc<Block>) {
         let block_height = block
             .coinbase_height()
             .expect("valid non-finalized blocks have a coinbase height");
+
+        tracing::trace!(?block_height, "Pushing new block into chain state");
 
         // update cumulative data members
         self.update_chain_state_with(&block);
@@ -48,6 +51,7 @@ impl Chain {
     }
 
     /// Remove the lowest height block of the non-finalized portion of a chain.
+    #[instrument(skip(self))]
     pub fn pop_root(&mut self) -> Arc<Block> {
         let block_height = self.lowest_height();
 
@@ -197,6 +201,7 @@ impl UpdateWith<Arc<Block>> for Chain {
         }
     }
 
+    #[instrument(skip(self), fields(%block))]
     fn revert_chain_state_with(&mut self, block: &Arc<Block>) {
         let block_hash = block.hash();
 
@@ -318,6 +323,7 @@ impl UpdateWith<Option<transaction::JoinSplitData<Groth16Proof>>> for Chain {
         }
     }
 
+    #[instrument(skip(self, joinsplit_data))]
     fn revert_chain_state_with(
         &mut self,
         joinsplit_data: &Option<transaction::JoinSplitData<Groth16Proof>>,

--- a/zebra-test/src/lib.rs
+++ b/zebra-test/src/lib.rs
@@ -73,6 +73,7 @@ pub fn init() {
                 });
             }))
             .panic_message(SkipTestReturnedErrPanicMessages)
+            .display_env_section(false)
             .install()
             .unwrap();
     })

--- a/zebra-test/src/transcript.rs
+++ b/zebra-test/src/transcript.rs
@@ -48,8 +48,8 @@ impl TransError {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("ErrorChecker Error: {0}")]
-struct ErrorCheckerError(Error);
+#[error("ErrorChecker Error")]
+struct ErrorCheckerError(#[source] Error);
 
 pub struct Transcript<R, S, I>
 where


### PR DESCRIPTION
TODO:

- [ ] Finish off this fix, and re-enable the tests:
  * the `CheckpointVerifier` tests depend on the `FinalizedState` handing out-of-order blocks
    - we might need to use FuturesUnordered to avoid race conditions and deadlocks

- [ ] Remove these changes from this PR:
  * the `BlockVerifier` tests depend on contextual verification of post-Sapling blocks, tracked in #745
  * the `zebrad` sync acceptance tests need network access in CI, implemented in #1188