### PR TITLE
Downgrade missing version strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3142,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "bech32",
  "bincode",
@@ -3180,11 +3180,11 @@ dependencies = [
 
 [[package]]
 name = "zebra-client"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 
 [[package]]
 name = "zebra-consensus"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "chrono",
  "color-eyre",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -3243,11 +3243,11 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 
 [[package]]
 name = "zebra-script"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "chrono",
  "color-eyre",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-test"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "color-eyre",
  "futures",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "color-eyre",
  "hex",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zebrad"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 edition = "2018"
 repository = "https://github.com/ZcashFoundation/zebra"
 

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -77,7 +77,7 @@ impl<A: abscissa_core::Application> Component<A> for Tracing {
     }
 
     fn version(&self) -> abscissa_core::Version {
-        abscissa_core::Version::parse("3.0.0-alpha.0").unwrap()
+        abscissa_core::Version::parse("1.0.0-alpha.0").unwrap()
     }
 
     fn before_shutdown(&self, _kind: Shutdown) -> Result<(), FrameworkError> {


### PR DESCRIPTION
## Motivation

Close https://github.com/ZcashFoundation/zebra/issues/1485

## Solution

- [x] Search for "3.0.0" strings in the codebase and replace where appropriate.
- [ ] Replace the `zebrad version` abscissa string with a cargo env var.

## Follow Up Work

It is possible that a new PR will replace all `1.0.0-alpha.0` tags with `1.0.0-alpha.1` after this PR is merged.