### PR TITLE
Rewrite GetData handling to match the zcashd implementation

### DIFF
--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -128,7 +128,7 @@ impl Handler {
                     if !transactions.is_empty() {
                         // if our peers start sending mixed solicited and unsolicited transactions,
                         // we should update this code to handle those responses
-                        error!("unexpected transaction from peer: transaction responses should be sent in a cintinuous batch, followed by notfound. Using partial received transactions as the peer response");
+                        error!("unexpected transaction from peer: transaction responses should be sent in a continuous batch, followed by notfound. Using partial received transactions as the peer response");
                         // TODO: does the caller need a list of missing transactions? (#1515)
                         Handler::Finished(Ok(Response::Transactions(transactions)))
                     } else {

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -193,7 +193,12 @@ pub enum Message {
     /// content of a specific object, and is usually sent after
     /// receiving an `inv` packet, after filtering known elements.
     ///
+    /// `zcashd` sends a response containing all known items, in a contiguous
+    /// list. Missing blocks are silently skipped. Missing transaction hashes are
+    /// included in a single `NotFound` message following the transactions.
+    ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#getdata)
+    /// [zcashd code](https://github.com/zcash/zcash/blob/e7b425298f6d9a54810cb7183f00be547e4d9415/src/main.cpp#L5523)
     GetData(Vec<InventoryHash>),
 
     /// A `block` message.
@@ -208,7 +213,12 @@ pub enum Message {
 
     /// A `notfound` message.
     ///
+    /// `zcashd` returns `notfound` if a requested transaction (`Tx`) isn't
+    /// available in its mempool or state. But missing blocks and headers are
+    /// silently skipped.
+    ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#notfound)
+    /// [zcashd code](https://github.com/zcash/zcash/blob/e7b425298f6d9a54810cb7183f00be547e4d9415/src/main.cpp#L5632)
     // See note above on `Inventory`.
     NotFound(Vec<InventoryHash>),
 

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -213,7 +213,7 @@ pub enum Message {
 
     /// A `notfound` message.
     ///
-    /// `zcashd` returns `notfound` if a requested transaction (`Tx`) isn't
+    /// `zcashd` returns `NotFound` if a requested transaction (`Tx`) isn't
     /// available in its mempool or state. But missing blocks and headers are
     /// silently skipped.
     ///

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -193,9 +193,10 @@ pub enum Message {
     /// content of a specific object, and is usually sent after
     /// receiving an `inv` packet, after filtering known elements.
     ///
-    /// `zcashd` sends a response containing all known items, in a contiguous
-    /// list. Missing blocks are silently skipped. Missing transaction hashes are
+    /// `zcashd` returns requested items in a single batch of messages.
+    /// Missing blocks are silently skipped. Missing transaction hashes are
     /// included in a single `NotFound` message following the transactions.
+    /// Other item or non-item messages can come before or after the batch.
     ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#getdata)
     /// [zcashd code](https://github.com/zcash/zcash/blob/e7b425298f6d9a54810cb7183f00be547e4d9415/src/main.cpp#L5523)
@@ -213,9 +214,13 @@ pub enum Message {
 
     /// A `notfound` message.
     ///
-    /// `zcashd` returns `NotFound` if a requested transaction (`Tx`) isn't
-    /// available in its mempool or state. But missing blocks and headers are
-    /// silently skipped.
+    /// When a peer requests a list of transaction hashes, `zcashd` returns:
+    ///   - a batch of messages containing found transactions, then
+    ///   - a `NotFound` message containing a list of transaction hashes that
+    ///      aren't available in its mempool or state.
+    ///
+    /// But when a peer requests blocks or headers, any missing items are
+    /// silently skipped, without any `NotFound` messages.
     ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#notfound)
     /// [zcashd code](https://github.com/zcash/zcash/blob/e7b425298f6d9a54810cb7183f00be547e4d9415/src/main.cpp#L5632)

--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -78,7 +78,7 @@ pub enum Request {
     /// Returns [`Response::Transactions`](super::Response::Transactions).
     TransactionsByHash(HashSet<transaction::Hash>),
 
-    /// Request block hashes of subsequent blocks in the chain, giving hashes of
+    /// Request block hashes of subsequent blocks in the chain, given hashes of
     /// known blocks.
     ///
     /// # Returns
@@ -104,7 +104,7 @@ pub enum Request {
         stop: Option<block::Hash>,
     },
 
-    /// Request headers of subsequent blocks in the chain, giving hashes of
+    /// Request headers of subsequent blocks in the chain, given hashes of
     /// known blocks.
     ///
     /// # Returns

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -179,11 +179,13 @@ impl Service<zn::Request> for Inbound {
                     .boxed()
             }
             zn::Request::TransactionsByHash(_transactions) => {
-                // `zcashd` returns a list of found blocks, followed by a
+                // `zcashd` returns a list of found transactions, followed by a
                 // `NotFound` message if any transactions are missing. `zcashd`
-                // says that SPV clients rely on this behaviour - are there any
-                // of them on the Zcash network?
+                // says that Simplified Payment Verification (SPV) clients rely on
+                // this behaviour - are there any of them on the Zcash network?
                 // https://github.com/zcash/zcash/blob/e7b425298f6d9a54810cb7183f00be547e4d9415/src/main.cpp#L5632
+                // We'll implement this request once we have a mempool:
+                // https://en.bitcoin.it/wiki/Protocol_documentation#getdata
                 debug!("ignoring unimplemented request");
                 async { Ok(zn::Response::Nil) }.boxed()
             }


### PR DESCRIPTION
## Motivation

When responding to `GetData` messages, `zcashd`:
* silently ignores missing blocks,
* but sends found transactions followed by a `NotFound` message:
https://github.com/zcash/zcash/blob/e7b425298f6d9a54810cb7183f00be547e4d9415/src/main.cpp#L5497

This is significantly different to the behaviour expected by Zebra's current connection state machine.

## Solution

- update Zebra's connection state machine peer response mappings, to correctly handle the `zcashd` implementation's responses
- make Zebra respond with a partial list of blocks if any blocks are missing, to match the `zcashd` implementation's expectations of our responses

The code in this pull request has:
  - Comments
  - A future test plan - see #1515 and #1048

## Review

@hdevalence or @yaahc can help me work out if this code is correct, and how to resolve the remaining TODOs.

This fix would be good to merge so we can discover other causes of #1435. But it's not particularly urgent.

## Related Issues

Closes #1307 - `zcashd` missing block handling
Resolves some possible causes of #1435 - temporary or permanent peer connection failures or hangs

## Follow Up Work

Refactor zebra-network Bitcoin to Zebra protocol translation layer #1515 - edited to include TODOs from this PR
Test translation for zebra-network::{Request, Response} protocol #1048