### PR TITLE
Rename State method names

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -244,7 +244,7 @@ impl StateService {
     /// best chain.
     pub fn best_transaction(&self, hash: transaction::Hash) -> Option<Arc<Transaction>> {
         self.mem
-            .transaction(hash)
+            .best_transaction(hash)
             .or_else(|| self.disk.transaction(hash))
     }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -275,7 +275,7 @@ impl StateService {
     }
 
     /// Return the [`Utxo`] pointed to by `outpoint` if it exists in any chain.
-    pub fn utxo(&self, outpoint: &transparent::OutPoint) -> Option<Utxo> {
+    pub fn any_utxo(&self, outpoint: &transparent::OutPoint) -> Option<Utxo> {
         self.mem
             .utxo(outpoint)
             .or_else(|| self.queued_blocks.utxo(outpoint))
@@ -625,7 +625,7 @@ impl Service<Request> for StateService {
 
                 let fut = self.pending_utxos.queue(outpoint);
 
-                if let Some(utxo) = self.utxo(&outpoint) {
+                if let Some(utxo) = self.any_utxo(&outpoint) {
                     self.pending_utxos.respond(&outpoint, utxo);
                 }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -286,7 +286,7 @@ impl StateService {
     /// `hash`.
     ///
     /// The block identified by `hash` is included in the chain of blocks yielded
-    /// by the iterator.
+    /// by the iterator. `hash` can come from any chain.
     pub fn any_ancestor_blocks(&self, hash: block::Hash) -> Iter<'_> {
         Iter {
             service: self,

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -242,7 +242,7 @@ impl StateService {
 
     /// Return the transaction identified by `hash` if it exists in the current
     /// best chain.
-    pub fn transaction(&self, hash: transaction::Hash) -> Option<Arc<Transaction>> {
+    pub fn best_transaction(&self, hash: transaction::Hash) -> Option<Arc<Transaction>> {
         self.mem
             .transaction(hash)
             .or_else(|| self.disk.transaction(hash))
@@ -612,7 +612,7 @@ impl Service<Request> for StateService {
             }
             Request::Transaction(hash) => {
                 metrics::counter!("state.requests", 1, "type" => "transaction");
-                let rsp = Ok(self.transaction(hash)).map(Response::Transaction);
+                let rsp = Ok(self.best_transaction(hash)).map(Response::Transaction);
                 async move { rsp }.boxed()
             }
             Request::Block(hash_or_height) => {

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -320,7 +320,7 @@ impl StateService {
     ///   * adding `max_len` hashes to the list.
     ///
     /// Returns an empty list if the state is empty.
-    pub fn collect_chain_hashes(
+    pub fn collect_best_chain_hashes(
         &self,
         intersection: Option<block::Hash>,
         stop: Option<block::Hash>,
@@ -428,7 +428,7 @@ impl StateService {
         max_len: usize,
     ) -> Vec<block::Hash> {
         let intersection = self.find_best_chain_intersection(known_blocks);
-        self.collect_chain_hashes(intersection, stop, max_len)
+        self.collect_best_chain_hashes(intersection, stop, max_len)
     }
 }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -299,7 +299,7 @@ impl StateService {
     /// Returns `None` if:
     ///   * there is no matching hash in the best chain, or
     ///   * the state is empty.
-    fn find_chain_intersection(&self, known_blocks: Vec<block::Hash>) -> Option<block::Hash> {
+    fn find_best_chain_intersection(&self, known_blocks: Vec<block::Hash>) -> Option<block::Hash> {
         // We can get a block locator request before we have downloaded the genesis block
         self.best_tip()?;
 
@@ -427,7 +427,7 @@ impl StateService {
         stop: Option<block::Hash>,
         max_len: usize,
     ) -> Vec<block::Hash> {
-        let intersection = self.find_chain_intersection(known_blocks);
+        let intersection = self.find_best_chain_intersection(known_blocks);
         self.collect_chain_hashes(intersection, stop, max_len)
     }
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -421,7 +421,7 @@ impl StateService {
     ///   * adding 500 hashes to the list.
     ///
     /// Returns an empty list if the state is empty.
-    pub fn find_chain_hashes(
+    pub fn find_best_chain_hashes(
         &self,
         known_blocks: Vec<block::Hash>,
         stop: Option<block::Hash>,
@@ -633,7 +633,7 @@ impl Service<Request> for StateService {
             }
             Request::FindBlockHashes { known_blocks, stop } => {
                 const MAX_FIND_BLOCK_HASHES_RESULTS: usize = 500;
-                let res = self.find_chain_hashes(known_blocks, stop, MAX_FIND_BLOCK_HASHES_RESULTS);
+                let res = self.find_best_chain_hashes(known_blocks, stop, MAX_FIND_BLOCK_HASHES_RESULTS);
                 async move { Ok(Response::BlockHashes(res)) }.boxed()
             }
             Request::FindBlockHeaders { known_blocks, stop } => {
@@ -645,7 +645,7 @@ impl Service<Request> for StateService {
                 //
                 // https://github.com/bitcoin/bitcoin/pull/4468/files#r17026905
                 let count = MAX_FIND_BLOCK_HEADERS_RESULTS - 2;
-                let res = self.find_chain_hashes(known_blocks, stop, count);
+                let res = self.find_best_chain_hashes(known_blocks, stop, count);
                 let res: Vec<_> = res
                     .iter()
                     .map(|&hash| {

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -633,7 +633,8 @@ impl Service<Request> for StateService {
             }
             Request::FindBlockHashes { known_blocks, stop } => {
                 const MAX_FIND_BLOCK_HASHES_RESULTS: usize = 500;
-                let res = self.find_best_chain_hashes(known_blocks, stop, MAX_FIND_BLOCK_HASHES_RESULTS);
+                let res =
+                    self.find_best_chain_hashes(known_blocks, stop, MAX_FIND_BLOCK_HASHES_RESULTS);
                 async move { Ok(Response::BlockHashes(res)) }.boxed()
             }
             Request::FindBlockHeaders { known_blocks, stop } => {

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -277,7 +277,7 @@ impl StateService {
     /// Return the [`Utxo`] pointed to by `outpoint` if it exists in any chain.
     pub fn any_utxo(&self, outpoint: &transparent::OutPoint) -> Option<Utxo> {
         self.mem
-            .utxo(outpoint)
+            .any_utxo(outpoint)
             .or_else(|| self.queued_blocks.utxo(outpoint))
             .or_else(|| self.disk.utxo(outpoint))
     }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -186,7 +186,7 @@ impl StateService {
         &mut self,
         prepared: &PreparedBlock,
     ) -> Result<(), ValidateContextError> {
-        let relevant_chain = self.chain(prepared.block.header.previous_block_hash);
+        let relevant_chain = self.any_ancestor_blocks(prepared.block.header.previous_block_hash);
         assert!(relevant_chain.len() >= POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN,
                 "contextual validation requires at least 28 (POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN) blocks");
 
@@ -287,7 +287,7 @@ impl StateService {
     ///
     /// The block identified by `hash` is included in the chain of blocks yielded
     /// by the iterator.
-    pub fn chain(&self, hash: block::Hash) -> Iter<'_> {
+    pub fn any_ancestor_blocks(&self, hash: block::Hash) -> Iter<'_> {
         Iter {
             service: self,
             state: IterState::NonFinalized(hash),
@@ -363,7 +363,7 @@ impl StateService {
 
         // We can use an "any chain" method here, because `final_hash` is in the best chain
         let mut res: Vec<_> = self
-            .chain(final_hash)
+            .any_ancestor_blocks(final_hash)
             .map(|block| block.hash())
             .take_while(|&hash| Some(hash) != intersection)
             .inspect(|hash| {

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -218,7 +218,7 @@ impl StateService {
 
     /// Return the tip of the current best chain.
     pub fn best_tip(&self) -> Option<(block::Height, block::Hash)> {
-        self.mem.tip().or_else(|| self.disk.tip())
+        self.mem.best_tip().or_else(|| self.disk.tip())
     }
 
     /// Return the depth of block `hash` in the current best chain.

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -452,7 +452,7 @@ impl Iter<'_> {
             IterState::Finalized(_) | IterState::Finished => unreachable!(),
         };
 
-        if let Some(block) = service.mem.block_by_hash(hash) {
+        if let Some(block) = service.mem.any_block_by_hash(hash) {
             let hash = block.header.previous_block_hash;
             self.state = IterState::NonFinalized(hash);
             Some(block)

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -222,7 +222,7 @@ impl StateService {
     }
 
     /// Return the depth of block `hash` in the current best chain.
-    pub fn depth(&self, hash: block::Hash) -> Option<u32> {
+    pub fn best_depth(&self, hash: block::Hash) -> Option<u32> {
         let tip = self.best_tip()?.0;
         let height = self
             .mem
@@ -597,7 +597,7 @@ impl Service<Request> for StateService {
             }
             Request::Depth(hash) => {
                 metrics::counter!("state.requests", 1, "type" => "depth");
-                let rsp = Ok(self.depth(hash)).map(Response::Depth);
+                let rsp = Ok(self.best_depth(hash)).map(Response::Depth);
                 async move { rsp }.boxed()
             }
             Request::Tip => {

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -142,8 +142,8 @@ impl NonFinalizedState {
     }
 
     /// Returns the `transparent::Output` pointed to by the given
-    /// `transparent::OutPoint` if it is present.
-    pub fn utxo(&self, outpoint: &transparent::OutPoint) -> Option<Utxo> {
+    /// `transparent::OutPoint` if it is present in any chain.
+    pub fn any_utxo(&self, outpoint: &transparent::OutPoint) -> Option<Utxo> {
         for chain in self.chain_set.iter().rev() {
             if let Some(output) = chain.created_utxos.get(outpoint) {
                 return Some(output.clone());

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -189,7 +189,7 @@ impl NonFinalizedState {
     }
 
     /// Returns the tip of the best chain.
-    pub fn tip(&self) -> Option<(block::Height, block::Hash)> {
+    pub fn best_tip(&self) -> Option<(block::Height, block::Hash)> {
         let best_chain = self.best_chain()?;
         let height = best_chain.non_finalized_tip_height();
         let hash = best_chain.non_finalized_tip_hash();
@@ -412,7 +412,7 @@ mod tests {
         state.commit_block(more_work_child.prepare());
         assert_eq!(2, state.chain_set.len());
 
-        let tip_hash = state.tip().unwrap().1;
+        let tip_hash = state.best_tip().unwrap().1;
         assert_eq!(expected_hash, tip_hash);
 
         Ok(())

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -216,7 +216,7 @@ impl NonFinalizedState {
     }
 
     /// Returns the given transaction if it exists in the best chain.
-    pub fn transaction(&self, hash: transaction::Hash) -> Option<Arc<Transaction>> {
+    pub fn best_transaction(&self, hash: transaction::Hash) -> Option<Arc<Transaction>> {
         let best_chain = self.best_chain()?;
         best_chain
             .tx_by_hash

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -153,8 +153,8 @@ impl NonFinalizedState {
         None
     }
 
-    /// Returns the `block` with the given hash in the any chain.
-    pub fn block_by_hash(&self, hash: block::Hash) -> Option<Arc<Block>> {
+    /// Returns the `block` with the given hash in any chain.
+    pub fn any_block_by_hash(&self, hash: block::Hash) -> Option<Arc<Block>> {
         for chain in self.chain_set.iter().rev() {
             if let Some(prepared) = chain
                 .height_by_hash


### PR DESCRIPTION
## Motivation

State method names can be confusing when referring to best chain or any chain.

## Solution

Rename functions as specified by https://github.com/ZcashFoundation/zebra/issues/1446

## Review

@teor2345 opened the issue but anyone can review.

## Related Issues

Closes https://github.com/ZcashFoundation/zebra/issues/1446
https://github.com/ZcashFoundation/zebra/pull/1354 will need a rebase after this PR merges

## Follow Up Work

Added follow-up work to https://github.com/ZcashFoundation/zebra/pull/1354

