### PR TITLE
swap best_chain_len and related constants to u32 for consistency

### DIFF
--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -1,17 +1,14 @@
-use zebra_chain::block;
-
 /// The maturity threshold for transparent coinbase outputs.
 ///
 /// A transaction MUST NOT spend a transparent output of a coinbase transaction
 /// from a block less than 100 blocks prior to the spend. Note that transparent
 /// outputs of coinbase transactions include Founders' Reward outputs.
-pub const MIN_TRASPARENT_COINBASE_MATURITY: block::Height = block::Height(100);
+pub const MIN_TRASPARENT_COINBASE_MATURITY: u32 = 100;
 
 /// The maximum chain reorganisation height.
 ///
 /// Allowing reorganisations past this height could allow double-spends of
 /// coinbase transactions.
-pub const MAX_BLOCK_REORG_HEIGHT: block::Height =
-    block::Height(MIN_TRASPARENT_COINBASE_MATURITY.0 - 1);
+pub const MAX_BLOCK_REORG_HEIGHT: u32 = MIN_TRASPARENT_COINBASE_MATURITY - 1;
 
 pub const SLED_FORMAT_VERSION: u32 = 1;

--- a/zebra-state/src/service/memory_state.rs
+++ b/zebra-state/src/service/memory_state.rs
@@ -493,13 +493,11 @@ impl NonFinalizedState {
     }
 
     /// Returns the length of the non-finalized portion of the current best chain.
-    pub fn best_chain_len(&self) -> block::Height {
-        block::Height(
-            self.best_chain()
-                .expect("only called after inserting a block")
-                .blocks
-                .len() as u32,
-        )
+    pub fn best_chain_len(&self) -> u32 {
+        self.best_chain()
+            .expect("only called after inserting a block")
+            .blocks
+            .len() as u32
     }
 
     /// Returns `true` if `hash` is contained in the non-finalized portion of any

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -48,10 +48,10 @@ fn test_block_locator_heights() {
             block::Height(min_height),
             "locators must end with the specified final height"
         );
-        assert!(height - final_height.0 <= constants::MAX_BLOCK_REORG_HEIGHT.0,
+        assert!(height - final_height.0 <= constants::MAX_BLOCK_REORG_HEIGHT,
                     format!("locator for {} must not be more than the maximum reorg height {} below the tip, but {} is {} blocks below the tip",
                          height,
-                         constants::MAX_BLOCK_REORG_HEIGHT.0,
+                         constants::MAX_BLOCK_REORG_HEIGHT,
                          final_height.0,
                          height - final_height.0));
     }

--- a/zebra-state/src/util.rs
+++ b/zebra-state/src/util.rs
@@ -8,7 +8,7 @@ pub fn block_locator_heights(tip_height: block::Height) -> Vec<block::Height> {
     // Stop at the reorg limit, or the genesis block.
     let min_locator_height = tip_height
         .0
-        .saturating_sub(constants::MAX_BLOCK_REORG_HEIGHT.0);
+        .saturating_sub(constants::MAX_BLOCK_REORG_HEIGHT);
     let locators = iter::successors(Some(1u32), |h| h.checked_mul(2))
         .flat_map(move |step| tip_height.0.checked_sub(step));
     let locators = iter::once(tip_height.0)

--- a/zebra-utils/src/bin/zebra-checkpoints/main.rs
+++ b/zebra-utils/src/bin/zebra-checkpoints/main.rs
@@ -89,7 +89,7 @@ fn main() -> Result<()> {
     // Zcash reorg limit.
     let height_limit = height_limit
         .0
-        .checked_sub(zebra_state::MAX_BLOCK_REORG_HEIGHT.0)
+        .checked_sub(zebra_state::MAX_BLOCK_REORG_HEIGHT)
         .map(block::Height)
         .expect("zcashd has some mature blocks: wait for zcashd to sync more blocks");
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

In other parts of the code we use `u32` types to represent depths between heights, rather than `block::Height` itself, to avoid confusing height diffs from heights themselves. This same pattern wasn't followed in consistently throughout `zebra-state`.

## Solution

This PR changes `best_chain_len` to return a `u32` instead of a `block::Height`, and changes the types of some constants that value is compared against, based on the same principle.

The code in this pull request has:
  - ~~Documentation Comments~~
  - ~~Unit Tests and Property Tests~~

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

@teor2345

## Related Issues

- [Tracking Issue](https://github.com/ZcashFoundation/zebra/issues/1250)
