### PR TITLE
Disable the nightly clippy unnecessary_wraps lint

### DIFF
--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -8,8 +8,10 @@
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_chain")]
 // #![deny(missing_docs)]
 #![allow(clippy::try_err)]
+// Disable some broken or unwanted clippy nightly lints
 #![allow(clippy::unknown_clippy_lints)]
 #![allow(clippy::from_iter_instead_of_collect)]
+#![allow(clippy::unnecessary_wraps)]
 
 #[macro_use]
 extern crate serde;

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -36,6 +36,9 @@
 // Re-enable this after cleaning the API surface.
 //#![deny(missing_docs)]
 #![allow(clippy::try_err)]
+// Disable some broken or unwanted clippy nightly lints
+#![allow(clippy::unknown_clippy_lints)]
+#![allow(clippy::unnecessary_wraps)]
 
 mod block;
 mod checkpoint;

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -38,6 +38,9 @@
 // Tracing causes false positives on this lint:
 // https://github.com/tokio-rs/tracing/issues/553
 #![allow(clippy::cognitive_complexity)]
+// Disable some broken or unwanted clippy nightly lints
+#![allow(clippy::unknown_clippy_lints)]
+#![allow(clippy::unnecessary_wraps)]
 
 #[macro_use]
 extern crate pin_project;

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -2,6 +2,9 @@
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_script")]
+// Disable some broken or unwanted clippy nightly lints
+#![allow(clippy::unknown_clippy_lints)]
+#![allow(clippy::unnecessary_wraps)]
 
 use displaydoc::Display;
 #[cfg(windows)]

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -5,8 +5,10 @@
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_state")]
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
+// Disable some broken or unwanted clippy nightly lints
 #![allow(clippy::unknown_clippy_lints)]
 #![allow(clippy::field_reassign_with_default)]
+#![allow(clippy::unnecessary_wraps)]
 
 mod config;
 mod constants;

--- a/zebra-test/src/lib.rs
+++ b/zebra-test/src/lib.rs
@@ -1,5 +1,6 @@
 //! Miscellaneous test code for Zebra.
 
+// Disable some broken or unwanted clippy nightly lints
 #![allow(clippy::unknown_clippy_lints)]
 #![allow(clippy::from_iter_instead_of_collect)]
 // Each lazy_static variable uses additional recursion

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -14,9 +14,10 @@
 #![warn(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]
 #![allow(dead_code)]
-#![allow(clippy::field_reassign_with_default)]
 #![allow(clippy::try_err)]
+// Disable some broken or unwanted clippy nightly lints
 #![allow(clippy::unknown_clippy_lints)]
+#![allow(clippy::field_reassign_with_default)]
 
 use color_eyre::eyre::Result;
 use eyre::WrapErr;


### PR DESCRIPTION
## Motivation

Clippy nightly has a new `unnecessary_wraps` lint. It seems to be a bit broken, or incompatible with our coding style.

Some of our functions return `Result` for consistency with similar functions. But the lint picks them up anyway.

## Solution

Disable the `unnecessary_wraps` lint in the Zebra crates that currently trigger it.

## Review

@yaahc likes clippy :-)

This review can happen at any time.

## Follow Up

Decide if we want to make the changes that clippy recommends #1304