### PR TITLE
Add unit tests for `NonFinalizedState`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,6 +3458,7 @@ dependencies = [
  "lazy_static",
  "metrics",
  "once_cell",
+ "primitive-types",
  "proptest",
  "serde",
  "sled",

--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -403,7 +403,7 @@ chain and updates all side chains to match.
 3. Remove the lowest height block from the best chain with
    `let finalized_block = best_chain.pop_root();`
 
-4. Add `best_chain` back to `self.chain_set` if it is not empty
+4. Add `best_chain` back to `self.chain_set` if `best_chain` is not empty
 
 5. For each remaining `chain` in `side_chains`
     - remove the lowest height block from `chain`

--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -403,11 +403,11 @@ chain and updates all side chains to match.
 3. Remove the lowest height block from the best chain with
    `let finalized_block = best_chain.pop_root();`
 
-4. Add `best_chain` back to `self.chain_set`
+4. Add `best_chain` back to `self.chain_set` if it is not empty
 
 5. For each remaining `chain` in `side_chains`
     - remove the lowest height block from `chain`
-    - If that block is equal to `finalized_block` add `chain` back to `self.chain_set`
+    - If that block is equal to `finalized_block` and `chain` is not empty add `chain` back to `self.chain_set`
     - Else, drop `chain`
 
 6. Return `finalized_block`
@@ -617,7 +617,7 @@ Zcash structures are encoded using `ZcashSerialize`/`ZcashDeserialize`.
 - The `hash_by_height` and `height_by_hash` trees provide a bijection between
   block heights and block hashes.  (Since the Sled state only stores finalized
   state, they are actually a bijection).
-  
+
 - The `block_by_height` tree provides a bijection between block heights and block
   data. There is no corresponding `height_by_block` tree: instead, hash the block,
   and use `height_by_hash`. (Since the Sled state only stores finalized state,
@@ -668,7 +668,7 @@ check that `block`'s parent hash is `null` (all zeroes) and its height is `0`.
 
     (Due to a [bug in zcashd](https://github.com/ZcashFoundation/zebra/issues/559),
     genesis block anchors and transactions are ignored during validation.)
-    
+
 4.  Update the `sprout_anchors` and `sapling_anchors` trees with the Sprout and
     Sapling anchors.
 

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -123,9 +123,9 @@ impl fmt::Debug for ExpandedDifficulty {
 #[derive(Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Work(u128);
 
-impl From<Work> for u128 {
-    fn from(work: Work) -> Self {
-        work.0
+impl Work {
+    pub fn as_u128(self) -> u128 {
+        self.0
     }
 }
 

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -260,36 +260,9 @@ impl TryFrom<ExpandedDifficulty> for Work {
     }
 }
 
-impl TryFrom<u128> for Work {
-    type Error = ();
-
-    fn try_from(value: u128) -> Result<Self, Self::Error> {
-        if value == 0 {
-            Err(())
-        } else {
-            Ok(Work(value))
-        }
-    }
-}
-
 impl From<ExpandedDifficulty> for CompactDifficulty {
     fn from(value: ExpandedDifficulty) -> Self {
         value.to_compact()
-    }
-}
-
-impl From<Work> for CompactDifficulty {
-    fn from(value: Work) -> Self {
-        let expanded = ExpandedDifficulty::from(value);
-        Self::from(expanded)
-    }
-}
-
-impl From<Work> for ExpandedDifficulty {
-    fn from(value: Work) -> Self {
-        let work: U256 = value.0.into();
-        let expanded = (!work + 1) / work;
-        ExpandedDifficulty(expanded)
     }
 }
 

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -123,6 +123,12 @@ impl fmt::Debug for ExpandedDifficulty {
 #[derive(Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Work(u128);
 
+impl From<Work> for u128 {
+    fn from(work: Work) -> Self {
+        work.0
+    }
+}
+
 impl fmt::Debug for Work {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // There isn't a standard way to represent alternate formats for the

--- a/zebra-chain/src/work/difficulty/arbitrary.rs
+++ b/zebra-chain/src/work/difficulty/arbitrary.rs
@@ -51,15 +51,7 @@ impl Arbitrary for Work {
         // In the Zcash protocol, a Work is converted from an ExpandedDifficulty.
         // But some randomised difficulties are impractically large, and will
         // never appear in any real-world block. So we just use a random Work value.
-        (any::<u128>())
-            .prop_filter_map("zero Work values are invalid", |w| {
-                if w == 0 {
-                    None
-                } else {
-                    Some(Work(w))
-                }
-            })
-            .boxed()
+        (1..std::u128::MAX).prop_map(Work).boxed()
     }
 
     type Strategy = BoxedStrategy<Self>;

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -35,3 +35,4 @@ spandoc = "0.2"
 tempdir = "0.3.7"
 tokio = { version = "0.2.22", features = ["full"] }
 proptest = "0.10.1"
+primitive-types = "0.7.2"

--- a/zebra-state/src/service/memory_state/chain.rs
+++ b/zebra-state/src/service/memory_state/chain.rs
@@ -485,18 +485,18 @@ mod tests {
     }
 
     #[test]
-    fn superchain_is_greater_than_subchain() -> Result<()> {
+    fn ord_matches_work() -> Result<()> {
         zebra_test::init();
-        let block: Arc<Block> =
-            zebra_test::vectors::BLOCK_MAINNET_434873_BYTES.zcash_deserialize_into()?;
+        let less_block = zebra_test::vectors::BLOCK_MAINNET_434873_BYTES
+            .zcash_deserialize_into::<Arc<Block>>()?
+            .set_work(1);
+        let more_block = less_block.clone().set_work(10);
 
         let mut lesser_chain = Chain::default();
-        lesser_chain.push(block.clone());
+        lesser_chain.push(less_block);
 
-        let fake_child = block.make_fake_child();
         let mut bigger_chain = Chain::default();
-        bigger_chain.push(block);
-        bigger_chain.push(fake_child);
+        bigger_chain.push(more_block);
 
         assert!(bigger_chain > lesser_chain);
 

--- a/zebra-state/src/service/memory_state/chain.rs
+++ b/zebra-state/src/service/memory_state/chain.rs
@@ -485,7 +485,7 @@ mod tests {
     }
 
     #[test]
-    fn bigger_is_greater() -> Result<()> {
+    fn superchain_is_greater_than_subchain() -> Result<()> {
         zebra_test::init();
         let block: Arc<Block> =
             zebra_test::vectors::BLOCK_MAINNET_434873_BYTES.zcash_deserialize_into()?;

--- a/zebra-state/src/service/memory_state/non_finalized_state.rs
+++ b/zebra-state/src/service/memory_state/non_finalized_state.rs
@@ -204,7 +204,7 @@ mod tests {
             zebra_test::vectors::BLOCK_MAINNET_419201_BYTES.zcash_deserialize_into()?;
         let block1: Arc<Block> =
             zebra_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
-        // Create a random block which will have a much worse difficulty hash
+        // Create a random block which will have a much worse difficulty threshold
         // than an intentionally mined block from the mainnet
         let child = block1.make_fake_child();
 

--- a/zebra-state/src/service/memory_state/non_finalized_state.rs
+++ b/zebra-state/src/service/memory_state/non_finalized_state.rs
@@ -247,4 +247,32 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    // This test gives full coverage for `take_chain_if`
+    fn commit_block_extending_best_chain_doesnt_drop_worst_chains() -> Result<()> {
+        zebra_test::init();
+
+        let block2: Arc<Block> =
+            zebra_test::vectors::BLOCK_MAINNET_419201_BYTES.zcash_deserialize_into()?;
+        let block1: Arc<Block> =
+            zebra_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
+        // Create a random block which will have a much worse difficulty hash
+        // than an intentionally mined block from the mainnet
+        let child1 = block1.make_fake_child();
+        let child2 = block2.make_fake_child();
+
+        let mut state = NonFinalizedState::default();
+        assert_eq!(0, state.chain_set.len());
+        state.commit_new_chain(block1);
+        assert_eq!(1, state.chain_set.len());
+        state.commit_block(block2);
+        assert_eq!(1, state.chain_set.len());
+        state.commit_block(child1);
+        assert_eq!(2, state.chain_set.len());
+        state.commit_block(child2);
+        assert_eq!(2, state.chain_set.len());
+
+        Ok(())
+    }
 }

--- a/zebra-state/src/service/memory_state/non_finalized_state.rs
+++ b/zebra-state/src/service/memory_state/non_finalized_state.rs
@@ -257,7 +257,7 @@ mod tests {
             zebra_test::vectors::BLOCK_MAINNET_419201_BYTES.zcash_deserialize_into()?;
         let block1: Arc<Block> =
             zebra_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
-        // Create a random block which will have a much worse difficulty hash
+        // Create a random block which will have a much worse difficulty threshold
         // than an intentionally mined block from the mainnet
         let child1 = block1.make_fake_child();
         let child2 = block2.make_fake_child();

--- a/zebra-state/src/service/memory_state/non_finalized_state.rs
+++ b/zebra-state/src/service/memory_state/non_finalized_state.rs
@@ -228,7 +228,7 @@ mod tests {
             zebra_test::vectors::BLOCK_MAINNET_419201_BYTES.zcash_deserialize_into()?;
         let block1: Arc<Block> =
             zebra_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
-        // Create a random block which will have a much worse difficulty hash
+        // Create a random block which will have a much worse difficulty threshold
         // than an intentionally mined block from the mainnet
         let child = block1.make_fake_child();
 

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -84,11 +84,11 @@ use proptest::prelude::*;
 fn round_trip_work_expanded() {
     zebra_test::init();
 
-    proptest!(|(work in 1..std::u128::MAX)| {
-        let work: U256 = work.into();
+    proptest!(|(work in any::<Work>())| {
+        let work: U256 = work.as_u128().into();
         let expanded = work_to_expanded(work);
         let work_after = Work::try_from(expanded).unwrap();
-        let work_after = u128::from(work_after);
+        let work_after = work_after.as_u128();
         let work_after = U256::from(work_after);
         prop_assert_eq!(work, work_after);
     });

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -1,4 +1,4 @@
-use std::{mem, sync::Arc};
+use std::{convert::TryFrom, mem, sync::Arc};
 
 use primitive_types::U256;
 use zebra_chain::{
@@ -6,6 +6,7 @@ use zebra_chain::{
     transaction::Transaction,
     transparent,
     work::difficulty::ExpandedDifficulty,
+    work::difficulty::Work,
 };
 
 use super::*;
@@ -76,6 +77,22 @@ static BLOCK_LOCATOR_CASES: &[(u32, u32)] = &[
     (1000, 901),
     (10000, 9901),
 ];
+
+use proptest::prelude::*;
+
+#[test]
+fn round_trip_work_expanded() {
+    zebra_test::init();
+
+    proptest!(|(work in 1..std::u128::MAX)| {
+        let work: U256 = work.into();
+        let expanded = work_to_expanded(work);
+        let work_after = Work::try_from(expanded).unwrap();
+        let work_after = u128::from(work_after);
+        let work_after = U256::from(work_after);
+        prop_assert_eq!(work, work_after);
+    });
+}
 
 /// Check that the block locator heights are sensible.
 #[test]

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -44,8 +44,15 @@ impl FakeChainHelper for Arc<Block> {
 
     fn set_work(mut self, work: u128) -> Arc<Block> {
         use primitive_types::U256;
-
         let work: U256 = work.into();
+
+        // Work is calculated from expanded difficulty with the equation `work = 2^256 / (expanded + 1)`
+        // By balancing the equation we get `expanded = (2^256 / work) - 1`
+        // `2^256` is too large to represent, so we instead use the following equivalent equations
+        // `expanded = (2^256 / work) - (work / work)`
+        // `expanded = (2^256 - work) / work`
+        // `expanded = ((2^256 - 1) - work + 1) / work`
+        // `(2^256 - 1 - work)` is equivalent to `!work` when work is a U256
         let expanded = (!work + 1) / work;
         let expanded = ExpandedDifficulty::from(expanded);
 

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -4,6 +4,7 @@ use zebra_chain::{
     block::{self, Block},
     transaction::Transaction,
     transparent,
+    work::difficulty::ExpandedDifficulty,
     work::difficulty::Work,
 };
 
@@ -42,9 +43,14 @@ impl FakeChainHelper for Arc<Block> {
     }
 
     fn set_work(mut self, work: u128) -> Arc<Block> {
-        let work = Work::try_from(work).expect("tests should only pass in valid work values");
+        use primitive_types::U256;
+
+        let work: U256 = work.into();
+        let expanded = (!work + 1) / work;
+        let expanded = ExpandedDifficulty::from(expanded);
+
         let block = Arc::make_mut(&mut self);
-        block.header.difficulty_threshold = work.into();
+        block.header.difficulty_threshold = expanded.into();
         self
     }
 }

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -84,13 +84,11 @@ use proptest::prelude::*;
 fn round_trip_work_expanded() {
     zebra_test::init();
 
-    proptest!(|(work in any::<Work>())| {
-        let work: U256 = work.as_u128().into();
+    proptest!(|(work_before in any::<Work>())| {
+        let work: U256 = work_before.as_u128().into();
         let expanded = work_to_expanded(work);
         let work_after = Work::try_from(expanded).unwrap();
-        let work_after = work_after.as_u128();
-        let work_after = U256::from(work_after);
-        prop_assert_eq!(work, work_after);
+        prop_assert_eq!(work_before, work_after);
     });
 }
 


### PR DESCRIPTION
## Motivation

Prior to this PR we'd already implemented the `NonFinalizedState` type but otherwise didn't add any new tests to ensure that it functions correctly.

## Solution

This PR adds some basic unit tests to cover basic functionality of the `NonFinalizedState` type. This PR also introduces a bug fix for `finalize` that was discovered when adding the unit tests.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

@teor2345

## Related Issues

- [Tracking Issue](https://github.com/ZcashFoundation/zebra/issues/1250)

## Follow Up Work

This PR doesn't add any property tests because much of the behaviour of this struct is influenced by the more or less random `hashes` assigned to arbitrary blocks, so we cannot consistently generate arbitrary chains where one is always "better" than the other. The alternative seems to be generating two arbitrary chains, comparing them to see which is better, and then doing the property test, but this would end up just being a reimplementation of the `NonFinalizedState`'s logic in the test itself to do the ordering check.
