### PR TITLE
state: document memory_cache_bytes, reduce default

### DIFF
--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -27,7 +27,16 @@ pub struct Config {
     /// | Other   | `std::env::current_dir()/cache`                 |                                    |
     pub cache_dir: PathBuf,
 
-    /// The maximum number of bytes to use caching data in memory.
+    /// Controls the size of the database cache, in bytes.
+    ///
+    /// This corresponds to `sled`'s [`cache_capacity`][cc] parameter.
+    /// Note that the behavior of this parameter is [somewhat
+    /// unintuitive][gh], measuring the on-disk size of the cached data,
+    /// not the in-memory size, which may be much larger, especially for
+    /// smaller keys and values.
+    ///
+    /// [cc]: https://docs.rs/sled/0.34.4/sled/struct.Config.html#method.cache_capacity
+    /// [gh]: https://github.com/spacejam/sled/issues/986#issuecomment-592950100
     pub memory_cache_bytes: u64,
 
     /// Whether to use an ephemeral database.
@@ -87,7 +96,7 @@ impl Default for Config {
 
         Self {
             cache_dir,
-            memory_cache_bytes: 512 * 1024 * 1024,
+            memory_cache_bytes: 50_000_000,
             ephemeral: false,
             debug_stop_at_height: None,
         }


### PR DESCRIPTION
Closes #1026

Because of the way that sled uses this parameter, the actual in-memory
size may be much larger.  Dialing this down should help avoid high
memory usage.