### PR TITLE
Panic if the lookahead limit is misconfigured

### DIFF
--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -214,16 +214,15 @@ where
         // We apply a timeout to the verifier to avoid hangs due to missing earlier blocks.
         let verifier = Timeout::new(verifier, BLOCK_VERIFY_TIMEOUT);
         // Warn the user if we're ignoring their configured lookahead limit
-        let lookahead_limit = if config.sync.lookahead_limit < MIN_LOOKAHEAD_LIMIT {
-            tracing::warn!(config_lookahead_limit = ?config.sync.lookahead_limit, ?MIN_LOOKAHEAD_LIMIT,
-                          "configured lookahead limit too low: using minimum lookahead limit");
+        assert!(
+            config.sync.lookahead_limit >= MIN_LOOKAHEAD_LIMIT,
+            "configured lookahead limit {} too low, must be at least {}",
+            config.sync.lookahead_limit,
             MIN_LOOKAHEAD_LIMIT
-        } else {
-            config.sync.lookahead_limit
-        };
+        );
         Self {
             genesis_hash: genesis_hash(config.network.network),
-            lookahead_limit,
+            lookahead_limit: config.sync.lookahead_limit,
             tip_network,
             downloads: Box::pin(Downloads::new(block_network, verifier)),
             state,


### PR DESCRIPTION
## Motivation

We should panic if the lookahead limit is misconfigured, so the user notices.

## Review

@yaahc made this suggestion, it can be merged whenever.

## Related Issues

Follow up for #1586.

## Follow Up Work

Create a consistent design for:
* defining limits for each config value
* enforcing those limits
* handing limit errors
