### PR TITLE
Add transaction version 5

### DIFF
--- a/zebra-chain/src/parameters.rs
+++ b/zebra-chain/src/parameters.rs
@@ -15,10 +15,12 @@
 mod genesis;
 mod network;
 mod network_upgrade;
+mod transaction;
 
 pub use genesis::*;
 pub use network::Network;
 pub use network_upgrade::*;
+pub use transaction::*;
 
 #[cfg(test)]
 mod tests;

--- a/zebra-chain/src/parameters/transaction.rs
+++ b/zebra-chain/src/parameters/transaction.rs
@@ -1,9 +1,9 @@
 //! Transaction consensus and utility parameters.
 
-///The version group ID for Overwinter transactions.
+/// The version group ID for Overwinter transactions.
 pub const OVERWINTER_VERSION_GROUP_ID: u32 = 0x03C4_8270;
 
-///The version group ID for Sapling transactions.
+/// The version group ID for Sapling transactions.
 pub const SAPLING_VERSION_GROUP_ID: u32 = 0x892F_2085;
 
 /// The version group ID for version 5 transactions.

--- a/zebra-chain/src/parameters/transaction.rs
+++ b/zebra-chain/src/parameters/transaction.rs
@@ -1,0 +1,8 @@
+//! Transaction consensus and utility parameters.
+
+///The Overwinter version group ID.
+pub const OVERWINTER_VERSION_GROUP_ID: u32 = 0x03C4_8270;
+///The Sapling version group ID.
+pub const SAPLING_VERSION_GROUP_ID: u32 = 0x892F_2085;
+///The Orchard version group ID.
+pub const ORCHARD_VERSION_GROUP_ID: u32 = 0x6A7_270A;

--- a/zebra-chain/src/parameters/transaction.rs
+++ b/zebra-chain/src/parameters/transaction.rs
@@ -1,8 +1,13 @@
 //! Transaction consensus and utility parameters.
 
-///The Overwinter version group ID.
+///The version group ID for Overwinter transactions.
 pub const OVERWINTER_VERSION_GROUP_ID: u32 = 0x03C4_8270;
-///The Sapling version group ID.
+
+///The version group ID for Sapling transactions.
 pub const SAPLING_VERSION_GROUP_ID: u32 = 0x892F_2085;
-///The Orchard version group ID.
-pub const ORCHARD_VERSION_GROUP_ID: u32 = 0x6A7_270A;
+
+/// The version group ID for version 5 transactions.
+///
+/// Orchard transactions must use transaction version 5 and this version
+/// group ID. Sapling transactions can use v4 or v5 transactions.
+pub const TX_V5_VERSION_GROUP_ID: u32 = 0x26A7_270A;

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -197,7 +197,7 @@ impl Transaction {
             // Maybe JoinSplits, maybe not, we're still deciding
             Transaction::V5 { .. } => {
                 unimplemented!(
-                    "v5 transaction format as specified in ZIP-225 after decision on 2021-03-05"
+                    "v5 transaction format as specified in ZIP-225 after decision on 2021-03-12"
                 )
             }
             // No JoinSplits

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -194,8 +194,20 @@ impl Transaction {
                     .flat_map(|joinsplit| joinsplit.nullifiers.iter()),
             ),
             // No JoinSplits
-            Transaction::V1 { .. } | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            _ => Box::new(std::iter::empty()),
+            Transaction::V1 { .. }
+            | Transaction::V2 {
+                joinsplit_data: None,
+                ..
+            }
+            | Transaction::V3 {
+                joinsplit_data: None,
+                ..
+            }
+            | Transaction::V4 {
+                joinsplit_data: None,
+                ..
+            }
+            | Transaction::V5 { .. } => Box::new(std::iter::empty()),
         }
     }
 
@@ -213,10 +225,13 @@ impl Transaction {
                 unimplemented!("v5 transaction format as specified in ZIP-225")
             }
             // No JoinSplits
-            Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
-                Box::new(std::iter::empty())
-            }
-            _ => Box::new(std::iter::empty()),
+            Transaction::V1 { .. }
+            | Transaction::V2 { .. }
+            | Transaction::V3 { .. }
+            | Transaction::V4 {
+                shielded_data: None,
+                ..
+            } => Box::new(std::iter::empty()),
         }
     }
 

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -194,7 +194,8 @@ impl Transaction {
                     .flat_map(|joinsplit| joinsplit.nullifiers.iter()),
             ),
             // No JoinSplits
-            _ => Box::new(std::iter::empty()),
+            Transaction::V1 { .. } | Transaction::V5 { .. } => Box::new(std::iter::empty()),
+            _ => Box::new(std::iter::empty())
         }
     }
 
@@ -208,8 +209,10 @@ impl Transaction {
                 shielded_data: Some(shielded_data),
                 ..
             } => Box::new(shielded_data.nullifiers()),
+            Transaction::V5 { .. } => unimplemented!("v5 transaction format as specified in ZIP-225"),
             // No JoinSplits
-            _ => Box::new(std::iter::empty()),
+            Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => Box::new(std::iter::empty()),
+            _ => Box::new(std::iter::empty())
         }
     }
 

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -99,7 +99,7 @@ pub enum Transaction {
         /// The shielded data for this transaction, if any.
         shielded_data: Option<ShieldedData>,
     },
-    /// An Orchard transaction (`version = 5`).
+    /// A `version = 5` transaction, which supports `Sapling` and `Orchard`.
     V5 {
         /// The transparent inputs to the transaction.
         tx_in: Vec<transparent::Input>,

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -195,7 +195,7 @@ impl Transaction {
             ),
             // No JoinSplits
             Transaction::V1 { .. } | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            _ => Box::new(std::iter::empty())
+            _ => Box::new(std::iter::empty()),
         }
     }
 
@@ -209,10 +209,14 @@ impl Transaction {
                 shielded_data: Some(shielded_data),
                 ..
             } => Box::new(shielded_data.nullifiers()),
-            Transaction::V5 { .. } => unimplemented!("v5 transaction format as specified in ZIP-225"),
+            Transaction::V5 { .. } => {
+                unimplemented!("v5 transaction format as specified in ZIP-225")
+            }
             // No JoinSplits
-            Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => Box::new(std::iter::empty()),
-            _ => Box::new(std::iter::empty())
+            Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
+                Box::new(std::iter::empty())
+            }
+            _ => Box::new(std::iter::empty()),
         }
     }
 

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -101,16 +101,15 @@ pub enum Transaction {
     },
     /// A `version = 5` transaction, which supports `Sapling` and `Orchard`.
     V5 {
-        /// The transparent inputs to the transaction.
-        inputs: Vec<transparent::Input>,
-        /// The transparent outputs from the transaction.
-        outputs: Vec<transparent::Output>,
         /// The earliest time or block height that this transaction can be added to the
         /// chain.
         lock_time: LockTime,
         /// The latest block height that this transaction can be added to the chain.
         expiry_height: block::Height,
-
+        /// The transparent inputs to the transaction.
+        inputs: Vec<transparent::Input>,
+        /// The transparent outputs from the transaction.
+        outputs: Vec<transparent::Output>,
         /// The rest of the transaction as bytes
         rest: Vec<u8>,
     },

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -42,7 +42,7 @@ use crate::{
 /// internally by different enum variants. Because we checkpoint on Sapling
 /// activation, we do not validate any pre-Sapling transaction types.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-// XXX consider boxing the Optional fields of V4 txs
+// XXX consider boxing the Optional fields of V4 and V5 txs
 #[allow(clippy::large_enum_variant)]
 pub enum Transaction {
     /// A fully transparent transaction (`version = 1`).

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -100,6 +100,8 @@ pub enum Transaction {
         shielded_data: Option<ShieldedData>,
     },
     /// A `version = 5` transaction, which supports `Sapling` and `Orchard`.
+    // TODO: does this transaction type support `Sprout`?
+    // Check for ZIP-225 updates after the decision on 2021-03-05.
     V5 {
         /// The earliest time or block height that this transaction can be added to the
         /// chain.
@@ -192,6 +194,12 @@ impl Transaction {
                     .joinsplits()
                     .flat_map(|joinsplit| joinsplit.nullifiers.iter()),
             ),
+            // Maybe JoinSplits, maybe not, we're still deciding
+            Transaction::V5 { .. } => {
+                unimplemented!(
+                    "v5 transaction format as specified in ZIP-225 after decision on 2021-03-05"
+                )
+            }
             // No JoinSplits
             Transaction::V1 { .. }
             | Transaction::V2 {
@@ -205,8 +213,7 @@ impl Transaction {
             | Transaction::V4 {
                 joinsplit_data: None,
                 ..
-            }
-            | Transaction::V5 { .. } => Box::new(std::iter::empty()),
+            } => Box::new(std::iter::empty()),
         }
     }
 

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -102,9 +102,9 @@ pub enum Transaction {
     /// A `version = 5` transaction, which supports `Sapling` and `Orchard`.
     V5 {
         /// The transparent inputs to the transaction.
-        tx_in: Vec<transparent::Input>,
+        inputs: Vec<transparent::Input>,
         /// The transparent outputs from the transaction.
-        tx_out: Vec<transparent::Output>,
+        outputs: Vec<transparent::Output>,
         /// The earliest time or block height that this transaction can be added to the
         /// chain.
         lock_time: LockTime,
@@ -129,7 +129,7 @@ impl Transaction {
             Transaction::V2 { ref inputs, .. } => inputs,
             Transaction::V3 { ref inputs, .. } => inputs,
             Transaction::V4 { ref inputs, .. } => inputs,
-            Transaction::V5 { ref tx_in, .. } => tx_in,
+            Transaction::V5 { ref inputs, .. } => inputs,
         }
     }
 
@@ -140,7 +140,7 @@ impl Transaction {
             Transaction::V2 { ref outputs, .. } => outputs,
             Transaction::V3 { ref outputs, .. } => outputs,
             Transaction::V4 { ref outputs, .. } => outputs,
-            Transaction::V5 { ref tx_out, .. } => tx_out,
+            Transaction::V5 { ref outputs, .. } => outputs,
         }
     }
 

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -99,6 +99,21 @@ pub enum Transaction {
         /// The shielded data for this transaction, if any.
         shielded_data: Option<ShieldedData>,
     },
+    /// An Orchard transaction (`version = 5`).
+    V5 {
+        /// The transparent inputs to the transaction.
+        tx_in: Vec<transparent::Input>,
+        /// The transparent outputs from the transaction.
+        tx_out: Vec<transparent::Output>,
+        /// The earliest time or block height that this transaction can be added to the
+        /// chain.
+        lock_time: LockTime,
+        /// The latest block height that this transaction can be added to the chain.
+        expiry_height: block::Height,
+
+        /// The rest of the transaction as bytes
+        rest: Vec<u8>,
+    },
 }
 
 impl Transaction {
@@ -114,6 +129,7 @@ impl Transaction {
             Transaction::V2 { ref inputs, .. } => inputs,
             Transaction::V3 { ref inputs, .. } => inputs,
             Transaction::V4 { ref inputs, .. } => inputs,
+            Transaction::V5 { ref tx_in, .. } => tx_in,
         }
     }
 
@@ -124,6 +140,7 @@ impl Transaction {
             Transaction::V2 { ref outputs, .. } => outputs,
             Transaction::V3 { ref outputs, .. } => outputs,
             Transaction::V4 { ref outputs, .. } => outputs,
+            Transaction::V5 { ref tx_out, .. } => tx_out,
         }
     }
 
@@ -134,6 +151,7 @@ impl Transaction {
             Transaction::V2 { lock_time, .. } => *lock_time,
             Transaction::V3 { lock_time, .. } => *lock_time,
             Transaction::V4 { lock_time, .. } => *lock_time,
+            Transaction::V5 { lock_time, .. } => *lock_time,
         }
     }
 
@@ -144,6 +162,7 @@ impl Transaction {
             Transaction::V2 { .. } => None,
             Transaction::V3 { expiry_height, .. } => Some(*expiry_height),
             Transaction::V4 { expiry_height, .. } => Some(*expiry_height),
+            Transaction::V5 { expiry_height, .. } => Some(*expiry_height),
         }
     }
 

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -256,8 +256,13 @@ impl Arbitrary for Transaction {
             NetworkUpgrade::Blossom | NetworkUpgrade::Heartwood | NetworkUpgrade::Canopy => {
                 Self::v4_strategy(ledger_state)
             }
-            // Blocked by #1823
-            //NetworkUpgrade::NU5 => Self::v5_strategy(ledger_state),
+            // Blocked by #1823 and #1824, see #1826
+            /*
+            NetworkUpgrade::NU5 => prop_oneof!(
+                Self::v4_strategy(ledger_state),
+                Self::v5_strategy(ledger_state)
+            ),
+            */
         }
     }
 

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -255,13 +255,12 @@ impl Arbitrary for Transaction {
             NetworkUpgrade::Sapling => Self::v3_strategy(ledger_state),
             NetworkUpgrade::Blossom | NetworkUpgrade::Heartwood | NetworkUpgrade::Canopy => {
                 Self::v4_strategy(ledger_state)
-            } // Blocked by #1823 and #1824, see #1826
-              /*
-              NetworkUpgrade::NU5 => prop_oneof!(
-                  Self::v4_strategy(ledger_state),
-                  Self::v5_strategy(ledger_state)
-              ),
-              */
+            }
+            NetworkUpgrade::NU5 => prop_oneof![
+                Self::v4_strategy(ledger_state),
+                Self::v5_strategy(ledger_state)
+            ]
+            .boxed(),
         }
     }
 

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -255,14 +255,13 @@ impl Arbitrary for Transaction {
             NetworkUpgrade::Sapling => Self::v3_strategy(ledger_state),
             NetworkUpgrade::Blossom | NetworkUpgrade::Heartwood | NetworkUpgrade::Canopy => {
                 Self::v4_strategy(ledger_state)
-            }
-            // Blocked by #1823 and #1824, see #1826
-            /*
-            NetworkUpgrade::NU5 => prop_oneof!(
-                Self::v4_strategy(ledger_state),
-                Self::v5_strategy(ledger_state)
-            ),
-            */
+            } // Blocked by #1823 and #1824, see #1826
+              /*
+              NetworkUpgrade::NU5 => prop_oneof!(
+                  Self::v4_strategy(ledger_state),
+                  Self::v5_strategy(ledger_state)
+              ),
+              */
         }
     }
 

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -114,9 +114,9 @@ impl Transaction {
             any::<Vec<u8>>(),
         )
             .prop_map(
-                |(tx_in, tx_out, lock_time, expiry_height, rest)| Transaction::V5 {
-                    tx_in,
-                    tx_out,
+                |(inputs, outputs, lock_time, expiry_height, rest)| Transaction::V5 {
+                    inputs,
+                    outputs,
                     lock_time,
                     expiry_height,
                     rest,

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -107,18 +107,18 @@ impl Transaction {
     /// Generate a proptest strategy for V5 Transactions
     pub fn v5_strategy(ledger_state: LedgerState) -> BoxedStrategy<Self> {
         (
-            transparent::Input::vec_strategy(ledger_state, 10),
-            vec(any::<transparent::Output>(), 0..10),
             any::<LockTime>(),
             any::<block::Height>(),
+            transparent::Input::vec_strategy(ledger_state, 10),
+            vec(any::<transparent::Output>(), 0..10),
             any::<Vec<u8>>(),
         )
             .prop_map(
-                |(inputs, outputs, lock_time, expiry_height, rest)| Transaction::V5 {
-                    inputs,
-                    outputs,
+                |(lock_time, expiry_height, inputs, outputs, rest)| Transaction::V5 {
                     lock_time,
                     expiry_height,
+                    inputs,
+                    outputs,
                     rest,
                 },
             )

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -6,7 +6,7 @@ use std::{io, sync::Arc};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
-    parameters::{ORCHARD_VERSION_GROUP_ID, OVERWINTER_VERSION_GROUP_ID, SAPLING_VERSION_GROUP_ID},
+    parameters::{OVERWINTER_VERSION_GROUP_ID, SAPLING_VERSION_GROUP_ID, TX_V5_VERSION_GROUP_ID},
     primitives::ZkSnarkProof,
     serialization::{
         ReadZcashExt, SerializationError, WriteZcashExt, ZcashDeserialize, ZcashDeserializeInto,
@@ -189,7 +189,7 @@ impl ZcashSerialize for Transaction {
             } => {
                 // Write version 5 and set the fOverwintered bit.
                 writer.write_u32::<LittleEndian>(5 | (1 << 31))?;
-                writer.write_u32::<LittleEndian>(ORCHARD_VERSION_GROUP_ID)?;
+                writer.write_u32::<LittleEndian>(TX_V5_VERSION_GROUP_ID)?;
                 tx_in.zcash_serialize(&mut writer)?;
                 tx_out.zcash_serialize(&mut writer)?;
                 lock_time.zcash_serialize(&mut writer)?;

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -305,16 +305,19 @@ impl ZcashDeserialize for Transaction {
                 if id != TX_V5_VERSION_GROUP_ID {
                     return Err(SerializationError::Parse("expected TX_V5_VERSION_GROUP_ID"));
                 }
+                let inputs = Vec::zcash_deserialize(&mut reader)?;
+                let outputs = Vec::zcash_deserialize(&mut reader)?;
+                let lock_time = LockTime::zcash_deserialize(&mut reader)?;
+                let expiry_height = block::Height(reader.read_u32::<LittleEndian>()?);
+                let mut rest = Vec::new();
+                reader.read_to_end(&mut rest)?;
+
                 Ok(Transaction::V5 {
-                    inputs: Vec::zcash_deserialize(&mut reader)?,
-                    outputs: Vec::zcash_deserialize(&mut reader)?,
-                    lock_time: LockTime::zcash_deserialize(&mut reader)?,
-                    expiry_height: block::Height(reader.read_u32::<LittleEndian>()?),
-                    rest: {
-                        let mut buffer = Vec::new();
-                        reader.read_to_end(&mut buffer)?;
-                        buffer
-                    },
+                    inputs,
+                    outputs,
+                    lock_time,
+                    expiry_height,
+                    rest,
                 })
             }
             (_, _) => Err(SerializationError::Parse("bad tx header")),

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -181,8 +181,8 @@ impl ZcashSerialize for Transaction {
                 }
             }
             Transaction::V5 {
-                tx_in,
-                tx_out,
+                inputs,
+                outputs,
                 lock_time,
                 expiry_height,
                 rest,
@@ -190,8 +190,8 @@ impl ZcashSerialize for Transaction {
                 // Write version 5 and set the fOverwintered bit.
                 writer.write_u32::<LittleEndian>(5 | (1 << 31))?;
                 writer.write_u32::<LittleEndian>(TX_V5_VERSION_GROUP_ID)?;
-                tx_in.zcash_serialize(&mut writer)?;
-                tx_out.zcash_serialize(&mut writer)?;
+                inputs.zcash_serialize(&mut writer)?;
+                outputs.zcash_serialize(&mut writer)?;
                 lock_time.zcash_serialize(&mut writer)?;
                 writer.write_u32::<LittleEndian>(expiry_height.0)?;
                 // write the rest
@@ -306,8 +306,8 @@ impl ZcashDeserialize for Transaction {
                     return Err(SerializationError::Parse("expected TX_V5_VERSION_GROUP_ID"));
                 }
                 Ok(Transaction::V5 {
-                    tx_in: Vec::zcash_deserialize(&mut reader)?,
-                    tx_out: Vec::zcash_deserialize(&mut reader)?,
+                    inputs: Vec::zcash_deserialize(&mut reader)?,
+                    outputs: Vec::zcash_deserialize(&mut reader)?,
                     lock_time: LockTime::zcash_deserialize(&mut reader)?,
                     expiry_height: block::Height(reader.read_u32::<LittleEndian>()?),
                     rest: {

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -187,8 +187,8 @@ impl ZcashSerialize for Transaction {
                 expiry_height,
                 rest,
             } => {
-                // Write version 4 and set the fOverwintered bit.
-                writer.write_u32::<LittleEndian>(4 | (1 << 31))?;
+                // Write version 5 and set the fOverwintered bit.
+                writer.write_u32::<LittleEndian>(5 | (1 << 31))?;
                 writer.write_u32::<LittleEndian>(ORCHARD_VERSION_GROUP_ID)?;
                 tx_in.zcash_serialize(&mut writer)?;
                 tx_out.zcash_serialize(&mut writer)?;

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -300,6 +300,23 @@ impl ZcashDeserialize for Transaction {
                     joinsplit_data,
                 })
             }
+            (5, false) => {
+                let id = reader.read_u32::<LittleEndian>()?;
+                if id != TX_V5_VERSION_GROUP_ID {
+                    return Err(SerializationError::Parse("expected TX_V5_VERSION_GROUP_ID"));
+                }
+                Ok(Transaction::V5 {
+                    tx_in: Vec::zcash_deserialize(&mut reader)?,
+                    tx_out: Vec::zcash_deserialize(&mut reader)?,
+                    lock_time: LockTime::zcash_deserialize(&mut reader)?,
+                    expiry_height: block::Height(reader.read_u32::<LittleEndian>()?),
+                    rest: {
+                        let mut buffer = Vec::new();
+                        reader.read_to_end(&mut buffer)?;
+                        buffer
+                    },
+                })
+            }
             (_, _) => Err(SerializationError::Parse("bad tx header")),
         }
     }

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -6,6 +6,7 @@ use std::{io, sync::Arc};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{
+    parameters::{ORCHARD_VERSION_GROUP_ID, OVERWINTER_VERSION_GROUP_ID, SAPLING_VERSION_GROUP_ID},
     primitives::ZkSnarkProof,
     serialization::{
         ReadZcashExt, SerializationError, WriteZcashExt, ZcashDeserialize, ZcashDeserializeInto,
@@ -15,10 +16,6 @@ use crate::{
 };
 
 use super::*;
-
-const OVERWINTER_VERSION_GROUP_ID: u32 = 0x03C4_8270;
-const SAPLING_VERSION_GROUP_ID: u32 = 0x892F_2085;
-const ORCHARD_VERSION_GROUP_ID: u32 = 0x6A7_270A;
 
 impl ZcashDeserialize for jubjub::Fq {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -181,19 +181,19 @@ impl ZcashSerialize for Transaction {
                 }
             }
             Transaction::V5 {
-                inputs,
-                outputs,
                 lock_time,
                 expiry_height,
+                inputs,
+                outputs,
                 rest,
             } => {
                 // Write version 5 and set the fOverwintered bit.
                 writer.write_u32::<LittleEndian>(5 | (1 << 31))?;
                 writer.write_u32::<LittleEndian>(TX_V5_VERSION_GROUP_ID)?;
-                inputs.zcash_serialize(&mut writer)?;
-                outputs.zcash_serialize(&mut writer)?;
                 lock_time.zcash_serialize(&mut writer)?;
                 writer.write_u32::<LittleEndian>(expiry_height.0)?;
+                inputs.zcash_serialize(&mut writer)?;
+                outputs.zcash_serialize(&mut writer)?;
                 // write the rest
                 writer.write_all(rest)?;
             }
@@ -305,18 +305,18 @@ impl ZcashDeserialize for Transaction {
                 if id != TX_V5_VERSION_GROUP_ID {
                     return Err(SerializationError::Parse("expected TX_V5_VERSION_GROUP_ID"));
                 }
-                let inputs = Vec::zcash_deserialize(&mut reader)?;
-                let outputs = Vec::zcash_deserialize(&mut reader)?;
                 let lock_time = LockTime::zcash_deserialize(&mut reader)?;
                 let expiry_height = block::Height(reader.read_u32::<LittleEndian>()?);
+                let inputs = Vec::zcash_deserialize(&mut reader)?;
+                let outputs = Vec::zcash_deserialize(&mut reader)?;
                 let mut rest = Vec::new();
                 reader.read_to_end(&mut rest)?;
 
                 Ok(Transaction::V5 {
-                    inputs,
-                    outputs,
                     lock_time,
                     expiry_height,
+                    inputs,
+                    outputs,
                     rest,
                 })
             }

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -1,8 +1,8 @@
 use super::Transaction;
 use crate::{
     parameters::{
-        ConsensusBranchId, NetworkUpgrade, ORCHARD_VERSION_GROUP_ID, OVERWINTER_VERSION_GROUP_ID,
-        SAPLING_VERSION_GROUP_ID,
+        ConsensusBranchId, NetworkUpgrade, OVERWINTER_VERSION_GROUP_ID, SAPLING_VERSION_GROUP_ID,
+        TX_V5_VERSION_GROUP_ID,
     },
     serialization::{WriteZcashExt, ZcashSerialize},
     transparent,
@@ -138,7 +138,7 @@ impl<'a> SigHasher<'a> {
             Transaction::V1 { .. } | Transaction::V2 { .. } => unreachable!(ZIP143_EXPLANATION),
             Transaction::V3 { .. } => OVERWINTER_VERSION_GROUP_ID,
             Transaction::V4 { .. } => SAPLING_VERSION_GROUP_ID,
-            Transaction::V5 { .. } => ORCHARD_VERSION_GROUP_ID,
+            Transaction::V5 { .. } => TX_V5_VERSION_GROUP_ID,
         })
     }
 

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -246,7 +246,7 @@ impl<'a> SigHasher<'a> {
             Transaction::V3 { joinsplit_data, .. } => joinsplit_data.is_some(),
             Transaction::V4 { joinsplit_data, .. } => joinsplit_data.is_some(),
             Transaction::V5 { .. } => {
-                unimplemented!("v5 transaction format as specified in ZIP-225")
+                unimplemented!("v5 transaction hash as specified in ZIP-225 and ZIP-244")
             }
         };
 
@@ -261,7 +261,7 @@ impl<'a> SigHasher<'a> {
 
         // This code, and the check above for has_joinsplits cannot be combined
         // into a single branch because the `joinsplit_data` type of each
-        // tranaction kind has a different type.
+        // transaction kind has a different type.
         //
         // For v3 joinsplit_data is a JoinSplitData<Bctv14Proof>
         // For v4 joinsplit_data is a JoinSplitData<Groth16Proof>
@@ -269,6 +269,8 @@ impl<'a> SigHasher<'a> {
         // The type parameter on these types prevents them from being unified,
         // which forces us to duplicate the logic in each branch even though the
         // code within each branch is identical.
+        //
+        // TODO: use a generic function to remove the duplicate code
         match self.trans {
             Transaction::V3 {
                 joinsplit_data: Some(jsd),

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -245,7 +245,7 @@ impl<'a> SigHasher<'a> {
             Transaction::V1 { .. } | Transaction::V2 { .. } => unreachable!(ZIP143_EXPLANATION),
             Transaction::V3 { joinsplit_data, .. } => joinsplit_data.is_some(),
             Transaction::V4 { joinsplit_data, .. } => joinsplit_data.is_some(),
-            Transaction::V5 { .. } => unimplemented!("v5 transaction"),
+            Transaction::V5 { .. } => unimplemented!("v5 transaction format as specified in ZIP-225"),
         };
 
         if !has_joinsplits {
@@ -409,7 +409,7 @@ impl<'a> SigHasher<'a> {
                 shielded_data: None,
                 ..
             } => return writer.write_all(&[0; 32]),
-            V5 { .. } => unimplemented!("v5 transaction"),
+            V5 { .. } => unimplemented!("v5 transaction hash as specified in ZIP-225 and ZIP-244"),
             V1 { .. } | V2 { .. } | V3 { .. } => unreachable!(ZIP243_EXPLANATION),
         };
 
@@ -446,7 +446,7 @@ impl<'a> SigHasher<'a> {
                 shielded_data: None,
                 ..
             } => return writer.write_all(&[0; 32]),
-            V5 { .. } => unimplemented!("v5 transaction"),
+            V5 { .. } => unimplemented!("v5 transaction hash as specified in ZIP-225 and ZIP-244"),
             V1 { .. } | V2 { .. } | V3 { .. } => unreachable!(ZIP243_EXPLANATION),
         };
 
@@ -471,7 +471,7 @@ impl<'a> SigHasher<'a> {
 
         let value_balance = match self.trans {
             V4 { value_balance, .. } => value_balance,
-            V5 { .. } => unimplemented!("v5 transaction"),
+            V5 { .. } => unimplemented!("v5 transaction hash as specified in ZIP-225 and ZIP-244"),
             V1 { .. } | V2 { .. } | V3 { .. } => unreachable!(ZIP243_EXPLANATION),
         };
 

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -1,6 +1,9 @@
 use super::Transaction;
 use crate::{
-    parameters::{ConsensusBranchId, NetworkUpgrade},
+    parameters::{
+        ConsensusBranchId, NetworkUpgrade, ORCHARD_VERSION_GROUP_ID, OVERWINTER_VERSION_GROUP_ID,
+        SAPLING_VERSION_GROUP_ID,
+    },
     serialization::{WriteZcashExt, ZcashSerialize},
     transparent,
 };
@@ -11,10 +14,6 @@ use std::io;
 
 static ZIP143_EXPLANATION: &str = "Invalid transaction version: after Overwinter activation transaction versions 1 and 2 are rejected";
 static ZIP243_EXPLANATION: &str = "Invalid transaction version: after Sapling activation transaction versions 1, 2, and 3 are rejected";
-
-const OVERWINTER_VERSION_GROUP_ID: u32 = 0x03C4_8270;
-const SAPLING_VERSION_GROUP_ID: u32 = 0x892F_2085;
-const ORCHARD_VERSION_GROUP_ID: u32 = 0x6A7_270A;
 
 const ZCASH_SIGHASH_PERSONALIZATION_PREFIX: &[u8; 12] = b"ZcashSigHash";
 const ZCASH_PREVOUTS_HASH_PERSONALIZATION: &[u8; 16] = b"ZcashPrevoutHash";

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -245,7 +245,9 @@ impl<'a> SigHasher<'a> {
             Transaction::V1 { .. } | Transaction::V2 { .. } => unreachable!(ZIP143_EXPLANATION),
             Transaction::V3 { joinsplit_data, .. } => joinsplit_data.is_some(),
             Transaction::V4 { joinsplit_data, .. } => joinsplit_data.is_some(),
-            Transaction::V5 { .. } => unimplemented!("v5 transaction format as specified in ZIP-225"),
+            Transaction::V5 { .. } => {
+                unimplemented!("v5 transaction format as specified in ZIP-225")
+            }
         };
 
         if !has_joinsplits {

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -14,6 +14,7 @@ static ZIP243_EXPLANATION: &str = "Invalid transaction version: after Sapling ac
 
 const OVERWINTER_VERSION_GROUP_ID: u32 = 0x03C4_8270;
 const SAPLING_VERSION_GROUP_ID: u32 = 0x892F_2085;
+const ORCHARD_VERSION_GROUP_ID: u32 = 0x6A7_270A;
 
 const ZCASH_SIGHASH_PERSONALIZATION_PREFIX: &[u8; 12] = b"ZcashSigHash";
 const ZCASH_PREVOUTS_HASH_PERSONALIZATION: &[u8; 16] = b"ZcashPrevoutHash";
@@ -129,6 +130,7 @@ impl<'a> SigHasher<'a> {
             Transaction::V1 { .. } | Transaction::V2 { .. } => unreachable!(ZIP143_EXPLANATION),
             Transaction::V3 { .. } => 3 | overwintered_flag,
             Transaction::V4 { .. } => 4 | overwintered_flag,
+            Transaction::V5 { .. } => 5 | overwintered_flag,
         })
     }
 
@@ -137,6 +139,7 @@ impl<'a> SigHasher<'a> {
             Transaction::V1 { .. } | Transaction::V2 { .. } => unreachable!(ZIP143_EXPLANATION),
             Transaction::V3 { .. } => OVERWINTER_VERSION_GROUP_ID,
             Transaction::V4 { .. } => SAPLING_VERSION_GROUP_ID,
+            Transaction::V5 { .. } => ORCHARD_VERSION_GROUP_ID,
         })
     }
 
@@ -243,6 +246,7 @@ impl<'a> SigHasher<'a> {
             Transaction::V1 { .. } | Transaction::V2 { .. } => unreachable!(ZIP143_EXPLANATION),
             Transaction::V3 { joinsplit_data, .. } => joinsplit_data.is_some(),
             Transaction::V4 { joinsplit_data, .. } => joinsplit_data.is_some(),
+            Transaction::V5 { .. } => unimplemented!("v5 transaction"),
         };
 
         if !has_joinsplits {
@@ -398,14 +402,15 @@ impl<'a> SigHasher<'a> {
         use Transaction::*;
 
         let shielded_data = match self.trans {
-            Transaction::V4 {
+            V4 {
                 shielded_data: Some(shielded_data),
                 ..
             } => shielded_data,
-            Transaction::V4 {
+            V4 {
                 shielded_data: None,
                 ..
             } => return writer.write_all(&[0; 32]),
+            V5 { .. } => unimplemented!("v5 transaction"),
             V1 { .. } | V2 { .. } | V3 { .. } => unreachable!(ZIP243_EXPLANATION),
         };
 
@@ -434,14 +439,15 @@ impl<'a> SigHasher<'a> {
         use Transaction::*;
 
         let shielded_data = match self.trans {
-            Transaction::V4 {
+            V4 {
                 shielded_data: Some(shielded_data),
                 ..
             } => shielded_data,
-            Transaction::V4 {
+            V4 {
                 shielded_data: None,
                 ..
             } => return writer.write_all(&[0; 32]),
+            V5 { .. } => unimplemented!("v5 transaction"),
             V1 { .. } | V2 { .. } | V3 { .. } => unreachable!(ZIP243_EXPLANATION),
         };
 
@@ -465,7 +471,8 @@ impl<'a> SigHasher<'a> {
         use Transaction::*;
 
         let value_balance = match self.trans {
-            Transaction::V4 { value_balance, .. } => value_balance,
+            V4 { value_balance, .. } => value_balance,
+            V5 { .. } => unreachable!("NOT IMPLEMENTED YET!"),
             V1 { .. } | V2 { .. } | V3 { .. } => unreachable!(ZIP243_EXPLANATION),
         };
 

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -471,7 +471,7 @@ impl<'a> SigHasher<'a> {
 
         let value_balance = match self.trans {
             V4 { value_balance, .. } => value_balance,
-            V5 { .. } => unreachable!("NOT IMPLEMENTED YET!"),
+            V5 { .. } => unimplemented!("v5 transaction"),
             V1 { .. } | V2 { .. } | V3 { .. } => unreachable!(ZIP243_EXPLANATION),
         };
 

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -290,7 +290,20 @@ impl<'a> SigHasher<'a> {
                 }
                 (&mut hash).write_all(&<[u8; 32]>::from(jsd.pub_key)[..])?;
             }
-            _ => unreachable!("already checked transaction kind above"),
+            Transaction::V5 { .. } => {
+                unimplemented!("v5 transaction hash as specified in ZIP-225 and ZIP-244")
+            }
+
+            Transaction::V1 { .. }
+            | Transaction::V2 { .. }
+            | Transaction::V3 {
+                joinsplit_data: None,
+                ..
+            }
+            | Transaction::V4 {
+                joinsplit_data: None,
+                ..
+            } => unreachable!("already checked transaction kind above"),
         };
 
         writer.write_all(hash.finalize().as_ref())

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -132,7 +132,10 @@ where
         async move {
             tracing::trace!(?tx);
             match &*tx {
-                Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
+                Transaction::V1 { .. }
+                | Transaction::V2 { .. }
+                | Transaction::V3 { .. }
+                | Transaction::V5 { .. } => {
                     tracing::debug!(?tx, "got transaction with wrong version");
                     Err(TransactionError::WrongVersion)
                 }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -136,8 +136,7 @@ where
                 | Transaction::V2 { .. }
                 | Transaction::V3 { .. }
                 | Transaction::V5 { .. } => {
-                    tracing::debug!(?tx, "got transaction with wrong version");
-                    Err(TransactionError::WrongVersion)
+                    unimplemented!("v5 transaction validation as specified in ZIP-216, ZIP-224, ZIP-225, and ZIP-244")
                 }
                 Transaction::V4 {
                     inputs,

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -132,11 +132,9 @@ where
         async move {
             tracing::trace!(?tx);
             match &*tx {
-                Transaction::V1 { .. }
-                | Transaction::V2 { .. }
-                | Transaction::V3 { .. }
-                | Transaction::V5 { .. } => {
-                    unimplemented!("v5 transaction validation as specified in ZIP-216, ZIP-224, ZIP-225, and ZIP-244")
+                Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
+                    tracing::debug!(?tx, "got transaction with wrong version");
+                    Err(TransactionError::WrongVersion)
                 }
                 Transaction::V4 {
                     inputs,
@@ -259,6 +257,9 @@ where
                     }
 
                     Ok(tx.hash())
+                }
+                Transaction::V5 { .. } => {
+                    unimplemented!("v5 transaction validation as specified in ZIP-216, ZIP-224, ZIP-225, and ZIP-244")
                 }
             }
         }

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -68,7 +68,10 @@ pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> 
                 Ok(())
             }
         }
-        Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
+        Transaction::V1 { .. }
+        | Transaction::V2 { .. }
+        | Transaction::V3 { .. }
+        | Transaction::V5 { .. } => {
             unreachable!("tx version is checked first")
         }
     }
@@ -111,7 +114,10 @@ pub fn coinbase_tx_no_joinsplit_or_spend(tx: &Transaction) -> Result<(), Transac
 
             Transaction::V4 { .. } => Ok(()),
 
-            Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
+            Transaction::V1 { .. }
+            | Transaction::V2 { .. }
+            | Transaction::V3 { .. }
+            | Transaction::V5 { .. } => {
                 unreachable!("tx version is checked first")
             }
         }

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -72,7 +72,7 @@ pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> 
         | Transaction::V2 { .. }
         | Transaction::V3 { .. }
         | Transaction::V5 { .. } => {
-            unreachable!("tx version is checked first")
+            unimplemented!("v5 transaction format as specified in ZIP-225")
         }
     }
 }
@@ -118,7 +118,7 @@ pub fn coinbase_tx_no_joinsplit_or_spend(tx: &Transaction) -> Result<(), Transac
             | Transaction::V2 { .. }
             | Transaction::V3 { .. }
             | Transaction::V5 { .. } => {
-                unreachable!("tx version is checked first")
+                unimplemented!("v5 coinbase validation as specified in ZIP-225 and the draft spec")
             }
         }
     } else {

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -68,10 +68,10 @@ pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> 
                 Ok(())
             }
         }
-        Transaction::V1 { .. }
-        | Transaction::V2 { .. }
-        | Transaction::V3 { .. }
-        | Transaction::V5 { .. } => {
+        Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
+            unreachable!("tx version is checked first")
+        }
+        Transaction::V5 { .. } => {
             unimplemented!("v5 transaction format as specified in ZIP-225")
         }
     }
@@ -114,10 +114,11 @@ pub fn coinbase_tx_no_joinsplit_or_spend(tx: &Transaction) -> Result<(), Transac
 
             Transaction::V4 { .. } => Ok(()),
 
-            Transaction::V1 { .. }
-            | Transaction::V2 { .. }
-            | Transaction::V3 { .. }
-            | Transaction::V5 { .. } => {
+            Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
+                unreachable!("tx version is checked first")
+            }
+
+            Transaction::V5 { .. } => {
                 unimplemented!("v5 coinbase validation as specified in ZIP-225 and the draft spec")
             }
         }

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -165,14 +165,16 @@ impl UpdateWith<PreparedBlock> for Chain {
             .zip(transaction_hashes.iter().cloned())
             .enumerate()
         {
+            use transaction::Transaction::*;
             let (inputs, shielded_data, joinsplit_data) = match transaction.deref() {
-                transaction::Transaction::V4 {
+                V4 {
                     inputs,
                     shielded_data,
                     joinsplit_data,
                     ..
                 } => (inputs, shielded_data, joinsplit_data),
-                _ => unreachable!(
+                V5 { .. } => unimplemented!("v5 transaction format as specified in ZIP-225"),
+                V1 | V2 | V3 => unreachable!(
                     "older transaction versions only exist in finalized blocks pre sapling",
                 ),
             };
@@ -223,14 +225,16 @@ impl UpdateWith<PreparedBlock> for Chain {
         for (transaction, transaction_hash) in
             block.transactions.iter().zip(transaction_hashes.iter())
         {
+            use transaction::Transaction::*;
             let (inputs, shielded_data, joinsplit_data) = match transaction.deref() {
-                transaction::Transaction::V4 {
+                V4 {
                     inputs,
                     shielded_data,
                     joinsplit_data,
                     ..
                 } => (inputs, shielded_data, joinsplit_data),
-                _ => unreachable!(
+                V5 { .. } => unimplemented!("v5 transaction format as specified in ZIP-225"),
+                V1 | V2 | V3 => unreachable!(
                     "older transaction versions only exist in finalized blocks pre sapling",
                 ),
             };

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -174,7 +174,7 @@ impl UpdateWith<PreparedBlock> for Chain {
                     ..
                 } => (inputs, shielded_data, joinsplit_data),
                 V5 { .. } => unimplemented!("v5 transaction format as specified in ZIP-225"),
-                V1 | V2 | V3 => unreachable!(
+                V1 { .. } | V2 { .. } | V3 { .. } => unreachable!(
                     "older transaction versions only exist in finalized blocks pre sapling",
                 ),
             };
@@ -234,7 +234,7 @@ impl UpdateWith<PreparedBlock> for Chain {
                     ..
                 } => (inputs, shielded_data, joinsplit_data),
                 V5 { .. } => unimplemented!("v5 transaction format as specified in ZIP-225"),
-                V1 | V2 | V3 => unreachable!(
+                V1 { .. } | V2 { .. } | V3 { .. } => unreachable!(
                     "older transaction versions only exist in finalized blocks pre sapling",
                 ),
             };

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -53,6 +53,7 @@ impl FakeChainHelper for Arc<Block> {
             Transaction::V2 { inputs, .. } => &mut inputs[0],
             Transaction::V3 { inputs, .. } => &mut inputs[0],
             Transaction::V4 { inputs, .. } => &mut inputs[0],
+            Transaction::V5 { tx_in, .. } => &mut tx_in[0],
         };
 
         match input {

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -53,7 +53,7 @@ impl FakeChainHelper for Arc<Block> {
             Transaction::V2 { inputs, .. } => &mut inputs[0],
             Transaction::V3 { inputs, .. } => &mut inputs[0],
             Transaction::V4 { inputs, .. } => &mut inputs[0],
-            Transaction::V5 { tx_in, .. } => &mut tx_in[0],
+            Transaction::V5 { inputs, .. } => &mut inputs[0],
         };
 
         match input {


### PR DESCRIPTION
## Motivation

Start the work in the next network upgrade transaction.

## Solution

Add the V5 transaction to the enum and add some common fields that we know are going to be there. The "rest" of the transaction is represented in as `Vec<u8>` in a `rest` field.

The prop tests are blocked on https://github.com/ZcashFoundation/zebra/pull/1823

The code in this pull request has:
  - [x] Documentation Comments
  - [ ] Unit Tests and Property Tests

## Review


## Related Issues

Closes https://github.com/ZcashFoundation/zebra/issues/1822
Closes #1826

## Follow Up Work
