### PR TITLE
Add tests for QueuedBlocks

### DIFF
--- a/zebra-state/src/service/memory_state/queued_blocks.rs
+++ b/zebra-state/src/service/memory_state/queued_blocks.rs
@@ -109,7 +109,7 @@ impl QueuedBlocks {
                     .expect("parent is present");
                 assert!(
                     removed.contains(&hash),
-                    "hash msut be present in parent hash list"
+                    "hash must be present in parent hash list"
                 );
             } else {
                 assert!(


### PR DESCRIPTION
## Motivation

Prior to this PR we implemented the `QueuedBlock` type according to RFC0005 but did not add tests.

## Solution

This PR adds whatever unit and property tests seem appropriate for sufficiently testing the behaviour of `QueuedBlocks`.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

@teor2345

## Related Issues

- [Tracking Issue](https://github.com/ZcashFoundation/zebra/issues/1250)

## Follow Up Work
