### PR TITLE
Add proptests for sled conversions

### DIFF
--- a/zebra-state/src/sled_state/sled_format.rs
+++ b/zebra-state/src/sled_state/sled_format.rs
@@ -302,6 +302,9 @@ mod tests {
         T::from_ivec(bytes)
     }
 
+    /// The round trip test covers types that are used as value field in a sled
+    /// Tree. Only these types are ever deserialized, and so they're the only
+    /// ones that implement both `IntoSled` and `FromSled`.
     fn assert_round_trip<T>(input: T)
     where
         T: IntoSled + FromSled + Clone + PartialEq + std::fmt::Debug,
@@ -311,6 +314,12 @@ mod tests {
         assert_eq!(before, after);
     }
 
+    /// This test asserts that types that are used as sled keys behave correctly.
+    /// Any type that implements `IntoIVec` can be used as a sled key. The value
+    /// is serialized via `IntoSled::into_ivec` when the `key`, `value` pair is
+    /// inserted into the sled tree. The `as_bytes` impl on the other hand is
+    /// called for most other operations when comparing a key against existing
+    /// keys in the sled database, such as `contains`.
     fn assert_as_bytes_matches_ivec<T>(input: T)
     where
         T: IntoSled + Clone,

--- a/zebra-state/src/sled_state/sled_format.rs
+++ b/zebra-state/src/sled_state/sled_format.rs
@@ -9,6 +9,7 @@ use zebra_chain::{
     sprout, transaction, transparent,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TransactionLocation {
     pub height: block::Height,
     pub index: u32,
@@ -123,6 +124,13 @@ impl IntoSled for block::Hash {
     }
 }
 
+impl FromSled for block::Hash {
+    fn from_ivec(bytes: sled::IVec) -> Self {
+        let array = bytes.as_ref().try_into().unwrap();
+        Self(array)
+    }
+}
+
 impl IntoSled for &sprout::Nullifier {
     type Bytes = [u8; 32];
 
@@ -156,13 +164,6 @@ impl IntoSled for () {
 
     fn into_ivec(self) -> sled::IVec {
         sled::IVec::default()
-    }
-}
-
-impl FromSled for block::Hash {
-    fn from_ivec(bytes: sled::IVec) -> Self {
-        let array = bytes.as_ref().try_into().unwrap();
-        Self(array)
     }
 }
 
@@ -272,5 +273,138 @@ impl SledDeserialize for sled::Tree {
             .expect("expected that sled errors would not occur");
 
         value_bytes.map(V::from_ivec)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::{arbitrary::any, prelude::*};
+    use std::ops::Deref;
+
+    impl Arbitrary for TransactionLocation {
+        type Parameters = ();
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            (any::<block::Height>(), any::<u32>())
+                .prop_map(|(height, index)| Self { height, index })
+                .boxed()
+        }
+
+        type Strategy = BoxedStrategy<Self>;
+    }
+
+    fn round_trip<T>(input: T) -> T
+    where
+        T: IntoSled + FromSled,
+    {
+        let bytes = input.into_ivec();
+        T::from_ivec(bytes)
+    }
+
+    fn assert_round_trip<T>(input: T)
+    where
+        T: IntoSled + FromSled + Clone + PartialEq + std::fmt::Debug,
+    {
+        let before = input.clone();
+        let after = round_trip(input);
+        assert_eq!(before, after);
+    }
+
+    fn assert_as_bytes_matches_ivec<T>(input: T)
+    where
+        T: IntoSled + Clone,
+    {
+        let before = input.clone();
+        let ivec = input.into_ivec();
+        assert_eq!(before.as_bytes().as_ref(), ivec.as_ref());
+    }
+
+    #[test]
+    fn roundtrip_transaction_location() {
+        zebra_test::init();
+        proptest!(|(val in any::<TransactionLocation>())| assert_round_trip(val));
+    }
+
+    #[test]
+    fn roundtrip_block_hash() {
+        zebra_test::init();
+        proptest!(|(val in any::<block::Hash>())| assert_round_trip(val));
+    }
+
+    #[test]
+    fn roundtrip_block_height() {
+        zebra_test::init();
+        proptest!(|(val in any::<block::Height>())| assert_round_trip(val));
+    }
+
+    #[test]
+    fn roundtrip_block() {
+        zebra_test::init();
+
+        proptest!(|(block in any::<Block>())| {
+            let bytes = block.into_ivec();
+            let deserialized: Arc<Block> = FromSled::from_ivec(bytes);
+            assert_eq!(&block, deserialized.deref());
+        });
+    }
+
+    #[test]
+    fn roundtrip_transparent_output() {
+        zebra_test::init();
+
+        proptest!(|(block in any::<transparent::Output>())| {
+            let bytes = block.into_ivec();
+            let deserialized: transparent::Output = FromSled::from_ivec(bytes);
+            assert_eq!(block, deserialized);
+        });
+    }
+
+    #[test]
+    fn key_matches_ivec_transaction_location() {
+        zebra_test::init();
+        proptest!(|(val in any::<TransactionLocation>())| assert_as_bytes_matches_ivec(val));
+    }
+
+    #[test]
+    fn key_matches_ivec_trans_hash() {
+        zebra_test::init();
+        proptest!(|(val in any::<transaction::Hash>())| assert_as_bytes_matches_ivec(val));
+    }
+
+    #[test]
+    fn key_matches_ivec_block_hash() {
+        zebra_test::init();
+        proptest!(|(val in any::<block::Hash>())| assert_as_bytes_matches_ivec(val));
+    }
+
+    #[test]
+    fn key_matches_ivec_sprout_nullifier() {
+        zebra_test::init();
+        proptest!(|(val in any::<sprout::Nullifier>())| assert_as_bytes_matches_ivec(&val));
+    }
+
+    #[test]
+    fn key_matches_ivec_sapling_nullifier() {
+        zebra_test::init();
+        proptest!(|(val in any::<sapling::Nullifier>())| assert_as_bytes_matches_ivec(&val));
+    }
+
+    #[test]
+    fn key_matches_ivec_block_height() {
+        zebra_test::init();
+        proptest!(|(val in any::<block::Height>())| assert_as_bytes_matches_ivec(val));
+    }
+
+    #[test]
+    fn key_matches_ivec_transparent_output() {
+        zebra_test::init();
+        proptest!(|(val in any::<transparent::Output>())| assert_as_bytes_matches_ivec(&val));
+    }
+
+    #[test]
+    fn key_matches_ivec_transparent_outpoint() {
+        zebra_test::init();
+        proptest!(|(val in any::<transparent::OutPoint>())| assert_as_bytes_matches_ivec(val));
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

As part of the finalized state implementation we added a set of helper traits to define common code for converting zebra types into and from serialized bytes in sled. These original PRs didn't add tests, but documented tests that should be added in the future. The main set being property tests that assert that types that implement `IntoSled` and `FromSled` can always equal their original value after a round trip.

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->

## Solution

This PR adds two sets of tests. Tests for types that can be used as values, and tests for types that can be used as keys. The former test covers the original test described in the tracking issue, for round trip conversions. Only values types in our sled trees ever get read back out of the database, so those are the only types that implement both IntoSled and FromSled. The other set of tests, for keys, tests the property that the `as_ref` implementation for `IVec` matches the `as_ref` implementation of `<Self as IntoSled>::as_bytes`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

@teor2345

## Related Issues

- [Tracking Issue](https://github.com/ZcashFoundation/zebra/issues/1249)

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
