### PR TITLE
Serialize/Deserialize sapling data in V5

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -112,6 +112,10 @@ pub enum Transaction {
         inputs: Vec<transparent::Input>,
         /// The transparent outputs from the transaction.
         outputs: Vec<transparent::Output>,
+        /// The shielded data for this transaction, if any.
+        shielded_data: Option<ShieldedData>,
+        /// The net value of Sapling spend transfers minus output transfers.
+        value_balance: Amount,
         /// The rest of the transaction as bytes
         rest: Vec<u8>,
     },

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -93,7 +93,7 @@ pub enum Transaction {
         /// The latest block height that this transaction can be added to the chain.
         expiry_height: block::Height,
         /// The net value of Sapling spend transfers minus output transfers.
-        value_balance: Amount,
+        sapling_value_balance: Amount,
         /// The JoinSplit data for this transaction, if any.
         joinsplit_data: Option<JoinSplitData<Groth16Proof>>,
         /// The shielded data for this transaction, if any.
@@ -115,7 +115,7 @@ pub enum Transaction {
         /// The shielded data for this transaction, if any.
         shielded_data: Option<ShieldedData>,
         /// The net value of Sapling spend transfers minus output transfers.
-        value_balance: Amount,
+        sapling_value_balance: Amount,
         /// The rest of the transaction as bytes
         rest: Vec<u8>,
     },

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -226,19 +226,24 @@ impl Transaction {
         // This function returns a boxed iterator because the different
         // transaction variants end up having different iterator types
         match self {
-            // JoinSplits with Groth Proofs
+            // Transactions with ShieldedData
             Transaction::V4 {
                 shielded_data: Some(shielded_data),
                 ..
             } => Box::new(shielded_data.nullifiers()),
-            Transaction::V5 { .. } => {
-                unimplemented!("v5 transaction format as specified in ZIP-225")
-            }
-            // No JoinSplits
+            Transaction::V5 {
+                shielded_data: Some(shielded_data),
+                ..
+            } => Box::new(shielded_data.nullifiers()),
+            // No ShieldedData
             Transaction::V1 { .. }
             | Transaction::V2 { .. }
             | Transaction::V3 { .. }
             | Transaction::V4 {
+                shielded_data: None,
+                ..
+            }
+            | Transaction::V5 {
                 shielded_data: None,
                 ..
             } => Box::new(std::iter::empty()),

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -111,14 +111,26 @@ impl Transaction {
             any::<block::Height>(),
             transparent::Input::vec_strategy(ledger_state, 10),
             vec(any::<transparent::Output>(), 0..10),
+            option::of(any::<ShieldedData>()),
+            any::<Amount>(),
             any::<Vec<u8>>(),
         )
             .prop_map(
-                |(lock_time, expiry_height, inputs, outputs, rest)| Transaction::V5 {
+                |(
                     lock_time,
                     expiry_height,
                     inputs,
                     outputs,
+                    shielded_data,
+                    value_balance,
+                    rest,
+                )| Transaction::V5 {
+                    lock_time,
+                    expiry_height,
+                    inputs,
+                    outputs,
+                    shielded_data,
+                    value_balance,
                     rest,
                 },
             )

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -89,7 +89,7 @@ impl Transaction {
                     outputs,
                     lock_time,
                     expiry_height,
-                    value_balance,
+                    sapling_value_balance,
                     shielded_data,
                     joinsplit_data,
                 )| Transaction::V4 {
@@ -97,7 +97,7 @@ impl Transaction {
                     outputs,
                     lock_time,
                     expiry_height,
-                    value_balance,
+                    sapling_value_balance,
                     shielded_data,
                     joinsplit_data,
                 },
@@ -122,7 +122,7 @@ impl Transaction {
                     inputs,
                     outputs,
                     shielded_data,
-                    value_balance,
+                    sapling_value_balance,
                     rest,
                 )| Transaction::V5 {
                     lock_time,
@@ -130,7 +130,7 @@ impl Transaction {
                     inputs,
                     outputs,
                     shielded_data,
-                    value_balance,
+                    sapling_value_balance,
                     rest,
                 },
             )

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -190,7 +190,7 @@ impl ZcashSerialize for Transaction {
                 outputs,
                 lock_time,
                 expiry_height,
-                value_balance,
+                sapling_value_balance,
                 shielded_data,
                 joinsplit_data,
             } => {
@@ -201,7 +201,7 @@ impl ZcashSerialize for Transaction {
                 outputs.zcash_serialize(&mut writer)?;
                 lock_time.zcash_serialize(&mut writer)?;
                 writer.write_u32::<LittleEndian>(expiry_height.0)?;
-                value_balance.zcash_serialize(&mut writer)?;
+                sapling_value_balance.zcash_serialize(&mut writer)?;
 
                 // The previous match arms serialize in one go, because the
                 // internal structure happens to nicely line up with the
@@ -235,7 +235,7 @@ impl ZcashSerialize for Transaction {
                 inputs,
                 outputs,
                 shielded_data,
-                value_balance,
+                sapling_value_balance,
                 rest,
             } => {
                 // Write version 5 and set the fOverwintered bit.
@@ -257,7 +257,7 @@ impl ZcashSerialize for Transaction {
                 };
                 sig_shielded_data.zcash_serialize(&mut writer)?;
 
-                value_balance.zcash_serialize(&mut writer)?;
+                sapling_value_balance.zcash_serialize(&mut writer)?;
 
                 // write the rest
                 writer.write_all(rest)?;
@@ -331,7 +331,7 @@ impl ZcashDeserialize for Transaction {
                 let outputs = Vec::zcash_deserialize(&mut reader)?;
                 let lock_time = LockTime::zcash_deserialize(&mut reader)?;
                 let expiry_height = block::Height(reader.read_u32::<LittleEndian>()?);
-                let value_balance = (&mut reader).zcash_deserialize_into()?;
+                let sapling_value_balance = (&mut reader).zcash_deserialize_into()?;
                 let shielded_spends = Vec::zcash_deserialize(&mut reader)?;
                 let shielded_outputs = Vec::zcash_deserialize(&mut reader)?;
                 let joinsplit_data = OptV4Jsd::zcash_deserialize(&mut reader)?;
@@ -343,7 +343,7 @@ impl ZcashDeserialize for Transaction {
                     outputs,
                     lock_time,
                     expiry_height,
-                    value_balance,
+                    sapling_value_balance,
                     shielded_data,
                     joinsplit_data,
                 })
@@ -361,7 +361,7 @@ impl ZcashDeserialize for Transaction {
                 let shielded_outputs = Vec::zcash_deserialize(&mut reader)?;
                 let shielded_data =
                     deserialize_shielded_data(&mut reader, shielded_spends, shielded_outputs)?;
-                let value_balance = (&mut reader).zcash_deserialize_into()?;
+                let sapling_value_balance = (&mut reader).zcash_deserialize_into()?;
 
                 let mut rest = Vec::new();
                 reader.read_to_end(&mut rest)?;
@@ -372,7 +372,7 @@ impl ZcashDeserialize for Transaction {
                     inputs,
                     outputs,
                     shielded_data,
-                    value_balance,
+                    sapling_value_balance,
                     rest,
                 })
             }

--- a/zebra-chain/src/transaction/shielded_data.rs
+++ b/zebra-chain/src/transaction/shielded_data.rs
@@ -98,11 +98,12 @@ impl ShieldedData {
     /// https://zips.z.cash/protocol/protocol.pdf#saplingbalance
     pub fn binding_verification_key(
         &self,
-        value_balance: Amount,
+        sapling_value_balance: Amount,
     ) -> redjubjub::VerificationKeyBytes<Binding> {
         let cv_old: ValueCommitment = self.spends().map(|spend| spend.cv).sum();
         let cv_new: ValueCommitment = self.outputs().map(|output| output.cv).sum();
-        let cv_balance: ValueCommitment = ValueCommitment::new(jubjub::Fr::zero(), value_balance);
+        let cv_balance: ValueCommitment =
+            ValueCommitment::new(jubjub::Fr::zero(), sapling_value_balance);
 
         let key_bytes: [u8; 32] = (cv_old - cv_new - cv_balance).into();
 

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -486,13 +486,16 @@ impl<'a> SigHasher<'a> {
     fn hash_value_balance<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         use Transaction::*;
 
-        let value_balance = match self.trans {
-            V4 { value_balance, .. } => value_balance,
+        let sapling_value_balance = match self.trans {
+            V4 {
+                sapling_value_balance,
+                ..
+            } => sapling_value_balance,
             V5 { .. } => unimplemented!("v5 transaction hash as specified in ZIP-225 and ZIP-244"),
             V1 { .. } | V2 { .. } | V3 { .. } => unreachable!(ZIP243_EXPLANATION),
         };
 
-        writer.write_all(&value_balance.to_bytes())?;
+        writer.write_all(&sapling_value_balance.to_bytes())?;
 
         Ok(())
     }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -141,7 +141,7 @@ where
                     // outputs,
                     // lock_time,
                     // expiry_height,
-                    value_balance,
+                    sapling_value_balance,
                     joinsplit_data,
                     shielded_data,
                     ..
@@ -194,7 +194,7 @@ where
                     }
 
                     if let Some(shielded_data) = shielded_data {
-                        check::shielded_balances_match(&shielded_data, *value_balance)?;
+                        check::shielded_balances_match(&shielded_data, *sapling_value_balance)?;
                         for spend in shielded_data.spends() {
                             // TODO: check that spend.cv and spend.rk are NOT of small
                             // order.
@@ -238,7 +238,7 @@ where
                             // transaction to verify.
                         });
 
-                        let bvk = shielded_data.binding_verification_key(*value_balance);
+                        let bvk = shielded_data.binding_verification_key(*sapling_value_balance);
                         let _rsp = redjubjub_verifier
                             .ready_and()
                             .await?

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -82,10 +82,10 @@ pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> 
 /// https://zips.z.cash/protocol/protocol.pdf#consensusfrombitcoin
 pub fn shielded_balances_match(
     shielded_data: &ShieldedData,
-    value_balance: Amount,
+    sapling_value_balance: Amount,
 ) -> Result<(), TransactionError> {
     if (shielded_data.spends().count() + shielded_data.outputs().count() != 0)
-        || i64::from(value_balance) == 0
+        || i64::from(sapling_value_balance) == 0
     {
         Ok(())
     } else {


### PR DESCRIPTION
## Motivation

Parse sapling data in transaction v5: https://github.com/ZcashFoundation/zebra/issues/1829

## Solution

It is very similar to V4 but the order of the fields is different in the 2 versions. This complicates a bit the de-duplication efforts.

For the serialize a new type `SigShieldedData` was added and the `ZcashSerialize` implementation is done against this new type that haves the shielded data and a flag to control if the serializing of the `binding_sig` field will be done here or not. V4 needs to serialize the `binding_sig` later so the flag for it is `false` while in V5 everything can be done in the same place so this flag is `true`.

For deserialization the idea is similar but we cant implement a type as `zcash_deserialize` cant access the instance(no `self` is available). So by now i implemented this as a function.

The rest is pretty straightforward however i am not sure if this is the best approach, open to options.

## Review

## Related Issues

If merged this will close  https://github.com/ZcashFoundation/zebra/issues/1829

