### PR TITLE
Fix spurious WrongVersion errors, clean up checks, and tidy debug info

### DIFF
--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -19,10 +19,20 @@ use byteorder::{ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// A runtime validated type for representing amounts of zatoshis
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, Serialize, Deserialize)]
 #[serde(try_from = "i64")]
 #[serde(bound = "C: Constraint")]
 pub struct Amount<C = NegativeAllowed>(i64, PhantomData<C>);
+
+// in a world where specialization existed
+// https://github.com/rust-lang/rust/issues/31844
+// we could do much better here
+// for now, drop the constraint
+impl<C> std::fmt::Debug for Amount<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Amount").field(&self.0).finish()
+    }
+}
 
 impl<C> Amount<C> {
     /// Convert this amount to a different Amount type if it satisfies the new constraint

--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 /// Arbitrary data inserted by miners into a coinbase transaction.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CoinbaseData(
     /// Invariant: this vec, together with the coinbase height, must be less than
     /// 100 bytes. We enforce this by only constructing CoinbaseData fields by
@@ -37,6 +37,20 @@ pub struct CoinbaseData(
 impl AsRef<[u8]> for CoinbaseData {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+impl std::fmt::Debug for CoinbaseData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let escaped = String::from_utf8(
+            self.0
+                .iter()
+                .cloned()
+                .flat_map(std::ascii::escape_default)
+                .collect(),
+        )
+        .expect("ascii::escape_default produces utf8");
+        f.debug_tuple("CoinbaseData").field(&escaped).finish()
     }
 }
 

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -28,8 +28,14 @@ pub enum TransactionError {
     #[error("coinbase input found in non-coinbase transaction")]
     CoinbaseInputFound,
 
-    #[error("coinbase transaction MUST NOT have any JoinSplit descriptions or Spend descriptions")]
-    CoinbaseHasJoinSplitOrSpend,
+    #[error("coinbase transaction MUST NOT have any JoinSplit descriptions")]
+    CoinbaseHasJoinSplit,
+
+    #[error("coinbase transaction MUST NOT have any Spend descriptions")]
+    CoinbaseHasSpend,
+
+    #[error("coinbase transaction MUST NOT have any Output descriptions pre-Heartwood")]
+    CoinbaseHasOutputPreHeartwood,
 
     #[error("coinbase transaction failed subsidy validation")]
     Subsidy(#[from] SubsidyError),

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -43,8 +43,11 @@ pub enum TransactionError {
     #[error("transaction version number MUST be >= 4")]
     WrongVersion,
 
-    #[error("at least one of tx_in_count, nShieldedSpend, and nJoinSplit MUST be nonzero")]
-    NoTransfer,
+    #[error("must have at least one input: transparent, shielded spend, or joinsplit")]
+    NoInputs,
+
+    #[error("must have at least one output: transparent, shielded output, or joinsplit")]
+    NoOutputs,
 
     #[error("if there are no Spends or Outputs, the value balance MUST be 0.")]
     BadBalance,

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -9,8 +9,8 @@ use futures::{
     stream::{FuturesUnordered, StreamExt},
     FutureExt,
 };
-
 use tower::{Service, ServiceExt};
+use tracing::Instrument;
 
 use zebra_chain::{
     parameters::NetworkUpgrade,
@@ -88,7 +88,9 @@ where
 
         let mut redjubjub_verifier = crate::primitives::redjubjub::VERIFIER.clone();
         let mut script_verifier = self.script_verifier.clone();
+        let span = tracing::debug_span!("tx", hash = ?tx.hash());
         async move {
+            tracing::trace!(?tx);
             match &*tx {
                 Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
                     Err(TransactionError::WrongVersion)
@@ -210,6 +212,7 @@ where
                 }
             }
         }
+        .instrument(span)
         .boxed()
     }
 }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -116,7 +116,7 @@ where
                     #[allow(clippy::if_same_then_else)] // delete when filled in
                     if tx.is_coinbase() {
                         // do something special for coinbase transactions
-                        check::coinbase_tx_does_not_spend_shielded(&tx)?;
+                        check::coinbase_tx_no_joinsplit_or_spend(&tx)?;
                     } else {
                         // otherwise, check no coinbase inputs
                         // feed all of the inputs to the script verifier

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -93,6 +93,7 @@ where
             tracing::trace!(?tx);
             match &*tx {
                 Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
+                    tracing::debug!(?tx, "got transaction with wrong version");
                     Err(TransactionError::WrongVersion)
                 }
                 Transaction::V4 {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -130,7 +130,7 @@ where
                         }
                     }
 
-                    check::some_money_is_spent(&tx)?;
+                    check::has_inputs_and_outputs(&tx)?;
                     check::any_coinbase_inputs_no_transparent_outputs(&tx)?;
 
                     let sighash = tx.sighash(

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -131,7 +131,6 @@ where
                     }
 
                     check::has_inputs_and_outputs(&tx)?;
-                    check::any_coinbase_inputs_no_transparent_outputs(&tx)?;
 
                     let sighash = tx.sighash(
                         NetworkUpgrade::Sapling, // TODO: pass this in

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -74,28 +74,6 @@ pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> 
     }
 }
 
-/// Check that a transaction with one or more transparent inputs from coinbase
-/// transactions has no transparent outputs.
-///
-/// Note that inputs from coinbase transactions include Founders’ Reward
-/// outputs.
-///
-/// https://zips.z.cash/protocol/canopy.pdf#consensusfrombitcoin
-pub fn any_coinbase_inputs_no_transparent_outputs(
-    tx: &Transaction,
-) -> Result<(), TransactionError> {
-    match tx {
-        Transaction::V4 { outputs, .. } => {
-            if !tx.contains_coinbase_input() || !outputs.is_empty() {
-                Ok(())
-            } else {
-                Err(TransactionError::NoTransfer)
-            }
-        }
-        _ => Err(TransactionError::WrongVersion),
-    }
-}
-
 /// Check that if there are no Spends or Outputs, that valueBalance is also 0.
 ///
 /// https://zips.z.cash/protocol/canopy.pdf#consensusfrombitcoin


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

Fixes the WrongVersion errors, cleans up checks, and tidies debug info.

## Solution

Described in commit messages

## Review

@dconnolly 

## Related Issues

Closes #1264 

## Follow Up Work

As a followup issue, we need to come up with a way to check whether a transaction spends outputs of a coinbase transaction.  This might require database format changes, so we should have a follow-up issue (#1342).

Testing the resulting code reveals that blocks aren't being committed for some reason, but this should be follow-on work, because I believe that it's a pre-existing problem revealed by removing the spurious errors.