### PR TITLE
Temporarily make CI test builds very verbose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --all
+          args: --verbose --verbose --all
       # Explicitly run any tests that are usually #[ignored], modulo ZEBRA_SKIP_NETWORK_TESTS
       - name: Run zebrad large sync tests
         env:
@@ -45,7 +45,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --manifest-path zebrad/Cargo.toml sync_large_checkpoints_ -- --ignored
+          args: --verbose --verbose --manifest-path zebrad/Cargo.toml sync_large_checkpoints_ -- --ignored
 
   build-chain-no-features:
     name: Build zebra-chain w/o features on ubuntu-latest


### PR DESCRIPTION
## Motivation

We want to fix the CI build issues in #1651, but the error doesn't give enough information.

## Solution

Use `--verbose --verbose` in the CI build to make the output very verbose.

## Review

@dconnolly let's try to get CI fixed as a top priority?

## Related Issues

Diagnostics for #1651

## Follow Up Work

Actually fix #1651
Revert this change?