### PR TITLE
Use max_items as bound in tower-batch

### DIFF
--- a/tower-batch/src/service.rs
+++ b/tower-batch/src/service.rs
@@ -57,8 +57,8 @@ where
         T::Error: Send + Sync,
         Request: Send + 'static,
     {
-        // XXX(hdevalence): is this bound good
-        let bound = 1;
+        // We use the max_items as maximum number of requests.
+        let bound = max_items;
         let (tx, rx) = mpsc::unbounded_channel();
         let (handle, worker) = Worker::new(service, rx, max_items, max_latency);
         tokio::spawn(worker.run());

--- a/tower-batch/src/service.rs
+++ b/tower-batch/src/service.rs
@@ -57,7 +57,11 @@ where
         T::Error: Send + Sync,
         Request: Send + 'static,
     {
-        // We use the max_items as maximum number of requests.
+        // The semaphore bound limits the maximum number of concurrent requests
+        // (specifically, requests which got a `Ready` from `poll_ready`, but haven't
+        // used their semaphore reservation in a `call` yet).
+        // We choose a bound that allows callers to check readiness for every item in
+        // a batch, then actually submit those items.
         let bound = max_items;
         let (tx, rx) = mpsc::unbounded_channel();
         let (handle, worker) = Worker::new(service, rx, max_items, max_latency);


### PR DESCRIPTION
## Motivation

We want to change the max number of requests of the semaphore in zebra-batch.

Closes https://github.com/ZcashFoundation/zebra/issues/1670

## Solution

I discussed with @teor2345  that the best by now for this will be to use `max_items` argument as `bound`.


## Review

@teor2345 
