### PR TITLE
Renable post merge stateful sync test from sapling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,6 @@ jobs:
           --container-mount-disk mount-path='/testnet',name="zebrad-cache-$SHORT_SHA-testnet-280000" \
           --container-restart-policy never \
           --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-419200",image=zebrad-cache-2a21c86-mainnet-419200 \
-          --create-disk name="zebrad-cache-$SHORT_SHA-testnet-280000",image=zebrad-cache-2a21c86-testnet-280000 \
           --machine-type n2-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
@@ -70,7 +69,6 @@ jobs:
           docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test .;
           docker run -i zebrad-test cargo test --workspace --no-fail-fast -- -Zunstable-options --include-ignored;
           docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-419200,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_past_sapling_mainnet --manifest-path zebrad/Cargo.toml sync_past_sapling_mainnet;
-          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-testnet-280000,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_past_sapling_testnet --manifest-path zebrad/Cargo.toml sync_past_sapling_testnet;
           "
       # Clean up
       - name: Delete test instance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,6 @@ jobs:
           --boot-disk-type pd-ssd \
           --container-image rust:buster \
           --container-mount-disk mount-path='/mainnet',name="zebrad-cache-$SHORT_SHA-mainnet-419200" \
-          --container-mount-disk mount-path='/testnet',name="zebrad-cache-$SHORT_SHA-testnet-280000" \
           --container-restart-policy never \
           --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-419200",image=zebrad-cache-2a21c86-mainnet-419200 \
           --machine-type n2-standard-4 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,8 @@ jobs:
           --container-mount-disk mount-path='/mainnet',name="zebrad-cache-$SHORT_SHA-mainnet-419200" \
           --container-mount-disk mount-path='/testnet',name="zebrad-cache-$SHORT_SHA-testnet-280000" \
           --container-restart-policy never \
-          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-419200",image=zebrad-cache-062a5ae-mainnet-419200 \
-          --create-disk name="zebrad-cache-$SHORT_SHA-testnet-280000",image=zebrad-cache-2935b4e-testnet-280000 \
+          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-419200",image=zebrad-cache-2a21c86-mainnet-419200 \
+          --create-disk name="zebrad-cache-$SHORT_SHA-testnet-280000",image=zebrad-cache-2a21c86-testnet-280000 \
           --machine-type n2-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

We disabled our post-Sapling stateful sync tests when the state format changed and required a re-caching of state.

## Solution

This re-enables the mainnet test with the newly synced v3 state disk, when testnet is also re-synced I'll enable that in another PR.

## Review

Not urgent, will test with a manual trigger of the 'Test' workflow.

## Related Issues

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->

## Follow Up Work

Re-enable the testnet variant when the re-sync disk is ready. @dconnolly 
