### PR TITLE
Disable issue URLs for "duplicate hash" errors

### DIFF
--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -161,9 +161,15 @@ impl Application for ZebradApp {
             .issue_filter(|kind| match kind {
                 color_eyre::ErrorKind::NonRecoverable(_) => true,
                 color_eyre::ErrorKind::Recoverable(error) => {
-                    !error.is::<tower::timeout::error::Elapsed>()
-                        && !error.is::<tokio::time::error::Elapsed>()
-                        && !error.to_string().contains("timed out")
+                    // type checks should be faster than string conversions
+                    if error.is::<tower::timeout::error::Elapsed>()
+                        || error.is::<tokio::time::error::Elapsed>()
+                    {
+                        return false;
+                    }
+
+                    let error_str = error.to_string();
+                    !error_str.contains("timed out") && !error_str.contains("duplicate hash")
                 }
             });
 

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -113,7 +113,7 @@ where
     #[instrument(level = "debug", skip(self), fields(%hash))]
     pub async fn download_and_verify(&mut self, hash: block::Hash) -> Result<(), Report> {
         if self.cancel_handles.contains_key(&hash) {
-            return Err(eyre!("duplicate hash queued for download"));
+            return Err(eyre!("duplicate hash queued for download: {:?}", hash));
         }
 
         // We construct the block requests sequentially, waiting for the peer


### PR DESCRIPTION
## Motivation

In our README, we tell users to ignore "duplicate hash" errors, so we should also disable the issue URL.

We also want to include the hash in the error. (We don't want the span active for all messages, because that's too verbose.)

## Review

@yaahc can review this fix whenever she has time.

## Related Issues

Reduces bug reports from #1372

## Follow Up Work

Sort out logging in #1381
Disable issue URLs when errors are created #1527