### PR TITLE
README: add a "without --locked" troubleshooting hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ that there is a lot of key functionality still missing.
 #### Build Troubleshooting
 
 If you're having trouble with:
-- **dependencies:** use `cargo install --locked ...` to build with the exact crate versions used for the release
+- **dependencies:** use `cargo install` without `--locked` to build with the latest versions of each dependency
 - **libclang:** check out the [clang-sys documentation](https://github.com/KyleMayes/clang-sys#dependencies)
 - **g++ or MSVC++:** try using clang or Xcode instead
 - **rustc:** use rustc 1.48 or later


### PR DESCRIPTION
We added "--locked" to the build instructions, but forgot to update the troubleshooting hints.