### PR TITLE
Include short sha in log messages and error urls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3018,6 +3018,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "vergen"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce50d8996df1f85af15f2cd8d33daae6e479575123ef4314a51a70a230739cb"
+dependencies = [
+ "bitflags",
+ "chrono",
+]
+
+[[package]]
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3343,6 +3353,7 @@ dependencies = [
  "tracing-flame",
  "tracing-futures",
  "tracing-subscriber 0.2.15",
+ "vergen",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -191,8 +191,7 @@ where
     fn call(&mut self, req: (TcpStream, SocketAddr)) -> Self::Future {
         let (tcp_stream, addr) = req;
 
-        let connector_span =
-            span!(parent: &self.parent_span, Level::INFO, "connector", addr = ?addr);
+        let connector_span = span!(Level::INFO, "connector", addr = ?addr);
         // set parent: None for the peer connection span, as it should exist
         // independently of its creation source (inbound connection, crawler,
         // initial peer, ...)

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -38,6 +38,10 @@ metrics-exporter-prometheus = "0.1.0-alpha.7"
 
 dirs = "3.0.1"
 inferno = { version = "0.10.1", default-features = false }
+vergen = "3.1.0"
+
+[build-dependencies]
+vergen = "3.1.0"
 
 [dev-dependencies]
 abscissa_core = { version = "0.5", features = ["testing"] }

--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -1,0 +1,12 @@
+extern crate vergen;
+
+use vergen::{generate_cargo_keys, ConstantsFlags};
+
+fn main() {
+    // Setup the flags, toggling off the 'SEMVER_FROM_CARGO_PKG' flag
+    let mut flags = ConstantsFlags::empty();
+    flags.toggle(ConstantsFlags::SHA_SHORT);
+
+    // Generate the 'cargo:' key output
+    generate_cargo_keys(flags).expect("Unable to generate the cargo keys!");
+}

--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -6,6 +6,7 @@ fn main() {
     // Setup the flags, toggling off the 'SEMVER_FROM_CARGO_PKG' flag
     let mut flags = ConstantsFlags::empty();
     flags.toggle(ConstantsFlags::SHA_SHORT);
+    flags.toggle(ConstantsFlags::REBUILD_ON_HEAD_CHANGE);
 
     // Generate the 'cargo:' key output
     generate_cargo_keys(flags).expect("Unable to generate the cargo keys!");

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -92,6 +92,7 @@ impl Application for ZebradApp {
         color_eyre::config::HookBuilder::default()
             .issue_url(concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/new"))
             .add_issue_metadata("version", env!("CARGO_PKG_VERSION"))
+            .add_issue_metadata("git sha", ZebradCmd::SHA)
             .issue_filter(|kind| match kind {
                 color_eyre::ErrorKind::NonRecoverable(_) => true,
                 color_eyre::ErrorKind::Recoverable(error) => {

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -43,6 +43,10 @@ pub struct ZebradApp {
     state: application::State<Self>,
 }
 
+impl ZebradApp {
+    pub const GIT_COMMIT: &'static str = env!("VERGEN_SHA_SHORT");
+}
+
 /// Initialize a new application instance.
 ///
 /// By default no configuration is loaded, and the framework state is
@@ -92,7 +96,7 @@ impl Application for ZebradApp {
         color_eyre::config::HookBuilder::default()
             .issue_url(concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/new"))
             .add_issue_metadata("version", env!("CARGO_PKG_VERSION"))
-            .add_issue_metadata("git commit", ZebradCmd::GIT_COMMIT)
+            .add_issue_metadata("git commit", Self::GIT_COMMIT)
             .issue_filter(|kind| match kind {
                 color_eyre::ErrorKind::NonRecoverable(_) => true,
                 color_eyre::ErrorKind::Recoverable(error) => {

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -92,7 +92,7 @@ impl Application for ZebradApp {
         color_eyre::config::HookBuilder::default()
             .issue_url(concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/new"))
             .add_issue_metadata("version", env!("CARGO_PKG_VERSION"))
-            .add_issue_metadata("git sha", ZebradCmd::SHA)
+            .add_issue_metadata("git commit", ZebradCmd::GIT_COMMIT)
             .issue_filter(|kind| match kind {
                 color_eyre::ErrorKind::NonRecoverable(_) => true,
                 color_eyre::ErrorKind::Recoverable(error) => {

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -54,7 +54,7 @@ impl ZebradCmd {
 
 impl Runnable for ZebradCmd {
     fn run(&self) {
-        let span = info_span!("zebrad", GIT_SHA = %Self::SHA);
+        let span = error_span!("git", SHA = %Self::SHA);
         let _guard = span.enter();
         match self {
             Generate(cmd) => cmd.run(),

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -38,7 +38,7 @@ pub enum ZebradCmd {
 }
 
 impl ZebradCmd {
-    pub const SHA: &'static str = env!("VERGEN_SHA_SHORT");
+    pub const GIT_COMMIT: &'static str = env!("VERGEN_SHA_SHORT");
 
     /// Returns true if this command is a server command.
     ///

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -54,7 +54,7 @@ impl ZebradCmd {
 
 impl Runnable for ZebradCmd {
     fn run(&self) {
-        let span = error_span!("git", SHA = %Self::SHA);
+        let span = error_span!("git", commit = %Self::GIT_COMMIT);
         let _guard = span.enter();
         match self {
             Generate(cmd) => cmd.run(),

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -54,7 +54,7 @@ impl ZebradCmd {
 
 impl Runnable for ZebradCmd {
     fn run(&self) {
-        let span = error_span!("git", commit = %Self::GIT_COMMIT);
+        let span = error_span!("", zebrad = %Self::GIT_COMMIT);
         let _guard = span.enter();
         match self {
             Generate(cmd) => cmd.run(),

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 pub const CONFIG_FILE: &str = "zebrad.toml";
 
 /// Zebrad Subcommands
-#[derive(Command, Debug, Options, Runnable)]
+#[derive(Command, Debug, Options)]
 pub enum ZebradCmd {
     /// The `generate` subcommand
     #[options(help = "generate a skeleton configuration")]
@@ -38,6 +38,8 @@ pub enum ZebradCmd {
 }
 
 impl ZebradCmd {
+    pub const SHA: &'static str = env!("VERGEN_SHA_SHORT");
+
     /// Returns true if this command is a server command.
     ///
     /// For example, `Start` acts as a Zcash node.
@@ -46,6 +48,20 @@ impl ZebradCmd {
             // List all the commands, so new commands have to make a choice here
             Start(_) => true,
             Generate(_) | Help(_) | Version(_) => false,
+        }
+    }
+}
+
+impl Runnable for ZebradCmd {
+    fn run(&self) {
+        let sha = Self::SHA;
+        let span = info_span!("zebrad", sha);
+        let _guard = span.enter();
+        match self {
+            Generate(cmd) => cmd.run(),
+            ZebradCmd::Help(cmd) => cmd.run(),
+            Start(cmd) => cmd.run(),
+            Version(cmd) => cmd.run(),
         }
     }
 }

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -54,8 +54,7 @@ impl ZebradCmd {
 
 impl Runnable for ZebradCmd {
     fn run(&self) {
-        let sha = Self::SHA;
-        let span = info_span!("zebrad", sha);
+        let span = info_span!("zebrad", GIT_SHA = %Self::SHA);
         let _guard = span.enter();
         match self {
             Generate(cmd) => cmd.run(),

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -8,6 +8,7 @@ use self::ZebradCmd::*;
 use self::{generate::GenerateCmd, start::StartCmd, version::VersionCmd};
 
 use crate::config::ZebradConfig;
+use crate::application::ZebradApp;
 
 use abscissa_core::{
     config::Override, Command, Configurable, FrameworkError, Help, Options, Runnable,
@@ -38,8 +39,6 @@ pub enum ZebradCmd {
 }
 
 impl ZebradCmd {
-    pub const GIT_COMMIT: &'static str = env!("VERGEN_SHA_SHORT");
-
     /// Returns true if this command is a server command.
     ///
     /// For example, `Start` acts as a Zcash node.
@@ -54,7 +53,7 @@ impl ZebradCmd {
 
 impl Runnable for ZebradCmd {
     fn run(&self) {
-        let span = error_span!("", zebrad = %Self::GIT_COMMIT);
+        let span = error_span!("", zebrad = ZebradApp::GIT_COMMIT);
         let _guard = span.enter();
         match self {
             Generate(cmd) => cmd.run(),


### PR DESCRIPTION
## Motivation

As we approach our alpha release we've decided we want to plan ahead for the user bug reports we will eventually receive. One of the bigger issues we foresee is determining exactly what version of the software users are running, and particularly how easy it may or may not be for users to accidentally discard this information when reporting bugs.

## Solution

To defend against this, we've decided to include the exact git sha for any given build in the compiled artifact. This information will then be re-exported as a span early in the application startup process, so that all logs and error messages should include the sha as their very first span. We've also added this sha as issue metadata for `color-eyre`'s github issue url auto generation feature, which should make sure that the sha is easily available in bug reports we receive, even in the absence of logs.

The code in this pull request has:
  - [ ] Documentation Comments
  - [ ] Unit Tests and Property Tests

## Review

## Related Issues

Partly implements https://github.com/ZcashFoundation/zebra/issues/692

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
