### PR TITLE
Avoid acceptance test port conflicts

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -904,10 +904,21 @@ fn sync_past_sapling_testnet() {
 /// times. For example: setting up both ends of a connection, or re-using
 /// the same port multiple times.
 fn random_known_port() -> u16 {
-    // Use the intersection of the IANA ephemeral port range, and the Linux
-    // ephemeral port range:
-    // https://en.wikipedia.org/wiki/Ephemeral_port#Range
-    rand::thread_rng().gen_range(49152, 60999)
+    // Use the intersection of the IANA/Windows/macOS ephemeral port range,
+    // and the Linux ephemeral port range:
+    //   - https://en.wikipedia.org/wiki/Ephemeral_port#Range
+    // excluding ports less than 53500, to avoid:
+    //   - typical Hyper-V reservations up to 52000:
+    //      - https://github.com/googlevr/gvr-unity-sdk/issues/1002
+    //      - https://github.com/docker/for-win/issues/3171
+    //   - the MOM-Clear port 51515
+    //      - https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/service-overview-and-network-port-requirements
+    //   - the LDAP Kerberos byte-swapped reservation 53249
+    //      - https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/ldap-kerberos-server-reset-tcp-sessions
+    //   - macOS and Windows sequential ephemeral port allocations,
+    //     starting from 49152:
+    //      - https://dataplane.org/ephemeralports.html
+    rand::thread_rng().gen_range(53500, 60999)
 }
 
 /// Returns the "magic" port number that tells the operating system to


### PR DESCRIPTION
## Motivation

Windows can reserve or use ports up to 53500.

Windows and macOS sequentially allocate ephemeral ports, starting at 41952.

See the code comment for the full details.

## Solution

Start Zebra's random acceptance test ports at 53500.

## Review

@oxarbitrage has also looked at this issue. It's urgent, because it's causing CI failures.

## Related Issues

Closes #1769 
Closes #1765 

## Follow Up Work

If these issues continue, we should:
- ask the OS to allocate a listener port, by configuring port `0`
- read the actual port from `zebrad`'s logs
- launch the test or conflicting process with that port

This is now ticket #1813.