### PR TITLE
Enable the metrics endpoint inside Dockerfile.build by default

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -35,6 +35,8 @@ ARG NETWORK=Mainnet
 
 RUN printf "[consensus]\n" >> /zebrad.toml
 RUN printf "checkpoint_sync = ${CHECKPOINT_SYNC}\n" >> /zebrad.toml
+RUN printf "[metrics]\n" >> /zebrad.toml
+RUN printf "endpoint_addr = '0.0.0.0:9999'\n" >> /zebrad.toml
 RUN printf "[network]\n" >> /zebrad.toml
 RUN printf "network = '${NETWORK}'\n" >> /zebrad.toml
 RUN printf "[state]\n" >> /zebrad.toml


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

I wasn't able to collect metrics from our deployed docker images of zebrad.

## Solution

Enable metrics endpoint for zebrad container deployments.

