### PR TITLE
State RFC: clarify difficulty

### DIFF
--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -39,9 +39,10 @@ state service.
 * **chain state**: The state of the ledger after application of a particular
   sequence of blocks (state transitions).
 
-* **difficulty**: The cumulative proof-of-work from genesis to the chain tip.
+* **cumulative difficulty**: The cumulative proof-of-work from genesis to the
+  chain tip.
 
-* **best chain**: The chain with the greatest difficulty. This chain
+* **best chain**: The chain with the greatest cumulative difficulty. This chain
   represents the consensus state of the Zcash network and transactions.
 
 * **side chain**: A chain which is not contained in the best chain.


### PR DESCRIPTION
## Motivation

The difficulty validation RFC will introduce a definition of per-block difficulty. But the state RFC already defines "difficulty" as cumulative difficulty.

## Solution

Make it clear that the state RFC definition is cumulative difficulty.

## Related Issues

#1036 difficulty RFC

## Review

This is a very small change.
It's not urgent at all.