### PR TITLE
Automatically disable colored output when writing to a file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,6 +3342,7 @@ name = "zebrad"
 version = "3.0.0-alpha.0"
 dependencies = [
  "abscissa_core",
+ "atty",
  "chrono",
  "color-eyre",
  "dirs",

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -38,6 +38,7 @@ metrics-exporter-prometheus = "0.1.0-alpha.7"
 
 dirs = "3.0.1"
 inferno = { version = "0.10.2", default-features = false }
+atty = "0.2.14"
 
 [build-dependencies]
 vergen = "3.1.0"

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -21,9 +21,12 @@ impl Tracing {
         let filter = config.filter.unwrap_or_else(|| "".to_string());
         let flame_root = &config.flamegraph;
 
+        // Only use color if tracing output is being sent to a terminal
+        let use_color = config.use_color && atty::is(atty::Stream::Stdout);
+
         // Construct a tracing subscriber with the supplied filter and enable reloading.
         let builder = FmtSubscriber::builder()
-            .with_ansi(config.use_color)
+            .with_ansi(use_color)
             .with_env_filter(filter)
             .with_filter_reloading();
         let filter_handle = builder.reload_handle();

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -45,7 +45,11 @@ pub struct ZebradConfig {
 pub struct TracingSection {
     /// Whether to use colored terminal output, if available.
     ///
-    /// Defaults to `true`.
+    /// Colored terminal output is automatically disabled if an output stream
+    /// is connected to a file. (Or another non-terminal device.)
+    ///
+    /// Defaults to `true`, which automatically enables colored output to
+    /// terminals.
     pub use_color: bool,
 
     /// The filter used for tracing events.


### PR DESCRIPTION
## Motivation

We want Zebra to write colored output when writing to a terminal, but automatically switch off colors when writing to a file, pipe, or non-terminal device.

We also want to disable abscissa colors ~and color_eyre~ when `config.tracing.use_color` is false.

## Solution

Pre-config:
* disable abscissa colors when stdout or stderr are not connected to a terminal

After config:
* disable tracing colors when stdout is not connected to a terminal, and when the config disables colors
* ~disable the color_eyre panic handler when stdout is not connected to a terminal, and when the config disables colors~

Already implemented:
* color_backtrace already disables colored backtraces when its not connected to a terminal

The code in this pull request has:
  - Comments
  - Manual testing for:
    - auto tracing color disable using `zebrad start | tee`
    - auto abscissa color disable using `zebrad | tee`
    - ~auto color_eyre disable by adding a `panic!()` after the config is loaded~

## Review

@hdevalence wrote the original PR #1408
@yaahc wrote `color_eyre`

## Follow Up Work

Eventually, we want to modify `color_eyre` so that it:
* automatically disables color when output is not to a terminal, and
* has a configuration that always turns colors off, because auto-detection isn't perfect, some users won't have color terminals, and others will want colors off for accessibility

Until that happens, there might be issues with grep and unterminated color sequences in Zebra's `color_eyre` output, but they hopefully won't be that common.