### PR TITLE
Difficulty Adjustment Validation - Implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,6 +3253,7 @@ dependencies = [
 name = "zebra-state"
 version = "3.0.0-alpha.0"
 dependencies = [
+ "chrono",
  "color-eyre",
  "dirs",
  "displaydoc",

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -93,8 +93,6 @@ pub(crate) const CONSENSUS_BRANCH_IDS: &[(NetworkUpgrade, ConsensusBranchId)] = 
     (Sapling, ConsensusBranchId(0x76b809bb)),
     (Blossom, ConsensusBranchId(0x2bb40e60)),
     (Heartwood, ConsensusBranchId(0xf5b9230b)),
-    // As of 24 September 2020. Could change before mainnet activation.
-    // See ZIP 251 for any updates.
     (Canopy, ConsensusBranchId(0xe9ff75a6)),
 ];
 

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -104,6 +104,11 @@ const PRE_BLOSSOM_POW_TARGET_SPACING: i64 = 150;
 /// The target block spacing after Blossom activation.
 const POST_BLOSSOM_POW_TARGET_SPACING: i64 = 75;
 
+/// The averaging window for difficulty threshold arithmetic mean calculations.
+///
+/// `PoWAveragingWindow` in the Zcash specification.
+pub const POW_AVERAGING_WINDOW: usize = 17;
+
 /// The multiplier used to derive the testnet minimum difficulty block time gap
 /// threshold.
 ///
@@ -222,6 +227,23 @@ impl NetworkUpgrade {
                 Some(network_upgrade.target_spacing() * TESTNET_MINIMUM_DIFFICULTY_GAP_MULTIPLIER)
             }
         }
+    }
+
+    /// Returns the averaging window timespan for the network upgrade.
+    ///
+    /// `AveragingWindowTimespan` from the Zcash specification.
+    pub fn averaging_window_timespan(&self) -> Duration {
+        self.target_spacing() * POW_AVERAGING_WINDOW as _
+    }
+
+    /// Returns the averaging window timespan for `network` and `height`.
+    ///
+    /// See `averaging_window_timespan` for details.
+    pub fn averaging_window_timespan_for_height(
+        network: Network,
+        height: block::Height,
+    ) -> Duration {
+        NetworkUpgrade::current(network, height).averaging_window_timespan()
     }
 }
 

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -264,7 +264,7 @@ impl NetworkUpgrade {
     ///
     /// `AveragingWindowTimespan` from the Zcash specification.
     pub fn averaging_window_timespan(&self) -> Duration {
-        self.target_spacing() * POW_AVERAGING_WINDOW as _
+        self.target_spacing() * (POW_AVERAGING_WINDOW as _)
     }
 
     /// Returns the averaging window timespan for `network` and `height`.

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -203,7 +203,7 @@ impl NetworkUpgrade {
 
     /// Returns the target block spacing for `network` and `height`.
     ///
-    /// See `target_spacing` for details.
+    /// See [`target_spacing()`] for details.
     pub fn target_spacing_for_height(network: Network, height: block::Height) -> Duration {
         NetworkUpgrade::current(network, height).target_spacing()
     }
@@ -269,7 +269,7 @@ impl NetworkUpgrade {
 
     /// Returns the averaging window timespan for `network` and `height`.
     ///
-    /// See `averaging_window_timespan` for details.
+    /// See [`averaging_window_timespan()`] for details.
     pub fn averaging_window_timespan_for_height(
         network: Network,
         height: block::Height,

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -19,6 +19,8 @@ use std::{
     fmt,
     iter::Sum,
     ops::Add,
+    ops::Div,
+    ops::Mul,
 };
 
 use primitive_types::U256;
@@ -396,6 +398,29 @@ impl From<ExpandedDifficulty> for U256 {
 impl Sum<ExpandedDifficulty> for ExpandedDifficulty {
     fn sum<I: Iterator<Item = ExpandedDifficulty>>(iter: I) -> Self {
         iter.map(|d| d.0).fold(U256::zero(), Add::add).into()
+    }
+}
+
+impl<T> Div<T> for ExpandedDifficulty
+where
+    T: Into<U256>,
+{
+    type Output = ExpandedDifficulty;
+
+    fn div(self, rhs: T) -> Self::Output {
+        ExpandedDifficulty(self.0 / rhs)
+    }
+}
+
+impl<T> Mul<T> for ExpandedDifficulty
+where
+    U256: Mul<T>,
+    <U256 as Mul<T>>::Output: Into<U256>,
+{
+    type Output = ExpandedDifficulty;
+
+    fn mul(self, rhs: T) -> ExpandedDifficulty {
+        ExpandedDifficulty((self.0 * rhs).into())
     }
 }
 

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -17,6 +17,8 @@ use std::{
     cmp::{Ordering, PartialEq, PartialOrd},
     convert::TryFrom,
     fmt,
+    iter::Sum,
+    ops::Add,
 };
 
 use primitive_types::U256;
@@ -382,6 +384,18 @@ impl ExpandedDifficulty {
 impl From<U256> for ExpandedDifficulty {
     fn from(value: U256) -> Self {
         ExpandedDifficulty(value)
+    }
+}
+
+impl From<ExpandedDifficulty> for U256 {
+    fn from(value: ExpandedDifficulty) -> Self {
+        value.0
+    }
+}
+
+impl Sum<ExpandedDifficulty> for ExpandedDifficulty {
+    fn sum<I: Iterator<Item = ExpandedDifficulty>>(iter: I) -> Self {
+        iter.map(|d| d.0).fold(U256::zero(), Add::add).into()
     }
 }
 

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -27,6 +27,7 @@ displaydoc = "0.1.7"
 rocksdb = "0.15.0"
 tempdir = "0.3.7"
 chrono = "0.4.19"
+primitive-types = "0.7.3"
 
 [dev-dependencies]
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "0.3", features = ["sync"] }
 displaydoc = "0.1.7"
 rocksdb = "0.15.0"
 tempdir = "0.3.7"
+chrono = "0.4.19"
 
 [dev-dependencies]
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -42,4 +42,8 @@ pub enum ValidateContextError {
     /// block.height is not one greater than its parent block's height
     #[non_exhaustive]
     NonSequentialBlock,
+
+    /// block.header.difficulty_threshold is not equal to the adjusted difficulty for the block
+    #[non_exhaustive]
+    InvalidDifficultyThreshold,
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -6,7 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use check::difficulty::{POW_AVERAGING_WINDOW, POW_MEDIAN_BLOCK_SPAN};
+use check::difficulty::POW_MEDIAN_BLOCK_SPAN;
 use futures::future::FutureExt;
 use non_finalized_state::{NonFinalizedState, QueuedBlocks};
 use tokio::sync::oneshot;
@@ -15,6 +15,7 @@ use tracing::instrument;
 use zebra_chain::{
     block::{self, Block},
     parameters::Network,
+    parameters::POW_AVERAGING_WINDOW,
     transaction,
     transaction::Transaction,
     transparent,

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -113,10 +113,17 @@ fn height_one_more_than_parent_height(
 /// value, then compares that value to the `difficulty_threshold`.
 /// Returns `Ok(())` if the values are equal.
 fn difficulty_threshold_is_valid(
-    _difficulty_threshold: CompactDifficulty,
-    _expected_difficulty: AdjustedDifficulty,
+    difficulty_threshold: CompactDifficulty,
+    expected_difficulty: AdjustedDifficulty,
 ) -> Result<(), ValidateContextError> {
-    Ok(())
+    // TODO: return an error on failure, after the calculation is implemented
+    #[allow(clippy::if_same_then_else)]
+    if difficulty_threshold == expected_difficulty.expected_difficulty_threshold() {
+        Ok(())
+    } else {
+        // This is the error case
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -13,8 +13,9 @@ use crate::{PreparedBlock, ValidateContextError};
 
 use super::check;
 
-pub mod difficulty;
 use difficulty::{AdjustedDifficulty, POW_MEDIAN_BLOCK_SPAN};
+
+pub(crate) mod difficulty;
 
 /// Check that `block` is contextually valid for `network`, based on the
 /// `finalized_tip_height` and `relevant_chain`.

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -5,6 +5,7 @@ use std::borrow::Borrow;
 use zebra_chain::{
     block::{self, Block},
     parameters::Network,
+    parameters::POW_AVERAGING_WINDOW,
     work::difficulty::CompactDifficulty,
 };
 
@@ -13,7 +14,7 @@ use crate::{PreparedBlock, ValidateContextError};
 use super::check;
 
 pub mod difficulty;
-use difficulty::{AdjustedDifficulty, POW_AVERAGING_WINDOW, POW_MEDIAN_BLOCK_SPAN};
+use difficulty::{AdjustedDifficulty, POW_MEDIAN_BLOCK_SPAN};
 
 /// Check that `block` is contextually valid for `network`, based on the
 /// `finalized_tip_height` and `relevant_chain`.

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -1,13 +1,19 @@
 //! Consensus critical contextual checks
 
+use std::borrow::Borrow;
+
 use zebra_chain::{
     block::{self, Block},
     parameters::Network,
+    work::difficulty::CompactDifficulty,
 };
 
 use crate::{PreparedBlock, ValidateContextError};
 
 use super::check;
+
+pub mod difficulty;
+use difficulty::{AdjustedDifficulty, POW_AVERAGING_WINDOW, POW_MEDIAN_BLOCK_SPAN};
 
 /// Check that `block` is contextually valid for `network`, based on the
 /// `finalized_tip_height` and `relevant_chain`.
@@ -16,6 +22,9 @@ use super::check;
 /// with its parent block.
 ///
 /// Panics if the finalized state is empty.
+///
+/// Skips the difficulty adjustment check if the state contains less than 28
+/// (`POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN`) blocks.
 #[tracing::instrument(
     name = "contextual_validation",
     fields(?network),
@@ -29,30 +38,51 @@ pub(crate) fn block_is_contextually_valid<C>(
 ) -> Result<(), ValidateContextError>
 where
     C: IntoIterator,
-    C::Item: AsRef<Block>,
+    C::Item: Borrow<Block>,
+    C::IntoIter: ExactSizeIterator,
 {
     let finalized_tip_height = finalized_tip_height
         .expect("finalized state must contain at least one block to do contextual validation");
     check::block_is_not_orphaned(finalized_tip_height, prepared.height)?;
 
-    let mut relevant_chain = relevant_chain.into_iter();
+    // Peek at the first block
+    let mut relevant_chain = relevant_chain.into_iter().peekable();
     let parent_block = relevant_chain
-        .next()
+        .peek()
         .expect("state must contain parent block to do contextual validation");
-    let parent_block = parent_block.as_ref();
+    let parent_block = parent_block.borrow();
     let parent_height = parent_block
         .coinbase_height()
         .expect("valid blocks have a coinbase height");
     check::height_one_more_than_parent_height(parent_height, prepared.height)?;
 
-    // TODO: validate difficulty adjustment
-    // TODO: other contextual validation design and implelentation
+    // Note: the difficulty check reads the first 28 blocks from the relevant
+    // chain iterator. If you want to use those blocks in other checks, you'll
+    // need to clone them here.
+
+    if relevant_chain.len() >= POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN {
+        let relevant_data = relevant_chain.map(|block| {
+            (
+                block.borrow().header.difficulty_threshold,
+                block.borrow().header.time,
+            )
+        });
+        // Reads the first 28 blocks from the iterator
+        let expected_difficulty =
+            AdjustedDifficulty::new_from_block(&prepared.block, network, relevant_data);
+        check::difficulty_threshold_is_valid(
+            prepared.block.header.difficulty_threshold,
+            expected_difficulty,
+        )?;
+    }
+
+    // TODO: other contextual validation design and implementation
     Ok(())
 }
 
 /// Returns `ValidateContextError::OrphanedBlock` if the height of the given
 /// block is less than or equal to the finalized tip height.
-pub(super) fn block_is_not_orphaned(
+fn block_is_not_orphaned(
     finalized_tip_height: block::Height,
     height: block::Height,
 ) -> Result<(), ValidateContextError> {
@@ -65,7 +95,7 @@ pub(super) fn block_is_not_orphaned(
 
 /// Returns `ValidateContextError::NonSequentialBlock` if the block height isn't
 /// equal to the parent_height+1.
-pub(super) fn height_one_more_than_parent_height(
+fn height_one_more_than_parent_height(
     parent_height: block::Height,
     height: block::Height,
 ) -> Result<(), ValidateContextError> {
@@ -74,6 +104,19 @@ pub(super) fn height_one_more_than_parent_height(
     } else {
         Ok(())
     }
+}
+
+/// Validate the `difficulty_threshold` from a candidate block's header, based
+/// on an `expected_difficulty` for that block.
+///
+/// Uses `expected_difficulty` to calculate the expected `ToCompact(Threshold())`
+/// value, then compares that value to the `difficulty_threshold`.
+/// Returns `Ok(())` if the values are equal.
+fn difficulty_threshold_is_valid(
+    _difficulty_threshold: CompactDifficulty,
+    _expected_difficulty: AdjustedDifficulty,
+) -> Result<(), ValidateContextError> {
+    Ok(())
 }
 
 #[cfg(test)]

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -47,10 +47,15 @@ where
         .expect("finalized state must contain at least one block to do contextual validation");
     check::block_is_not_orphaned(finalized_tip_height, prepared.height)?;
 
-    // Peek at the first block
-    let mut relevant_chain = relevant_chain.into_iter().peekable();
+    // The maximum number of blocks used by contextual checks
+    const MAX_CONTEXT_BLOCKS: usize = POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN;
+    let relevant_chain: Vec<_> = relevant_chain
+        .into_iter()
+        .take(MAX_CONTEXT_BLOCKS)
+        .collect();
+
     let parent_block = relevant_chain
-        .peek()
+        .get(0)
         .expect("state must contain parent block to do contextual validation");
     let parent_block = parent_block.borrow();
     let parent_height = parent_block
@@ -58,18 +63,13 @@ where
         .expect("valid blocks have a coinbase height");
     check::height_one_more_than_parent_height(parent_height, prepared.height)?;
 
-    // Note: the difficulty check reads the first 28 blocks from the relevant
-    // chain iterator. If you want to use those blocks in other checks, you'll
-    // need to clone them here.
-
     if relevant_chain.len() >= POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN {
-        let relevant_data = relevant_chain.map(|block| {
+        let relevant_data = relevant_chain.iter().map(|block| {
             (
                 block.borrow().header.difficulty_threshold,
                 block.borrow().header.time,
             )
         });
-        // Reads the first 28 blocks from the iterator
         let expected_difficulty =
             AdjustedDifficulty::new_from_block(&prepared.block, network, relevant_data);
         check::difficulty_threshold_is_valid(

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -110,20 +110,18 @@ fn height_one_more_than_parent_height(
 /// Validate the `difficulty_threshold` from a candidate block's header, based
 /// on an `expected_difficulty` for that block.
 ///
-/// Uses `expected_difficulty` to calculate the expected `ToCompact(Threshold())`
-/// value, then compares that value to the `difficulty_threshold`.
-/// Returns `Ok(())` if the values are equal.
+/// Uses `expected_difficulty` to calculate the expected difficulty value, then
+/// compares that value to the `difficulty_threshold`.
+///
+/// The check passes if the values are equal.
 fn difficulty_threshold_is_valid(
     difficulty_threshold: CompactDifficulty,
     expected_difficulty: AdjustedDifficulty,
 ) -> Result<(), ValidateContextError> {
-    // TODO: return an error on failure, after the calculation is implemented
-    #[allow(clippy::if_same_then_else)]
     if difficulty_threshold == expected_difficulty.expected_difficulty_threshold() {
         Ok(())
     } else {
-        // This is the error case
-        Ok(())
+        Err(ValidateContextError::InvalidDifficultyThreshold)
     }
 }
 

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -14,6 +14,8 @@ use super::check;
 ///
 /// The relevant chain is an iterator over the ancestors of `block`, starting
 /// with its parent block.
+///
+/// Panics if the finalized state is empty.
 #[tracing::instrument(
     name = "contextual_validation",
     fields(?network),
@@ -30,7 +32,7 @@ where
     C::Item: AsRef<Block>,
 {
     let finalized_tip_height = finalized_tip_height
-        .expect("finalized state must contain at least one block to use the non-finalized state");
+        .expect("finalized state must contain at least one block to do contextual validation");
     check::block_is_not_orphaned(finalized_tip_height, prepared.height)?;
 
     let mut relevant_chain = relevant_chain.into_iter();

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -211,10 +211,9 @@ impl AdjustedDifficulty {
                     .expect("difficulty thresholds in previously verified blocks are valid")
             })
             .sum();
-        let total: U256 = total.into();
-        let divisor: U256 = POW_AVERAGING_WINDOW.into();
 
-        (total / divisor).into()
+        let divisor: U256 = POW_AVERAGING_WINDOW.into();
+        total / divisor
     }
 
     /// Calculate the bounded median timespan. The median timespan is the

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -115,21 +115,15 @@ impl AdjustedDifficulty {
     {
         let candidate_height = (previous_block_height + 1).expect("next block height is valid");
 
-        // unzip would be a lot nicer here, but we can't satisfy its trait bounds
-        let context: Vec<_> = context
+        let (relevant_difficulty_thresholds, relevant_times) = context
             .into_iter()
             .take(POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN)
-            .collect();
-        let relevant_difficulty_thresholds = context
-            .iter()
-            .map(|pair| pair.0)
-            .collect::<Vec<_>>()
+            .unzip::<_, _, Vec<_>, Vec<_>>();
+
+        let relevant_difficulty_thresholds = relevant_difficulty_thresholds
             .try_into()
             .expect("not enough context: difficulty adjustment needs at least 28 (PoWAveragingWindow + PoWMedianBlockSpan) headers");
-        let relevant_times = context
-            .iter()
-            .map(|pair| pair.1)
-            .collect::<Vec<_>>()
+        let relevant_times = relevant_times
             .try_into()
             .expect("not enough context: difficulty adjustment needs at least 28 (PoWAveragingWindow + PoWMedianBlockSpan) headers");
 

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -1,0 +1,127 @@
+//! Block difficulty adjustment calculations for contextual validation.
+
+use chrono::{DateTime, Utc};
+
+use std::convert::TryInto;
+
+use zebra_chain::{block, block::Block, parameters::Network, work::difficulty::CompactDifficulty};
+
+/// The averaging window for difficulty threshold arithmetic mean calculations.
+///
+/// `PoWAveragingWindow` in the Zcash specification.
+pub const POW_AVERAGING_WINDOW: usize = 17;
+
+/// The median block span for time median calculations.
+///
+/// `PoWMedianBlockSpan` in the Zcash specification.
+pub const POW_MEDIAN_BLOCK_SPAN: usize = 11;
+
+/// Contains the context needed to calculate the adjusted difficulty for a block.
+#[allow(dead_code)]
+pub(super) struct AdjustedDifficulty {
+    /// The `header.time` field from the candidate block
+    candidate_time: DateTime<Utc>,
+    /// The coinbase height from the candidate block
+    ///
+    /// If we only have the header, this field is calculated from the previous
+    /// block height.
+    candidate_height: block::Height,
+    /// The configured network
+    network: Network,
+    /// The `header.difficulty_threshold`s from the previous
+    /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) blocks, in reverse height
+    /// order.
+    relevant_difficulty_thresholds: [CompactDifficulty; 28],
+    /// The `header.time`s from the previous
+    /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) blocks, in reverse height
+    /// order.
+    ///
+    /// Only the first and last `PoWMedianBlockSpan` times are used. Times
+    /// `11..=16` are ignored.
+    relevant_times: [DateTime<Utc>; 28],
+}
+
+impl AdjustedDifficulty {
+    /// Initialise and return a new `AdjustedDifficulty` using a `candidate_block`,
+    /// `network`, and a `context`.
+    ///
+    /// The `context` contains the previous
+    /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) `difficulty_threshold`s and
+    /// `time`s from the relevant chain for `candidate_block`, in reverse height
+    /// order, starting with the previous block.
+    ///
+    /// Note that the `time`s might not be in reverse chronological order, because
+    /// block times are supplied by miners.
+    ///
+    /// Panics:
+    /// If the `context` contains fewer than 28 items.
+    pub fn new_from_block<C>(
+        candidate_block: &Block,
+        network: Network,
+        context: C,
+    ) -> AdjustedDifficulty
+    where
+        C: IntoIterator<Item = (CompactDifficulty, DateTime<Utc>)>,
+    {
+        let candidate_block_height = candidate_block
+            .coinbase_height()
+            .expect("semantically valid blocks have a coinbase height");
+        let previous_block_height = (candidate_block_height - 1)
+            .expect("contextual validation is never run on the genesis block");
+
+        AdjustedDifficulty::new_from_header(
+            &candidate_block.header,
+            previous_block_height,
+            network,
+            context,
+        )
+    }
+
+    /// Initialise and return a new `AdjustedDifficulty` using a
+    /// `candidate_header`, `previous_block_height`, `network`, and a `context`.
+    ///
+    /// Designed for use when validating block headers, where the full block has not
+    /// been downloaded yet.
+    ///
+    /// See `new_from_block` for detailed information about the `context`.
+    ///
+    /// Panics:
+    /// If the context contains fewer than 28 items.
+    pub fn new_from_header<C>(
+        candidate_header: &block::Header,
+        previous_block_height: block::Height,
+        network: Network,
+        context: C,
+    ) -> AdjustedDifficulty
+    where
+        C: IntoIterator<Item = (CompactDifficulty, DateTime<Utc>)>,
+    {
+        let candidate_height = (previous_block_height + 1).expect("next block height is valid");
+
+        // unzip would be a lot nicer here, but we can't satisfy its trait bounds
+        let context: Vec<_> = context
+            .into_iter()
+            .take(POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN)
+            .collect();
+        let relevant_difficulty_thresholds = context
+            .iter()
+            .map(|pair| pair.0)
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("not enough context: difficulty adjustment needs at least 28 (PoWAveragingWindow + PoWMedianBlockSpan) headers");
+        let relevant_times = context
+            .iter()
+            .map(|pair| pair.1)
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("not enough context: difficulty adjustment needs at least 28 (PoWAveragingWindow + PoWMedianBlockSpan) headers");
+
+        AdjustedDifficulty {
+            candidate_time: candidate_header.time,
+            candidate_height,
+            network,
+            relevant_difficulty_thresholds,
+            relevant_times,
+        }
+    }
+}

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -68,7 +68,8 @@ impl AdjustedDifficulty {
     /// Note that the `time`s might not be in reverse chronological order, because
     /// block times are supplied by miners.
     ///
-    /// Panics:
+    /// # Panics
+    ///
     /// If the `context` contains fewer than 28 items.
     pub fn new_from_block<C>(
         candidate_block: &Block,
@@ -100,7 +101,8 @@ impl AdjustedDifficulty {
     ///
     /// See `new_from_block` for detailed information about the `context`.
     ///
-    /// Panics:
+    /// # Panics
+    ///
     /// If the context contains fewer than 28 items.
     pub fn new_from_header<C>(
         candidate_header: &block::Header,

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -35,14 +35,15 @@ pub(super) struct AdjustedDifficulty {
     /// The `header.difficulty_threshold`s from the previous
     /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) blocks, in reverse height
     /// order.
-    relevant_difficulty_thresholds: [CompactDifficulty; 28],
+    relevant_difficulty_thresholds:
+        [CompactDifficulty; POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN],
     /// The `header.time`s from the previous
     /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) blocks, in reverse height
     /// order.
     ///
     /// Only the first and last `PoWMedianBlockSpan` times are used. Times
     /// `11..=16` are ignored.
-    relevant_times: [DateTime<Utc>; 28],
+    relevant_times: [DateTime<Utc>; POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN],
 }
 
 impl AdjustedDifficulty {
@@ -216,7 +217,9 @@ impl AdjustedDifficulty {
     /// slice of `PoWMedianBlockSpan` (11) blocks in the relevant chain.
     ///
     /// Implements `MedianTime` from the Zcash specification.
-    fn median_time(mut median_block_span_times: [DateTime<Utc>; 11]) -> DateTime<Utc> {
+    fn median_time(
+        mut median_block_span_times: [DateTime<Utc>; POW_MEDIAN_BLOCK_SPAN],
+    ) -> DateTime<Utc> {
         median_block_span_times.sort_unstable();
         median_block_span_times[POW_MEDIAN_BLOCK_SPAN / 2]
     }

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -99,7 +99,7 @@ impl AdjustedDifficulty {
     /// Designed for use when validating block headers, where the full block has not
     /// been downloaded yet.
     ///
-    /// See `new_from_block` for detailed information about the `context`.
+    /// See [`new_from_block()`] for detailed information about the `context`.
     ///
     /// # Panics
     ///
@@ -165,7 +165,7 @@ impl AdjustedDifficulty {
     /// `candidate_height`, `network`, and the relevant `difficulty_threshold`s and
     /// `time`s.
     ///
-    /// See `expected_difficulty_threshold` for details.
+    /// See [`expected_difficulty_threshold()`] for details.
     ///
     /// Implements `ThresholdBits` from the Zcash specification. (Which excludes the
     /// Testnet minimum difficulty adjustment.)
@@ -264,7 +264,7 @@ impl AdjustedDifficulty {
     ///
     /// Implements `ActualTimespan` from the Zcash specification.
     ///
-    /// See `median_timespan_bounded` for details.
+    /// See [`median_timespan_bounded()`] for details.
     fn median_timespan(&self) -> Duration {
         let newer_times: [DateTime<Utc>; POW_MEDIAN_BLOCK_SPAN] = self.relevant_times
             [0..POW_MEDIAN_BLOCK_SPAN]


### PR DESCRIPTION
## Motivation

This PR implements the contextual difficulty validation RFC #1246.

The Zcash block difficulty adjustment is one of the core Zcash consensus rules. Zebra must implement this consensus rule to make sure that its cached chain state is consistent with the consensus of Zcash nodes.

Difficulty adjustment is also a significant part of Zcash's security guarantees. It ensures that the network continues to resist takeover attacks, even as the number of Zcash miners grows. (That's why this check is in the first alpha release.)

## Solution

Calculate the expected difficulty threshold for each block, and check that the block's `difficulty_threshold` field matches the expected value.

See the [RFC reference-level implementation section](https://github.com/teor2345/zebra/blob/contextual-difficulty-rfc/book/src/dev/rfcs/0006-contextual-difficulty.md#reference-level-explanation) for details.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Manual testing using `debug_contextual_verify` from #1354
    - Using `checkpoint_sync`, I was able to test the entire mainnet and testnet chains, despite bugs like #1348 

I'll implement unit tests or property tests in a future PR. (I need to check if there are any other urgent tasks before I start work on testing.)

## Review

@yaahc reviewed the difficulty RFC.

These checks need to go in the first alpha, so we should try to get the review done by Friday 27 November.

## Related Issues

Manually tested using `debug_contextual_verify` from #1354
Testing via the non-finalized state is blocked by #1348
Proof of work tracking issue #802

## Follow Up Work

Write unit tests or property tests
See the tracking issue #802 for details
