### PR TITLE
Simplify C++ compiler dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Building `zebrad` requires [Rust](https://www.rust-lang.org/tools/install),
      - Using `rustup` installs the stable Rust toolchain, which `zebrad` targets.
 2. Install Zebra's build dependencies:
      - **libclang:** the `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` packages, depending on your package manager
-     - **a C++ compiler:** use `clang`, `g++`, `Xcode`, `MSVC`, or similar
+     - **clang** or another C++ complier: `g++`, `Xcode`, or `MSVC`
 3. Run `cargo install --locked --git https://github.com/ZcashFoundation/zebra --tag v1.0.0-alpha.0 zebrad`
 4. Run `zebrad start`
 


### PR DESCRIPTION
We might as well prefer clang, but mention alternatives