### PR TITLE
Fix grep now that `gcloud compute instance-groups list` has more than one result

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -106,7 +106,7 @@ jobs:
         id: does-group-exist
         continue-on-error: true
         run: |
-          gcloud compute instance-groups list | grep "zebrad-$BRANCH_NAME"\ \ "$REGION"
+          gcloud compute instance-groups list | grep "zebrad-$BRANCH_NAME" | grep "$REGION"
 
       # Deploy new managed instance group using the new instance template
       - name: Create managed instance group

--- a/.github/workflows/zcashd-cd.yml
+++ b/.github/workflows/zcashd-cd.yml
@@ -53,7 +53,7 @@ jobs:
         id: does-group-exist
         continue-on-error: true
         run: |
-          gcloud compute instance-groups list | grep "zcashd-$BRANCH_NAME-${{ github.event.inputs.network }}"\ \ "$REGION"
+          gcloud compute instance-groups list | grep "zcashd-$BRANCH_NAME-${{ github.event.inputs.network }}" | grep "$REGION"
 
       # Deploy new managed instance group using the new instance template
       - name: Create managed instance group


### PR DESCRIPTION


<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

After merging #1844 , `gcloud compute instance-groups list` has more than one result, breaking our `grep` in cd.yml

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->

Grep for the instance group name, then pipe result to grep for region.


## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

Somewhat
