### PR TITLE
Add responsible-disclosure.md

### DIFF
--- a/responsible_disclosure.md
+++ b/responsible_disclosure.md
@@ -30,5 +30,3 @@ Zcash is a technology that provides strong privacy. Notes are encrypted to their
 The standard describes reporters of vulnerabilities including full details of an issue, in order to reproduce it. This is necessary for instance in the case of an external researcher both demonstrating and proving that there really is a security issue, and that security issue really has the impact that they say it has - allowing the development team to accurately prioritize and resolve the issue.
 
 In the case of a counterfeiting bug, however, just like in CVE-2019-7167, we might decide not to include those details with our reports to partners ahead of coordinated release, so long as we are sure that they are vulnerable.
-
-

--- a/responsible_disclosure.md
+++ b/responsible_disclosure.md
@@ -1,0 +1,34 @@
+This page is copyright Zcash Foundation, 2021. It is posted in order to conform to this standard: https://github.com/RD-Crypto-Spec/Responsible-Disclosure/tree/d47a5a3dafa5942c8849a93441745fdd186731e6
+
+# Security Disclosures
+## Receiving Disclosures
+
+The Zcash Foundation is committed to working with researchers who submit security vulnerability notifications to us to resolve those issues on an appropriate timeline and perform a coordinated release, giving credit to the reporter if they would like.
+
+Please submit issues to security@zfnd.org, using the following PGP key:
+
+<TODO: generate, multiple backup>
+
+## Sending Disclosures
+
+In the case where we become aware of security issues affecting other projects that has never affected Zebra or Zcash, our intention is to inform those projects of security issues on a best effort basis.
+
+In the case where we fix a security issue in Zebra or Zcash that also affects the following neighboring projects, our intention is to engage in responsible disclosures with them as described in https://github.com/RD-Crypto-Spec/Responsible-Disclosure, subject to the deviations described in the section at the bottom of this document.
+
+## Bilateral Responsible Disclosure Agreements
+
+We have set up agreements with the following neighboring projects to share vulnerability information, subject to the deviations described in the next section.
+
+Specifically, we have agreed to engage in responsible disclosures for security issues affecting Zebra or Zcash technology with the following contacts:
+
+- The Electric Coin Company - security@z.cash via PGP
+
+## Deviations from the Standard
+
+Zcash is a technology that provides strong privacy. Notes are encrypted to their destination, and then the monetary base is kept via zero-knowledge proofs intended to only be creatable by the real holder of Zcash. If this fails, and a counterfeiting bug results, that counterfeiting bug might be exploited without any way for blockchain analyzers to identify the perpetrator or which data in the blockchain has been used to exploit the bug. Rollbacks before that point, such as have been executed in some other projects in such cases, are therefore impossible.
+
+The standard describes reporters of vulnerabilities including full details of an issue, in order to reproduce it. This is necessary for instance in the case of an external researcher both demonstrating and proving that there really is a security issue, and that security issue really has the impact that they say it has - allowing the development team to accurately prioritize and resolve the issue.
+
+In the case of a counterfeiting bug, however, just like in CVE-2019-7167, we might decide not to include those details with our reports to partners ahead of coordinated release, so long as we are sure that they are vulnerable.
+
+

--- a/responsible_disclosure.md
+++ b/responsible_disclosure.md
@@ -5,9 +5,7 @@ This page is copyright Zcash Foundation, 2021. It is posted in order to conform 
 
 The Zcash Foundation is committed to working with researchers who submit security vulnerability notifications to us to resolve those issues on an appropriate timeline and perform a coordinated release, giving credit to the reporter if they would like.
 
-Please submit issues to security@zfnd.org, using the following PGP key:
-
-<TODO: generate, multiple backup>
+Please submit issues to security@zfnd.org.
 
 ## Sending Disclosures
 

--- a/responsible_disclosure.md
+++ b/responsible_disclosure.md
@@ -29,4 +29,4 @@ Zcash is a technology that provides strong privacy. Notes are encrypted to their
 
 The standard describes reporters of vulnerabilities including full details of an issue, in order to reproduce it. This is necessary for instance in the case of an external researcher both demonstrating and proving that there really is a security issue, and that security issue really has the impact that they say it has - allowing the development team to accurately prioritize and resolve the issue.
 
-In the case of a counterfeiting bug, however, just like in CVE-2019-7167, we might decide not to include those details with our reports to partners ahead of coordinated release, so long as we are sure that they are vulnerable.
+In the case of a counterfeiting bug, we might decide not to include those details with our reports to partners ahead of coordinated release, so long as we are sure that they are vulnerable.


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

Publicly commit to our security disclosure policy.

## Solution

Add a responsible-disclosure.md that lists our bilateral disclosure agreement with the ECC and soon our public PGP key for reporting security issues to us.

## Review

Not super urgent; @teor2345 has been part of this discussion.

## Related Issues

#1489

## Follow-on work

https://github.com/ZcashFoundation/zebra/issues/1638

