### PR TITLE
consensus: add NU plumbing to block,tx,script verifiers

### DIFF
--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -25,7 +25,6 @@ use tracing::Instrument;
 use zebra_chain::{
     block::{self, Block},
     parameters::Network,
-    parameters::NetworkUpgrade,
     transparent,
     work::equihash,
 };
@@ -83,9 +82,8 @@ where
     S::Future: Send + 'static,
 {
     pub fn new(network: Network, state_service: S) -> Self {
-        let branch = NetworkUpgrade::Sapling.branch_id().unwrap();
-        let script_verifier = script::Verifier::new(state_service.clone(), branch);
-        let transaction_verifier = transaction::Verifier::new(script_verifier);
+        let transaction_verifier =
+            transaction::Verifier::new(network, script::Verifier::new(state_service.clone()));
 
         Self {
             network,
@@ -176,6 +174,7 @@ where
                     .call(transaction::Request::Block {
                         transaction: transaction.clone(),
                         known_utxos: known_utxos.clone(),
+                        height,
                     });
                 async_checks.push(rsp);
             }

--- a/zebra-consensus/src/script.rs
+++ b/zebra-consensus/src/script.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
 use tracing::Instrument;
 
-use zebra_chain::{parameters::ConsensusBranchId, transaction::Transaction, transparent};
+use zebra_chain::{parameters::NetworkUpgrade, transaction::Transaction, transparent};
 use zebra_state::Utxo;
 
 use crate::BoxError;
@@ -21,27 +21,34 @@ use crate::BoxError;
 #[derive(Debug, Clone)]
 pub struct Verifier<ZS> {
     state: ZS,
-    branch: ConsensusBranchId,
 }
 
 impl<ZS> Verifier<ZS> {
-    pub fn new(state: ZS, branch: ConsensusBranchId) -> Self {
-        Self { state, branch }
+    pub fn new(state: ZS) -> Self {
+        Self { state }
     }
 }
 
 /// A script verification request.
-///
-/// Ideally, this would supply only an `Outpoint` and the unlock script,
-/// rather than the entire `Transaction`, but we call a C++
-/// implementation, and its FFI requires the entire transaction.
-/// At some future point, we could investigate reducing the size of the
-/// request.
 #[derive(Debug)]
 pub struct Request {
+    /// Ideally, this would supply only an `Outpoint` and the unlock script,
+    /// rather than the entire `Transaction`, but we call a C++
+    /// implementation, and its FFI requires the entire transaction.
+    ///
+    /// This causes quadratic script verification behavior, so
+    /// at some future point, we need to reform this data.
     pub transaction: Arc<Transaction>,
     pub input_index: usize,
+    /// A set of additional UTXOs known in the context of this verification request.
+    ///
+    /// This allows specifying additional UTXOs that are not already known to the chain state.
     pub known_utxos: Arc<HashMap<transparent::OutPoint, Utxo>>,
+    /// The network upgrade active in the context of this verification request.
+    ///
+    /// Because the consensus branch ID changes with each network upgrade,
+    /// it has to be specified on a per-request basis.
+    pub upgrade: NetworkUpgrade,
 }
 
 impl<ZS> tower::Service<Request> for Verifier<ZS>
@@ -68,13 +75,16 @@ where
             transaction,
             input_index,
             known_utxos,
+            upgrade,
         } = req;
         let input = &transaction.inputs()[input_index];
+        let branch_id = upgrade
+            .branch_id()
+            .expect("post-Sapling NUs have a consensus branch ID");
 
         match input {
             transparent::Input::PrevOut { outpoint, .. } => {
                 let outpoint = *outpoint;
-                let branch_id = self.branch;
 
                 let span = tracing::trace_span!("script", ?outpoint);
                 let query =


### PR DESCRIPTION


## Solution

Closes #1367 by propagating the network upgrade through the service
requests.

- [ ] Test on a chain sync: 

## Review

Blocks chain sync


## Follow Up Work

As a followup, we need to fix the error handling that caused script errors to be wrongly interpreted, and check the sighash implementation used by the transaction verifier.