### PR TITLE
Move BoxError to zebrad's lib.rs

### DIFF
--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -18,7 +18,7 @@ use zebra_chain::{
 use zebra_network as zn;
 use zebra_state as zs;
 
-use crate::config::ZebradConfig;
+use crate::{config::ZebradConfig, BoxError};
 
 mod downloads;
 use downloads::{AlwaysHedge, Downloads};
@@ -113,8 +113,6 @@ pub(super) const BLOCK_VERIFY_TIMEOUT: Duration = Duration::from_secs(180);
 /// sometimes get stuck in a failure loop, due to leftover downloads from
 /// previous sync runs.
 const SYNC_RESTART_DELAY: Duration = Duration::from_secs(61);
-
-type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// Helps work around defects in the bitcoin protocol by checking whether
 /// the returned hashes actually extend a chain tip.

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -26,6 +26,13 @@
 #[macro_use]
 extern crate tracing;
 
+/// Error type alias to make working with tower traits easier.
+///
+/// Note: the 'static lifetime bound means that the *type* cannot have any
+/// non-'static lifetimes, (e.g., when a type contains a borrow and is
+/// parameterized by 'a), *not* that the object itself has 'static lifetime.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
 mod components;
 
 pub mod application;


### PR DESCRIPTION
## Motivation

Move `zebrad`'s `BoxError` type alias to `lib.rs`, for consistency with other crates.

## Review

I haven't tagged anyone, because this review is not urgent.

## Related Issues

Found during #1620.