### PR TITLE
Fix shutdown panics

### DIFF
--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -28,6 +28,7 @@ pub mod parameters;
 pub mod primitives;
 pub mod sapling;
 pub mod serialization;
+pub mod shutdown;
 pub mod sprout;
 pub mod transaction;
 pub mod transparent;

--- a/zebra-chain/src/shutdown.rs
+++ b/zebra-chain/src/shutdown.rs
@@ -3,7 +3,7 @@
 //! A global flag indicates when the application is shutting down so actions can be taken
 //! at different parts of the codebase.
 
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// A flag to indicate if zebrad is shutting down.
 pub static IS_SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
@@ -12,7 +12,6 @@ pub static IS_SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
 ///
 /// Returns false otherwise.
 pub fn is_shutting_down() -> bool {
-    use std::sync::atomic::Ordering;
     // ## Correctness:
     //
     // Since we're shutting down, and this is a one-time operation,
@@ -20,4 +19,8 @@ pub fn is_shutting_down() -> bool {
     // ordering.
     // https://doc.rust-lang.org/nomicon/atomics.html#sequentially-consistent
     IS_SHUTTING_DOWN.load(Ordering::SeqCst)
+}
+
+pub fn set_shutting_down() {
+    IS_SHUTTING_DOWN.store(true, Ordering::SeqCst);
 }

--- a/zebra-chain/src/shutdown.rs
+++ b/zebra-chain/src/shutdown.rs
@@ -5,7 +5,9 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-/// A flag to indicate if zebrad is shutting down.
+/// A flag to indicate if Zebra is shutting down.
+///
+/// Initialized to `false` at startup.
 pub static IS_SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
 
 /// Returns true if the application is shutting down.
@@ -21,6 +23,7 @@ pub fn is_shutting_down() -> bool {
     IS_SHUTTING_DOWN.load(Ordering::SeqCst)
 }
 
+/// Sets the Zebra shutdown flag to `true`.
 pub fn set_shutting_down() {
     IS_SHUTTING_DOWN.store(true, Ordering::SeqCst);
 }

--- a/zebra-chain/src/shutdown.rs
+++ b/zebra-chain/src/shutdown.rs
@@ -7,3 +7,17 @@ use std::sync::atomic::AtomicBool;
 
 /// A flag to indicate if zebrad is shutting down.
 pub static IS_SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
+
+/// Returns true if the application is shutting down.
+///
+/// Returns false otherwise.
+pub fn is_shutting_down() -> bool {
+    use std::sync::atomic::Ordering;
+    // ## Correctness:
+    //
+    // Since we're shutting down, and this is a one-time operation,
+    // performance is not important. So we use the strongest memory
+    // ordering.
+    // https://doc.rust-lang.org/nomicon/atomics.html#sequentially-consistent
+    IS_SHUTTING_DOWN.load(Ordering::SeqCst)
+}

--- a/zebra-chain/src/shutdown.rs
+++ b/zebra-chain/src/shutdown.rs
@@ -1,0 +1,9 @@
+//! Shutdown related code.
+//!
+//! A global flag indicates when the application is shutting down so actions can be taken
+//! at different parts of the codebase.
+
+use std::sync::atomic::AtomicBool;
+
+/// A flag to indicate if zebrad is shutting down.
+pub static IS_SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -905,9 +905,12 @@ where
         });
 
         async move {
-            commit_finalized_block
-                .await
-                .expect("commit_finalized_block should not panic")
+            let fut = commit_finalized_block.await;
+            if zebra_chain::shutdown::is_shutting_down() {
+                Err(VerifyCheckpointError::Finished)
+            } else {
+                fut.expect("commit_finalized_block should not panic")
+            }
         }
         .boxed()
     }

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -793,7 +793,7 @@ where
 
 #[derive(Debug, Error)]
 pub enum VerifyCheckpointError {
-    #[error("checkpoint request after checkpointing finished")]
+    #[error("checkpoint request after the final checkpoint has been verified")]
     Finished,
     #[error("block at {height:?} is higher than the maximum checkpoint {max_height:?}")]
     TooHigh {
@@ -832,6 +832,8 @@ pub enum VerifyCheckpointError {
         expected: block::Hash,
         found: block::Hash,
     },
+    #[error("zebra is shutting down")]
+    ShuttingDown,
 }
 
 /// The CheckpointVerifier service implementation.
@@ -907,7 +909,7 @@ where
         async move {
             let result = commit_finalized_block.await;
             if zebra_chain::shutdown::is_shutting_down() {
-                Err(VerifyCheckpointError::Finished)
+                Err(VerifyCheckpointError::ShuttingDown)
             } else {
                 result.expect("commit_finalized_block should not panic")
             }

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -908,6 +908,13 @@ where
 
         async move {
             let result = commit_finalized_block.await;
+            // Avoid a panic on shutdown
+            //
+            // When `zebrad` is terminated using Ctrl-C, the `commit_finalized_block` task
+            // can return a `JoinError::Cancelled`. We expect task cancellation on shutdown,
+            // so we don't need to panic here. The persistent state is correct even when the
+            // task is cancelled, because block data is committed inside transactions, in
+            // height order.
             if zebra_chain::shutdown::is_shutting_down() {
                 Err(VerifyCheckpointError::ShuttingDown)
             } else {

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -905,11 +905,11 @@ where
         });
 
         async move {
-            let fut = commit_finalized_block.await;
+            let result = commit_finalized_block.await;
             if zebra_chain::shutdown::is_shutting_down() {
                 Err(VerifyCheckpointError::Finished)
             } else {
-                fut.expect("commit_finalized_block should not panic")
+                result.expect("commit_finalized_block should not panic")
             }
         }
         .boxed()

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -91,4 +91,4 @@ pub mod types {
 
 use std::sync::atomic::AtomicBool;
 /// A flag to indicate if zebrad is shutting down.
-pub static IS_SHUTDOWN: AtomicBool = AtomicBool::new(false);
+pub static IS_SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -88,3 +88,7 @@ pub use crate::{
 pub mod types {
     pub use crate::{meta_addr::MetaAddr, protocol::types::PeerServices};
 }
+
+use std::sync::atomic::AtomicBool;
+/// A flag to indicate if zebrad is shutting down.
+pub static IS_SHUTDOWN: AtomicBool = AtomicBool::new(false);

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -88,7 +88,3 @@ pub use crate::{
 pub mod types {
     pub use crate::{meta_addr::MetaAddr, protocol::types::PeerServices};
 }
-
-use std::sync::atomic::AtomicBool;
-/// A flag to indicate if zebrad is shutting down.
-pub static IS_SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -168,14 +168,6 @@ impl<T: std::fmt::Debug> MustUseOneshotSender<T> {
             .unwrap_or_else(
                 || panic!("called is_canceled() after using oneshot sender: oneshot must be used exactly once: {:?}", self))
     }
-
-    /// Returns true if the application is shutting down.
-    ///
-    /// Returns false otherwise.
-    pub fn is_shutting_down(&self) -> bool {
-        use std::sync::atomic::Ordering;
-        zebra_chain::shutdown::IS_SHUTTING_DOWN.load(Ordering::Relaxed)
-    }
 }
 
 impl<T: std::fmt::Debug> From<oneshot::Sender<T>> for MustUseOneshotSender<T> {
@@ -188,7 +180,7 @@ impl<T: std::fmt::Debug> Drop for MustUseOneshotSender<T> {
     #[instrument(skip(self))]
     fn drop(&mut self) {
         // we don't panic if we are shutting down anyway
-        if !self.is_shutting_down() {
+        if !zebra_chain::shutdown::is_shutting_down() {
             // is_canceled() will not panic, because we check is_none() first
             assert!(
                 self.tx.is_none() || self.is_canceled(),

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -168,6 +168,14 @@ impl<T: std::fmt::Debug> MustUseOneshotSender<T> {
             .unwrap_or_else(
                 || panic!("called is_canceled() after using oneshot sender: oneshot must be used exactly once: {:?}", self))
     }
+
+    /// Returns true if the application is shutting down.
+    ///
+    /// Returns false otherwise.
+    pub fn is_shutdown(&self) -> bool {
+        use std::sync::atomic::Ordering;
+        crate::IS_SHUTDOWN.load(Ordering::Relaxed)
+    }
 }
 
 impl<T: std::fmt::Debug> From<oneshot::Sender<T>> for MustUseOneshotSender<T> {
@@ -179,12 +187,15 @@ impl<T: std::fmt::Debug> From<oneshot::Sender<T>> for MustUseOneshotSender<T> {
 impl<T: std::fmt::Debug> Drop for MustUseOneshotSender<T> {
     #[instrument(skip(self))]
     fn drop(&mut self) {
-        // is_canceled() will not panic, because we check is_none() first
-        assert!(
-            self.tx.is_none() || self.is_canceled(),
-            "unused oneshot sender: oneshot must be used or canceled: {:?}",
-            self
-        );
+        // we don't evaluate if we are shutting down
+        if !self.is_shutdown() {
+            // is_canceled() will not panic, because we check is_none() first
+            assert!(
+                self.tx.is_none() || self.is_canceled(),
+                "unused oneshot sender: oneshot must be used or canceled: {:?}",
+                self
+            );
+        }
     }
 }
 

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -174,7 +174,7 @@ impl<T: std::fmt::Debug> MustUseOneshotSender<T> {
     /// Returns false otherwise.
     pub fn is_shutting_down(&self) -> bool {
         use std::sync::atomic::Ordering;
-        crate::IS_SHUTTING_DOWN.load(Ordering::Relaxed)
+        zebra_chain::shutdown::IS_SHUTTING_DOWN.load(Ordering::Relaxed)
     }
 }
 

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -172,9 +172,9 @@ impl<T: std::fmt::Debug> MustUseOneshotSender<T> {
     /// Returns true if the application is shutting down.
     ///
     /// Returns false otherwise.
-    pub fn is_shutdown(&self) -> bool {
+    pub fn is_shutting_down(&self) -> bool {
         use std::sync::atomic::Ordering;
-        crate::IS_SHUTDOWN.load(Ordering::Relaxed)
+        crate::IS_SHUTTING_DOWN.load(Ordering::Relaxed)
     }
 }
 
@@ -187,8 +187,8 @@ impl<T: std::fmt::Debug> From<oneshot::Sender<T>> for MustUseOneshotSender<T> {
 impl<T: std::fmt::Debug> Drop for MustUseOneshotSender<T> {
     #[instrument(skip(self))]
     fn drop(&mut self) {
-        // we don't evaluate if we are shutting down
-        if !self.is_shutdown() {
+        // we don't panic if we are shutting down anyway
+        if !self.is_shutting_down() {
             // is_canceled() will not panic, because we check is_none() first
             assert!(
                 self.tx.is_none() || self.is_canceled(),

--- a/zebrad/src/components/tokio.rs
+++ b/zebrad/src/components/tokio.rs
@@ -34,7 +34,7 @@ impl TokioComponent {
 /// Zebrad's graceful shutdown function, blocks until one of the supported
 /// shutdown signals is received.
 async fn shutdown() {
-    zebra_network::IS_SHUTTING_DOWN.store(true, Ordering::Relaxed);
+    zebra_chain::shutdown::IS_SHUTTING_DOWN.store(true, Ordering::Relaxed);
     imp::shutdown().await;
 }
 

--- a/zebrad/src/components/tokio.rs
+++ b/zebrad/src/components/tokio.rs
@@ -3,7 +3,7 @@
 use crate::prelude::*;
 use abscissa_core::{Application, Component, FrameworkError, Shutdown};
 use color_eyre::Report;
-use std::future::Future;
+use std::{future::Future, sync::atomic::Ordering};
 use tokio::runtime::Runtime;
 
 /// An Abscissa component which owns a Tokio runtime.
@@ -34,6 +34,7 @@ impl TokioComponent {
 /// Zebrad's graceful shutdown function, blocks until one of the supported
 /// shutdown signals is received.
 async fn shutdown() {
+    zebra_network::IS_SHUTDOWN.store(true, Ordering::Relaxed);
     imp::shutdown().await;
 }
 

--- a/zebrad/src/components/tokio.rs
+++ b/zebrad/src/components/tokio.rs
@@ -34,7 +34,7 @@ impl TokioComponent {
 /// Zebrad's graceful shutdown function, blocks until one of the supported
 /// shutdown signals is received.
 async fn shutdown() {
-    zebra_network::IS_SHUTDOWN.store(true, Ordering::Relaxed);
+    zebra_network::IS_SHUTTING_DOWN.store(true, Ordering::Relaxed);
     imp::shutdown().await;
 }
 


### PR DESCRIPTION
## Motivation

Attempt to fix panics on shutdown. If merged it will close https://github.com/ZcashFoundation/zebra/issues/1574 and close https://github.com/ZcashFoundation/zebra/issues/1576

## Solution

Added a shutdown flag so the check can be skipped when shutting down and the panics avoided.

## Tasks

- [x] Move all the new code into a `zebra_chain::shutdown` module
- [x] Document why we use the `SeqCst` memory ordering at the top of that module: https://github.com/ZcashFoundation/zebra/pull/1637/files#r565944454
- [x] Bug fix: set `IS_SHUTTING_DOWN` to true after shutdown has started, rather than at startup
- [x] Refactor: set `IS_SHUTTING_DOWN` to true in a new function, rather than copying and pasting the code in multiple places
- [x] Add fix for panic in #1576
- [x] Minor fixes for the checkpoint verifier panic
- [x] Change the description of `VerifyCheckpointError::Finished` to `checkpoint request after the final checkpoint has been verified`

### Optional Tasks

- add a small unit test that checks that IS_SHUTTING_DOWN is false: (#1666)
  - at the start of the test, and
  - after you've spawned a `shutdown()` task using `spawn_blocking` 

We don't need to check that `IS_SHUTTING_DOWN` becomes true - we'll notice the panics if that part of the code ever breaks.

## Follow Up

Restart tests #1666
Panic hook refactor #1677 
Graceful shutdown redesign #1678