### PR TITLE
Force Clippy nightly lints to all warn, never error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           name: Clippy (nightly)
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets
+          args: --all-features --all-targets -- -W clippy::all
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
## Motivation

Our current Clippy nightly job does not force warnings to error, but errors still error, even though we never want the informational nightly job to result in a failed GItHub check.

## Solution

Tell rustc that all default Clippy lints result in warnings, never errors/denials.
