### PR TITLE
Perform state reads synchronously, avoid transactional writes

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -7,7 +7,7 @@ use std::{
     time::Instant,
 };
 
-use futures::future::{FutureExt, TryFutureExt};
+use futures::future::FutureExt;
 use memory_state::{NonFinalizedState, QueuedBlocks};
 use tokio::sync::broadcast;
 use tower::{util::BoxService, Service};
@@ -213,26 +213,24 @@ impl Service<Request> for StateService {
             }
             Request::Depth(hash) => {
                 // todo: handle in memory and sled
-                self.sled.depth(hash).map_ok(Response::Depth).boxed()
+                let rsp = self.sled.depth(hash).map(Response::Depth);
+                async move { rsp }.boxed()
             }
             Request::Tip => {
                 // todo: handle in memory and sled
-                self.sled.tip().map_ok(Response::Tip).boxed()
+                let rsp = self.sled.tip().map(Response::Tip);
+                async move { rsp }.boxed()
             }
             Request::BlockLocator => {
                 // todo: handle in memory and sled
-                self.sled
-                    .block_locator()
-                    .map_ok(Response::BlockLocator)
-                    .boxed()
+                let rsp = self.sled.block_locator().map(Response::BlockLocator);
+                async move { rsp }.boxed()
             }
             Request::Transaction(_) => unimplemented!(),
             Request::Block(hash_or_height) => {
                 //todo: handle in memory and sled
-                self.sled
-                    .block(hash_or_height)
-                    .map_ok(Response::Block)
-                    .boxed()
+                let rsp = self.sled.block(hash_or_height).map(Response::Block);
+                async move { rsp }.boxed()
             }
             Request::AwaitUtxo(outpoint) => {
                 let fut = self.pending_utxos.queue(outpoint);

--- a/zebra-state/src/sled_state.rs
+++ b/zebra-state/src/sled_state.rs
@@ -1,6 +1,6 @@
 //! The primary implementation of the `zebra_state::Service` built upon sled
 
-use std::{collections::HashMap, convert::TryInto,  sync::Arc};
+use std::{collections::HashMap, convert::TryInto, sync::Arc};
 
 use tracing::trace;
 use zebra_chain::{


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

Metrics revealed that after introducing the state component, it became the bottleneck for checkpointed sync:
 
![Screenshot from 2020-10-22 22-18-15](https://user-images.githubusercontent.com/44879/97055598-fa358f80-153b-11eb-8c1c-0a9666a5ab08.png)

Using perf + [inferno](https://docs.rs/inferno/0.10.1/inferno/index.html) revealed that we spend a lot of time on locking:  

![Screenshot from 2020-10-23 12-58-54](https://user-images.githubusercontent.com/44879/97055680-27823d80-153c-11eb-9971-c74c1fda2d9f.png)

However, we already use an actor model with message passing for state queries, so all queries are processed in one thread and the only reason writes have to be transactional is that we defer reads to returned futures.

## Solution

Perform reads synchronously and remove use of the transactional sled API, significantly improving performance.

![Screenshot from 2020-10-23 14-25-39](https://user-images.githubusercontent.com/44879/97056334-957b3480-153d-11eb-9f4f-2af40f018007.png)
![Screenshot from 2020-10-23 14-34-27](https://user-images.githubusercontent.com/44879/97056316-8d22f980-153d-11eb-808d-2c7c95baa1a2.png)

(The legend in the second panel of the grafana screenshot is cut off, but it's 10s windows instead of 1s windows.  Notice that the rates line up, indicating that we propagate backpressure properly)

