### PR TITLE
Log configured network in every log message

### DIFF
--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -145,6 +145,9 @@ impl Application for ZebradApp {
 
         let config = command.process_config(config)?;
 
+        let span = error_span!("", net = ?config.network.network);
+        let _guard = span.enter();
+
         let theme = if Self::outputs_are_ttys() && config.tracing.use_color {
             color_eyre::config::Theme::dark()
         } else {
@@ -248,10 +251,8 @@ impl Application for ZebradApp {
         // application configuration is processed
         self.register_components(command)?;
 
+        // Fire callback to signal state in the application lifecycle
         let config = self.config.take().unwrap();
-
-        // Fire callback regardless of whether any config was loaded to
-        // in order to signal state in the application lifecycle
         self.after_config(config)?;
 
         Ok(())

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -158,6 +158,7 @@ impl Application for ZebradApp {
             .issue_url(concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/new"))
             .add_issue_metadata("version", env!("CARGO_PKG_VERSION"))
             .add_issue_metadata("git commit", Self::git_commit())
+            .add_issue_metadata("Zcash network", config.network.network)
             .issue_filter(|kind| match kind {
                 color_eyre::ErrorKind::NonRecoverable(_) => true,
                 color_eyre::ErrorKind::Recoverable(error) => {

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -249,11 +249,12 @@ impl Application for ZebradApp {
         }
 
         // Activate the global span, so it's visible when we load the other
-        // components
+        // components. Space is at a premium here, so we use an empty message,
+        // short commit hash, and the unique part of the network name.
         let global_span = error_span!(
             "",
             zebrad = ZebradApp::git_commit(),
-            net = ?self.config.clone().unwrap().network.network,
+            net = &self.config.clone().unwrap().network.network.to_string()[..4],
         );
         let global_guard = global_span.enter();
         // leak the global span, to make sure it stays active

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -7,7 +7,6 @@ mod version;
 use self::ZebradCmd::*;
 use self::{generate::GenerateCmd, start::StartCmd, version::VersionCmd};
 
-use crate::application::{app_config, ZebradApp};
 use crate::config::ZebradConfig;
 
 use abscissa_core::{
@@ -53,13 +52,6 @@ impl ZebradCmd {
 
 impl Runnable for ZebradCmd {
     fn run(&self) {
-        let span = error_span!(
-            "",
-            zebrad = ZebradApp::git_commit(),
-            net = ?app_config().network.network
-        );
-        let _guard = span.enter();
-
         match self {
             Generate(cmd) => cmd.run(),
             ZebradCmd::Help(cmd) => cmd.run(),

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -7,7 +7,7 @@ mod version;
 use self::ZebradCmd::*;
 use self::{generate::GenerateCmd, start::StartCmd, version::VersionCmd};
 
-use crate::application::ZebradApp;
+use crate::application::{app_config, ZebradApp};
 use crate::config::ZebradConfig;
 
 use abscissa_core::{
@@ -53,8 +53,13 @@ impl ZebradCmd {
 
 impl Runnable for ZebradCmd {
     fn run(&self) {
-        let span = error_span!("", zebrad = ZebradApp::git_commit());
+        let span = error_span!(
+            "",
+            zebrad = ZebradApp::git_commit(),
+            net = ?app_config().network.network
+        );
         let _guard = span.enter();
+
         match self {
             Generate(cmd) => cmd.run(),
             ZebradCmd::Help(cmd) => cmd.run(),


### PR DESCRIPTION
## Motivation

When users send us bug reports, we want to know if they're running on Mainnet or Testnet.

## Solution

Features:
- [x] Add the configured network at the start of (almost) all log messages
- [x] Add the configured network to the error report issue URL
- [x] Add a panic metadata section to the panic report

Tests:
- [x] Passes the existing acceptance tests

Info log example:
```
Jan 08 17:18:54.510  INFO {zebrad="83f33cfe" net=Main}: zebrad::commands::start: Starting zebrad
```

Metadata example:

In the panic report:
```
Metadata:
version: 1.0.0-alpha.0
git commit: a4182846
Zcash network: Mainnet
```

In the issue:
|key|value|
|--|--|
|**version**|1.0.0-alpha.0|
|**git commit**|f222a680|
|**Zcash network**|Mainnet|
|**location**|zebrad/src/components/metrics.rs:21:9|

### Alternative Solutions

Add the configured network at the start of debug and trace log messages only

## Review

I'd like @dconnolly and @yaahc to both review this PR, because it changes our log format.
The review isn't urgent at all.

## Related Issues

Closes #1457

## Follow Up Work

#1381 Make logging consistent
#1575 Global span doesn't appear on some early spawned tasks
  - this is a very minor bug that we won't need to fix unless we get a lot of bug reports in one of two early spawned tasks