### PR TITLE
Add an info-level log when UTXO requests are pruned

### DIFF
--- a/zebra-state/src/service/pending_utxos.rs
+++ b/zebra-state/src/service/pending_utxos.rs
@@ -61,4 +61,9 @@ impl PendingUtxos {
     pub fn prune(&mut self) {
         self.0.retain(|_, chan| chan.receiver_count() > 0);
     }
+
+    /// Returns the number of utxos that are being waited on.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 }


### PR DESCRIPTION
## Motivation

I'm seeing some hangs during the initial sync, these logs might help identify the cause.

## Solution

Add an info-level log when UTXO requests are pruned.
And a debug-level log when no requests are pruned.

Testing:
- I have manually run the code, and the info-level logs appear correct

## Review

@yaahc be nice to get this in eventually.

## Follow Up Work

If Zebra keeps hanging, log a bug with the logs showing utxo changes.