### PR TITLE
Downgrade a per-block log to debug level

### DIFF
--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -33,7 +33,7 @@ impl Chain {
     pub fn push(&mut self, block: PreparedBlock) {
         // update cumulative data members
         self.update_chain_state_with(&block);
-        tracing::info!(block = %block.block, "adding block to chain");
+        tracing::debug!(block = %block.block, "adding block to chain");
         self.blocks.insert(block.height, block);
     }
 


### PR DESCRIPTION
## Motivation

`zebrad` logs by default at info-level, and we don't want an info-level log line for each of a few hundred thousand blocks.

## Solution

Downgrade the info-level log to debug.

## Review

@yaahc wrote this code. It's urgent, because it hides warnings and errors in the logs.

## Follow Up

It would be nice to log new blocks only after we've synced to the tip - but that's not urgent at all. People can use metrics, or watch the block locator heights.
