### PR TITLE
Allow colors to be disabled in tracing output

### DIFF
--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -1,12 +1,11 @@
-use std::path::Path;
-
+use abscissa_core::{Component, FrameworkError, FrameworkErrorKind, Shutdown};
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{
     fmt::Formatter, layer::SubscriberExt, reload::Handle, util::SubscriberInitExt, EnvFilter,
     FmtSubscriber,
 };
 
-use abscissa_core::{Component, FrameworkError, FrameworkErrorKind, Shutdown};
+use crate::config::TracingSection;
 
 use super::flame;
 
@@ -18,7 +17,10 @@ pub struct Tracing {
 
 impl Tracing {
     /// Try to create a new [`Tracing`] component with the given `filter`.
-    pub fn new(filter: &str, flame_root: Option<&Path>) -> Result<Self, FrameworkError> {
+    pub fn new(config: TracingSection) -> Result<Self, FrameworkError> {
+        let filter = config.filter.unwrap_or_else(|| "".to_string());
+        let flame_root = &config.flamegraph;
+
         // Construct a tracing subscriber with the supplied filter and enable reloading.
         let builder = FmtSubscriber::builder()
             .with_ansi(true)

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -23,7 +23,7 @@ impl Tracing {
 
         // Construct a tracing subscriber with the supplied filter and enable reloading.
         let builder = FmtSubscriber::builder()
-            .with_ansi(true)
+            .with_ansi(config.use_color)
             .with_env_filter(filter)
             .with_filter_reloading();
         let filter_handle = builder.reload_handle();

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -43,6 +43,11 @@ pub struct ZebradConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct TracingSection {
+    /// Whether to use colored terminal output, if available.
+    ///
+    /// Defaults to `true`.
+    pub use_color: bool,
+
     /// The filter used for tracing events.
     ///
     /// The filter is used to create a `tracing-subscriber`
@@ -101,6 +106,7 @@ pub struct TracingSection {
 impl Default for TracingSection {
     fn default() -> Self {
         Self {
+            use_color: true,
             filter: None,
             endpoint_addr: None,
             flamegraph: None,


### PR DESCRIPTION

## Motivation

Applying regexes to tracing output to filter on spans can run into problems if there are color codes in the output.  This can be dealt with either by filtering the output with an appropriate sed command or commenting out the `with_ansi` line in the component, but this is a more ergonomic solution.

## Solution

Add a config field and pass the config to the tracing component.  The changes are made to minimize conflicts with @dconnolly's Opentelemetry work (#1395). 

