### PR TITLE
Add team approval to the RFC pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/rfc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/rfc.md
@@ -29,3 +29,13 @@ XXXX-my-feature with the filename of the RFC
 
 -->
 [Rendered](https://github.com/ZcashFoundation/zebra/blob/my-branch-name/book/src/dev/rfcs/XXXX-my-feature.md).
+
+## Zebra Team Approval
+
+Everyone on the Zebra team should review design RFCs:
+
+- [ ] @dconnolly 
+- [ ] @hdevalence 
+- [ ] @oxarbitrage 
+- [ ] @teor2345 
+- [ ] @yaahc 


### PR DESCRIPTION
## Motivation

When we created the RFC process, we decided that all Zebra team members should review each RFC.

But sometimes team members forget to do a review, or RFCs are merged before everyone has had a chance to review.

## Solution

This change adds a list of team members to the RFC pull request template, with a checkbox for each team member.

## Review Guidelines (for Reviewer)

**Does this pull request improve Zebra?**

- [ ] Pull Request
  - The pull request is complete
  - The PR contains changes to related code (unrelated changes can be split into another PR)
  - Any follow-up tasks are listed in a GitHub issue

- [ ] Documentation
  - Docs summarise how the template should be used

## Zebra Team Approval

Since this is a decision we've already made, I don't think everyone needs to review it.