### PR TITLE
Fix nightly clippy lints

### DIFF
--- a/zebra-chain/src/sprout/arbitrary.rs
+++ b/zebra-chain/src/sprout/arbitrary.rs
@@ -19,7 +19,7 @@ impl<P: ZkSnarkProof + Arbitrary + 'static> Arbitrary for JoinSplit<P> {
             array::uniform2(any::<commitment::NoteCommitment>()),
             array::uniform32(any::<u8>()),
             array::uniform32(any::<u8>()),
-            array::uniform2(any::<note::MAC>()),
+            array::uniform2(any::<note::Mac>()),
             any::<P>(),
             array::uniform2(any::<note::EncryptedNote>()),
         )

--- a/zebra-chain/src/sprout/joinsplit.rs
+++ b/zebra-chain/src/sprout/joinsplit.rs
@@ -39,7 +39,7 @@ pub struct JoinSplit<P: ZkSnarkProof> {
     /// JoinSplit description.
     pub random_seed: [u8; 32],
     /// A message authentication tag.
-    pub vmacs: [note::MAC; 2],
+    pub vmacs: [note::Mac; 2],
     /// A ZK JoinSplit proof, either a
     /// [`Groth16Proof`](crate::primitives::Groth16Proof) or a
     /// [`Bctv14Proof`](crate::primitives::Bctv14Proof).
@@ -86,8 +86,8 @@ impl<P: ZkSnarkProof> ZcashDeserialize for JoinSplit<P> {
             ephemeral_key: x25519_dalek::PublicKey::from(reader.read_32_bytes()?),
             random_seed: reader.read_32_bytes()?,
             vmacs: [
-                note::MAC::zcash_deserialize(&mut reader)?,
-                note::MAC::zcash_deserialize(&mut reader)?,
+                note::Mac::zcash_deserialize(&mut reader)?,
+                note::Mac::zcash_deserialize(&mut reader)?,
             ],
             zkproof: P::zcash_deserialize(&mut reader)?,
             enc_ciphertexts: [

--- a/zebra-chain/src/sprout/note.rs
+++ b/zebra-chain/src/sprout/note.rs
@@ -16,7 +16,7 @@ use crate::{
 
 use super::{commitment::CommitmentRandomness, keys::PayingKey};
 
-pub use mac::MAC;
+pub use mac::Mac;
 
 pub use ciphertexts::EncryptedNote;
 

--- a/zebra-chain/src/sprout/note/mac.rs
+++ b/zebra-chain/src/sprout/note/mac.rs
@@ -10,9 +10,9 @@ use std::io::{self, Read};
     any(test, feature = "proptest-impl"),
     derive(proptest_derive::Arbitrary)
 )]
-pub struct MAC([u8; 32]);
+pub struct Mac([u8; 32]);
 
-impl ZcashDeserialize for MAC {
+impl ZcashDeserialize for Mac {
     fn zcash_deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         let bytes = reader.read_32_bytes()?;
 
@@ -20,7 +20,7 @@ impl ZcashDeserialize for MAC {
     }
 }
 
-impl ZcashSerialize for MAC {
+impl ZcashSerialize for Mac {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         writer.write_all(&self.0[..])
     }

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -204,12 +204,12 @@ impl ZcashDeserialize for Transaction {
             }),
             (2, false) => {
                 // Version 2 transactions use Sprout-on-BCTV14.
-                type OptV2JSD = Option<JoinSplitData<Bctv14Proof>>;
+                type OptV2Jsd = Option<JoinSplitData<Bctv14Proof>>;
                 Ok(Transaction::V2 {
                     inputs: Vec::zcash_deserialize(&mut reader)?,
                     outputs: Vec::zcash_deserialize(&mut reader)?,
                     lock_time: LockTime::zcash_deserialize(&mut reader)?,
-                    joinsplit_data: OptV2JSD::zcash_deserialize(&mut reader)?,
+                    joinsplit_data: OptV2Jsd::zcash_deserialize(&mut reader)?,
                 })
             }
             (3, true) => {
@@ -220,13 +220,13 @@ impl ZcashDeserialize for Transaction {
                     ));
                 }
                 // Version 3 transactions use Sprout-on-BCTV14.
-                type OptV3JSD = Option<JoinSplitData<Bctv14Proof>>;
+                type OptV3Jsd = Option<JoinSplitData<Bctv14Proof>>;
                 Ok(Transaction::V3 {
                     inputs: Vec::zcash_deserialize(&mut reader)?,
                     outputs: Vec::zcash_deserialize(&mut reader)?,
                     lock_time: LockTime::zcash_deserialize(&mut reader)?,
                     expiry_height: block::Height(reader.read_u32::<LittleEndian>()?),
-                    joinsplit_data: OptV3JSD::zcash_deserialize(&mut reader)?,
+                    joinsplit_data: OptV3Jsd::zcash_deserialize(&mut reader)?,
                 })
             }
             (4, true) => {
@@ -237,7 +237,7 @@ impl ZcashDeserialize for Transaction {
                     ));
                 }
                 // Version 4 transactions use Sprout-on-Groth16.
-                type OptV4JSD = Option<JoinSplitData<Groth16Proof>>;
+                type OptV4Jsd = Option<JoinSplitData<Groth16Proof>>;
 
                 // The previous match arms deserialize in one go, because the
                 // internal structure happens to nicely line up with the
@@ -254,7 +254,7 @@ impl ZcashDeserialize for Transaction {
                 let value_balance = (&mut reader).zcash_deserialize_into()?;
                 let mut shielded_spends = Vec::zcash_deserialize(&mut reader)?;
                 let mut shielded_outputs = Vec::zcash_deserialize(&mut reader)?;
-                let joinsplit_data = OptV4JSD::zcash_deserialize(&mut reader)?;
+                let joinsplit_data = OptV4Jsd::zcash_deserialize(&mut reader)?;
 
                 use futures::future::Either::*;
                 let shielded_data = if !shielded_spends.is_empty() {

--- a/zebra-chain/src/transparent/serialize.rs
+++ b/zebra-chain/src/transparent/serialize.rs
@@ -175,7 +175,7 @@ impl ZcashSerialize for Input {
                 let total_len = height_len + data.as_ref().len();
                 writer.write_compactsize(total_len as u64)?;
                 write_coinbase_height(*height, &mut writer)?;
-                writer.write_all(&data.as_ref()[..])?;
+                writer.write_all(data.as_ref())?;
                 writer.write_u32::<LittleEndian>(*sequence)?;
             }
         }


### PR DESCRIPTION
## Motivation

Some of us build with nightly clippy, and like to have warning-free builds.

Here are the latest fixes:
* capitalised acronyms (rust style is to titlecase acronyms)
* redundant range
