### PR TITLE
Replace into with Some in difficulty::arbitrary

### DIFF
--- a/zebra-chain/src/work/difficulty/arbitrary.rs
+++ b/zebra-chain/src/work/difficulty/arbitrary.rs
@@ -18,9 +18,8 @@ impl Arbitrary for CompactDifficulty {
                 // In the Zcash protocol, a CompactDifficulty is generated using the difficulty
                 // adjustment functions. Instead of using those functions, we make a random
                 // ExpandedDifficulty, then convert it to a CompactDifficulty.
-                ExpandedDifficulty::from_hash(&block::Hash(bytes))
-                    .to_compact()
-                    .into()
+                Some(ExpandedDifficulty::from_hash(&block::Hash(bytes))
+                    .to_compact())
             })
             .boxed()
     }
@@ -58,7 +57,7 @@ impl Arbitrary for Work {
                 if w == 0 {
                     None
                 } else {
-                    Work(w).into()
+                    Some(Work(w))
                 }
             })
             .boxed()

--- a/zebra-chain/src/work/difficulty/arbitrary.rs
+++ b/zebra-chain/src/work/difficulty/arbitrary.rs
@@ -18,8 +18,7 @@ impl Arbitrary for CompactDifficulty {
                 // In the Zcash protocol, a CompactDifficulty is generated using the difficulty
                 // adjustment functions. Instead of using those functions, we make a random
                 // ExpandedDifficulty, then convert it to a CompactDifficulty.
-                Some(ExpandedDifficulty::from_hash(&block::Hash(bytes))
-                    .to_compact())
+                Some(ExpandedDifficulty::from_hash(&block::Hash(bytes)).to_compact())
             })
             .boxed()
     }


### PR DESCRIPTION
## Motivation

Using `Some(_)` rather than `_.into()` is more explicit.

## Solution

Replace `_.into()` with `Some(_)` in difficulty::arbitrary.

## Related Issues

This is a leftover style fix from PR #1196.
