### PR TITLE
Partly revert removal of docs and coverage CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+
+  coverage:
+    name: Coverage (+nightly)
+    timeout-minutes: 30
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          profile: minimal
+          components: llvm-tools-preview
+
+      - name: Install rustfilt symbol demangler
+        run: |
+          cargo install rustfilt
+      - name: Rerun tests for coverage
+        env:
+          RUSTFLAGS: -Zinstrument-coverage -C link-dead-code -C debuginfo=2
+          LLVM_PROFILE_FILE: "${{ github.workspace }}/test.%p.profraw"
+          ZEBRA_SKIP_NETWORK_TESTS: 1
+        run: |
+          cargo test
+          cargo test --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM - > filenames.txt
+      - name: Merge coverage data
+        run: |
+          $(rustc --print target-libdir)/../bin/llvm-profdata merge test.*.profraw -o test.profdata
+      - name: Generate detailed html coverage report for github artifact
+        run: |
+          $(rustc --print target-libdir)/../bin/llvm-cov show -format=html -ignore-filename-regex=".*/.cargo/registry/.*" -ignore-filename-regex=".*/.cargo/git/.*" -ignore-filename-regex=".*/.rustup/.*" -Xdemangler=rustfilt -show-instantiations -output-dir=./coverage -instr-profile=./test.profdata $(printf -- "-object %s " $(cat filenames.txt))
+      - uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: ./coverage
+
+      - name: Generate lcov coverage report for codecov
+        run: |
+          $(rustc --print target-libdir)/../bin/llvm-cov export -format=lcov -instr-profile=test.profdata $(printf -- "-object %s " $(cat filenames.txt)) > "lcov.info"
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v1
+

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
   coverage:
     name: Coverage (+nightly)
     timeout-minutes: 30
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,70 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  build:
+    name: Build and Deploy Docs (+beta)
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@master
+
+    - name: Install latest beta
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: beta
+        override: true
+
+    - name: Install mdbook
+      run: |
+        cd book
+        curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.5/mdbook-v0.4.5-x86_64-unknown-linux-gnu.tar.gz | tar xz
+        # Add the book directory to the $PATH
+        echo "$GITHUB_WORKSPACE/book" >> $GITHUB_PATH
+    - name: Build Zebra book
+      run: |
+        mdbook build book/
+    - name: Deploy Zebra book to firebase
+      uses: w9jds/firebase-action@v2.0.0
+      with:
+        args: deploy
+      env:
+        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        PROJECT_PATH: book/
+        PROJECT_ID: zebra-book
+
+    - name: Build external docs
+      run: |
+        # Exclude zebra-utils, it is not for library or app users
+        cargo doc --no-deps --workspace --exclude zebra-utils
+      env:
+        RUSTDOCFLAGS: "--html-in-header katex-header.html"
+
+    - name: Deploy external docs to firebase
+      uses: w9jds/firebase-action@v2.0.0
+      with:
+        args: deploy
+      env:
+        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        PROJECT_ID: zealous-zebra
+
+    - name: Build internal docs
+      run: |
+        cargo doc --no-deps --document-private-items
+      env:
+        RUSTDOCFLAGS: "--html-in-header katex-header.html"
+
+    - name: Deploy external docs to firebase
+      uses: w9jds/firebase-action@v2.0.0
+      with:
+        args: deploy
+      env:
+        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+PROJECT_ID: zebra-doc-internal
+


### PR DESCRIPTION
## Motivation

Research and fix the cause of failing CI docs and coverage.

## Solution

Revert https://github.com/ZcashFoundation/zebra/pull/1688 fully but use `beta` as the toolchain instead of `nightly` in the docs. For the coverage we need to stay in nightly as coverage uses a compiler option `-Z` only available there. 

More info about docs failure at https://github.com/Alexhuszagh/rust-lexical/issues/55

We used nightly because of some nightly-only docs feature that are available in beta now.

## Review

@dconnolly after CI pass.

## Related Issues

Close https://github.com/ZcashFoundation/zebra/issues/1689  and close https://github.com/ZcashFoundation/zebra/issues/1690