### PR TITLE
network: correct data modeling for headers messages

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -18,7 +18,7 @@ use std::fmt;
 
 pub use hash::Hash;
 pub use header::BlockTimeError;
-pub use header::Header;
+pub use header::{CountedHeader, Header};
 pub use height::Height;
 pub use root_hash::RootHash;
 

--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -109,3 +109,12 @@ impl Header {
         }
     }
 }
+
+/// A header with a count of the number of transactions in its block.
+///
+/// This structure is used in the Bitcoin network protocol.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CountedHeader {
+    pub header: Header,
+    pub transaction_count: usize,
+}

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -182,12 +182,10 @@ pub enum Message {
     ///
     /// Returns block headers in response to a getheaders packet.
     ///
+    /// Each block header is accompanied by a transaction count.
+    ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#headers)
-    // Note that the block headers in this packet include a
-    // transaction count (a var_int, so there can be more than 81
-    // bytes per header) as opposed to the block headers that are
-    // hashed by miners.
-    Headers(Vec<block::Header>),
+    Headers(Vec<block::CountedHeader>),
 
     /// A `getdata` message.
     ///

--- a/zebra-network/src/protocol/internal/response.rs
+++ b/zebra-network/src/protocol/internal/response.rs
@@ -22,7 +22,7 @@ pub enum Response {
     BlockHashes(Vec<block::Hash>),
 
     /// A list of block headers.
-    BlockHeaders(Vec<block::Header>),
+    BlockHeaders(Vec<block::CountedHeader>),
 
     /// A list of transactions.
     Transactions(Vec<Arc<Transaction>>),

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -40,5 +40,5 @@ pub enum Response {
     BlockHashes(Vec<block::Hash>),
 
     /// The response to a `FindBlockHeaders` request.
-    BlockHeaders(Vec<block::Header>),
+    BlockHeaders(Vec<block::CountedHeader>),
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -644,9 +644,13 @@ impl Service<Request> for StateService {
                 let res: Vec<_> = res
                     .iter()
                     .map(|&hash| {
-                        self.best_block(hash.into())
-                            .expect("block for found hash is in the best chain")
-                            .header
+                        let block = self
+                            .best_block(hash.into())
+                            .expect("block for found hash is in the best chain");
+                        block::CountedHeader {
+                            transaction_count: block.transactions.len(),
+                            header: block.header,
+                        }
                     })
                     .collect();
                 async move { Ok(Response::BlockHeaders(res)) }.boxed()


### PR DESCRIPTION
We modeled a Bitcoin `headers` message as being a list of block headers.
However, the actual data structure is slightly different: it's a list of (block
header, transaction count) pairs.  This caused zcashd to reject our headers
messages.

To fix this, introduce a new `CountedHeader` struct with a `block::Header` and
transaction count `usize`, then thread it through the inbound service and the
state.

I tested this locally by running Zebra with these changes and inspecting a
trace-level log of the span of a peer connection that requested a nontrivial
headers packet from us, and verified that it did not reject our message.

Closes #1424.
Closes #1409.
Closes #1398.