### PR TITLE
Set ZEBRA_SKIP_NETWORK_TESTS using Windows syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,14 @@ jobs:
       - name: Install LLVM on Windows
         if: matrix.os == 'windows-latest'
         run: choco install llvm -y
-      - name: Skip network tests on Ubuntu and Windows
+      - name: Skip network tests on Ubuntu
         # Ubuntu runners don't have network or DNS configured during test steps
-        # Windows runners have an unreliable network
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'
+        if: matrix.os == 'ubuntu-latest'
         run: echo "ZEBRA_SKIP_NETWORK_TESTS=1" >> $GITHUB_ENV
+      - name: Skip network tests on Windows
+        # Windows runners have an unreliable network
+        if: matrix.os == 'windows-latest'
+        run: echo "ZEBRA_SKIP_NETWORK_TESTS=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Show env vars
         run: |
             echo "ZEBRA_SKIP_NETWORK_TESTS=${{ env.ZEBRA_SKIP_NETWORK_TESTS }}"
@@ -50,8 +53,10 @@ jobs:
         with:
           command: test
           args: --verbose --all
-      # Explicitly run any tests that are usually #[ignored], modulo ZEBRA_SKIP_NETWORK_TESTS
+      # Explicitly run any tests that are usually #[ignored]
       - name: Run zebrad large sync tests
+        # Skip the entire step on Ubuntu and Windows, because the test would be skipped anyway due to ZEBRA_SKIP_NETWORK_TESTS
+        if: matrix.os == 'macOS-latest'
         uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
## Motivation

The large sync tests run on Windows, but we want to disable them.

The "Show env vars" CI step prints `ZEBRA_SKIP_NETWORK_TESTS=` on Windows, but we expect `ZEBRA_SKIP_NETWORK_TESTS=1`.

The `if` command should support `==`, `!=`, and `||`, so they are unlikely to be the problem:
https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#operators

## Solution

Use Powershell syntax to set `ZEBRA_SKIP_NETWORK_TESTS` on Windows:
https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#environment-files

Also skip the entire large sync test step on Ubuntu and Windows, because the tests are skipped anyway due to `ZEBRA_SKIP_NETWORK_TESTS`. This saves some compilation time.

## Outcome

The `Show env vars` step in this PR outputs:
```
ZEBRA_SKIP_NETWORK_TESTS=1
CARGO_INCREMENTAL=0
RUST_BACKTRACE=full
```

🎉 

## Review

This review is a high priority if Windows CI keeps failing after #1777.
