### PR TITLE
assert that sled maps are collision free

### DIFF
--- a/zebra-state/src/sled_state.rs
+++ b/zebra-state/src/sled_state.rs
@@ -239,7 +239,7 @@ impl FinalizedState {
                     // Index the block
                     hash_by_height.zs_insert(height, hash)?;
                     height_by_hash.zs_insert(hash, height)?;
-                    block_by_height.zs_insert(height, &*block)?;
+                    block_by_height.zs_insert(height, &block)?;
 
                     // TODO: sprout and sapling anchors (per block)
 

--- a/zebra-state/src/sled_state/sled_format.rs
+++ b/zebra-state/src/sled_state/sled_format.rs
@@ -245,7 +245,7 @@ impl SledSerialize for sled::transaction::TransactionalTree {
         let value_bytes = value.into_ivec();
         let previous = self.insert(key_bytes, value_bytes)?;
 
-        assert!(previous.is_none(), format!("state insertion error: duplicate key {:?} when inserting value {:?}", key, value));
+        assert!(previous.is_none());
 
         Ok(())
     }

--- a/zebra-state/src/sled_state/sled_format.rs
+++ b/zebra-state/src/sled_state/sled_format.rs
@@ -243,7 +243,10 @@ impl SledSerialize for sled::transaction::TransactionalTree {
     {
         let key_bytes = key.into_ivec();
         let value_bytes = value.into_ivec();
-        self.insert(key_bytes, value_bytes)?;
+        let previous = self.insert(key_bytes, value_bytes)?;
+
+        assert!(previous.is_none());
+
         Ok(())
     }
 }

--- a/zebra-state/src/sled_state/sled_format.rs
+++ b/zebra-state/src/sled_state/sled_format.rs
@@ -245,7 +245,7 @@ impl SledSerialize for sled::transaction::TransactionalTree {
         let value_bytes = value.into_ivec();
         let previous = self.insert(key_bytes, value_bytes)?;
 
-        assert!(previous.is_none(), format!("state insertion error: duplicate key {:?} when inserting value {:?}", key, value));
+        assert!(previous.is_none(), format!("state insertion error: duplicate key {:?} when inserting value {:?}", key_bytes, value_bytes));
 
         Ok(())
     }

--- a/zebra-state/src/sled_state/sled_format.rs
+++ b/zebra-state/src/sled_state/sled_format.rs
@@ -241,11 +241,18 @@ impl SledSerialize for sled::transaction::TransactionalTree {
         K: IntoSled,
         V: IntoSled,
     {
+        use std::any::type_name;
+
         let key_bytes = key.into_ivec();
         let value_bytes = value.into_ivec();
         let previous = self.insert(key_bytes, value_bytes)?;
 
-        assert!(previous.is_none());
+        assert!(
+            previous.is_none(),
+            "previous value was not none when inserting into ({}, {}) sled Tree",
+            type_name::<K>(),
+            type_name::<V>()
+        );
 
         Ok(())
     }

--- a/zebra-state/src/sled_state/sled_format.rs
+++ b/zebra-state/src/sled_state/sled_format.rs
@@ -245,7 +245,7 @@ impl SledSerialize for sled::transaction::TransactionalTree {
         let value_bytes = value.into_ivec();
         let previous = self.insert(key_bytes, value_bytes)?;
 
-        assert!(previous.is_none(), format!("state insertion error: duplicate key {:?} when inserting value {:?}", key_bytes, value_bytes));
+        assert!(previous.is_none(), format!("state insertion error: duplicate key {:?} when inserting value {:?}", key, value));
 
         Ok(())
     }

--- a/zebra-state/src/sled_state/sled_format.rs
+++ b/zebra-state/src/sled_state/sled_format.rs
@@ -245,7 +245,7 @@ impl SledSerialize for sled::transaction::TransactionalTree {
         let value_bytes = value.into_ivec();
         let previous = self.insert(key_bytes, value_bytes)?;
 
-        assert!(previous.is_none());
+        assert!(previous.is_none(), format!("state insertion error: duplicate key {:?} when inserting value {:?}", key, value));
 
         Ok(())
     }


### PR DESCRIPTION
## Motivation

Based @teor2345's and my discussion earlier, we decided that rather than trying to write tests to assert that our maps are bijections we should simply assume that sled works as advertised, and instead add the necessary checks in our code to ensure that the set behaves as expected.

## Solution

Thanks to the `IntoSled` and `SledSerialize` traits, `sled::Tree::insert` is only called in one location in our codebase. This PR changes our serialize impl so that it checks the return value of `insert`, which is `Option<IVec>` containing the previous value at the given `key`, if there is one. Now we will assert that the previous value is always none.

This PR also also tweeks the sled trait impls to reorganize how they handle references and arcs, and when data is moved by value and by reference. This is mostly so that we can still debug print the `key` after serializing it for sled, but the changes have cleaned up some inconsistencies. All existing impls already created the `IVec` in `into_ivec` by copying bytes, rather than by moving ownership out of `self`, so there was no reason to continue taking `self` by value in that function. Then we needed to change existing impls to not take types by reference, which broke existing code, for which I added generic impls for IntoSled for `&'a T` and `Arc<T>` where T: IntoSled.

Once I added these new impls I realized that our sled trait impls were much more consistent so I cleaned up the existing tests to be more uniform and added new prop tests to assert that serialization and deserialization still works regardless of if its serialized initially through a reference or an `Arc`.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

@teor2345

## Related Issues

- [Tracking Issue](https://github.com/ZcashFoundation/zebra/issues/1249)

## Follow Up Work
