### PR TITLE
Add a maximum queued height metric to the finalized state

### DIFF
--- a/zebra-state/src/sled_state.rs
+++ b/zebra-state/src/sled_state.rs
@@ -38,7 +38,7 @@ use self::sled_format::TransactionLocation;
 pub struct FinalizedState {
     /// Queued blocks that arrived out of order, indexed by their parent block hash.
     queued_by_prev_hash: HashMap<block::Hash, QueuedBlock>,
-    max_queued_height: i32,
+    max_queued_height: i64,
 
     hash_by_height: sled::Tree,
     height_by_hash: sled::Tree,
@@ -192,7 +192,7 @@ impl FinalizedState {
             // use -1 as a sentinel value for "None", because 0 is a valid height
             self.max_queued_height = -1;
         } else {
-            self.max_queued_height = std::cmp::max(self.max_queued_height, height.0);
+            self.max_queued_height = std::cmp::max(self.max_queued_height, height.0 as _);
         }
 
         metrics::gauge!("state.finalized.queued.max.height", self.max_queued_height);


### PR DESCRIPTION
## Motivation

To diagnose pipeline bugs like #1259, we need more information about Zebra's internal queues.


## Solution

- Add a maximum queued height metric to the finalized state
- Rename all the finalized state metrics to contain "finalized".
  - Distinguishes finalized state metrics from the non-finalized state metrics in N+1

The code in this pull request has:
  - [x] ~Documentation~ Comments
    - adding another metric to existing metrics
  - ~Unit Tests and Property Tests~
    - I ran the code, and the metrics work as expected

## Review

@yaahc is working on the state right now.
This change can happen at any time.

@hdevalence should be aware of this change, because it breaks existing finalized state metrics dashboards.

## Related Issues

#1259 duplicate error in checkpoint verifier
#1261 checkpoint verifier metrics fix
#1263 non-finalized state metrics

## Follow Up Work

None