### PR TITLE
WIP: Handle merged inv messages

### DIFF
--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -281,6 +281,7 @@ impl Handler {
                     Handler::Finished(Err(PeerError::NotFound(items)))
                 }
             }
+            // TODO: does zcashd concatenate inv messages of different types?
             (Handler::FindBlocks, Message::Inv(items))
                 if items
                     .iter()
@@ -768,6 +769,7 @@ where
                 {
                     Request::TransactionsByHash(transaction_hashes(&items).collect())
                 }
+                // TODO: does zcashd concatenate inv messages of the same or different types?
                 [InventoryHash::Block(_), rest @ ..]
                     if rest
                         .iter()
@@ -804,6 +806,7 @@ where
                 {
                     Request::TransactionsByHash(transaction_hashes(&items).collect())
                 }
+                // TODO: does zcashd concatenate getdata messages of the same or different types?
                 _ => {
                     // temporary logging to help us decide how to handle multiples
                     let blocks = items

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -768,6 +768,13 @@ where
                 {
                     Request::TransactionsByHash(transaction_hashes(&items).collect())
                 }
+                [InventoryHash::Block(_), rest @ ..]
+                    if rest
+                        .iter()
+                        .all(|item| matches!(item, InventoryHash::Block(_))) =>
+                {
+                    Err(PeerError::WrongMessage("inv with multiple blocks"))?
+                }
                 _ => Err(PeerError::WrongMessage("inv with mixed item types"))?,
             },
             Message::GetData(items) => match &items[..] {

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -48,8 +48,8 @@ pub enum PeerError {
     /// A peer sent us a message we don't support.
     #[error("Remote peer sent an unsupported message type: {0}")]
     UnsupportedMessage(&'static str),
-    /// A peer sent us a message we couldn't interpret in context.
-    #[error("Remote peer sent an uninterpretable message: {0}")]
+    /// A peer sent us a message we couldn't transform into our request/response protocol
+    #[error("Remote peer sent a message that was not a Zebra request/response: {0}")]
     WrongMessage(&'static str),
     /// We got a `Reject` message. This does not necessarily mean that
     /// the peer connection is in a bad state, but for the time being


### PR DESCRIPTION
## Work In Progress

https://github.com/teor2345/zebra/tree/split-merged-inv

## Motivation

`zcashd` sometimes merges multiple block or transaction `InventoryHash`es into the same `Inv` message.

But in Zebra, we want to process these merged messages as a stream of separate `Inv` messages.

## Solution

- [ ] split messages in the `peer_rx` stream in `Handshake`, before the inventory collector runs on the stream
- [ ] split `Inv` messages by `InventoryHash` type
- [ ] split small multi-block `Inv` messages into a series of single block messages
- [ ] move the large `peer_rx` wrapper closures into separate functions
- [ ] move connection wrapper closures into functions
- [ ] apply all connection wrappers in `handshake`, and move them to that file
  - [ ] make a comment in `connection`

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Integration Tests

## Review

This is a draft PR that might never get merged.

## Related Issues

This might be a fix for recent sync issues, which might be related to #1721 

## Follow Up Work

Finish the PR