### PR TITLE
Fix a typo in Transaction

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -40,7 +40,7 @@ use crate::{
 ///
 /// Zcash has a number of different transaction formats. They are represented
 /// internally by different enum variants. Because we checkpoint on Sapling
-/// activation, we do not parse any pre-Sapling transaction types.
+/// activation, we do not validate any pre-Sapling transaction types.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 // XXX consider boxing the Optional fields of V4 txs
 #[allow(clippy::large_enum_variant)]


### PR DESCRIPTION
## Motivation

We parse v1, v2, and v3 transactions, but we don't validate them, due to the Sapling checkpoint. (We need to parse them so we can spend their transparent outputs.)

But the `Transaction` comment says that we don't parse them.

## Solution

Fix the comment typo.