### PR TITLE
Add sync and inbound timeouts

### DIFF
--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -88,6 +88,14 @@ pub const MAX_QUEUED_BLOCKS_PER_HEIGHT: usize = 4;
 /// bugs. So the most efficient gap is slightly less than 500 blocks.
 pub const MAX_CHECKPOINT_HEIGHT_GAP: usize = 400;
 
+/// We limit the memory usage and download contention for each checkpoint,
+/// based on the cumulative size of the serialized blocks in the chain.
+///
+/// Deserialized blocks (in memory) are slightly larger than serialized blocks
+/// (on the network or disk). But they should be within a constant factor of the
+/// serialized size.
+pub const MAX_CHECKPOINT_BYTE_COUNT: u64 = 32 * 1024 * 1024;
+
 /// A checkpointing block verifier.
 ///
 /// Verifies blocks using a supplied list of checkpoints. There must be at

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -53,6 +53,7 @@ mod transaction;
 pub mod chain;
 pub mod error;
 
+pub use checkpoint::MAX_CHECKPOINT_BYTE_COUNT;
 pub use checkpoint::MAX_CHECKPOINT_HEIGHT_GAP;
 pub use config::Config;
 

--- a/zebra-utils/src/bin/zebra-checkpoints/main.rs
+++ b/zebra-utils/src/bin/zebra-checkpoints/main.rs
@@ -24,12 +24,6 @@ use std::os::unix::process::ExitStatusExt;
 
 mod args;
 
-/// We limit the memory usage for each checkpoint, based on the cumulative size of
-/// the serialized blocks in the chain. Deserialized blocks are slightly larger
-/// than serialized blocks, but they should be within a constant factor of the
-/// serialized size.
-const MAX_CHECKPOINT_BYTE_COUNT: u64 = 32 * 1024 * 1024;
-
 /// Initialise tracing using its defaults.
 fn init_tracing() {
     tracing_subscriber::Registry::default()
@@ -135,7 +129,7 @@ fn main() -> Result<()> {
 
         // check if checkpoint
         if height == block::Height(0)
-            || cumulative_bytes >= MAX_CHECKPOINT_BYTE_COUNT
+            || cumulative_bytes >= zebra_consensus::MAX_CHECKPOINT_BYTE_COUNT
             || height_gap.0 >= zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP as u32
         {
             // print to output

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -33,11 +33,24 @@ where
     ZS: Service<zs::Request, Response = zs::Response, Error = BoxError> + Send + Clone + 'static,
     ZS::Future: Send,
 {
+    // Services
+    /// A service that forwards requests to connected peers, and returns their
+    /// responses.
     network: ZN,
+
+    /// A service that verifies downloaded blocks.
     verifier: ZV,
+
+    /// A service that manages cached blockchain state.
     state: ZS,
+
+    // Internal downloads state
+    /// A list of pending block download and verify tasks.
     #[pin]
     pending: FuturesUnordered<JoinHandle<Result<block::Hash, (BoxError, block::Hash)>>>,
+
+    /// A list of channels that can be used to cancel pending block download and
+    /// verify tasks.
     cancel_handles: HashMap<block::Hash, oneshot::Sender<()>>,
 }
 

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -188,13 +188,21 @@ where
         );
         // We apply a timeout to the verifier to avoid hangs due to missing earlier blocks.
         let verifier = Timeout::new(verifier, BLOCK_VERIFY_TIMEOUT);
+        // Warn the user if we're ignoring their configured lookahead limit
+        let lookahead_limit = if config.sync.lookahead_limit < MIN_LOOKAHEAD_LIMIT {
+            tracing::warn!(config_lookahead_limit = ?config.sync.lookahead_limit, ?MIN_LOOKAHEAD_LIMIT,
+                          "configured lookahead limit too low: using minimum lookahead limit");
+            MIN_LOOKAHEAD_LIMIT
+        } else {
+            config.sync.lookahead_limit
+        };
         Self {
             tip_network,
             state,
             downloads: Box::pin(Downloads::new(block_network, verifier)),
             prospective_tips: HashSet::new(),
             genesis_hash: genesis_hash(config.network.network),
-            lookahead_limit: std::cmp::max(config.sync.lookahead_limit, MIN_LOOKAHEAD_LIMIT),
+            lookahead_limit,
         }
     }
 

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -64,7 +64,7 @@ const TIPS_RESPONSE_TIMEOUT: Duration = Duration::from_secs(6);
 ///
 /// If this timeout is set too low, the syncer will sometimes get stuck in a
 /// failure loop.
-const BLOCK_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
+pub(super) const BLOCK_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Controls how long we wait for a block verify request to complete.
 ///
@@ -92,7 +92,7 @@ const BLOCK_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
 ///
 /// If this timeout is set too low, the syncer will sometimes get stuck in a
 /// failure loop.
-const BLOCK_VERIFY_TIMEOUT: Duration = Duration::from_secs(180);
+pub(super) const BLOCK_VERIFY_TIMEOUT: Duration = Duration::from_secs(180);
 
 /// Controls how long we wait to restart syncing after finishing a sync run.
 ///

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -43,10 +43,21 @@ where
     ZV: Service<Arc<Block>, Response = block::Hash, Error = BoxError> + Send + Clone + 'static,
     ZV::Future: Send,
 {
+    // Services
+    /// A service that forwards requests to connected peers, and returns their
+    /// responses.
     network: ZN,
+
+    /// A service that verifies downloaded blocks.
     verifier: ZV,
+
+    // Internal downloads state
+    /// A list of pending block download and verify tasks.
     #[pin]
     pending: FuturesUnordered<JoinHandle<Result<block::Hash, (BoxError, block::Hash)>>>,
+
+    /// A list of channels that can be used to cancel pending block download and
+    /// verify tasks.
     cancel_handles: HashMap<block::Hash, oneshot::Sender<()>>,
 }
 


### PR DESCRIPTION
## Motivation

The sync service sometimes hangs (#1559).

It's also possible that the inbound service sometimes hangs, but we just don't notice.

## Solution

Add timeouts to:
- the sync verifier
- the inbound downloads
- the inbound verifier

Add some timeout constraints as a unit test.
Add correctness warning docs to the network and verify timeouts.

Document the services used by sync and inbound.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Partial Unit Tests
  - [x] Manual Testing
  - [x] A Test Plan - see #1592

### Manual Testing

I ran 4 `zebrad` instances:
- 3 mainnet:
  - 1 close to tip
  - 2 ephemeral
- 1 testnet:
  - 1 close to tip

None of them have hung after about 12 hours, so it seems like this PR fixes our sync hangs.

I'm now running 5 `zebrad` instances:
- 2 mainnet:
  - 1 close to tip
  - 1 ephemeral
- 3 testnet:
  - 1 close to tip
  - 2 ephemeral

They also succeeded, but the ephemeral mainnet instance is lagging about 500 blocks behind the tip, and some of the testnet instances have a low number of peers. (These both look like #1435, but with a much lower impact.)

## Review

I've been talking to @yaahc about these bugs.

I'd like to get this PR merged by Friday, so I don't have to change my #1435 fixes too much.

## Related Issues

Closes #1559 
Handles one part of #1389
Removes some potential causes of #1435 and makes it easier to diagnose

## Follow Up Work

We won't know if we've completely fixed this issue until we've also fixed:
- Peer connections hang temporarily or fail permanently #1435

We need some sync hang tests. I have some ideas, and I'll write them up tomorrow.

- [x] Open a follow-up task to create a consistent design for:
  * defining limits for each config value
  * enforcing those limits
  * handing limit errors
This is now #1591.