### PR TITLE
Move genesis parameters to zebra-chain from zebra-consensus

### DIFF
--- a/zebra-chain/src/parameters.rs
+++ b/zebra-chain/src/parameters.rs
@@ -12,9 +12,11 @@
 //! Typically, consensus parameters are accessed via a function that takes a
 //! `Network` and `block::Height`.
 
+mod genesis;
 mod network;
 mod network_upgrade;
 
+pub use genesis::*;
 pub use network::Network;
 pub use network_upgrade::*;
 

--- a/zebra-chain/src/parameters/genesis.rs
+++ b/zebra-chain/src/parameters/genesis.rs
@@ -1,6 +1,6 @@
 //! Genesis consensus parameters for each Zcash network.
 
-use zebra_chain::{block, parameters::Network};
+use crate::{block, parameters::Network};
 
 /// The previous block hash for the genesis block.
 ///

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -30,11 +30,11 @@ use tower::{Service, ServiceExt};
 use tracing::instrument;
 use zebra_chain::{
     block::{self, Block},
-    parameters::Network,
+    parameters::{Network, GENESIS_PREVIOUS_BLOCK_HASH},
 };
 use zebra_state as zs;
 
-use crate::{parameters, BoxError};
+use crate::BoxError;
 
 pub(crate) mod list;
 mod types;
@@ -568,7 +568,7 @@ where
             // Since genesis blocks are hard-coded in zcashd, and not verified
             // like other blocks, the genesis parent hash is set by the
             // consensus parameters.
-            BeforeGenesis => parameters::GENESIS_PREVIOUS_BLOCK_HASH,
+            BeforeGenesis => GENESIS_PREVIOUS_BLOCK_HASH,
             InitialTip(hash) | PreviousCheckpoint(hash) => hash,
             FinalCheckpoint => return,
         };

--- a/zebra-consensus/src/checkpoint/list.rs
+++ b/zebra-consensus/src/checkpoint/list.rs
@@ -8,7 +8,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::{parameters, BoxError};
+use crate::BoxError;
 
 use std::{
     collections::{BTreeMap, HashSet},
@@ -17,7 +17,7 @@ use std::{
 };
 
 use zebra_chain::block;
-use zebra_chain::parameters::Network;
+use zebra_chain::parameters::{genesis_hash, Network};
 
 const MAINNET_CHECKPOINTS: &str = include_str!("main-checkpoints.txt");
 const TESTNET_CHECKPOINTS: &str = include_str!("test-checkpoints.txt");
@@ -73,7 +73,7 @@ impl CheckpointList {
         };
 
         match checkpoint_list.hash(block::Height(0)) {
-            Some(hash) if hash == parameters::genesis_hash(network) => checkpoint_list,
+            Some(hash) if hash == genesis_hash(network) => checkpoint_list,
             Some(_) => {
                 panic!("The hard-coded genesis checkpoint does not match the network genesis hash")
             }
@@ -102,8 +102,8 @@ impl CheckpointList {
         // Check that the list starts with the correct genesis block
         match checkpoints.iter().next() {
             Some((block::Height(0), hash))
-                if (hash == &parameters::genesis_hash(Network::Mainnet)
-                    || hash == &parameters::genesis_hash(Network::Testnet)) => {}
+                if (hash == &genesis_hash(Network::Mainnet)
+                    || hash == &genesis_hash(Network::Testnet)) => {}
             Some((block::Height(0), _)) => {
                 Err("the genesis checkpoint does not match the Mainnet or Testnet genesis hash")?
             }

--- a/zebra-consensus/src/parameters.rs
+++ b/zebra-consensus/src/parameters.rs
@@ -12,10 +12,8 @@
 //! Typically, consensus parameters are accessed via a function that takes a
 //! `Network` and `block::Height`.
 
-pub mod genesis;
 pub mod minimum_difficulty;
 
-pub use genesis::*;
 pub use minimum_difficulty::*;
 
 #[cfg(test)]

--- a/zebra-state/src/sled_state.rs
+++ b/zebra-state/src/sled_state.rs
@@ -6,7 +6,7 @@ use tracing::trace;
 use zebra_chain::serialization::{ZcashDeserialize, ZcashSerialize};
 use zebra_chain::{
     block::{self, Block},
-    parameters::Network,
+    parameters::{Network, GENESIS_PREVIOUS_BLOCK_HASH},
 };
 
 use crate::{BoxError, Config, HashOrHeight, QueuedBlock};
@@ -89,7 +89,7 @@ impl FinalizedState {
             .expect("inability to look up tip is unrecoverable")
             .map(|(_, hash)| hash)
             // if the state is empty, return the genesis previous block hash
-            .unwrap_or(block::Hash([0; 32]))
+            .unwrap_or(GENESIS_PREVIOUS_BLOCK_HASH)
     }
 
     /// Returns the height of the current finalized tip block.

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -11,9 +11,9 @@ use tracing_futures::Instrument;
 
 use zebra_chain::{
     block::{self, Block},
-    parameters::Network,
+    parameters::{genesis_hash, Network},
 };
-use zebra_consensus::{checkpoint, parameters};
+use zebra_consensus::checkpoint;
 use zebra_network as zn;
 use zebra_state as zs;
 
@@ -162,7 +162,7 @@ where
             verifier,
             prospective_tips: HashSet::new(),
             pending_blocks: Box::pin(FuturesUnordered::new()),
-            genesis_hash: parameters::genesis_hash(chain),
+            genesis_hash: genesis_hash(chain),
         }
     }
 


### PR DESCRIPTION
Should close https://github.com/ZcashFoundation/zebra/issues/1134

- `zebra-consensus/src/parameters/chain.rs` was moved into `zebra-chain/src/parameters/chain.rs`
- adjusted all the places where the content of the file was used.
- use `GENESIS_PREVIOUS_BLOCK_HASH` in `zebra_state/src/sled_state.rs`