### PR TITLE
remove unused mutability to defuse deadlock

### DIFF
--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -55,7 +55,7 @@ impl Tracing {
     /// Reload the currently-active filter with the supplied value.
     ///
     /// This can be used to provide a dynamic tracing filter endpoint.
-    pub fn reload_filter(&mut self, filter: impl Into<EnvFilter>) {
+    pub fn reload_filter(&self, filter: impl Into<EnvFilter>) {
         self.filter_handle
             .reload(filter)
             .expect("the subscriber is not dropped before the component is");

--- a/zebrad/src/components/tracing/endpoint.rs
+++ b/zebrad/src/components/tracing/endpoint.rs
@@ -104,10 +104,10 @@ To set the filter, POST the new filter string to /filter:
             .expect("response with known status code cannot fail"),
         (&Method::POST, "/filter") => match read_filter(req).await {
             Ok(filter) => {
-                app_writer()
-                    .state_mut()
+                app_reader()
+                    .state()
                     .components
-                    .get_downcast_mut::<Tracing>()
+                    .get_downcast_ref::<Tracing>()
                     .expect("Tracing component should be available")
                     .reload_filter(filter);
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -789,7 +789,6 @@ async fn metrics_endpoint() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn tracing_endpoint() -> Result<()> {
     use hyper::{Body, Client, Request, Uri};
 


### PR DESCRIPTION
## Motivation

For a while now our tracing endpoint for configuring filters at runtime has been broken. The root cause of this was deadlock trying to access the state. The endpoint attempts to acquire an exclusive lock on the global application state, which is already locked by at least one reader for the entire duration of async execution.

## Solution

This PR changes the reload function to instead take a shared reference, allowing it to utilize a shared lock of the global state, rather than asking for an exclusive one. The underlying reload api already didn't require mutability, so the required change is extremely minimal.

The code in this pull request has:
  - [ ] Documentation Comments
  - [ ] Unit Tests and Property Tests

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

## Related Issues

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->

closes https://github.com/ZcashFoundation/zebra/issues/1001

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
