### PR TITLE
Partly revert "Fix poll_ready usage in ChainVerifier"

### DIFF
--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -82,7 +82,10 @@ where
         // The chain verifier holds one slot in each verifier, for each concurrent task.
         // Therefore, any shared buffers or batches polled by these verifiers should double
         // their bounds. (For example, the state service buffer.)
-        ready!(self.checkpoint.poll_ready(cx).map_err(VerifyChainError::Checkpoint))?;
+        ready!(self
+            .checkpoint
+            .poll_ready(cx)
+            .map_err(VerifyChainError::Checkpoint))?;
         ready!(self.block.poll_ready(cx).map_err(VerifyChainError::Block))?;
         Poll::Ready(Ok(()))
     }

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -27,6 +27,19 @@ use crate::{
     BoxError, Config,
 };
 
+/// The bound for the chain verifier's buffer.
+///
+/// We choose the verifier buffer bound based on the maximum number of
+/// concurrent verifier users, to avoid contention:
+///   - the `ChainSync` component
+///   - the `Inbound` service
+///   - a miner component, which we might add in future, and
+///   - 1 extra slot to avoid contention.
+///
+/// We deliberately add extra slots, because they only cost a small amount of
+/// memory, but missing slots can significantly slow down Zebra.
+const VERIFIER_BUFFER_BOUND: usize = 4;
+
 /// The chain verifier routes requests to either the checkpoint verifier or the
 /// block verifier, depending on the maximum checkpoint height.
 struct ChainVerifier<S>
@@ -140,6 +153,6 @@ where
             checkpoint,
             max_checkpoint_height,
         }),
-        3,
+        VERIFIER_BUFFER_BOUND,
     )
 }


### PR DESCRIPTION
Reverts ZcashFoundation/zebra#1700

This revert is ok, because the underlying bug in `tower::Buffer` has been fixed. See #1593 for details.

But the code needs a few tweaks to avoid unlikely deadlocks.

The underlying services aren't directly buffered, but they do use some buffered services. We have open tickets for checking their buffer bounds (#1675), and dealing with backpressure more generally (#1618).