### PR TITLE
WIP - Validate shielded coinbase

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -210,12 +210,10 @@ impl Transaction {
     }
     /// Access the shielded data of this transaction.
     /// Only V4 transactions will return Some() if any shielded data is present.
-    pub fn shields(&self) -> Option<ShieldedData> {
+    pub fn shielded_data(&self) -> Option<&ShieldedData> {
         match self {
-            Transaction::V1 { .. } => None,
-            Transaction::V2 { .. } => None,
-            Transaction::V3 { .. } => None,
-            Transaction::V4 { shielded_data, .. } => shielded_data.clone(),
+            Transaction::V4 { shielded_data, .. } => shielded_data.as_ref(),
+            _ => None,
         }
     }
 }

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -185,4 +185,27 @@ impl Transaction {
     ) -> blake2b_simd::Hash {
         sighash::SigHasher::new(self, hash_type, network_upgrade, input).sighash()
     }
+
+    /// Access the joinsplits of this transaction, regardless of version.
+    // Todo: signature haves to be like:
+    // pub fn joinsplits<P: ZkSnarkProof>(&self) -> Option<JoinSplitData<P>> {
+    // but i was not able to make that work yet
+    pub fn joinsplits(&self) -> bool {
+        match self {
+            Transaction::V1 { .. } => false,
+            Transaction::V2 { joinsplit_data, .. } => joinsplit_data.is_some(),
+            Transaction::V3 { joinsplit_data, .. } => joinsplit_data.is_some(),
+            Transaction::V4 { joinsplit_data, .. } => joinsplit_data.is_some(),
+        }
+    }
+    /// Access the shielded data of this transaction.
+    /// Only V4 transactions will return Some() if any shielded data is present.
+    pub fn shields(&self) -> Option<ShieldedData> {
+        match self {
+            Transaction::V1 { .. } => None,
+            Transaction::V2 { .. } => None,
+            Transaction::V3 { .. } => None,
+            Transaction::V4 { shielded_data, .. } => shielded_data.clone(),
+        }
+    }
 }

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -99,6 +99,12 @@ pub fn subsidy_is_valid(block: &Block, network: Network) -> Result<(), BlockErro
         .activation_height(network)
         .expect("Canopy activation height is known");
 
+    // Validate shielded coinbase
+    let shielded_validation = subsidy::general::shielded_coinbase(height, network, coinbase);
+    if !shielded_validation {
+        panic!("Failed validating shielded coinbase");
+    }
+
     // TODO: the sum of the coinbase transaction outputs must be less than or equal to the block subsidy plus transaction fees
 
     // Check founders reward and funding streams

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -100,10 +100,7 @@ pub fn subsidy_is_valid(block: &Block, network: Network) -> Result<(), BlockErro
         .expect("Canopy activation height is known");
 
     // Validate shielded coinbase
-    let shielded_validation = subsidy::general::shielded_coinbase(height, network, coinbase);
-    if !shielded_validation {
-        panic!("Failed validating shielded coinbase");
-    }
+    subsidy::general::shielded_coinbase(height, network, coinbase)?;
 
     // TODO: the sum of the coinbase transaction outputs must be less than or equal to the block subsidy plus transaction fees
 

--- a/zebra-consensus/src/block/subsidy/general.rs
+++ b/zebra-consensus/src/block/subsidy/general.rs
@@ -102,6 +102,24 @@ pub fn find_output_with_amount(
         .collect()
 }
 
+/// Validate shielded consensus rules as described in [ZIP-213][ZIP-213]
+///
+/// [ZIP-213]: https://zips.z.cash/zip-0213#specification
+pub fn shielded_coinbase(height: Height, network: Network, transaction: &Transaction) -> bool {
+    let heartwood_height = Heartwood
+        .activation_height(network)
+        .expect("heartwood activation height should be available");
+
+    if height < heartwood_height {
+        if !transaction.joinsplits() && transaction.shields().is_none() {
+            return true;
+        }
+    } else if !transaction.joinsplits() {
+        return true;
+    }
+    false
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/zebra-consensus/src/block/subsidy/general.rs
+++ b/zebra-consensus/src/block/subsidy/general.rs
@@ -111,12 +111,13 @@ pub fn shielded_coinbase(height: Height, network: Network, transaction: &Transac
         .expect("heartwood activation height should be available");
 
     if height < heartwood_height {
-        if !transaction.joinsplits() && transaction.shields().is_none() {
+        if transaction.joinsplits().is_none() && transaction.shields().is_none() {
             return true;
         }
-    } else if !transaction.joinsplits() {
+    } else if transaction.joinsplits().is_none() {
         return true;
     }
+
     false
 }
 

--- a/zebra-consensus/src/block/subsidy/general.rs
+++ b/zebra-consensus/src/block/subsidy/general.rs
@@ -111,7 +111,7 @@ pub fn shielded_coinbase(height: Height, network: Network, transaction: &Transac
         .expect("heartwood activation height should be available");
 
     if height < heartwood_height {
-        if transaction.joinsplits().is_none() && transaction.shields().is_none() {
+        if transaction.joinsplits().is_none() && transaction.shielded_data().is_none() {
             return true;
         }
     } else if transaction.joinsplits().is_none() {

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -9,6 +9,9 @@ pub enum SubsidyError {
 
     #[error("founders reward output not found")]
     FoundersRewardNotFound,
+
+    #[error("shielded coinbase validation failed")]
+    ShieldedCoinbaseFailed,
 }
 
 #[derive(Error, Debug, PartialEq)]


### PR DESCRIPTION
## TODO

- [ ] Replace `Either` with a custom type
- [ ] Check we've implemented all the ZIP-213 rules
- [ ] Add tests
- [ ] Merge

## Motivation

Shielded coinbase are available after Heartwood NU. Consensus rules for this are described at [ZIP-213](https://zips.z.cash/zip-0213#specification)   

## Solution

Implement `shielded_coinbase()` function to the `subsidy::general` that makes rules validation.

## Related Issues

- https://github.com/ZcashFoundation/zebra/issues/608

- https://github.com/ZcashFoundation/zebra/pull/1129