### PR TITLE
Update block metrics after async transaction verification

### DIFF
--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -178,6 +178,7 @@ where
             while let Some(result) = async_checks.next().await {
                 result.map_err(VerifyBlockError::Transaction)?;
             }
+
             // Update the metrics after all the validation is finished
             tracing::trace!("verified block");
             metrics::gauge!("block.verified.block.height", height.0 as _);

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -162,10 +162,6 @@ where
 
             // TODO: context-free header verification: merkle root
 
-            tracing::trace!("verified block");
-            metrics::gauge!("block.verified.block.height", height.0 as _);
-            metrics::counter!("block.verified.block.count", 1);
-
             let mut async_checks = FuturesUnordered::new();
 
             for transaction in &block.transactions {
@@ -182,6 +178,10 @@ where
             while let Some(result) = async_checks.next().await {
                 result.map_err(VerifyBlockError::Transaction)?;
             }
+            
+            tracing::trace!("verified block");
+            metrics::gauge!("block.verified.block.height", height.0 as _);
+            metrics::counter!("block.verified.block.count", 1);
 
             // Finally, submit the block for contextual verification.
             match state_service

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -179,6 +179,7 @@ where
                 result.map_err(VerifyBlockError::Transaction)?;
             }
             
+            // Update the metrics after all the validation is finished
             tracing::trace!("verified block");
             metrics::gauge!("block.verified.block.height", height.0 as _);
             metrics::counter!("block.verified.block.count", 1);

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -178,7 +178,6 @@ where
             while let Some(result) = async_checks.next().await {
                 result.map_err(VerifyBlockError::Transaction)?;
             }
-            
             // Update the metrics after all the validation is finished
             tracing::trace!("verified block");
             metrics::gauge!("block.verified.block.height", height.0 as _);


### PR DESCRIPTION
## Motivation

Previously, the `BlockVerifier` updated the block verification metrics immediately before calling `CommitBlock`.

But in #1173, we added async transaction verification to the `BlockVerifier`, between the metrics update and `CommitBlock`.

This re-ordering of metrics and validation could confuse metrics users.

## Solution

Move all the `BlockVerifier` validation before the metrics update.

## Related Issues

This bug was introduced in #1173.
