### PR TITLE
fixup! zebrad: hack to skip alreadyverified errors

### DIFF
--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -183,8 +183,12 @@ where
                             tracing::trace!(?hash, "verified and committed block to state");
                         }
                         Err(e) => {
-                            tracing::warn!(?e, "error downloading and verifying block");
-                            continue 'sync;
+                            if format!("{:?}", e).contains("AlreadyVerified {") {
+                                tracing::debug!(error = ?e, "block was already verified, possibly from a previous sync run, continuing");
+                            } else {
+                                tracing::warn!(?e, "error downloading and verifying block");
+                                continue 'sync;
+                            }
                         }
                     }
                 }
@@ -217,7 +221,7 @@ where
 
                         Err(e) => {
                             if format!("{:?}", e).contains("AlreadyVerified {") {
-                                tracing::info!(error = ?e, "error seems like it might be already verified, this is probably fine i guess?")
+                                tracing::debug!(error = ?e, "block was already verified, possibly from a previous sync run, continuing");
                             } else {
                                 tracing::warn!(?e, "error downloading and verifying block");
                                 continue 'sync;


### PR DESCRIPTION

## Motivation

The hack introduced in #1298 to handle already-verified errors was incomplete.

## Follow Up Work

This will be eliminated by #1321 some time after the first alpha.