### PR TITLE
Clarify CheckpointVerifier errors

### DIFF
--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -80,7 +80,7 @@ pub enum BlockError {
     #[error("block contains invalid transactions")]
     Transaction(#[from] TransactionError),
 
-    #[error("block haves no transactions")]
+    #[error("block has no transactions")]
     NoTransactions,
 
     #[error("block {0:?} is already in the chain at depth {1:?}")]


### PR DESCRIPTION
## Motivation

I can't diagnose the repeated `Duplicate` errors from the `CheckpointVerifier` (#1259), because the error names and messages are ambiguous, the same error is used in multiple unrelated places, and the errors don't contain enough context.

## Solution

Improve the `CheckpointVerifier` errors:
* rename some errors to be more specific
* reword some error messages
* add context to some errors
* turn an unreachable error into `unreachable!`

The code in this pull request has:
  - ~Documentation Comments~ - minor modifications to existing error handling code
  - ~Unit Tests and Property Tests~ - minor modifications to existing error handling code

## Review

I'd like @yaahc to review this change, because she knows a lot about error handling.
This change is urgent, because it's blocking the tests for the difficulty PR #1256.

I'd like @hdevalence to be aware of these changes, because he is fixing the `Duplicate` errors in #1259.

## Related Issues

This PR contains diagnostics for the `Duplicate` errors bug #1259.
Bug #1259 blocks the tests for the difficulty fix PR #1256.

## Follow Up Work

Once #1259 is fixed, we'll probably want to reduce the `AlreadyVerified` info log to a trace. I'll make a note on the sync tracking issue.
