### PR TITLE
Fix Block Height contextual verification

### DIFF
--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -8,6 +8,8 @@
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_chain")]
 // #![deny(missing_docs)]
 #![allow(clippy::try_err)]
+#![allow(clippy::unknown_clippy_lints)]
+#![allow(clippy::from_iter_instead_of_collect)]
 
 #[macro_use]
 extern crate serde;

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -5,6 +5,8 @@
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_state")]
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
+#![allow(clippy::unknown_clippy_lints)]
+#![allow(clippy::field_reassign_with_default)]
 
 mod config;
 mod constants;

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -190,15 +190,17 @@ impl StateService {
         );
         check::block_is_not_orphaned(finalized_tip_height, block)?;
 
-        let parent_block = self
-            .block(block.hash().into())
-            .expect("the parent's presence has already been checked");
+        let mut relevant_chain = self.chain(block.header.previous_block_hash);
+        let parent_block = relevant_chain
+            .next()
+            .expect("state must contain parent block to do contextual validation");
         let parent_height = parent_block
             .coinbase_height()
             .expect("valid blocks have a coinbase height");
         check::height_one_more_than_parent_height(parent_height, block)?;
 
-        // TODO: contextual validation design and implementation
+        // TODO: validate difficulty adjustment
+        // TODO: other contextual validation design and implelentation
         Ok(())
     }
 
@@ -269,7 +271,6 @@ impl StateService {
     ///
     /// The block identified by `hash` is included in the chain of blocks yielded
     /// by the iterator.
-    #[allow(dead_code)]
     pub fn chain(&self, hash: block::Hash) -> Iter<'_> {
         Iter {
             service: self,

--- a/zebra-test/src/lib.rs
+++ b/zebra-test/src/lib.rs
@@ -1,5 +1,7 @@
 //! Miscellaneous test code for Zebra.
 
+#![allow(clippy::unknown_clippy_lints)]
+#![allow(clippy::from_iter_instead_of_collect)]
 // Each lazy_static variable uses additional recursion
 #![recursion_limit = "256"]
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -14,6 +14,8 @@
 #![warn(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]
 #![allow(clippy::try_err)]
+#![allow(clippy::unknown_clippy_lints)]
+#![allow(clippy::field_reassign_with_default)]
 
 use color_eyre::eyre::Result;
 use eyre::WrapErr;


### PR DESCRIPTION
## Motivation

`check_contextual_validity` mistakenly uses the new block's hash to try
to get the parent block from the state. This causes a panic, because the
new block isn't in the state yet.

## Solution

Use `StateService::chain` to get the parent block, because we'll be using `chain` for difficulty adjustment contextual verification anyway.

Add a span with the height, hash, and network to `check_contextual_validity`.

Also silence some new nightly clippy warnings.

Testing:
    - The `check_contextual_validity` function can't be checked by unit or property tests, but it will be tested by the contextual sync and sync to tip CI tests


## Review

@yaahc who wrote the original code.

This bug makes it impossible to sync past the last checkpoint.
It's not blocking anything yet, but it does make it harder to do other sync and verify work.

## Related Issues

PR #1291 introduced this bug
