### PR TITLE
Add a debug config option, which runs some contextual checks on finalized blocks

### DIFF
--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -43,6 +43,12 @@ pub struct Config {
     ///
     /// Set to `None` by default: Zebra continues syncing indefinitely.
     pub debug_stop_at_height: Option<u32>,
+
+    /// Run each contextual verification check on all the blocks it supports.
+    ///
+    /// Set to `false` by default: Zebra runs contextual verification only on
+    /// post-checkpoint blocks.
+    pub debug_contextual_verify: bool,
 }
 
 fn gen_temp_path(prefix: &str) -> PathBuf {
@@ -107,6 +113,7 @@ impl Default for Config {
             cache_dir,
             ephemeral: false,
             debug_stop_at_height: None,
+            debug_contextual_verify: false,
         }
     }
 }

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -41,7 +41,7 @@ pub struct Config {
 
     /// Commit blocks to the finalized state up to this height, then exit Zebra.
     ///
-    /// If `None`, continue syncing indefinitely.
+    /// Set to `None` by default: Zebra continues syncing indefinitely.
     pub debug_stop_at_height: Option<u32>,
 }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -28,7 +28,7 @@ use crate::{
 
 use self::finalized_state::FinalizedState;
 
-mod check;
+pub(crate) mod check;
 mod finalized_state;
 mod non_finalized_state;
 #[cfg(test)]

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -23,9 +23,9 @@ pub(crate) mod difficulty;
 /// The relevant chain is an iterator over the ancestors of `block`, starting
 /// with its parent block.
 ///
-/// # Panics
+/// Panics if the finalized state is empty.
 ///
-/// If the state contains less than 28
+/// Skips the difficulty adjustment check if the state contains less than 28
 /// (`POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN`) blocks.
 #[tracing::instrument(
     name = "contextual_validation",
@@ -53,11 +53,6 @@ where
         .into_iter()
         .take(MAX_CONTEXT_BLOCKS)
         .collect();
-    assert_eq!(
-        relevant_chain.len(),
-        POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN,
-        "state must contain enough blocks to do contextual validation"
-    );
 
     let parent_block = relevant_chain
         .get(0)
@@ -68,18 +63,20 @@ where
         .expect("valid blocks have a coinbase height");
     check::height_one_more_than_parent_height(parent_height, prepared.height)?;
 
-    let relevant_data = relevant_chain.iter().map(|block| {
-        (
-            block.borrow().header.difficulty_threshold,
-            block.borrow().header.time,
-        )
-    });
-    let expected_difficulty =
-        AdjustedDifficulty::new_from_block(&prepared.block, network, relevant_data);
-    check::difficulty_threshold_is_valid(
-        prepared.block.header.difficulty_threshold,
-        expected_difficulty,
-    )?;
+    if relevant_chain.len() >= POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN {
+        let relevant_data = relevant_chain.iter().map(|block| {
+            (
+                block.borrow().header.difficulty_threshold,
+                block.borrow().header.time,
+            )
+        });
+        let expected_difficulty =
+            AdjustedDifficulty::new_from_block(&prepared.block, network, relevant_data);
+        check::difficulty_threshold_is_valid(
+            prepared.block.header.difficulty_threshold,
+            expected_difficulty,
+        )?;
+    }
 
     // TODO: other contextual validation design and implementation
     Ok(())

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -287,14 +287,19 @@ impl FinalizedState {
     /// based on the committed finalized state.
     ///
     /// Only used for debugging.
-    /// Contextual verification is only performed if `debug_contextual_verify` is true.
+    /// Contextual verification is only performed if `debug_contextual_verify` is true,
+    /// and there is at least one block in the finalized state.
     ///
     /// Panics if contextual verification fails.
     fn check_contextual_validity(&mut self, finalized_block: &FinalizedBlock) {
         if self.debug_contextual_verify {
             let finalized_tip_height = self.finalized_tip_height();
-            let relevant_chain = self.chain(finalized_tip_height.map(Into::into));
+            // Skip contextual verification if the finalized state is empty
+            if finalized_tip_height.is_none() {
+                return;
+            }
 
+            let relevant_chain = self.chain(finalized_tip_height.map(Into::into));
             check::block_is_contextually_valid(
                 // Fake a prepared block
                 &PreparedBlock {

--- a/zebra-state/src/service/finalized_state/iter.rs
+++ b/zebra-state/src/service/finalized_state/iter.rs
@@ -1,0 +1,50 @@
+//! An iterator for FinalizedState, in reverse chain order.
+
+use std::sync::Arc;
+
+use super::FinalizedState;
+
+use zebra_chain::block::{self, Block};
+
+pub struct Iter<'a> {
+    pub(super) finalized_state: &'a FinalizedState,
+    pub(super) height: Option<block::Height>,
+}
+
+impl Iterator for Iter<'_> {
+    type Item = Arc<Block>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let Iter {
+            finalized_state,
+            height,
+        } = self;
+
+        if let Some(height) = *height {
+            if let Some(block) = finalized_state.block(height.into()) {
+                self.height = height - 1;
+                return Some(block);
+            }
+        }
+
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl std::iter::FusedIterator for Iter<'_> {}
+
+impl ExactSizeIterator for Iter<'_> {
+    fn len(&self) -> usize {
+        match (self.height, self.finalized_state.finalized_tip_height()) {
+            (Some(height), Some(finalized_tip_height)) if (height <= finalized_tip_height) => {
+                (height.0 + 1) as _
+            }
+            _ => 0,
+        }
+    }
+}


### PR DESCRIPTION
## TODO

- [ ] remove the config option and just make it run unconditionally
- [ ] Rebase on `main` after PR #1500 merges
- [ ] Rename FinalizedState::chain (#1354) to ancestor_blocks
- [ ] Work out how to handle the `PreparedBlock` / `FinalizedBlock` type mismatch in `block_is_contextually_valid`.

## Motivation

Zebra's contextual validation checks are difficult to test, because we only run contextual validation on post-Sapling blocks.

Some checks aren't implemented for pre-Sapling blocks, but others work just fine. We can test these checks on finalized blocks, as long as we respect the preconditions for each check.

This code helped me test contextual verification. But we might not want to merge and maintain it. Or we might want to use it temporarily, then replace it with a better solution like configurable network upgrade heights (#1135).

## Solution

Add a `debug_contextual_verify` option to the finalized state, which is off by default.

When `debug_contextual_verify` is true:
* run the contextual validity checks before each `CommitFinalized` block is added to the finalized state
* skip contextual verification if the finalized state is empty - the height check requires at least one previous block

(We don't run this extra contextual verification on blocks from the non-finalized state, because they've already been contextually verified.)

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

@yaahc  is familiar with contextual verification and the `chain` iterator abstraction.
@hdevalence can help us decide if we want to merge this code.

## Related Issues

Difficulty contextual verification implementation PR #1355
