### PR TITLE
Readd the docs CI with new firebase project ids

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,6 +1,0 @@
-{
-  "projects": {
-    "doc": "zealous-zebra",
-    "doc-internal": "zebra-doc-internal"
-  }
-}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,12 +31,6 @@ jobs:
     - name: Build Zebra book
       run: |
         mdbook build book/
-    - name: Switch to book project
-      uses: w9jds/firebase-action@v2.0.0
-      with:
-        args: use zebra-book-b535f
-      env:
-        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
     - name: Deploy Zebra book to firebase
       uses: w9jds/firebase-action@v2.0.0
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,76 @@
+name: Docs
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  build:
+    name: Build and Deploy Docs (+beta)
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@master
+
+    - name: Install latest beta
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: beta
+        override: true
+
+    - name: Install mdbook
+      run: |
+        cd book
+        curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.5/mdbook-v0.4.5-x86_64-unknown-linux-gnu.tar.gz | tar xz
+        # Add the book directory to the $PATH
+        echo "$GITHUB_WORKSPACE/book" >> $GITHUB_PATH
+    - name: Build Zebra book
+      run: |
+        mdbook build book/
+    - name: Switch to book project
+      uses: w9jds/firebase-action@v2.0.0
+      with:
+        args: use zebra-book-b535f
+      env:
+        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+    - name: Deploy Zebra book to firebase
+      uses: w9jds/firebase-action@v2.0.0
+      with:
+        args: deploy
+      env:
+        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        PROJECT_PATH: book/
+        PROJECT_ID: zebra-book-b535f
+
+    - name: Build external docs
+      run: |
+        # Exclude zebra-utils, it is not for library or app users
+        cargo doc --no-deps --workspace --exclude zebra-utils
+      env:
+        RUSTDOCFLAGS: "--html-in-header katex-header.html"
+
+    - name: Deploy external docs to firebase
+      uses: w9jds/firebase-action@v2.0.0
+      with:
+        args: deploy
+      env:
+        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        PROJECT_ID: zebra-doc-external
+
+    - name: Build internal docs
+      run: |
+        cargo doc --no-deps --document-private-items
+      env:
+        RUSTDOCFLAGS: "--html-in-header katex-header.html"
+
+    - name: Deploy internal docs to firebase
+      uses: w9jds/firebase-action@v2.0.0
+      with:
+        args: deploy
+      env:
+        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        PROJECT_ID: zebra-doc-internal-e9fd4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Docs
 
 on:
-  pull_request:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -28,9 +28,11 @@ jobs:
         curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.5/mdbook-v0.4.5-x86_64-unknown-linux-gnu.tar.gz | tar xz
         # Add the book directory to the $PATH
         echo "$GITHUB_WORKSPACE/book" >> $GITHUB_PATH
+    
     - name: Build Zebra book
       run: |
         mdbook build book/
+    
     - name: Deploy Zebra book to firebase
       uses: w9jds/firebase-action@v2.0.0
       with:


### PR DESCRIPTION
Reverts ZcashFoundation/zebra#1787 but with new project ids.

In case is needed in the future i am going to post some notes here.

- The firebase token we were using was somehow expired, have to get a new one. In order to do this you need a gmail account to be part of the zfnd organization. I had to download firebase tools binary(https://firebase.google.com/docs/cli#install-cli-mac-linux) and execute the following to get a new token:

  `./firebase-tools-linux login:ci`

  The token printed needs to be added to github zebra repo secrets as `FIREBASE_TOKEN` repository secret.

- I created 3 new projects in firebase(I used the web but can be done from the console as well), the projects IDs ended up being:
  - `zealous-zebra` - Was already there. Used by `cd.yml`, `manual-deploy.yml` and `test-yml`
  - `zebra-book-b535f` - Added. Used for the mdbook.
  - `zebra-doc-external` - Added. Used for the external docs.
  - `zebra-doc-internal-e9fd4` - Added. Used for the internal docs.
  
  Some of them were added suffixes automatically.
- Use this projects IDs in the `workflows/docs.yml` to deploy the 3 projects.

I also deleted  the `.firebaserc` file that it can be used to have project aliases but i think it was confusing so removed it.

This PR will close https://github.com/ZcashFoundation/zebra/issues/1784