### PR TITLE
Disable unreliable `sync_large_checkpoints_testnet`

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -745,7 +745,7 @@ fn sync_large_checkpoints_mainnet() -> Result<()> {
     Ok(())
 }
 
-// Todo: We had a `sync_large_checkpoints_mainnet` here but it was removed because
+// Todo: We had a `sync_large_checkpoints_testnet` here but it was removed because
 // the testnet is unreliable(#1222). Enable after we have more testnet instances(#1791).
 
 /// Sync `network` until `zebrad` reaches `height`, and ensure that

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -745,27 +745,8 @@ fn sync_large_checkpoints_mainnet() -> Result<()> {
     Ok(())
 }
 
-/* This test is very unreliable so we are fully disabling it until
-we deploy more testnet instances(#1222).
-Todo: Enable after we have more testnet instances. */
-/*
-/// Test if `zebrad` can sync some larger checkpoints on testnet.
-///
-/// This test does not run by default, see `sync_large_checkpoints_mainnet`
-/// for details.
-#[test]
-#[ignore]
-fn sync_large_checkpoints_testnet() -> Result<()> {
-    sync_until(
-        LARGE_CHECKPOINT_TEST_HEIGHT,
-        Testnet,
-        STOP_AT_HEIGHT_REGEX,
-        LARGE_CHECKPOINT_TIMEOUT,
-        None,
-    )
-    .map(|_tempdir| ())
-}
-*/
+// Todo: We had a `sync_large_checkpoints_mainnet` here but it was removed because
+// the testnet is unreliable(#1222). Enable after we have more testnet instances(#1791).
 
 /// Sync `network` until `zebrad` reaches `height`, and ensure that
 /// the output contains `stop_regex`. If `reuse_tempdir` is supplied,

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -745,9 +745,9 @@ fn sync_large_checkpoints_mainnet() -> Result<()> {
     Ok(())
 }
 
-/* This test is very unreliable so we are fully disabling it until 
-   we deploy more testnet instances(#1222).
-   Todo: Enable after we have more testnet instances. */
+/* This test is very unreliable so we are fully disabling it until
+we deploy more testnet instances(#1222).
+Todo: Enable after we have more testnet instances. */
 /*
 /// Test if `zebrad` can sync some larger checkpoints on testnet.
 ///

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -745,6 +745,10 @@ fn sync_large_checkpoints_mainnet() -> Result<()> {
     Ok(())
 }
 
+/* This test is very unreliable so we are fully disabling it until 
+   we deploy more testnet instances(#1222).
+   Todo: Enable after we have more testnet instances. */
+/*
 /// Test if `zebrad` can sync some larger checkpoints on testnet.
 ///
 /// This test does not run by default, see `sync_large_checkpoints_mainnet`
@@ -761,6 +765,7 @@ fn sync_large_checkpoints_testnet() -> Result<()> {
     )
     .map(|_tempdir| ())
 }
+*/
 
 /// Sync `network` until `zebrad` reaches `height`, and ensure that
 /// the output contains `stop_regex`. If `reuse_tempdir` is supplied,


### PR DESCRIPTION
## Motivation

Several pull requests fail the CI because the `sync_large_checkpoints_testnet` are very unreliable.

## Solution

Disable the test until we have more testnet instances(#1222)

## Review

Anyone can review.