### PR TITLE
Limit inbound download and verify queue

### DIFF
--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -36,9 +36,10 @@ const FANOUT: usize = 4;
 /// retries may be concurrent, inner retries are sequential.
 const BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 2;
 
-/// A lower bound on the user-specified lookahead limit, set to two
-/// checkpoint intervals so that we're sure that the lookahead limit
-/// always contains at least one complete checkpoint interval.
+/// A lower bound on the user-specified lookahead limit.
+///
+/// Set to two checkpoint intervals, so that we're sure that the lookahead
+/// limit always contains at least one complete checkpoint.
 const MIN_LOOKAHEAD_LIMIT: usize = zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP * 2;
 
 /// Controls how long we wait for a tips response to return.


### PR DESCRIPTION
## Motivation

The `Inbound` service's `Downloads` queue can grow without limit.

See #1618 for some general background.

## Solution

Drop new requests when the Inbound downloads queue reaches a fixed limit.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Manual Tests
    - I tested it on mainnet and testnet over the weekend, and it seemed to have a similar pattern of running well, but eventually hanging (due to a known issue #1435)
    - The new warning did not appear in the logs on mainnet or testnet

## Review

This change is a lower priority than #1620, so I'm not going to tag anyone for review.

## Follow Up Work

Do the rest of #1618.
