### PR TITLE
Stop using CallAllUnordered in peer_set::add_initial_peers

### DIFF
--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -194,28 +194,16 @@ where
     S::Future: Send + 'static,
 {
     info!(?initial_peers, "Connecting to initial peer set");
-    use futures::TryStreamExt;
+    let mut handshakes = initial_peers
+        .iter()
+        .map(|request| connector.clone().oneshot(*request))
+        .collect::<futures::stream::FuturesUnordered<_>>();
 
-    let fut = initial_peers
-        .clone()
-        .into_iter()
-        .map(|request| connector.clone().oneshot(request))
-        .collect::<futures::stream::FuturesUnordered<_>>()
-        .try_collect::<Vec<_>>();
-
-    match fut.await {
-        Ok(vector) => {
-            for change in vector {
-                tx.send(Ok(change)).await?
-            }
-            dbg!("success");
-            Ok(())
-        }
-        Err(e) => {
-            dbg!(e);
-            Ok(())
-        }
+    while let Some(handshake_result) = handshakes.next().await {
+        tx.send(handshake_result).await?;
     }
+
+    Ok(())
 }
 
 /// Bind to `addr`, listen for peers using `handshaker`, then send the


### PR DESCRIPTION
## Motivation

Stop using `CallAllUnordered` as suggested in https://github.com/ZcashFoundation/zebra/issues/1696

## Solution

Work in progress. Having some problems so looking for some hints. I will like @teor2345 to take a look if possible.

I am trying to collect in a vector the `tower::discover::Change<std::net::SocketAddr, peer::client::Client>` that in theory can be used as arguments to `tx.send()`.

However when i execute this code i always get the error arm of the match:

```
[zebra-network/src/peer_set/initialize.rs:215] e = Os {
    code: 101,
    kind: Other,
    message: "Network is unreachable",
}
```

If i change to `FuturesOrdered` i geta similar but different error:

```
[zebra-network/src/peer_set/initialize.rs:215] e = Os {
    code: 111,
    kind: ConnectionRefused,
    message: "Connection refused",
}
```

I tried other alternatives however by now i will like to know what could be wrong in this approach or if i need to change it please suggest. Thanks. 

## Review

@teor2345 

## Related Tickets

Closes #1696.