### PR TITLE
Remove unused dependencies found using cargo-udeps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2810,18 +2810,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
-name = "tower-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project 0.4.27",
- "tower-service",
-]
-
-[[package]]
 name = "tracing"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3215,7 +3203,6 @@ dependencies = [
  "tower",
  "tower-batch",
  "tower-fallback",
- "tower-util",
  "tracing",
  "tracing-error",
  "tracing-futures",
@@ -3296,7 +3283,6 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
- "tracing-error",
  "zebra-chain",
  "zebra-test",
 ]

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4.19"
-color-eyre = "0.5.10"
 displaydoc = "0.1.7"
 jubjub = "0.5.1"
 once_cell = "1.5"
@@ -21,7 +20,6 @@ metrics = "0.12"
 thiserror = "1.0.22"
 tokio = { version = "0.3.4", features = ["time", "sync", "stream", "tracing"] }
 tower = { version = "0.4", features = ["timeout", "util", "buffer"] }
-tower-util = "0.3"
 tracing = "0.1.22"
 tracing-futures = "0.2.4"
 
@@ -32,6 +30,7 @@ zebra-state = { path = "../zebra-state" }
 zebra-script = { path = "../zebra-script" }
 
 [dev-dependencies]
+color-eyre = "0.5.10"
 rand = "0.7"
 spandoc = "0.2"
 tokio = { version = "0.3.4", features = ["full"] }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 [dependencies]
 zebra-chain = { path = "../zebra-chain" }
 
-color-eyre = "0.5.10"
 dirs = "3.0.1"
 hex = "0.4.2"
 lazy_static = "1.4.0"
@@ -20,7 +19,6 @@ futures = "0.3.7"
 metrics = "0.12"
 tower = { version = "0.4", features = ["buffer", "util"] }
 tracing = "0.1"
-tracing-error = "0.1.2"
 thiserror = "1.0.22"
 tokio = { version = "0.3.4", features = ["sync"] }
 displaydoc = "0.1.7"
@@ -34,6 +32,7 @@ rlimit = "0.5.3"
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/" }
 
+color-eyre = "0.5.10"
 once_cell = "1.5"
 spandoc = "0.2"
 tempdir = "0.3.7"

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1.0.22"
 pretty_assertions = "0.6.1"
 owo-colors = "1.2.0"
 proptest = "0.10.1"
-tempdir = "0.3.7"
 
 [dev-dependencies]
+tempdir = "0.3.7"
 tokio = { version = "0.3.4", features = ["full"] }


### PR DESCRIPTION
## Motivation

Zebra has a few unused dependencies, let's remove them before the first alpha release, to speed up compile times.

## Solution

Remove unused dependencies found using `cargo-udeps`, or downgrade them to dev dependencies.

Testing
  - Manually test that each crate still builds individually with debug and test builds, using the script in #1364

## Review

@dconnolly manages dependencies.

It would be good to get this in before the first alpha release, but it's not essential.

## Follow Up Work

I don't know how to disable unused features, and check that it actually works. And I don't think there's any utility that does it automatically.