### PR TITLE
Add internal iterator API for accessing relevant chain blocks

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -254,9 +254,10 @@ impl StateService {
     }
 
     /// Return an iterator over the relevant chain of the block identified by
-    /// `hash_or_height`. Heights iterate over the best chain. Hashes iterate
-    /// over the chain containing the hash, which can be the best chain or a
-    /// side chain.
+    /// `hash`.
+    ///
+    /// The block identified by `hash` is included in the chain of blocks yielded
+    /// by the iterator.
     #[allow(dead_code)]
     pub fn chain(&self, hash: block::Hash) -> Iter<'_> {
         Iter {

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -278,7 +278,7 @@ enum IterState {
     Finished,
 }
 
-impl<'a> Iter<'a> {
+impl Iter<'_> {
     fn next_non_finalized_block(&mut self) -> Option<Arc<Block>> {
         let Iter { service, state } = self;
 
@@ -324,7 +324,7 @@ impl<'a> Iter<'a> {
     }
 }
 
-impl<'a> Iterator for Iter<'a> {
+impl Iterator for Iter<'_> {
     type Item = Arc<Block>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -337,6 +337,8 @@ impl<'a> Iterator for Iter<'a> {
         }
     }
 }
+
+impl std::iter::FusedIterator for Iter<'_> {}
 
 impl Service<Request> for StateService {
     type Response = Response;

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -254,7 +254,9 @@ impl StateService {
     }
 
     /// Return an iterator over the relevant chain of the block identified by
-    /// `hash_or_height`.
+    /// `hash_or_height`. Heights iterate over the best chain. Hashes iterate
+    /// over the chain containing the hash, which can be the best chain or a
+    /// side chain. 
     #[allow(dead_code)]
     pub fn chain(&self, hash_or_height: HashOrHeight) -> Iter<'_> {
         Iter {

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -248,9 +248,11 @@ impl StateService {
         self.mem.hash(height).or_else(|| self.sled.hash(height))
     }
 
-    /// Return the hash for the block at `height` in the current best chain.
-    pub fn height(&self, hash: block::Hash) -> Option<block::Height> {
-        self.mem.height(hash).or_else(|| self.sled.height(hash))
+    /// Return the height for the block at `hash` in any chain.
+    pub fn height_by_hash(&self, hash: block::Hash) -> Option<block::Height> {
+        self.mem
+            .height_by_hash(hash)
+            .or_else(|| self.sled.height(hash))
     }
 
     /// Return the utxo pointed to by `outpoint` if it exists in any chain.
@@ -355,7 +357,7 @@ impl ExactSizeIterator for Iter<'_> {
         match self.state {
             IterState::NonFinalized(hash) => self
                 .service
-                .height(hash)
+                .height_by_hash(hash)
                 .map(|height| (height.0 + 1) as _)
                 .unwrap_or(0),
             IterState::Finalized(height) => (height.0 + 1) as _,

--- a/zebra-state/src/service/memory_state/non_finalized_state.rs
+++ b/zebra-state/src/service/memory_state/non_finalized_state.rs
@@ -135,6 +135,21 @@ impl NonFinalizedState {
         None
     }
 
+    /// Returns the `block` with the given hash in the any chain.
+    pub fn block_by_hash(&self, hash: block::Hash) -> Option<Arc<Block>> {
+        for chain in self.chain_set.iter().rev() {
+            if let Some(block) = chain
+                .height_by_hash
+                .get(&hash)
+                .and_then(|height| chain.blocks.get(height))
+            {
+                return Some(block.clone());
+            }
+        }
+
+        None
+    }
+
     /// Returns the `block` at a given height or hash in the best chain.
     pub fn block(&self, hash_or_height: HashOrHeight) -> Option<Arc<Block>> {
         let best_chain = self.best_chain()?;

--- a/zebra-state/src/service/memory_state/non_finalized_state.rs
+++ b/zebra-state/src/service/memory_state/non_finalized_state.rs
@@ -180,7 +180,7 @@ impl NonFinalizedState {
         Some(height)
     }
 
-    /// Returns the depth of `hash` in any chain.
+    /// Returns the height of `hash` in any chain.
     pub fn height_by_hash(&self, hash: block::Hash) -> Option<block::Height> {
         for chain in self.chain_set.iter().rev() {
             if let Some(height) = chain.height_by_hash.get(&hash) {

--- a/zebra-state/src/service/memory_state/non_finalized_state.rs
+++ b/zebra-state/src/service/memory_state/non_finalized_state.rs
@@ -180,6 +180,17 @@ impl NonFinalizedState {
         Some(height)
     }
 
+    /// Returns the depth of `hash` in any chain.
+    pub fn height_by_hash(&self, hash: block::Hash) -> Option<block::Height> {
+        for chain in self.chain_set.iter().rev() {
+            if let Some(height) = chain.height_by_hash.get(&hash) {
+                return Some(*height);
+            }
+        }
+
+        None
+    }
+
     /// Returns the given transaction if it exists in the best chain.
     pub fn transaction(&self, hash: transaction::Hash) -> Option<Arc<Transaction>> {
         let best_chain = self.best_chain()?;


### PR DESCRIPTION
## Motivation

The difficulty calculation logic needs the ability to access the last 28 blocks of a block's relevant chain. Before this PR the state internals have had APIs for getting individual blocks but no easy way to abstract over "the last n blocks of a chain starting at this block".

## Solution

This PR adds a `chain` method to `StateService` in `zebra-state`. This function provides an iterator API that abstracts over the `StateService`. It will first attempt to find the given block from the non-finalized state, and if it doesn't exist there it falls back to the finalized state.

The code in this pull request has:
  - [x] Documentation Comments
  - [ ] Unit Tests and Property Tests

## Review

@teor2345

## Related Issues

## Follow Up Work

