### PR TITLE
Re-enable the macOS conflict acceptance tests

### DIFF
--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -163,8 +163,8 @@ impl<T> TestChild<T> {
     ///
     /// ## BUGS
     ///
-    /// On Windows, this function can return `Ok` for processes that have
-    /// panicked. See #1781.
+    /// On Windows (and possibly macOS), this function can return `Ok` for
+    /// processes that have panicked. See #1781.
     #[spandoc::spandoc]
     pub fn kill(&mut self) -> Result<()> {
         /// SPANDOC: Killing child process
@@ -363,8 +363,8 @@ impl<T> TestChild<T> {
     ///
     /// ## BUGS
     ///
-    /// On Windows, this function can return `true` for processes that have
-    /// panicked. See #1781.
+    /// On Windows and macOS, this function can return `true` for processes that
+    /// have panicked. See #1781.
     pub fn is_running(&mut self) -> bool {
         matches!(self.child.try_wait(), Ok(None))
     }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1223,16 +1223,17 @@ where
     // In node1 we want to check for the success regex
     // If there are any errors, we also want to print the node2 output.
     let output1 = node1.wait_with_output();
-    // This mut is only used on cfg(unix), due to #1781.
+    // This mut is only used on some platforms, due to #1781.
     #[allow(unused_mut)]
     let (output1, mut node2) = node2.kill_on_error(output1)?;
 
     // node2 should have panicked due to a conflict. Kill it here anyway, so it
     // doesn't outlive the test on error.
     //
-    // This code doesn't work on Windows. It's cleanup code that only runs when
-    // node2 doesn't panic as expected. So it's ok to skip it. See #1781.
-    #[cfg(unix)]
+    // This code doesn't work on Windows or macOS. It's cleanup code that only
+    // runs when node2 doesn't panic as expected. So it's ok to skip it.
+    // See #1781.
+    #[cfg(target_os = "linux")]
     if node2.is_running() {
         use color_eyre::eyre::eyre;
         return node2

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1204,12 +1204,6 @@ where
     T: ZebradTestDirExt,
     U: ZebradTestDirExt,
 {
-    // By DNS issues we want to skip all port conflict tests on macOS by now.
-    // Follow up at #1631
-    if cfg!(target_os = "macos") {
-        return Ok(());
-    }
-
     // Start the first node
     let node1 = first_dir.spawn_child(&["start"])?;
 


### PR DESCRIPTION
## Motivation

We didn't re-enable the macOS conflict tests as part of PR #1613.

(The comment said we were waiting for PR #1631, but we were actually waiting for #1613.)