### PR TITLE
Avoid verbose default logs

### DIFF
--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -33,7 +33,7 @@ impl Chain {
     pub fn push(&mut self, block: PreparedBlock) {
         // update cumulative data members
         self.update_chain_state_with(&block);
-        tracing::info!(block = %block.block, "adding block to chain");
+        tracing::debug!(block = %block.block, "adding block to chain");
         self.blocks.insert(block.height, block);
     }
 


### PR DESCRIPTION
## Motivation

Zebra's default logs should support a typical workflow:
1. Developer or user runs Zebra with the default config
2. They send the logs to a terminal
3. When they see a bug, they copy-paste the last few log lines into a bug report

## Solution

Temporarily downgrade a verbose info-level log to debug level.

After this change:
* more important warnings and errors will be visible in the terminal
* copying and pasting recent logs will capture more important log messages
* we won't have an info-level progress report for every block

Create follow up tasks to design better progress reports and log levels in #1380 and #1381.

## Review

@hdevalence should review this change because he made the original change.

## Related Issues

This log level has been:
* changed from debug to info in #1348
* changed from info to debug in #1373 
* changed from debug to info in #1375

@hdevalence and I have discussed this change. We agreed on a debug-level log as a temporary solution. I opened tickets #1380 and #1381 to come up with a permanent solution.

## Follow Up Work

We'll provide regular progress reports in `zebrad`'s logs in #1380.
We'll create a consistent logging design for Zebra in ticket #1381.