### PR TITLE
Fix individual crate compilation failures

### DIFF
--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-tokio = { version = "0.3", features = ["time", "sync", "stream", "tracing"] }
+tokio = { version = "0.3", features = ["time", "sync", "stream", "tracing", "macros"] }
 tower = { version = "0.4", features = ["util", "buffer"] }
 futures-core = "0.3.6"
 pin-project = "0.4.27"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"
 
 futures = "0.3"
-tokio = { version = "0.3", features = ["net", "time", "stream", "tracing", "macros"] }
+tokio = { version = "0.3", features = ["net", "time", "stream", "tracing", "macros", "rt-multi-thread"] }
 tokio-util = { version = "0.5", features = ["codec"] }
 tower = { version = "0.4", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 


### PR DESCRIPTION
## Motivation

Some Zebra crates don't compile individually due to missing features in their dependencies. 

## Solution

Add those features to each crate's dependency list.

## Review

@hdevalence can review this change whenever he likes.

It would be nice to get it fixed before the first alpha.

## Follow Up Work

Detect these kind of dependency bugs in CI #1364