### PR TITLE
Stop panicking when ClientRequests return an error

### DIFF
--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -12,6 +12,8 @@ mod error;
 mod handshake;
 
 use client::ClientRequest;
+use client::ClientRequestReceiver;
+use client::InProgressClientRequest;
 use client::MustUseOneshotSender;
 use error::ErrorSlot;
 

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -12,6 +12,7 @@ mod error;
 mod handshake;
 
 use client::ClientRequest;
+use client::MustUseOneshotSender;
 use error::ErrorSlot;
 
 pub use client::Client;

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -56,6 +56,7 @@ impl<T: std::fmt::Debug> MustUseOneshotSender<T> {
     /// Forwards `t` to `tx.send()`, and marks this sender as used.
     ///
     /// Panics if `tx.send()` is used more than once.
+    #[instrument(skip(self))]
     pub fn send(mut self, t: T) -> Result<(), T> {
         self.tx
             .take()
@@ -71,6 +72,7 @@ impl<T: std::fmt::Debug> MustUseOneshotSender<T> {
     /// Returns `tx.cancellation()`.
     ///
     /// Panics if `tx.send()` has previously been used.
+    #[instrument(skip(self))]
     pub fn cancellation(&mut self) -> oneshot::Cancellation<'_, T> {
         self.tx
             .as_mut()
@@ -83,6 +85,7 @@ impl<T: std::fmt::Debug> MustUseOneshotSender<T> {
     /// Returns `tx.is_canceled()`.
     ///
     /// Panics if `tx.send()` has previously been used.
+    #[instrument(skip(self))]
     pub fn is_canceled(&self) -> bool {
         self.tx
             .as_ref()
@@ -99,6 +102,7 @@ impl<T: std::fmt::Debug> From<oneshot::Sender<T>> for MustUseOneshotSender<T> {
 }
 
 impl<T: std::fmt::Debug> Drop for MustUseOneshotSender<T> {
+    #[instrument(skip(self))]
     fn drop(&mut self) {
         // is_canceled() will not panic, because we check is_none() first
         assert!(
@@ -126,6 +130,7 @@ impl Service<Request> for Client {
         }
     }
 
+    #[instrument(skip(self))]
     fn call(&mut self, request: Request) -> Self::Future {
         use futures::future::FutureExt;
 

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -33,6 +33,8 @@ pub(super) struct ClientRequest {
     /// future that may be moved around before it resolves.
     ///
     /// INVARIANT: `tx.send()` must be called before dropping `tx`.
+    ///
+    /// JUSTIFICATION: the `peer::Client` will translate all `Request`s into a `ClientRequest` which it sends to a background task, and if the send replies with `Ok(())` it will assume that it is safe to unconditionally poll the `Receiver` tied to the `Sender` used to create the `ClientRequest`.
     pub tx: MustUseOneshotSender<Result<Response, SharedPeerError>>,
     /// The tracing context for the request, so that work the connection task does
     /// processing messages in the context of this request will have correct context.

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -134,7 +134,6 @@ impl<T: std::fmt::Debug> MustUseOneshotSender<T> {
     /// Forwards `t` to `tx.send()`, and marks this sender as used.
     ///
     /// Panics if `tx.send()` is used more than once.
-    #[instrument(skip(self))]
     pub fn send(mut self, t: T) -> Result<(), T> {
         self.tx
             .take()
@@ -150,7 +149,6 @@ impl<T: std::fmt::Debug> MustUseOneshotSender<T> {
     /// Returns `tx.cancellation()`.
     ///
     /// Panics if `tx.send()` has previously been used.
-    #[instrument(skip(self))]
     pub fn cancellation(&mut self) -> oneshot::Cancellation<'_, T> {
         self.tx
             .as_mut()
@@ -163,7 +161,6 @@ impl<T: std::fmt::Debug> MustUseOneshotSender<T> {
     /// Returns `tx.is_canceled()`.
     ///
     /// Panics if `tx.send()` has previously been used.
-    #[instrument(skip(self))]
     pub fn is_canceled(&self) -> bool {
         self.tx
             .as_ref()
@@ -208,7 +205,6 @@ impl Service<Request> for Client {
         }
     }
 
-    #[instrument(skip(self))]
     fn call(&mut self, request: Request) -> Self::Future {
         use futures::future::FutureExt;
 

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -25,11 +25,14 @@ pub struct Client {
 
 /// A message from the `peer::Client` to the `peer::Server`.
 #[derive(Debug)]
+#[must_use = "tx.send() must be called before drop"]
 pub(super) struct ClientRequest {
     /// The actual request.
     pub request: Request,
     /// The return message channel, included because `peer::Client::call` returns a
     /// future that may be moved around before it resolves.
+    ///
+    /// INVARIANT: `tx.send()` must be called before dropping `tx`.
     pub tx: oneshot::Sender<Result<Response, SharedPeerError>>,
     /// The tracing context for the request, so that work the connection task does
     /// processing messages in the context of this request will have correct context.

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -345,7 +345,6 @@ where
     Tx: Sink<Message, Error = SerializationError> + Unpin,
 {
     /// Consume this `Connection` to form a spawnable future containing its event loop.
-    #[instrument(skip(self, peer_rx))]
     pub async fn run<Rx>(mut self, mut peer_rx: Rx)
     where
         Rx: Stream<Item = Result<Message, SerializationError>> + Unpin,
@@ -538,7 +537,6 @@ where
     /// remote peer.
     ///
     /// NOTE: the caller should use .instrument(msg.span) to instrument the function.
-    #[instrument(skip(self))]
     async fn handle_client_request(&mut self, req: InProgressClientRequest) {
         trace!(?req.request);
         use Request::*;

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -7,7 +7,7 @@
 //! And it's unclear if these assumptions match the `zcashd` implementation.
 //! It should be refactored into a cleaner set of request/response pairs (#1515).
 
-use std::{collections::HashSet, fmt, sync::Arc};
+use std::{collections::HashSet, sync::Arc};
 
 use futures::{
     channel::{mpsc, oneshot},
@@ -495,8 +495,9 @@ where
     /// Marks the peer as having failed with error `e`.
     fn fail_with<E>(&mut self, e: E)
     where
-        E: Into<SharedPeerError> + fmt::Display,
+        E: Into<SharedPeerError>,
     {
+        let e = e.into();
         debug!(%e, "failing peer service with error");
         // Update the shared error slot
         let mut guard = self
@@ -507,7 +508,7 @@ where
         if guard.is_some() {
             panic!("called fail_with on already-failed connection state");
         } else {
-            *guard = Some(e.into());
+            *guard = Some(e);
         }
         // Drop the guard immediately to release the mutex.
         std::mem::drop(guard);

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -10,7 +10,7 @@
 use std::{collections::HashSet, sync::Arc};
 
 use futures::{
-    channel::{mpsc, oneshot},
+    channel::mpsc,
     future::{self, Either},
     prelude::*,
     stream::Stream,
@@ -34,7 +34,7 @@ use crate::{
     BoxError,
 };
 
-use super::{ClientRequest, ErrorSlot, PeerError, SharedPeerError};
+use super::{ClientRequest, ErrorSlot, MustUseOneshotSender, PeerError, SharedPeerError};
 
 #[derive(Debug)]
 pub(super) enum Handler {
@@ -312,7 +312,7 @@ pub(super) enum State {
     /// Awaiting a peer message we can interpret as a client request.
     AwaitingResponse {
         handler: Handler,
-        tx: oneshot::Sender<Result<Response, SharedPeerError>>,
+        tx: MustUseOneshotSender<Result<Response, SharedPeerError>>,
         span: tracing::Span,
     },
     /// A failure has occurred and we are shutting down the connection.

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -304,6 +304,7 @@ impl Handler {
     }
 }
 
+#[must_use = "AwaitingResponse.tx.send() must be called before drop"]
 pub(super) enum State {
     /// Awaiting a client request or a peer message.
     AwaitingRequest,

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -36,6 +36,7 @@ use crate::{
 
 use super::{ClientRequest, ErrorSlot, PeerError, SharedPeerError};
 
+#[derive(Debug)]
 pub(super) enum Handler {
     /// Indicates that the handler has finished processing the request.
     /// An error here is scoped to the request.
@@ -303,6 +304,7 @@ impl Handler {
     }
 }
 
+#[derive(Debug)]
 #[must_use = "AwaitingResponse.tx.send() must be called before drop"]
 pub(super) enum State {
     /// Awaiting a client request or a peer message.
@@ -710,9 +712,9 @@ where
             Ok((AwaitingRequest, None)) => unreachable!(
                 "successful AwaitingRequest states must send a response on tx, but tx is None",
             ),
-            Ok((AwaitingResponse { .. }, Some(tx))) => unreachable!(
-                "successful AwaitingResponse states must keep tx, but tx is Some: {:?}",
-                tx
+            Ok((new_state @ AwaitingResponse { .. }, Some(tx))) => unreachable!(
+                "successful AwaitingResponse states must keep tx, but tx is Some: {:?} for: {:?}",
+                tx, new_state,
             ),
         };
     }

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -341,6 +341,7 @@ where
     Tx: Sink<Message, Error = SerializationError> + Unpin,
 {
     /// Consume this `Connection` to form a spawnable future containing its event loop.
+    #[instrument(skip(self, peer_rx))]
     pub async fn run<Rx>(mut self, mut peer_rx: Rx)
     where
         Rx: Stream<Item = Result<Message, SerializationError>> + Unpin,
@@ -533,6 +534,7 @@ where
     /// remote peer.
     ///
     /// NOTE: the caller should use .instrument(msg.span) to instrument the function.
+    #[instrument(skip(self))]
     async fn handle_client_request(&mut self, req: ClientRequest) {
         trace!(?req.request);
         use Request::*;

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -466,7 +466,7 @@ where
                                 if server_tx
                                     .send(ClientRequest {
                                         request,
-                                        tx,
+                                        tx: tx.into(),
                                         span: tracing::Span::current(),
                                     })
                                     .await

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -489,6 +489,8 @@ where
                                             let _ =
                                                 tx.send(Err(PeerError::ConnectionClosed.into()));
                                         } else if e.is_full() {
+                                            // TODO: wait for the sink to be ready, or wait for a timeout,
+                                            // then close the connection with an overloaded error (#1551)
                                             let ClientRequest { tx, .. } = e.into_inner();
                                             let _ = tx.send(Err(PeerError::Overloaded.into()));
                                         } else {

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -188,6 +188,7 @@ where
         Poll::Ready(Ok(()))
     }
 
+    #[instrument(skip(self))]
     fn call(&mut self, req: (TcpStream, SocketAddr)) -> Self::Future {
         let (tcp_stream, addr) = req;
 

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -188,7 +188,6 @@ where
         Poll::Ready(Ok(()))
     }
 
-    #[instrument(skip(self))]
     fn call(&mut self, req: (TcpStream, SocketAddr)) -> Self::Future {
         let (tcp_stream, addr) = req;
 


### PR DESCRIPTION
## Motivation

Zebra's connection-handling code panics because it drops the ClientRequest oneshot sender in the error case (#1471).

## Solution

- call ClientRequest.tx.send even if there is an error
- document this invariant

The code in this pull request has:
  - [x] Documentation Comments
  - No tests 😞
  - A future test plan - see #1515 and #1048

## Review

I need @yaahc's help with some ownership issues.

## Related Issues

Closes #1471
Closes #1510 - fixes at least one known cause of this panic

Closes #1027 - matches are now exhaustive (some patterns contain partial wildcards, but those matches are panics)

Partial work on #1435 - fixes multiple potential hangs, but testing shows we still sometimes end up with an empty or very small peer set

## Follow Up Work

Refactor zebra-network Bitcoin to Zebra protocol translation layer #1515
Test translation for zebra-network::{Request, Response} protocol #1048
Split up the large files and functions in zebra-network #1557

Check that these panics are resolved:
- Panic: ClientRequest oneshot sender must not be dropped #1471
- Panic: called fail_with on already-failed connection state #1510

Make heartbeats timeout if the connection request queue stays full #1551