### PR TITLE
Add network integration test for quick post sapling sync testing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           gcloud compute instance-templates create-with-container "zebrad-$BRANCH_NAME-$SHORT_SHA" \
           --container-image "gcr.io/$PROJECT_ID/$REPOSITORY/$BRANCH_NAME:$SHORT_SHA" \
-          --create-disk name=zebrad-cache-$SHORT_SHA,size=100GB,type=pd-balanced,auto-delete=no \
+          --create-disk name=zebrad-cache-$SHORT_SHA,size=100GB,type=pd-balanced \
           --container-mount-disk mount-path="/zebrad-cache",name=zebrad-cache-$SHORT_SHA \
           --machine-type n2d-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --manifest-path zebrad/Cargo.toml sync_large_checkpoints_mainnet sync_large_checkpoints_testnet -- --ignored
+          args: --verbose --manifest-path zebrad/Cargo.toml sync_large_checkpoints_ -- --ignored
       - name: Run zebrad tracing test
         env:
           RUST_BACKTRACE: full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --manifest-path zebrad/Cargo.toml -- --ignored
+          args: --verbose --manifest-path zebrad/Cargo.toml sync_large_checkpoints_mainnet sync_large_checkpoints_testnet -- --ignored
+      - name: Run zebrad tracing test
+        env:
+          RUST_BACKTRACE: full
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --manifest-path zebrad/Cargo.toml tracing_endpoint -- --ignored
 
   build-chain-no-features:
     name: Build zebra-chain w/o features on ubuntu-latest

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -58,7 +58,7 @@ jobs:
         gcloud compute instances create-with-container "zebrad-$BRANCH_NAME-$SHORT_SHA" \
         --container-image "gcr.io/$PROJECT_ID/$REPOSITORY/$BRANCH_NAME:$SHORT_SHA" \
         --container-mount-disk mount-path='/zebrad-cache',name=zebrad-cache-$SHORT_SHA \
-        --create-disk name=zebrad-cache-$SHORT_SHA,size=100GB,type=pd-balanced,auto-delete=no \
+        --create-disk name=zebrad-cache-$SHORT_SHA,size=100GB,type=pd-balanced \
         --machine-type n2-standard-4 \
         --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
         --tags zebrad \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           cd zebra/;
           docker build -f docker/Dockerfile.test -t zebrad-test .;
           docker run -i zebrad-test cargo test --workspace --no-fail-fast -- -Zunstable-options --include-ignored;
-          docker run -it --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-mainnet-sapling-activation,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_sapling_mainnet --manifest-path zebrad/Cargo.toml sync_to_sapling_mainnet;
+          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-mainnet-sapling-activation,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_sapling_mainnet --manifest-path zebrad/Cargo.toml sync_to_sapling_mainnet;
           "
       # Clean up
       - name: Delete test instance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,8 +52,8 @@ jobs:
           --boot-disk-size 100GB \
           --boot-disk-type pd-ssd \
           --container-image rust:buster \
-          --container-mount-disk mount-path='/zebrad-cache',name=zebrad-cache-mainnet-sapling-activation \
-          --create-disk name=zebrad-cache-mainnet-sapling-activation,image=zebrad-cache-062a5ae-mainnet-height-419200 \
+          --container-mount-disk mount-path='/zebrad-cache',name="zebrad-cache-$SHORT_SHA-mainnet-419200" \
+          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-419200",image=zebrad-cache-062a5ae-mainnet-height-419200 \
           --machine-type n2-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,11 +48,12 @@ jobs:
       # Creates Compute Engine virtual machine instance w/ disks
       - name: Create instance
         run: |
-          gcloud compute instances create "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" \
+          gcloud compute instances create-with-container "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" \
           --boot-disk-size 100GB \
           --boot-disk-type pd-ssd \
-          --image-family cos-stable \
-          --image-project cos-cloud \
+          --container-image rust:buster \
+          --container-mount-disk mount-path='/zebrad-cache',name=zebrad-cache-mainnet-sapling-activation \
+          --create-disk name=zebrad-cache-mainnet-sapling-activation,image=zebrad-cache-062a5ae-mainnet-height-419200 \
           --machine-type n2-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
@@ -62,9 +63,13 @@ jobs:
       # Build and run test container
       - name: Run all tests
         run: |
-          gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --zone "$ZONE" \
-          --command "git clone -b $BRANCH_NAME https://github.com/ZcashFoundation/zebra.git; cd zebra/; docker build -f docker/Dockerfile.test -t zebrad-test .; docker run -i zebrad-test cargo test --workspace --no-fail-fast -- -Zunstable-options --include-ignored"
-
+          gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --zone "$ZONE" --command \
+          "git clone -b $BRANCH_NAME https://github.com/ZcashFoundation/zebra.git;
+          cd zebra/;
+          docker build -f docker/Dockerfile.test -t zebrad-test .;
+          docker run -i zebrad-test cargo test --workspace --no-fail-fast -- -Zunstable-options --include-ignored;
+          docker run -it --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-mainnet-sapling-activation,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_sapling_mainnet --manifest-path zebrad/Cargo.toml sync_to_sapling_mainnet;
+          "
       # Clean up
       - name: Delete test instance
         # Always run even if the earlier step fails

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           cd zebra/;
           docker build -f docker/Dockerfile.test -t zebrad-test .;
           docker run -i zebrad-test cargo test --workspace --no-fail-fast -- -Zunstable-options --include-ignored;
-          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-mainnet-sapling-activation,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_sapling_mainnet --manifest-path zebrad/Cargo.toml sync_to_sapling_mainnet;
+          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-419200,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_sapling_mainnet --manifest-path zebrad/Cargo.toml sync_to_sapling_mainnet;
           "
       # Clean up
       - name: Delete test instance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           cd zebra/;
           docker build -f docker/Dockerfile.test -t zebrad-test .;
           docker run -i zebrad-test cargo test --workspace --no-fail-fast -- -Zunstable-options --include-ignored;
-          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-419200,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_sapling_mainnet --manifest-path zebrad/Cargo.toml sync_to_sapling_mainnet;
+          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-419200,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_past_sapling_mainnet --manifest-path zebrad/Cargo.toml sync_past_sapling_mainnet;
           "
       # Clean up
       - name: Delete test instance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
           echo "SHORT_SHA=$(git rev-parse --short=7 $GITHUB_SHA)" >> $GITHUB_ENV && \
           echo "REPOSITORY=$REPOSITORY" >> $GITHUB_ENV
 
-      # Setup gcloud CLI
       - name: Set up gcloud
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
@@ -52,8 +51,11 @@ jobs:
           --boot-disk-size 100GB \
           --boot-disk-type pd-ssd \
           --container-image rust:buster \
-          --container-mount-disk mount-path='/zebrad-cache',name="zebrad-cache-$SHORT_SHA-mainnet-419200" \
-          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-419200",image=zebrad-cache-062a5ae-mainnet-height-419200 \
+          --container-mount-disk mount-path='/mainnet',name="zebrad-cache-$SHORT_SHA-mainnet-419200" \
+          --container-mount-disk mount-path='/testnet',name="zebrad-cache-$SHORT_SHA-testnet-280000" \
+          --container-restart-policy never \
+          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-419200",image=zebrad-cache-062a5ae-mainnet-419200 \
+          --create-disk name="zebrad-cache-$SHORT_SHA-testnet-280000",image=zebrad-cache-2935b4e-testnet-280000 \
           --machine-type n2-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
@@ -69,6 +71,7 @@ jobs:
           docker build -f docker/Dockerfile.test -t zebrad-test .;
           docker run -i zebrad-test cargo test --workspace --no-fail-fast -- -Zunstable-options --include-ignored;
           docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-419200,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_past_sapling_mainnet --manifest-path zebrad/Cargo.toml sync_past_sapling_mainnet;
+          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-testnet-280000,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_past_sapling_testnet --manifest-path zebrad/Cargo.toml sync_past_sapling_testnet;
           "
       # Clean up
       - name: Delete test instance

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -16,4 +16,6 @@ EXPOSE 8233 18233
 
 COPY . .
 
+RUN cargo test --all --no-run
+
 CMD cargo test --workspace --no-fail-fast -- -Zunstable-options --include-ignored

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
 
@@ -9,6 +11,15 @@ pub enum Network {
     Mainnet,
     /// The testnet.
     Testnet,
+}
+
+impl fmt::Display for Network {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Network::Mainnet => f.write_str("Mainnet"),
+            Network::Testnet => f.write_str("Testnet"),
+        }
+    }
 }
 
 impl Network {

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -6,9 +6,10 @@ use tracing::instrument;
 
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
-use std::{convert::Infallible as NoDir, io::BufRead};
 use std::{
+    convert::Infallible as NoDir,
     fmt::Write as _,
+    io::BufRead,
     io::{BufReader, Lines, Read},
     path::Path,
     process::{Child, ChildStdout, Command, ExitStatus, Output, Stdio},

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -4,14 +4,12 @@ use color_eyre::{
 };
 use tracing::instrument;
 
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
 use std::{convert::Infallible as NoDir, io::BufRead};
 use std::{
     fmt::Write as _,
-    io::{BufReader, Lines},
-};
-#[cfg(unix)]
-use std::{io::Read, os::unix::process::ExitStatusExt};
-use std::{
+    io::{BufReader, Lines, Read},
     path::Path,
     process::{Child, ChildStdout, Command, ExitStatus, Output, Stdio},
     time::{Duration, Instant},

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -86,7 +86,7 @@ impl CommandExt for Command {
             dir,
             deadline: None,
             stdout: None,
-            bypass_test_stdout: false,
+            bypass_test_capture: false,
         })
     }
 }
@@ -153,7 +153,7 @@ pub struct TestChild<T> {
     pub child: Child,
     pub stdout: Option<Lines<BufReader<ChildStdout>>>,
     pub deadline: Option<Instant>,
-    bypass_test_stdout: bool,
+    bypass_test_capture: bool,
 }
 
 impl<T> TestChild<T> {
@@ -194,8 +194,8 @@ impl<T> TestChild<T> {
 
     /// Configures testrunner to forward stdout to the true stdout rather than
     /// fakestdout used by cargo tests.
-    pub fn bypass_test_stdout(mut self, cond: bool) -> Self {
-        self.bypass_test_stdout = cond;
+    pub fn bypass_test_capture(mut self, cond: bool) -> Self {
+        self.bypass_test_capture = cond;
         self
     }
 
@@ -230,7 +230,7 @@ impl<T> TestChild<T> {
             // since we're about to discard this line write it to stdout so our
             // test runner can capture it and display if the test fails, may
             // cause weird reordering for stdout / stderr
-            if !self.bypass_test_stdout {
+            if !self.bypass_test_capture {
                 println!("{}", line);
             } else {
                 use std::io::Write;

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -44,3 +44,9 @@ abscissa_core = { version = "0.5", features = ["testing"] }
 once_cell = "1.5"
 tempdir = "0.3.7"
 zebra-test = { path = "../zebra-test" }
+
+[features]
+test_sync_to_sapling_mainnet = []
+test_sync_to_sapling_testnet = []
+test_sync_past_sapling_mainnet = []
+test_sync_past_sapling_testnet = []

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -13,7 +13,7 @@
 
 #![warn(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]
-#![allow(clippy::dead_code)]
+#![allow(dead_code)]
 #![allow(clippy::field_reassign_with_default)]
 #![allow(clippy::try_err)]
 #![allow(clippy::unknown_clippy_lints)]

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -614,10 +614,9 @@ fn sync_until(
     network: Network,
     stop_regex: &str,
     timeout: Duration,
-    reuse_tempdir: impl Into<Option<TempDir>>,
+    reuse_tempdir: Option<TempDir>,
 ) -> Result<TempDir> {
     zebra_test::init();
-    let reuse_tempdir = reuse_tempdir.into();
 
     if env::var_os("ZEBRA_SKIP_NETWORK_TESTS").is_some() {
         // This message is captured by the test runner, use
@@ -668,6 +667,7 @@ fn create_cached_database_height(network: Network, height: Height) -> Result<()>
     config.network.network = network;
     config.state.debug_stop_at_height = Some(height.0);
     let dir = PathBuf::from("/");
+
     fs::File::create(dir.join("zebrad.toml"))?.write_all(toml::to_string(&config)?.as_bytes())?;
 
     let mut child = dir.spawn_child(&["start"])?.with_timeout(timeout);

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -651,7 +651,6 @@ fn cached_sapling_test_config() -> Result<ZebradConfig> {
     let mut config = persistent_test_config()?;
     config.consensus.checkpoint_sync = true;
     config.state.cache_dir = "/zebrad-cache".into();
-    config.state.memory_cache_bytes = 52428800;
     Ok(config)
 }
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -688,10 +688,19 @@ fn create_cached_database(network: Network) -> Result<()> {
 }
 
 fn sync_past_sapling(network: Network) -> Result<()> {
-    let height = NetworkUpgrade::Sapling.activation_height(network).unwrap() + 1000;
+    let height = NetworkUpgrade::Sapling.activation_height(network).unwrap() + 1200;
     create_cached_database_height(network, height.unwrap())
 }
 
+// These tests are ignored because they're too long running to run during our
+// traditional CI, and they depend on persistent state that cannot be made
+// available in github actions or google cloud build. Instead we run these tests
+// directly in a vm we spin up on google compute engine, where we can mount
+// drives populated by the first two tests and then use those to more quickly
+// run the second two tests.
+
+// Create a cached copy of the mainnet database up to the sapling activation
+// height.
 #[test]
 #[ignore]
 fn create_mainnet_cache() {
@@ -699,6 +708,8 @@ fn create_mainnet_cache() {
     let network = Mainnet;
     create_cached_database(network).unwrap();
 }
+// Create a cached copy of the testnet database up to the sapling activation
+// height.
 #[test]
 #[ignore]
 fn create_testnet_cache() {
@@ -707,6 +718,7 @@ fn create_testnet_cache() {
     create_cached_database(network).unwrap();
 }
 
+/// Test syncing 1200 blocks (3 checkpoints) past the last checkpoint on mainnet.
 #[test]
 #[ignore]
 fn sync_past_sapling_mainnet() {
@@ -715,6 +727,7 @@ fn sync_past_sapling_mainnet() {
     sync_past_sapling(network).unwrap();
 }
 
+/// Test syncing 1200 blocks (3 checkpoints) past the last checkpoint on testnet.
 #[test]
 #[ignore]
 fn sync_past_sapling_testnet() {

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -672,7 +672,7 @@ fn create_cached_database_height(network: Network, height: Height) -> Result<()>
     let mut child = dir
         .spawn_child(&["start"])?
         .with_timeout(timeout)
-        .bypass_test_stdout(true);
+        .bypass_test_capture(true);
 
     let network = format!("network: {},", network);
     child.expect_stdout(&network)?;

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -13,9 +13,10 @@
 
 #![warn(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]
+#![allow(clippy::dead_code)]
+#![allow(clippy::field_reassign_with_default)]
 #![allow(clippy::try_err)]
 #![allow(clippy::unknown_clippy_lints)]
-#![allow(clippy::field_reassign_with_default)]
 
 use color_eyre::eyre::Result;
 use eyre::WrapErr;
@@ -698,28 +699,27 @@ fn sync_past_sapling(network: Network) -> Result<()> {
 // drives populated by the first two tests, snapshot those drives, and then use
 // those to more quickly run the second two tests.
 
-// Create a cached copy of the mainnet database up to the sapling activation
-// height.
-#[test]
-#[ignore]
-fn create_mainnet_cache() {
+// Sync up to the sapling activation height on mainnet and stop.
+#[cfg_attr(feature = "test_sync_to_sapling_mainnet", test)]
+fn sync_to_sapling_mainnet() {
     zebra_test::init();
     let network = Mainnet;
     create_cached_database(network).unwrap();
 }
-// Create a cached copy of the testnet database up to the sapling activation
-// height.
-#[test]
-#[ignore]
-fn create_testnet_cache() {
+// Sync to the sapling activation height testnet and stop.
+#[cfg_attr(feature = "test_sync_to_sapling_testnet", test)]
+fn sync_to_sapling_testnet() {
     zebra_test::init();
     let network = Testnet;
     create_cached_database(network).unwrap();
 }
 
 /// Test syncing 1200 blocks (3 checkpoints) past the last checkpoint on mainnet.
-#[test]
-#[ignore]
+///
+/// This assumes that the config'd state is already synced at or near Sapling
+/// activation on mainnet. If the state has already synced past Sapling
+/// activation by 1200 blocks, it will fail.
+#[cfg_attr(feature = "test_sync_past_sapling_mainnet", test)]
 fn sync_past_sapling_mainnet() {
     zebra_test::init();
     let network = Mainnet;
@@ -727,8 +727,11 @@ fn sync_past_sapling_mainnet() {
 }
 
 /// Test syncing 1200 blocks (3 checkpoints) past the last checkpoint on testnet.
-#[test]
-#[ignore]
+///
+/// This assumes that the config'd state is already synced at or near Sapling
+/// activation on testnet. If the state has already synced past Sapling
+/// activation by 1200 blocks, it will fail.
+#[cfg_attr(feature = "test_sync_past_sapling_testnet", test)]
 fn sync_past_sapling_testnet() {
     zebra_test::init();
     let network = Testnet;

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -696,8 +696,8 @@ fn sync_past_sapling(network: Network) -> Result<()> {
 // traditional CI, and they depend on persistent state that cannot be made
 // available in github actions or google cloud build. Instead we run these tests
 // directly in a vm we spin up on google compute engine, where we can mount
-// drives populated by the first two tests and then use those to more quickly
-// run the second two tests.
+// drives populated by the first two tests, snapshot those drives, and then use
+// those to more quickly run the second two tests.
 
 // Create a cached copy of the mainnet database up to the sapling activation
 // height.


### PR DESCRIPTION
## Motivation

This change implements the second of three tests described in the [basic network integration testing RFC](https://github.com/ZcashFoundation/zebra/pull/1007). This test is meant to act as a quick test of sync behavior immediately post checkpointing.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This test is implemented by persisting a copy of the database that has been synced to sapling checkpoint height. This starting point is then used to sync the next few thousand blocks immediately after the Sapling activation.

## Related Issues

- https://github.com/ZcashFoundation/zebra/pull/1007

## Unresolved Questions

This design is currently an incomplete sketch of just the initial pieces of the final integration test. Syncing to a certain point and backing up the database, and starting from the backup if one already exists. This doesn't help us on our CI as it is currently implemented. Github Actions and Google Cloud Build both have little to no support for persistent data on test runners. We would have to copy the entire database over the network before each test run. There are a couple of solutions that I'm currently investigating:

### VM + Custom Job Queue

Setup a persistent VM used to run these tests and some basic CI infra that can be used to dispatch and queue test jobs to that VM. That VM would then own the persisted copy of the up-to-sapling database. Test jobs would be sent from github actions and/or google cloud build, which would tell the remote VM to download the pre compiled zebrad image and run the test. Once the test completes it would reply back to the runner that requested the job, passing it the test results and letting its process exit.

### Custom FUSE

Alternatively, we might be able to setup a simple FUSE that we can then mount in our Github Actions or Google Cloud Build containers. The FUSE would be only implement the minimum API needed to represent the single database file used by sled. It would implement copy on write functionality, where if sled tries to read a block that hasn't been updated locally it will read that block from the database file over the network, and if sled tries to write to an existing block or write a new one it would store the new block data in memory or on another file locally, rather than writing that data back to the database file on the network.

Edit: I've been doing more research on this option, it looks like all we'd need to do is setup a webserver to store the synced sled database files, then we could read bits and pieces of those files with https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests. Then we'd have a binary we run in ci to mount the FUSE in the tempdir, and based on which parts of the database file it needs to read it would either use the locally cached data (from previous writes) or do an http fetch to get the piece of the database it needs over the network for first time reads of old data.
