### PR TITLE
Improve metrics acceptance test failure messages

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -769,10 +769,12 @@ async fn metrics_endpoint() -> Result<()> {
     let res = client.get(Uri::from_static(url)).await?;
     assert!(res.status().is_success());
     let body = hyper::body::to_bytes(res).await?;
-    assert!(std::str::from_utf8(&body)
-        .expect("metrics response is valid UTF-8")
-        .contains("metrics snapshot"),
-        "metrics exporter returns data in the expected format");
+    assert!(
+        std::str::from_utf8(&body)
+            .expect("metrics response is valid UTF-8")
+            .contains("metrics snapshot"),
+        "metrics exporter returns data in the expected format"
+    );
 
     child.kill()?;
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -770,8 +770,9 @@ async fn metrics_endpoint() -> Result<()> {
     assert!(res.status().is_success());
     let body = hyper::body::to_bytes(res).await?;
     assert!(std::str::from_utf8(&body)
-        .unwrap()
-        .contains("metrics snapshot"));
+        .expect("metrics response is valid UTF-8")
+        .contains("metrics snapshot"),
+        "metrics exporter returns data in the expected format");
 
     child.kill()?;
 


### PR DESCRIPTION
## Motivation

The metrics acceptance test is currenly failing, and its failure message is confusing.

## Solution

Add an expect message and an assert message.

## Review

@dconnolly is working on a fix for the underlying metrics issue.
This log fix is not urgent at all.

## Related Issues

Test failure caused by PR #1430 and fixed by PR #1440.

## Follow Up Work

Fix the underlying metrics bugs.