### PR TITLE
Make `cargo run` use `zebrad` by default

### DIFF
--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -5,6 +5,9 @@ license = "MIT OR Apache-2.0"
 version = "1.0.0-alpha.0"
 edition = "2018"
 repository = "https://github.com/ZcashFoundation/zebra"
+# make `cargo run` use `zebrad` by default
+# when run in the workspace directory
+default-run = "zebrad"
 
 [dependencies]
 zebra-chain = { path = "../zebra-chain" }


### PR DESCRIPTION
## Motivation

When `cargo run` is run in the workspace directory, it can see two executables:
- `zebrad`
- `zebra_checkpoints`

So it exits with an error, and asks the user to choose one of them.

But `zebrad` should be the default - most users don't care about `zebra_checkpoints`.

## Solution

Adding `default-run = "zebrad"` to `zebrad/Cargo.toml` makes the workspace run `zebrad` by default.
(`default-run` is redundant for the`zebrad` crate itself.)

## Review

I think @yaahc knows more about cargo.
This change can be merged at any time.
