### PR TITLE
Bump versions for zebrad 1.0.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 dependencies = [
  "bech32",
  "bincode",
@@ -3901,7 +3901,7 @@ version = "1.0.0-alpha.0"
 
 [[package]]
 name = "zebra-consensus"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 dependencies = [
  "chrono",
  "color-eyre",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -3964,7 +3964,7 @@ version = "1.0.0-alpha.0"
 
 [[package]]
 name = "zebra-script"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "displaydoc",
  "hex",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 dependencies = [
  "chrono",
  "color-eyre",
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-test"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 dependencies = [
  "color-eyre",
  "futures",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 dependencies = [
  "color-eyre",
  "hex",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/README.md
+++ b/README.md
@@ -129,10 +129,6 @@ Zebra primarily depends on pure Rust crates, and some Rust/C++ crates:
 
 There are a few bugs in the Zebra alpha release that we're still working on
 fixing:
-- [Occasional panics in the `tokio` time wheel implementation #1452](https://github.com/ZcashFoundation/zebra/issues/1452)
-  - workaround: restart `zebrad`
-- [Occasional panics during client requests #1471](https://github.com/ZcashFoundation/zebra/issues/1471)
-  - workaround: restart `zebrad`
 - [Peer connections sometimes fail permanently #1435](https://github.com/ZcashFoundation/zebra/issues/1435)
   - these permanent failures can happen after a network disconnection, sleep, or individual peer disconnections
   - workaround: use `Control-C` to exit `zebrad`, and then restart `zebrad`

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Building `zebrad` requires [Rust](https://www.rust-lang.org/tools/install),
 2. Install Zebra's build dependencies:
      - **libclang:** the `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` packages, depending on your package manager
      - **clang** or another C++ compiler: `g++`, `Xcode`, or `MSVC`
-3. Run `cargo install --locked --git https://github.com/ZcashFoundation/zebra --tag v1.0.0-alpha.0 zebrad`
+3. Run `cargo install --locked --git https://github.com/ZcashFoundation/zebra --tag v1.0.0-alpha.1 zebrad`
 4. Run `zebrad start`
 
 If you're interested in testing out `zebrad` please feel free, but keep in mind

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ like to find out more or get involved!
 
 ## Alpha Releases
 
-Our first alpha release is planned for December 8th, 2020.
+Every few weeks, we release a new Zebra alpha release.
 
-The goals of this release are to:
+The goals of the alpha release series are to:
 - participate in the Zcash network,
 - replicate the Zcash chain state,
 - implement the Zcash proof of work consensus rules, and
@@ -127,8 +127,7 @@ Zebra primarily depends on pure Rust crates, and some Rust/C++ crates:
 
 ### Known Issues
 
-There are a few bugs in the Zebra alpha release that we're still working on
-fixing:
+There are a few bugs in Zebra that we're still working on fixing:
 - [Peer connections sometimes fail permanently #1435](https://github.com/ZcashFoundation/zebra/issues/1435)
   - these permanent failures can happen after a network disconnection, sleep, or individual peer disconnections
   - workaround: use `Control-C` to exit `zebrad`, and then restart `zebrad`
@@ -137,9 +136,9 @@ fixing:
 
 ## Future Work
 
-In 2021, we intend to add RPC support and wallet integration.  This phased
-approach allows us to test Zebra's independent implementation of the consensus
-rules, before asking users to entrust it with their funds.
+In 2021, we intend to finish validation, add RPC support, and add wallet integration.
+This phased approach allows us to test Zebra's independent implementation of the
+consensus rules, before asking users to entrust it with their funds.
 
 Features:
 - full consensus rule validation

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -58,7 +58,7 @@ pub const TIMESTAMP_TRUNCATION_SECONDS: i64 = 30 * 60;
 ///
 /// [BIP 14]: https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki
 // XXX can we generate this from crate metadata?
-pub const USER_AGENT: &str = "/🦓Zebra🦓:1.0.0-alpha.0/";
+pub const USER_AGENT: &str = "/🦓Zebra🦓:1.0.0-alpha.1/";
 
 /// The Zcash network protocol version implemented by this crate, and advertised
 /// during connection setup.

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-test"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zebra-utils"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 edition = "2018"
 # Prevent accidental publication of this utility crate.
 publish = false

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zebrad"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 edition = "2018"
 repository = "https://github.com/ZcashFoundation/zebra"
 # make `cargo run` use `zebrad` by default

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -77,7 +77,7 @@ impl<A: abscissa_core::Application> Component<A> for Tracing {
     }
 
     fn version(&self) -> abscissa_core::Version {
-        abscissa_core::Version::parse("1.0.0-alpha.0").unwrap()
+        abscissa_core::Version::parse("1.0.0-alpha.1").unwrap()
     }
 
     fn before_shutdown(&self, _kind: Shutdown) -> Result<(), FrameworkError> {


### PR DESCRIPTION
Tag message when this is merged:

```
Zebra's second alpha brings multiple reliability and stability improvements for long-running syncs.
We've resolved known panics during syncing, and reduced the number of sync hangs.

Some notable changes include:

Added:
- Add peer set tracing (#1468)
- Add Sentry support behind a feature flag (#1461)
- Log configured network in every log message (#1568)

Changed:
- Export new precompute api in zebra-script (#1493)
- Rewrite peer block request hander to match the zcashd implementation (#1518)

Fixed:
- Avoid panics when there are multiple failures on the same connection (#1600)
- Add sync and inbound timeouts to prevent hangs (#1586) 
- Fix Zebra versions so all crates are on the 1.0.0-alpha series (#1488)
- Make `cargo run` use `zebrad` rather than failing (#1569)
- Panic if the lookahead limit is misconfigured (#1589)
- Recommend using --locked with `cargo install` (#1490)
- Simplify C++ compiler dependency in the README (#1498)
- Stop failing acceptance tests if their directories already exist (#1588)
- Stop panicking when ClientRequests return an error (#1531)
- Upgrade to tokio 0.3.6 to avoid a time wheel panic (#1583, #1511)

Currently, Zebra does not validate all the Zcash consensus rules.
```