### PR TITLE
Disable transaction checks that depend on a broken API

### DIFF
--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -16,6 +16,7 @@ use crate::error::TransactionError;
 ///
 /// https://zips.z.cash/protocol/canopy.pdf#sproutnonmalleability
 /// https://zips.z.cash/protocol/canopy.pdf#txnencodingandconsensus
+#[allow(dead_code)]
 pub fn validate_joinsplit_sig(
     joinsplit_data: &JoinSplitData<Groth16Proof>,
     sighash: &[u8],


### PR DESCRIPTION
## Motivation

The transaction verifier and its sub-verifiers need to validate
transactions based on the block's network upgrade.

To find the network upgrade, we need the block height and network. But
the transaction verifier requests and data structures don't provide this
information.

## Solution

So we temporarily disable all the transaction verifier checks that depend
on a hard-coded network upgrade.

Temporary workaround for #1367.

The code in this pull request has been tested manually:
  - Mainnet sync makes progress after these changes

We can write unit tests as part of #1367.

## Review

I think @yaahc and @dconnolly wrote this code.

This fix is urgent, because #1367 blocks post-Blossom transaction verification.

## Related Issues

Bug report #1367 
PR that introduced this bug #1173

## Follow Up Work

Fix the transaction and script verifier APIs to use the current network upgrade #1367