### PR TITLE
Comment out collecting Sentry stacktraces for now

### DIFF
--- a/zebrad/src/sentry.rs
+++ b/zebrad/src/sentry.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 use sentry::{
     integrations::backtrace::current_stacktrace,
     protocol::{Event, Exception, Mechanism},
@@ -15,7 +16,11 @@ where
             ..Default::default()
         }),
         value: Some(msg.to_string()),
-        stacktrace: current_stacktrace(),
+        // Sentry does not handle panic = abort well yet, and when gibven this
+        // stacktrace, it consists only of this line, making Sentry dedupe
+        // events together by their stacetrace fingerprint incorrectly.
+        //
+        // stacktrace: current_stacktrace(),
         ..Default::default()
     };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

While panic = abort, Sentry collects the same one-line stack trace for all panics,
making it incorrectly dedupe different errors into one.

## Solution

Comment out the line that collects the stacetraces for now until panic = abort is better fixed upstream that will produce better stacktraces when this line is called.

The code in this pull request has:
  - [x] Documentation Comments
  - [ ] Unit Tests and Property Tests

## Review

@yaahc knows all 🔮 

## Follow Up Work

After the panic propagation in tower is fixed, re-enabling this should result in better stacktraces even with panic = abort (@yaahc correct me if I have that wrong)
