### PR TITLE
Start node-problem-detector on deployed instances to collect memory stats

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,10 +87,8 @@ jobs:
           --container-image "gcr.io/$PROJECT_ID/$REPOSITORY/$BRANCH_NAME:$SHORT_SHA" \
           --create-disk name=zebrad-cache-$SHORT_SHA,size=100GB,type=pd-balanced \
           --container-mount-disk mount-path="/zebrad-cache",name=zebrad-cache-$SHORT_SHA \
-          --image-family cos-stable \
-          --image-project cos-cloud \
           --machine-type n2d-standard-4 \
-          --metadata=google-monitoring-enabled=true \
+          --metadata startup-script="systemctl start node-problem-detector" \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
           --tags zebrad \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,6 +87,8 @@ jobs:
           --container-image "gcr.io/$PROJECT_ID/$REPOSITORY/$BRANCH_NAME:$SHORT_SHA" \
           --create-disk name=zebrad-cache-$SHORT_SHA,size=100GB,type=pd-balanced \
           --container-mount-disk mount-path="/zebrad-cache",name=zebrad-cache-$SHORT_SHA \
+          --image-family cos-stable \
+          --image-project cos-cloud \
           --machine-type n2d-standard-4 \
           --metadata=google-monitoring-enabled=true \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -88,6 +88,7 @@ jobs:
           --create-disk name=zebrad-cache-$SHORT_SHA,size=100GB,type=pd-balanced \
           --container-mount-disk mount-path="/zebrad-cache",name=zebrad-cache-$SHORT_SHA \
           --machine-type n2d-standard-4 \
+          --metadata=google-monitoring-enabled=true \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
           --tags zebrad \

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -59,6 +59,8 @@ jobs:
         --container-image "gcr.io/$PROJECT_ID/$REPOSITORY/$BRANCH_NAME:$SHORT_SHA" \
         --container-mount-disk mount-path='/zebrad-cache',name=zebrad-cache-$SHORT_SHA \
         --create-disk name=zebrad-cache-$SHORT_SHA,size=100GB,type=pd-balanced \
+        --image-family cos-stable \
+        --image-project cos-cloud \
         --machine-type n2-standard-4 \
         --metadata=google-monitoring-enabled=true \
         --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -60,6 +60,7 @@ jobs:
         --container-mount-disk mount-path='/zebrad-cache',name=zebrad-cache-$SHORT_SHA \
         --create-disk name=zebrad-cache-$SHORT_SHA,size=100GB,type=pd-balanced \
         --machine-type n2-standard-4 \
+        --metadata=google-monitoring-enabled=true \
         --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
         --tags zebrad \
         --zone us-central1-a

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -59,7 +59,7 @@ jobs:
         --container-image "gcr.io/$PROJECT_ID/$REPOSITORY/$BRANCH_NAME:$SHORT_SHA" \
         --container-mount-disk mount-path='/zebrad-cache',name=zebrad-cache-$SHORT_SHA \
         --create-disk name=zebrad-cache-$SHORT_SHA,size=100GB,type=pd-balanced \
-        --image-family cos-stable \
+        --image-family cos-dev \
         --image-project cos-cloud \
         --machine-type n2-standard-4 \
         --metadata=google-monitoring-enabled=true \

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -62,7 +62,7 @@ jobs:
         --image-family cos-dev \
         --image-project cos-cloud \
         --machine-type n2-standard-4 \
-        --metadata startup-script="systemctl start node-problem-detector" \
+        --metadata google-monitoring-enabled=true,startup-script="systemctl start node-problem-detector" \
         --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
         --tags zebrad \
         --zone us-central1-a

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -62,7 +62,7 @@ jobs:
         --image-family cos-dev \
         --image-project cos-cloud \
         --machine-type n2-standard-4 \
-        --metadata=google-monitoring-enabled=true \
+        --metadata startup-script="systemctl start node-problem-detector" \
         --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
         --tags zebrad \
         --zone us-central1-a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,8 @@ jobs:
           --container-restart-policy never \
           --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-419200",image=zebrad-cache-062a5ae-mainnet-419200 \
           --create-disk name="zebrad-cache-$SHORT_SHA-testnet-280000",image=zebrad-cache-2935b4e-testnet-280000 \
+          --image-family cos-stable \
+          --image-project cos-cloud \
           --machine-type n2-standard-4 \
           --metadata=google-monitoring-enabled=true \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
           --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-419200",image=zebrad-cache-062a5ae-mainnet-419200 \
           --create-disk name="zebrad-cache-$SHORT_SHA-testnet-280000",image=zebrad-cache-2935b4e-testnet-280000 \
           --machine-type n2-standard-4 \
+          --metadata=google-monitoring-enabled=true \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
           --tags zebrad \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,10 +55,8 @@ jobs:
           --container-restart-policy never \
           --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-419200",image=zebrad-cache-062a5ae-mainnet-419200 \
           --create-disk name="zebrad-cache-$SHORT_SHA-testnet-280000",image=zebrad-cache-2935b4e-testnet-280000 \
-          --image-family cos-stable \
-          --image-project cos-cloud \
           --machine-type n2-standard-4 \
-          --metadata=google-monitoring-enabled=true \
+          --metadata startup-script="systemctl start node-problem-detector" \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
           --tags zebrad \


### PR DESCRIPTION


## Motivation

The current default metrics available in gcloud about our zebrad nodes deployed on VMs don't have metrics about memory usage.

## Solution

Add google-monitoring-enabled=true metadata to deployed instances

Enables the Node Problem Detector on Container-Optimized OS, which collects metrics on memory usage, open tcp connections, processes, cpu steal, swap usage, on top of existing host-collected metrics.

## Review

Not urgent.
