### PR TITLE
Fix clippy Ok and Vec::push lints

### DIFF
--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -393,8 +393,7 @@ fn founders_reward_validation_failure() -> Result<(), Report> {
         .unwrap();
 
     // Build new block
-    let mut transactions: Vec<Arc<zebra_chain::transaction::Transaction>> = Vec::new();
-    transactions.push(Arc::new(tx));
+    let transactions: Vec<Arc<zebra_chain::transaction::Transaction>> = vec![Arc::new(tx)];
     let block = Block {
         header: block.header,
         transactions,

--- a/zebra-consensus/src/checkpoint/list.rs
+++ b/zebra-consensus/src/checkpoint/list.rs
@@ -55,7 +55,7 @@ impl FromStr for CheckpointList {
             };
         }
 
-        Ok(CheckpointList::from_list(checkpoint_list)?)
+        CheckpointList::from_list(checkpoint_list)
     }
 }
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -783,7 +783,7 @@ fn sync_until(
         // This message is captured by the test runner, use
         // `cargo test -- --nocapture` to see it.
         eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
-        return Ok(testdir()?);
+        return testdir();
     }
 
     // Use a persistent state, so we can handle large syncs

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -122,14 +122,13 @@ where
         let default_config_path = path.join("zebrad.toml");
 
         if default_config_path.exists() {
-            let mut extra_args: Vec<_> = Vec::new();
-            extra_args.push("-c");
-            extra_args.push(
+            let mut extra_args: Vec<_> = vec![
+                "-c",
                 default_config_path
                     .as_path()
                     .to_str()
                     .expect("Path is valid Unicode"),
-            );
+            ];
             extra_args.extend_from_slice(args);
             self.spawn_child_with_command(env!("CARGO_BIN_EXE_zebrad"), &extra_args)
         } else {


### PR DESCRIPTION
## Motivation

Nightly clippy has some new lints for:
* Ok/?
* Vec::push()

## Solution

Fix those lints to avoid warnings.

## Review

Anyone can review, this is not urgent at all.
(Unless you use warning-free builds in your workflow.)