### PR TITLE
Update comments for the inbound service

### DIFF
--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -69,9 +69,6 @@ pub enum Setup {
 
     /// Network setup failed, because the setup channel permanently failed.
     /// The service keeps returning readiness errors for every request.
-    ///
-    /// We keep hold of the closed oneshot, so we can use it to create a
-    /// new error for each `poll_ready` call.
     FailedRecv { error: SharedRecvError },
 }
 
@@ -221,8 +218,8 @@ impl Service<zn::Request> for Inbound {
         //    "load shed directly" pattern from #1618.
         //  * currently, the state service is always ready, unless its buffer is full.
         //    So we might also want to propagate backpressure from its buffer.
-        //  * if we want to propagate backpressure, add a ReadyCache for each service, to ensure
-        //    that each poll_ready has a matching call. See #1593 for details.
+        //  * poll_ready needs to be implemented carefully, to avoid hangs or deadlocks.
+        //    See #1593 for details.
         Poll::Ready(result)
     }
 


### PR DESCRIPTION
## Motivation

Some of the inbound comments were obsoleted by a recent error refactor. 

Others aren't accurate any more, since the tower::Buffer reservation leaks have been fixed.