### PR TITLE
Enable RUST_BACKTRACE=full for test and build/deploy images

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -35,4 +35,6 @@ RUN printf "endpoint_addr = '0.0.0.0:3000'\n" >> /zebrad.toml
 
 EXPOSE 3000 8233 18233
 
+ENV RUST_BACKTRACE full
+
 CMD [ "/zebrad", "-c", "/zebrad.toml", "start" ]

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -7,7 +7,7 @@ RUN apt-get update && \
 RUN mkdir /zebra
 WORKDIR /zebra
 
-ENV RUST_BACKTRACE 1
+ENV RUST_BACKTRACE full
 ENV CARGO_HOME /zebra/.cargo/
 
 RUN rustc -V; cargo -V; rustup -V


### PR DESCRIPTION
## Motivation

Currently the deploy/release images don't display any backtrace.

## Solution

Enable backtrace and relevant code snippets.