### PR TITLE
Upgrade to tokio 0.3.6 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,7 +1263,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.3.5",
+ "tokio 0.3.6",
  "tokio-util 0.4.0",
  "tracing",
  "tracing-futures",
@@ -1421,7 +1421,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.2",
  "socket2",
- "tokio 0.3.5",
+ "tokio 0.3.6",
  "tower-service",
  "tracing",
  "want",
@@ -1737,7 +1737,7 @@ dependencies = [
  "metrics-util",
  "parking_lot",
  "thiserror",
- "tokio 0.3.5",
+ "tokio 0.3.6",
 ]
 
 [[package]]
@@ -3173,8 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.3.5"
-source = "git+https://github.com/tokio-rs/tokio?rev=9706ca92a8deb69d6e29265f21424042fea966c5#9706ca92a8deb69d6e29265f21424042fea966c5"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "720ba21c25078711bf456d607987d95bce90f7c3bea5abe1db587862e7a1e87c"
 dependencies = [
  "autocfg",
  "bytes 0.6.0",
@@ -3195,8 +3196,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.3.1"
-source = "git+https://github.com/tokio-rs/tokio?rev=9706ca92a8deb69d6e29265f21424042fea966c5#9706ca92a8deb69d6e29265f21424042fea966c5"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46dfffa59fc3c8aad216ed61bdc2c263d2b9d87a9c8ac9de0c11a813e51b6db7"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -3240,7 +3242,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.1.11",
- "tokio 0.3.5",
+ "tokio 0.3.6",
 ]
 
 [[package]]
@@ -3254,7 +3256,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.0",
- "tokio 0.3.5",
+ "tokio 0.3.6",
 ]
 
 [[package]]
@@ -3275,7 +3277,7 @@ dependencies = [
  "futures-util",
  "hdrhistogram 6.3.4",
  "pin-project 1.0.2",
- "tokio 0.3.5",
+ "tokio 0.3.6",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3291,7 +3293,7 @@ dependencies = [
  "futures-core",
  "pin-project 0.4.27",
  "rand 0.7.3",
- "tokio 0.3.5",
+ "tokio 0.3.6",
  "tower",
  "tower-fallback",
  "tracing",
@@ -3305,7 +3307,7 @@ version = "0.1.0"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio 0.3.5",
+ "tokio 0.3.6",
  "tower",
  "tracing",
  "zebra-test",
@@ -3914,7 +3916,7 @@ dependencies = [
  "serde",
  "spandoc",
  "thiserror",
- "tokio 0.3.5",
+ "tokio 0.3.6",
  "tower",
  "tower-batch",
  "tower-fallback",
@@ -3946,7 +3948,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "thiserror",
- "tokio 0.3.5",
+ "tokio 0.3.6",
  "tokio-util 0.5.1",
  "tower",
  "tracing",
@@ -3995,7 +3997,7 @@ dependencies = [
  "spandoc",
  "tempdir",
  "thiserror",
- "tokio 0.3.5",
+ "tokio 0.3.6",
  "tower",
  "tracing",
  "zebra-chain",
@@ -4017,7 +4019,7 @@ dependencies = [
  "spandoc",
  "tempdir",
  "thiserror",
- "tokio 0.3.5",
+ "tokio 0.3.6",
  "tower",
  "tracing",
  "tracing-error",
@@ -4062,7 +4064,7 @@ dependencies = [
  "serde",
  "tempdir",
  "thiserror",
- "tokio 0.3.5",
+ "tokio 0.3.6",
  "toml",
  "tower",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ panic = "abort"
 panic = "abort"
 
 [patch.crates-io]
-# awaiting tower 0.4
-tower = { git = "https://github.com/tower-rs/tower", rev = "d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39" }
 
-# awaiting stable versions which depend on tokio 0.3
+
+# awaiting stable versions which all depend on tokio 1.0, see #1086 for details
 hyper = { git = "https://github.com/hyperium/hyper", rev = "ed2b22a7f66899d338691552fbcb6c0f2f4e06b9" }
 metrics = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
 metrics-exporter-prometheus = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
+tower = { git = "https://github.com/tower-rs/tower", rev = "d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,6 @@ panic = "abort"
 # awaiting tower 0.4
 tower = { git = "https://github.com/tower-rs/tower", rev = "d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39" }
 
-# fix for #1452, should be included in tokio 0.3.6 or later
-tokio = { git = "https://github.com/tokio-rs/tokio", rev = "9706ca92a8deb69d6e29265f21424042fea966c5" }
-
 # awaiting stable versions which depend on tokio 0.3
 hyper = { git = "https://github.com/hyperium/hyper", rev = "ed2b22a7f66899d338691552fbcb6c0f2f4e06b9" }
 metrics = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-tokio = { version = "0.3", features = ["time", "sync", "stream", "tracing", "macros"] }
+tokio = { version = "0.3.6", features = ["time", "sync", "stream", "tracing", "macros"] }
 tower = { version = "0.4", features = ["util", "buffer"] }
 futures-core = "0.3.6"
 pin-project = "0.4.27"
@@ -17,7 +17,7 @@ futures = "0.3.7"
 [dev-dependencies]
 ed25519-zebra = "2.1.0"
 rand = "0.7"
-tokio = { version = "0.3", features = ["full"]}
+tokio = { version = "0.3.6", features = ["full"]}
 tracing = "0.1.22"
 zebra-test = { path = "../zebra-test/" }
 tower-fallback = { path = "../tower-fallback/" }

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -13,4 +13,4 @@ tracing = "0.1"
 
 [dev-dependencies]
 zebra-test = { path = "../zebra-test/" }
-tokio = { version = "0.3", features = ["full"]}
+tokio = { version = "0.3.6", features = ["full"]}

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3.7"
 futures-util = "0.3.6"
 metrics = "0.13.0-alpha.8"
 thiserror = "1.0.23"
-tokio = { version = "0.3.4", features = ["time", "sync", "stream", "tracing"] }
+tokio = { version = "0.3.6", features = ["time", "sync", "stream", "tracing"] }
 tower = { version = "0.4", features = ["timeout", "util", "buffer"] }
 tracing = "0.1.22"
 tracing-futures = "0.2.4"
@@ -33,7 +33,7 @@ zebra-script = { path = "../zebra-script" }
 color-eyre = "0.5.10"
 rand = "0.7"
 spandoc = "0.2"
-tokio = { version = "0.3.4", features = ["full"] }
+tokio = { version = "0.3.6", features = ["full"] }
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.15"
 

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"
 
 futures = "0.3"
-tokio = { version = "0.3.4", features = ["net", "time", "stream", "tracing", "macros", "rt-multi-thread"] }
+tokio = { version = "0.3.6", features = ["net", "time", "stream", "tracing", "macros", "rt-multi-thread"] }
 tokio-util = { version = "0.5", features = ["codec"] }
 tower = { version = "0.4", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -20,7 +20,7 @@ metrics = "0.13.0-alpha.8"
 tower = { version = "0.4", features = ["buffer", "util"] }
 tracing = "0.1"
 thiserror = "1.0.23"
-tokio = { version = "0.3.4", features = ["sync"] }
+tokio = { version = "0.3.6", features = ["sync"] }
 displaydoc = "0.1.7"
 rocksdb = "0.15.0"
 tempdir = "0.3.7"
@@ -36,7 +36,7 @@ color-eyre = "0.5.10"
 once_cell = "1.5"
 spandoc = "0.2"
 tempdir = "0.3.7"
-tokio = { version = "0.3.4", features = ["full"] }
+tokio = { version = "0.3.6", features = ["full"] }
 proptest = "0.10.1"
 proptest-derive = "0.2"
 primitive-types = "0.8.0"

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -25,4 +25,4 @@ proptest = "0.10.1"
 
 [dev-dependencies]
 tempdir = "0.3.7"
-tokio = { version = "0.3.4", features = ["full"] }
+tokio = { version = "0.3.6", features = ["full"] }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -24,7 +24,7 @@ rand = "0.7"
 
 hyper = { version = "0.14.0-dev", features = ["full"] }
 futures = "0.3"
-tokio = { version = "0.3.4", features = ["time", "rt-multi-thread", "stream", "macros", "tracing", "signal"] }
+tokio = { version = "0.3.6", features = ["time", "rt-multi-thread", "stream", "macros", "tracing", "signal"] }
 tower = { version = "0.4", features = ["hedge", "limit"] }
 pin-project = "0.4.23"
 


### PR DESCRIPTION
## Motivation

Zebra depends on a git version of tokio, but tokio has released 0.3.6, which contains the panic fixes we need.

## Solution

* make all crates depend on tokio 0.3.6
* remove the git dependency
* update the comments for the remaining git dependencies based on the latest releases, see #1086 for details

The code in this pull request:
  - [x] Passes existing tests

## Review

Anyone can review this change, but @dconnolly manages dependencies.

Let's get this change merged this week, so we can test it in the later half of the sprint.

## Related Issues

Closes #1539

## Follow Up Work

Remove git dependencies on Hyper, Metrics, Tower #1086
  - waiting on stable releases of metrics and metrics-http-exporter that depend on tokio 1.0