### PR TITLE
Async DNS seeder lookups

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -34,7 +34,6 @@ pub struct Config {
 impl Config {
     async fn parse_peers(peers: HashSet<String>) -> HashSet<SocketAddr> {
         use futures::stream::StreamExt;
-        // See https://docs.rs/futures/0.3.12/futures/stream/trait.StreamExt.html
         let peer_addresses = peers
             .clone()
             .into_iter()

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -32,6 +32,10 @@ pub struct Config {
 }
 
 impl Config {
+    /// Concurrently resolves `peers` into zero or more IP addresses, with a timeout
+    /// of a few seconds on each DNS request.
+    ///
+    /// If DNS resolution fails or times out for all peers, returns an empty list.
     async fn parse_peers(peers: HashSet<String>) -> HashSet<SocketAddr> {
         use futures::stream::StreamExt;
         let peer_addresses = peers

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -38,7 +38,7 @@ impl Config {
         let peer_addresses = peers
             .clone()
             .into_iter()
-            .map(|host| Config::resolve_host(host))
+            .map(Config::resolve_host)
             .collect::<futures::stream::FuturesUnordered<_>>()
             .concat()
             .await;
@@ -67,7 +67,7 @@ impl Config {
     /// If DNS resolution fails or times out, returns an empty list.
     async fn resolve_host(host: String) -> HashSet<SocketAddr> {
         let fut = tokio::net::lookup_host(&host);
-        let fut = tokio::time::timeout(Duration::from_nanos(1), fut);
+        let fut = tokio::time::timeout(crate::constants::DNS_LOOKUP_TIMEOUT, fut);
 
         match fut.await {
             Ok(Ok(ips)) => ips.collect(),

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -110,10 +110,10 @@ lazy_static! {
 
 /// The timeout for DNS lookups.
 ///
-/// [6.1.3.3  Efficient Resource Usage] from RFC [Requirements for Internet Hosts]
+/// [6.1.3.3 Efficient Resource Usage] from [RFC 1123: Requirements for Internet Hosts]
 /// suggest no less than 5 seconds for resolving timeout.
 ///
-/// [Requirements for Internet Hosts] https://tools.ietf.org/rfcmarkup?doc=1123
+/// [RFC 1123: Requirements for Internet Hosts] https://tools.ietf.org/rfcmarkup?doc=1123
 /// [6.1.3.3  Efficient Resource Usage] https://tools.ietf.org/rfcmarkup?doc=1123#page-77
 pub const DNS_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
 

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -108,6 +108,15 @@ lazy_static! {
     }.expect("regex is valid");
 }
 
+/// The timeout for DNS lookups.
+///
+/// [6.1.3.3  Efficient Resource Usage] from RFC [Requirements for Internet Hosts]
+/// suggest no less than 5 seconds for resolving timeout.
+///
+/// [Requirements for Internet Hosts] https://tools.ietf.org/rfcmarkup?doc=1123
+/// [6.1.3.3  Efficient Resource Usage] https://tools.ietf.org/rfcmarkup?doc=1123#page-77
+pub const DNS_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Magic numbers used to identify different Zcash networks.
 pub mod magics {
     use super::*;

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -141,7 +141,7 @@ where
         let tx = peerset_tx.clone();
 
         // Connect the tx end to the 3 peer sources:
-        add_initial_peers(initial_peers, connector, tx)
+        add_initial_peers(initial_peers.await, connector, tx)
     };
 
     // 2. Initial peers, specified in the config.

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -135,14 +135,18 @@ where
 
     let listen_guard = tokio::spawn(listen(config.listen_addr, listener, peerset_tx.clone()));
 
-    let initial_peers_fut = {
-        let initial_peers = config.initial_peers();
-        let connector = connector.clone();
-        let tx = peerset_tx.clone();
+    let connector = connector.clone();
+    let tx = peerset_tx.clone();
 
+    // Clone some values so we can move them
+    let config_clone = config.clone();
+    let connector_clone = connector.clone();
+
+    let initial_peers_fut = async move {
         // Connect the tx end to the 3 peer sources:
-        add_initial_peers(initial_peers.await, connector, tx)
-    };
+        add_initial_peers(config_clone.initial_peers().await, connector_clone, tx).await
+    }
+    .boxed();
 
     // 2. Initial peers, specified in the config.
     let add_guard = tokio::spawn(initial_peers_fut);


### PR DESCRIPTION
## Motivation

I am trying to replace `to_socket_addrs()` with my crated function `resolve()`. This is work in progress for #1613.

So i basically will want to replace https://github.com/oxarbitrage/zebra/blob/8a9a32b2f4f3e1e735def4ade717884885184243/zebra-network/src/config.rs#L46 with https://github.com/oxarbitrage/zebra/blob/8a9a32b2f4f3e1e735def4ade717884885184243/zebra-network/src/config.rs#L42 where `replace` is a new custom function that should return the same data.

`to_socket_addrs()` returns `Result<Iterator>` but `replace()` returns `Option<Iterator>` which are not the same. This can be a first issue.

Additionally i think there is something else, according to some hints i got from @teor2345 in discord something like this will need to be added to the combination:

https://github.com/ZcashFoundation/zebra/blob/4f172ab6747de137fc8c1ead27290b4c27816ad5/zebrad/src/components/inbound.rs#L257

Which makes the implementation even more complicated for my skills. Looking for some additional hints to make more progress here.
  
## Solution

Share the problem with others.

The code in this pull request has:
  - [ ] Documentation Comments
  - [ ] Unit Tests and Property Tests

## Review

I will like @yaahc or @teor2345 to take a look.

## Related Issues

Closes #1613

Note: #1613 is about DNS seeders, #1631 is about listener ports. This PR fixes the DNS seeders.

## Follow Up Work

None by now.
