### PR TITLE
Disable issue URLs on all timeouts

### DIFF
--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -162,6 +162,8 @@ impl Application for ZebradApp {
                 color_eyre::ErrorKind::NonRecoverable(_) => true,
                 color_eyre::ErrorKind::Recoverable(error) => {
                     !error.is::<tower::timeout::error::Elapsed>()
+                        && !error.is::<tokio::time::error::Elapsed>()
+                        && !error.to_string().contains("timed out")
                 }
             })
             .install()


### PR DESCRIPTION
## Motivation

Zebra suggests that users report request timeouts, and provides an issue URL to create a bug. But timeouts are a normal part of any peer-to-peer protocol.

## Solution

Disable issue URLs on `tokio` timeouts and custom errors containing "timed out".

Issue URLs are already disabled on `tower` timeouts.

- [x] Manual testing: the issue URL is missing from timeout error logs

## Review

This change is important for the first alpha release, because it helps prevent spurious bug reports.

@yaahc wrote this code, but anyone should feel free to review.

## Related Issues

In #1372, we talked about disabling issue URLs for duplicate blocks as well

## Follow Up Work

#1381 create a consistent design for logging
