### PR TITLE
Upgrade ed25519-zebra to version 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,20 +920,6 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85a1fff1b329c96789427b09d4d5949b2d2f717851fd1e65a18878bee19d1ff"
-dependencies = [
- "curve25519-dalek",
- "hex",
- "rand_core 0.5.1",
- "serde",
- "sha2",
- "thiserror",
-]
-
-[[package]]
-name = "ed25519-zebra"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a128b76af6dd4b427e34a6fd43dc78dbfe73672ec41ff615a2414c1a0ad0409"
@@ -3391,7 +3377,7 @@ name = "tower-batch"
 version = "0.2.1"
 dependencies = [
  "color-eyre",
- "ed25519-zebra 2.2.0",
+ "ed25519-zebra",
  "futures 0.3.13",
  "futures-core",
  "pin-project 0.4.27",
@@ -3976,7 +3962,7 @@ dependencies = [
  "chrono",
  "color-eyre",
  "displaydoc",
- "ed25519-zebra 1.0.1",
+ "ed25519-zebra",
  "equihash",
  "futures 0.3.13",
  "hex",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -39,7 +39,7 @@ proptest-derive = { version = "0.3.0", optional = true }
 
 # ZF deps
 displaydoc = "0.1.7"
-ed25519-zebra = "1"
+ed25519-zebra = "2"
 equihash = "0.1"
 redjubjub = "0.2"
 bitflags = "1.2.1"


### PR DESCRIPTION
## Motivation

We need to validate signatures after Canopy NU where [ZIP-215](https://github.com/zcash/zips/blob/master/zip-0215.rst) was implemented.

## Solution

In this 2 tickets: https://github.com/ZcashFoundation/zebra/issues/1565 and https://github.com/ZcashFoundation/zebra/issues/1667 the conclusion is to just upgrade and validate everything using `ed25519-zebra` version 2.

This PR upgrades `ed25519-zebra`, all tests are passing and zebra is syncing.

I think some testing will be needed, some ideas could be the followings however not sure if totally required:

- [ ] Sync zebra up to mainnet and testnet tips, where new signatures will be present.

## Review

## Related Issues

- Close https://github.com/ZcashFoundation/zebra/issues/1565
- Close https://github.com/ZcashFoundation/zebra/issues/1667

## Follow Up Work

- get some recent block (after canopy) from zcashd and add it as a test vector into zebra #1099
- check that modified signatures and modified data don't pass validation #196