### PR TITLE
Add download, build and run instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ full validating node:
 
 ### Dependencies
 
-Zebra depends on a number of pure Rust crates, and some Rust/C++ crates:
+Zebra primarily depends on pure Rust crates, and some Rust/C++ crates:
 - [rocksdb](https://crates.io/crates/rocksdb)
 - [zcash_script](https://crates.io/crates/zcash_script)
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ fixing:
 - [Peer connections sometimes fail permanently #1435](https://github.com/ZcashFoundation/zebra/issues/1435)
   - these permanent failures can happen after a network disconnection, sleep, or individual peer disconnections
   - workaround: use `Control-C` to exit `zebrad`, and then restart `zebrad`
-  - [Duplicate block errors #1372](https://github.com/ZcashFoundation/zebra/issues/1372)
-    - these errors can be ignored, unless they happen frequently
+- [Duplicate block errors #1372](https://github.com/ZcashFoundation/zebra/issues/1372)
+  - these errors can be ignored, unless they happen frequently
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -31,17 +31,14 @@ details.
 ### Getting Started
 
 `zebrad` requires [Rust](https://www.rust-lang.org/tools/install),
-[libclang](https://clang.llvm.org/), and a C++ compiler.
+[libclang](https://clang.llvm.org/get_started.html), and a C++ compiler.
 
 #### Detailed Build and Run Instructions
 
-1. Install `cargo` and `rustc`
-     - most people use [rustup](https://rustup.rs/) or their package manager
-2. Install the dependencies for the
-   [rocksdb](https://crates.io/crates/rocksdb) and
-   [zcash_script](https://crates.io/crates/zcash_script) Rust crates, including:
-     - **libclang:** `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` 
-     - **a C++ compiler:** `clang`, `g++`, `Xcode`, `MSVC`, or similar
+1. Install [`cargo` and `rustc`](https://www.rust-lang.org/tools/install)
+2. Install Zebra's build dependencies:
+     - **libclang:** the `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` packages
+     - **a C++ compiler:** use `clang`, `g++`, `Xcode`, `MSVC`, or similar
 3. Run `cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.0.0-alpha.0 zebrad`
 4. Run `zebrad start`
 
@@ -137,6 +134,12 @@ fixing:
   - workaround: use `Control-C` to exit `zebrad`, and then restart `zebrad`
 - [Duplicate block errors #1372](https://github.com/ZcashFoundation/zebra/issues/1372)
   - these errors can be ignored, unless they happen frequently
+
+### Dependencies
+
+Zebra depends on a number of pure Rust crates, and some Rust/C++ crates:
+- rocksdb: check out the [rocksdb dependencies](https://crates.io/crates/rocksdb) and
+- zcash_script: check out the [zcash_script dependencies](https://crates.io/crates/zcash_script)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ details.
 
 ### Getting Started
 
-`zebrad` requires [Rust](https://www.rust-lang.org/tools/install),
+Building `zebrad` requires [Rust](https://www.rust-lang.org/tools/install),
 [libclang](https://clang.llvm.org/get_started.html), and a C++ compiler.
+
+Running `zebrad` requires a machine with 
 
 #### Detailed Build and Run Instructions
 
@@ -73,6 +75,16 @@ We usually run `zebrad` on systems with:
 - 4+ CPU cores
 - 16+ GB RAM
 - 50GB+ available disk space for finalized state
+- 100+ Mbps network connections
+
+`zebrad` might build and run fine on smaller and slower systems - we haven't
+tested its exact limits yet.
+
+### Network Usage
+
+`zebrad`'s typical network usage is:
+- initial sync: 30 GB download
+- ongoing updates: 10-50 MB upload and download per day, depending on peer requests
 
 The major constraint we've found on `zebrad` performance is the network weather,
 especially the ability to make good connections to other Zcash network peers.

--- a/README.md
+++ b/README.md
@@ -30,14 +30,19 @@ details.
 
 ### Getting Started
 
+`zebrad` requires [Rust](https://www.rust-lang.org/tools/install)
+
+Depending on your platform, you may also need to install LLVM and clang, as we
+do on Debian.
+
 Run `cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.0.0-alpha.0 zebrad`
 
-If you're interested in testing out `zebrad` please feel free, but keep in
-mind that there is a lot of key functionality still missing.
+If you're interested in testing out `zebrad` please feel free, but keep in mind
+that there is a lot of key functionality still missing.
 
 ### System Requirements
 
-We usually build zebrad on systems with:
+We usually build `zebrad` on systems with:
 - 2+ CPU cores
 - 7+ GB RAM
 - 14+ GB of disk space
@@ -45,12 +50,18 @@ We usually build zebrad on systems with:
 On many-core machines (like, 32-core) the build is very fast; on 2-core machines
 it's less fast.
 
-We usually run zebrad on systems with:
+We continuously test that our builds and tests pass on:
+- Windows Server 2019
+- macOS Big Sur 11.0
+- Ubuntu 18.04 / the latest LTS
+- Debian Buster
+
+We usually run `zebrad` on systems with:
 - 4+ CPU cores
 - 16+ GB RAM
 - 50GB+ available disk space for finalized state
 
-The major constraint we've found on zebrad performance is the network weather,
+The major constraint we've found on `zebrad` performance is the network weather,
 especially the ability to make good connections to other Zcash network peers.
 
 ### Current Features

--- a/README.md
+++ b/README.md
@@ -115,7 +115,25 @@ full validating node:
 - transaction scripts (incomplete)
 - batch verification (incomplete)
 
-### Future Work
+### Dependencies
+
+Zebra depends on a number of pure Rust crates, and some Rust/C++ crates:
+- [rocksdb](https://crates.io/crates/rocksdb)
+- [zcash_script](https://crates.io/crates/zcash_script)
+
+### Known Issues
+
+There are a few bugs in the Zebra alpha release that we're still working on
+fixing:
+- [Occasional panics in the `tokio` time wheel implementation #1452](https://github.com/ZcashFoundation/zebra/issues/1452)
+  - workaround: restart `zebrad`
+- [Peer connections sometimes fail permanently #1435](https://github.com/ZcashFoundation/zebra/issues/1435)
+  - these permanent failures can happen after a network disconnection, sleep, or individual peer disconnections
+  - workaround: use `Control-C` to exit `zebrad`, and then restart `zebrad`
+- [Duplicate block errors #1372](https://github.com/ZcashFoundation/zebra/issues/1372)
+  - these errors can be ignored, unless they happen frequently
+
+## Future Work
 
 In 2021, we intend to add RPC support and wallet integration.  This phased
 approach allows us to test Zebra's independent implementation of the consensus
@@ -132,24 +150,6 @@ Performance and Reliability:
 - reliable syncing under poor network conditions
 - batch verification
 - performance tuning
-
-### Known Issues
-
-There are a few bugs in the Zebra alpha release that we're still working on
-fixing:
-- [Occasional panics in the `tokio` time wheel implementation #1452](https://github.com/ZcashFoundation/zebra/issues/1452)
-  - workaround: restart `zebrad`
-- [Peer connections sometimes fail permanently #1435](https://github.com/ZcashFoundation/zebra/issues/1435)
-  - these permanent failures can happen after a network disconnection, sleep, or individual peer disconnections
-  - workaround: use `Control-C` to exit `zebrad`, and then restart `zebrad`
-- [Duplicate block errors #1372](https://github.com/ZcashFoundation/zebra/issues/1372)
-  - these errors can be ignored, unless they happen frequently
-
-### Dependencies
-
-Zebra depends on a number of pure Rust crates, and some Rust/C++ crates:
-- rocksdb: check out the [rocksdb dependencies](https://crates.io/crates/rocksdb) and
-- zcash_script: check out the [zcash_script dependencies](https://crates.io/crates/zcash_script)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,21 @@ mind that there is a lot of key functionality still missing.
 
 ### System Requirements
 
-**TBD**
+We usually build zebrad on systems with:
+- 2+ CPU cores
+- 7+ GB RAM
+- 14+ GB of disk space
+
+On many-core machines (like, 32-core) the build is very fast; on 2-core machines
+it's less fast.
+
+We usually run zebrad on systems with:
+- 4+ CPU cores
+- 16+ GB RAM
+- 50GB+ available disk space for finalized state
+
+The major constraint we've found on zebrad performance is the network weather,
+especially the ability to make good connections to other Zcash network peers.
 
 ### Current Features
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ details.
 
 ### Getting Started
 
-Run `cargo ...` **TODO**
+Run `cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.0.0-alpha.0 zebrad`
 
-If you're interested in testing out `zebrad` please feel free, but keep in mind
-that there is a lot of key functionality still missing.
+If you're interested in testing out `zebrad` please feel free, but keep in
+mind that there is a lot of key functionality still missing.
 
 ### System Requirements
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Building `zebrad` requires [Rust](https://www.rust-lang.org/tools/install),
 #### Detailed Build and Run Instructions
 
 1. Install [`cargo` and `rustc`](https://www.rust-lang.org/tools/install). 
-     - Using `rustup` by default installs the stable Rust toolchain, which is what `zebrad` targets.
+     - Using `rustup` installs the stable Rust toolchain, which `zebrad` targets.
 2. Install Zebra's build dependencies:
-     - **libclang:** the `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` packages
+     - **libclang:** the `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` packages, depending on your package manager
      - **a C++ compiler:** use `clang`, `g++`, `Xcode`, `MSVC`, or similar
 3. Run `cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.0.0-alpha.0 zebrad`
 4. Run `zebrad start`
@@ -53,7 +53,7 @@ If you're having trouble with:
 - **libclang:** check out the [clang-sys documentation](https://github.com/KyleMayes/clang-sys#dependencies)
 - **g++ or MSVC++:** try using clang or Xcode instead
 - **rustc:** use rustc 1.48 or later
-  - Zebra's minimum supported Rust version (MSRV) may change in future release
+  - Zebra does not have a minimum supported Rust version (MSRV) policy yet
 
 ### System Requirements
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Our first alpha release is planned for December 8th, 2020.
 
 The goals of this release are to:
 - participate in the Zcash network,
-- replicate the Zcash chain state, and
-- implement the Zcash proof of work consensus rules,
+- replicate the Zcash chain state,
+- implement the Zcash proof of work consensus rules, and
 - sync on Mainnet under excellent network conditions.
 
 Currently, Zebra does not validate all the Zcash consensus rules. It may be

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ There are a few bugs in the Zebra alpha release that we're still working on
 fixing:
 - [Occasional panics in the `tokio` time wheel implementation #1452](https://github.com/ZcashFoundation/zebra/issues/1452)
   - workaround: restart `zebrad`
+- [Occasional panics during client requests #1471](https://github.com/ZcashFoundation/zebra/issues/1471)
+  - workaround: restart `zebrad`
 - [Peer connections sometimes fail permanently #1435](https://github.com/ZcashFoundation/zebra/issues/1435)
   - these permanent failures can happen after a network disconnection, sleep, or individual peer disconnections
   - workaround: use `Control-C` to exit `zebrad`, and then restart `zebrad`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Building `zebrad` requires [Rust](https://www.rust-lang.org/tools/install),
 
 #### Detailed Build and Run Instructions
 
-1. Install [`cargo` and `rustc`](https://www.rust-lang.org/tools/install)
+1. Install [`cargo` and `rustc`](https://www.rust-lang.org/tools/install). 
+     - Using `rustup` by default installs the stable Rust toolchain, which is what `zebrad` targets.
 2. Install Zebra's build dependencies:
      - **libclang:** the `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` packages
      - **a C++ compiler:** use `clang`, `g++`, `Xcode`, `MSVC`, or similar

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ that there is a lot of key functionality still missing.
 #### Build Troubleshooting
 
 If you're having trouble with:
-- libclang: check out the [clang-sys documentation](https://github.com/KyleMayes/clang-sys#dependencies)
-- g++ or MSVC++: try using clang or Xcode instead
-- rustc: use rustc 1.48 or later
+- **dependencies:** use `cargo install --locked ...` to build with the exact crate versions used for the release
+- **libclang:** check out the [clang-sys documentation](https://github.com/KyleMayes/clang-sys#dependencies)
+- **g++ or MSVC++:** try using clang or Xcode instead
+- **rustc:** use rustc 1.48 or later
   - Zebra's minimum supported Rust version (MSRV) may change in future release
 
 ### System Requirements

--- a/README.md
+++ b/README.md
@@ -30,12 +30,19 @@ details.
 
 ### Getting Started
 
-`zebrad` requires [Rust](https://www.rust-lang.org/tools/install)
+`zebrad` requires [Rust](https://www.rust-lang.org/tools/install),
+[libclang](https://clang.llvm.org/), and a C++ compiler.
 
-Depending on your platform, you may also need to install LLVM and clang, as we
-do on Debian.
+#### Detailed Build and Run Instructions
 
-Run `cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.0.0-alpha.0 zebrad`
+1. Install `cargo` and `rustc`
+2. Install the dependencies for the
+   [rocksdb](https://crates.io/crates/rocksdb) and
+   [zcash_script](https://crates.io/crates/zcash_script) Rust crates, including:
+     - libclang: different distributions call it `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` 
+     - a C++ compiler: `clang++`, `g++`, `Xcode`, `MSVC++`, or your platform's `cc`
+3. Run `cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.0.0-alpha.0 zebrad`
+4. Run `zebrad start`
 
 If you're interested in testing out `zebrad` please feel free, but keep in mind
 that there is a lot of key functionality still missing.

--- a/README.md
+++ b/README.md
@@ -36,16 +36,25 @@ details.
 #### Detailed Build and Run Instructions
 
 1. Install `cargo` and `rustc`
+     - most people use [rustup](https://rustup.rs/) or their package manager
 2. Install the dependencies for the
    [rocksdb](https://crates.io/crates/rocksdb) and
    [zcash_script](https://crates.io/crates/zcash_script) Rust crates, including:
-     - libclang: different distributions call it `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` 
-     - a C++ compiler: `clang++`, `g++`, `Xcode`, `MSVC++`, or your platform's `cc`
+     - **libclang:** `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` 
+     - **a C++ compiler:** `clang`, `g++`, `Xcode`, `MSVC`, or similar
 3. Run `cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.0.0-alpha.0 zebrad`
 4. Run `zebrad start`
 
 If you're interested in testing out `zebrad` please feel free, but keep in mind
 that there is a lot of key functionality still missing.
+
+#### Build Troubleshooting
+
+If you're having trouble with:
+- libclang: check out the [clang-sys documentation](https://github.com/KyleMayes/clang-sys#dependencies)
+- g++ or MSVC++: try using clang or Xcode instead
+- rustc: use rustc 1.48 or later
+  - Zebra's minimum supported Rust version (MSRV) may change in future release
 
 ### System Requirements
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ details.
 Building `zebrad` requires [Rust](https://www.rust-lang.org/tools/install),
 [libclang](https://clang.llvm.org/get_started.html), and a C++ compiler.
 
-Running `zebrad` requires a machine with 
-
 #### Detailed Build and Run Instructions
 
 1. Install [`cargo` and `rustc`](https://www.rust-lang.org/tools/install)


### PR DESCRIPTION
## Motivation

People need to know how to download, build, and run Zebra.

## Solution

Add instructions to the README for:
- [x] downloading Zebra
- [x] building Zebra, including:
  - [x] system requirements
  - [x] dependencies
- [x] running Zebra, including:
  - [x] system requirements
  - [x] bandwidth requirements

### Testing

I used a Nix derivation to test the minimal set of `zebrad` build dependencies:
https://github.com/ZcashFoundation/zebra/pull/1479/files#diff-77a3453382ae70e97668e6f838e841e1c9164cf1fa4654d685a77472a4d0b133R12

`cacert` is a standard package which can be ignored.

## Review

We want to get these changes in the first alpha release, so they're urgent.

@yaahc did the first draft, @dconnolly should check the system requirements.

## Related Issues

Closes #1450 
Closes #1475

## Follow Up Work

We'll revise the README for future releases, and split out a changelog.