### PR TITLE
export new precompute api in zebra-script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3247,7 +3247,7 @@ version = "1.0.0-alpha.0"
 
 [[package]]
 name = "zebra-script"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 dependencies = [
  "displaydoc",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3130,9 +3130,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf1995ddb0c827f160357922a96c0cd34c6dd759757cb2b799128d6f420c91e"
+checksum = "381b15f5e9b000121834a4fcf4351e020e42ed1b23620da3cf5c650f896d7a6a"
 dependencies = [
  "bindgen",
  "blake2b_simd",
@@ -3142,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "bech32",
  "bincode",
@@ -3180,11 +3180,11 @@ dependencies = [
 
 [[package]]
 name = "zebra-client"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 
 [[package]]
 name = "zebra-consensus"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "chrono",
  "color-eyre",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -3243,11 +3243,11 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 
 [[package]]
 name = "zebra-script"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "chrono",
  "color-eyre",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-test"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "color-eyre",
  "futures",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "3.0.0-alpha.0"
+version = "1.0.0-alpha.0"
 dependencies = [
  "color-eyre",
  "hex",

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -20,6 +20,7 @@ use zebra_chain::{
     transparent,
 };
 
+use zebra_script::CachedFfiTransaction;
 use zebra_state as zs;
 
 use crate::{error::TransactionError, script, BoxError};
@@ -150,11 +151,14 @@ where
                     } else {
                         // otherwise, check no coinbase inputs
                         // feed all of the inputs to the script verifier
+                        let cached_ffi_transaction =
+                            Arc::new(CachedFfiTransaction::new(tx.clone()));
+
                         for input_index in 0..inputs.len() {
                             let rsp = script_verifier.ready_and().await?.call(script::Request {
                                 upgrade,
                                 known_utxos: known_utxos.clone(),
-                                transaction: tx.clone(),
+                                cached_ffi_transaction: cached_ffi_transaction.clone(),
                                 input_index,
                             });
 

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zcash_script = "0.1.4"
+zcash_script = "0.1.5"
 zebra-chain = { path = "../zebra-chain" }
 thiserror = "1.0.22"
 displaydoc = "0.1.7"

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -203,4 +203,140 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn reuse_script_verifier_pass_pass() -> Result<()> {
+        zebra_test::init();
+
+        let coin = u64::pow(10, 8);
+        let transaction =
+            SCRIPT_TX.zcash_deserialize_into::<Arc<zebra_chain::transaction::Transaction>>()?;
+
+        let verifier = super::PrecomputedTransaction::new(&transaction);
+
+        let input_index = 0;
+        let branch_id = Blossom
+            .branch_id()
+            .expect("Blossom has a ConsensusBranchId");
+
+        let amount = 212 * coin;
+        let output = transparent::Output {
+            value: amount.try_into()?,
+            lock_script: transparent::Script(SCRIPT_PUBKEY.clone()),
+        };
+        verifier.is_valid(branch_id, (input_index, output))?;
+
+        let amount = 212 * coin;
+        let output = transparent::Output {
+            value: amount.try_into()?,
+            lock_script: transparent::Script(SCRIPT_PUBKEY.clone()),
+        };
+        verifier.is_valid(branch_id, (input_index, output))?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn reuse_script_verifier_pass_fail() -> Result<()> {
+        zebra_test::init();
+
+        let coin = u64::pow(10, 8);
+        let transaction =
+            SCRIPT_TX.zcash_deserialize_into::<Arc<zebra_chain::transaction::Transaction>>()?;
+
+        let verifier = super::PrecomputedTransaction::new(&transaction);
+
+        let input_index = 0;
+        let branch_id = Blossom
+            .branch_id()
+            .expect("Blossom has a ConsensusBranchId");
+
+        let amount = 212 * coin;
+        let output = transparent::Output {
+            value: amount.try_into()?,
+            lock_script: transparent::Script(SCRIPT_PUBKEY.clone()),
+        };
+        verifier.is_valid(branch_id, (input_index, output))?;
+
+        let amount = 211 * coin;
+        let output = transparent::Output {
+            value: amount.try_into()?,
+            lock_script: transparent::Script(SCRIPT_PUBKEY.clone()),
+        };
+        verifier
+            .is_valid(branch_id, (input_index, output))
+            .unwrap_err();
+
+        Ok(())
+    }
+
+    #[test]
+    fn reuse_script_verifier_fail_pass() -> Result<()> {
+        zebra_test::init();
+
+        let coin = u64::pow(10, 8);
+        let transaction =
+            SCRIPT_TX.zcash_deserialize_into::<Arc<zebra_chain::transaction::Transaction>>()?;
+
+        let verifier = super::PrecomputedTransaction::new(&transaction);
+
+        let input_index = 0;
+        let branch_id = Blossom
+            .branch_id()
+            .expect("Blossom has a ConsensusBranchId");
+
+        let amount = 211 * coin;
+        let output = transparent::Output {
+            value: amount.try_into()?,
+            lock_script: transparent::Script(SCRIPT_PUBKEY.clone()),
+        };
+        verifier
+            .is_valid(branch_id, (input_index, output))
+            .unwrap_err();
+
+        let amount = 212 * coin;
+        let output = transparent::Output {
+            value: amount.try_into()?,
+            lock_script: transparent::Script(SCRIPT_PUBKEY.clone()),
+        };
+        verifier.is_valid(branch_id, (input_index, output))?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn reuse_script_verifier_fail_fail() -> Result<()> {
+        zebra_test::init();
+
+        let coin = u64::pow(10, 8);
+        let transaction =
+            SCRIPT_TX.zcash_deserialize_into::<Arc<zebra_chain::transaction::Transaction>>()?;
+
+        let verifier = super::PrecomputedTransaction::new(&transaction);
+
+        let input_index = 0;
+        let branch_id = Blossom
+            .branch_id()
+            .expect("Blossom has a ConsensusBranchId");
+
+        let amount = 211 * coin;
+        let output = transparent::Output {
+            value: amount.try_into()?,
+            lock_script: transparent::Script(SCRIPT_PUBKEY.clone()),
+        };
+        verifier
+            .is_valid(branch_id, (input_index, output))
+            .unwrap_err();
+
+        let amount = 210 * coin;
+        let output = transparent::Output {
+            value: amount.try_into()?,
+            lock_script: transparent::Script(SCRIPT_PUBKEY.clone()),
+        };
+        verifier
+            .is_valid(branch_id, (input_index, output))
+            .unwrap_err();
+
+        Ok(())
+    }
 }

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -127,7 +127,7 @@ impl CachedFfiTransaction {
                 #[cfg(not(windows))]
                 flags,
                 #[cfg(windows)]
-                flags.try_into().expect("why bindgen whyyy"),
+                flags.try_into().expect("zcash_script_SCRIPT_FLAGS_VERIFY_* enum values fit in a c_uint"),
                 consensus_branch_id,
                 &mut err,
             )
@@ -150,11 +150,11 @@ impl CachedFfiTransaction {
 // data to be mutated from different threads if copied.
 //
 // CachedFFiTransaction needs to be Send and Sync to be stored within a `Box<dyn
-// Future + Send + Sync + static>`. The async block `CachedFfiTransaction` is
-// owned by in `zebra_consensus/src/transaction.rs` holds it across an await
-// point when the transaction verifier is spawning all of the script verifier
-// futures, because the service readiness check requires an await between each
-// task spawn. Each `script` future needs a copy of the
+// Future + Send + Sync + static>`. In `zebra_consensus/src/transaction.rs`, an
+// async block owns a `CachedFfiTransaction`, and holds it across an await
+// point, while the transaction verifier is spawning all of the script verifier
+// futures. The service readiness check requires this await between each task
+// spawn. Each `script` future needs a copy of the
 // `Arc<CachedFfiTransaction>` so that it can simultaniously verify inputs
 // without cloning the c++ allocated type unnecessarily.
 //

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -9,7 +9,6 @@
 use displaydoc::Display;
 #[cfg(windows)]
 use std::convert::TryInto;
-use std::sync::Arc;
 use thiserror::Error;
 use zcash_script::{
     zcash_script_error_t, zcash_script_error_t_zcash_script_ERR_OK,
@@ -56,56 +55,17 @@ impl From<zcash_script_error_t> for Error {
     }
 }
 
-/// Thin safe wrapper around ffi interface provided by libzcash_script
-fn verify_script(
-    script_pub_key: impl AsRef<[u8]>,
-    amount: i64,
-    tx_to: impl AsRef<[u8]>,
-    n_in: u32,
-    consensus_branch_id: u32,
-) -> Result<(), Error> {
-    let script_pub_key = script_pub_key.as_ref();
-    let tx_to = tx_to.as_ref();
-
-    let script_ptr = script_pub_key.as_ptr();
-    let script_len = script_pub_key.len();
-    let tx_to_ptr = tx_to.as_ptr();
-    let tx_to_len = tx_to.len();
-    let mut err = 0;
-
-    let flags = zcash_script::zcash_script_SCRIPT_FLAGS_VERIFY_P2SH
-        | zcash_script::zcash_script_SCRIPT_FLAGS_VERIFY_CHECKLOCKTIMEVERIFY;
-
-    let ret = unsafe {
-        zcash_script::zcash_script_verify(
-            script_ptr,
-            script_len as u32,
-            amount,
-            tx_to_ptr,
-            tx_to_len as u32,
-            n_in,
-            #[cfg(not(windows))]
-            flags,
-            #[cfg(windows)]
-            flags.try_into().expect("why bindgen whyyy"),
-            consensus_branch_id,
-            &mut err,
-        )
-    };
-
-    if ret == 1 {
-        Ok(())
-    } else {
-        Err(Error::from(err))
-    }
-}
-
-struct Verifier {
+/// A preprocessed Transction which can be used to verify scripts within said
+/// Transaction.
+pub struct PrecomputedTransaction {
     precomputed: *mut std::ffi::c_void,
 }
 
-impl Verifier {
-    pub fn new(transaction: Arc<Transaction>) -> Self {
+unsafe impl Send for PrecomputedTransaction {}
+
+impl PrecomputedTransaction {
+    /// Construct a `PrecomputedTransaction` from a `Transaction`.
+    pub fn new(transaction: &Transaction) -> Self {
         let tx_to = transaction
             .zcash_serialize_to_vec()
             .expect("serialization into a vec is infallible");
@@ -121,6 +81,14 @@ impl Verifier {
         Self { precomputed }
     }
 
+    /// Verify a script within a transaction given the corresponding
+    /// `transparent::Output` it is spending and the `ConsensusBranchId` of the block
+    /// containing the transaction.
+    ///
+    /// # Details
+    ///
+    /// input index corresponds to the index of the `TransparentInput` which in
+    /// `transaction` used to identify the `previous_output`
     pub fn is_valid(
         &self,
         branch_id: ConsensusBranchId,
@@ -165,47 +133,14 @@ impl Verifier {
     }
 }
 
-impl Drop for Verifier {
+impl Drop for PrecomputedTransaction {
     fn drop(&mut self) {
         unsafe { zcash_script::zcash_script_free_precomputed_tx(self.precomputed) };
     }
 }
 
-/// Verify a script within a transaction given the corresponding
-/// `transparent::Output` it is spending and the `ConsensusBranchId` of the block
-/// containing the transaction.
-///
-/// # Details
-///
-/// input index corresponds to the index of the `TransparentInput` which in
-/// `transaction` used to identify the `previous_output`
-pub fn is_valid(
-    transaction: Arc<Transaction>,
-    branch_id: ConsensusBranchId,
-    (input_index, previous_output): (u32, transparent::Output),
-) -> Result<(), Error> {
-    assert!((input_index as usize) < transaction.inputs().len());
-
-    let tx_to = transaction
-        .zcash_serialize_to_vec()
-        .expect("serialization into a vec is infallible");
-
-    let transparent::Output { value, lock_script } = previous_output;
-
-    verify_script(
-        &lock_script.0,
-        value.into(),
-        &tx_to,
-        input_index as _,
-        branch_id.into(),
-    )?;
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
     use hex::FromHex;
     use std::convert::TryInto;
     use std::sync::Arc;
@@ -222,7 +157,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_valid_script_parsed() -> Result<()> {
+    fn verify_valid_script() -> Result<()> {
         zebra_test::init();
 
         let transaction =
@@ -238,62 +173,33 @@ mod tests {
             .branch_id()
             .expect("Blossom has a ConsensusBranchId");
 
-        is_valid(transaction, branch_id, (input_index, output))?;
-
-        Ok(())
-    }
-
-    #[test]
-    fn verify_valid_script_parsed_precomputed() -> Result<()> {
-        zebra_test::init();
-
-        let transaction =
-            SCRIPT_TX.zcash_deserialize_into::<Arc<zebra_chain::transaction::Transaction>>()?;
-        let coin = u64::pow(10, 8);
-        let amount = 212 * coin;
-        let output = transparent::Output {
-            value: amount.try_into()?,
-            lock_script: transparent::Script(SCRIPT_PUBKEY.clone()),
-        };
-        let input_index = 0;
-        let branch_id = Blossom
-            .branch_id()
-            .expect("Blossom has a ConsensusBranchId");
-
-        let verifier = super::Verifier::new(transaction);
+        let verifier = super::PrecomputedTransaction::new(&transaction);
         verifier.is_valid(branch_id, (input_index, output))?;
 
         Ok(())
     }
 
     #[test]
-    fn verify_valid_script() -> Result<()> {
+    fn fail_invalid_script() -> Result<()> {
         zebra_test::init();
 
-        let coin = i64::pow(10, 8);
-        let script_pub_key = &*SCRIPT_PUBKEY;
-        let amount = 212 * coin;
-        let tx_to = &*SCRIPT_TX;
-        let n_in = 0;
-        let branch_id = 0x2bb40e60;
+        let transaction =
+            SCRIPT_TX.zcash_deserialize_into::<Arc<zebra_chain::transaction::Transaction>>()?;
+        let coin = u64::pow(10, 8);
+        let amount = 211 * coin;
+        let output = transparent::Output {
+            value: amount.try_into()?,
+            lock_script: transparent::Script(SCRIPT_PUBKEY.clone()),
+        };
+        let input_index = 0;
+        let branch_id = Blossom
+            .branch_id()
+            .expect("Blossom has a ConsensusBranchId");
 
-        verify_script(script_pub_key, amount, tx_to, n_in, branch_id)?;
-
-        Ok(())
-    }
-
-    #[test]
-    fn dont_verify_invalid_script() -> Result<()> {
-        zebra_test::init();
-
-        let coin = i64::pow(10, 8);
-        let script_pub_key = &*SCRIPT_PUBKEY;
-        let amount = 212 * coin;
-        let tx_to = &*SCRIPT_TX;
-        let n_in = 0;
-        let branch_id = 0x2bb40e61;
-
-        verify_script(script_pub_key, amount, tx_to, n_in, branch_id).unwrap_err();
+        let verifier = super::PrecomputedTransaction::new(&transaction);
+        verifier
+            .is_valid(branch_id, (input_index, output))
+            .unwrap_err();
 
         Ok(())
     }

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -87,8 +87,8 @@ impl PrecomputedTransaction {
     ///
     /// # Details
     ///
-    /// input index corresponds to the index of the `TransparentInput` which in
-    /// `transaction` used to identify the `previous_output`
+    /// The `input_index` corresponds to the index of the `TransparentInput` which in
+    /// `transaction` used to identify the `previous_output`.
     pub fn is_valid(
         &self,
         branch_id: ConsensusBranchId,

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -64,34 +64,6 @@ pub struct CachedFfiTransaction {
     precomputed: *mut std::ffi::c_void,
 }
 
-// # SAFETY
-//
-// ## Justification
-//
-// `CachedFfiTransaction` is not `Send` and `Sync` by default because of the
-// `*mut c_void` it contains. This is because raw pointers could allow the same
-// data to be mutated from different threads if copied.
-//
-// CachedFFiTransaction needs to be Send and Sync to be stored within a `Box<dyn
-// Future + Send + Sync + static>`. The async block `CachedFfiTransaction` is
-// owned by in `zebra_consensus/src/transaction.rs` holds it across an await
-// point when the transaction verifier is spawning all of the script verifier
-// futures, because the service readiness check requires an await between each
-// task spawn. Each `script` future needs a copy of the
-// `Arc<CachedFfiTransaction>` so that it can simultaniously verify inputs
-// without cloning the c++ allocated type unnecessarily.
-//
-// ## Explanation
-//
-// It is safe for us to mark this as `Send` and `Sync` because the data pointed
-// to by `precomputed` is never modified after it is constructed and points to
-// heap memory with a stable memory location. The function
-// `zcash_script::zcash_script_verify_precomputed` only reads from the
-// precomputed context while verifying inputs, which makes it safe to treat this
-// pointer like a shared reference (given that is how it is used).
-unsafe impl Send for CachedFfiTransaction {}
-unsafe impl Sync for CachedFfiTransaction {}
-
 impl CachedFfiTransaction {
     /// Construct a `PrecomputedTransaction` from a `Transaction`.
     pub fn new(transaction: Arc<Transaction>) -> Self {
@@ -168,6 +140,34 @@ impl CachedFfiTransaction {
         }
     }
 }
+
+// # SAFETY
+//
+// ## Justification
+//
+// `CachedFfiTransaction` is not `Send` and `Sync` by default because of the
+// `*mut c_void` it contains. This is because raw pointers could allow the same
+// data to be mutated from different threads if copied.
+//
+// CachedFFiTransaction needs to be Send and Sync to be stored within a `Box<dyn
+// Future + Send + Sync + static>`. The async block `CachedFfiTransaction` is
+// owned by in `zebra_consensus/src/transaction.rs` holds it across an await
+// point when the transaction verifier is spawning all of the script verifier
+// futures, because the service readiness check requires an await between each
+// task spawn. Each `script` future needs a copy of the
+// `Arc<CachedFfiTransaction>` so that it can simultaniously verify inputs
+// without cloning the c++ allocated type unnecessarily.
+//
+// ## Explanation
+//
+// It is safe for us to mark this as `Send` and `Sync` because the data pointed
+// to by `precomputed` is never modified after it is constructed and points to
+// heap memory with a stable memory location. The function
+// `zcash_script::zcash_script_verify_precomputed` only reads from the
+// precomputed context while verifying inputs, which makes it safe to treat this
+// pointer like a shared reference (given that is how it is used).
+unsafe impl Send for CachedFfiTransaction {}
+unsafe impl Sync for CachedFfiTransaction {}
 
 impl Drop for CachedFfiTransaction {
     fn drop(&mut self) {

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -127,7 +127,9 @@ impl CachedFfiTransaction {
                 #[cfg(not(windows))]
                 flags,
                 #[cfg(windows)]
-                flags.try_into().expect("zcash_script_SCRIPT_FLAGS_VERIFY_* enum values fit in a c_uint"),
+                flags
+                    .try_into()
+                    .expect("zcash_script_SCRIPT_FLAGS_VERIFY_* enum values fit in a c_uint"),
                 consensus_branch_id,
                 &mut err,
             )


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

The current version of zebra_script has an issue where it serializes and deserializes the same transaction for every input in that transaction, which can cause massive overhead when there are many inputs in a transaction.

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->

## Solution

This PR leverages the new `PrecomputedTransaction` API @str4d exported in `libzcash_script`. We pass the serialized transaction to the c++ code once in order to get a pointer to the deserialized representation that the C++ code understands, then we pass that pointer back into the C++ code every time we verify an input.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

## Related Issues

Closes #1345

## Follow Up Work

