### PR TITLE
Delete outdated transaction comments

### DIFF
--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -111,9 +111,6 @@ where
                     let mut async_checks = FuturesUnordered::new();
 
                     // Handle transparent inputs and outputs.
-                    // These are left unimplemented!() pending implementation
-                    // of the async script RFC.
-                    #[allow(clippy::if_same_then_else)] // delete when filled in
                     if tx.is_coinbase() {
                         // do something special for coinbase transactions
                         check::coinbase_tx_no_joinsplit_or_spend(&tx)?;


### PR DESCRIPTION
## Motivation

There is an outdated comment and a redundant lint suppression in the transaction verifier.

## Solution

Delete them.

## Review

@dconnolly wrote this code.

This change isn't urgent at all - the comments are just a bit confusing.
