### PR TITLE
Calculate and validate founders reward addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,6 +4016,7 @@ dependencies = [
  "futures-util",
  "jubjub 0.6.0",
  "metrics",
+ "num-integer",
  "once_cell",
  "pairing",
  "rand 0.7.3",

--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -7,6 +7,7 @@ mod script;
 mod serialize;
 
 pub use address::Address;
+pub use address::OpCode;
 pub use script::Script;
 
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -1,7 +1,7 @@
 //! Transparent-related (Bitcoin-inherited) functionality.
 #![allow(clippy::unit_arg)]
 
-mod address;
+pub mod address;
 mod keys;
 mod script;
 mod serialize;
@@ -19,9 +19,7 @@ mod prop;
 
 use crate::{
     amount::{Amount, NonNegative},
-    block,
-    parameters::Network,
-    transaction,
+    block, transaction,
 };
 
 /// Arbitrary data inserted by miners into a coinbase transaction.
@@ -114,10 +112,4 @@ pub struct Output {
 
     /// The lock script defines the conditions under which this output can be spent.
     pub lock_script: Script,
-}
-
-/// Custom type that holds a script and the network it belongs to.
-pub struct ScriptForNetwork {
-    pub script: Script,
-    pub network: Network,
 }

--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -19,7 +19,9 @@ mod prop;
 
 use crate::{
     amount::{Amount, NonNegative},
-    block, transaction,
+    block,
+    parameters::Network,
+    transaction,
 };
 
 /// Arbitrary data inserted by miners into a coinbase transaction.
@@ -112,4 +114,10 @@ pub struct Output {
 
     /// The lock script defines the conditions under which this output can be spent.
     pub lock_script: Script,
+}
+
+/// Custom type that holds a script and the network it belongs to.
+pub struct ScriptForNetwork {
+    pub script: Script,
+    pub network: Network,
 }

--- a/zebra-chain/src/transparent/address.rs
+++ b/zebra-chain/src/transparent/address.rs
@@ -62,7 +62,7 @@ pub enum Address {
 
 /// Minimal subset of script opcodes.
 /// Ported from https://github.com/zcash/librustzcash/blob/master/zcash_primitives/src/legacy.rs#L10
-enum OpCode {
+pub enum OpCode {
     // stack ops
     Dup = 0x76,
 
@@ -183,42 +183,16 @@ impl ZcashDeserialize for Address {
     }
 }
 
-pub trait ToAddressWithNetwork {
+trait ToAddressWithNetwork {
     /// Convert `self` to an `Address`, given the current `network`.
     fn to_address(&self, network: Network) -> Address;
 }
 
 impl ToAddressWithNetwork for Script {
-    /// Return the `Address` that `self` contains, using the same minimal algorithm as `zcashd`.
-    ///
-    /// See https://github.com/zcash/librustzcash/blob/master/zcash_primitives/src/legacy.rs#L43
     fn to_address(&self, network: Network) -> Address {
-        if self.0.len() == 25
-            && self.0[0..3] == [OpCode::Dup as u8, OpCode::Hash160 as u8, 0x14]
-            && self.0[23..25] == [OpCode::EqualVerify as u8, OpCode::CheckSig as u8]
-        {
-            let mut script_hash = [0; 20];
-            script_hash.copy_from_slice(&self.0[3..23]);
-
-            Address::PayToScriptHash {
-                network,
-                script_hash,
-            }
-        } else if self.0.len() == 23
-            && self.0[0..2] == [OpCode::Hash160 as u8, 0x14]
-            && self.0[22] == OpCode::Equal as u8
-        {
-            let mut script_hash = [0; 20];
-            script_hash.copy_from_slice(&self.0[2..22]);
-            Address::PayToScriptHash {
-                network,
-                script_hash,
-            }
-        } else {
-            Address::PayToScriptHash {
-                network,
-                script_hash: Address::hash_payload(&self.0[..]),
-            }
+        Address::PayToScriptHash {
+            network,
+            script_hash: Address::hash_payload(&self.0[..]),
         }
     }
 }

--- a/zebra-chain/src/transparent/address.rs
+++ b/zebra-chain/src/transparent/address.rs
@@ -189,7 +189,9 @@ pub trait ToAddressWithNetwork {
 }
 
 impl ToAddressWithNetwork for Script {
-    // https://github.com/zcash/librustzcash/blob/master/zcash_primitives/src/legacy.rs#L43
+    /// Return the `Address` that `self` contains, using the same minimal algorithm as `zcashd`.
+    ///
+    /// See https://github.com/zcash/librustzcash/blob/master/zcash_primitives/src/legacy.rs#L43
     fn to_address(&self, network: Network) -> Address {
         if self.0.len() == 25
             && self.0[0..3] == [OpCode::Dup as u8, OpCode::Hash160 as u8, 0x14]

--- a/zebra-chain/src/transparent/address.rs
+++ b/zebra-chain/src/transparent/address.rs
@@ -14,7 +14,7 @@ use crate::{
     serialization::{SerializationError, ZcashDeserialize, ZcashSerialize},
 };
 
-use super::{Script, ScriptForNetwork};
+use super::Script;
 
 /// Magic numbers used to identify what networks Transparent Addresses
 /// are associated with.
@@ -183,7 +183,7 @@ impl ZcashDeserialize for Address {
     }
 }
 
-trait ToAddressWithNetwork {
+pub trait ToAddressWithNetwork {
     /// Convert `self` to an `Address`, given the current `network`.
     fn to_address(&self, network: Network) -> Address;
 }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -19,6 +19,7 @@ bls12_381 = "0.3.1"
 futures = "0.3.13"
 futures-util = "0.3.6"
 metrics = "0.13.0-alpha.8"
+num-integer = "0.1.44"
 thiserror = "1.0.24"
 tokio = { version = "0.3.6", features = ["time", "sync", "stream", "tracing"] }
 tower = { version = "0.4", features = ["timeout", "util", "buffer"] }

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -118,7 +118,6 @@ pub fn subsidy_is_valid(block: &Block, network: Network) -> Result<(), BlockErro
             .expect("invalid Amount: founders reward should be valid");
         let matching_values = subsidy::general::find_output_with_amount(coinbase, founders_reward);
 
-        // TODO: no validation yet, just calling founders reward address functions
         let founders_reward_address =
             subsidy::founders_reward::founders_reward_address(height, network)
                 .expect("we should have an address");
@@ -128,7 +127,6 @@ pub fn subsidy_is_valid(block: &Block, network: Network) -> Result<(), BlockErro
             network,
         );
 
-        // TODO: the exact founders reward value must be sent as a single output to the correct address
         if !matching_values.is_empty()
             && !matching_address.is_empty()
             && matching_values == matching_address

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 
 use zebra_chain::{
     block::{Block, Hash, Header, Height},
-    parameters::{Network, NetworkUpgrade},
+    parameters::Network,
     transaction,
     work::{difficulty::ExpandedDifficulty, equihash},
 };

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -121,6 +121,13 @@ pub fn subsidy_is_valid(block: &Block, network: Network) -> Result<(), BlockErro
             .expect("invalid Amount: founders reward should be valid");
         let matching_values = subsidy::general::find_output_with_amount(coinbase, founders_reward);
 
+        // TODO: no validation yet, just calling founders reward address functions
+        let founders_reward_address =
+            subsidy::founders_reward::founders_reward_address(height, network)
+                .expect("we should have an address");
+        let _matching_address =
+            subsidy::founders_reward::find_output_with_address(coinbase, &founders_reward_address);
+
         // TODO: the exact founders reward value must be sent as a single output to the correct address
         if !matching_values.is_empty() {
             Ok(())

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -127,14 +127,17 @@ pub fn subsidy_is_valid(block: &Block, network: Network) -> Result<(), BlockErro
             network,
         );
 
-        if !matching_values.is_empty()
-            && !matching_address.is_empty()
-            && matching_values == matching_address
-        {
-            Ok(())
-        } else {
-            Err(SubsidyError::FoundersRewardNotFound)?
+        if matching_values.is_empty() {
+            return Err(SubsidyError::FoundersRewardAmountNotFound)?;
         }
+        if matching_address.is_empty() {
+            return Err(SubsidyError::FoundersRewardAddressNotFound)?;
+        }
+        if matching_values != matching_address {
+            return Err(SubsidyError::FoundersRewardDifferentOutput)?;
+        }
+
+        Ok(())
     } else if halving_div < 4 {
         // Funding streams are paid from Canopy activation to the second halving
         // Note: Canopy activation is at the first halving on mainnet, but not on testnet

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -125,11 +125,17 @@ pub fn subsidy_is_valid(block: &Block, network: Network) -> Result<(), BlockErro
         let founders_reward_address =
             subsidy::founders_reward::founders_reward_address(height, network)
                 .expect("we should have an address");
-        let _matching_address =
-            subsidy::founders_reward::find_output_with_address(coinbase, &founders_reward_address);
+        let matching_address = subsidy::founders_reward::find_output_with_address(
+            coinbase,
+            founders_reward_address,
+            network,
+        );
 
         // TODO: the exact founders reward value must be sent as a single output to the correct address
-        if !matching_values.is_empty() {
+        if !matching_values.is_empty()
+            && !matching_address.is_empty()
+            && matching_values == matching_address
+        {
             Ok(())
         } else {
             Err(SubsidyError::FoundersRewardNotFound)?

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -101,9 +101,6 @@ pub fn subsidy_is_valid(block: &Block, network: Network) -> Result<(), BlockErro
     let coinbase = block.transactions.get(0).ok_or(SubsidyError::NoCoinbase)?;
 
     let halving_div = subsidy::general::halving_divisor(height, network);
-    let canopy_activation_height = NetworkUpgrade::Canopy
-        .activation_height(network)
-        .expect("Canopy activation height is known");
 
     // TODO: the sum of the coinbase transaction outputs must be less than or equal to the block subsidy plus transaction fees
 
@@ -115,7 +112,7 @@ pub fn subsidy_is_valid(block: &Block, network: Network) -> Result<(), BlockErro
         )
     } else if halving_div.count_ones() != 1 {
         unreachable!("invalid halving divisor: the halving divisor must be a non-zero power of two")
-    } else if height < canopy_activation_height {
+    } else if subsidy::founders_reward::founders_reward_active(height, network) {
         // Founders rewards are paid up to Canopy activation, on both mainnet and testnet
         let founders_reward = subsidy::founders_reward::founders_reward(height, network)
             .expect("invalid Amount: founders reward should be valid");

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -121,11 +121,8 @@ pub fn subsidy_is_valid(block: &Block, network: Network) -> Result<(), BlockErro
         let founders_reward_address =
             subsidy::founders_reward::founders_reward_address(height, network)
                 .expect("we should have an address");
-        let matching_address = subsidy::founders_reward::find_output_with_address(
-            coinbase,
-            founders_reward_address,
-            network,
-        );
+        let matching_address =
+            subsidy::founders_reward::find_output_with_address(coinbase, founders_reward_address);
 
         if matching_values.is_empty() {
             return Err(SubsidyError::FoundersRewardAmountNotFound)?;

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -95,7 +95,7 @@ pub fn check_script_form(lock_script: Script, address: Address) -> bool {
         .expect("we should get address bytes here");
 
     address_hash = address_hash[2..22].to_vec();
-    address_hash.insert(0, 0x14 as u8);
+    address_hash.insert(0, 0x14_u8);
     address_hash.insert(0, OpCode::Hash160 as u8);
     address_hash.insert(address_hash.len(), OpCode::Equal as u8);
     if lock_script.0.len() == address_hash.len() && lock_script == Script(address_hash) {

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -60,7 +60,7 @@ pub fn founders_reward_address(height: Height, network: Network) -> Result<Addre
         .expect("blossom activation height should be available");
 
     if !founders_reward_active(height, network) {
-        panic!("no address returned after canopy");
+        panic!("founders reward address lookup on invalid block: block is after canopy activation");
     }
 
     let mut adjusted_height = height;

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -71,15 +71,14 @@ pub fn founders_reward_address(height: Height, network: Network) -> Result<Addre
         );
     }
 
-    let address_index = 1 + (adjusted_height.0 / founders_address_change_interval().0);
+    let address_index = (adjusted_height.0 / founders_address_change_interval().0) as usize;
+    let addresses = match network {
+        Network::Mainnet => FOUNDERS_REWARD_ADDRESSES_MAINNET,
+        Network::Testnet => FOUNDERS_REWARD_ADDRESSES_TESTNET,
+    };
+    let address: Address =
+        Address::from_str(addresses[address_index]).expect("we should get a taddress here");
 
-    let mut addresses = FOUNDERS_REWARD_ADDRESSES_MAINNET;
-    if network == Network::Testnet {
-        addresses = FOUNDERS_REWARD_ADDRESSES_TESTNET;
-    }
-
-    let address: Address = Address::from_str(addresses[(address_index - 1) as usize])
-        .expect("we should get a taddress here");
     Ok(address)
 }
 

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -7,11 +7,16 @@ use std::convert::TryFrom;
 use zebra_chain::{
     amount::{Amount, Error, NonNegative},
     block::Height,
-    parameters::Network,
+    parameters::{Network, NetworkUpgrade::*},
+    transaction::Transaction,
+    transparent::{Address, Output},
 };
 
 use crate::block::subsidy::general::{block_subsidy, halving_divisor};
-use crate::parameters::subsidy::FOUNDERS_FRACTION_DIVISOR;
+use crate::parameters::subsidy::{
+    BLOSSOM_POW_TARGET_SPACING_RATIO, FOUNDERS_FRACTION_DIVISOR, FOUNDERS_REWARD_ADDRESSES_MAINNET,
+    FOUNDER_ADDRESS_CHANGE_INTERVAL,
+};
 
 /// `FoundersReward(height)` as described in [protocol specification §7.7][7.7]
 ///
@@ -26,11 +31,66 @@ pub fn founders_reward(height: Height, network: Network) -> Result<Amount<NonNeg
     }
 }
 
+/// Get the founders reward t-address for the specified block height as described in [protocol specification §7.8][7.8]
+///
+/// [7.8]: https://zips.z.cash/protocol/canopy.pdf#foundersreward
+pub fn founders_reward_address(height: Height, network: Network) -> Result<String, Error> {
+    let blossom_height = Blossom
+        .activation_height(network)
+        .expect("blossom activation height should be available");
+    let canopy_height = Canopy
+        .activation_height(network)
+        .expect("canopy activation height should be available");
+
+    if height >= canopy_height {
+        panic!("no address returned after canopy");
+    }
+
+    let mut adjusted_height = height;
+    if height >= blossom_height {
+        adjusted_height = Height(
+            blossom_height.0
+                + ((height.0 - blossom_height.0) / (BLOSSOM_POW_TARGET_SPACING_RATIO as u32)),
+        );
+    }
+
+    let address_index = 1 + (adjusted_height.0 / FOUNDER_ADDRESS_CHANGE_INTERVAL as u32);
+    Ok(FOUNDERS_REWARD_ADDRESSES_MAINNET[(address_index - 1) as usize].to_string())
+}
+
+/// Returns a list of outputs in `Transaction`, which have a script address equal to `String`.
+pub fn find_output_with_address(transaction: &Transaction, address: &str) -> Vec<Output> {
+    let calculated_addr: Address = address.parse().unwrap();
+
+    // For debugging
+    println!("Looking for founders reward address in new coinbase transaction:");
+    for (output_number, o) in transaction.outputs().iter().enumerate() {
+        let lock_script = o.lock_script.clone();
+
+        // For one of the coinbase outputs the address we get from the lock_script should be one of
+        // the ones in the FOUNDERS_REWARD_ADDRESSES_MAINNET array, not happening.
+        let output_address: Address = Address::from(lock_script);
+
+        println!(
+            "Output: {} Calculated address: {} Output address: {}",
+            output_number, calculated_addr, output_address
+        );
+        println!();
+    }
+
+    // never matching
+    transaction
+        .outputs()
+        .iter()
+        .filter(|o| Address::from(o.lock_script.clone()) == calculated_addr)
+        .cloned()
+        .collect()
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use color_eyre::Report;
-    use zebra_chain::parameters::NetworkUpgrade::*;
     #[test]
     fn test_founders_reward() -> Result<(), Report> {
         zebra_test::init();
@@ -57,6 +117,48 @@ mod test {
         // After first halving(coinciding with Canopy) founders reward will expire
         // https://z.cash/support/faq/#does-the-founders-reward-expire
         assert_eq!(Amount::try_from(0), founders_reward(canopy_height, network));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_founders_address() -> Result<(), Report> {
+        let network = Network::Mainnet;
+
+        let blossom_height = Blossom.activation_height(network).unwrap();
+        let canopy_height = Canopy.activation_height(network).unwrap();
+
+        // the index in the founders reward address array that will be active at height
+        let mut index = 0;
+
+        // from genesis to blossom the founder reward address changes at FOUNDER_ADDRESS_CHANGE_INTERVAL
+        for n in (1..blossom_height.0).step_by(FOUNDER_ADDRESS_CHANGE_INTERVAL as usize) {
+            assert_eq!(
+                founders_reward_address(Height(n), network)?,
+                FOUNDERS_REWARD_ADDRESSES_MAINNET[index as usize].to_string()
+            );
+            index += 1;
+        }
+
+        // after blossom the first change happening at block 656_866 in the mainnet
+        // Todo: explain this better - after blossom there is still time left for the next change in
+        // founder address but the remaining is calculated with the new formula.
+        let first_change_after_blossom_mainnet = 656_866;
+        assert_eq!(
+            founders_reward_address(Height(first_change_after_blossom_mainnet), network)?,
+            FOUNDERS_REWARD_ADDRESSES_MAINNET[index as usize].to_string()
+        );
+
+        // after the first change after blossom the addresses changes at FOUNDER_ADDRESS_CHANGE_INTERVAL * 2
+        for n in (first_change_after_blossom_mainnet..canopy_height.0)
+            .step_by((FOUNDER_ADDRESS_CHANGE_INTERVAL * 2) as usize)
+        {
+            assert_eq!(
+                founders_reward_address(Height(n), network)?,
+                FOUNDERS_REWARD_ADDRESSES_MAINNET[index as usize].to_string()
+            );
+            index += 1;
+        }
 
         Ok(())
     }

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -85,8 +85,8 @@ pub fn founders_reward_address(height: Height, network: Network) -> Result<Addre
 
     Ok(address)
 }
-/// Given a founders reward address and a lock script from an output make sure the script
-/// is well formed as described in [protocol specification §7.8][7.8]
+/// Given a founders reward address, create a script and check if it is the same
+/// as the given lock_script as described in [protocol specification §7.8][7.8]
 ///
 /// [7.8]: https://zips.z.cash/protocol/protocol.pdf#foundersreward.
 pub fn check_script_form(lock_script: Script, address: Address) -> bool {

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -225,21 +225,4 @@ mod test {
 
         Ok(())
     }
-
-    #[test]
-    fn test_founders_address_ceiling() -> Result<(), Report> {
-        // Test proves why `div_ceil` needs to be used.
-        // `truncate(n/d) + 1` is 1 more than `ceiling(n/d)` when `n/d` is an integer.
-        // Suppose `SLOW_START_SHIFT.0 + PRE_BLOSSOM_HALVING_INTERVAL.0 = 480_000` instead
-        // of current protocol defined value of `850_000`.
-        let numerator = 480_000;
-
-        // `truncate(n) + 1` will output the wrong result
-        assert_eq!((numerator / FOUNDERS_ADDRESS_COUNT) + 1, 10001);
-
-        // `div_ceil` will output the right thing
-        assert_eq!(div_ceil(numerator, FOUNDERS_ADDRESS_COUNT), 10000);
-
-        Ok(())
-    }
 }

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -24,6 +24,9 @@ pub fn founders_reward_active(height: Height, network: Network) -> bool {
         .activation_height(network)
         .expect("Canopy activation height is known");
 
+    // The Zcash Specification and ZIPs explain the end of the founders reward in different ways,
+    // because some were written before the set of Canopy network upgrade ZIPs was decided.
+    // These are the canonical checks recommended by `zcashd` developers.
     height < canopy_activation_height && halving_divisor(height, network) == 1
 }
 

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -15,7 +15,7 @@ use zebra_chain::{
     transparent::{Address, Output, ScriptForNetwork},
 };
 
-use crate::block::subsidy::general::{block_subsidy, halving_divisor};
+use crate::block::subsidy::general::block_subsidy;
 use crate::parameters::subsidy::*;
 
 /// Returns `true` if we are in the founders reward period of the blockchain.
@@ -31,7 +31,7 @@ pub fn founders_reward_active(height: Height, network: Network) -> bool {
 ///
 /// [7.7]: https://zips.z.cash/protocol/protocol.pdf#subsidies
 pub fn founders_reward(height: Height, network: Network) -> Result<Amount<NonNegative>, Error> {
-    if halving_divisor(height, network) == 1 && founders_reward_active(height, network) {
+    if founders_reward_active(height, network) {
         // this calculation is exact, because the block subsidy is divisible by
         // the FOUNDERS_FRACTION_DIVISOR until long after the first halving
         block_subsidy(height, network)? / FOUNDERS_FRACTION_DIVISOR

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -114,7 +114,7 @@ pub fn check_script_form(lock_script: Script, address: Address) -> bool {
     if lock_script_hash == address_hash {
         return true;
     }
-    return false;
+    false
 }
 
 /// Returns a list of outputs in `Transaction`, which have a script address equal to `String`.

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -93,25 +93,12 @@ pub fn check_script_form(lock_script: Script, address: Address) -> bool {
     let mut address_hash = address
         .zcash_serialize_to_vec()
         .expect("we should get address bytes here");
-    let mut lock_script_hash = lock_script.0;
 
-    // Make sure the lock script haves the start and end we need.
-    if !(lock_script_hash[0] == OpCode::Hash160 as u8
-        && lock_script_hash[lock_script_hash.len() - 1] == OpCode::Equal as u8)
-    {
-        return false;
-    }
-
-    // Remove prefix from lock_script.
-    let prefix_len = 2;
-    lock_script_hash = address_hash[prefix_len..address_hash.len() - prefix_len].to_vec();
-
-    // Remove prefix from given address.
-    address_hash = address_hash[prefix_len..address_hash.len() - prefix_len].to_vec();
-
-    // To be valid the bytes in the center of the lock_script hash from output should be the
-    // same as the ones in the center of the given address hash.
-    if lock_script_hash == address_hash {
+    address_hash = address_hash[2..22].to_vec();
+    address_hash.insert(0, 0x14 as u8);
+    address_hash.insert(0, OpCode::Hash160 as u8);
+    address_hash.insert(address_hash.len(), OpCode::Equal as u8);
+    if lock_script.0.len() == address_hash.len() && lock_script == Script(address_hash) {
         return true;
     }
     false

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -45,7 +45,7 @@ pub fn founders_reward(height: Height, network: Network) -> Result<Amount<NonNeg
 
 /// Function `FounderAddressChangeInterval` as specified in [protocol specification §7.8][7.8]
 ///
-/// [7.8]: https://zips.z.cash/protocol/canopy.pdf#foundersreward
+/// [7.8]: https://zips.z.cash/protocol/protocol.pdf#foundersreward
 pub fn founders_address_change_interval() -> Height {
     let interval = div_ceil(
         SLOW_START_SHIFT.0 + PRE_BLOSSOM_HALVING_INTERVAL.0,
@@ -56,7 +56,7 @@ pub fn founders_address_change_interval() -> Height {
 
 /// Get the founders reward t-address for the specified block height as described in [protocol specification §7.8][7.8]
 ///
-/// [7.8]: https://zips.z.cash/protocol/canopy.pdf#foundersreward
+/// [7.8]: https://zips.z.cash/protocol/protocol.pdf#foundersreward
 pub fn founders_reward_address(height: Height, network: Network) -> Result<Address, Error> {
     let blossom_height = Blossom
         .activation_height(network)

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -12,7 +12,7 @@ use zebra_chain::{
     block::Height,
     parameters::{Network, NetworkUpgrade::*},
     transaction::Transaction,
-    transparent::{Address, Output, ScriptForNetwork},
+    transparent::{address::ToAddressWithNetwork, Address, Output},
 };
 
 use crate::block::subsidy::general::block_subsidy;
@@ -91,9 +91,7 @@ pub fn find_output_with_address(
     transaction
         .outputs()
         .iter()
-        .filter(|o| {
-            o.lock_script.clone().to_address(network) == address
-        })
+        .filter(|o| o.lock_script.to_address(network) == address)
         .cloned()
         .collect()
 }

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -177,6 +177,8 @@ mod test {
     // TODO: Ignored because we loop through all the founders reward period block by block.
     #[ignore]
     fn test_founders_address() -> Result<(), Report> {
+        zebra_test::init();
+
         founders_address_for_network(Network::Mainnet)?;
         founders_address_for_network(Network::Testnet)?;
 
@@ -219,6 +221,8 @@ mod test {
 
     #[test]
     fn test_founders_address_count() -> Result<(), Report> {
+        zebra_test::init();
+
         assert_eq!(
             FOUNDERS_REWARD_ADDRESSES_MAINNET.len() as u32,
             FOUNDERS_ADDRESS_COUNT

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -175,7 +175,7 @@ mod test {
 
     #[test]
     // TODO: Ignored because we loop through all the founders reward period block by block.
-    //#[ignore]
+    #[ignore]
     fn test_founders_address() -> Result<(), Report> {
         founders_address_for_network(Network::Mainnet)?;
         founders_address_for_network(Network::Testnet)?;

--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -379,7 +379,8 @@ fn founders_reward_validation_failure() -> Result<(), Report> {
         Arc::<Block>::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_415000_BYTES[..])
             .expect("block should deserialize");
 
-    // Build the new transaction with modified coinbase outputs
+    // Build the new transaction with modified coinbase outputs.
+    // Here we are keeping only the first output which is not the founders reward payment.
     let tx = block
         .transactions
         .get(0)
@@ -402,9 +403,15 @@ fn founders_reward_validation_failure() -> Result<(), Report> {
     // Validate it
     let result = check::subsidy_is_valid(&block, network).unwrap_err();
     let expected = BlockError::Transaction(TransactionError::Subsidy(
-        SubsidyError::FoundersRewardNotFound,
+        SubsidyError::FoundersRewardAmountNotFound,
     ));
     assert_eq!(expected, result);
+
+    // Todo: Using the second output, which haves the correct amount, modify the lock_script
+    // and trigger SubsidyError::FoundersRewardAddressNotFound
+
+    // Todo: Using the 2 outputs, exchange the lock_script between them
+    // and trigger SubsidyError::FoundersRewardDifferentOutput
 
     Ok(())
 }

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -16,8 +16,14 @@ pub enum SubsidyError {
     #[error("no coinbase transaction in block")]
     NoCoinbase,
 
-    #[error("founders reward output not found")]
-    FoundersRewardNotFound,
+    #[error("founders reward amount not found in output")]
+    FoundersRewardAmountNotFound,
+
+    #[error("founders reward address not found in output")]
+    FoundersRewardAddressNotFound,
+
+    #[error("founders reward amount and address found but they are not in the same output")]
+    FoundersRewardDifferentOutput,
 }
 
 #[derive(Error, Debug, PartialEq)]

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -42,17 +42,8 @@ pub const POST_BLOSSOM_HALVING_INTERVAL: Height =
 /// Usage: founders_reward = block_subsidy / FOUNDERS_FRACTION_DIVISOR
 pub const FOUNDERS_FRACTION_DIVISOR: u64 = 5;
 
-/// Function `FounderAddressChangeInterval` as specified in [protocol specification §7.8][7.8]
-///
-/// Rust trucates the division down, to get ceiling effect we sum 1 to the end of the calculation.
-/// We use the main network lenght as both networks are the same in size.
-///
-/// [7.8]: https://zips.z.cash/protocol/canopy.pdf#foundersreward
-
-pub const FOUNDER_ADDRESS_CHANGE_INTERVAL: u64 =
-    ((SLOW_START_SHIFT.0 + PRE_BLOSSOM_HALVING_INTERVAL.0)
-        / FOUNDERS_REWARD_ADDRESSES_MAINNET.len() as u32) as u64
-        + 1;
+/// The number of founders reward address intervals, for both mainnet and testnet.
+pub const FOUNDERS_ADDRESS_COUNT: u32 = 48;
 
 /// Mainnet founder adress list as specified in [protocol specification §7.8][7.8]
 ///

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -47,7 +47,7 @@ pub const FOUNDERS_ADDRESS_COUNT: u32 = 48;
 
 /// Mainnet founder adress list as specified in [protocol specification §7.8][7.8]
 ///
-/// [7.8]: https://zips.z.cash/protocol/canopy.pdf#foundersreward
+/// [7.8]: https://zips.z.cash/protocol/protocol.pdf#foundersreward
 pub const FOUNDERS_REWARD_ADDRESSES_MAINNET: [&str; 48] = [
     "t3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd",
     "t3cL9AucCajm3HXDhb5jBnJK2vapVoXsop3",
@@ -101,7 +101,7 @@ pub const FOUNDERS_REWARD_ADDRESSES_MAINNET: [&str; 48] = [
 
 /// Testnet founder adress list as specified in [protocol specification §7.8][7.8]
 ///
-/// [7.8]: https://zips.z.cash/protocol/canopy.pdf#foundersreward
+/// [7.8]: https://zips.z.cash/protocol/protocol.pdf#foundersreward
 pub const FOUNDERS_REWARD_ADDRESSES_TESTNET: [&str; 48] = [
     "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
     "t2N9PH9Wk9xjqYg9iin1Ua3aekJqfAtE543",

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -41,3 +41,123 @@ pub const POST_BLOSSOM_HALVING_INTERVAL: Height =
 ///
 /// Usage: founders_reward = block_subsidy / FOUNDERS_FRACTION_DIVISOR
 pub const FOUNDERS_FRACTION_DIVISOR: u64 = 5;
+
+/// Function `FounderAddressChangeInterval` as specified in [protocol specification §7.8][7.8]
+///
+/// Rust trucates the division down, to get ceiling effect we sum 1 to the end of the calculation.
+/// We use the main network lenght as both networks are the same in size.
+///
+/// [7.8]: https://zips.z.cash/protocol/canopy.pdf#foundersreward
+
+pub const FOUNDER_ADDRESS_CHANGE_INTERVAL: u64 =
+    ((SLOW_START_SHIFT.0 + PRE_BLOSSOM_HALVING_INTERVAL.0)
+        / FOUNDERS_REWARD_ADDRESSES_MAINNET.len() as u32) as u64
+        + 1;
+
+/// Mainnet founder adress list as specified in [protocol specification §7.8][7.8]
+///
+/// [7.8]: https://zips.z.cash/protocol/canopy.pdf#foundersreward
+pub const FOUNDERS_REWARD_ADDRESSES_MAINNET: [&str; 48] = [
+    "t3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd",
+    "t3cL9AucCajm3HXDhb5jBnJK2vapVoXsop3",
+    "t3fqvkzrrNaMcamkQMwAyHRjfDdM2xQvDTR",
+    "t3TgZ9ZT2CTSK44AnUPi6qeNaHa2eC7pUyF",
+    "t3SpkcPQPfuRYHsP5vz3Pv86PgKo5m9KVmx",
+    "t3Xt4oQMRPagwbpQqkgAViQgtST4VoSWR6S",
+    "t3ayBkZ4w6kKXynwoHZFUSSgXRKtogTXNgb",
+    "t3adJBQuaa21u7NxbR8YMzp3km3TbSZ4MGB",
+    "t3K4aLYagSSBySdrfAGGeUd5H9z5Qvz88t2",
+    "t3RYnsc5nhEvKiva3ZPhfRSk7eyh1CrA6Rk",
+    "t3Ut4KUq2ZSMTPNE67pBU5LqYCi2q36KpXQ",
+    "t3ZnCNAvgu6CSyHm1vWtrx3aiN98dSAGpnD",
+    "t3fB9cB3eSYim64BS9xfwAHQUKLgQQroBDG",
+    "t3cwZfKNNj2vXMAHBQeewm6pXhKFdhk18kD",
+    "t3YcoujXfspWy7rbNUsGKxFEWZqNstGpeG4",
+    "t3bLvCLigc6rbNrUTS5NwkgyVrZcZumTRa4",
+    "t3VvHWa7r3oy67YtU4LZKGCWa2J6eGHvShi",
+    "t3eF9X6X2dSo7MCvTjfZEzwWrVzquxRLNeY",
+    "t3esCNwwmcyc8i9qQfyTbYhTqmYXZ9AwK3X",
+    "t3M4jN7hYE2e27yLsuQPPjuVek81WV3VbBj",
+    "t3gGWxdC67CYNoBbPjNvrrWLAWxPqZLxrVY",
+    "t3LTWeoxeWPbmdkUD3NWBquk4WkazhFBmvU",
+    "t3P5KKX97gXYFSaSjJPiruQEX84yF5z3Tjq",
+    "t3f3T3nCWsEpzmD35VK62JgQfFig74dV8C9",
+    "t3Rqonuzz7afkF7156ZA4vi4iimRSEn41hj",
+    "t3fJZ5jYsyxDtvNrWBeoMbvJaQCj4JJgbgX",
+    "t3Pnbg7XjP7FGPBUuz75H65aczphHgkpoJW",
+    "t3WeKQDxCijL5X7rwFem1MTL9ZwVJkUFhpF",
+    "t3Y9FNi26J7UtAUC4moaETLbMo8KS1Be6ME",
+    "t3aNRLLsL2y8xcjPheZZwFy3Pcv7CsTwBec",
+    "t3gQDEavk5VzAAHK8TrQu2BWDLxEiF1unBm",
+    "t3Rbykhx1TUFrgXrmBYrAJe2STxRKFL7G9r",
+    "t3aaW4aTdP7a8d1VTE1Bod2yhbeggHgMajR",
+    "t3YEiAa6uEjXwFL2v5ztU1fn3yKgzMQqNyo",
+    "t3g1yUUwt2PbmDvMDevTCPWUcbDatL2iQGP",
+    "t3dPWnep6YqGPuY1CecgbeZrY9iUwH8Yd4z",
+    "t3QRZXHDPh2hwU46iQs2776kRuuWfwFp4dV",
+    "t3enhACRxi1ZD7e8ePomVGKn7wp7N9fFJ3r",
+    "t3PkLgT71TnF112nSwBToXsD77yNbx2gJJY",
+    "t3LQtHUDoe7ZhhvddRv4vnaoNAhCr2f4oFN",
+    "t3fNcdBUbycvbCtsD2n9q3LuxG7jVPvFB8L",
+    "t3dKojUU2EMjs28nHV84TvkVEUDu1M1FaEx",
+    "t3aKH6NiWN1ofGd8c19rZiqgYpkJ3n679ME",
+    "t3MEXDF9Wsi63KwpPuQdD6by32Mw2bNTbEa",
+    "t3WDhPfik343yNmPTqtkZAoQZeqA83K7Y3f",
+    "t3PSn5TbMMAEw7Eu36DYctFezRzpX1hzf3M",
+    "t3R3Y5vnBLrEn8L6wFjPjBLnxSUQsKnmFpv",
+    "t3Pcm737EsVkGTbhsu2NekKtJeG92mvYyoN",
+];
+
+/// Testnet founder adress list as specified in [protocol specification §7.8][7.8]
+///
+/// [7.8]: https://zips.z.cash/protocol/canopy.pdf#foundersreward
+pub const FOUNDERS_REWARD_ADDRESSES_TESTNET: [&str; 48] = [
+    "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
+    "t2N9PH9Wk9xjqYg9iin1Ua3aekJqfAtE543",
+    "t2NGQjYMQhFndDHguvUw4wZdNdsssA6K7x2",
+    "t2ENg7hHVqqs9JwU5cgjvSbxnT2a9USNfhy",
+    "t2BkYdVCHzvTJJUTx4yZB8qeegD8QsPx8bo",
+    "t2J8q1xH1EuigJ52MfExyyjYtN3VgvshKDf",
+    "t2Crq9mydTm37kZokC68HzT6yez3t2FBnFj",
+    "t2EaMPUiQ1kthqcP5UEkF42CAFKJqXCkXC9",
+    "t2F9dtQc63JDDyrhnfpzvVYTJcr57MkqA12",
+    "t2LPirmnfYSZc481GgZBa6xUGcoovfytBnC",
+    "t26xfxoSw2UV9Pe5o3C8V4YybQD4SESfxtp",
+    "t2D3k4fNdErd66YxtvXEdft9xuLoKD7CcVo",
+    "t2DWYBkxKNivdmsMiivNJzutaQGqmoRjRnL",
+    "t2C3kFF9iQRxfc4B9zgbWo4dQLLqzqjpuGQ",
+    "t2MnT5tzu9HSKcppRyUNwoTp8MUueuSGNaB",
+    "t2AREsWdoW1F8EQYsScsjkgqobmgrkKeUkK",
+    "t2Vf4wKcJ3ZFtLj4jezUUKkwYR92BLHn5UT",
+    "t2K3fdViH6R5tRuXLphKyoYXyZhyWGghDNY",
+    "t2VEn3KiKyHSGyzd3nDw6ESWtaCQHwuv9WC",
+    "t2F8XouqdNMq6zzEvxQXHV1TjwZRHwRg8gC",
+    "t2BS7Mrbaef3fA4xrmkvDisFVXVrRBnZ6Qj",
+    "t2FuSwoLCdBVPwdZuYoHrEzxAb9qy4qjbnL",
+    "t2SX3U8NtrT6gz5Db1AtQCSGjrpptr8JC6h",
+    "t2V51gZNSoJ5kRL74bf9YTtbZuv8Fcqx2FH",
+    "t2FyTsLjjdm4jeVwir4xzj7FAkUidbr1b4R",
+    "t2EYbGLekmpqHyn8UBF6kqpahrYm7D6N1Le",
+    "t2NQTrStZHtJECNFT3dUBLYA9AErxPCmkka",
+    "t2GSWZZJzoesYxfPTWXkFn5UaxjiYxGBU2a",
+    "t2RpffkzyLRevGM3w9aWdqMX6bd8uuAK3vn",
+    "t2JzjoQqnuXtTGSN7k7yk5keURBGvYofh1d",
+    "t2AEefc72ieTnsXKmgK2bZNckiwvZe3oPNL",
+    "t2NNs3ZGZFsNj2wvmVd8BSwSfvETgiLrD8J",
+    "t2ECCQPVcxUCSSQopdNquguEPE14HsVfcUn",
+    "t2JabDUkG8TaqVKYfqDJ3rqkVdHKp6hwXvG",
+    "t2FGzW5Zdc8Cy98ZKmRygsVGi6oKcmYir9n",
+    "t2DUD8a21FtEFn42oVLp5NGbogY13uyjy9t",
+    "t2UjVSd3zheHPgAkuX8WQW2CiC9xHQ8EvWp",
+    "t2TBUAhELyHUn8i6SXYsXz5Lmy7kDzA1uT5",
+    "t2Tz3uCyhP6eizUWDc3bGH7XUC9GQsEyQNc",
+    "t2NysJSZtLwMLWEJ6MH3BsxRh6h27mNcsSy",
+    "t2KXJVVyyrjVxxSeazbY9ksGyft4qsXUNm9",
+    "t2J9YYtH31cveiLZzjaE4AcuwVho6qjTNzp",
+    "t2QgvW4sP9zaGpPMH1GRzy7cpydmuRfB4AZ",
+    "t2NDTJP9MosKpyFPHJmfjc5pGCvAU58XGa4",
+    "t29pHDBWq7qN4EjwSEHg8wEqYe9pkmVrtRP",
+    "t2Ez9KM8VJLuArcxuEkNRAkhNvidKkzXcjJ",
+    "t2D5y7J5fpXajLbGrMBQkFg2mFN8fo3n8cX",
+    "t2UV2wr1PTaUiybpkV3FdSdGxUJeZdZztyt",
+];


### PR DESCRIPTION
## TODO

See #338

## Motivation

Part of the bock subsidy. We merged the validation of founders reward amounts and general block subsidy framework at https://github.com/ZcashFoundation/zebra/pull/1051 and we have a RFC for the whole process being written at https://github.com/ZcashFoundation/zebra/pull/1129.

This PR deals with the founder reward addresses that should be present in the coinbase outputs that must match a calculated address according to current height.
- Calculation of the address is done at `founders_reward_address()` and tested at `test_founders_address()`.
- Given a coinbase transaction and a calculated address `find_output_with_address()` will look into the outputs trying to get the address. Test at `subsidy_is_valid_test()`.

<strike>Problem: Calculated address are transparent address while what we have inside outputs is P2SH scripts. We need to decode(or whatever is the right word here) the script to get an address.</strike> Resolved

This is a draft PR and currently need lot of adjustments but it is posted to get help with the above problem. Still, i will probably continue on top of it so feel free to make comments/suggestions for any part of it. 

