### PR TITLE
Log when the syncer awaits peer readiness

### DIFF
--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -351,7 +351,8 @@ where
             })
             .map_err(|e| eyre!(e))?;
 
-        tracing::info!(?block_locator, "trying to obtain new chain tips");
+        tracing::info!("trying to obtain new chain tips");
+        tracing::debug!(?block_locator, "got block locator");
 
         let mut requests = FuturesUnordered::new();
         for _ in 0..FANOUT {
@@ -465,8 +466,8 @@ where
         let tips = std::mem::take(&mut self.prospective_tips);
 
         let mut download_set = HashSet::new();
-        tracing::info!(?tip, "trying to extend chain tips");
         for tip in tips {
+            tracing::info!(?tip, "trying to extend chain tips");
             let mut responses = FuturesUnordered::new();
             for _ in 0..FANOUT {
                 responses.push(

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -351,7 +351,7 @@ where
             })
             .map_err(|e| eyre!(e))?;
 
-        tracing::debug!(?block_locator, "trying to obtain new chain tips");
+        tracing::info!(?block_locator, "trying to obtain new chain tips");
 
         let mut requests = FuturesUnordered::new();
         for _ in 0..FANOUT {
@@ -465,8 +465,8 @@ where
         let tips = std::mem::take(&mut self.prospective_tips);
 
         let mut download_set = HashSet::new();
+        tracing::info!(?tip, "trying to extend chain tips");
         for tip in tips {
-            tracing::debug!(?tip, "extending tip");
             let mut responses = FuturesUnordered::new();
             for _ in 0..FANOUT {
                 responses.push(


### PR DESCRIPTION
## Motivation

#1435 causes the peer set to stay in a pending state, which makes the `ChainSync` hang when it calls `ready_and` for network requests.

## Solution

Log at info-level before calling `ready_and` on the peer set, for better diagnostics.

Closes #1633.

The underlying bug in #1633 should be fixed by PR #1709 and ticket #1435.

## Review

This is a small routine logging change.
