### PR TITLE
Fix a state config comment

### DIFF
--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -41,7 +41,7 @@ pub struct Config {
 
     /// Commit blocks to the finalized state up to this height, then exit Zebra.
     ///
-    /// If `None`, continue syncing indefinitely.
+    /// Set to `None` by default: Zebra continues syncing indefinitely.
     pub debug_stop_at_height: Option<u32>,
 }
 


### PR DESCRIPTION
Minor fix to a state config comment, to explain the meaning of `None`.