### PR TITLE
Move all contextual validation code into its own function

### DIFF
--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -1,8 +1,63 @@
 //! Consensus critical contextual checks
 
-use zebra_chain::block::{self, Block};
+use zebra_chain::{
+    block::{self, Block},
+    parameters::Network,
+};
 
 use crate::ValidateContextError;
+
+use super::check;
+
+/// Check that `block` is contextually valid for `network`, based on the
+/// `finalized_tip_height` and `relevant_chain`.
+///
+/// The relevant chain is an iterator over the ancestors of `block`, starting
+/// with its parent block.
+pub(crate) fn block_is_contextually_valid<C>(
+    block: &Block,
+    network: Network,
+    finalized_tip_height: Option<block::Height>,
+    relevant_chain: C,
+) -> Result<(), ValidateContextError>
+where
+    C: IntoIterator,
+    C::Item: AsRef<Block>,
+{
+    let height = block
+        .coinbase_height()
+        .expect("semantically valid blocks have a coinbase height");
+    let hash = block.hash();
+
+    let span = tracing::info_span!(
+        "StateService::check_contextual_validity",
+        ?height,
+        ?network,
+        ?hash
+    );
+    let _entered = span.enter();
+
+    let finalized_tip_height = finalized_tip_height
+        .expect("finalized state must contain at least one block to use the non-finalized state");
+    check::block_is_not_orphaned(finalized_tip_height, block)?;
+
+    let mut relevant_chain = relevant_chain.into_iter();
+    let parent_block = relevant_chain
+        .next()
+        .expect("state must contain parent block to do contextual validation");
+    let parent_block = parent_block.as_ref();
+    let parent_height = parent_block
+        .coinbase_height()
+        .expect("valid blocks have a coinbase height");
+    let parent_hash = parent_block.hash();
+    check::height_one_more_than_parent_height(parent_height, block)?;
+    // should be impossible by design, so no handleable error is thrown
+    assert_eq!(parent_hash, block.header.previous_block_hash);
+
+    // TODO: validate difficulty adjustment
+    // TODO: other contextual validation design and implelentation
+    Ok(())
+}
 
 /// Returns `ValidateContextError::OrphanedBlock` if the height of the given
 /// block is less than or equal to the finalized tip height.


### PR DESCRIPTION
## Motivation

The contextual validation function is hard to test.

It also directly accesses the sled state, but we want to work on sled and contextual validation at the same time.

## Solution

Move the contextual validation function into the check module, and call it via a wrapper in the state service.

This change has two benefits:
* reduces conflicts with the sled refactor and any replacement
* allows the function to be called independently for testing

The code in this pull request has:
  - [x] Documentation Comments
  - ~Unit Tests and Property Tests~
    - This code change is a basic refactor which enables future tests

## Review

@yaahc is also working on a sled refactor right now, they might conflict.

## Follow Up Work

Do the rest of the difficulty contextual validation #802