### PR TITLE
Fix format used to store transactions in sled

### DIFF
--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -14,4 +14,4 @@ pub const MIN_TRASPARENT_COINBASE_MATURITY: block::Height = block::Height(100);
 pub const MAX_BLOCK_REORG_HEIGHT: block::Height =
     block::Height(MIN_TRASPARENT_COINBASE_MATURITY.0 - 1);
 
-pub const SLED_FORMAT_VERSION: u32 = 0;
+pub const SLED_FORMAT_VERSION: u32 = 1;


### PR DESCRIPTION
## Motivation

While working on the block locator fix PR together with Henry we noticed that we'd accidentally serialized entire transactions in `tx_by_hash`, instead of serializing just the height of the block and the index of the transaction within the block, as described by the original RFC.

## Solution

We've fixed it by adding a `TransactionLocation` new type, which handles the sled format traits. We've removed the sled format impls for `Transaction` to prevent inserting the wrong data in the future. Finally we've bumped the database format to reflect the change in the format on the disk and its incompatibility with previous versions.
