### PR TITLE
Add a Nix derivation for zebrad

### DIFF
--- a/zebrad/nix/zebrad.nix
+++ b/zebrad/nix/zebrad.nix
@@ -15,6 +15,7 @@ in
       nixpkgs.latest.rustChannels.stable.rust
       # zebra can use any C++ compiler
       clang
+      # bindgen requires libclang
       llvmPackages.libclang
     ];
 

--- a/zebrad/nix/zebrad.nix
+++ b/zebrad/nix/zebrad.nix
@@ -1,0 +1,43 @@
+# usage:
+#   nix-shell --pure zebrad.nix --run 'zebrad start'
+
+let
+  moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+  nixpkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
+in
+  with nixpkgs;
+  stdenv.mkDerivation {
+    name = "zebra_shell";
+    buildInputs = [
+      cacert
+      nixpkgs.latest.rustChannels.stable.rust
+      # for a specific Rust version
+      #(rustChannelOf { channel = "1.48"; }).rust
+      clang
+      llvmPackages.libclang
+    ];
+
+    LIBCLANG_PATH = llvmPackages.libclang.lib + "/lib";
+
+    # There's possibly a cleaner way to do this using `carnix` or the standard
+    # Nix Rust tooling. But I don't know if they support the Mozilla Rust
+    # overlay, which we need for rustc 1.48.
+
+    shellHook = ''
+      # ignore the cargo config in $HOME
+      export CARGO_HOME=$(mktemp -d)
+      # put the targets in a temp dir
+      export CARGO_TARGET_DIR=$(mktemp -d)
+
+      # branch/tag/ref: use a specific git reference
+      #   - required, because cargo defaults to the master branch
+      # locked: use the exact versions in Cargo.lock (optional)
+      # root/no-track: use a temporary install directory (optional)
+      cargo install --git https://github.com/ZcashFoundation/zebra \
+        --branch main \
+        --locked \
+        --root $(mktemp -d) \
+        --no-track \
+        zebrad
+   '';
+  }

--- a/zebrad/nix/zebrad.nix
+++ b/zebrad/nix/zebrad.nix
@@ -10,9 +10,10 @@ in
     name = "zebra_shell";
     buildInputs = [
       cacert
-      nixpkgs.latest.rustChannels.stable.rust
-      # for a specific Rust version
+      # stable updates automatically, select a specific Rust version using:
       #(rustChannelOf { channel = "1.48"; }).rust
+      nixpkgs.latest.rustChannels.stable.rust
+      # zebra can use any C++ compiler
       clang
       llvmPackages.libclang
     ];

--- a/zebrad/nix/zebrad.nix
+++ b/zebrad/nix/zebrad.nix
@@ -7,7 +7,7 @@ let
 in
   with nixpkgs;
   stdenv.mkDerivation {
-    name = "zebra_shell";
+    name = "zebrad";
     buildInputs = [
       cacert
       # stable updates automatically, select a specific Rust version using:
@@ -27,19 +27,25 @@ in
 
     shellHook = ''
       # ignore the cargo config in $HOME
-      export CARGO_HOME=$(mktemp -d)
-      # put the targets in a temp dir
-      export CARGO_TARGET_DIR=$(mktemp -d)
+#      export CARGO_HOME=$(mktemp -d)
+      # put the build products in a temp dir
+#      export CARGO_TARGET_DIR=$(mktemp -d)
 
       # branch/tag/ref: use a specific git reference
       #   - required, because cargo defaults to the master branch
       # locked: use the exact versions in Cargo.lock (optional)
       # root/no-track: use a temporary install directory (optional)
       cargo install --git https://github.com/ZcashFoundation/zebra \
-        --branch main \
+        --tag v1.0.0-alpha.0 \
         --locked \
-        --root $(mktemp -d) \
-        --no-track \
         zebrad
+
+# Alternate arguments:
+# use a branch instead
+#        --branch main \
+# install to a temporary directory
+#        --root $(mktemp -d) \
+# don't update the cargo metadata
+#        --no-track \
    '';
   }


### PR DESCRIPTION
## TODO

- [ ] add `~/.cargo/bin/zebrad` to the `PATH`, so users can launch `zebrad`
- [ ] build from the checked-out repository, rather than a git tag

## Motivation

We need to know `zebrad`'s dependencies, and Nix derivations explicitly describe all the dependencies needed to build a piece of software.

Also, Nix users might appreciate this derivation for `zebrad`.

## Solution

Write a Nix derivation that builds `zebrad`.

## Review

@hdevalence has NixOS.

This PR can merge any time after the first alpha release.

## Follow Up Work

There's possibly a cleaner way to do this using `carnix` or the standard Nix Rust tooling. But I don't know if they support the Mozilla Rust overlay, which we need for rustc 1.48.