### PR TITLE
Implement outbound connection rate limiting - config rename with alias

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -39,6 +39,7 @@ pub struct Config {
     /// This duration only pertains to the rate at which zebra crawls for new
     /// peers, not the rate zebra connects to new peers, which is restricted to
     /// CandidateSet::PEER_CONNECTION_INTERVAL
+    #[serde(alias = "new_peer_interval")]
     pub crawl_new_peer_interval: Duration,
 }
 

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -34,6 +34,10 @@ pub struct Config {
     pub peerset_initial_target_size: usize,
 
     /// How frequently we attempt to connect to a new peer.
+    ///
+    /// This duration only pertains to the rate at which zebra crawls for new
+    /// peers, not the rate zebra connects to new peers, which is restricted to
+    /// CandidateSet::PEER_CONNECTION_INTERVAL (100 milliseconds)
     pub new_peer_interval: Duration,
 }
 

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -33,12 +33,13 @@ pub struct Config {
     /// set size to reduce Zebra's bandwidth usage.
     pub peerset_initial_target_size: usize,
 
-    /// How frequently we attempt to connect to a new peer.
+    /// How frequently we attempt to crawl the network to discover new peer
+    /// connections.
     ///
     /// This duration only pertains to the rate at which zebra crawls for new
     /// peers, not the rate zebra connects to new peers, which is restricted to
-    /// CandidateSet::PEER_CONNECTION_INTERVAL (100 milliseconds)
-    pub new_peer_interval: Duration,
+    /// CandidateSet::PEER_CONNECTION_INTERVAL
+    pub crawl_new_peer_interval: Duration,
 }
 
 impl Config {
@@ -150,7 +151,7 @@ impl Default for Config {
             network: Network::Mainnet,
             initial_mainnet_peers: mainnet_peers,
             initial_testnet_peers: testnet_peers,
-            new_peer_interval: Duration::from_secs(60),
+            crawl_new_peer_interval: Duration::from_secs(60),
 
             // The default peerset target size should be large enough to ensure
             // nodes have a reliable set of peers. But it should also be limited

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -6,7 +6,7 @@ use std::{
 
 use chrono::Utc;
 use futures::stream::{FuturesUnordered, StreamExt};
-use tokio::time::{sleep, sleep_until, Instant, Sleep};
+use tokio::time::{sleep, sleep_until, Sleep};
 use tower::{Service, ServiceExt};
 
 use crate::{types::MetaAddr, AddressBook, BoxError, PeerAddrState, Request, Response};

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -203,6 +203,12 @@ where
     ///
     /// Live `Responded` peers will stay live if they keep responding, or
     /// become a reconnection candidate if they stop responding.
+    ///
+    /// ## Security
+    ///
+    /// Zebra resists distributed denial of service attacks by making sure that
+    /// new peer connections are initiated at least
+    /// `MIN_PEER_CONNECTION_INTERVAL` apart.
     pub async fn next(&mut self) -> Option<MetaAddr> {
         let now = Instant::now();
         let mut sleep = sleep_until(now + Self::MIN_PEER_CONNECTION_INTERVAL);

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -115,7 +115,13 @@ where
     S: Service<Request, Response = Response, Error = BoxError>,
     S::Future: Send + 'static,
 {
-    const PEER_CONNECTION_INTERVAL: Duration = Duration::from_millis(100);
+    /// The minimum time between successive calls to `CandidateSet::next()`.
+    ///
+    /// ## Security
+    ///
+    /// Zebra resists distributed denial of service attacks by making sure that new peer connections
+    /// are initiated at least `MIN_PEER_CONNECTION_INTERVAL` apart.
+    const MIN_PEER_CONNECTION_INTERVAL: Duration = Duration::from_millis(100);
 
     /// Uses `peer_set` and `peer_service` to manage a [`CandidateSet`] of peers.
     pub fn new(peer_set: Arc<Mutex<AddressBook>>, peer_service: S) -> CandidateSet<S> {

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -328,7 +328,7 @@ where
                     trace!("too many in-flight handshakes, dropping demand signal");
                     continue;
                 }
-                if let Some(candidate) = candidates.next() {
+                if let Some(candidate) = candidates.next().await {
                     debug!(?candidate.addr, "attempting outbound connection in response to demand");
                     connector.ready_and().await?;
                     handshakes.push(

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -171,7 +171,7 @@ where
 
     let crawl_guard = tokio::spawn(
         crawl_and_dial(
-            config.new_peer_interval,
+            config.crawl_new_peer_interval,
             demand_tx,
             demand_rx,
             candidates,
@@ -269,7 +269,7 @@ where
 /// Given a channel that signals a need for new peers, try to connect to a peer
 /// and send the resulting `peer::Client` through a channel.
 #[instrument(skip(
-    new_peer_interval,
+    crawl_new_peer_interval,
     demand_tx,
     demand_rx,
     candidates,
@@ -277,7 +277,7 @@ where
     success_tx
 ))]
 async fn crawl_and_dial<C, S>(
-    new_peer_interval: std::time::Duration,
+    crawl_new_peer_interval: std::time::Duration,
     mut demand_tx: mpsc::Sender<()>,
     mut demand_rx: mpsc::Receiver<()>,
     mut candidates: CandidateSet<S>,
@@ -304,7 +304,7 @@ where
     // never terminates.
     handshakes.push(future::pending().boxed());
 
-    let mut crawl_timer = tokio::time::interval(new_peer_interval);
+    let mut crawl_timer = tokio::time::interval(crawl_new_peer_interval);
 
     loop {
         metrics::gauge!(


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

Zebra doesn't limit its outbound connection rate. This is a distributed denial of service risk.

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->

## Solution

- [x] Make `CandidateSet.next()` into an async function
- [x] Add a timer that yields 1 peer every `0.1` seconds
- [x] Update the docs on `new_peer_interval` so it's clear that it's the crawl interval, not the peer connection rate limit

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->

The code in this pull request has:
  - [x] Documentation Comments
  - [ ] Unit Tests and Property Tests

## Review

@teor2345 

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

## Related Issues

Closes https://github.com/ZcashFoundation/zebra/issues/1847

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
