### PR TITLE
Diagnostics for listener conflict CI failures

### DIFF
--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -227,6 +227,7 @@ where
     S: Service<(TcpStream, SocketAddr), Response = peer::Client, Error = BoxError> + Clone,
     S::Future: Send + 'static,
 {
+    info!("Trying to open Zcash protocol endpoint at {}...", addr);
     let listener_result = TcpListener::bind(addr).await;
 
     let listener = match listener_result {

--- a/zebrad/src/components/metrics.rs
+++ b/zebrad/src/components/metrics.rs
@@ -12,13 +12,13 @@ impl MetricsEndpoint {
     /// Create the component.
     pub fn new(config: &ZebradConfig) -> Result<Self, FrameworkError> {
         if let Some(addr) = config.metrics.endpoint_addr {
+            info!("Trying to open metrics endpoint at {}...", addr);
             let endpoint_result = metrics_exporter_prometheus::PrometheusBuilder::new()
                 .listen_address(addr)
                 .install();
             match endpoint_result {
-                Ok(endpoint) => {
+                Ok(()) => {
                     info!("Opened metrics endpoint at {}", addr);
-                    endpoint
                 }
                 Err(e) => panic!(
                     "Opening metrics endpoint listener {:?} failed: {:?}. \


### PR DESCRIPTION
## Motivation

The `zebrad` listener conflict tests are failing occasionally, and we're not quite sure why.

See #1765 for details.

## Solution

- Add a "Trying" log before every listener bind, to see if the bind is delayed
- Log the configured and actual address where possible

## Review

These CI diagnostics are important, it will be hard to diagnose #1765 without them.

## Related Issues

This PR adds diagnostics for #1765, but it doesn't fix it.

This is a follow up to #1736, which did not fix the CI failures. But it might have made them less frequent.

## Follow Up Work

Actually fix the bug in #1765.