### PR TITLE
Make the state usage clearer in script::Verifier

### DIFF
--- a/zebra-consensus/src/script.rs
+++ b/zebra-consensus/src/script.rs
@@ -100,6 +100,7 @@ where
             transparent::Input::PrevOut { outpoint, .. } => {
                 let outpoint = *outpoint;
 
+                // Avoid calling the state service if the utxo is already known
                 let span = tracing::trace_span!("script", ?outpoint);
                 let query =
                     span.in_scope(|| self.state.call(zebra_state::Request::AwaitUtxo(outpoint)));


### PR DESCRIPTION
## Motivation

I missed the delayed call the first time I read this code, so let's make it explicit in a comment.