### PR TITLE
Run CI workflow on push to #main & manual request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: pull_request
+on:
+  workflow_dispatch: 
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

We used to always run the CI workflow on push/merge to #main and at some point stopped; we still link to the status of this workflow on #main from our README. I think we should bring it back. 

Also allows manual triggering of the workflow, which can come in handy if you are working
on a branch but haven't opened a PR yet.

## Solution

Runs the CI workflow on each push/merge to #main, and enables manual triggers from the GitHub UI.

## Review

Not urgent, anyone can review.

## Related Issues

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
