### PR TITLE
Block time contextual validation

### DIFF
--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -63,8 +63,8 @@ pub struct CompactDifficulty(pub(crate) u32);
 
 impl fmt::Debug for CompactDifficulty {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // There isn't a standard way to represent alternate formats for the
-        // same value.
+        // There isn't a standard way to show different representations of the
+        // same value
         f.debug_tuple("CompactDifficulty")
             // Use hex, because it's a float
             .field(&format_args!("{:#010x}", self.0))
@@ -139,8 +139,8 @@ impl Work {
 
 impl fmt::Debug for Work {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // There isn't a standard way to represent alternate formats for the
-        // same value.
+        // There isn't a standard way to show different representations of the
+        // same value
         f.debug_tuple("Work")
             // Use hex, because expanded difficulty is in hex.
             .field(&format_args!("{:#x}", self.0))

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -63,9 +63,13 @@ pub struct CompactDifficulty(pub(crate) u32);
 
 impl fmt::Debug for CompactDifficulty {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // There isn't a standard way to represent alternate formats for the
+        // same value.
         f.debug_tuple("CompactDifficulty")
             // Use hex, because it's a float
             .field(&format_args!("{:#010x}", self.0))
+            // Use expanded difficulty, for bitwise difficulty comparisons
+            .field(&format_args!("{:?}", self.to_expanded()))
             .finish()
     }
 }

--- a/zebra-chain/src/work/difficulty/tests/vectors.rs
+++ b/zebra-chain/src/work/difficulty/tests/vectors.rs
@@ -19,15 +19,29 @@ fn debug_format() {
 
     assert_eq!(
         format!("{:?}", CompactDifficulty(0)),
-        "CompactDifficulty(0x00000000)"
+        "CompactDifficulty(0x00000000, None)"
     );
     assert_eq!(
         format!("{:?}", CompactDifficulty(1)),
-        "CompactDifficulty(0x00000001)"
+        "CompactDifficulty(0x00000001, None)"
     );
     assert_eq!(
         format!("{:?}", CompactDifficulty(u32::MAX)),
-        "CompactDifficulty(0xffffffff)"
+        "CompactDifficulty(0xffffffff, None)"
+    );
+    let one = CompactDifficulty((1 << PRECISION) + (1 << 16));
+    assert_eq!(
+        format!("{:?}", one),
+        "CompactDifficulty(0x01010000, Some(ExpandedDifficulty(\"0000000000000000000000000000000000000000000000000000000000000001\")))");
+    let mant = CompactDifficulty(OFFSET as u32 * (1 << PRECISION) + UNSIGNED_MANTISSA_MASK);
+    assert_eq!(
+        format!("{:?}", mant),
+        "CompactDifficulty(0x037fffff, Some(ExpandedDifficulty(\"00000000000000000000000000000000000000000000000000000000007fffff\")))"
+    );
+    let exp = CompactDifficulty(((31 + OFFSET - 2) as u32) * (1 << PRECISION) + (1 << 16));
+    assert_eq!(
+        format!("{:?}", exp),
+        "CompactDifficulty(0x20010000, Some(ExpandedDifficulty(\"0100000000000000000000000000000000000000000000000000000000000000\")))"
     );
 
     assert_eq!(

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -43,6 +43,14 @@ pub enum ValidateContextError {
     #[non_exhaustive]
     NonSequentialBlock,
 
+    /// block.header.time is less than or equal to the median-time-past for the block
+    #[non_exhaustive]
+    TimeTooEarly,
+
+    /// block.header.time is greater than the median-time-past for the block plus 90 minutes
+    #[non_exhaustive]
+    TimeTooLate,
+
     /// block.header.difficulty_threshold is not equal to the adjusted difficulty for the block
     #[non_exhaustive]
     InvalidDifficultyThreshold,

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -36,39 +36,39 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub struct CommitBlockError(#[from] ValidateContextError);
 
 /// An error describing why a block failed contextual validation.
-#[derive(displaydoc::Display, Debug, Error)]
+#[derive(Debug, Error)]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum ValidateContextError {
-    /// block height {candidate_height:?} is lower than the current finalized height {finalized_tip_height:?}
+    #[error("block height {candidate_height:?} is lower than the current finalized height {finalized_tip_height:?}")]
     #[non_exhaustive]
     OrphanedBlock {
         candidate_height: block::Height,
         finalized_tip_height: block::Height,
     },
 
-    /// block height {candidate_height:?} is not one greater than its parent block's height {parent_height:?}
+    #[error("block height {candidate_height:?} is not one greater than its parent block's height {parent_height:?}")]
     #[non_exhaustive]
     NonSequentialBlock {
         candidate_height: block::Height,
         parent_height: block::Height,
     },
 
-    /// block time {candidate_time:?} is less than or equal to the median-time-past for the block {median_time_past:?}
+    #[error("block time {candidate_time:?} is less than or equal to the median-time-past for the block {median_time_past:?}")]
     #[non_exhaustive]
     TimeTooEarly {
         candidate_time: DateTime<Utc>,
         median_time_past: DateTime<Utc>,
     },
 
-    /// block time {candidate_time:?} is greater than the median-time-past for the block plus 90 minutes {block_time_max:?}
+    #[error("block time {candidate_time:?} is greater than the median-time-past for the block plus 90 minutes {block_time_max:?}")]
     #[non_exhaustive]
     TimeTooLate {
         candidate_time: DateTime<Utc>,
         block_time_max: DateTime<Utc>,
     },
 
-    /// block difficulty threshold {difficulty_threshold:?} is not equal to the expected difficulty for the block {expected_difficulty:?}
+    #[error("block difficulty threshold {difficulty_threshold:?} is not equal to the expected difficulty for the block {expected_difficulty:?}")]
     #[non_exhaustive]
     InvalidDifficultyThreshold {
         difficulty_threshold: CompactDifficulty,

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -14,9 +14,7 @@ use crate::{PreparedBlock, ValidateContextError};
 
 use super::check;
 
-use difficulty::{
-    AdjustedDifficulty, BLOCK_MAX_TIME_TESTNET_ACTIVATION_HEIGHT, POW_MEDIAN_BLOCK_SPAN,
-};
+use difficulty::{AdjustedDifficulty, POW_MEDIAN_BLOCK_SPAN, TESTNET_MAX_TIME_START_HEIGHT};
 
 pub(crate) mod difficulty;
 
@@ -150,8 +148,8 @@ fn difficulty_threshold_is_valid(
         })?
     }
 
-    // The maximum time rule is only active on Testnet from height 653606 onwards
-    if (network == Network::Mainnet || candidate_height >= BLOCK_MAX_TIME_TESTNET_ACTIVATION_HEIGHT)
+    // The maximum time rule is only active on Testnet from a specific height
+    if (network == Network::Mainnet || candidate_height >= TESTNET_MAX_TIME_START_HEIGHT)
         && candidate_time > block_time_max
     {
         Err(ValidateContextError::TimeTooLate {

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -271,11 +271,7 @@ impl AdjustedDifficulty {
     ///
     /// See [`median_timespan_bounded()`] for details.
     fn median_timespan(&self) -> Duration {
-        let newer_times: [DateTime<Utc>; POW_MEDIAN_BLOCK_SPAN] = self.relevant_times
-            [0..POW_MEDIAN_BLOCK_SPAN]
-            .try_into()
-            .expect("relevant times is the correct length");
-        let newer_median = AdjustedDifficulty::median_time(newer_times);
+        let newer_median = self.median_time_past();
 
         let older_times: [DateTime<Utc>; POW_MEDIAN_BLOCK_SPAN] = self.relevant_times
             [POW_AVERAGING_WINDOW..]
@@ -285,6 +281,21 @@ impl AdjustedDifficulty {
 
         // `ActualTimespan` in the Zcash specification
         newer_median - older_median
+    }
+
+    /// Calculate the median of the `time`s from the previous
+    /// `PoWMedianBlockSpan` (11) blocks in the relevant chain.
+    ///
+    /// Implements `median-time-past` and `MedianTime(candidate_height)` from the
+    /// Zcash specification. (These functions are identical, but they are
+    /// specified in slightly different ways.)
+    pub fn median_time_past(&self) -> DateTime<Utc> {
+        let median_times: [DateTime<Utc>; POW_MEDIAN_BLOCK_SPAN] = self.relevant_times
+            [0..POW_MEDIAN_BLOCK_SPAN]
+            .try_into()
+            .expect("relevant times is the correct length");
+
+        AdjustedDifficulty::median_time(median_times)
     }
 
     /// Calculate the median of the `median_block_span_times`: the `time`s from a

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -42,6 +42,11 @@ pub const POW_MAX_ADJUST_DOWN_PERCENT: i32 = 32;
 /// Part of the block header consensus rules in the Zcash specification.
 pub const BLOCK_MAX_TIME_SINCE_MEDIAN: i64 = 90 * 60;
 
+/// The activation height for the block maximum time rule on Testnet.
+///
+/// Part of the block header consensus rules in the Zcash specification.
+pub const BLOCK_MAX_TIME_TESTNET_ACTIVATION_HEIGHT: block::Height = block::Height(653606);
+
 /// Contains the context needed to calculate the adjusted difficulty for a block.
 pub(super) struct AdjustedDifficulty {
     /// The `header.time` field from the candidate block
@@ -145,6 +150,11 @@ impl AdjustedDifficulty {
             relevant_difficulty_thresholds,
             relevant_times,
         }
+    }
+
+    /// Returns the candidate block's height.
+    pub fn candidate_height(&self) -> block::Height {
+        self.candidate_height
     }
 
     /// Returns the candidate block's time field.

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -36,7 +36,7 @@ pub const POW_MAX_ADJUST_UP_PERCENT: i32 = 16;
 /// `PoWMaxAdjustDown * 100` in the Zcash specification.
 pub const POW_MAX_ADJUST_DOWN_PERCENT: i32 = 32;
 
-/// The maximum number of seconds between the `meadian-time-past` of a block,
+/// The maximum number of seconds between the `median-time-past` of a block,
 /// and the block's `time` field.
 ///
 /// Part of the block header consensus rules in the Zcash specification.

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -1,4 +1,9 @@
 //! Block difficulty adjustment calculations for contextual validation.
+//!
+//! This module supports the following consensus rule calculations:
+//!  * `ThresholdBits` from the Zcash Specification,
+//!  * the Testnet minimum difficulty adjustment from ZIPs 205 and 208, and
+//!  * `median-time-past`.
 
 use chrono::{DateTime, Duration, Utc};
 use primitive_types::U256;

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -45,7 +45,7 @@ pub const BLOCK_MAX_TIME_SINCE_MEDIAN: i64 = 90 * 60;
 /// The activation height for the block maximum time rule on Testnet.
 ///
 /// Part of the block header consensus rules in the Zcash specification.
-pub const BLOCK_MAX_TIME_TESTNET_ACTIVATION_HEIGHT: block::Height = block::Height(653606);
+pub const TESTNET_MAX_TIME_START_HEIGHT: block::Height = block::Height(653_606);
 
 /// Contains the context needed to calculate the adjusted difficulty for a block.
 pub(super) struct AdjustedDifficulty {

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -36,6 +36,12 @@ pub const POW_MAX_ADJUST_UP_PERCENT: i32 = 16;
 /// `PoWMaxAdjustDown * 100` in the Zcash specification.
 pub const POW_MAX_ADJUST_DOWN_PERCENT: i32 = 32;
 
+/// The maximum number of seconds between the `meadian-time-past` of a block,
+/// and the block's `time` field.
+///
+/// Part of the block header consensus rules in the Zcash specification.
+pub const BLOCK_MAX_TIME_SINCE_MEDIAN: i64 = 90 * 60;
+
 /// Contains the context needed to calculate the adjusted difficulty for a block.
 pub(super) struct AdjustedDifficulty {
     /// The `header.time` field from the candidate block
@@ -139,6 +145,11 @@ impl AdjustedDifficulty {
             relevant_difficulty_thresholds,
             relevant_times,
         }
+    }
+
+    /// Returns the candidate block's time field.
+    pub fn candidate_time(&self) -> DateTime<Utc> {
+        self.candidate_time
     }
 
     /// Calculate the expected `difficulty_threshold` for a candidate block, based


### PR DESCRIPTION
## Motivation

Difficulty adjustment validation uses block times as inputs. These block times are supplied by miners, but constrained by consensus rules. Currently, Zebra doesn't implement the contextual time consensus checks, so we could end up following a chain with bad times.

These bad times affect the difficulty adjustment calculations, making it much easier to generate bad blocks.

## Solution

* For each block, `time` MUST be strictly greater than the `median-time-past` of that block.
* For all blocks on the production network, and for block heights 653606 or greater on the test network, `time` MUST be less than or equal to the `median-time-past` of that block plus 90 · 60 seconds.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Manual Testing
    - we'll create unit tests in #1414

This PR also adds context to the state validation errors.

## Review

@yaahc reviewed the rest of the contextual difficulty validation
This is an urgent extra consensus rule, to make sure Zebra follows the best chain

## Related Issues

Closes #1413

## Follow Up Work

Write tests in #1414