### PR TITLE
Support systems where bash isn't in /usr/bin

### DIFF
--- a/zebra-utils/coverage
+++ b/zebra-utils/coverage
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -e
 set -o xtrace
 


### PR DESCRIPTION
Support systems where bash isn't in /usr/bin.

Also remove the space between `#!` and `/`, because some OSes don't support a space there.