### PR TITLE
Add a comment about handling errors to zebra-batch service

### DIFF
--- a/tower-batch/src/service.rs
+++ b/tower-batch/src/service.rs
@@ -94,6 +94,9 @@ where
         // Then, poll to acquire a semaphore permit. If we acquire a permit,
         // then there's enough buffer capacity to send a new request. Otherwise,
         // we need to wait for capacity.
+
+        // In tokio 0.3.7, `acquire_owned` panics if its semaphore returns an error,
+        // so we don't need to handle errors until we upgrade to tokio 1.0.
         ready!(self.semaphore.poll_acquire(cx));
 
         Poll::Ready(Ok(()))


### PR DESCRIPTION
## Motivation

Document the difference between tokio 0.3.7 and 1.0 for error handling.

Closes https://github.com/ZcashFoundation/zebra/issues/1669
