### PR TITLE
Explain why we stay connected on Inbound errors

### DIFF
--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -884,7 +884,10 @@ where
                     metrics::counter!("pool.closed.loadshed", 1);
                     self.fail_with(PeerError::Overloaded);
                 } else {
-                    // We could send a reject to the remote peer.
+                    // We could send a reject to the remote peer, but that might cause
+                    // them to disconnect, and we might be using them to sync blocks.
+                    // For similar reasons, we don't want to fail_with() here - we
+                    // only close the connection if the peer is doing something wrong.
                     error!(%e,
                            connection_state = ?self.state,
                            client_receiver = ?self.client_rx,


### PR DESCRIPTION
## Motivation

There is a single connection error case where we don't close the peer connection, without any documentation for this special case.

## Solution

Add a comment:

We might be syncing using this peer, so it's ok to just ignore any internal errors in their Inbound requests, and drop the request.

## Review

This review is less urgent than the hang fixes, so I'm not tagging anyone.

## Related Issues

Found when implementing #1620
