### PR TITLE
Add check to ensure heights in state service are sequential

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -194,7 +194,10 @@ impl StateService {
         let parent_height = parent_block
             .coinbase_height()
             .expect("valid blocks have a coinbase height");
+        let parent_hash = parent_block.hash();
         check::height_one_more_than_parent_height(parent_height, block)?;
+        // should be impossible by design, so no handleable error is thrown
+        assert_eq!(parent_hash, block.header.previous_block_hash);
 
         // TODO: contextual validation design and implementation
         Ok(())

--- a/zebra-state/src/sled_state.rs
+++ b/zebra-state/src/sled_state.rs
@@ -148,7 +148,15 @@ impl FinalizedState {
         let height = queued_block.block.coinbase_height().unwrap();
         self.queued_by_prev_hash.insert(prev_hash, queued_block);
 
-        while let Some(queued_block) = self.queued_by_prev_hash.remove(&self.finalized_tip_hash()) {
+        loop {
+            let finalized_tip_hash = self.finalized_tip_hash();
+            let queued_block =
+                if let Some(queued_block) = self.queued_by_prev_hash.remove(&finalized_tip_hash) {
+                    queued_block
+                } else {
+                    break;
+                };
+
             let height = queued_block
                 .block
                 .coinbase_height()
@@ -172,6 +180,8 @@ impl FinalizedState {
                         + 1,
                     Some(height)
                 );
+
+                assert_eq!(finalized_tip_hash, prev_hash);
             }
 
             self.commit_finalized(queued_block);

--- a/zebra-state/src/sled_state.rs
+++ b/zebra-state/src/sled_state.rs
@@ -154,11 +154,11 @@ impl FinalizedState {
                 .coinbase_height()
                 .expect("valid blocks must have a height");
 
-            if prev_hash == block::Hash([0; 32]) {
+            if self.block_by_height.is_empty() {
                 assert_eq!(
-                    1,
-                    self.block_by_height.len(),
-                    "cannot commit genesis block to a populated state"
+                    block::Hash([0; 32]),
+                    prev_hash,
+                    "the first block added to an empty state must be a genesis block"
                 );
                 assert_eq!(
                     block::Height(0),

--- a/zebra-state/src/sled_state.rs
+++ b/zebra-state/src/sled_state.rs
@@ -181,7 +181,10 @@ impl FinalizedState {
                     Some(height)
                 );
 
-                assert_eq!(finalized_tip_hash, prev_hash);
+                assert_eq!(
+                    finalized_tip_hash,
+                    queued_block.block.header.previous_block_hash
+                );
             }
 
             self.commit_finalized(queued_block);


### PR DESCRIPTION
## Motivation

Right now we don't check as that blocks committed to the state service form a valid chain other than by their hashes. This check isn't strictly necessary, since only valid blocks should ever be committed via the `CommitBlockFinalized` interface, and `CommitBlock` does (or soon will do) its own checking to ensure that heights are appropriately sequential. However, this could help catch programmer errors, so it's nice to have.

## Solution

This PR adds an assert that compares the previous tip hash to the new block being committed.

## Review

@teor2345 

## Related Issues

- [Tracking Issue](https://github.com/ZcashFoundation/zebra/issues/1249)

## Follow Up Work

- Update the state service itself to contain the related consensus critical checks that would ensure this test can only catch bugs and not legitimate recoverable errors - PR #1291
