### PR TITLE
Use the rustc unknown lints attribute

### DIFF
--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -404,9 +404,7 @@ where
 mod test {
     use super::*;
 
-    use std::{
-        collections::hash_map::RandomState, collections::HashSet, fmt::Debug, iter::FromIterator,
-    };
+    use std::{collections::hash_map::RandomState, collections::HashSet, fmt::Debug};
 
     use color_eyre::eyre::Result;
 
@@ -601,20 +599,19 @@ mod test {
         let another_one = Amount::<NonNegative>::try_from(1)?;
         let zero = Amount::<NonNegative>::try_from(0)?;
 
-        let hash_set: HashSet<Amount<NonNegative>, RandomState> =
-            HashSet::from_iter([one].iter().cloned());
+        let hash_set: HashSet<Amount<NonNegative>, RandomState> = [one].iter().cloned().collect();
         assert_eq!(hash_set.len(), 1);
 
         let hash_set: HashSet<Amount<NonNegative>, RandomState> =
-            HashSet::from_iter([one, one].iter().cloned());
+            [one, one].iter().cloned().collect();
         assert_eq!(hash_set.len(), 1, "Amount hashes are consistent");
 
         let hash_set: HashSet<Amount<NonNegative>, RandomState> =
-            HashSet::from_iter([one, another_one].iter().cloned());
+            [one, another_one].iter().cloned().collect();
         assert_eq!(hash_set.len(), 1, "Amount hashes are by value");
 
         let hash_set: HashSet<Amount<NonNegative>, RandomState> =
-            HashSet::from_iter([one, zero].iter().cloned());
+            [one, zero].iter().cloned().collect();
         assert_eq!(
             hash_set.len(),
             2,

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -16,7 +16,6 @@
 // Use the old lint name to build without warnings on stable until 1.51 is stable
 #![allow(clippy::unknown_clippy_lints)]
 // The actual lints we want to disable
-#![allow(clippy::from_iter_instead_of_collect)]
 #![allow(clippy::unnecessary_wraps)]
 
 #[macro_use]

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -9,7 +9,13 @@
 // #![deny(missing_docs)]
 #![allow(clippy::try_err)]
 // Disable some broken or unwanted clippy nightly lints
+// Build without warnings on nightly 2021-01-17 and later and stable 1.51 and later
+#![allow(unknown_lints)]
+// Disable old lint warnings on nightly until 1.51 is stable
+#![allow(renamed_and_removed_lints)]
+// Use the old lint name to build without warnings on stable until 1.51 is stable
 #![allow(clippy::unknown_clippy_lints)]
+// The actual lints we want to disable
 #![allow(clippy::from_iter_instead_of_collect)]
 #![allow(clippy::unnecessary_wraps)]
 

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -37,7 +37,13 @@
 //#![deny(missing_docs)]
 #![allow(clippy::try_err)]
 // Disable some broken or unwanted clippy nightly lints
+// Build without warnings on nightly 2021-01-17 and later and stable 1.51 and later
+#![allow(unknown_lints)]
+// Disable old lint warnings on nightly until 1.51 is stable
+#![allow(renamed_and_removed_lints)]
+// Use the old lint name to build without warnings on stable until 1.51 is stable
 #![allow(clippy::unknown_clippy_lints)]
+// The actual lints we want to disable
 #![allow(clippy::unnecessary_wraps)]
 
 mod block;

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -39,7 +39,13 @@
 // https://github.com/tokio-rs/tracing/issues/553
 #![allow(clippy::cognitive_complexity)]
 // Disable some broken or unwanted clippy nightly lints
+// Build without warnings on nightly 2021-01-17 and later and stable 1.51 and later
+#![allow(unknown_lints)]
+// Disable old lint warnings on nightly until 1.51 is stable
+#![allow(renamed_and_removed_lints)]
+// Use the old lint name to build without warnings on stable until 1.51 is stable
 #![allow(clippy::unknown_clippy_lints)]
+// The actual lints we want to disable
 #![allow(clippy::unnecessary_wraps)]
 
 #[macro_use]

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -3,7 +3,13 @@
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_script")]
 // Disable some broken or unwanted clippy nightly lints
+// Build without warnings on nightly 2021-01-17 and later and stable 1.51 and later
+#![allow(unknown_lints)]
+// Disable old lint warnings on nightly until 1.51 is stable
+#![allow(renamed_and_removed_lints)]
+// Use the old lint name to build without warnings on stable until 1.51 is stable
 #![allow(clippy::unknown_clippy_lints)]
+// The actual lints we want to disable
 #![allow(clippy::unnecessary_wraps)]
 
 use displaydoc::Display;

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -2,15 +2,6 @@
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_script")]
-// Disable some broken or unwanted clippy nightly lints
-// Build without warnings on nightly 2021-01-17 and later and stable 1.51 and later
-#![allow(unknown_lints)]
-// Disable old lint warnings on nightly until 1.51 is stable
-#![allow(renamed_and_removed_lints)]
-// Use the old lint name to build without warnings on stable until 1.51 is stable
-#![allow(clippy::unknown_clippy_lints)]
-// The actual lints we want to disable
-#![allow(clippy::unnecessary_wraps)]
 
 use displaydoc::Display;
 #[cfg(windows)]

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -110,11 +110,12 @@ impl Config {
         (path, opts)
     }
 
-    /// Construct a config for an ephemeral in memory database
-    pub fn ephemeral() -> Self {
-        let mut config = Self::default();
-        config.ephemeral = true;
-        config
+    /// Construct a config for an ephemeral database
+    pub fn ephemeral() -> Config {
+        Config {
+            ephemeral: true,
+            ..Config::default()
+        }
     }
 
     /// Calculate the database's share of `open_file_limit`

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -13,7 +13,6 @@
 // Use the old lint name to build without warnings on stable until 1.51 is stable
 #![allow(clippy::unknown_clippy_lints)]
 // The actual lints we want to disable
-#![allow(clippy::field_reassign_with_default)]
 #![allow(clippy::unnecessary_wraps)]
 
 mod config;

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -6,7 +6,13 @@
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
 // Disable some broken or unwanted clippy nightly lints
+// Build without warnings on nightly 2021-01-17 and later and stable 1.51 and later
+#![allow(unknown_lints)]
+// Disable old lint warnings on nightly until 1.51 is stable
+#![allow(renamed_and_removed_lints)]
+// Use the old lint name to build without warnings on stable until 1.51 is stable
 #![allow(clippy::unknown_clippy_lints)]
+// The actual lints we want to disable
 #![allow(clippy::field_reassign_with_default)]
 #![allow(clippy::unnecessary_wraps)]
 

--- a/zebra-test/src/lib.rs
+++ b/zebra-test/src/lib.rs
@@ -1,10 +1,16 @@
 //! Miscellaneous test code for Zebra.
 
-// Disable some broken or unwanted clippy nightly lints
-#![allow(clippy::unknown_clippy_lints)]
-#![allow(clippy::from_iter_instead_of_collect)]
 // Each lazy_static variable uses additional recursion
 #![recursion_limit = "256"]
+// Disable some broken or unwanted clippy nightly lints
+// Build without warnings on nightly 2021-01-17 and later and stable 1.51 and later
+#![allow(unknown_lints)]
+// Disable old lint warnings on nightly until 1.51 is stable
+#![allow(renamed_and_removed_lints)]
+// Use the old lint name to build without warnings on stable until 1.51 is stable
+#![allow(clippy::unknown_clippy_lints)]
+// The actual lints we want to disable
+#![allow(clippy::from_iter_instead_of_collect)]
 
 use color_eyre::section::PanicMessage;
 use owo_colors::OwoColorize;

--- a/zebra-test/src/lib.rs
+++ b/zebra-test/src/lib.rs
@@ -2,15 +2,6 @@
 
 // Each lazy_static variable uses additional recursion
 #![recursion_limit = "256"]
-// Disable some broken or unwanted clippy nightly lints
-// Build without warnings on nightly 2021-01-17 and later and stable 1.51 and later
-#![allow(unknown_lints)]
-// Disable old lint warnings on nightly until 1.51 is stable
-#![allow(renamed_and_removed_lints)]
-// Use the old lint name to build without warnings on stable until 1.51 is stable
-#![allow(clippy::unknown_clippy_lints)]
-// The actual lints we want to disable
-#![allow(clippy::from_iter_instead_of_collect)]
 
 use color_eyre::section::PanicMessage;
 use owo_colors::OwoColorize;

--- a/zebra-test/src/vectors/block.rs
+++ b/zebra-test/src/vectors/block.rs
@@ -3,7 +3,7 @@
 use hex::FromHex;
 use lazy_static::lazy_static;
 
-use std::{collections::BTreeMap, iter::FromIterator};
+use std::collections::BTreeMap;
 
 lazy_static! {
 
@@ -22,8 +22,7 @@ lazy_static! {
     /// Mainnet blocks, indexed by height
     ///
     /// This is actually a bijective map, the tests ensure that values are unique.
-    pub static ref MAINNET_BLOCKS: BTreeMap<u32, &'static [u8]> = BTreeMap::from_iter(
-        [
+    pub static ref MAINNET_BLOCKS: BTreeMap<u32, &'static [u8]> = [
             // Genesis
             (0, BLOCK_MAINNET_GENESIS_BYTES.as_ref()),
             // BeforeOverwinter
@@ -62,14 +61,12 @@ lazy_static! {
             (975_066, BLOCK_MAINNET_975066_BYTES.as_ref()),
             (982_681, BLOCK_MAINNET_982681_BYTES.as_ref()),
             // TODO: Canopy and First Halving, see #1099
-        ].iter().cloned()
-    );
+        ].iter().cloned().collect();
 
     /// Testnet blocks, indexed by height
     ///
     /// This is actually a bijective map, the tests ensure that values are unique.
-    pub static ref TESTNET_BLOCKS: BTreeMap<u32, &'static [u8]> = BTreeMap::from_iter(
-        [
+    pub static ref TESTNET_BLOCKS: BTreeMap<u32, &'static [u8]> = [
             // Genesis
             (0, BLOCK_TESTNET_GENESIS_BYTES.as_ref()),
             // BeforeOverwinter
@@ -120,8 +117,7 @@ lazy_static! {
             // Shielded coinbase
             (1_101_629, BLOCK_TESTNET_1101629_BYTES.as_ref()),
             // TODO: First Halving, see #1104
-        ].iter().cloned()
-    );
+        ].iter().cloned().collect();
 
     // Mainnet
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -39,11 +39,16 @@ use zebrad::config::ZebradConfig;
 const LAUNCH_DELAY: Duration = Duration::from_secs(3);
 
 fn default_test_config() -> Result<ZebradConfig> {
-    let mut config = ZebradConfig::default();
-    config.state = zebra_state::Config::ephemeral();
-    config.network.listen_addr = "127.0.0.1:0".parse()?;
-
-    Ok(config)
+    let auto_port_ipv4_local = zebra_network::Config {
+        listen_addr: "127.0.0.1:0".parse()?,
+        ..zebra_network::Config::default()
+    };
+    let local_ephemeral = ZebradConfig {
+        state: zebra_state::Config::ephemeral(),
+        network: auto_port_ipv4_local,
+        ..ZebradConfig::default()
+    };
+    Ok(local_ephemeral)
 }
 
 fn persistent_test_config() -> Result<ZebradConfig> {

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -15,15 +15,6 @@
 #![forbid(unsafe_code)]
 #![allow(dead_code)]
 #![allow(clippy::try_err)]
-// Disable some broken or unwanted clippy nightly lints
-// Build without warnings on nightly 2021-01-17 and later and stable 1.51 and later
-#![allow(unknown_lints)]
-// Disable old lint warnings on nightly until 1.51 is stable
-#![allow(renamed_and_removed_lints)]
-// Use the old lint name to build without warnings on stable until 1.51 is stable
-#![allow(clippy::unknown_clippy_lints)]
-// The actual lints we want to disable
-#![allow(clippy::field_reassign_with_default)]
 
 use color_eyre::eyre::Result;
 use eyre::WrapErr;

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -16,7 +16,13 @@
 #![allow(dead_code)]
 #![allow(clippy::try_err)]
 // Disable some broken or unwanted clippy nightly lints
+// Build without warnings on nightly 2021-01-17 and later and stable 1.51 and later
+#![allow(unknown_lints)]
+// Disable old lint warnings on nightly until 1.51 is stable
+#![allow(renamed_and_removed_lints)]
+// Use the old lint name to build without warnings on stable until 1.51 is stable
 #![allow(clippy::unknown_clippy_lints)]
+// The actual lints we want to disable
 #![allow(clippy::field_reassign_with_default)]
 
 use color_eyre::eyre::Result;


### PR DESCRIPTION
## Motivation

The clippy unknown lints attribute was deprecated in nightly in rust-lang/rust#80524. The old lint name now produces a warning.

## Solution

Eliminate as many lints as possible, then configure retained lints to avoid warnings on nightly and stable. That's a bit tricky, at least for the transition period.

### Retained Lints

1. Since we're using `allow(unknown_lints)` to suppress warnings, we need to add the canonical name, so we can continue to build without warnings on nightly.

2. But we also need to keep the old name, so we can continue to build without warnings on stable.

3. And therefore, we also need to disable the "removed lints" warning, otherwise we'll get warnings about the old name on nightly.

We'll need to keep this transitional clippy config from nightly 2021-01-17 until rustc 1.51 is stable.

## Review

This change is a low priority, unless your workflow depends on building without warnings on nightly.

## Related Issues

rust-lang/rust#80524 - the deprecation PR