### PR TITLE
Enable zebrad sync tests by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fetch
-      - name: install LLVM on Windows
+      - name: Install LLVM on Windows
         if: matrix.os == 'windows-latest'
         run: choco install llvm -y
+      - name: Skip network tests on Ubuntu
+        # Ubuntu runners don't have network or DNS configured during test steps
+        if: matrix.os == 'ubuntu-latest'
+        run: echo "ZEBRA_SKIP_NETWORK_TESTS=1" >> $GITHUB_ENV
       - name: Run tests
         env:
           RUST_BACKTRACE: full
@@ -67,7 +71,7 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: install LLVM on Windows
+      - name: Install LLVM on Windows
         if: matrix.os == 'windows-latest'
         run: choco install llvm -y
       - name: cargo fetch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,10 @@ jobs:
       - name: Install LLVM on Windows
         if: matrix.os == 'windows-latest'
         run: choco install llvm -y
-      - name: Skip network tests on Ubuntu
+      - name: Skip network tests on Ubuntu and Windows
         # Ubuntu runners don't have network or DNS configured during test steps
-        if: matrix.os == 'ubuntu-latest'
+        # Windows runners have an unreliable network
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'
         run: echo "ZEBRA_SKIP_NETWORK_TESTS=1" >> $GITHUB_ENV
       - name: Run tests
         env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Skip network tests on Ubuntu
+        # Ubuntu runners don't have network or DNS configured during test steps
+        run: echo "ZEBRA_SKIP_NETWORK_TESTS=1" >> $GITHUB_ENV
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -231,7 +231,7 @@ impl<T> TestChild<T> {
             }
         }
 
-        if self.past_deadline() && self.is_running() {
+        if self.is_running() {
             // If the process exits between is_running and kill, we will see
             // spurious errors here. If that happens, ignore "no such process"
             // errors from kill.

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -460,7 +460,6 @@ fn valid_generated_config(command: &str, expected_output: &str) -> Result<()> {
 /// If your test environment does not have network access, skip
 /// this test by setting the `ZEBRA_SKIP_NETWORK_TESTS` env var.
 #[test]
-#[ignore]
 fn sync_one_checkpoint_mainnet() -> Result<()> {
     sync_one_checkpoint(Mainnet)
 }
@@ -470,7 +469,6 @@ fn sync_one_checkpoint_mainnet() -> Result<()> {
 /// If your test environment does not have network access, skip
 /// this test by setting the `ZEBRA_SKIP_NETWORK_TESTS` env var.
 #[test]
-#[ignore]
 fn sync_one_checkpoint_testnet() -> Result<()> {
     sync_one_checkpoint(Testnet)
 }


### PR DESCRIPTION
## Motivation

In the past, we have accidentally merged PRs that break `zebrad`'s sync functionality. So we want to add a basic genesis sync test to the `zebrad` acceptance tests.

## Solution

- [x] enable the sync tests by default 
- set the `ZEBRA_SKIP_NETWORK_TESTS` env var on any CI jobs that fail
  - [x] Disable `CI / Test on ubuntu-latest`, because it fails
  - [x] Check that other CI runners succeed
  - [x] Check if `Google Cloud Build` fails
    - needs branch in ZcashFoundation/zebra? - see #1180 
  - [x] Check if tests for `cd.yml` fail
    - needs merge to main?

## Related Issues

Closes #1141.

## Follow-up work

### CI Reliability

Make sure CI is reliable, even if the seeder sends us slow peers
* Tune the sync test timeouts, if needed
* Add sync retries, if needed

This work doesn't need a ticket - we only need to do it if we see CI failures.

### Extended Sync Tests

Once we are sure that the genesis sync is reliable, we can add longer sync tests.
See #1004 (RFC) and #745 (tracking issue) for details.
