### PR TITLE
CI: bump build and test timeouts to 60 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     name: Test (+${{ matrix.rust }}) on ${{ matrix.os }}
     # The large timeout is to accommodate Windows builds
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -58,12 +58,12 @@ jobs:
 
   build-chain-no-features:
     name: Build (+${{ matrix.rust }}) zebra-chain w/o features on ubuntu-latest
-    timeout-minutes: 30
-    runs-on: ubuntu-latest    
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         rust: [stable, beta]
-    
+
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -82,7 +82,7 @@ jobs:
 
   build:
     name: Build (+${{ matrix.rust }}) on ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

We've started running the CI workflow on #main post-merge again. Several job steps are running into timeouts on #main. We're also fiddling with the cargo env vars to avoid running out of space on the GitHub runners.

## Solution

To give some margins to trying all these tweaks, this change bumps the timeouts on the build and test jobs/steps to one hour.

## Review

Anyone can review, but @oxarbitrage @teor2345 . Medium urgent as we have timeouts on CI runs on #main.

## Related Issues

#1756

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
