### PR TITLE
CandidateSet: Document Listener Port Connections

### DIFF
--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -11,9 +11,10 @@ use crate::{types::MetaAddr, AddressBook, BoxError, PeerAddrState, Request, Resp
 /// It divides the set of all possible candidate peers into disjoint subsets,
 /// using the `PeerAddrState`:
 ///
-/// 1. `Responded` peers, which we previously connected to. If we have not received
-///    any messages from a `Responded` peer within a cutoff time, we assume that it
-///    has disconnected or hung, and attempt reconnection;
+/// 1. `Responded` peers, which we previously had inbound or outbound connections
+///    to. If we have not received any messages from a `Responded` peer within a
+///    cutoff time, we assume that it has disconnected or hung, and attempt
+///    reconnection;
 /// 2. `NeverAttempted` peers, which we learned about from other peers or a DNS
 ///    seeder, but have never connected to;
 /// 3. `Failed` peers, to whom we attempted to connect but were unable to;
@@ -37,13 +38,13 @@ use crate::{types::MetaAddr, AddressBook, BoxError, PeerAddrState, Request, Resp
 ///  │                               │
 ///  │                               │
 ///  │                               │
-///  │                               │
-///  │                               │
-///  │                               │
-///  │                               │
-///  │                               │
-///  ├───────────────────────────────┼───────────────────────────────┐
-///  │ PeerSet AddressBook           ▼                               │
+///  │ ┌──────────────────┐          │
+///  │ │  Listener Port   │          │
+///  │ │ Peer Connections │          │
+///  │ └──────────────────┘          │
+///  │          │                    │
+///  ├──────────┼────────────────────┼───────────────────────────────┐
+///  │ PeerSet  ▼  AddressBook       ▼                               │
 ///  │ ┌─────────────┐       ┌────────────────┐      ┌─────────────┐ │
 ///  │ │  Possibly   │       │`NeverAttempted`│      │  `Failed`   │ │
 ///  │ │Disconnected │       │     Peers      │      │   Peers     │◀┼┐


### PR DESCRIPTION
## Motivation

The current `CandidateSet` state diagram doesn't document how peer addresses from inbound connections get into the `AddressBook`.

## Solution

Inbound connections on the Zcash protocol listener port perform a handshake. If the handshake is successful, it adds the peer to the `AddressBook`.

Change the `CandidateSet` description and diagram to document this missing state transition.

## Review

@dconnolly and I discussed this change as part of the zebra-network security fixes. It is a medium priority.

## Related Issues

Limit reconnection rate to each individual peer address #1848
Zebra should eventually stop trying to contact peers that always fail #1849
Limit the number of active peers in zebra-network #1850

## Follow Up Work

Actually fix the security issues