### PR TITLE
Add manual deploy workflow for zcashd images

### DIFF
--- a/.github/workflows/zcashd-cd.yml
+++ b/.github/workflows/zcashd-cd.yml
@@ -1,0 +1,77 @@
+name: Zcashd Manual Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        default: 'testnet'
+      size:
+        default: 10
+
+env:
+  PROJECT_ID: zealous-zebra
+  REGION: us-east1
+  ZONE: us-east1-b
+
+jobs:
+
+  deploy:
+    name: Deploy mainnet nodes
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set project and image names
+        run: |
+          BRANCH_NAME=$(expr $GITHUB_REF : '.*/\(.*\)') && \
+          BRANCH_NAME=${BRANCH_NAME,,} && \
+          REPOSITORY=${GITHUB_REPOSITORY,,} && \
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV && \
+          echo "SHORT_SHA=$(git rev-parse --short=7 $GITHUB_SHA)" >> $GITHUB_ENV && \
+          echo "REPOSITORY=$REPOSITORY" >> $GITHUB_ENV
+
+      # Setup gcloud CLI
+      - name: Set up gcloud SDK environment
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '295.0.0'
+          project_id: ${{ env.PROJECT_ID }}
+          service_account_key: ${{ secrets.GCLOUD_AUTH }}
+
+      # Create instance template from container image
+      - name: Create instance template
+        run: |
+          gcloud compute instance-templates create-with-container "zcashd-$BRANCH_NAME-$SHORT_SHA" \
+          --container-image "electriccoinco/zcashd" \
+          --container-env ZCASHD_NETWORK="${{ github.event.inputs.network }}" \
+          --machine-type n2d-standard-4 \
+          --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
+          --scopes cloud-platform \
+          --tags zcashd \
+
+      # Check if our destination instance group exists already
+      - name: Check if instance group exists
+        id: does-group-exist
+        continue-on-error: true
+        run: |
+          gcloud compute instance-groups list | grep "zcashd-$BRANCH_NAME-${{ github.event.inputs.network }}"\ \ "$REGION"
+
+      # Deploy new managed instance group using the new instance template
+      - name: Create managed instance group
+        if: steps.does-group-exist.outcome == 'failure'
+        run: |
+          gcloud compute instance-groups managed create \
+          "zcashd-$BRANCH_NAME-${{ github.event.inputs.network }}" \
+          --template "zcashd-$BRANCH_NAME-$SHORT_SHA" \
+          --region "$REGION" \
+          --size "${{ github.event.inputs.size }}"
+
+      # Rolls out update to existing group using the new instance template
+      - name: Update managed instance group
+        if: steps.does-group-exist.outcome == 'success'
+        run: |
+          gcloud compute instance-groups managed rolling-action start-update \
+          "zcashd-$BRANCH_NAME-${{ github.event.inputs.network }}" \
+          --version template="zcashd-$BRANCH_NAME-$SHORT_SHA" \
+          --region "$REGION"

--- a/.github/workflows/zcashd-cd.yml
+++ b/.github/workflows/zcashd-cd.yml
@@ -11,7 +11,6 @@ on:
 env:
   PROJECT_ID: zealous-zebra
   REGION: us-central1
-  ZONE: us-central1-c
 
 jobs:
 
@@ -44,7 +43,7 @@ jobs:
           --boot-disk-size 100GB \
           --container-image "electriccoinco/zcashd" \
           --container-env ZCASHD_NETWORK="${{ github.event.inputs.network }}" \
-          --machine-type n2d-standard-4 \
+          --machine-type n2-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
           --tags zcashd \

--- a/.github/workflows/zcashd-cd.yml
+++ b/.github/workflows/zcashd-cd.yml
@@ -10,8 +10,8 @@ on:
 
 env:
   PROJECT_ID: zealous-zebra
-  REGION: us-east1
-  ZONE: us-east1-b
+  REGION: us-central1
+  ZONE: us-central1-c
 
 jobs:
 
@@ -26,10 +26,8 @@ jobs:
         run: |
           BRANCH_NAME=$(expr $GITHUB_REF : '.*/\(.*\)') && \
           BRANCH_NAME=${BRANCH_NAME,,} && \
-          REPOSITORY=${GITHUB_REPOSITORY,,} && \
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV && \
           echo "SHORT_SHA=$(git rev-parse --short=7 $GITHUB_SHA)" >> $GITHUB_ENV && \
-          echo "REPOSITORY=$REPOSITORY" >> $GITHUB_ENV
 
       # Setup gcloud CLI
       - name: Set up gcloud SDK environment
@@ -43,6 +41,7 @@ jobs:
       - name: Create instance template
         run: |
           gcloud compute instance-templates create-with-container "zcashd-$BRANCH_NAME-$SHORT_SHA" \
+          --boot-disk-size 100GB \
           --container-image "electriccoinco/zcashd" \
           --container-env ZCASHD_NETWORK="${{ github.event.inputs.network }}" \
           --machine-type n2d-standard-4 \

--- a/.github/workflows/zcashd-cd.yml
+++ b/.github/workflows/zcashd-cd.yml
@@ -27,7 +27,7 @@ jobs:
           BRANCH_NAME=$(expr $GITHUB_REF : '.*/\(.*\)') && \
           BRANCH_NAME=${BRANCH_NAME,,} && \
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV && \
-          echo "SHORT_SHA=$(git rev-parse --short=7 $GITHUB_SHA)" >> $GITHUB_ENV && \
+          echo "SHORT_SHA=$(git rev-parse --short=7 $GITHUB_SHA)" >> $GITHUB_ENV
 
       # Setup gcloud CLI
       - name: Set up gcloud SDK environment


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

The Zebra sync tests currently run on mainnet and testnet. Sometimes the testnet nodes are slow or unreliable, so the sync tests are unreliable.

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->

## Solution

Deploy about 10 Zebra or zcashd instances on testnet, to increase the average speed and reduce the average latency of testnet. This PR adds a github action workflow for deploying a group of zcashd nodes

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->

The code in this pull request has:
  - [x] Documentation Comments

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

## Related Issues

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->

https://github.com/ZcashFoundation/zebra/issues/1222

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
