### PR TITLE
Update to Tokio 0.3, Tower 0.4, development hyper and metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
+
+[[package]]
 name = "canonical-path"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +465,15 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
  "bitflags",
 ]
@@ -1046,7 +1061,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.1",
+ "pin-project 1.0.2",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1166,7 +1181,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1174,7 +1189,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 0.2.23",
  "tokio-util 0.3.1",
  "tracing",
  "tracing-futures",
@@ -1230,7 +1245,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -1241,7 +1256,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "http",
 ]
 
@@ -1272,7 +1287,7 @@ version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1282,9 +1297,9 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.1",
+ "pin-project 1.0.2",
  "socket2",
- "tokio",
+ "tokio 0.2.23",
  "tower-service",
  "tracing",
  "want",
@@ -1360,6 +1375,15 @@ dependencies = [
  "quick-xml",
  "rgb",
  "str_stack",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1467,6 +1491,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,7 +1591,7 @@ checksum = "f3fc63816bd5f8bde5eb31ce471f9633adc69ba1c55b44191b4d5fc7e263e8ab"
 dependencies = [
  "log",
  "metrics-core",
- "tokio",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -1614,15 +1647,15 @@ dependencies = [
  "metrics-observer-prometheus",
  "metrics-observer-yaml",
  "metrics-util",
- "parking_lot",
+ "parking_lot 0.10.2",
  "quanta",
 ]
 
 [[package]]
 name = "metrics-util"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11f8090a8886339f9468a04eeea0711e4cf27538b134014664308041307a1c5"
+checksum = "277619f040719a5a23d75724586d5601286e8fa53451cfaaca3b8c627c2c2378"
 dependencies = [
  "crossbeam-epoch 0.8.2",
  "serde",
@@ -1658,26 +1691,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio-named-pipes"
-version = "0.1.7"
+name = "mio"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
+checksum = "f33bc887064ef1fd66020c9adfc45bb9f33d75a42096c81e7c56c65b75dd1a8b"
 dependencies = [
- "log",
- "mio",
- "miow 0.3.5",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
  "libc",
- "mio",
+ "log",
+ "miow 0.3.6",
+ "ntapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1694,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi 0.3.9",
@@ -1737,6 +1760,15 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
  "version_check 0.9.2",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1844,8 +1876,19 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
- "lock_api",
- "parking_lot_core",
+ "lock_api 0.3.4",
+ "parking_lot_core 0.7.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api 0.4.2",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -1855,10 +1898,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if 0.1.10",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if 0.1.10",
+ "cloudabi 0.1.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.5.0",
  "winapi 0.3.9",
 ]
 
@@ -1885,11 +1943,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
 dependencies = [
- "pin-project-internal 1.0.1",
+ "pin-project-internal 1.0.2",
 ]
 
 [[package]]
@@ -1905,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
+checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -1919,6 +1977,12 @@ name = "pin-project-lite"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
 
 [[package]]
 name = "pin-utils"
@@ -2559,9 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 
 [[package]]
 name = "socket2"
@@ -2717,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
@@ -2794,18 +2858,33 @@ version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
+ "memchr",
+ "mio 0.6.22",
+ "pin-project-lite 0.1.11",
+ "slab",
+]
+
+[[package]]
+name = "tokio"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfe2523e6fa84ddf5e688151d4e5fddc51678de9752c6512a24714c23818d61"
+dependencies = [
+ "autocfg",
+ "bytes 0.6.0",
+ "futures-core",
+ "lazy_static",
  "libc",
  "memchr",
- "mio",
- "mio-named-pipes",
- "mio-uds",
+ "mio 0.7.6",
  "num_cpus",
- "pin-project-lite",
+ "parking_lot 0.11.1",
+ "pin-project-lite 0.2.0",
  "signal-hook-registry",
  "slab",
  "tokio-macros",
@@ -2815,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.6"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+checksum = "21d30fdbb5dc2d8f91049691aa1a9d4d4ae422a21c334ce8936e5886d30c5c45"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -2826,30 +2905,30 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
- "tokio",
+ "pin-project-lite 0.1.11",
+ "tokio 0.2.23",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73af76301319bcacf00d26d3c75534ef248dcad7ceaf36d93ec902453c3b1706"
+dependencies = [
+ "bytes 0.6.0",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.1.11",
+ "tokio 0.3.4",
 ]
 
 [[package]]
@@ -2863,14 +2942,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.3.1"
-source = "git+https://github.com/tower-rs/tower?rev=1a84543#1a845433177b31ebc6daff765ee81468c42d6676"
+version = "0.4.0"
+source = "git+https://github.com/tower-rs/tower?rev=5e1e07744820028877654c336a3b9fe057bf46f1#5e1e07744820028877654c336a3b9fe057bf46f1"
 dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
- "pin-project 0.4.27",
- "tokio",
+ "pin-project 1.0.2",
+ "tokio 0.3.4",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2886,7 +2965,7 @@ dependencies = [
  "futures-core",
  "pin-project 0.4.27",
  "rand 0.7.3",
- "tokio",
+ "tokio 0.3.4",
  "tower",
  "tower-fallback",
  "tracing",
@@ -2900,7 +2979,7 @@ version = "0.1.0"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.3.4",
  "tower",
  "tracing",
  "zebra-test",
@@ -2909,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "tower-layer"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower?rev=1a84543#1a845433177b31ebc6daff765ee81468c42d6676"
+source = "git+https://github.com/tower-rs/tower?rev=5e1e07744820028877654c336a3b9fe057bf46f1#5e1e07744820028877654c336a3b9fe057bf46f1"
 
 [[package]]
 name = "tower-service"
@@ -2937,7 +3016,7 @@ checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -3045,7 +3124,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -3088,9 +3167,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f98e67a4d84f730d343392f9bfff7d21e3fca562b9cb7a43b768350beeddc6"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
@@ -3340,7 +3419,7 @@ dependencies = [
  "serde",
  "spandoc",
  "thiserror",
- "tokio",
+ "tokio 0.3.4",
  "tower",
  "tower-batch",
  "tower-fallback",
@@ -3361,7 +3440,7 @@ version = "3.0.0-alpha.0"
 dependencies = [
  "bitflags",
  "byteorder",
- "bytes",
+ "bytes 0.6.0",
  "chrono",
  "futures",
  "hex",
@@ -3373,8 +3452,8 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "thiserror",
- "tokio",
- "tokio-util 0.2.0",
+ "tokio 0.3.4",
+ "tokio-util 0.5.0",
  "tower",
  "tracing",
  "tracing-error",
@@ -3419,7 +3498,7 @@ dependencies = [
  "spandoc",
  "tempdir",
  "thiserror",
- "tokio",
+ "tokio 0.3.4",
  "tower",
  "tracing",
  "tracing-error",
@@ -3442,7 +3521,7 @@ dependencies = [
  "spandoc",
  "tempdir",
  "thiserror",
- "tokio",
+ "tokio 0.3.4",
  "tower",
  "tracing",
  "tracing-error",
@@ -3484,7 +3563,7 @@ dependencies = [
  "serde",
  "tempdir",
  "thiserror",
- "tokio",
+ "tokio 0.3.4",
  "toml",
  "tower",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,15 @@ checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
+name = "ahash"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
@@ -81,7 +90,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -90,14 +99,14 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "arc-swap"
-version = "0.4.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+checksum = "0688b520bcc7498f6ca8fa006e8031d353e3fd4f51bd4a50fb03cc4230b28bd2"
 
 [[package]]
 name = "arrayref"
@@ -137,7 +146,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -180,6 +189,12 @@ name = "bech32"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
+
+[[package]]
+name = "beef"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "474a626a67200bd107d44179bb3d4fc61891172d11696609264589be6a0e6a43"
 
 [[package]]
 name = "bincode"
@@ -235,15 +250,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "bitvec"
@@ -431,7 +437,7 @@ dependencies = [
  "num-traits",
  "serde",
  "time",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -458,15 +464,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -767,6 +764,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "3.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
+dependencies = [
+ "ahash 0.3.8",
+ "cfg-if 0.1.10",
+ "num_cpus",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,7 +815,7 @@ checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -820,12 +828,6 @@ dependencies = [
  "quote 1.0.7",
  "syn 1.0.48",
 ]
-
-[[package]]
-name = "dtoa"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "ed25519-zebra"
@@ -952,22 +954,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "funty"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,7 +1073,7 @@ dependencies = [
  "libc",
  "log",
  "rustc_version",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1177,9 +1163,8 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+version = "0.3.0"
+source = "git+https://github.com/hyperium/h2#cbbdd305b1afc1eaf19f2e3b26f9419048041e7d"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -1189,8 +1174,8 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.23",
- "tokio-util 0.3.1",
+ "tokio",
+ "tokio-util 0.4.0",
  "tracing",
  "tracing-futures",
 ]
@@ -1212,6 +1197,20 @@ dependencies = [
  "crossbeam-channel 0.3.9",
  "flate2",
  "nom 4.2.3",
+ "num-traits",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3c22708574c44e924720c5b3a116326c688e6d532f438c77c007ec8768644f9"
+dependencies = [
+ "base64 0.12.3",
+ "byteorder",
+ "crossbeam-channel 0.4.4",
+ "flate2",
+ "nom 5.1.2",
  "num-traits",
 ]
 
@@ -1283,9 +1282,8 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+version = "0.14.0-dev"
+source = "git+https://github.com/hyperium/hyper/?rev=ed2b22a7f66899d338691552fbcb6c0f2f4e06b9#ed2b22a7f66899d338691552fbcb6c0f2f4e06b9"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
@@ -1299,7 +1297,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.2",
  "socket2",
- "tokio 0.2.23",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -1320,20 +1318,6 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "im"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
-dependencies = [
- "bitmaps",
- "rand_core 0.5.1",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check 0.9.2",
 ]
 
 [[package]]
@@ -1367,7 +1351,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48b0b7698c16bccca4617de8f9ede9f58ab44a68ad6b2a4920fd74e491de580d"
 dependencies = [
- "ahash",
+ "ahash 0.4.6",
  "itoa",
  "lazy_static",
  "log",
@@ -1384,15 +1368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1426,16 +1401,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,6 +1411,19 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
+dependencies = [
+ "arrayvec 0.5.2",
+ "bitflags",
+ "cfg-if 0.1.10",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -1460,7 +1438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
  "cc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1473,21 +1451,6 @@ dependencies = [
  "cc",
  "glob",
  "libc",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
-
-[[package]]
-name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
 ]
 
 [[package]]
@@ -1567,98 +1530,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.13.0-alpha.8"
+source = "git+https://github.com/ZcashFoundation/metrics?rev=971133128e5aebe3ad177acffc6154449736cfa2#971133128e5aebe3ad177acffc6154449736cfa2"
+dependencies = [
+ "beef",
+ "metrics-macros",
+ "proc-macro-hack",
+ "sharded-slab",
+]
+
+[[package]]
 name = "metrics-core"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c064b3a1ff41f4bf6c91185c8a0caeccf8a8a27e9d0f92cc54cf3dbec812f48"
 
 [[package]]
-name = "metrics-exporter-http"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14017d204ae062dc5c68a321e3dbdcd9b30181305cb6b067932f7f03f754e27"
+name = "metrics-exporter-prometheus"
+version = "0.1.0-alpha.7"
+source = "git+https://github.com/ZcashFoundation/metrics?rev=971133128e5aebe3ad177acffc6154449736cfa2#971133128e5aebe3ad177acffc6154449736cfa2"
 dependencies = [
+ "hdrhistogram 7.1.0",
  "hyper",
- "log",
- "metrics-core",
-]
-
-[[package]]
-name = "metrics-exporter-log"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3fc63816bd5f8bde5eb31ce471f9633adc69ba1c55b44191b4d5fc7e263e8ab"
-dependencies = [
- "log",
- "metrics-core",
- "tokio 0.2.23",
-]
-
-[[package]]
-name = "metrics-observer-json"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe930460a6c336b8f873dcfb28da3f805fd0dbadbea7beaf3042c7fb1d9fcd3"
-dependencies = [
- "hdrhistogram",
- "metrics-core",
+ "metrics 0.13.0-alpha.8",
  "metrics-util",
- "serde_json",
+ "parking_lot",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
-name = "metrics-observer-prometheus"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bfe24ad8285ef8b239232135a65f89cc5fa4690bbfaf8907f4bef38f8b08eba"
+name = "metrics-macros"
+version = "0.1.0-alpha.5"
+source = "git+https://github.com/ZcashFoundation/metrics?rev=971133128e5aebe3ad177acffc6154449736cfa2#971133128e5aebe3ad177acffc6154449736cfa2"
 dependencies = [
- "hdrhistogram",
- "metrics-core",
- "metrics-util",
-]
-
-[[package]]
-name = "metrics-observer-yaml"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f66811013592560efc75d75a92d6e2f415a11b52f085e51d9fb4d1edec6335"
-dependencies = [
- "hdrhistogram",
- "metrics-core",
- "metrics-util",
- "serde_yaml",
-]
-
-[[package]]
-name = "metrics-runtime"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0e4f69639ccc0c6b2f0612164f9817349eb25545ed1ffb5ef3e1e1c1d220b4"
-dependencies = [
- "arc-swap",
- "atomic-shim",
- "crossbeam-utils 0.7.2",
- "im",
- "metrics",
- "metrics-core",
- "metrics-exporter-http",
- "metrics-exporter-log",
- "metrics-observer-json",
- "metrics-observer-prometheus",
- "metrics-observer-yaml",
- "metrics-util",
- "parking_lot 0.10.2",
- "quanta",
+ "lazy_static",
+ "proc-macro-hack",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "regex",
+ "syn 1.0.48",
 ]
 
 [[package]]
 name = "metrics-util"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277619f040719a5a23d75724586d5601286e8fa53451cfaaca3b8c627c2c2378"
+version = "0.4.0-alpha.6"
+source = "git+https://github.com/ZcashFoundation/metrics?rev=971133128e5aebe3ad177acffc6154449736cfa2#971133128e5aebe3ad177acffc6154449736cfa2"
 dependencies = [
- "crossbeam-epoch 0.8.2",
- "serde",
+ "arc-swap",
+ "atomic-shim",
+ "crossbeam-epoch 0.9.0",
+ "crossbeam-utils 0.8.0",
+ "dashmap",
+ "indexmap",
+ "metrics 0.13.0-alpha.8",
 ]
 
 [[package]]
@@ -1673,46 +1599,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow 0.2.1",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f33bc887064ef1fd66020c9adfc45bb9f33d75a42096c81e7c56c65b75dd1a8b"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.6",
+ "miow",
  "ntapi",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1722,18 +1617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1758,6 +1642,7 @@ version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
+ "lexical-core",
  "memchr",
  "version_check 0.9.2",
 ]
@@ -1768,7 +1653,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1840,7 +1725,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1872,37 +1757,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.2",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
- "lock_api 0.4.2",
- "parking_lot_core 0.8.0",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi 0.0.3",
- "libc",
- "redox_syscall",
- "smallvec 1.5.0",
- "winapi 0.3.9",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1912,12 +1773,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
  "cfg-if 0.1.10",
- "cloudabi 0.1.0",
+ "cloudabi",
  "instant",
  "libc",
  "redox_syscall",
  "smallvec 1.5.0",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2105,18 +1966,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quanta"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21484fda3d8ad7affee37755c77a5d0da527543f0af0c7f731c14e2215645d39"
-dependencies = [
- "atomic-shim",
- "ctor",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2171,7 +2020,7 @@ dependencies = [
  "libc",
  "rand_core 0.3.1",
  "rdrand",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2235,15 +2084,6 @@ name = "rand_xorshift"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
 dependencies = [
  "rand_core 0.5.1",
 ]
@@ -2348,7 +2188,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2537,18 +2377,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7baae0a99f1a324984bcdc5f0718384c1f69775f1c7eec8b859b71b443e3fd7"
-dependencies = [
- "dtoa",
- "linked-hash-map",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
 name = "sha2"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,16 +2425,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sized-chunks"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,7 +2454,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2776,7 +2594,7 @@ dependencies = [
  "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2834,7 +2652,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2854,23 +2672,6 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
- "memchr",
- "mio 0.6.22",
- "pin-project-lite 0.1.11",
- "slab",
-]
-
-[[package]]
-name = "tokio"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dfe2523e6fa84ddf5e688151d4e5fddc51678de9752c6512a24714c23818d61"
@@ -2881,15 +2682,15 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "mio 0.7.6",
+ "mio",
  "num_cpus",
- "parking_lot 0.11.1",
+ "parking_lot",
  "pin-project-lite 0.2.0",
  "signal-hook-registry",
  "slab",
  "tokio-macros",
  "tracing",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2905,16 +2706,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "24793699f4665ba0416ed287dc794fe6b11a4aa5e4e95b58624f45f6c46b97d4"
 dependencies = [
  "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project-lite 0.1.11",
- "tokio 0.2.23",
+ "tokio",
 ]
 
 [[package]]
@@ -2928,7 +2729,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.1.11",
- "tokio 0.3.4",
+ "tokio",
 ]
 
 [[package]]
@@ -2947,9 +2748,9 @@ source = "git+https://github.com/tower-rs/tower?rev=5e1e07744820028877654c336a3b
 dependencies = [
  "futures-core",
  "futures-util",
- "hdrhistogram",
+ "hdrhistogram 6.3.4",
  "pin-project 1.0.2",
- "tokio 0.3.4",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2965,7 +2766,7 @@ dependencies = [
  "futures-core",
  "pin-project 0.4.27",
  "rand 0.7.3",
- "tokio 0.3.4",
+ "tokio",
  "tower",
  "tower-fallback",
  "tracing",
@@ -2979,7 +2780,7 @@ version = "0.1.0"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio 0.3.4",
+ "tokio",
  "tower",
  "tracing",
  "zebra-test",
@@ -3270,12 +3071,6 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -3283,12 +3078,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -3302,7 +3091,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3310,16 +3099,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
 
 [[package]]
 name = "wyz"
@@ -3337,15 +3116,6 @@ dependencies = [
  "rand_core 0.5.1",
  "serde",
  "zeroize",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -3412,14 +3182,14 @@ dependencies = [
  "futures",
  "futures-util",
  "jubjub 0.5.1",
- "metrics",
+ "metrics 0.12.1",
  "once_cell",
  "rand 0.7.3",
  "redjubjub",
  "serde",
  "spandoc",
  "thiserror",
- "tokio 0.3.4",
+ "tokio",
  "tower",
  "tower-batch",
  "tower-fallback",
@@ -3445,14 +3215,14 @@ dependencies = [
  "futures",
  "hex",
  "indexmap",
- "metrics",
+ "metrics 0.12.1",
  "pin-project 0.4.27",
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
  "serde",
  "thiserror",
- "tokio 0.3.4",
+ "tokio",
  "tokio-util 0.5.0",
  "tower",
  "tracing",
@@ -3489,7 +3259,7 @@ dependencies = [
  "futures",
  "hex",
  "lazy_static",
- "metrics",
+ "metrics 0.12.1",
  "once_cell",
  "primitive-types",
  "proptest",
@@ -3498,7 +3268,7 @@ dependencies = [
  "spandoc",
  "tempdir",
  "thiserror",
- "tokio 0.3.4",
+ "tokio",
  "tower",
  "tracing",
  "tracing-error",
@@ -3521,7 +3291,7 @@ dependencies = [
  "spandoc",
  "tempdir",
  "thiserror",
- "tokio 0.3.4",
+ "tokio",
  "tower",
  "tracing",
  "tracing-error",
@@ -3555,15 +3325,15 @@ dependencies = [
  "gumdrop",
  "hyper",
  "inferno",
- "metrics",
- "metrics-runtime",
+ "metrics 0.13.0-alpha.8",
+ "metrics-exporter-prometheus",
  "once_cell",
  "pin-project 0.4.27",
  "rand 0.7.3",
  "serde",
  "tempdir",
  "thiserror",
- "tokio 0.3.4",
+ "tokio",
  "toml",
  "tower",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ panic = "abort"
 
 [patch.crates-io]
 tower = { git = "https://github.com/tower-rs/tower", rev = "5e1e07744820028877654c336a3b9fe057bf46f1" }
+hyper = { git = "https://github.com/hyperium/hyper/", rev = "ed2b22a7f66899d338691552fbcb6c0f2f4e06b9" }
+metrics = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
+metrics-exporter-prometheus = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ panic = "abort"
 panic = "abort"
 
 [patch.crates-io]
-tower = { git = "https://github.com/tower-rs/tower", rev = "1a84543" }
+tower = { git = "https://github.com/tower-rs/tower", rev = "5e1e07744820028877654c336a3b9fe057bf46f1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ panic = "abort"
 panic = "abort"
 
 [patch.crates-io]
-tower = { git = "https://github.com/tower-rs/tower", rev = "5e1e07744820028877654c336a3b9fe057bf46f1" }
+tower = { git = "https://github.com/tower-rs/tower", rev = "d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39" }
 hyper = { git = "https://github.com/hyperium/hyper/", rev = "ed2b22a7f66899d338691552fbcb6c0f2f4e06b9" }
 metrics = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
 metrics-exporter-prometheus = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -6,8 +6,8 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-tokio = { version = "0.2.22", features = ["time", "sync", "stream", "tracing"] }
-tower = { version = "0.3", features = ["util", "buffer"] }
+tokio = { version = "0.3", features = ["time", "sync", "stream", "tracing"] }
+tower = { version = "0.4", features = ["util", "buffer"] }
 futures-core = "0.3.6"
 pin-project = "0.4.27"
 tracing = "0.1.21"
@@ -17,7 +17,7 @@ futures = "0.3.7"
 [dev-dependencies]
 ed25519-zebra = "2.1.0"
 rand = "0.7"
-tokio = { version = "0.2", features = ["full"]}
+tokio = { version = "0.3", features = ["full"]}
 tracing = "0.1.21"
 zebra-test = { path = "../zebra-test/" }
 tower-fallback = { path = "../tower-fallback/" }

--- a/tower-batch/src/lib.rs
+++ b/tower-batch/src/lib.rs
@@ -89,6 +89,7 @@ pub mod error;
 pub mod future;
 mod layer;
 mod message;
+mod semaphore;
 mod service;
 mod worker;
 

--- a/tower-batch/src/message.rs
+++ b/tower-batch/src/message.rs
@@ -7,6 +7,7 @@ pub(crate) struct Message<Request, Fut> {
     pub(crate) request: Request,
     pub(crate) tx: Tx<Fut>,
     pub(crate) span: tracing::Span,
+    pub(super) _permit: crate::semaphore::Permit,
 }
 
 /// Response sender

--- a/tower-batch/src/semaphore.rs
+++ b/tower-batch/src/semaphore.rs
@@ -1,0 +1,78 @@
+// Copied from tower/src/semaphore.rs
+// When/if tower-batch is upstreamed, delete this file
+// and use the common tower semaphore implementation
+
+pub(crate) use self::sync::OwnedSemaphorePermit as Permit;
+use futures_core::ready;
+use std::{
+    fmt,
+    future::Future,
+    mem,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::sync;
+
+#[derive(Debug)]
+pub(crate) struct Semaphore {
+    semaphore: Arc<sync::Semaphore>,
+    state: State,
+}
+
+enum State {
+    Waiting(Pin<Box<dyn Future<Output = Permit> + Send + Sync + 'static>>),
+    Ready(Permit),
+    Empty,
+}
+
+impl Semaphore {
+    pub(crate) fn new(permits: usize) -> Self {
+        Self {
+            semaphore: Arc::new(sync::Semaphore::new(permits)),
+            state: State::Empty,
+        }
+    }
+
+    pub(crate) fn poll_acquire(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        loop {
+            self.state = match self.state {
+                State::Ready(_) => return Poll::Ready(()),
+                State::Waiting(ref mut fut) => {
+                    let permit = ready!(Pin::new(fut).poll(cx));
+                    State::Ready(permit)
+                }
+                State::Empty => State::Waiting(Box::pin(self.semaphore.clone().acquire_owned())),
+            };
+        }
+    }
+
+    pub(crate) fn take_permit(&mut self) -> Option<Permit> {
+        if let State::Ready(permit) = mem::replace(&mut self.state, State::Empty) {
+            return Some(permit);
+        }
+        None
+    }
+}
+
+impl Clone for Semaphore {
+    fn clone(&self) -> Self {
+        Self {
+            semaphore: self.semaphore.clone(),
+            state: State::Empty,
+        }
+    }
+}
+
+impl fmt::Debug for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            State::Waiting(_) => f
+                .debug_tuple("State::Waiting")
+                .field(&format_args!("..."))
+                .finish(),
+            State::Ready(ref r) => f.debug_tuple("State::Ready").field(&r).finish(),
+            State::Empty => f.debug_tuple("State::Empty").finish(),
+        }
+    }
+}

--- a/tower-batch/src/service.rs
+++ b/tower-batch/src/service.rs
@@ -5,6 +5,7 @@ use super::{
     BatchControl,
 };
 
+use crate::semaphore::Semaphore;
 use futures_core::ready;
 use std::task::{Context, Poll};
 use tokio::sync::{mpsc, oneshot};
@@ -18,7 +19,19 @@ pub struct Batch<T, Request>
 where
     T: Service<BatchControl<Request>>,
 {
-    tx: mpsc::Sender<Message<Request, T::Future>>,
+    // Note: this actually _is_ bounded, but rather than using Tokio's unbounded
+    // channel, we use tokio's semaphore separately to implement the bound.
+    tx: mpsc::UnboundedSender<Message<Request, T::Future>>,
+    // When the buffer's channel is full, we want to exert backpressure in
+    // `poll_ready`, so that callers such as load balancers could choose to call
+    // another service rather than waiting for buffer capacity.
+    //
+    // Unfortunately, this can't be done easily using Tokio's bounded MPSC
+    // channel, because it doesn't expose a polling-based interface, only an
+    // `async fn ready`, which borrows the sender. Therefore, we implement our
+    // own bounded MPSC on top of the unbounded channel, using a semaphore to
+    // limit how many items are in the channel.
+    semaphore: Semaphore,
     handle: Handle,
 }
 
@@ -45,10 +58,16 @@ where
         Request: Send + 'static,
     {
         // XXX(hdevalence): is this bound good
-        let (tx, rx) = mpsc::channel(1);
+        let bound = 1;
+        let (tx, rx) = mpsc::unbounded_channel();
         let (handle, worker) = Worker::new(service, rx, max_items, max_latency);
         tokio::spawn(worker.run());
-        Batch { tx, handle }
+        let semaphore = Semaphore::new(bound);
+        Batch {
+            tx,
+            handle,
+            semaphore,
+        }
     }
 
     fn get_worker_error(&self) -> crate::BoxError {
@@ -66,40 +85,43 @@ where
     type Future = ResponseFuture<T::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // If the inner service has errored, then we error here.
-        if ready!(self.tx.poll_ready(cx)).is_err() {
-            Poll::Ready(Err(self.get_worker_error()))
-        } else {
-            Poll::Ready(Ok(()))
+        // First, check if the worker is still alive.
+        if self.tx.is_closed() {
+            // If the inner service has errored, then we error here.
+            return Poll::Ready(Err(self.get_worker_error()));
         }
+
+        // Then, poll to acquire a semaphore permit. If we acquire a permit,
+        // then there's enough buffer capacity to send a new request. Otherwise,
+        // we need to wait for capacity.
+        ready!(self.semaphore.poll_acquire(cx));
+
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, request: Request) -> Self::Future {
-        // TODO:
-        // ideally we'd poll_ready again here so we don't allocate the oneshot
-        // if the try_send is about to fail, but sadly we can't call poll_ready
-        // outside of task context.
-        let (tx, rx) = oneshot::channel();
+        tracing::trace!("sending request to buffer worker");
+        let _permit = self
+            .semaphore
+            .take_permit()
+            .expect("buffer full; poll_ready must be called first");
 
         // get the current Span so that we can explicitly propagate it to the worker
         // if we didn't do this, events on the worker related to this span wouldn't be counted
         // towards that span since the worker would have no way of entering it.
         let span = tracing::Span::current();
-        tracing::trace!(parent: &span, "sending request to batch worker");
-        match self.tx.try_send(Message { request, span, tx }) {
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                ResponseFuture::failed(self.get_worker_error())
-            }
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                // When `mpsc::Sender::poll_ready` returns `Ready`, a slot
-                // in the channel is reserved for the handle. Other `Sender`
-                // handles may not send a message using that slot. This
-                // guarantees capacity for `request`.
-                //
-                // Given this, the only way to hit this code path is if
-                // `poll_ready` has not been called & `Ready` returned.
-                panic!("buffer full; poll_ready must be called first");
-            }
+
+        // If we've made it here, then a semaphore permit has already been
+        // acquired, so we can freely allocate a oneshot.
+        let (tx, rx) = oneshot::channel();
+
+        match self.tx.send(Message {
+            request,
+            span,
+            tx,
+            _permit,
+        }) {
+            Err(_) => ResponseFuture::failed(self.get_worker_error()),
             Ok(_) => ResponseFuture::new(rx),
         }
     }
@@ -113,6 +135,7 @@ where
         Self {
             tx: self.tx.clone(),
             handle: self.handle.clone(),
+            semaphore: self.semaphore.clone(),
         }
     }
 }

--- a/tower-batch/tests/ed25519.rs
+++ b/tower-batch/tests/ed25519.rs
@@ -10,7 +10,7 @@ use color_eyre::{eyre::eyre, Report};
 use ed25519_zebra::*;
 use futures::stream::{FuturesUnordered, StreamExt};
 use rand::thread_rng;
-use tokio::sync::broadcast::{channel, RecvError, Sender};
+use tokio::sync::broadcast::{channel, error::RecvError, Sender};
 use tower::{Service, ServiceExt};
 use tower_batch::{Batch, BatchControl};
 use tower_fallback::Fallback;

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -6,11 +6,11 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-tower = "0.3"
+tower = "0.4"
 futures-core = "0.3.6"
 pin-project = "0.4.27"
 tracing = "0.1"
 
 [dev-dependencies]
 zebra-test = { path = "../zebra-test/" }
-tokio = { version = "0.2", features = ["full"]}
+tokio = { version = "0.3", features = ["full"]}

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -19,8 +19,8 @@ futures = "0.3.7"
 futures-util = "0.3.6"
 metrics = "0.12"
 thiserror = "1.0.22"
-tokio = { version = "0.2.22", features = ["time", "sync", "stream", "tracing"] }
-tower = { version = "0.3", features = ["timeout", "util", "buffer"] }
+tokio = { version = "0.3", features = ["time", "sync", "stream", "tracing"] }
+tower = { version = "0.4", features = ["timeout", "util", "buffer"] }
 tower-util = "0.3"
 tracing = "0.1.21"
 tracing-futures = "0.2.4"
@@ -34,7 +34,7 @@ zebra-script = { path = "../zebra-script" }
 [dev-dependencies]
 rand = "0.7"
 spandoc = "0.2"
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "0.3", features = ["full"] }
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.15"
 

--- a/zebra-consensus/src/primitives/redjubjub.rs
+++ b/zebra-consensus/src/primitives/redjubjub.rs
@@ -14,7 +14,7 @@ use futures::future::{ready, Ready};
 use once_cell::sync::Lazy;
 use rand::thread_rng;
 
-use tokio::sync::broadcast::{channel, RecvError, Sender};
+use tokio::sync::broadcast::{channel, error::RecvError, Sender};
 use tower::{util::ServiceFn, Service};
 use tower_batch::{Batch, BatchControl};
 use tower_fallback::Fallback;

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 bitflags = "1.2"
 byteorder = "1.3"
-bytes = "0.5"
+bytes = "0.6"
 chrono = "0.4"
 hex = "0.4"
 # indexmap has rayon support for parallel iteration,
@@ -22,9 +22,9 @@ serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"
 
 futures = "0.3"
-tokio = { version = "0.2.22", features = ["net", "time", "stream", "tracing", "macros"] }
-tokio-util = { version = "0.2", features = ["codec"] }
-tower = { version = "0.3", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
+tokio = { version = "0.3", features = ["net", "time", "stream", "tracing", "macros"] }
+tokio-util = { version = "0.5", features = ["codec"] }
+tower = { version = "0.4", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 
 metrics = "0.12"
 tracing = "0.1"

--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -93,7 +93,7 @@ mod tests {
         use futures::stream::StreamExt;
         use tokio_util::codec::Framed;
 
-        let mut listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let listen_addr = listener.local_addr().unwrap();
 
         let conn = tokio::net::TcpStream::connect(listen_addr).await.unwrap();

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -23,7 +23,7 @@ use futures::{
     prelude::*,
     stream::Stream,
 };
-use tokio::time::{delay_for, Delay};
+use tokio::time::{sleep, Sleep};
 use tower::Service;
 use tracing_futures::Instrument;
 
@@ -221,7 +221,7 @@ pub struct Connection<S, Tx> {
     /// A timeout for a client request. This is stored separately from
     /// State so that we can move the future out of it independently of
     /// other state handling.
-    pub(super) request_timer: Option<Delay>,
+    pub(super) request_timer: Option<Sleep>,
     pub(super) svc: S,
     pub(super) client_rx: mpsc::Receiver<ClientRequest>,
     /// A slot for an error shared between the Connection and the Client that uses it.
@@ -553,7 +553,7 @@ where
         } {
             Ok(new_state) => {
                 self.state = new_state;
-                self.request_timer = Some(delay_for(constants::REQUEST_TIMEOUT));
+                self.request_timer = Some(sleep(constants::REQUEST_TIMEOUT));
             }
             Err(e) => self.fail_with(e),
         }

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -211,7 +211,7 @@ where
     S: Service<(TcpStream, SocketAddr), Response = peer::Client, Error = BoxError> + Clone,
     S::Future: Send + 'static,
 {
-    let mut listener = TcpListener::bind(addr).await?;
+    let listener = TcpListener::bind(addr).await?;
     let local_addr = listener.local_addr()?;
     info!("Opened Zcash protocol endpoint at {}", local_addr);
     loop {

--- a/zebra-network/src/peer_set/inventory_registry.rs
+++ b/zebra-network/src/peer_set/inventory_registry.rs
@@ -1,8 +1,7 @@
 //! Inventory Registry Implementation
 //!
 //! [RFC]: https://zebra.zfnd.org/dev/rfcs/0003-inventory-tracking.html
-use crate::{protocol::external::InventoryHash, BoxError};
-use futures::Stream;
+
 use std::{
     collections::{HashMap, HashSet},
     net::SocketAddr,
@@ -10,17 +9,20 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
+
+use futures::{Stream, StreamExt};
 use tokio::{
     sync::broadcast,
     time::{self, Interval},
 };
+
+use crate::{protocol::external::InventoryHash, BoxError};
 
 /// An Inventory Registry for tracking recent inventory advertisements by peer.
 ///
 /// For more details please refer to the [RFC].
 ///
 /// [RFC]: https://zebra.zfnd.org/dev/rfcs/0003-inventory-tracking.html
-#[derive(Debug)]
 pub struct InventoryRegistry {
     /// Map tracking the inventory advertisements from the current interval
     /// period
@@ -28,9 +30,24 @@ pub struct InventoryRegistry {
     /// Map tracking inventory advertisements from the previous interval period
     prev: HashMap<InventoryHash, HashSet<SocketAddr>>,
     /// Stream of incoming inventory hashes to register
-    inv_stream: broadcast::Receiver<(InventoryHash, SocketAddr)>,
+    inv_stream: Pin<
+        Box<
+            dyn Stream<Item = Result<(InventoryHash, SocketAddr), broadcast::error::RecvError>>
+                + Send
+                + 'static,
+        >,
+    >,
     /// Interval tracking how frequently we should rotate our maps
     interval: Interval,
+}
+
+impl std::fmt::Debug for InventoryRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InventoryRegistry")
+            .field("current", &self.current)
+            .field("prev", &self.prev)
+            .finish()
+    }
 }
 
 impl InventoryRegistry {
@@ -39,7 +56,7 @@ impl InventoryRegistry {
         Self {
             current: Default::default(),
             prev: Default::default(),
-            inv_stream,
+            inv_stream: inv_stream.into_stream().boxed(),
             interval: time::interval(Duration::from_secs(75)),
         }
     }
@@ -60,7 +77,7 @@ impl InventoryRegistry {
     /// - rotates HashMaps based on interval events
     /// - drains the inv_stream channel and registers all advertised inventory
     pub fn poll_inventory(&mut self, cx: &mut Context<'_>) -> Result<(), BoxError> {
-        while let Poll::Ready(_) = self.interval.poll_tick(cx) {
+        while let Poll::Ready(_) = Pin::new(&mut self.interval).poll_next(cx) {
             self.rotate();
         }
 
@@ -80,7 +97,7 @@ impl InventoryRegistry {
         // rather than propagating it through the peer set's Service::poll_ready
         // implementation, where reporting a failure means reporting a permanent
         // failure of the peer set.
-        use broadcast::RecvError;
+        use broadcast::error::RecvError;
         while let Poll::Ready(Some(channel_result)) = Pin::new(&mut self.inv_stream).poll_next(cx) {
             match channel_result {
                 Ok((hash, addr)) => self.register(hash, addr),

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -104,11 +104,10 @@ impl Builder {
 
 // ======== Encoding =========
 
-impl Encoder for Codec {
-    type Item = Message;
+impl Encoder<Message> for Codec {
     type Error = Error;
 
-    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, item: Message, dst: &mut BytesMut) -> Result<(), Self::Error> {
         use Error::Parse;
         // XXX(HACK): this is inefficient and does an extra allocation.
         // instead, we should have a size estimator for the message, reserve
@@ -587,7 +586,7 @@ mod tests {
         let services = PeerServices::NODE_NETWORK;
         let timestamp = Utc.timestamp(1_568_000_000, 0);
 
-        let mut rt = Runtime::new().unwrap();
+        let rt = Runtime::new().unwrap();
 
         let v = Message::Version {
             version: crate::constants::CURRENT_VERSION,
@@ -634,7 +633,7 @@ mod tests {
     fn filterload_message_round_trip() {
         zebra_test::init();
 
-        let mut rt = Runtime::new().unwrap();
+        let rt = Runtime::new().unwrap();
 
         let v = Message::FilterLoad {
             filter: Filter(vec![0; 35999]),
@@ -670,7 +669,7 @@ mod tests {
     fn filterload_message_too_large_round_trip() {
         zebra_test::init();
 
-        let mut rt = Runtime::new().unwrap();
+        let rt = Runtime::new().unwrap();
 
         let v = Message::FilterLoad {
             filter: Filter(vec![0; 40000]),
@@ -706,7 +705,7 @@ mod tests {
         use zebra_chain::serialization::ZcashDeserializeInto;
         zebra_test::init();
 
-        let mut rt = Runtime::new().unwrap();
+        let rt = Runtime::new().unwrap();
 
         // make tests with a Tx message
         let tx = zebra_test::vectors::DUMMY_TX1

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -18,11 +18,11 @@ serde = { version = "1", features = ["serde_derive"] }
 
 futures = "0.3.7"
 metrics = "0.12"
-tower = { version = "0.3.1", features = ["buffer", "util"] }
+tower = { version = "0.4", features = ["buffer", "util"] }
 tracing = "0.1"
 tracing-error = "0.1.2"
 thiserror = "1.0.22"
-tokio = { version = "0.2.22", features = ["sync"] }
+tokio = { version = "0.3", features = ["sync"] }
 displaydoc = "0.1.7"
 rocksdb = "0.15.0"
 
@@ -33,6 +33,6 @@ zebra-test = { path = "../zebra-test/" }
 once_cell = "1.5"
 spandoc = "0.2"
 tempdir = "0.3.7"
-tokio = { version = "0.2.22", features = ["full"] }
+tokio = { version = "0.3", features = ["full"] }
 proptest = "0.10.1"
 primitive-types = "0.7.3"

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 hex = "0.4.2"
 lazy_static = "1.4.0"
-tower = { version = "0.3.1", features = ["util"] }
+tower = { version = "0.4", features = ["util"] }
 futures = "0.3.7"
 color-eyre = "0.5.7"
 tracing = "0.1.21"
@@ -25,4 +25,4 @@ proptest = "0.10.1"
 tempdir = "0.3.7"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "0.3", features = ["full"] }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -19,7 +19,7 @@ toml = "0.5"
 chrono = "0.4"
 rand = "0.7"
 
-hyper = "0.13.9"
+hyper = { version = "0.14.0-dev", features = ["full"] }
 futures = "0.3"
 tokio = { version = "0.3", features = ["time", "rt-multi-thread", "stream", "macros", "tracing", "signal"] }
 tower = { version = "0.4", features = ["hedge", "limit"] }
@@ -33,8 +33,8 @@ tracing-futures = "0.2"
 tracing-flame = "0.1.0"
 tracing-subscriber = { version = "0.2.15", features = ["tracing-log"] }
 tracing-error = "0.1.2"
-metrics-runtime = "0.13"
-metrics = "0.12"
+metrics = "0.13.0-alpha.8"
+metrics-exporter-prometheus = "0.1.0-alpha.7"
 
 dirs = "3.0.1"
 inferno = { version = "0.10.1", default-features = false }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -21,8 +21,8 @@ rand = "0.7"
 
 hyper = "0.13.9"
 futures = "0.3"
-tokio = { version = "0.2.22", features = ["time", "rt-threaded", "stream", "macros", "tracing", "signal"] }
-tower = { version = "0.3", features = ["hedge", "limit"] }
+tokio = { version = "0.3", features = ["time", "rt-multi-thread", "stream", "macros", "tracing", "signal"] }
+tower = { version = "0.4", features = ["hedge", "limit"] }
 pin-project = "0.4.23"
 
 color-eyre = { version = "0.5.7", features = ["issue-url"] }

--- a/zebrad/src/components/metrics.rs
+++ b/zebrad/src/components/metrics.rs
@@ -1,54 +1,23 @@
 //! An HTTP endpoint for metrics collection.
 
-use std::net::SocketAddr;
-
 use abscissa_core::{Component, FrameworkError};
-use metrics_runtime::{exporters::HttpExporter, observers::PrometheusBuilder, Receiver};
 
-use crate::{components::tokio::TokioComponent, config::ZebradConfig};
+use crate::config::ZebradConfig;
 
 /// Abscissa component which runs a metrics endpoint.
 #[derive(Debug, Component)]
-#[component(inject = "init_tokio(zebrad::components::tokio::TokioComponent)")]
-pub struct MetricsEndpoint {
-    addr: Option<SocketAddr>,
-}
+pub struct MetricsEndpoint {}
 
 impl MetricsEndpoint {
     /// Create the component.
     pub fn new(config: &ZebradConfig) -> Result<Self, FrameworkError> {
-        Ok(Self {
-            addr: config.metrics.endpoint_addr,
-        })
-    }
-
-    /// Tokio endpoint dependency stub.
-    pub fn init_tokio(&mut self, tokio_component: &TokioComponent) -> Result<(), FrameworkError> {
-        let addr = if let Some(addr) = self.addr {
-            addr
-        } else {
-            return Ok(());
-        };
-
-        info!("Initializing metrics endpoint at {}", addr);
-
-        // XXX do we need to hold on to the receiver?
-        let receiver = Receiver::builder()
-            .build()
-            .expect("Receiver config should be valid");
-        // XXX ???? connect this ???
-        let _sink = receiver.sink();
-
-        let endpoint = HttpExporter::new(receiver.controller(), PrometheusBuilder::new(), addr);
-
-        tokio_component
-            .rt
-            .as_ref()
-            .expect("runtime should not be taken")
-            .spawn(endpoint.async_run());
-
-        metrics::set_boxed_recorder(Box::new(receiver)).expect("XXX FIXME ERROR CONVERSION");
-
-        Ok(())
+        if let Some(addr) = config.metrics.endpoint_addr {
+            info!("Initializing metrics endpoint at {}", addr);
+            metrics_exporter_prometheus::PrometheusBuilder::new()
+                .listen_address(addr)
+                .install()
+                .expect("FIXME ERROR CONVERSION");
+        }
+        Ok(Self {})
     }
 }

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -557,11 +557,11 @@ where
     fn update_metrics(&self) {
         metrics::gauge!(
             "sync.prospective_tips.len",
-            self.prospective_tips.len() as i64
+            self.prospective_tips.len() as f64
         );
         metrics::gauge!(
             "sync.downloads.in_flight",
-            self.downloads.in_flight() as i64
+            self.downloads.in_flight() as f64
         );
     }
 }

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -5,7 +5,7 @@ use futures::{
     future::FutureExt,
     stream::{FuturesUnordered, StreamExt},
 };
-use tokio::time::delay_for;
+use tokio::time::sleep;
 use tower::{
     builder::ServiceBuilder, hedge::Hedge, limit::ConcurrencyLimit, retry::Retry, timeout::Timeout,
     Service, ServiceExt,
@@ -153,7 +153,7 @@ where
         // due to protocol limitations
         self.request_genesis().await?;
 
-        // Distinguishes a restart from a start, so we don't delay when starting
+        // Distinguishes a restart from a start, so we don't sleep when starting
         // the sync process, but we can keep restart logic in one place.
         let mut started_once = false;
 
@@ -163,7 +163,7 @@ where
                 self.prospective_tips = HashSet::new();
                 self.downloads.cancel_all();
                 self.update_metrics();
-                delay_for(SYNC_RESTART_TIMEOUT).await;
+                sleep(SYNC_RESTART_TIMEOUT).await;
             } else {
                 started_once = true;
             }

--- a/zebrad/src/components/tokio.rs
+++ b/zebrad/src/components/tokio.rs
@@ -22,9 +22,8 @@ impl TokioComponent {
     pub fn new() -> Result<Self, FrameworkError> {
         Ok(Self {
             rt: Some(
-                tokio::runtime::Builder::new()
+                tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
-                    .threaded_scheduler()
                     .build()
                     .unwrap(),
             ),


### PR DESCRIPTION
## Motivation

The "histogram out of range resize disabled" errors should be fixed upstream by https://github.com/tower-rs/tower/pull/484 , which was made against the development version of Tower (0.4).  To pick these changes up, we need to migrate to Tower 0.4, which uses Tokio 0.3.  This means migrating to Tokio 0.3.  Clearing Tokio 0.2 out of our dependency tree means using development versions of `hyper` and `metrics`; otherwise, trying to run those futures on our main runtime will fail.

## Solution

Update dependencies to Tokio 0.3.

## Review

@yaahc 

## Follow Up Work

We should change #1086 to "remove git dependencies on tower, hyper, metrics" as the ecosystem stabilizes on Tokio 0.3.