### PR TITLE
Add a sync test with 2000 blocks, and make it off by default

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -482,7 +482,11 @@ fn sync_one_checkpoint_testnet() -> Result<()> {
 /// Test if `zebrad` can sync the second checkpoint on mainnet.
 ///
 /// The second checkpoint contains a large number of blocks.
+/// This test might fail or timeout on slow or unreliable networks,
+/// so we don't run it by default. It also takes a lot longer than
+/// our 10 second target time for default tests.
 #[test]
+#[ignore]
 fn sync_two_checkpoints_mainnet() -> Result<()> {
     sync_until(
         "verified checkpoint range block_count=2000",
@@ -493,8 +497,10 @@ fn sync_two_checkpoints_mainnet() -> Result<()> {
 
 /// Test if `zebrad` can sync the second checkpoint on testnet.
 ///
-/// The second checkpoint contains a large number of blocks.
+/// This test does not run by default, see `sync_two_checkpoints_mainnet`
+/// for details.
 #[test]
+#[ignore]
 fn sync_two_checkpoints_testnet() -> Result<()> {
     sync_until(
         "verified checkpoint range block_count=2000",

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -479,6 +479,30 @@ fn sync_one_checkpoint_testnet() -> Result<()> {
     )
 }
 
+/// Test if `zebrad` can sync the second checkpoint on mainnet.
+///
+/// The second checkpoint contains a large number of blocks.
+#[test]
+fn sync_two_checkpoints_mainnet() -> Result<()> {
+    sync_until(
+        "verified checkpoint range block_count=2000",
+        Mainnet,
+        Duration::from_secs(120),
+    )
+}
+
+/// Test if `zebrad` can sync the second checkpoint on testnet.
+///
+/// The second checkpoint contains a large number of blocks.
+#[test]
+fn sync_two_checkpoints_testnet() -> Result<()> {
+    sync_until(
+        "verified checkpoint range block_count=2000",
+        Testnet,
+        Duration::from_secs(120),
+    )
+}
+
 /// Sync `network` until `zebrad` outputs `regex`.
 /// Returns an error if `timeout` elapses before `regex` is output.
 ///


### PR DESCRIPTION
## Motivation

In #1179, I add a basic sync test, which downloads the first checkpoint.

But the first checkpoint only contains the genesis block. It would be good to test a bit more of Zebra.

## Solution

Add a sync test that downloads the second checkpoint, but make it off by default. We can't run it all the time, because it can take up to 2 minutes to complete. (Or fail on slow or unreliable networks.)

If we like this test, we should run it in CI.

## Related Issues

#1141 - basic sync test

## Follow-Up Work

- [x] Opened #1188 to enable `sync_two_checkpoints_mainnet` and `sync_two_checkpoints_testnet` in CI
