### PR TITLE
Replace canopy.pdf instances left in our codebase

### DIFF
--- a/book/src/dev/rfcs/0009-zebra-client.md
+++ b/book/src/dev/rfcs/0009-zebra-client.md
@@ -68,9 +68,9 @@ execute independently and are scheduled co-operatively using explicit yield
 points. Tasks are executed on the Tokio runtime, which can either be single-
 or multi-threaded.
 
-[ps_scan]: https://zips.z.cash/protocol/canopy.pdf#saplingscan
-[ps_keys]: https://zips.z.cash/protocol/canopy.pdf#addressesandkeys
-[ps_sapk]: https://zips.z.cash/protocol/canopy.pdf#saplingkeycomponents
+[ps_scan]: https://zips.z.cash/protocol/protocol.pdf#saplingscan
+[ps_keys]: https://zips.z.cash/protocol/protocol.pdf#addressesandkeys
+[ps_sapk]: https://zips.z.cash/protocol/protocol.pdf#saplingkeycomponents
 [tokio-task]: https://docs.rs/tokio/0.2.22/tokio/task/index.html
 
 # Guide-level explanation

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -14,8 +14,8 @@ use crate::error::TransactionError;
 
 /// Validate the JoinSplit binding signature.
 ///
-/// https://zips.z.cash/protocol/canopy.pdf#sproutnonmalleability
-/// https://zips.z.cash/protocol/canopy.pdf#txnencodingandconsensus
+/// https://zips.z.cash/protocol/protocol.pdf#sproutnonmalleability
+/// https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
 pub fn validate_joinsplit_sig(
     joinsplit_data: &JoinSplitData<Groth16Proof>,
     sighash: &[u8],
@@ -32,7 +32,7 @@ pub fn validate_joinsplit_sig(
 /// * at least one of tx_in_count, nShieldedSpend, and nJoinSplit MUST be non-zero.
 /// * at least one of tx_out_count, nShieldedOutput, and nJoinSplit MUST be non-zero.
 ///
-/// https://zips.z.cash/protocol/canopy.pdf#txnencodingandconsensus
+/// https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
 pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> {
     // The consensus rule is written in terms of numbers, but our transactions
     // hold enum'd data. Mixing pattern matching and numerical checks is risky,
@@ -76,7 +76,7 @@ pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> 
 
 /// Check that if there are no Spends or Outputs, that valueBalance is also 0.
 ///
-/// https://zips.z.cash/protocol/canopy.pdf#consensusfrombitcoin
+/// https://zips.z.cash/protocol/protocol.pdf#consensusfrombitcoin
 pub fn shielded_balances_match(
     shielded_data: &ShieldedData,
     value_balance: Amount,
@@ -92,7 +92,7 @@ pub fn shielded_balances_match(
 
 /// Check that a coinbase tx does not have any JoinSplit or Spend descriptions.
 ///
-/// https://zips.z.cash/protocol/canopy.pdf#txnencodingandconsensus
+/// https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
 pub fn coinbase_tx_no_joinsplit_or_spend(tx: &Transaction) -> Result<(), TransactionError> {
     if tx.is_coinbase() {
         match tx {


### PR DESCRIPTION
## Motivation

While working on some confirmations for https://github.com/ZcashFoundation/zebra/pull/1823 i found that we still have some links pointing to canopy.pdf.

After the NU for Canopy passed the content from the canopy.pdf was merged into protocol.pdf.
 
## Solution

We should always point to protocol.pdf except when the sections we are referring to are not stable yet. When this happens we should do a routine cleanup like this PR to replace the links after the NU pass. For example now that we are working on NU5 i will expect links to orchard.pdf. This are fine for a while, then we need to change them.

This PR changes all the canopy.pdf instances we have left in our codebase(we changed a few before).

## Review

Anyone can review, this is low priority.
