### PR TITLE
Fix poll_ready usage for the Inbound service

### DIFF
--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -873,6 +873,7 @@ where
 
         if self.svc.ready_and().await.is_err() {
             // Treat all service readiness errors as Overloaded
+            // TODO: treat `TryRecvError::Closed` in `Inbound::poll_ready` as a fatal error (#1655)
             self.fail_with(PeerError::Overloaded);
             return;
         }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -530,13 +530,6 @@ impl Service<Request> for StateService {
     type Future =
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
-    // ## Correctness:
-    //
-    // This function must not return Poll::Pending, unless:
-    // 1. We remove all instances of `call_all` on the state service, or fix the leaked
-    //    service reservation in the `CallAll` implementation:
-    //    https://github.com/tower-rs/tower/blob/master/tower/src/util/call_all/common.rs#L112
-    // 2. We schedule the current task for wakeup via the `Context`
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let now = Instant::now();
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -530,6 +530,13 @@ impl Service<Request> for StateService {
     type Future =
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
+    // ## Correctness:
+    //
+    // This function must not return Poll::Pending, unless:
+    // 1. We remove all instances of `call_all` on the state service, or fix the leaked
+    //    service reservation in the `CallAll` implementation:
+    //    https://github.com/tower-rs/tower/blob/master/tower/src/util/call_all/common.rs#L112
+    // 2. We schedule the current task for wakeup via the `Context`
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let now = Instant::now();
 

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -1,6 +1,5 @@
 use std::{
     future::Future,
-    mem,
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll},
@@ -10,7 +9,6 @@ use futures::{
     future::{FutureExt, TryFutureExt},
     stream::Stream,
 };
-use mem::swap;
 use oneshot::error::TryRecvError;
 use tokio::sync::oneshot;
 use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, Service, ServiceExt};

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -183,8 +183,8 @@ impl Service<zn::Request> for Inbound {
                     Setup::FailedRecv { error }
                 }
             },
-            // Make sure we left the network setup in a valid state
-            Setup::FailedInit => unreachable!("incomplete Inbound initialization"),
+            // Make sure previous network setups were left in a valid state
+            Setup::FailedInit => unreachable!("incomplete previous Inbound initialization"),
             // If network setup failed, report service failure
             Setup::FailedRecv { error } => {
                 result = Err(error.clone().into());
@@ -202,6 +202,11 @@ impl Service<zn::Request> for Inbound {
                 }
             }
         };
+
+        // Make sure we're leaving the network setup in a valid state
+        if matches!(self.network_setup, Setup::FailedInit) {
+            unreachable!("incomplete Inbound initialization after poll_ready state handling");
+        }
 
         // TODO:
         //  * do we want to propagate backpressure from the download queue or its outbound network?


### PR DESCRIPTION
## Motivation

The `Inbound` service misuses `poll_ready`, filling up buffers, and potentially causing hangs.

See #1593 for a general explanation.

## Solution

Make sure each `poll_ready` is followed by a `call`:
* Use the `ServiceExt::oneshot` pattern from #1593
* Document that `ServiceExt::call_all` uses `poll_ready` internally
* Document a state service `poll_ready` constraint due to a bug in `ServiceExt::call_all`

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Manual Testing

## Review

@yaahc and @oxarbitrage might want to look at this PR to see some `poll_ready` example code.

## Related Issues

Solves some of the hangs from #1435 

## Follow Up Work

Do the rest of #1593 
