### PR TITLE
Reduce the equihash proptest run time

### DIFF
--- a/zebra-chain/src/work/tests/prop.rs
+++ b/zebra-chain/src/work/tests/prop.rs
@@ -1,4 +1,6 @@
-use proptest::prelude::*;
+use proptest::{arbitrary::any, prelude::*, test_runner::Config};
+
+use std::env;
 
 use crate::block::{self, Block};
 use crate::serialization::{ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize};
@@ -41,11 +43,17 @@ fn equihash_prop_test_solution() -> color_eyre::eyre::Result<()> {
             .expect("block test vector should deserialize");
         block.header.solution.check(&block.header)?;
 
-        proptest!(|(fake_header in randomized_solutions(block.header))| {
-                fake_header.solution
-                    .check(&fake_header)
-                    .expect_err("block header should not validate on randomized solution");
-            });
+        // The equihash solution test can be really slow, so we use fewer cases by
+        // default. Set the PROPTEST_CASES env var to override this default.
+        proptest!(Config::with_cases(env::var("PROPTEST_CASES")
+                                      .ok()
+                                      .and_then(|v| v.parse().ok())
+                                      .unwrap_or(64)),
+                |(fake_header in randomized_solutions(block.header))| {
+            fake_header.solution
+                .check(&fake_header)
+                .expect_err("block header should not validate on randomized solution");
+        });
     }
 
     Ok(())
@@ -108,11 +116,15 @@ fn equihash_prop_test_input() -> color_eyre::eyre::Result<()> {
             .expect("block test vector should deserialize");
         block.header.solution.check(&block.header)?;
 
-        proptest!(|(fake_header in randomized_input(block.header))| {
-                fake_header.solution
-                    .check(&fake_header)
-                    .expect_err("equihash solution should not validate on randomized input");
-            });
+        proptest!(Config::with_cases(env::var("PROPTEST_CASES")
+                                  .ok()
+                                  .and_then(|v| v.parse().ok())
+                                 .unwrap_or(64)),
+              |(fake_header in randomized_input(block.header))| {
+            fake_header.solution
+                .check(&fake_header)
+                .expect_err("equihash solution should not validate on randomized input");
+        });
     }
 
     Ok(())


### PR DESCRIPTION
Reduce the default number of cases run by the equihash proptests,
so they run in under 10 seconds on my machine.

Set the PROPTEST_CASES env var to override the default.