### PR TITLE
CI cleanup - remove isolated tracking_endpoint test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,6 @@ jobs:
         with:
           command: test
           args: --verbose --manifest-path zebrad/Cargo.toml sync_large_checkpoints_ -- --ignored
-      - name: Run zebrad tracing test
-        env:
-          RUST_BACKTRACE: full
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --manifest-path zebrad/Cargo.toml tracing_endpoint -- --ignored
 
   build-chain-no-features:
     name: Build zebra-chain w/o features on ubuntu-latest


### PR DESCRIPTION
## Motivation

To close https://github.com/ZcashFoundation/zebra/issues/1630

## Solution

Remove the duplicated test from the CI.

## Review

Anyone can review, this a low priority PR.

## Related Issues

https://github.com/ZcashFoundation/zebra/issues/1630