### PR TITLE
Decrease the UTXO request timeout

### DIFF
--- a/zebra-consensus/src/script.rs
+++ b/zebra-consensus/src/script.rs
@@ -12,10 +12,15 @@ use crate::BoxError;
 ///
 /// The exact value is non-essential, but this should be long enough to allow
 /// out-of-order verification of blocks (UTXOs are not required to be ready
-/// immediately) while being short enough to prune blocks that are too far in the
-/// future to be worth keeping in the queue, and to fail blocks that reference
-/// invalid UTXOs.
-const UTXO_LOOKUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+/// immediately) while being short enough to:
+///   * prune blocks that are too far in the future to be worth keeping in the
+///     queue,
+///   * fail blocks that reference invalid UTXOs, and
+///   * fail blocks that reference UTXOs from blocks that have temporarily failed
+///     to download, because a peer sent Zebra a bad list of block hashes. (The
+///     UTXO verification failure will restart the sync, and re-download the
+///     chain in the correct order.)
+const UTXO_LOOKUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3 * 60);
 
 /// Asynchronous script verification.
 ///


### PR DESCRIPTION
## Motivation

UTXO requests during transaction input verification can time out because:

1. The block that creates the UTXO is queued for download or verify, but it hasn't been committed yet. The creating block might spend UTXOs that come from other recent blocks, so UTXO verification can depend on a (non-contiguous) sequence of block verifications.

   In this case, Zebra should wait for additional block download and verify tasks to complete.

2. The block that creates the UTXO isn't queued for download. This can happen because the block is gossiped block that's much higher than the current tip, or because a peer sent the syncer a bad list of block hashes.

   In this case, Zebra should discard the timed out block, and restart the sync.

As a side-effect, this change should make it easier to diagnose UTXO hangs like #1406, because bad queries will fail faster. And it should make Zebra a bit more usable, because Zebra won't hang waiting for impossible UTXOs for quite as long.

## Solution

We need to choose a timeout that balances waiting for queued correct blocks, and restarting after an incorrect block. So we time out after 180 seconds.

Assuming Zebra can download at least 1 MB per second, 180 seconds is enough time to download at least a few hundred blocks. So Zebra should be able to download and verify the next block before the UTXOs that it creates time out. (Since Zebra has already verified all the blocks before the next block, its UTXO requests should return immediately.)

Even if some peers time out downloads, a block can only be pending download for 80 seconds (4 retries * 20 second timeout) before the download fails. So the UTXO timeout doesn't need to be much larger than this overall download timeout - because a download timeout will happen before a UTXO timeout on slow networks.

Alternately, if the download for the creating block was never queued, Zebra should timeout as soon as possible - so it can restart the sync and download the creating block.

## Review

@hdevalence wrote this code.

This change should help diagnose the UTXO hangs in #1406, which could affect Mainnet. So it would be good to get it in soon.

## Related Issues

The UTXO timeout was introduced by PR #1391

## Follow Up Work

Diagnose the sync hangs in #1406
Tune Zebra for testnet