### PR TITLE
Disable fail-fast from test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, beta]


### PR DESCRIPTION
## Motivation

If a test fail in some platform we still want to see how it went in the others.

## Solution

Disable the `fail-fast` feature from the tests job.