### PR TITLE
Explicitly auto-delete additional cache disks

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           gcloud compute instance-templates create-with-container "zebrad-$BRANCH_NAME-$SHORT_SHA" \
           --container-image "gcr.io/$PROJECT_ID/$REPOSITORY/$BRANCH_NAME:$SHORT_SHA" \
-          --create-disk name=zebrad-cache-$SHORT_SHA,size=100GB,type=pd-balanced \
+          --create-disk name=zebrad-cache-$SHORT_SHA,auto-delete=yes,size=100GB,type=pd-balanced \
           --container-mount-disk mount-path="/zebrad-cache",name=zebrad-cache-$SHORT_SHA \
           --machine-type n2d-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -58,7 +58,7 @@ jobs:
         gcloud compute instances create-with-container "zebrad-$BRANCH_NAME-$SHORT_SHA" \
         --container-image "gcr.io/$PROJECT_ID/$REPOSITORY/$BRANCH_NAME:$SHORT_SHA" \
         --container-mount-disk mount-path='/zebrad-cache',name=zebrad-cache-$SHORT_SHA \
-        --create-disk name=zebrad-cache-$SHORT_SHA,size=100GB,type=pd-balanced \
+        --create-disk name=zebrad-cache-$SHORT_SHA,auto-delete=yes,size=100GB,type=pd-balanced \
         --machine-type n2-standard-4 \
         --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
         --tags zebrad \


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->

This property is supposedly set to 'true' by default, but we are still leaving disks behind, which is costing us money.

## Solution

Explicitly set auto-delete=yes.

Perhaps because:[ "...if the disk is later detached from the instance, this option won't apply."](https://cloud.google.com/sdk/gcloud/reference/compute/instance-templates/create-with-container#--disk)

## Review

Not very.

## Related Issues

Resolves #1845 

