### PR TITLE
Reduce acceptance test sled memory usage

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -31,7 +31,7 @@ use zebrad::config::ZebradConfig;
 fn default_test_config() -> Result<ZebradConfig> {
     let mut config = ZebradConfig::default();
     config.state = zebra_state::Config::ephemeral();
-    config.state.memory_cache_bytes = 256000000;
+    config.state.memory_cache_bytes /= 2;
     config.network.listen_addr = "127.0.0.1:0".parse()?;
 
     Ok(config)

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -31,7 +31,6 @@ use zebrad::config::ZebradConfig;
 fn default_test_config() -> Result<ZebradConfig> {
     let mut config = ZebradConfig::default();
     config.state = zebra_state::Config::ephemeral();
-    config.state.memory_cache_bytes /= 2;
     config.network.listen_addr = "127.0.0.1:0".parse()?;
 
     Ok(config)


### PR DESCRIPTION
## Motivation

PR #1233 changed the default `memory_cache_bytes`, but left the
acceptance tests with their old value.

## Solution

To avoid similar issues in future, we ~simply divide the default by 2~ just use the default memory limit setting.

## Related Issues

Ticket #1026 sled memory usage
PR #1233 default and documentation changes for `memory_cache_bytes`.

## Reviewer

@hdevalence was the author of PR #1233, this PR is a follow-up.
This is a one line change.

This PR is not urgent, unless we are having test memory usage issues.
@dconnolly, you might want to check the `memory_cache_bytes` setting in the long-running sync tests.