### PR TITLE
Revert "Hedge every syncer block download request"

### DIFF
--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -142,9 +142,6 @@ where
         // making a less-fallible network service, and the Hedge layer
         // tries to reduce latency of that less-fallible service.
         //
-        // We hedge every request. If we don't have any recent timings,
-        // Hedge issues a second request with no delay.
-        //
         // XXX add ServiceBuilder::hedge() so this becomes
         // ServiceBuilder::new().hedge(...).retry(...)...
         let block_network = Hedge::new(
@@ -154,7 +151,7 @@ where
                 .timeout(BLOCK_DOWNLOAD_TIMEOUT)
                 .service(peers),
             AlwaysHedge,
-            0,
+            20,
             0.95,
             2 * SYNC_RESTART_TIMEOUT,
         );


### PR DESCRIPTION
This reverts commit 656bd24ba7f54173289bf49fb98c0ef300a37181.

The Hedge middleware keeps a pair of histograms, writing into one in the
current time interval and reading from the previous time interval's
data.  This means that the reverted change resulted in doubling all
block downloads until after at least the second measurement interval
(which means that the time measurements are also incorrect, as they're
operating under double the network load...)
