### PR TITLE
Incomplete: Wake waiting tower-batch clones on close

### DIFF
--- a/tower-batch/src/semaphore.rs
+++ b/tower-batch/src/semaphore.rs
@@ -1,6 +1,8 @@
-// Copied from tower/src/semaphore.rs
-// When/if tower-batch is upstreamed, delete this file
-// and use the common tower semaphore implementation
+// Copied from tower/src/semaphore.rs, commit:
+// d4d1c67 hedge: use auto-resizing histograms (#484)
+//
+// When we upgrade to tower 0.4, we can use tokio's PollSemaphore, like tower's:
+// ccfaffc buffer, limit: use `tokio-util`'s `PollSemaphore` (#556)
 
 pub(crate) use self::sync::OwnedSemaphorePermit as Permit;
 use futures_core::ready;
@@ -9,7 +11,7 @@ use std::{
     future::Future,
     mem,
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, Weak},
     task::{Context, Poll},
 };
 use tokio::sync;
@@ -20,13 +22,32 @@ pub(crate) struct Semaphore {
     state: State,
 }
 
+#[derive(Debug)]
+pub(crate) struct Close {
+    semaphore: Weak<sync::Semaphore>,
+    permits: usize,
+}
+
 enum State {
-    Waiting(Pin<Box<dyn Future<Output = Permit> + Send + Sync + 'static>>),
+    Waiting(Pin<Box<dyn Future<Output = Permit> + Send + 'static>>),
     Ready(Permit),
     Empty,
 }
 
 impl Semaphore {
+    pub(crate) fn new_with_close(permits: usize) -> (Self, Close) {
+        let semaphore = Arc::new(sync::Semaphore::new(permits));
+        let close = Close {
+            semaphore: Arc::downgrade(&semaphore),
+            permits,
+        };
+        let semaphore = Self {
+            semaphore,
+            state: State::Empty,
+        };
+        (semaphore, close)
+    }
+
     pub(crate) fn new(permits: usize) -> Self {
         Self {
             semaphore: Arc::new(sync::Semaphore::new(permits)),
@@ -73,6 +94,26 @@ impl fmt::Debug for State {
                 .finish(),
             State::Ready(ref r) => f.debug_tuple("State::Ready").field(&r).finish(),
             State::Empty => f.debug_tuple("State::Empty").finish(),
+        }
+    }
+}
+
+impl Close {
+    /// Close the semaphore, waking any remaining tasks currently awaiting a permit.
+    pub(crate) fn close(self) {
+        // The maximum number of permits that a `tokio::sync::Semaphore`
+        // can hold is usize::MAX >> 3. If we attempt to add more than that
+        // number of permits, the semaphore will panic.
+        // XXX(eliza): another shift is kinda janky but if we add (usize::MAX
+        // > 3 - initial permits) the semaphore impl panics (I think due to a
+        // bug in tokio?).
+        // TODO(eliza): Tokio should _really_ just expose `Semaphore::close`
+        // publicly so we don't have to do this nonsense...
+        const MAX: usize = std::usize::MAX >> 4;
+        if let Some(semaphore) = self.semaphore.upgrade() {
+            // If we added `MAX - available_permits`, any tasks that are
+            // currently holding permits could drop them, overflowing the max.
+            semaphore.add_permits(MAX - self.permits);
         }
     }
 }

--- a/tower-batch/src/semaphore.rs
+++ b/tower-batch/src/semaphore.rs
@@ -32,7 +32,7 @@ pub(crate) struct Close {
 }
 
 enum State {
-    Waiting(Pin<Box<dyn Future<Output = Permit> + Send + 'static>>),
+    Waiting(Pin<Box<dyn Future<Output = Permit> + Send + Sync + 'static>>),
     Ready(Permit),
     Empty,
 }

--- a/tower-batch/src/semaphore.rs
+++ b/tower-batch/src/semaphore.rs
@@ -4,6 +4,9 @@
 // When we upgrade to tower 0.4, we can use tokio's PollSemaphore, like tower's:
 // ccfaffc buffer, limit: use `tokio-util`'s `PollSemaphore` (#556)
 
+// Ignore lints on this copied code
+#![allow(dead_code)]
+
 pub(crate) use self::sync::OwnedSemaphorePermit as Permit;
 use futures_core::ready;
 use std::{


### PR DESCRIPTION
## Motivation

tower-rs/tower#480 fixes tower's semaphore, to avoid a hang when clones are waiting on another dropped clone. The fix wakes waiting clones when another clone is dropped.

We should apply the same fix to `tower-batch`, which has a copy of tower's semaphore impl.

## Solution

- Copy `semaphore.rs` from our pinned version of `tower` to `tower-batch`
- Update the header comment based on tokio 1.0
- Add a missing `Sync` bound on the semaphore's future
- Silence clippy unused code warnings

## Review

We don't know if this hang is happening in practice, so this isn't urgent.

## Related Issues

Closes #1671.

## Follow Up Work

When we upgrade to tokio 1.0, we can use `tokio_util::PollSemaphore`, rather than copying this code from `tower`.