### PR TITLE
Move chain order assertions to commit_finalized_direct

### DIFF
--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -49,10 +49,7 @@ where
     let parent_height = parent_block
         .coinbase_height()
         .expect("valid blocks have a coinbase height");
-    let parent_hash = parent_block.hash();
     check::height_one_more_than_parent_height(parent_height, block)?;
-    // should be impossible by design, so no handleable error is thrown
-    assert_eq!(parent_hash, block.header.previous_block_hash);
 
     // TODO: validate difficulty adjustment
     // TODO: other contextual validation design and implelentation


### PR DESCRIPTION
## Motivation

We want to make sure that no Zebra code can commit out-of-order blocks to the finalized state.

We can ensure this constraint using assertions, just before we write to the database.

## Solution

Move the chain order assertions to `commit_finalized_direct`.

Also remove a duplicate assert in the contextual verification function.

The code in this pull request has:
  - [x] Comments
  - ~Unit Tests and Property Tests~
    - these assertions are a substitute for unit tests that we can't write

## Review

This PR probably conflicts with @yaahc's state database rewrite.
