### PR TITLE
Add beta rust to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,33 +70,6 @@ jobs:
           RUST_BACKTRACE: full
         run: cargo build --verbose --no-default-features
 
-  build-beta:
-    name: Build using rust beta on ${{ matrix.os }}
-    timeout-minutes: 30
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
-          override: true
-      - name: Install LLVM on Windows
-        if: matrix.os == 'windows-latest'
-        run: choco install llvm -y
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --release
-  
   build:
     name: Build on ${{ matrix.os }}
     timeout-minutes: 30
@@ -104,12 +77,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        rust: [stable,beta]
 
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           override: true
       - name: Install LLVM on Windows
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        rust: [stable, beta]
 
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           override: true
       - name: cargo fetch
         uses: actions-rs/cargo@v1
@@ -77,7 +78,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [stable,beta]
+        rust: [stable, beta]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
 
   test:
-    name: Test on ${{ matrix.os }} with Rust ${{ matrix.rust }}
+    name: Test (+${{ matrix.rust }}) on ${{ matrix.os }}
     # The large timeout is to accommodate Windows builds
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
@@ -72,7 +72,7 @@ jobs:
         run: cargo build --verbose --no-default-features
 
   build:
-    name: Build on ${{ matrix.os }} with Rust ${{ matrix.rust }}
+    name: Build (+${{ matrix.rust }}) on ${{ matrix.os }}
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,33 @@ jobs:
           RUST_BACKTRACE: full
         run: cargo build --verbose --no-default-features
 
+  build-beta:
+    name: Build using rust beta on ${{ matrix.os }}
+    timeout-minutes: 30
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: beta
+          override: true
+      - name: Install LLVM on Windows
+        if: matrix.os == 'windows-latest'
+        run: choco install llvm -y
+      - name: cargo fetch
+        uses: actions-rs/cargo@v1
+        with:
+          command: fetch
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --release
+  
   build:
     name: Build on ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
 
   test:
-    name: Test on ${{ matrix.os }}
+    name: Test on ${{ matrix.os }} with Rust ${{ matrix.rust }}
     # The large timeout is to accommodate Windows builds
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
@@ -72,7 +72,7 @@ jobs:
         run: cargo build --verbose --no-default-features
 
   build:
-    name: Build on ${{ matrix.os }}
+    name: Build on ${{ matrix.os }} with Rust ${{ matrix.rust }}
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           args: --verbose --manifest-path zebrad/Cargo.toml sync_large_checkpoints_ -- --ignored
 
   build-chain-no-features:
-    name: Build zebra-chain w/o features (+${{ matrix.rust }}) on ubuntu-latest
+    name: Build (+${{ matrix.rust }}) zebra-chain w/o features on ubuntu-latest
     timeout-minutes: 30
     runs-on: ubuntu-latest    
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,18 @@ jobs:
           args: --verbose --manifest-path zebrad/Cargo.toml sync_large_checkpoints_ -- --ignored
 
   build-chain-no-features:
-    name: Build zebra-chain w/o features on ubuntu-latest
+    name: Build zebra-chain w/o features (+${{ matrix.rust }}) on ubuntu-latest
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest    
+    strategy:
+      matrix:
+        rust: [stable, beta]
+    
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           override: true
       - name: cargo fetch
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
## Motivation

Add CI for building and testing in rust beta. https://github.com/ZcashFoundation/zebra/issues/1712

## Solution

Use `toolchain: beta` https://github.com/marketplace/actions/rust-toolchain

Please note that even if the new additions will run in parallel this changes can increase the overall time to run the full CI.

This PR if merged will close https://github.com/ZcashFoundation/zebra/issues/1712

## Review
@dconnolly 