### PR TITLE
Revert "Downgrade a per-block log to debug level"

### DIFF
--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -33,7 +33,7 @@ impl Chain {
     pub fn push(&mut self, block: PreparedBlock) {
         // update cumulative data members
         self.update_chain_state_with(&block);
-        tracing::debug!(block = %block.block, "adding block to chain");
+        tracing::info!(block = %block.block, "adding block to chain");
         self.blocks.insert(block.height, block);
     }
 


### PR DESCRIPTION
Reverts ZcashFoundation/zebra#1373

I changed the level for the new-block-committed event to info on purpose; it's the only info-level log in that part of the verification pipeline, and downgrading it mixes it in with many other log messages that were intended to exist at a lower level of detail.

It is already possible to filter for warnings by only asking for warning and above level.