### PR TITLE
README: clang and libclang are different

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ that there is a lot of key functionality still missing.
 #### Build Troubleshooting
 
 If you're having trouble with:
-- **dependencies:** use `cargo install` without `--locked` to build with the latest versions of each dependency
+- **dependencies:**
+  - install both `libclang` and `clang` - they are usually different packages
+  - use `cargo install` without `--locked` to build with the latest versions of each dependency
 - **libclang:** check out the [clang-sys documentation](https://github.com/KyleMayes/clang-sys#dependencies)
 - **g++ or MSVC++:** try using clang or Xcode instead
 - **rustc:** use rustc 1.48 or later


### PR DESCRIPTION
## Motivation

Some users try to build Zebra with just `clang`, but it needs `libclang` as well.

## Solution

Add a troubleshooting step to install `clang` and `libclang`.

## Review

We should get this in soon, to reduce user confusion.

Anyone can review.

## Related Issues

A user tried to just install `clang` in https://github.com/ZcashFoundation/zebra/issues/1496#issuecomment-742798347

## Follow Up Work

Add a `zebrad` Nix derivation, to track exact dependencies #1479 