### PR TITLE
Revert "Stop using CallAllUnordered in peer_set::add_initial_peers"

### DIFF
--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -194,6 +194,12 @@ where
     S::Future: Send + 'static,
 {
     info!(?initial_peers, "Connecting to initial peer set");
+    // ## Correctness:
+    //
+    // Each `CallAll` can hold one `Buffer` or `Batch` reservation for
+    // an indefinite period. We can use `CallAllUnordered` without filling
+    // the underlying `Inbound` buffer, because we immediately drive this
+    // single `CallAll` to completion, and handshakes have a short timeout.
     use tower::util::CallAllUnordered;
     let addr_stream = futures::stream::iter(initial_peers.into_iter());
     let mut handshakes = CallAllUnordered::new(connector, addr_stream);


### PR DESCRIPTION
Reverts ZcashFoundation/zebra#1705

This change is safe because:
* the underlying bug in `tower::Buffer` has been fixed, see #1593
* the underlying `Inbound` service is wrapped in a `load_shed` layer, so it's not possible for it to hang, even if these requests use up one reservation per clone
* there are 3-4 initial peers by default, and the default buffer size of 20 allows 5+ inbound requests per peer
* some of those inbound requests will immediately fail because the network isn't ready yet, and that helps avoid hangs

See the buffer bound and load shed code:
https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/commands/start.rs#L71