### PR TITLE
Stop using /dev/shm on Linux

### DIFF
--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "1.0.22"
 tokio = { version = "0.2.22", features = ["sync"] }
 displaydoc = "0.1.7"
 rocksdb = "0.15.0"
+tempdir = "0.3.7"
 
 [dev-dependencies]
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }


### PR DESCRIPTION
## Motivation

1. Some systems have a very small `/dev/shm`.
For example, docker's default `/dev/shm` size is 64 MB: https://github.com/docker-library/postgres/issues/416
And `/dev/shm` isn't really intended for applications to store arbitrary-sized temporary files. It's meant to be used as a file-based interface to shared memory for inter-process communication.

2. We copied a bunch of complex code from sled, which we don't really need.
(We also didn't credit the author, which is required under the MIT and Apache licenses.)

3. To help users identify orphaned Zebra temporary directories, we should prefix them with "zebra", the state version, and the network.

## Solution

1. use the temporary directory on all operating systems, and use TempDir to generate the temporary path in the temporary directory
2. delete the code that we copied from sled
3. prefix the temporary path with the state version and network

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Acceptance Tests

## Review

@yaahc wrote this code.

This review is not urgent.

This bug could cause errors on long-running ephemeral tests in docker containers with the default `/dev/shm` size. But we're not seeing those errors yet.

## Related Issues

This bug existed in sled, and we copied it across when we moved to RocksDB in #1325.
