### PR TITLE
WIP: Add all necessary sled trees to zebra-state as defined in RFC0005

### DIFF
--- a/zebra-chain/src/sapling/note/nullifiers.rs
+++ b/zebra-chain/src/sapling/note/nullifiers.rs
@@ -31,7 +31,7 @@ fn prf_nf(nk: [u8; 32], rho: [u8; 32]) -> [u8; 32] {
     any(test, feature = "proptest-impl"),
     derive(proptest_derive::Arbitrary)
 )]
-pub struct Nullifier([u8; 32]);
+pub struct Nullifier(pub [u8; 32]);
 
 impl From<[u8; 32]> for Nullifier {
     fn from(buf: [u8; 32]) -> Self {

--- a/zebra-chain/src/sprout/note/nullifiers.rs
+++ b/zebra-chain/src/sprout/note/nullifiers.rs
@@ -67,7 +67,7 @@ impl From<NullifierSeed> for [u8; 32] {
     any(test, feature = "proptest-impl"),
     derive(proptest_derive::Arbitrary)
 )]
-pub struct Nullifier(pub(crate) [u8; 32]);
+pub struct Nullifier(pub [u8; 32]);
 
 impl From<[u8; 32]> for Nullifier {
     fn from(bytes: [u8; 32]) -> Self {

--- a/zebra-chain/src/transaction/shielded_data.rs
+++ b/zebra-chain/src/transaction/shielded_data.rs
@@ -65,13 +65,13 @@ impl ShieldedData {
 
     /// Collect the [`Nullifier`]s for this transaction, if it contains
     /// [`Spend`]s.
-    pub fn nullifiers(&self) -> Vec<Nullifier> {
-        self.spends().map(|spend| spend.nullifier).collect()
+    pub fn nullifiers(&self) -> impl Iterator<Item = &Nullifier> {
+        self.spends().map(|spend| &spend.nullifier)
     }
 
     /// Collect the cm_u's for this transaction, if it contains [`Output`]s.
-    pub fn note_commitments(&self) -> Vec<jubjub::Fq> {
-        self.outputs().map(|output| output.cm_u).collect()
+    pub fn note_commitments(&self) -> impl Iterator<Item = &jubjub::Fq> {
+        self.outputs().map(|output| &output.cm_u)
     }
 
     /// Calculate the Spend/Output binding verification key.

--- a/zebra-client/src/lib.rs
+++ b/zebra-client/src/lib.rs
@@ -1,11 +1,3 @@
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_client")]
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/zebra-rpc/src/lib.rs
+++ b/zebra-rpc/src/lib.rs
@@ -1,11 +1,3 @@
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_rpc")]
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -61,7 +61,12 @@ impl Config {
         if self.ephemeral {
             config.temporary(self.ephemeral)
         } else {
-            let path = self.cache_dir.join(net_dir).join("state");
+            let path = self
+                .cache_dir
+                .join("state")
+                .join(format!("v{}", crate::constants::SLED_FORMAT_VERSION))
+                .join(net_dir);
+
             config.path(path)
         }
     }

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -13,3 +13,5 @@ pub const MIN_TRASPARENT_COINBASE_MATURITY: block::Height = block::Height(100);
 /// coinbase transactions.
 pub const MAX_BLOCK_REORG_HEIGHT: block::Height =
     block::Height(MIN_TRASPARENT_COINBASE_MATURITY.0 - 1);
+
+pub const SLED_FORMAT_VERSION: u32 = 0;

--- a/zebra-state/src/sled_state.rs
+++ b/zebra-state/src/sled_state.rs
@@ -243,6 +243,12 @@ impl FinalizedState {
 
                     // TODO: sprout and sapling anchors (per block)
 
+                    // Consensus-critical bug in zcashd: transactions in the
+                    // genesis block are ignored.
+                    if block.header.previous_block_hash == block::Hash([0; 32]) {
+                        return Ok(hash);
+                    }
+
                     // Index each transaction
                     for transaction in block.transactions.iter() {
                         let transaction_hash = transaction.hash();

--- a/zebra-state/src/sled_state/sled_format.rs
+++ b/zebra-state/src/sled_state/sled_format.rs
@@ -4,8 +4,9 @@ use std::{convert::TryInto, sync::Arc};
 use zebra_chain::{
     block,
     block::Block,
+    sapling,
     serialization::{ZcashDeserialize, ZcashSerialize},
-    transaction,
+    sprout, transaction,
     transaction::Transaction,
     transparent,
 };
@@ -86,6 +87,42 @@ impl IntoSled for block::Hash {
     }
     fn into_ivec(self) -> sled::IVec {
         self.as_bytes().as_ref().into()
+    }
+}
+
+impl IntoSled for &sprout::Nullifier {
+    type Bytes = [u8; 32];
+
+    fn as_bytes(&self) -> Self::Bytes {
+        self.0
+    }
+
+    fn into_ivec(self) -> sled::IVec {
+        self.as_bytes().as_ref().into()
+    }
+}
+
+impl IntoSled for &sapling::Nullifier {
+    type Bytes = [u8; 32];
+
+    fn as_bytes(&self) -> Self::Bytes {
+        self.0
+    }
+
+    fn into_ivec(self) -> sled::IVec {
+        self.as_bytes().as_ref().into()
+    }
+}
+
+impl IntoSled for () {
+    type Bytes = [u8; 0];
+
+    fn as_bytes(&self) -> Self::Bytes {
+        []
+    }
+
+    fn into_ivec(self) -> sled::IVec {
+        sled::IVec::default()
     }
 }
 

--- a/zebra-state/src/sled_state/sled_format.rs
+++ b/zebra-state/src/sled_state/sled_format.rs
@@ -1,0 +1,205 @@
+//! Module defining exactly how to move types in and out of sled
+use std::{convert::TryInto, sync::Arc};
+
+use zebra_chain::{
+    block,
+    block::Block,
+    serialization::{ZcashDeserialize, ZcashSerialize},
+    transaction,
+    transaction::Transaction,
+    transparent,
+};
+
+use crate::BoxError;
+
+// Helper trait for defining the exact format used to interact with sled per
+// type.
+pub trait IntoSled {
+    // The type used to compare a value as a key to other keys stored in a
+    // sled::Tree
+    type Bytes: AsRef<[u8]>;
+
+    // function to convert the current type to its sled format in `zs_get()`
+    // without necessarily allocating a new IVec
+    fn as_bytes(&self) -> Self::Bytes;
+
+    // function to convert the current type into its sled format
+    fn into_ivec(self) -> sled::IVec;
+}
+
+// Helper type for retrieving types from sled with the correct format
+pub trait FromSled: Sized {
+    // function to convert the sled bytes back into the deserialized type
+    fn from_ivec(bytes: sled::IVec) -> Result<Self, BoxError>;
+}
+
+impl IntoSled for &Block {
+    type Bytes = Vec<u8>;
+
+    fn as_bytes(&self) -> Self::Bytes {
+        self.zcash_serialize_to_vec()
+            .expect("serialization to vec doesn't fail")
+    }
+
+    fn into_ivec(self) -> sled::IVec {
+        self.as_bytes().into()
+    }
+}
+
+impl FromSled for Arc<Block> {
+    fn from_ivec(bytes: sled::IVec) -> Result<Self, BoxError> {
+        let block = Arc::<Block>::zcash_deserialize(bytes.as_ref())?;
+        Ok(block)
+    }
+}
+
+impl IntoSled for &Arc<Transaction> {
+    type Bytes = Vec<u8>;
+
+    fn as_bytes(&self) -> Self::Bytes {
+        self.zcash_serialize_to_vec()
+            .expect("serialization to vec doesn't fail")
+    }
+
+    fn into_ivec(self) -> sled::IVec {
+        self.as_bytes().into()
+    }
+}
+
+impl IntoSled for transaction::Hash {
+    type Bytes = [u8; 32];
+
+    fn as_bytes(&self) -> Self::Bytes {
+        self.0
+    }
+
+    fn into_ivec(self) -> sled::IVec {
+        self.as_bytes().as_ref().into()
+    }
+}
+
+impl IntoSled for block::Hash {
+    type Bytes = [u8; 32];
+
+    fn as_bytes(&self) -> Self::Bytes {
+        self.0
+    }
+    fn into_ivec(self) -> sled::IVec {
+        self.as_bytes().as_ref().into()
+    }
+}
+
+impl FromSled for block::Hash {
+    fn from_ivec(bytes: sled::IVec) -> Result<Self, BoxError> {
+        let array = bytes.as_ref().try_into().unwrap();
+        Ok(Self(array))
+    }
+}
+
+impl IntoSled for block::Height {
+    type Bytes = [u8; 4];
+
+    fn as_bytes(&self) -> Self::Bytes {
+        self.0.to_be_bytes()
+    }
+    fn into_ivec(self) -> sled::IVec {
+        self.as_bytes().as_ref().into()
+    }
+}
+
+impl FromSled for block::Height {
+    fn from_ivec(bytes: sled::IVec) -> Result<Self, BoxError> {
+        let array = bytes.as_ref().try_into().unwrap();
+        Ok(block::Height(u32::from_be_bytes(array)))
+    }
+}
+
+impl IntoSled for &transparent::Output {
+    type Bytes = Vec<u8>;
+
+    fn as_bytes(&self) -> Self::Bytes {
+        self.zcash_serialize_to_vec()
+            .expect("serialization to vec doesn't fail")
+    }
+
+    fn into_ivec(self) -> sled::IVec {
+        self.as_bytes().into()
+    }
+}
+
+impl FromSled for transparent::Output {
+    fn from_ivec(bytes: sled::IVec) -> Result<Self, BoxError> {
+        Self::zcash_deserialize(&*bytes).map_err(Into::into)
+    }
+}
+
+impl IntoSled for transparent::OutPoint {
+    type Bytes = Vec<u8>;
+
+    fn as_bytes(&self) -> Self::Bytes {
+        self.zcash_serialize_to_vec()
+            .expect("serialization to vec doesn't fail")
+    }
+
+    fn into_ivec(self) -> sled::IVec {
+        self.as_bytes().into()
+    }
+}
+
+/// Helper trait for inserting (Key, Value) pairs into sled with a consistently
+/// defined format
+pub trait SledSerialize {
+    /// Serialize and insert the given key and value into a sled tree.
+    fn zs_insert<K, V>(
+        &self,
+        key: K,
+        value: V,
+    ) -> Result<(), sled::transaction::UnabortableTransactionError>
+    where
+        K: IntoSled,
+        V: IntoSled;
+}
+
+impl SledSerialize for sled::transaction::TransactionalTree {
+    fn zs_insert<K, V>(
+        &self,
+        key: K,
+        value: V,
+    ) -> Result<(), sled::transaction::UnabortableTransactionError>
+    where
+        K: IntoSled,
+        V: IntoSled,
+    {
+        let key_bytes = key.into_ivec();
+        let value_bytes = value.into_ivec();
+        self.insert(key_bytes, value_bytes)?;
+        Ok(())
+    }
+}
+
+/// Helper trait for retrieving values from sled trees with a consistently
+/// defined format
+pub trait SledDeserialize {
+    /// Serialize the given key and use that to get and deserialize the
+    /// corresponding value from a sled tree, if it is present.
+    fn zs_get<K, V>(&self, key: &K) -> Result<Option<V>, BoxError>
+    where
+        K: IntoSled,
+        V: FromSled;
+}
+
+impl SledDeserialize for sled::Tree {
+    fn zs_get<K, V>(&self, key: &K) -> Result<Option<V>, BoxError>
+    where
+        K: IntoSled,
+        V: FromSled,
+    {
+        let key_bytes = key.as_bytes();
+
+        let value_bytes = self.get(key_bytes)?;
+
+        let value = value_bytes.map(V::from_ivec).transpose()?;
+
+        Ok(value)
+    }
+}

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -1,35 +1,6 @@
-use std::ffi::OsStr;
-
-use zebra_chain::{block, parameters::Network};
+use zebra_chain::block;
 
 use super::*;
-
-#[test]
-fn test_path_mainnet() {
-    test_path(Network::Mainnet);
-}
-
-#[test]
-fn test_path_testnet() {
-    test_path(Network::Testnet);
-}
-
-/// Check the sled path for `network`.
-fn test_path(network: Network) {
-    zebra_test::init();
-
-    let config = Config::default();
-    // we can't do many useful tests on this value, because it depends on the
-    // local environment and OS.
-    let sled_config = config.sled_config(network);
-    let mut path = sled_config.get_path();
-    assert_eq!(path.file_name(), Some(OsStr::new("state")));
-    assert!(path.pop());
-    match network {
-        Network::Mainnet => assert_eq!(path.file_name(), Some(OsStr::new("mainnet"))),
-        Network::Testnet => assert_eq!(path.file_name(), Some(OsStr::new("testnet"))),
-    }
-}
 
 /// Block heights, and the expected minimum block locator height
 static BLOCK_LOCATOR_CASES: &[(u32, u32)] = &[


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

At least for the near future, zebrad will not have the full test infrastructure
that we need to properly test new code paths that only get called on blocks
created after the sapling network upgrade, such as the `script::Verifier`. As a
result we are likely going to rely heavily on manual testing to verify new
features work as intended. We will then improve the speed with which we can
manually test zebra by backing up a copy of the `zebra-state` sled database
synced up to the sapling activation height, where we can easily reset by wiping
out the current sled database and replacing it with the backed up copy.

This plan however requires makes changes to the sled database format costly.
Each time we add a new tree to the sled database the backed up database must be
deleted and re-created from genesis. To alleviate this issue we need to get
sled as close to the final format as we can as quickly as possible.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This change adds the expected sled trees as defined in the RFC. At the time of
writing the precise set of trees needed is a known unknown. Once we've finished
implementing incremental merkle trees however we should be able to determine
the proper format of the rest of the trees needed and include them in this PR,
hopefully bringing us to our final stable sled database format.

As part of this PR I've introduced a set of helper traits for consolidating the
definitions for how our types are stored and retrieved from sled. This should
help improve auditability by isolating related logic to one part of the file,
and ensuring that we use a single definition for the conversion across
`sled_state.rs`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Related Issues

- [Tracking Issue](https://github.com/ZcashFoundation/zebra/issues/1049)

## Test Plan

The introduction of `IntoSled` and `FromSled` makes it possible to unit test
our conversion formats in a way that wasn't possible before. Now it should be
relatively trivial to add a set of proptests that test each type that has both
an `IntoSled` and a `FromSled` implementation to verify that the round trip
conversion always returns the correct value.

- [x] Move serialization helpers into a submodule of `sled_state.rs`
- [ ] Add prop tests for each type that implements both `IntoSled` and `FromSled`

## TODOs

- [x]  Add a version number to the path (e.g., ~/.cache/zebra/v1/mainnet/), detect when an older version is present, and delete it

#### Reviews

- [x] rebase on main and force-push, so GitHub's `Commits` and `Files Changed` only show changes from this PR

#### Bugs

- [x] If the block is a genesis block, skip any transaction updates. (Due to a bug in zcashd, genesis block transactions are ignored during validation.)
  - **Note: this fix requires a state version increment, because states containing genesis transactions allow some transactions that `zcashd` rejects.**

#### Incomplete

- [x] For each `TransparentInput::PrevOut { outpoint, .. }` in the transaction's `inputs()`, remove `outpoint` from `utxo_by_output`
- [x] Insert `(transaction_hash, BE32(block_height) || BE32(tx_index))` to `tx_by_hash`
- [x] For each `JoinSplit` description in the transaction, insert `(nullifiers[0],())` and `(nullifiers[1],())` into `sprout_nullifiers`
- [x] For each `Spend` description in the transaction, insert `(nullifier,())` into `sapling_nullifiers`

When we can compute anchors:
- [ ] Add sprout_anchors and sapling_anchors in `FinalizedState`
