### PR TITLE
Add a comment about a mempool request bug

### DIFF
--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -74,7 +74,8 @@ pub enum Request {
         transaction: Arc<Transaction>,
         /// Additional UTXOs which are known at the time of verification.
         known_utxos: Arc<HashMap<transparent::OutPoint, zs::Utxo>>,
-        /// The active NU in the context of this verification.
+        /// Bug: this field should be the next block height, because some
+        /// consensus rules depend on the exact height. See #1683.
         upgrade: NetworkUpgrade,
     },
 }


### PR DESCRIPTION
## Motivation

Transaction verifier mempool requests should take the next block height,
because some consensus rules depend on the exact height.

See #1683.

This is a comment-only change to document the bug, not a bug fix.
