### PR TITLE
Sync test reliability

### DIFF
--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -528,6 +528,7 @@ where
         //
         // So we just download and verify the genesis block here.
         while !self.state_contains(self.genesis_hash).await? {
+            tracing::info!("starting genesis block download and verify");
             self.downloads
                 .download_and_verify(self.genesis_hash)
                 .await

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -148,6 +148,9 @@ where
         // making a less-fallible network service, and the Hedge layer
         // tries to reduce latency of that less-fallible service.
         //
+        // We hedge every request. If we don't have any recent timings,
+        // Hedge issues a second request with no delay.
+        //
         // XXX add ServiceBuilder::hedge() so this becomes
         // ServiceBuilder::new().hedge(...).retry(...)...
         let block_network = Hedge::new(
@@ -157,7 +160,7 @@ where
                 .timeout(BLOCK_DOWNLOAD_TIMEOUT)
                 .service(peers),
             AlwaysHedge,
-            20,
+            0,
             0.95,
             2 * SYNC_RESTART_TIMEOUT,
         );


### PR DESCRIPTION
## Motivation

The testnet genesis sync tests are unreliable: they don't complete before the 30 second test timeout.

There could be a few causes for this issue, based on the logs:
- the initial peer setup is slow
- the peer chosen for the first genesis download attempt is slow, and hedging doesn't start until block 20

## Solution

- [x] Activate Hedge as soon as Zebra starts (from the genesis block download), rather than waiting until the histogram has 20 entries
  - this change improves request latency at genesis, immediately after a restart, and after long network delays
- [x] Improve genesis block download diagnostics

## Related Issues

Closes #1207 

## Follow-Up Tasks

- Disable testnet sync tests, unless an env var is specified (open a new ticket, if there is a testnet sync failure after this fix)
- Deploy more zcashd instances on testnet (#1222)