### PR TITLE
Recommend using --locked with `cargo install` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Building `zebrad` requires [Rust](https://www.rust-lang.org/tools/install),
 2. Install Zebra's build dependencies:
      - **libclang:** the `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` packages, depending on your package manager
      - **a C++ compiler:** use `clang`, `g++`, `Xcode`, `MSVC`, or similar
-3. Run `cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.0.0-alpha.0 zebrad`
+3. Run `cargo install --locked --git https://github.com/ZcashFoundation/zebra --tag v1.0.0-alpha.0 zebrad`
 4. Run `zebrad start`
 
 If you're interested in testing out `zebrad` please feel free, but keep in mind


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

cargo build != cargo install, we should just make it as easy as possible to install in one go

## Solution

Instead of suggesting --locked when troubleshooting, just include it in the suggested command.

## Follow Up Work

Add an equivalent parallel CI test that approximates our README instructions amap to install rust, install clang/llvm, cargo install zebrad
