### PR TITLE
Network tracing tweaks

### DIFF
--- a/zebra-chain/src/serialization/error.rs
+++ b/zebra-chain/src/serialization/error.rs
@@ -7,14 +7,14 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum SerializationError {
     /// An io error that prevented deserialization
-    #[error("unable to deserialize type")]
+    #[error("io error: {0}")]
     Io(#[from] io::Error),
     /// The data to be deserialized was malformed.
     // XXX refine errors
     #[error("parse error: {0}")]
     Parse(&'static str),
     /// An error caused when validating a zatoshi `Amount`
-    #[error("input couldn't be parsed as a zatoshi `Amount`")]
+    #[error("input couldn't be parsed as a zatoshi `Amount`: {source}")]
     Amount {
         /// The source error indicating how the num failed to validate
         #[from]

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -561,8 +561,9 @@ where
 
     // This function has its own span, because we're creating a new work
     // context (namely, the work of processing the inbound msg as a request)
-    #[instrument(skip(self))]
+    #[instrument(name = "msg_as_req", skip(self, msg), fields(%msg))]
     async fn handle_message_as_request(&mut self, msg: Message) {
+        trace!(?msg);
         let req = match msg {
             Message::Ping(nonce) => {
                 trace!(?nonce, "responding to heartbeat");

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -32,7 +32,7 @@ pub enum PeerError {
     #[error("Client request timed out")]
     ClientRequestTimeout,
     /// A serialization error occurred while reading or writing a message.
-    #[error("Serialization error")]
+    #[error("Serialization error: {0}")]
     Serialization(#[from] SerializationError),
     /// A badly-behaved remote peer sent a handshake message after the handshake was
     /// already complete.

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -293,7 +293,10 @@ where
                     handshakes.push(
                         connector
                             .call(candidate.addr)
-                            .map_err(move |_| candidate)
+                            .map_err(move |e| {
+                                debug!(?candidate.addr, ?e, "failed to connect to candidate");
+                                candidate
+                            })
                             .boxed(),
                     );
                 } else {
@@ -318,7 +321,7 @@ where
                 success_tx.send(Ok(change)).await?;
             }
             Right((Some(Err(candidate)), _)) => {
-                debug!(?candidate.addr, "failed to connect to peer");
+                debug!(?candidate.addr, "marking candidate as failed");
                 candidates.report_failed(candidate);
                 // The demand signal that was taken out of the queue
                 // to attempt to connect to the failed candidate never

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -320,7 +320,12 @@ impl Decoder for Codec {
                 trace!(
                     ?self.state,
                     ?magic,
-                    command = %String::from_utf8_lossy(&command),
+                    command = %String::from_utf8(
+                        command.iter()
+                            .cloned()
+                            .flat_map(std::ascii::escape_default)
+                            .collect()
+                    ).unwrap(),
                     body_len,
                     ?checksum,
                     "read header from src buffer"

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -7,7 +7,6 @@ use chrono::{DateTime, Utc};
 
 use zebra_chain::{
     block::{self, Block},
-    fmt::{DisplayToDebug, SummaryDebug},
     transaction::Transaction,
 };
 
@@ -31,7 +30,7 @@ use crate::meta_addr::MetaAddr;
 /// during serialization).
 ///
 /// [btc_wiki_protocol]: https://en.bitcoin.it/wiki/Protocol_documentation
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub enum Message {
     /// A `version` message.
     ///
@@ -309,92 +308,28 @@ pub enum RejectReason {
     Other = 0x50,
 }
 
-/// Summarise `Vec`s when debugging messages
-impl fmt::Debug for Message {
+impl fmt::Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Message::Version {
-                version,
-                services,
-                timestamp,
-                address_recv,
-                address_from,
-                nonce,
-                user_agent,
-                start_height,
-                relay,
-            } => f
-                .debug_struct("Version")
-                .field("version", version)
-                .field("services", services)
-                .field("timestamp", timestamp)
-                .field("address_recv", address_recv)
-                .field("address_from", address_from)
-                .field("nonce", nonce)
-                .field("user_agent", user_agent)
-                .field("start_height", start_height)
-                .field("relay", relay)
-                .finish(),
-            Message::Verack => f.debug_tuple("Verack").finish(),
-            Message::Ping(nonce) => f.debug_tuple("Ping").field(nonce).finish(),
-            Message::Pong(nonce) => f.debug_tuple("Pong").field(nonce).finish(),
-            Message::Reject {
-                message,
-                ccode,
-                reason,
-                data,
-            } => f
-                .debug_struct("Reject")
-                .field("message", message)
-                .field("ccode", ccode)
-                .field("reason", reason)
-                .field("data", data)
-                .finish(),
-            Message::GetAddr => f.debug_tuple("GetAddr").finish(),
-            Message::Addr(addr) => f.debug_tuple("Addr").field(&SummaryDebug(addr)).finish(),
-            Message::GetBlocks { known_blocks, stop } => f
-                .debug_struct("GetBlocks")
-                .field("known_blocks", &SummaryDebug(known_blocks))
-                .field("stop", stop)
-                .finish(),
-            Message::Inv(inv) => f.debug_tuple("Inv").field(&SummaryDebug(inv)).finish(),
-            Message::GetHeaders { known_blocks, stop } => f
-                .debug_struct("GetHeaders")
-                .field("known_blocks", &SummaryDebug(known_blocks))
-                .field("stop", stop)
-                .finish(),
-            Message::Headers(headers) => f
-                .debug_tuple("Headers")
-                .field(&SummaryDebug(headers))
-                .finish(),
-            Message::GetData(data) => f.debug_tuple("GetData").field(&SummaryDebug(data)).finish(),
-            Message::Block(block) => f
-                .debug_tuple("Block")
-                .field(&DisplayToDebug(block))
-                .finish(),
-            Message::Tx(tx) => f.debug_tuple("Tx").field(&tx).finish(),
-            Message::NotFound(not_found) => f
-                .debug_tuple("NotFound")
-                .field(&SummaryDebug(not_found))
-                .finish(),
-            Message::Mempool => f.debug_tuple("Mempool").finish(),
-            Message::FilterLoad {
-                filter,
-                hash_functions_count,
-                tweak,
-                flags,
-            } => f
-                .debug_struct("FilterLoad")
-                .field("filter", filter)
-                .field("hash_functions_count", hash_functions_count)
-                .field("tweak", tweak)
-                .field("flags", flags)
-                .finish(),
-            Message::FilterAdd { data } => f
-                .debug_struct("FilterAdd")
-                .field("data", &SummaryDebug(data))
-                .finish(),
-            Message::FilterClear => f.debug_tuple("FilterClear").finish(),
-        }
+        f.write_str(match self {
+            Message::Version { .. } => "version",
+            Message::Verack => "verack",
+            Message::Ping(_) => "ping",
+            Message::Pong(_) => "pong",
+            Message::Reject { .. } => "reject",
+            Message::GetAddr => "getaddr",
+            Message::Addr(_) => "addr",
+            Message::GetBlocks { .. } => "getblocks",
+            Message::Inv(_) => "inv",
+            Message::GetHeaders { .. } => "getheaders",
+            Message::Headers(_) => "headers",
+            Message::GetData(_) => "getdata",
+            Message::Block(_) => "block",
+            Message::Tx(_) => "tx",
+            Message::NotFound(_) => "notfound",
+            Message::Mempool => "mempool",
+            Message::FilterLoad { .. } => "filterload",
+            Message::FilterAdd { .. } => "filteradd",
+            Message::FilterClear => "filterclear",
+        })
     }
 }

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -7,8 +7,8 @@ mod version;
 use self::ZebradCmd::*;
 use self::{generate::GenerateCmd, start::StartCmd, version::VersionCmd};
 
-use crate::config::ZebradConfig;
 use crate::application::ZebradApp;
+use crate::config::ZebradConfig;
 
 use abscissa_core::{
     config::Override, Command, Configurable, FrameworkError, Help, Options, Runnable,


### PR DESCRIPTION

## Motivation

Clean up trace data in `zebra-network` so that it's more usable at debug and trace level.

## Solution

1. Only include the message type in the span handling the message, and demote the full message to an event at trace level.  Reason: it's more compact, and because the message-handling span is already scoped to a peer span, there's no risk of confusion between different messages.

2. Fix a missing `{0}` in the `PeerError::Serialization` variant.

3. Avoid putting null bytes in trace-level output (causing various tools to interpret it as binary and stop processing).

## Review

This is a pretty lightweight PR and helps with the network debugging we need to do, but isn't otherwise urgent.

