### PR TITLE
Temporarily avoid a panic when downcasting to redjubjub::Error fails

### DIFF
--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -67,13 +67,20 @@ pub enum TransactionError {
 
     #[error("bindingSig MUST represent a valid signature under the transaction binding validating key bvk of SigHash")]
     RedJubjub(redjubjub::Error),
+
+    // temporary error type until #1186 is fixed
+    #[error("Downcast from BoxError to redjubjub::Error failed")]
+    InternalDowncastError(String),
 }
 
 impl From<BoxError> for TransactionError {
     fn from(err: BoxError) -> Self {
         match err.downcast::<redjubjub::Error>() {
             Ok(e) => TransactionError::RedJubjub(*e),
-            Err(e) => panic!(e),
+            Err(e) => TransactionError::InternalDowncastError(format!(
+                "downcast to redjubjub::Error failed, original error: {:?}",
+                e
+            )),
         }
     }
 }


### PR DESCRIPTION
## Motivation

Zebra panics with a downcast error due to bug #1357.

We want to do a permanent fix as part of #1186, but that change will take more time, and it is not as urgent.

Right now, the panic is blocking other testing.

## Solution

Turn the panic into a temporary internal error type, which contains the original error formatted as a string. This downgrades the panic to a log message, with a level chosen by the code that processes the error. (Typically info-level.)

The code in this pull request has:
  - [x] Documentation Comments

## Review

@hdevalence is working on the permanent fix.

I need this panic fixed urgently, so I can complete a full sync to test the difficulty contextual validation. I expect that others also want these panics fixed, so they can do tests.

## Related Issues

Closes #1357
Cleanup underlying issue in #1186

## Follow Up Work

The temporary internal error type should be removed when #1186 is fixed.
