### PR TITLE
Remove a post-Canopy panic in funding stream block subsidy validation

### DIFF
--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -132,7 +132,9 @@ pub fn subsidy_is_valid(block: &Block, network: Network) -> Result<(), BlockErro
         // Funding streams are paid from Canopy activation to the second halving
         // Note: Canopy activation is at the first halving on mainnet, but not on testnet
         // ZIP-1014 only applies to mainnet, ZIP-214 contains the specific rules for testnet
-        unimplemented!("funding stream block subsidy validation is not implemented")
+        tracing::trace!("funding stream block subsidy validation is not implemented");
+        // Return ok for now
+        Ok(())
     } else {
         // Future halving, with no founders reward or funding streams
         Ok(())


### PR DESCRIPTION
## Motivation

Block validation panics when we reach canopy, because funding stream block subsidy validation is not yet implemented.

## Solution

Turn the panic into a trace log.

Funding stream block subsidy validation will be implemented as part of block subsidy validation in #801.

The code in this pull request has been tested manually:
  - Syncing past canopy on Mainnet

## Review

@oxarbitrage and I wrote this code.

This review is urgent, so I'm also tagging the zebra-team, in case @oxarbitrage is not around today.

## Follow Up Work

We'll implement this feature in #801.
