### PR TITLE
Avoid panics when there are multiple failures on the same connection

### DIFF
--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -840,6 +840,7 @@ where
         if self.svc.ready_and().await.is_err() {
             // Treat all service readiness errors as Overloaded
             self.fail_with(PeerError::Overloaded);
+            return;
         }
 
         let rsp = match self.svc.call(req).await {

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -511,8 +511,32 @@ where
             .0
             .lock()
             .expect("mutex should be unpoisoned");
-        if guard.is_some() {
-            panic!("called fail_with on already-failed connection state");
+        if let Some(original_error) = guard.clone() {
+            // A failed connection might experience further errors if we:
+            // 1. concurrently process two different messages
+            // 2. check for a failed state for the second message
+            // 3. fail the connection due to the first message
+            // 4. fail the connection due to the second message
+            //
+            // It's not clear:
+            // * if this is actually a bug,
+            // * how we can modify Zebra to avoid it.
+            //
+            // This warning can also happen due to these bugs:
+            // * we mark a connection as failed without using fail_with
+            // * we call fail_with without checking for a failed connection
+            //   state
+            //
+            // See the original bug #1510, the initial fix #1531, and the later
+            // bug #1599.
+            warn!(?original_error,
+                  new_error = ?e,
+                  connection_state = ?self.state,
+                  client_receiver = ?self.client_rx,
+                  "calling fail_with on already-failed connection state: ignoring new error");
+            // we don't need to clean up the connection, the original call to
+            // fail_with does that
+            return;
         } else {
             *guard = Some(e);
         }


### PR DESCRIPTION
## Motivation

`zebrad` keeps panicking occasionally because it calls `fail_with` multiple times on the same connection.

We can fix one obvious cause of this bug, but we can't rule out correctly written code also encountering it.

## Solution

* fix the overload handling code, which calls `fail_with` then continues to process the current request
* downgrade the panic to a warning
* improve logging for connection failures and state errors

The code in this pull request has:
  - [x] Existing Documentation Comments
  - [x] Manual testing

## Review

@dconnolly is familiar with this bug.

Let's try to get this fix merged by the end of the sprint.

## Related Issues

The original bug #1510
A partial initial fix #1531
Closes #1599

## Follow Up Work

We should refactor this code so invariant violations like this are caught by the compiler, rather than happening under very specific network conditions - #1610

For bugs that we can't make into compilation errors, we should create better tests for the network code.
