### PR TITLE
Improve network message and state request docs

### DIFF
--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -121,20 +121,15 @@ pub enum Message {
         data: Option<[u8; 32]>,
     },
 
-    /// An `addr` message.
-    ///
-    /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#addr)
-    Addr(Vec<MetaAddr>),
-
     /// A `getaddr` message.
     ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#getaddr)
     GetAddr,
 
-    /// A `block` message.
+    /// An `addr` message.
     ///
-    /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#block)
-    Block(Arc<Block>),
+    /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#addr)
+    Addr(Vec<MetaAddr>),
 
     /// A `getblocks` message.
     ///
@@ -155,16 +150,14 @@ pub enum Message {
         stop: Option<block::Hash>,
     },
 
-    /// A `headers` message.
+    /// An `inv` message.
     ///
-    /// Returns block headers in response to a getheaders packet.
+    /// Allows a node to advertise its knowledge of one or more
+    /// objects. It can be received unsolicited, or in reply to
+    /// `getblocks`.
     ///
-    /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#headers)
-    // Note that the block headers in this packet include a
-    // transaction count (a var_int, so there can be more than 81
-    // bytes per header) as opposed to the block headers that are
-    // hashed by miners.
-    Headers(Vec<block::Header>),
+    /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#inv)
+    Inv(Vec<InventoryHash>),
 
     /// A `getheaders` message.
     ///
@@ -173,7 +166,7 @@ pub enum Message {
     /// of its best chain and determine the blocks following the intersection
     /// point.
     ///
-    /// The peer responds with an `headers` packet with the hashes of subsequent blocks.
+    /// The peer responds with an `headers` packet with the headers of subsequent blocks.
     /// If supplied, the `stop` parameter specifies the last header to request.
     /// Otherwise, the maximum number of block headers (160) are sent.
     ///
@@ -185,14 +178,16 @@ pub enum Message {
         stop: Option<block::Hash>,
     },
 
-    /// An `inv` message.
+    /// A `headers` message.
     ///
-    /// Allows a node to advertise its knowledge of one or more
-    /// objects. It can be received unsolicited, or in reply to
-    /// `getblocks`.
+    /// Returns block headers in response to a getheaders packet.
     ///
-    /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#inv)
-    Inv(Vec<InventoryHash>),
+    /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#headers)
+    // Note that the block headers in this packet include a
+    // transaction count (a var_int, so there can be more than 81
+    // bytes per header) as opposed to the block headers that are
+    // hashed by miners.
+    Headers(Vec<block::Header>),
 
     /// A `getdata` message.
     ///
@@ -203,16 +198,21 @@ pub enum Message {
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#getdata)
     GetData(Vec<InventoryHash>),
 
-    /// A `notfound` message.
+    /// A `block` message.
     ///
-    /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#notfound)
-    // See note above on `Inventory`.
-    NotFound(Vec<InventoryHash>),
+    /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#block)
+    Block(Arc<Block>),
 
     /// A `tx` message.
     ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#tx)
     Tx(Arc<Transaction>),
+
+    /// A `notfound` message.
+    ///
+    /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#notfound)
+    // See note above on `Inventory`.
+    NotFound(Vec<InventoryHash>),
 
     /// A `mempool` message.
     ///

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -83,45 +83,49 @@ pub enum Request {
         // sapling_anchor: sapling::tree::Root,
     },
 
-    /// Computes the depth in the best chain of the block identified by the given hash.
+    /// Computes the depth in the current best chain of the block identified by the given hash.
     ///
     /// Returns
     ///
-    /// * [`Response::Depth(Some(depth))`](Response::Depth) if the block is in the main chain;
+    /// * [`Response::Depth(Some(depth))`](Response::Depth) if the block is in the best chain;
     /// * [`Response::Depth(None)`](Response::Depth) otherwise.
     Depth(block::Hash),
 
     /// Returns [`Response::Tip`] with the current best chain tip.
     Tip,
 
-    /// Computes a block locator object based on the current chain state.
+    /// Computes a block locator object based on the current best chain.
     ///
     /// Returns [`Response::BlockLocator`] with hashes starting
-    /// from the current chain tip and reaching backwards towards the genesis
-    /// block. The first hash is the current chain tip. The last hash is the tip
-    /// of the finalized portion of the state. If the state is empty, the block
-    /// locator is also empty.
+    /// from the best chain tip, and following the chain of previous
+    /// hashes. The first hash is the best chain tip. The last hash is
+    /// the tip of the finalized portion of the state. Block locators
+    /// are not continuous - some intermediate hashes might be skipped.
+    ///
+    /// If the state is empty, the block locator is also empty.
     BlockLocator,
 
-    /// Looks up a transaction by hash.
+    /// Looks up a transaction by hash in the current best chain.
     ///
     /// Returns
     ///
-    /// * [`Response::Transaction(Some(Arc<Transaction>))`](Response::Transaction) if the transaction is known;
+    /// * [`Response::Transaction(Some(Arc<Transaction>))`](Response::Transaction) if the transaction is in the best chain;
     /// * [`Response::Transaction(None)`](Response::Transaction) otherwise.
     Transaction(transaction::Hash),
 
-    /// Looks up a block by hash or height.
+    /// Looks up a block by hash or height in the current best chain.
     ///
     /// Returns
     ///
-    /// * [`Response::Block(Some(Arc<Block>))`](Response::Block) if the block is known;
-    /// * [`Response::Block(None)`](Response::Transaction) otherwise.
+    /// * [`Response::Block(Some(Arc<Block>))`](Response::Block) if the block is in the best chain;
+    /// * [`Response::Block(None)`](Response::Block) otherwise.
     ///
     /// Note: the [`HashOrHeight`] can be constructed from a [`block::Hash`] or
     /// [`block::Height`] using `.into()`.
     Block(HashOrHeight),
 
-    /// Request a UTXO identified by the given Outpoint
+    /// Request a UTXO identified by the given Outpoint in any chain.
+    ///
+    /// Returns UTXOs fron any chain, including side-chains.
     AwaitUtxo(transparent::OutPoint),
 }


### PR DESCRIPTION
## Motivation

The network message and state request docs are incomplete, and sometimes confusing. But we can fix that!

## Solution

Put the network messages in a more logical order
Fix a typo in the FindHeaders message

Document best and any chain state requests
Explain that the block locator is sparse
Don't refer to genesis in the block locator, it's confusing

## Review

@yaahc is familiar with the state service, which has the major changes.
(The messages changes are just copy and paste, and a single word typo.)

These doc updates can happen at any time, but they'll cause merge issues with upcoming state request changes like #1306

## Related Issues

Blocks #1306
