### PR TITLE
add commands and logs section to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,9 +25,11 @@ Then:
 
 
 **Platform**
+
 The output of `uname -a` (UNIX), or version and 32 or 64-bit (Windows)
 
 **Description**
+
 Enter your issue details here.
 One way to structure the description:
 
@@ -40,3 +42,11 @@ I tried this:
 I expected to see this happen: [explanation]
 
 Instead, this happened: [explanation]
+
+**Commands**
+
+Introduce the exact sequence of command line instructions executed so the team can reproduce the problem.
+
+**Logs**
+
+Paste your entire output or logs. If they are too big please upload them somewhere like [Gist](https://gist.github.com/) and add a link to it here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -49,4 +49,6 @@ Introduce the exact sequence of command line instructions executed so the team c
 
 **Logs**
 
-Paste your entire output or logs. If they are too big please upload them somewhere like [Gist](https://gist.github.com/) and add a link to it here.
+Copy and paste the last 100 Zebra log lines.
+
+If you can, upload the full logs to [Gist](https://gist.github.com/), and add a link to them here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -45,7 +45,7 @@ Instead, this happened: [explanation]
 
 **Commands**
 
-Introduce the exact sequence of command line instructions executed so the team can reproduce the problem.
+Copy and paste the exact commands you used, so the team can try to reproduce the issue.
 
 **Logs**
 


### PR DESCRIPTION
## Motivation

The template for bugs report do not have sections for commands executed by the issuer neither to paste the logs.

## Solution

- Add a commands section into template bug report so the team can reproduce the problem the issuer is facing.
- Add a logs section into template bug report so the team can view the same output the issuer is seeing.

## Review

Anyone can review.

## Related Issues

Should close https://github.com/ZcashFoundation/zebra/issues/1503

