### PR TITLE
Fix options order in metrics docker commands

### DIFF
--- a/book/src/user/metrics.md
+++ b/book/src/user/metrics.md
@@ -13,10 +13,10 @@ sudo docker volume create grafana-storage
 sudo docker volume create prometheus-storage
 
 # run prometheus with the included config
-sudo docker -d run --network host -v prometheus-storage:/prometheus -v /path/to/zebra/prometheus.yaml:/etc/prometheus/prometheus.yml  prom/prometheus
+sudo docker run --detach --network host --volume prometheus-storage:/prometheus --volume /path/to/zebra/prometheus.yaml:/etc/prometheus/prometheus.yml  prom/prometheus
 
 # run grafana
-sudo docker -d run --network host -e GF_SERVER_HTTP_PORT=3030 -e GF_SERVER_HTTP_ADDR=localhost -v grafana-storage:/var/lib/grafana grafana/grafana
+sudo docker run --detach --network host --env GF_SERVER_HTTP_PORT=3030 --env GF_SERVER_HTTP_ADDR=localhost --volume grafana-storage:/var/lib/grafana grafana/grafana
 ```
 
 Now the grafana dashboard is available at [http://localhost:3030](http://localhost:3030) ; the default username and password is `admin`/`admin`.


### PR DESCRIPTION
## Motivation

The correct `docker run` syntax is `docker run -d`.

Also, long-form options are more readable.

## Solution

Fix the docker commands, and use long-form command options.

## Review

This review can be done at any time, it's not urgent at all.

