### PR TITLE
Stop panicking on side chain contextual validation

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -268,7 +268,6 @@ impl StateService {
     }
 
     /// Return the height for the block at `hash` in any chain.
-    #[allow(dead_code)]
     pub fn any_height_by_hash(&self, hash: block::Hash) -> Option<block::Height> {
         self.mem
             .any_height_by_hash(hash)
@@ -516,7 +515,7 @@ impl ExactSizeIterator for Iter<'_> {
         match self.state {
             IterState::NonFinalized(hash) => self
                 .service
-                .best_height_by_hash(hash)
+                .any_height_by_hash(hash)
                 .map(|height| (height.0 + 1) as _)
                 .unwrap_or(0),
             IterState::Finalized(height) => (height.0 + 1) as _,


### PR DESCRIPTION
## Motivation

Zebra panics when it tries to contextually validate ~a~ some side-chain blocks.

Edit: The panic only happens when the side-chain is at least 2 blocks long 

## Solution

Allow any chain when calculating the length of the iterator, rather than mistakenly using the best chain.

## Testing

The code in this pull request doesn't have tests, because we haven't written any tests for the non-finalized state (see #1135). 

## Review

This is a trivial fix.

@yaahc wrote this code, but it's urgent that we get this fix merged before the first alpha release, so @hdevalence or @dconnolly can also review.

## Related Issues

Closes #1464

## Follow Up Work

Write tests for the non-finalized state #1135