### PR TITLE
Manual deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -144,9 +144,9 @@ jobs:
         run: |
           gcloud compute instance-templates create-with-container "zebrad-$BRANCH_NAME-$SHORT_SHA" \
           --container-image "gcr.io/$PROJECT_ID/$REPOSITORY/$BRANCH_NAME:$SHORT_SHA" \
-          --machine-type n2-standard-4 \
           --create-disk name=zebrad-cache-$SHORT_SHA,size=100GB,type=pd-balanced,auto-delete=no \
           --container-mount-disk mount-path="/zebrad-cache",name=zebrad-cache-$SHORT_SHA \
+          --machine-type n2-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
           --tags zebrad \

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -40,7 +40,10 @@ jobs:
       run: |
         gcloud builds submit \
           --config cloudbuild.yaml \
-          --substitutions SHORT_SHA="$SHORT_SHA",BRANCH_NAME="$BRANCH_NAME"
+          --substitutions SHORT_SHA="$SHORT_SHA",\
+          BRANCH_NAME="$BRANCH_NAME",\
+          _CHECKPOINT_SYNC="${{ github.event.inputs.checkpoint_sync }}",\
+          _NETWORK="${{ github.event.inputs.network }}"
 
     # Run once: create firewall rule to allow incoming traffic to the node
     # - name: Create Zcash incoming traffic firewall rule

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,0 +1,64 @@
+name: Deploy a zebrad node
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        default: 'mainnet'
+      checkpoint_sync:
+        default: true
+
+env:
+  PROJECT_ID: zealous-zebra
+
+jobs:
+
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set project and image names
+      run: |
+        BRANCH_NAME=$(expr $GITHUB_REF : '.*/\(.*\)') && \
+        BRANCH_NAME=${BRANCH_NAME,,} && \
+        REPOSITORY=${GITHUB_REPOSITORY,,} && \
+        echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV && \
+        echo "SHORT_SHA=$(git rev-parse --short=7 $GITHUB_SHA)" >> $GITHUB_ENV && \
+        echo "REPOSITORY=$REPOSITORY" >> $GITHUB_ENV
+
+    - name: Set up gcloud
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      with:
+        version: '295.0.0'
+        project_id: ${{ env.PROJECT_ID }}
+        service_account_key: ${{ secrets.GCLOUD_AUTH }}
+
+    # Build and push image to Google Container Registry
+    - name: Build
+      # Tagging w/ the commit SHA blocks the :latest tag on GCR
+      run: |
+        gcloud builds submit \
+          --config cloudbuild.yaml \
+          --substitutions SHORT_SHA="$SHORT_SHA",BRANCH_NAME="$BRANCH_NAME"
+
+    # Run once: create firewall rule to allow incoming traffic to the node
+    # - name: Create Zcash incoming traffic firewall rule
+    #   run: |
+    #     gcloud compute firewall-rules create "allow-zcash" \
+    #     --target-tags zebrad \
+    #     --allow tcp:8233,tcp:18233 \
+    #     --source-ranges 0.0.0.0/0 \
+    #     --description="Allow incoming Zcash traffic from anywhere" \
+
+    # Creates Compute Engine virtual machine instance w/ zebrad container and disks
+    - name: Create instance running zebrad container image
+      run: |
+        gcloud compute instances create-with-container "zebra-$BRANCH_NAME-$SHORT_SHA" \
+        --container-image "gcr.io/$PROJECT_ID/$REPOSITORY/$BRANCH_NAME:$SHORT_SHA" \
+        --container-mount-disk mount-path='/zebrad-cache',name=zebrad-cache-$SHORT_SHA \
+        --create-disk name=zebrad-cache-$SHORT_SHA,size=100GB,type=pd-balanced,auto-delete=no \
+        --machine-type n2-standard-4 \
+        --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
+        --tags zebrad \
+        --zone us-central1-a

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       network:
-        default: 'mainnet'
+        default: 'Mainnet'
       checkpoint_sync:
         default: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,9 @@ ARG checkpoint_sync=true
 ARG network=Mainnet
 
 RUN printf "[consensus]\n" >> /zebrad.toml
-RUN printf "checkpoint_sync = $checkpoint_sync\n" >> /zebrad.toml
+RUN printf "checkpoint_sync = ${checkpoint_sync}\n" >> /zebrad.toml
 RUN printf "[network]\n" >> /zebrad.toml
-RUN printf "network = $network\n" >> /zebrad.toml
+RUN printf "network = '${network}'\n" >> /zebrad.toml
 RUN printf "[state]\n" >> /zebrad.toml
 RUN printf "cache_dir = '/zebrad-cache'\n" >> /zebrad.toml
 RUN printf "memory_cache_bytes = 52428800\n" >> /zebrad.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,13 +35,13 @@ FROM debian:buster-slim AS zebrad-release
 
 COPY --from=builder /zebra/target/release/zebrad /
 
-ARG checkpoint_sync=true
-ARG network=Mainnet
+ARG CHECKPOINT_SYNC=true
+ARG NETWORK=Mainnet
 
 RUN printf "[consensus]\n" >> /zebrad.toml
-RUN printf "checkpoint_sync = ${checkpoint_sync}\n" >> /zebrad.toml
+RUN printf "checkpoint_sync = ${CHECKPOINT_SYNC}\n" >> /zebrad.toml
 RUN printf "[network]\n" >> /zebrad.toml
-RUN printf "network = '${network}'\n" >> /zebrad.toml
+RUN printf "network = '${NETWORK}'\n" >> /zebrad.toml
 RUN printf "[state]\n" >> /zebrad.toml
 RUN printf "cache_dir = '/zebrad-cache'\n" >> /zebrad.toml
 RUN printf "memory_cache_bytes = 52428800\n" >> /zebrad.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,13 @@ FROM debian:buster-slim AS zebrad-release
 
 COPY --from=builder /zebra/target/release/zebrad /
 
+ARG checkpoint_sync=true
+ARG network=Mainnet
+
 RUN printf "[consensus]\n" >> /zebrad.toml
-RUN printf "checkpoint_sync = true\n" >> /zebrad.toml
+RUN printf "checkpoint_sync = $checkpoint_sync\n" >> /zebrad.toml
+RUN printf "[network]\n" >> /zebrad.toml
+RUN printf "network = $network\n" >> /zebrad.toml
 RUN printf "[state]\n" >> /zebrad.toml
 RUN printf "cache_dir = '/zebrad-cache'\n" >> /zebrad.toml
 RUN printf "memory_cache_bytes = 52428800\n" >> /zebrad.toml

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,8 +1,22 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--target', 'zebra-tests', '-t', 'gcr.io/$PROJECT_ID/zcashfoundation/zebra/tests/$BRANCH_NAME:$SHORT_SHA', '.']
+  args: ['build',
+         '--target',
+         'zebra-tests',
+         '-t',
+         'gcr.io/$PROJECT_ID/zcashfoundation/zebra/tests/$BRANCH_NAME:$SHORT_SHA',
+         '.']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--target', 'zebrad-release', '-t', 'gcr.io/$PROJECT_ID/zcashfoundation/zebra/$BRANCH_NAME:$SHORT_SHA', '.']
+  args: ['build',
+         '--build-arg',
+         'checkpoint_sync=${_CHECKPOINT_SYNC}',
+         '--build-arg',
+         'network=${_NETWORK}',
+         '--target',
+         'zebrad-release',
+         '-t',
+         'gcr.io/$PROJECT_ID/zcashfoundation/zebra/$BRANCH_NAME:$SHORT_SHA',
+         '.']
 
 images:
 - 'gcr.io/$PROJECT_ID/zcashfoundation/zebra/tests/$BRANCH_NAME:$SHORT_SHA'
@@ -10,5 +24,6 @@ images:
 
 options:
     machineType: 'N1_HIGHCPU_32'
+    substitution_option: 'ALLOW_LOOSE'
 
 timeout: 1800s # 30 mins


### PR DESCRIPTION
## Motivation

I keep enabling the CD workflow for just a branch to deploy a node. This is better.

## Solution

This allows triggering a workflow from the Actions tab to deploy a single zebrad node that will sync from genesis to tip (or attempt to) as a container on a VM. It's up to the human to clean it up when they're done with it. 

The code in this pull request has:
  - [x] Documentation Comments
