### PR TITLE
Temporally disable sync_large_checkpoints on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,16 @@ jobs:
           command: test
           args: --verbose --all
       # Explicitly run any tests that are usually #[ignored], modulo ZEBRA_SKIP_NETWORK_TESTS
-      # This tests are temporally disabled by #1651
-      #
-      # - name: Run zebrad large sync tests
-      #  env:
-      #    RUST_BACKTRACE: full
-      #  uses: actions-rs/cargo@v1
-      #  with:
-      #    command: test
-      #    args: --verbose --manifest-path zebrad/Cargo.toml sync_large_checkpoints_ -- --ignored
+      - name: Run zebrad large sync tests
+        # There is a compiler issue when building the acceptance integration
+        # test binary, this disables these tests on Windows for now.
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+        env:
+          RUST_BACKTRACE: full
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --manifest-path zebrad/Cargo.toml sync_large_checkpoints_ -- --ignored
 
   build-chain-no-features:
     name: Build zebra-chain w/o features on ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,15 @@ jobs:
           command: test
           args: --verbose --all
       # Explicitly run any tests that are usually #[ignored], modulo ZEBRA_SKIP_NETWORK_TESTS
-      - name: Run zebrad large sync tests
-        env:
-          RUST_BACKTRACE: full
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --manifest-path zebrad/Cargo.toml sync_large_checkpoints_ -- --ignored
+      # This tests are temporally disabled by #1651
+      #
+      # - name: Run zebrad large sync tests
+      #  env:
+      #    RUST_BACKTRACE: full
+      #  uses: actions-rs/cargo@v1
+      #  with:
+      #    command: test
+      #    args: --verbose --manifest-path zebrad/Cargo.toml sync_large_checkpoints_ -- --ignored
 
   build-chain-no-features:
     name: Build zebra-chain w/o features on ubuntu-latest


### PR DESCRIPTION
## Motivation

Windows tests are failing the large checkpoints isolated tests: https://github.com/ZcashFoundation/zebra/issues/1651

## Solution

Temporally disable the tests until a fix is found and implemented. Code was commented out instead of removed as a reminder that this needs to be fixed.

## Review

Anyone can review. #1651 is high priority and this fix can give us more room to work on it later.
