### PR TITLE
zebrad acceptance test cleanup

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -234,12 +234,12 @@ fn generate_args() -> Result<()> {
     assert_with_context!(
         testdir.path().exists(),
         &output,
-        "unexpected deletion of test temp directory"
+        "test temp directory not found"
     );
     assert_with_context!(
         generated_config_path.exists(),
         &output,
-        "unexpected deletion of config file"
+        "generated config file not found"
     );
 
     Ok(())
@@ -355,7 +355,7 @@ fn persistent_mode() -> Result<()> {
     assert_with_context!(
         cache_dir.read_dir()?.count() > 0,
         &output,
-        "unexpected empty state directory from persistent state config"
+        "state directory empty despite persistent state config"
     );
 
     Ok(())
@@ -447,7 +447,7 @@ fn ephemeral(cache_dir_config: EphemeralConfig, cache_dir_check: EphemeralCheck)
                     .count()
                     == 0,
                 &output,
-                "unexpected items in ignored_cache_dir for ephemeral {:?} {:?}: {:?}",
+                "ignored_cache_dir not empty for ephemeral {:?} {:?}: {:?}",
                 cache_dir_config,
                 cache_dir_check,
                 ignored_cache_dir.read_dir().unwrap().collect::<Vec<_>>()
@@ -487,7 +487,7 @@ fn ephemeral(cache_dir_config: EphemeralConfig, cache_dir_check: EphemeralCheck)
     assert_with_context!(
         run_dir_file_names == expected_run_dir_file_names,
         &output,
-        "unexpected items in run_dir for ephemeral {:?} {:?}: expected {:?}, actual: {:?}",
+        "run_dir not empty for ephemeral {:?} {:?}: expected {:?}, actual: {:?}",
         cache_dir_config,
         cache_dir_check,
         expected_run_dir_file_names,
@@ -576,7 +576,7 @@ fn valid_generated_config(command: &str, expected_output: &str) -> Result<()> {
     assert_with_context!(
         generated_config_path.exists(),
         &output,
-        "config file generation failed"
+        "generated config file not found"
     );
 
     // Run command using temp dir and kill it after a few seconds
@@ -595,12 +595,12 @@ fn valid_generated_config(command: &str, expected_output: &str) -> Result<()> {
     assert_with_context!(
         testdir.path().exists(),
         &output,
-        "unexpected deletion of test temp directory"
+        "test temp directory not found"
     );
     assert_with_context!(
         generated_config_path.exists(),
         &output,
-        "unexpected deletion of config file"
+        "generated config file not found"
     );
 
     Ok(())


### PR DESCRIPTION
## Motivation

Some of the `zebrad` acceptance tests:
* are missing some useful checks
* don't provide useful failure messages
* contain code that can be replaced by utility functions
* contain redundant `zebrad` arguments

## Solution

Test Improvements:
* run the same checks on ephemeral mode and misconfigured ephemeral mode
* refactor the ephemeral tests into a single function

Logging:
* add format string arguments to the test assertion macro
* use the format strings to provide useful error messages

Cleanup:
* always use the utility functions to write config files
* delete redundant `zebrad start` arguments

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Acceptance Tests

## Review

This review can be done at any time. @yaahc is the person with the most experience with these tests, but anyone can review.

We should try to get it done before we make any more changes to the acceptance tests, to avoid merge conflicts.

## Related Issues

#1537 cleanup the acceptance tests using utility functions
* changed the tests so they used the utility functions to write config files, with a few exceptions

## Follow Up Work

The acceptance tests still occasionally fail for me, but I am running a few `zebrad` and `zcashd` instances, so I would expect a few port conflicts.