### PR TITLE
Add mdbook stuff to path using environment files/variables

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
         cd book
         curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.1/mdbook-v0.4.1-x86_64-unknown-linux-gnu.tar.gz | tar xz
         # Add the book directory to the $PATH
-        echo "::add-path::$GITHUB_WORKSPACE/book"
+        echo "$GITHUB_WORKSPACE/book" >> $GITHUB_PATH
 
     - name: Build Zebra book
       run: |


### PR DESCRIPTION
## Motivation

Fixes #1309

## Solution

Use environment files (exposed as env vars) instead of workflow commands.

## Related Issues

#1309 
