### PR TITLE
Silence a clippy equal arguments warning

### DIFF
--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -609,6 +609,7 @@ mod test {
         Ok(())
     }
 
+    #[allow(clippy::eq_op)]
     fn ordering<C1, C2>() -> Result<()>
     where
         C1: Constraint + Debug,


### PR DESCRIPTION
The unit tests need to pass identical arguments to an equality comparison,
to make sure equality is implemented correctly.