### PR TITLE
Add Review and Follow Up to PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,13 @@ Summarize the solution and provide any necessary context needed to understand
 the code change.
 -->
 
+## Follow Up Work
+
+<!--
+Is there anything missing from the solution?
+What still needs to be done?
+-->
+
 ## Related Issues
 <!--
 Please link to any existing GitHub issues pertaining to this PR.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,6 +45,7 @@ Add or skip tasks as needed.
 - [ ] Pull Request
   - The pull request is complete: code, documentation, and tests
   - The PR contains changes to related code (unrelated changes can be split into another PR)
+  - The PR does everything listed in the tickets that it closes
   - Any follow-up tasks are listed in a GitHub issue
 
 - [ ] Code
@@ -61,8 +62,7 @@ Add or skip tasks as needed.
 
 - [ ] Tests
   - The tests make sure the code implements the Zcash consensus rules
-  - Consensus rules have success and failure tests
+  - Consensus rules have success tests, failure tests, and property tests
   - Edge cases and errors have tests
   - The consensus rules are tested on the block lists in `zebra_test::vectors`
   - Tests cover mainnet and testnet
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,9 +9,11 @@ Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
 ## Motivation
 
 <!--
-Explain the context and why you're making that change. What is the problem
-you're trying to solve? In some cases there is not a problem and this can be
-thought of as being the motivation for your change.
+Explain the context and why you're making that change.
+What is the problem you're trying to solve?
+If there's no specific problem, what is the motivation for your change?
+
+If you are implementing a design RFC, list the specific sections or functions here.
 -->
 
 ## Solution
@@ -52,7 +54,7 @@ Add or skip tasks as needed.
 - [ ] Pull Request
   - The pull request is complete: code, documentation, and tests
   - The PR contains changes to related code (unrelated changes can be split into another PR)
-  - The PR does everything listed in the tickets that it closes
+  - The PR does everything listed in the tickets that it closes, or the designs that it finishes
   - Any follow-up tasks are listed in a GitHub issue
 
 - [ ] Code

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,25 +52,25 @@ Add or skip tasks as needed.
 **Does this pull request improve Zebra?**
 
 - [ ] Pull Request
-  - The pull request is complete: code, documentation, and tests
+  - **Is the pull request complete: code, documentation, and tests?**
   - The PR contains changes to related code (unrelated changes can be split into another PR)
   - The PR does everything listed in the tickets that it closes, or the designs that it finishes
   - Any follow-up tasks are listed in a GitHub issue
 
 - [ ] Code
-  - The code implements the specifications or design documents
+  - **Does the code implement the specifications or design documents?**
   - Changes from the specifications or design documents are explained in comments
   - The code is readable, and does not appear to have any bugs
   - Any known issues or limitations are documented
 
 - [ ] Documentation
-  - Docs summarise how the code should be used
+  - **Do the docs summarise how the code should be used?**
   - Docs reference specifications or design documents
   - New public code has doc comments: `#![deny(missing_docs)]`
   - Complex private code has doc comments
 
 - [ ] Tests
-  - The tests make sure the code implements the Zcash consensus rules
+  - **Do the tests make sure the code implements the Zcash consensus rules?**
   - Consensus rules have success tests, failure tests, and property tests
   - Edge cases and errors have tests
   - The consensus rules are tested on the block lists in `zebra_test::vectors`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -60,7 +60,7 @@ Add or skip tasks as needed.
 - [ ] Code
   - **Does the code implement the specifications or design documents?**
   - Changes from the specifications or design documents are explained in comments
-  - The code is readable, and does not appear to have any bugs
+  - The code is readable and maintainable
   - Any known issues or limitations are documented
 
 - [ ] Documentation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,7 @@
 <!--
-Thank you for your Pull Request. Please provide a description above and review
-the requirements below.
+Thank you for your Pull Request.
 
-Bug fixes and new features should include tests.
+Please provide a description above and fill in the information below.
 
 Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
 -->
@@ -26,3 +25,44 @@ the code change.
 <!--
 Please link to any existing GitHub issues pertaining to this PR.
 -->
+
+## Review Guidelines (for Reviewer)
+<!--
+This is a flexible checklist for the reviewer to fill in.
+
+Developers:
+Add extra tasks to the review using list items.
+Skip review tasks using ~~strikethrough~~.
+If you want this pull request to have a specific reviewer, tag them in the list of reviewers.
+
+Reviewer:
+This checklist can help you do your review.
+Add or skip tasks as needed.
+-->
+
+**Does this pull request improve Zebra?**
+
+- [ ] Pull Request
+  - The pull request is complete: code, documentation, and tests
+  - The PR contains changes to related code (unrelated changes can be split into another PR)
+  - Any follow-up tasks are listed in a GitHub issue
+
+- [ ] Code
+  - The code implements the specifications or design documents
+  - Changes from the specifications or design documents are explained in comments
+  - The code is readable, and does not appear to have any bugs
+  - Any known issues or limitations are documented
+
+- [ ] Documentation
+  - Docs summarise how the code should be used
+  - Docs reference specifications or design documents
+  - New public code has doc comments: `#![deny(missing_docs)]`
+  - Complex private code has doc comments
+
+- [ ] Tests
+  - The tests make sure the code implements the Zcash consensus rules
+  - Consensus rules have success and failure tests
+  - Edge cases and errors have tests
+  - The consensus rules are tested on the block lists in `zebra_test::vectors`
+  - Tests cover mainnet and testnet
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,7 +41,7 @@ This is a flexible checklist for the reviewer to fill in.
 
 Developers:
 Add extra tasks to the review using list items.
-Skip review tasks using ~~strikethrough~~.
+Skip review tasks using ~~strikethrough~~, or just delete them.
 If you want this pull request to have a specific reviewer, tag them in the list of reviewers.
 
 Reviewer:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,5 @@
 <!--
 Thank you for your Pull Request.
-
 Please provide a description above and fill in the information below.
 
 Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
@@ -12,8 +11,6 @@ Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
 Explain the context and why you're making that change.
 What is the problem you're trying to solve?
 If there's no specific problem, what is the motivation for your change?
-
-If you are implementing a design RFC, list the specific sections or functions here.
 -->
 
 ## Solution
@@ -21,6 +18,25 @@ If you are implementing a design RFC, list the specific sections or functions he
 <!--
 Summarize the solution and provide any necessary context needed to understand
 the code change.
+If this PR implements parts of a design RFC or ticket, list those parts here.
+-->
+
+The code in this pull request has:
+  - [ ] Documentation Comments
+  - [ ] Unit Tests and Property Tests
+
+## Review
+
+<!--
+How urgent is this code review?
+Is this PR blocking any other work?
+If you want a specific reviewer for this PR, tag them here.
+-->
+
+## Related Issues
+
+<!--
+Please link to any existing GitHub issues pertaining to this PR.
 -->
 
 ## Follow Up Work
@@ -29,49 +45,3 @@ the code change.
 Is there anything missing from the solution?
 What still needs to be done?
 -->
-
-## Related Issues
-<!--
-Please link to any existing GitHub issues pertaining to this PR.
--->
-
-## Review Guidelines (for Reviewer)
-<!--
-This is a flexible checklist for the reviewer to fill in.
-
-Developers:
-Add extra tasks to the review using list items.
-Skip review tasks using ~~strikethrough~~, or just delete them.
-If you want this pull request to have a specific reviewer, tag them in the list of reviewers.
-
-Reviewer:
-This checklist can help you do your review.
-Add or skip tasks as needed.
--->
-
-**Does this pull request improve Zebra?**
-
-- [ ] Pull Request
-  - **Is the pull request complete: code, documentation, and tests?**
-  - The PR contains changes to related code (unrelated changes can be split into another PR)
-  - The PR does everything listed in the tickets that it closes, or the designs that it finishes
-  - Any follow-up tasks are listed in a GitHub issue
-
-- [ ] Code
-  - **Does the code implement the specifications or design documents?**
-  - Changes from the specifications or design documents are explained in comments
-  - The code is readable and maintainable
-  - Any known issues or limitations are documented
-
-- [ ] Documentation
-  - **Do the docs summarise how the code should be used?**
-  - Docs reference specifications or design documents
-  - New public code has doc comments: `#![deny(missing_docs)]`
-  - Complex private code has doc comments
-
-- [ ] Tests
-  - **Do the tests make sure the code implements the Zcash consensus rules?**
-  - Consensus rules have success tests, failure tests, and property tests
-  - Edge cases and errors have tests
-  - The consensus rules are tested on the block lists in `zebra_test::vectors`
-  - Tests cover mainnet and testnet


### PR DESCRIPTION
## Motivation

We've been talking about our PR process for the last few weeks, and we've identified some issues:
* we don't know who should review a PR
* we don't know how urgent PR reviews are
* it's hard to tell how much of a design or ticket is implemented in a PR
* we don't consistently track follow-up tasks
* sometimes we forget documentation or tests

## Solution

Make changes to the PR template:
* Add a Review section
* Add a Follow Up section
* Add a checklist to Solution with docs and tests
* Edit some existing section text so it's shorter

## Related Issues

#1177 was my original suggestion, but it's way too long.

## Follow Up

Move the reviewer guidelines from #1177 into the dev guide in the book, if we think that's a good idea.