### PR TITLE
switch to source based coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Merge coverage data
         run: $(rustc --print target-libdir)/../bin/llvm-profdata merge --sparse test.*.profraw -o test.profdata
       - name: Generate detailed html coverage report for github artifact
-        run: $(rustc --print target-libdir)/../bin/llvm-cov show -format=html -Xdemangler=rustfilt -show-instantiations -output-dir=./coverage -instr-profile=./test.profdata $(find target/debug/deps -type f -perm -u+x ! -name '*.so')
+        run: $(rustc --print target-libdir)/../bin/llvm-cov show -format=html -ignore-filename-regex="*/.cargo/registry/*" -Xdemangler=rustfilt -show-instantiations -output-dir=./coverage -instr-profile=./test.profdata $(find target/debug/deps -type f -perm -u+x ! -name '*.so')
       - uses: actions/upload-artifact@v2
         with:
           name: coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,20 +13,26 @@ jobs:
   coverage:
     name: Coverage
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
-      - name: Skip network tests on Ubuntu
-        # Ubuntu runners don't have network or DNS configured during test steps
-        run: echo "ZEBRA_SKIP_NETWORK_TESTS=1" >> $GITHUB_ENV
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.16.0'
-          timeout: 600
+          profile: minimal
+          components: llvm-tools-preview
+      - name: Install rustfilt symbol demangler
+        run: cargo install rustfilt
+      - name: Rerun tests for coverage
+        run: cargo test
+        env:
+          RUSTFLAGS: -Zinstrument-coverage
+          LLVM_PROFILE_FILE: "${{ github.workspace }}/test.%p.profraw"
+          ZEBRA_SKIP_NETWORK_TESTS: 1
+      - name: Merge coverage data
+        run: $(rustc --print target-libdir)/../bin/llvm-profdata merge --sparse test.*.profraw -o test.profdata
+      - name: Generate coverage report
+        run: $(rustc --print target-libdir)/../bin/llvm-cov export -format=lcov -instr-profile=test.profdata $(find target/debug/deps -type f -perm -u+x ! -name '*.so') > "lcov.info"
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v1.0.15
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Merge coverage data
         run: $(rustc --print target-libdir)/../bin/llvm-profdata merge --sparse test.*.profraw -o test.profdata
       - name: Generate detailed html coverage report for github artifact
-        run: $(rustc --print target-libdir)/../bin/llvm-cov show -format=html -ignore-filename-regex="*/.cargo/registry/*" -Xdemangler=rustfilt -show-instantiations -output-dir=./coverage -instr-profile=./test.profdata $(find target/debug/deps -type f -perm -u+x ! -name '*.so')
+        run: $(rustc --print target-libdir)/../bin/llvm-cov show -format=html -ignore-filename-regex=".*/.cargo/registry/.*" -ignore-filename-regex=".*/.cargo/git/.*" -ignore-filename-regex=".*/.rustup/.*" -Xdemangler=rustfilt -show-instantiations -output-dir=./coverage -instr-profile=./test.profdata $(find target/debug/deps -type f -perm -u+x ! -name '*.so')
       - uses: actions/upload-artifact@v2
         with:
           name: coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,29 +16,43 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           override: true
           profile: minimal
           components: llvm-tools-preview
+
       - name: Install rustfilt symbol demangler
-        run: cargo install rustfilt
+        run: |
+          cargo install rustfilt
+
       - name: Rerun tests for coverage
-        run: cargo test
         env:
-          RUSTFLAGS: -Zinstrument-coverage
+          RUSTFLAGS: -Zinstrument-coverage -C link-dead-code -C debuginfo=2
           LLVM_PROFILE_FILE: "${{ github.workspace }}/test.%p.profraw"
           ZEBRA_SKIP_NETWORK_TESTS: 1
+        run: |
+          cargo test
+          cargo test --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM - > filenames.txt
+
       - name: Merge coverage data
-        run: $(rustc --print target-libdir)/../bin/llvm-profdata merge --sparse test.*.profraw -o test.profdata
+        run: |
+          $(rustc --print target-libdir)/../bin/llvm-profdata merge test.*.profraw -o test.profdata
+
       - name: Generate detailed html coverage report for github artifact
-        run: $(rustc --print target-libdir)/../bin/llvm-cov show -format=html -ignore-filename-regex=".*/.cargo/registry/.*" -ignore-filename-regex=".*/.cargo/git/.*" -ignore-filename-regex=".*/.rustup/.*" -Xdemangler=rustfilt -show-instantiations -output-dir=./coverage -instr-profile=./test.profdata $(find target/debug/deps -type f -perm -u+x ! -name '*.so')
+        run: |
+          $(rustc --print target-libdir)/../bin/llvm-cov show -format=html -ignore-filename-regex=".*/.cargo/registry/.*" -ignore-filename-regex=".*/.cargo/git/.*" -ignore-filename-regex=".*/.rustup/.*" -Xdemangler=rustfilt -show-instantiations -output-dir=./coverage -instr-profile=./test.profdata $(printf -- "-object %s " $(cat filenames.txt))
+
       - uses: actions/upload-artifact@v2
         with:
           name: coverage
           path: ./coverage
+
       - name: Generate lcov coverage report for codecov
-        run: $(rustc --print target-libdir)/../bin/llvm-cov export -format=lcov -instr-profile=test.profdata $(find target/debug/deps -type f -perm -u+x ! -name '*.so') > "lcov.info"
+        run: |
+          $(rustc --print target-libdir)/../bin/llvm-cov export -format=lcov -instr-profile=test.profdata $(printf -- "-object %s " $(cat filenames.txt)) > "lcov.info"
+
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,13 @@ jobs:
           ZEBRA_SKIP_NETWORK_TESTS: 1
       - name: Merge coverage data
         run: $(rustc --print target-libdir)/../bin/llvm-profdata merge --sparse test.*.profraw -o test.profdata
-      - name: Generate coverage report
+      - name: Generate detailed html coverage report for github artifact
+        run: $(rustc --print target-libdir)/../bin/llvm-cov show -format=html -Xdemangler=rustfilt -show-instantiations -output-dir=./coverage -instr-profile=./test.profdata $(find target/debug/deps -type f -perm -u+x ! -name '*.so')
+      - uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: ./coverage
+      - name: Generate lcov coverage report for codecov
         run: $(rustc --print target-libdir)/../bin/llvm-cov export -format=lcov -instr-profile=test.profdata $(find target/debug/deps -type f -perm -u+x ! -name '*.so') > "lcov.info"
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Cargo files
 /target/
+/coverage-target/
 # Firebase caches (?)
 .firebase/
 # Emacs detritus

--- a/zebra-utils/coverage
+++ b/zebra-utils/coverage
@@ -2,22 +2,28 @@
 set -e
 set -o xtrace
 
-rm -rf ./target/
-mkdir -p ./target/coverage
-ZEBRA_SKIP_NETWORK_TESTS=1 LLVM_PROFILE_FILE="${PWD}/target/coverage/test.%p.profraw" RUSTFLAGS="-Zinstrument-coverage" cargo test
-$(rustc --print target-libdir)/../bin/llvm-profdata merge --sparse ./target/coverage/test.*.profraw -o ./target/coverage/test.profdata
+export CARGO_TARGET_DIR="coverage-target"
 
-rm -rf ./target/coverage/html/
-# This one works and shows all the details I want in the CLI
-$(rustc --print target-libdir)/../bin/llvm-cov show \
+rm -rf ./"$CARGO_TARGET_DIR"/coverage
+mkdir -p ./$CARGO_TARGET_DIR/coverage
+export ZEBRA_SKIP_NETWORK_TESTS=1
+export LLVM_PROFILE_FILE="${PWD}/$CARGO_TARGET_DIR/coverage/test.%m.profraw"
+export RUSTFLAGS="-Zinstrument-coverage -C link-dead-code -C debuginfo=2"
+cargo +nightly test --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM - > ./$CARGO_TARGET_DIR/files.txt
+cargo +nightly test
+$(rustc +nightly --print target-libdir)/../bin/llvm-profdata merge --sparse ./$CARGO_TARGET_DIR/coverage/test.*.profraw -o ./$CARGO_TARGET_DIR/coverage/test.profdata
+
+rm -rf ./$CARGO_TARGET_DIR/coverage/html/
+
+$(rustc +nightly --print target-libdir)/../bin/llvm-cov show \
 	-format=html \
 	-Xdemangler=rustfilt \
 	-show-instantiations \
-	-output-dir=./target/coverage/html \
+	-output-dir=./$CARGO_TARGET_DIR/coverage/html \
 	-ignore-filename-regex=".*/.cargo/registry/.*" \
 	-ignore-filename-regex=".*/.cargo/git/.*" \
 	-ignore-filename-regex=".*/.rustup/.*" \
-	-instr-profile=./target/coverage/test.profdata \
-	$(find target/ -type f -perm -u+x ! -name '*.so')
+	-instr-profile=./$CARGO_TARGET_DIR/coverage/test.profdata \
+	$(printf -- "-object %s " $(cat ./$CARGO_TARGET_DIR/files.txt))
 
-xdg-open ./target/coverage/html/index.html
+xdg-open ./$CARGO_TARGET_DIR/coverage/html/index.html

--- a/zebra-utils/coverage
+++ b/zebra-utils/coverage
@@ -1,0 +1,23 @@
+#! /bin/bash
+set -e
+set -o xtrace
+
+rm -rf ./target/
+mkdir -p ./target/coverage
+ZEBRA_SKIP_NETWORK_TESTS=1 LLVM_PROFILE_FILE="${PWD}/target/coverage/test.%p.profraw" RUSTFLAGS="-Zinstrument-coverage" cargo test
+$(rustc --print target-libdir)/../bin/llvm-profdata merge --sparse ./target/coverage/test.*.profraw -o ./target/coverage/test.profdata
+
+rm -rf ./target/coverage/html/
+# This one works and shows all the details I want in the CLI
+$(rustc --print target-libdir)/../bin/llvm-cov show \
+	-format=html \
+	-Xdemangler=rustfilt \
+	-show-instantiations \
+	-output-dir=./target/coverage/html \
+	-ignore-filename-regex=".*/.cargo/registry/.*" \
+	-ignore-filename-regex=".*/.cargo/git/.*" \
+	-ignore-filename-regex=".*/.rustup/.*" \
+	-instr-profile=./target/coverage/test.profdata \
+	$(find target/ -type f -perm -u+x ! -name '*.so')
+
+xdg-open ./target/coverage/html/index.html

--- a/zebra-utils/coverage
+++ b/zebra-utils/coverage
@@ -29,6 +29,6 @@ $(rustc +nightly --print target-libdir)/../bin/llvm-cov show \
 $(rustc +nightly --print target-libdir)/../bin/llvm-cov export \
 	-format=lcov \
 	-instr-profile=./$CARGO_TARGET_DIR/coverage/test.profdata \
-	$(printf -- "-object %s " $(cat ./$CARGO_TARGET_DIR/files.txt)) > "./$CARG_TARGET_DIR/coverage/lcov.info"
+	$(printf -- "-object %s " $(cat ./$CARGO_TARGET_DIR/files.txt)) > "./$CARGO_TARGET_DIR/coverage/lcov.info"
 
 xdg-open ./$CARGO_TARGET_DIR/coverage/html/index.html

--- a/zebra-utils/coverage
+++ b/zebra-utils/coverage
@@ -9,9 +9,9 @@ mkdir -p ./$CARGO_TARGET_DIR/coverage
 export ZEBRA_SKIP_NETWORK_TESTS=1
 export LLVM_PROFILE_FILE="${PWD}/$CARGO_TARGET_DIR/coverage/test.%m.profraw"
 export RUSTFLAGS="-Zinstrument-coverage -C link-dead-code -C debuginfo=2"
-cargo +nightly test --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM - > ./$CARGO_TARGET_DIR/files.txt
 cargo +nightly test
-$(rustc +nightly --print target-libdir)/../bin/llvm-profdata merge --sparse ./$CARGO_TARGET_DIR/coverage/test.*.profraw -o ./$CARGO_TARGET_DIR/coverage/test.profdata
+cargo +nightly test --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM - > ./$CARGO_TARGET_DIR/files.txt
+$(rustc +nightly --print target-libdir)/../bin/llvm-profdata merge ./$CARGO_TARGET_DIR/coverage/test.*.profraw -o ./$CARGO_TARGET_DIR/coverage/test.profdata
 
 rm -rf ./$CARGO_TARGET_DIR/coverage/html/
 

--- a/zebra-utils/coverage
+++ b/zebra-utils/coverage
@@ -3,12 +3,12 @@ set -e
 set -o xtrace
 
 export CARGO_TARGET_DIR="coverage-target"
-
-rm -rf ./"$CARGO_TARGET_DIR"/coverage
-mkdir -p ./$CARGO_TARGET_DIR/coverage
 export ZEBRA_SKIP_NETWORK_TESTS=1
 export LLVM_PROFILE_FILE="${PWD}/$CARGO_TARGET_DIR/coverage/test.%m.profraw"
 export RUSTFLAGS="-Zinstrument-coverage -C link-dead-code -C debuginfo=2"
+
+rm -rf ./"$CARGO_TARGET_DIR"/coverage
+mkdir -p ./$CARGO_TARGET_DIR/coverage
 cargo +nightly test
 cargo +nightly test --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM - > ./$CARGO_TARGET_DIR/files.txt
 $(rustc +nightly --print target-libdir)/../bin/llvm-profdata merge ./$CARGO_TARGET_DIR/coverage/test.*.profraw -o ./$CARGO_TARGET_DIR/coverage/test.profdata
@@ -25,5 +25,10 @@ $(rustc +nightly --print target-libdir)/../bin/llvm-cov show \
 	-ignore-filename-regex=".*/.rustup/.*" \
 	-instr-profile=./$CARGO_TARGET_DIR/coverage/test.profdata \
 	$(printf -- "-object %s " $(cat ./$CARGO_TARGET_DIR/files.txt))
+
+$(rustc +nightly --print target-libdir)/../bin/llvm-cov export \
+	-format=lcov \
+	-instr-profile=./$CARGO_TARGET_DIR/coverage/test.profdata \
+	$(printf -- "-object %s " $(cat ./$CARGO_TARGET_DIR/files.txt)) > "./$CARG_TARGET_DIR/coverage/lcov.info"
 
 xdg-open ./$CARGO_TARGET_DIR/coverage/html/index.html


### PR DESCRIPTION
## Motivation

Source-based coverage is more accurate and useful than 'gcov-based' coverage that we currently rely on:

![image](https://user-images.githubusercontent.com/552961/99113756-c5a67800-25bd-11eb-9579-0a82f52de614.png)
_Above: A comparison of the gcov (left) and source-based coverage (right) results. gcov highlights skipped lines, marked with #####, while source-based coverage highlights exact regions of code that were skipped. Note that on line 30, one boolean subexpression is short-circuited. This is surfaced by source-based coverage but not gcov._

https://blog.rust-lang.org/inside-rust/2020/11/12/source-based-code-coverage.html

## Solution

This PR switches to using `-Zinstrument-coverage` to calculate coverage using llvm's source based coverage instrumentation. We then upload that report in two different formats. First, we create an html report using `llvm-cov show`, which includes the exact coverage report, including details down to the specific regions in a line that are covered, and coverage per expansion of generic types.

A second format is then used to upload the coverage to `codecov`, this is because codecov doesn't currently support region based coverage results, so we have to fall back to an older format that they do understand. This discards some information and shows lines as covered when they're only partially covered, but should still be useful for tracking statistics and for ease of access.

The code in this pull request has:
  - [ ] Documentation Comments
  - [ ] Unit Tests and Property Tests

## Review

@dconnolly 
<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

## Related Issues

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
