### PR TITLE
Stop sending blocks and transactions on error

### DIFF
--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -911,6 +911,7 @@ where
                 for transaction in transactions.into_iter() {
                     if let Err(e) = self.peer_tx.send(Message::Tx(transaction)).await {
                         self.fail_with(e);
+                        return;
                     }
                 }
             }
@@ -919,6 +920,7 @@ where
                 for block in blocks.into_iter() {
                     if let Err(e) = self.peer_tx.send(Message::Block(block)).await {
                         self.fail_with(e);
+                        return;
                     }
                 }
             }


### PR DESCRIPTION
## Motivation

Zebra continues sending blocks and transactions to peers after there is an error on the connection.

This causes panics like #1599.

## Solution

Return after the first error when sending blocks or transactions.

## Review

@yaahc is doing the refactor of this code.

This fix is urgent, because it stops Zebra panicking when peer connections have errors.

## Related Issues

#1610 - initial refactor attempt
#1817 - current refactor attempt

## Follow Up Work

Finish the refactor that prevents future bugs like this #1817