### PR TITLE
state: add config.debug_stop_at_height

### DIFF
--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -1,6 +1,8 @@
-use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use zebra_chain::parameters::Network;
+
+use serde::{Deserialize, Serialize};
+
+use zebra_chain::{block, parameters::Network};
 
 /// Configuration for the state service.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -38,6 +40,11 @@ pub struct Config {
     ///
     /// [`cache_dir`]: struct.Config.html#structfield.cache_dir
     pub ephemeral: bool,
+
+    /// If present, Zebra will shut down at the given block height.
+    ///
+    /// This is useful for debugging.
+    pub debug_stop_at_height: Option<block::Height>,
 }
 
 impl Config {
@@ -79,6 +86,7 @@ impl Default for Config {
             cache_dir,
             memory_cache_bytes: 512 * 1024 * 1024,
             ephemeral: false,
+            debug_stop_at_height: None,
         }
     }
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -46,8 +46,6 @@ struct StateService {
     pending_utxos: utxo::PendingUtxos,
     /// Instant tracking the last time `pending_utxos` was pruned
     last_prune: Instant,
-    /// If set, stop after this height is reached.
-    debug_stop_at_height: Option<block::Height>,
 }
 
 impl StateService {
@@ -65,7 +63,6 @@ impl StateService {
             queued_blocks,
             pending_utxos,
             last_prune: Instant::now(),
-            debug_stop_at_height: config.debug_stop_at_height,
         }
     }
 
@@ -138,10 +135,6 @@ impl StateService {
                     .map_err(CloneError::from);
                 let _ = rsp_tx.send(result);
                 new_parents.push(hash);
-                if self.debug_stop_at_height == block.coinbase_height() {
-                    tracing::info!("reached stop height, shutting down");
-                    std::process::exit(0)
-                }
             }
         }
     }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -130,7 +130,7 @@ impl StateService {
             for QueuedBlock { block, rsp_tx } in queued_children {
                 let hash = block.hash();
                 let result = self
-                    .validate_and_commit(block.clone())
+                    .validate_and_commit(block)
                     .map(|()| hash)
                     .map_err(CloneError::from);
                 let _ = rsp_tx.send(result);


### PR DESCRIPTION
Adds an option for debugging that exits the process after a block with
the specified height has been received by the state system.

## Motivation

We'd like to be able to shut down the node at a particular height, for use in testing, generating state dumps, etc.

## Solution

Adds a `debug_stop_at_height` option to the config, and checks after attempting to commit a block whether the block's coinbase height is the stop height.
