### PR TITLE
Fix Windows conflict test failures on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, beta]

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -354,7 +354,8 @@ impl<T> TestChild<T> {
             .unwrap_or(false)
     }
 
-    fn is_running(&mut self) -> bool {
+    /// Is this process currently running?
+    pub fn is_running(&mut self) -> bool {
         matches!(self.child.try_wait(), Ok(None))
     }
 }

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -160,6 +160,11 @@ pub struct TestChild<T> {
 
 impl<T> TestChild<T> {
     /// Kill the child process.
+    ///
+    /// ## BUGS
+    ///
+    /// On Windows, this function can return `Ok` for processes that have
+    /// panicked. See #1781.
     #[spandoc::spandoc]
     pub fn kill(&mut self) -> Result<()> {
         /// SPANDOC: Killing child process
@@ -355,6 +360,11 @@ impl<T> TestChild<T> {
     }
 
     /// Is this process currently running?
+    ///
+    /// ## BUGS
+    ///
+    /// On Windows, this function can return `true` for processes that have
+    /// panicked. See #1781.
     pub fn is_running(&mut self) -> bool {
         matches!(self.child.try_wait(), Ok(None))
     }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1229,14 +1229,22 @@ where
     // In node1 we want to check for the success regex
     // If there are any errors, we also want to print the node2 output.
     let output1 = node1.wait_with_output();
+    // This mut is only used on cfg(unix), due to #1781.
+    #[allow(unused_mut)]
     let (output1, mut node2) = node2.kill_on_error(output1)?;
 
-    // node2 should have panicked due to a conflict. Kill it here
-    // anyway, so it doesn't outlive the test on error.
+    // node2 should have panicked due to a conflict. Kill it here anyway, so it
+    // doesn't outlive the test on error.
+    //
+    // This code doesn't work on Windows. It's cleanup code that only runs when
+    // node2 doesn't panic as expected. So it's ok to skip it. See #1781.
+    #[cfg(unix)]
     if node2.is_running() {
         use color_eyre::eyre::eyre;
         return node2
-            .kill_on_error::<(), _>(Err(eyre!("conflicted node2 did not panic")))
+            .kill_on_error::<(), _>(Err(eyre!(
+                "conflicted node2 was still running, but the test expected a panic"
+            )))
             .context_from(&output1)
             .map(|_| ());
     }


### PR DESCRIPTION
## Motivation

In #1770, we unconditionally kill the conflicted node in the conflict acceptance tests. But on Windows, this makes `was_killed` return `true`, failing the tests. We didn't pick up this error in the PR, due to testnet unreliability, which will be fixed by #1222.

## Solution

- [x] Only kill the conflicted node if it is still running
- [x] Make the code where both nodes are running as short as possible

## Review

CI is failing all the time on `main`, so this PR is critical priority.

Since I don't have a Windows box locally, we should make sure Windows, macOS, and Linux CI pass on this PR.

## Follow Up Work

Maybe we should disable the testnet large sync tests, or [disable fail_fast](https://github.com/ZcashFoundation/zebra/pull/1776) in CI.

Fix the Windows-specific bugs in `TestChild::kill` and `TestChild::is_running` #1781