### PR TITLE
Increase the conflict acceptance test launch delay

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -37,9 +37,9 @@ use zebrad::config::ZebradConfig;
 
 /// The amount of time we wait after launching `zebrad`.
 ///
-/// Previously, this value was 1 second, which caused occasional
-/// `tracing_endpoint` test failures on some machines.
-const LAUNCH_DELAY: Duration = Duration::from_secs(3);
+/// Previously, this value was 3 seconds, which caused rare
+/// `metrics_conflict` test failures in Windows CI.
+const LAUNCH_DELAY: Duration = Duration::from_secs(10);
 
 fn default_test_config() -> Result<ZebradConfig> {
     let auto_port_ipv4_local = zebra_network::Config {
@@ -1087,7 +1087,7 @@ fn zcash_listener_conflict() -> Result<()> {
 /// exclusive use of the port. The second node will panic with the Zcash metrics
 /// conflict hint added in #1535.
 #[test]
-fn zcash_metrics_conflict() -> Result<()> {
+fn zebra_metrics_conflict() -> Result<()> {
     zebra_test::init();
 
     // [Note on port conflict](#Note on port conflict)
@@ -1115,7 +1115,7 @@ fn zcash_metrics_conflict() -> Result<()> {
 /// exclusive use of the port. The second node will panic with the Zcash tracing
 /// conflict hint added in #1535.
 #[test]
-fn zcash_tracing_conflict() -> Result<()> {
+fn zebra_tracing_conflict() -> Result<()> {
     zebra_test::init();
 
     // [Note on port conflict](#Note on port conflict)
@@ -1142,7 +1142,7 @@ fn zcash_tracing_conflict() -> Result<()> {
 /// listener ports. The first node should get exclusive access to the database.
 /// The second node will panic with the Zcash state conflict hint added in #1535.
 #[test]
-fn zcash_state_conflict() -> Result<()> {
+fn zebra_state_conflict() -> Result<()> {
     zebra_test::init();
 
     // A persistent config has a fixed temp state directory, but asks the OS to

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1059,7 +1059,7 @@ async fn tracing_endpoint() -> Result<()> {
 /// It is expected that the first node spawned will get exclusive use of the port.
 /// The second node will panic with the Zcash listener conflict hint added in #1535.
 #[test]
-fn zcash_listener_conflict() -> Result<()> {
+fn zebra_zcash_listener_conflict() -> Result<()> {
     zebra_test::init();
 
     // [Note on port conflict](#Note on port conflict)

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -38,7 +38,7 @@ use zebrad::config::ZebradConfig;
 /// The amount of time we wait after launching `zebrad`.
 ///
 /// Previously, this value was 3 seconds, which caused rare
-/// `metrics_conflict` test failures in Windows CI.
+/// metrics or tracing test failures in Windows CI.
 const LAUNCH_DELAY: Duration = Duration::from_secs(10);
 
 fn default_test_config() -> Result<ZebradConfig> {


### PR DESCRIPTION
## Motivation

The Windows CI failed the metrics_conflict test, because node1 opened its listener after node2:
https://github.com/ZcashFoundation/zebra/pull/1733/checks?check_run_id=1899814880#step:7:1584

```
Error: 
   0: Access is denied. (os error 5)

Unread Stderr:
   The application panicked (crashed).
   Message:  Opening metrics endpoint listener 127.0.0.1:49752 failed

   14: zebra_test::command::TestChild<tempdir::TempDir>::kill<tempdir::TempDir><unknown>
      at D:\a\zebra\zebra\zebra-test\src\command.rs:166
       164 │     pub fn kill(&mut self) -> Result<()> {
       165 │         /// SPANDOC: Killing child process
       166 >         self.child.kill().context_from(self)?;
       167 │ 
       168 │         Ok(())
  15: acceptance::check_config_conflict<tempdir::TempDir,tempdir::TempDir><unknown>
      at D:\a\zebra\zebra\zebrad\tests\acceptance.rs:1215
      1213 │     // Second node is terminated by panic, no need to kill.
      1214 │     std::thread::sleep(LAUNCH_DELAY);
      1215 >     node1.kill()?;
```

## Solution

Also rename the tests - the listener is for the Zcash protocol, but the state, metrics, and tracing are Zebra-specific.

