### PR TITLE
Add initial support for NU5 to zebra

### DIFF
--- a/zebra-chain/src/block/root_hash.rs
+++ b/zebra-chain/src/block/root_hash.rs
@@ -55,7 +55,7 @@ impl RootHash {
                 ChainHistoryActivationReserved(bytes)
             }
             Heartwood | Canopy => ChainHistoryRoot(ChainHistoryMmrRootHash(bytes)),
-            NU5 => unimplemented!("NU5 upgrade is still in progress and not fully implemented"),
+            NU5 => unimplemented!("NU5 uses hashAuthDataRoot as specified in ZIP-244"),
         }
     }
 

--- a/zebra-chain/src/block/root_hash.rs
+++ b/zebra-chain/src/block/root_hash.rs
@@ -55,6 +55,7 @@ impl RootHash {
                 ChainHistoryActivationReserved(bytes)
             }
             Heartwood | Canopy => ChainHistoryRoot(ChainHistoryMmrRootHash(bytes)),
+            NU5 => unimplemented!("NU5 upgrade is still in progress and not fully implemented"),
         }
     }
 

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -205,8 +205,7 @@ impl NetworkUpgrade {
     pub fn target_spacing(&self) -> Duration {
         let spacing_seconds = match self {
             Genesis | BeforeOverwinter | Overwinter | Sapling => PRE_BLOSSOM_POW_TARGET_SPACING,
-            Blossom | Heartwood | Canopy => POST_BLOSSOM_POW_TARGET_SPACING,
-            NU5 => unimplemented!("NU5 upgrade is still in progress and not fully implemented"),
+            Blossom | Heartwood | Canopy | NU5 => POST_BLOSSOM_POW_TARGET_SPACING,
         };
 
         Duration::seconds(spacing_seconds)

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -96,6 +96,7 @@ pub(crate) const CONSENSUS_BRANCH_IDS: &[(NetworkUpgrade, ConsensusBranchId)] = 
     (Blossom, ConsensusBranchId(0x2bb40e60)),
     (Heartwood, ConsensusBranchId(0xf5b9230b)),
     (Canopy, ConsensusBranchId(0xe9ff75a6)),
+    (NU5, ConsensusBranchId(0xf919a198)),
 ];
 
 /// The target block spacing before Blossom.

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -37,6 +37,8 @@ pub enum NetworkUpgrade {
     Heartwood,
     /// The Zcash protocol after the Canopy upgrade.
     Canopy,
+    /// The Zcash protocol after the NU5 upgrade.
+    NU5,
 }
 
 /// Mainnet network upgrade activation heights.
@@ -200,6 +202,7 @@ impl NetworkUpgrade {
         let spacing_seconds = match self {
             Genesis | BeforeOverwinter | Overwinter | Sapling => PRE_BLOSSOM_POW_TARGET_SPACING,
             Blossom | Heartwood | Canopy => POST_BLOSSOM_POW_TARGET_SPACING,
+            NU5 => unimplemented!("NU5 upgrade is still in progress and not fully implemented"),
         };
 
         Duration::seconds(spacing_seconds)

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -38,6 +38,9 @@ pub enum NetworkUpgrade {
     /// The Zcash protocol after the Canopy upgrade.
     Canopy,
     /// The Zcash protocol after the NU5 upgrade.
+    ///
+    /// Note: Network Upgrade 5 includes the Orchard Shielded Protocol, and
+    /// other changes. The NU5 code name has not been chosen yet.
     NU5,
 }
 

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -56,6 +56,7 @@ pub(crate) const MAINNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] 
     (block::Height(653_600), Blossom),
     (block::Height(903_000), Heartwood),
     (block::Height(1_046_400), Canopy),
+    // TODO: Add NU5 mainnet activation height
 ];
 
 /// Testnet network upgrade activation heights.
@@ -70,6 +71,7 @@ pub(crate) const TESTNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] 
     (block::Height(584_000), Blossom),
     (block::Height(903_800), Heartwood),
     (block::Height(1_028_500), Canopy),
+    // TODO: Add NU5 testnet activation height
 ];
 
 /// The Consensus Branch Id, used to bind transactions and blocks to a

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -236,6 +236,9 @@ impl Arbitrary for Transaction {
             NetworkUpgrade::Blossom | NetworkUpgrade::Heartwood | NetworkUpgrade::Canopy => {
                 Self::v4_strategy(ledger_state)
             }
+            NetworkUpgrade::NU5 => {
+                unimplemented!("NU5 upgrade is still in progress and not fully implemented")
+            }
         }
     }
 

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -237,7 +237,7 @@ impl Arbitrary for Transaction {
                 Self::v4_strategy(ledger_state)
             }
             NetworkUpgrade::NU5 => {
-                unimplemented!("NU5 upgrade is still in progress and not fully implemented")
+                unimplemented!("NU5 upgrade can use v4 or v5 transactions, as specified in ZIP-225")
             }
         }
     }

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -85,7 +85,9 @@ impl<'a> SigHasher<'a> {
             Sapling | Blossom | Heartwood | Canopy => self
                 .hash_sighash_zip243(&mut hash)
                 .expect("serialization into hasher never fails"),
-            NU5 => unimplemented!("NU5 upgrade uses a new transaction digest algorithm, as specified in ZIP-244"),
+            NU5 => unimplemented!(
+                "NU5 upgrade uses a new transaction digest algorithm, as specified in ZIP-244"
+            ),
         }
 
         hash.finalize()

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -85,6 +85,7 @@ impl<'a> SigHasher<'a> {
             Sapling | Blossom | Heartwood | Canopy => self
                 .hash_sighash_zip243(&mut hash)
                 .expect("serialization into hasher never fails"),
+            NU5 => unimplemented!("NU5 upgrade is still in progress and not fully implemented"),
         }
 
         hash.finalize()

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -85,7 +85,7 @@ impl<'a> SigHasher<'a> {
             Sapling | Blossom | Heartwood | Canopy => self
                 .hash_sighash_zip243(&mut hash)
                 .expect("serialization into hasher never fails"),
-            NU5 => unimplemented!("NU5 upgrade is still in progress and not fully implemented"),
+            NU5 => unimplemented!("NU5 upgrade uses a new transaction digest algorithm, as specified in ZIP-244"),
         }
 
         hash.finalize()

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -189,7 +189,7 @@ mod test {
         zebra_test::init();
 
         let highest_network_upgrade = NetworkUpgrade::current(network, block::Height::MAX);
-        assert!(highest_network_upgrade == Canopy || highest_network_upgrade == Heartwood,
+        assert!(highest_network_upgrade == NU5 || highest_network_upgrade == Canopy,
                 "expected coverage of all network upgrades: add the new network upgrade to the list in this test");
 
         for &network_upgrade in &[
@@ -199,6 +199,7 @@ mod test {
             Blossom,
             Heartwood,
             Canopy,
+            NU5,
         ] {
             let height = network_upgrade.activation_height(network);
             if let Some(height) = height {

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -57,9 +57,8 @@ impl Version {
             (Mainnet, Heartwood) => 170_011,
             (Testnet, Canopy) => 170_012,
             (Mainnet, Canopy) => 170_013,
-            (_, NU5) => {
-                unimplemented!("NU5 upgrade is still in progress and not fully implemented")
-            }
+            (Testnet, NU5) => 170_014,
+            (Mainnet, NU5) => 170_015,
         })
     }
 

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -57,6 +57,9 @@ impl Version {
             (Mainnet, Heartwood) => 170_011,
             (Testnet, Canopy) => 170_012,
             (Mainnet, Canopy) => 170_013,
+            (_, NU5) => {
+                unimplemented!("NU5 upgrade is still in progress and not fully implemented")
+            }
         })
     }
 


### PR DESCRIPTION
## Motivation

We want to add a `NetworkUpgrade::NU5` network upgrade variant, and a network protocol version for `NU5`.

## Solution

This change updates various enums and constants to include variants for `NU5`.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

@teor2345 

## Related Issues

Closes https://github.com/ZcashFoundation/zebra/issues/1797

## Follow Up Work

Need to implement actual `NU5` logic, currently we panic if `NU5` code paths get executed.