### PR TITLE
Compute the expected body length to reduce heap allocations

### DIFF
--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -174,6 +174,10 @@ impl Codec {
     /// Obtain the size of the body of a given message. This will match the
     /// number of bytes written to the writer provided to `write_body` for the
     /// same message.
+    ///
+    /// TODO: Replace with a size estimate, to avoid multiple serializations
+    /// for large data structures like lists, blocks, and transactions.
+    /// See #1774.
     fn body_length(&self, msg: &Message) -> usize {
         struct FakeWriter(usize);
 


### PR DESCRIPTION
## Motivation

Unnecessary allocation(s) in the external protocol codec implementation.

## Solution

Let's precompute the expected body length of a network message and reserve this capacity in the provided buffer. Also compute the checksum in-place.

## Review

This review is a low priority.

## Follow Up

Add a size estimator #1774 
Proptest our message implementation #27
Add benchmarks for network messages #1775
