### PR TITLE
Fix UTXO registration bugs and tidy state code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "tower"
 version = "0.4.0"
-source = "git+https://github.com/tower-rs/tower?rev=5e1e07744820028877654c336a3b9fe057bf46f1#5e1e07744820028877654c336a3b9fe057bf46f1"
+source = "git+https://github.com/tower-rs/tower?rev=d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39#d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "tower-layer"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower?rev=5e1e07744820028877654c336a3b9fe057bf46f1#5e1e07744820028877654c336a3b9fe057bf46f1"
+source = "git+https://github.com/tower-rs/tower?rev=d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39#d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39"
 
 [[package]]
 name = "tower-service"

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -852,7 +852,7 @@ where
                 .ready_and()
                 .await
                 .expect("Verified checkpoints must be committed transactionally")
-                .call(zs::Request::CommitFinalizedBlock { block })
+                .call(zs::Request::CommitFinalizedBlock(block.into()))
                 .await
                 .expect("Verified checkpoints must be committed transactionally")
             {

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -320,9 +320,9 @@ async fn continuous_blockchain(restart_height: Option<block::Height>) -> Result<
 
                     /// SPANDOC: Add block to the state {?height}
                     ready_state_service
-                        .call(zebra_state::Request::CommitFinalizedBlock {
-                            block: block.clone(),
-                        })
+                        .call(zebra_state::Request::CommitFinalizedBlock(
+                            block.clone().into(),
+                        ))
                         .await
                         .map_err(|e| eyre!(e))?;
                 }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -88,7 +88,7 @@ where
 
         let mut redjubjub_verifier = crate::primitives::redjubjub::VERIFIER.clone();
         let mut script_verifier = self.script_verifier.clone();
-        let span = tracing::debug_span!("tx", hash = ?tx.hash());
+        let span = tracing::debug_span!("tx", hash = %tx.hash());
         async move {
             tracing::trace!(?tx);
             match &*tx {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -222,6 +222,7 @@ where
                     // Finally, wait for all asynchronous checks to complete
                     // successfully, or fail verification if they error.
                     while let Some(check) = async_checks.next().await {
+                        tracing::trace!(?check, remaining = async_checks.len());
                         check?;
                     }
 

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -23,6 +23,6 @@ mod tests;
 pub use config::Config;
 pub use constants::MAX_BLOCK_REORG_HEIGHT;
 pub use error::{BoxError, CloneError, CommitBlockError, ValidateContextError};
-pub use request::{HashOrHeight, Request};
+pub use request::{FinalizedBlock, HashOrHeight, PreparedBlock, Request};
 pub use response::Response;
 pub use service::init;

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -86,7 +86,7 @@ impl StateService {
     ///
     /// [1]: https://zebra.zfnd.org/dev/rfcs/0005-state-updates.html#committing-non-finalized-blocks
     #[instrument(skip(self, block))]
-    fn queue_and_commit_non_finalized_blocks(
+    fn queue_and_commit_non_finalized(
         &mut self,
         block: Arc<Block>,
     ) -> oneshot::Receiver<Result<block::Hash, BoxError>> {
@@ -390,7 +390,7 @@ impl Service<Request> for StateService {
                 metrics::counter!("state.requests", 1, "type" => "commit_block");
 
                 self.pending_utxos.check_block(&block);
-                let rsp_rx = self.queue_and_commit_non_finalized_blocks(block);
+                let rsp_rx = self.queue_and_commit_non_finalized(block);
 
                 async move {
                     rsp_rx
@@ -408,7 +408,7 @@ impl Service<Request> for StateService {
 
                 self.pending_utxos.check_block(&block);
                 self.disk
-                    .queue_and_commit_finalized_blocks(QueuedBlock { block, rsp_tx });
+                    .queue_and_commit_finalized(QueuedBlock { block, rsp_tx });
 
                 async move {
                     rsp_rx

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -83,11 +83,12 @@ impl StateService {
     /// in RFC0005.
     ///
     /// [1]: https://zebra.zfnd.org/dev/rfcs/0005-state-updates.html#committing-non-finalized-blocks
-    #[instrument(skip(self, prepared))]
+    #[instrument(level = "debug", skip(self, prepared))]
     fn queue_and_commit_non_finalized(
         &mut self,
         prepared: PreparedBlock,
     ) -> oneshot::Receiver<Result<block::Hash, BoxError>> {
+        tracing::debug!(block = %prepared.block, "queueing block for contextual verification");
         let parent_hash = prepared.block.header.previous_block_hash;
 
         if self.mem.any_chain_contains(&prepared.hash) || self.disk.hash(prepared.height).is_some()

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -166,7 +166,7 @@ impl StateService {
             let queued_children = self.queued_blocks.dequeue_children(parent_hash);
 
             for (child, rsp_tx) in queued_children {
-                let child_hash = child.hash.clone();
+                let child_hash = child.hash;
                 tracing::trace!(?child_hash, "validating queued child");
                 let result = self
                     .validate_and_commit(child)

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -262,7 +262,10 @@ impl StateService {
 
     /// Return the utxo pointed to by `outpoint` if it exists in any chain.
     pub fn utxo(&self, outpoint: &transparent::OutPoint) -> Option<transparent::Output> {
-        self.mem.utxo(outpoint).or_else(|| self.disk.utxo(outpoint))
+        self.mem
+            .utxo(outpoint)
+            .or_else(|| self.disk.utxo(outpoint))
+            .or_else(|| self.queued_blocks.utxo(outpoint))
     }
 
     /// Return an iterator over the relevant chain of the block identified by

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -92,7 +92,7 @@ impl FinalizedState {
     ///
     /// After queueing a finalized block, this method checks whether the newly
     /// queued block (and any of its descendants) can be committed to the state.
-    pub fn queue_and_commit_finalized_blocks(&mut self, queued_block: QueuedBlock) {
+    pub fn queue_and_commit_finalized(&mut self, queued_block: QueuedBlock) {
         let prev_hash = queued_block.block.header.previous_block_hash;
         let height = queued_block.block.coinbase_height().unwrap();
         self.queued_by_prev_hash.insert(prev_hash, queued_block);

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -35,12 +35,10 @@ impl Chain {
         let block_height = block
             .coinbase_height()
             .expect("valid non-finalized blocks have a coinbase height");
-
-        trace!(?block_height, "Pushing new block into chain state");
-
         // update cumulative data members
         self.update_chain_state_with(&block);
         self.blocks.insert(block_height, block);
+        trace!("pushed block onto chain");
     }
 
     /// Remove the lowest height block of the non-finalized portion of a chain.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -29,16 +29,16 @@ pub struct Chain {
 
 impl Chain {
     /// Push a contextually valid non-finalized block into a chain as the new tip.
-    #[instrument(skip(self, block), fields(block = %block.block))]
+    #[instrument(level = "debug", skip(self, block), fields(block = %block.block))]
     pub fn push(&mut self, block: PreparedBlock) {
         // update cumulative data members
         self.update_chain_state_with(&block);
+        tracing::info!(block = %block.block, "adding block to chain");
         self.blocks.insert(block.height, block);
-        trace!("pushed block onto chain");
     }
 
     /// Remove the lowest height block of the non-finalized portion of a chain.
-    #[instrument(skip(self))]
+    #[instrument(level = "debug", skip(self))]
     pub fn pop_root(&mut self) -> PreparedBlock {
         let block_height = self.lowest_height();
 

--- a/zebra-state/src/service/non_finalized_state/queued_blocks.rs
+++ b/zebra-state/src/service/non_finalized_state/queued_blocks.rs
@@ -66,11 +66,10 @@ impl QueuedBlocks {
             .unwrap_or_default()
             .into_iter()
             .map(|hash| {
-                let queued = self
+                self
                     .blocks
                     .remove(&hash)
-                    .expect("block is present if its hash is in by_parent");
-                queued
+                    .expect("block is present if its hash is in by_parent")
             })
             .collect::<Vec<_>>();
 

--- a/zebra-state/src/service/non_finalized_state/queued_blocks.rs
+++ b/zebra-state/src/service/non_finalized_state/queued_blocks.rs
@@ -66,8 +66,7 @@ impl QueuedBlocks {
             .unwrap_or_default()
             .into_iter()
             .map(|hash| {
-                self
-                    .blocks
+                self.blocks
                     .remove(&hash)
                     .expect("block is present if its hash is in by_parent")
             })

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -17,7 +17,7 @@ async fn populated_state(
 ) -> BoxService<Request, Response, BoxError> {
     let requests = blocks
         .into_iter()
-        .map(|block| Request::CommitFinalizedBlock { block });
+        .map(|block| Request::CommitFinalizedBlock(block.into()));
 
     let config = Config::ephemeral();
     let network = Network::Mainnet;

--- a/zebra-state/src/service/utxo.rs
+++ b/zebra-state/src/service/utxo.rs
@@ -37,6 +37,9 @@ impl PendingUtxos {
     /// by the given `transparent::OutPoint` that the `Output` has arrived.
     pub fn respond(&mut self, outpoint: transparent::OutPoint, output: transparent::Output) {
         if let Some(sender) = self.0.remove(&outpoint) {
+            // Adding the outpoint as a field lets us crossreference
+            // with the trace of the verification that made the request.
+            tracing::trace!(?outpoint, "found pending UTXO");
             let _ = sender.send(output);
         }
     }
@@ -48,6 +51,7 @@ impl PendingUtxos {
             return;
         }
 
+        tracing::trace!("scanning new block for pending UTXOs");
         for transaction in block.transactions.iter() {
             let transaction_hash = transaction.hash();
             for (index, output) in transaction.outputs().iter().enumerate() {

--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -17,7 +17,7 @@ static COMMIT_FINALIZED_BLOCK_MAINNET: Lazy<Vec<(Request, Result<Response, Trans
         let hash = block.hash();
         vec![
             (
-                Request::CommitFinalizedBlock { block },
+                Request::CommitFinalizedBlock(block.into()),
                 Ok(Response::Committed(hash)),
             ),
             (
@@ -37,7 +37,7 @@ static COMMIT_FINALIZED_BLOCK_TESTNET: Lazy<Vec<(Request, Result<Response, Trans
         let hash = block.hash();
         vec![
             (
-                Request::CommitFinalizedBlock { block },
+                Request::CommitFinalizedBlock(block.into()),
                 Ok(Response::Committed(hash)),
             ),
             (

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -110,7 +110,7 @@ where
     /// This method waits for the network to become ready, and returns an error
     /// only if the network service fails. It returns immediately after queuing
     /// the request.
-    #[instrument(skip(self), fields(%hash))]
+    #[instrument(level = "debug", skip(self), fields(%hash))]
     pub async fn download_and_verify(&mut self, hash: block::Hash) -> Result<(), Report> {
         if self.cancel_handles.contains_key(&hash) {
             return Err(eyre!("duplicate hash queued for download"));

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -110,7 +110,7 @@ where
     /// This method waits for the network to become ready, and returns an error
     /// only if the network service fails. It returns immediately after queuing
     /// the request.
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(%hash))]
     pub async fn download_and_verify(&mut self, hash: block::Hash) -> Result<(), Report> {
         if self.cancel_handles.contains_key(&hash) {
             return Err(eyre!("duplicate hash queued for download"));


### PR DESCRIPTION
## Motivation

The existing UTXO registration and lookup code does not work, preventing the chain sync from working.

## Solution

This PR accomplishes four main tasks (steps are documented in more detail in commit messages).

1. Our UTXO lookup system did not account for the fact that transactions can spend outputs of previous transactions in the same block.  To fix this, we add additional context to the script verification request and pass it through the transaction verification request (ef17677a25e9556968b5fa9c287d6f4327ea8414).

2. Our UTXO lookup system did not correctly query blocks which had been submitted to the state but were queued rather than committed.  To fix this, we need to scan those blocks (7b298a1).

3. The state code had no way to pass context and precomputed data for contextual verification, making it unable to pass context on UTXOs or on other data we already know we will require, such as Sprout and Sapling anchors.  To fix this, we introduce `PreparedBlock` and `FinalizedBlock` types that carry this data, and propagate them through the state code (ca3251b).

4. Various tracing and instrumentation changes made in support of figuring out the problem and solutions (1)-(3).

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

High priority: this PR blocks and is blocked by all other work on the state; this PR is necessary for block verification not to stall nearly immediately.

## Follow Up Work

After this change is made, we can actually test block verification, and should do so.

In the long-run, we can aim to make state updates more efficient by moving computation out of the state service and into the construction of the `PreparedBlock` and `FinalizedBlock` structures, which happens in the *caller* task, not the state task. See ca3251b for more details.  We can also correctly handle sprout and sapling anchors without having to make future changes of a similar level of invasiveness as these ones.

We also need to run through the entirety of our state update logic to ensure that it correctly handles intra-block data, which was not considered in the UTXO registration design and was probably not considered in the state update logic.
 
