### PR TITLE
Bind grafana to localhost in metrics instructions

### DIFF
--- a/book/src/user/metrics.md
+++ b/book/src/user/metrics.md
@@ -4,6 +4,8 @@ Zebra has support for Prometheus, configured using the [`MetricsSection`][metric
 
 This requires supporting infrastructure to collect and visualize metrics, for example:
 
+1. Install Prometheus and Grafana via Docker
+
 ```
 # create a storage volume for grafana (once)
 sudo docker volume create grafana-storage
@@ -18,5 +20,19 @@ sudo docker -d run --network host -e GF_SERVER_HTTP_PORT=3030 -e GF_SERVER_HTTP_
 ```
 
 Now the grafana dashboard is available at [http://localhost:3030](http://localhost:3030) ; the default username and password is `admin`/`admin`.
+Prometheus scrapes Zebra on `localhost:9999`, and provides the results on `locahost:9090`.
+
+2. Configure Grafana with a Prometheus HTTP Data Source, using Zebra's `metrics.endpoint_addr`.
+
+In zebrad.toml:
+```
+[metrics]
+endpoint_addr = "127.0.0.1:9999"
+```
+
+In the grafana dashboard:
+1. Create a new Prometheus Data Source
+2. Enter the HTTP URL: `127.0.0.1:9090`
+3. Save the configuration
 
 [metrics_section]: https://doc.zebra.zfnd.org/zebrad/config/struct.MetricsSection.html

--- a/book/src/user/metrics.md
+++ b/book/src/user/metrics.md
@@ -11,10 +11,10 @@ sudo docker volume create grafana-storage
 sudo docker volume create prometheus-storage
 
 # run prometheus with the included config
-sudo docker run --network host -v prometheus-storage:/prometheus -v /path/to/zebra/prometheus.yaml:/etc/prometheus/prometheus.yml  prom/prometheus
+sudo docker -d run --network host -v prometheus-storage:/prometheus -v /path/to/zebra/prometheus.yaml:/etc/prometheus/prometheus.yml  prom/prometheus
 
 # run grafana
-sudo docker run -d --network host -e GF_SERVER_HTTP_PORT=3030 -v grafana-storage:/var/lib/grafana grafana/grafana
+sudo docker -d run --network host -e GF_SERVER_HTTP_PORT=3030 -e GF_SERVER_HTTP_ADDR=localhost -v grafana-storage:/var/lib/grafana grafana/grafana
 ```
 
 Now the grafana dashboard is available at [http://localhost:3030](http://localhost:3030) ; the default username and password is `admin`/`admin`.


### PR DESCRIPTION
## Motivation

The Zebra metrics instructions bind grafana to all local interfaces, allowing access from the wider internet.

Since we run docker with host networking, docker containers have access to D-Bus and other
security-related services on localhost. So it's risky to also expose them to the wider internet.

## Solution

Binding grafana to localhost makes it inaccessible from the wider internet,
which is a secure default.

Users can modify this default by changing or removing the `GF_SERVER_HTTP_ADDR`.

Also detach both docker containers, so commands can be run in sequence.

## Related Issues

None