### PR TITLE
Pin the version of tarpaulin used for collecting coverage to 0.16.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: 'latest'
+          version: '0.16.0'
           timeout: 600
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1.0.14


### PR DESCRIPTION
## Motivation

0.17.0 has a bug that causes segfaults:
https://github.com/xd009642/tarpaulin/issues/618

## Solution

Pin the version of tarpaulin used for collecting coverage to 0.16.0, for now

## Related Issues

https://github.com/xd009642/tarpaulin/issues/618

## Follow Up Work

Move back to latest in the future, or leave it pinned?
