### PR TITLE
zebra: move to 1.x-based versioning.

### DIFF
--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-client/Cargo.toml
+++ b/zebra-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-client"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -57,7 +57,8 @@ pub const TIMESTAMP_TRUNCATION_SECONDS: i64 = 30 * 60;
 /// This must be a valid [BIP 14] user agent.
 ///
 /// [BIP 14]: https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki
-pub const USER_AGENT: &str = "/🦓Zebra🦓:3.0.0-alpha.0/";
+// XXX can we generate this from crate metadata?
+pub const USER_AGENT: &str = "/🦓Zebra🦓:1.0.0-alpha.0/";
 
 /// The Zcash network protocol version implemented by this crate, and advertised
 /// during connection setup.

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-test"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zebra-utils"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 edition = "2018"
 # Prevent accidental publication of this utility crate.
 publish = false


### PR DESCRIPTION
Previously we set the crate versions to 3.x, so that the major version was
aligned with the NU version.  But we want to be able to make API changes
independently of the NU schedule.

## Follow Up Work

In the future, we might want to generate the default BIP14 UA string from the crate metadata using `vergen` - #692