### PR TITLE
Document that connect_isolated only works on mainnet

### DIFF
--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -35,6 +35,10 @@ use crate::{peer, BoxError, Config, Request, Response};
 /// connection allows this method to be used with clearnet or Tor transports.
 ///
 /// - `user_agent`: a valid BIP14 user-agent, e.g., the empty string.
+///
+/// # Bug
+///
+/// `connect_isolated` only works on `Mainnet`, see #1687.
 pub fn connect_isolated(
     conn: TcpStream,
     user_agent: String,


### PR DESCRIPTION
Document that connect_isolated only works on mainnet, until we fix the underlying bug.

See #1687.