### PR TITLE
Support systems where bash isn't in /usr/bin

### DIFF
--- a/zebra-utils/zebrad-hash-lookup
+++ b/zebra-utils/zebrad-hash-lookup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/zebra-utils/zebrad-log-filter
+++ b/zebra-utils/zebrad-log-filter
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
## Motivation

Some systems don't put the `bash` command in `/usr/bin`, but the zebra-utils shell scripts expect it to be there.

## Solution

Use `/usr/bin/env bash` instead.

## Review

This code review is not urgent at all - this is a minor bug that can be fixed at any time.
