### PR TITLE
Prevent PeerSet service to be buffered

### DIFF
--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -432,7 +432,6 @@ where
                     .ready_services
                     .get_index_mut(index)
                     .expect("preselected index must be valid");
-
                 trace!(preselected_index = index, ?key);
                 match service.poll_ready(cx) {
                     Poll::Ready(Ok(())) => return Poll::Ready(Ok(())),


### PR DESCRIPTION
## Motivation

Multiple calls to `poll_ready()`to the `PeerSet` service can cause fill ups and hangs if they are buffered.

https://github.com/ZcashFoundation/zebra/issues/1697

## Solution

The solution of this PR is to get the name of the service type as a string and check if that contains the word "Buffer" at runtime.
This uses https://doc.rust-lang.org/std/any/fn.type_name.html and by the notes it can fail at some edge cases.

Current and accepted type for the service is:

`&mut tower::load::peak_ewma::PeakEwma<zebra_network::peer::client::Client`

I manually tested this by changing the string to search from `Buffer` to `PeakEwma`, then started zebra and got the panic:

```
...
The application panicked (crashed).
Message:  assertion failed: !format!("{:?}", type_of(& service)).contains("PeakEwma")
...
``` 

The code in this pull request has:
  - [x] Manually tested
  - [ ] Unit Tests

## Review
@teor2345 when they get the time.

## Related Issues

If the solution is good enough to be merged this will close https://github.com/ZcashFoundation/zebra/issues/1697

## Follow Up Work

Maybe do a test case in a separated issue.