### PR TITLE
Adjust the crawl interval and acceptance test timeout

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -47,7 +47,7 @@ const LAUNCH_DELAY: Duration = Duration::from_secs(10);
 fn default_test_config() -> Result<ZebradConfig> {
     let auto_port_ipv4_local = zebra_network::Config {
         listen_addr: "127.0.0.1:0".parse()?,
-        new_peer_interval: Duration::from_secs(30),
+        crawl_new_peer_interval: Duration::from_secs(30),
         ..zebra_network::Config::default()
     };
     let local_ephemeral = ZebradConfig {

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -47,7 +47,7 @@ const LAUNCH_DELAY: Duration = Duration::from_secs(10);
 fn default_test_config() -> Result<ZebradConfig> {
     let auto_port_ipv4_local = zebra_network::Config {
         listen_addr: "127.0.0.1:0".parse()?,
-        new_peer_interval: 30,
+        new_peer_interval: Duration::from_secs(30),
         ..zebra_network::Config::default()
     };
     let local_ephemeral = ZebradConfig {

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -47,6 +47,7 @@ const LAUNCH_DELAY: Duration = Duration::from_secs(10);
 fn default_test_config() -> Result<ZebradConfig> {
     let auto_port_ipv4_local = zebra_network::Config {
         listen_addr: "127.0.0.1:0".parse()?,
+        new_peer_interval: 30,
         ..zebra_network::Config::default()
     };
     let local_ephemeral = ZebradConfig {
@@ -662,7 +663,7 @@ const STOP_AT_HEIGHT_REGEX: &str = "stopping at configured height";
 
 const STOP_ON_LOAD_TIMEOUT: Duration = Duration::from_secs(5);
 // usually it's much shorter than this
-const SMALL_CHECKPOINT_TIMEOUT: Duration = Duration::from_secs(30);
+const SMALL_CHECKPOINT_TIMEOUT: Duration = Duration::from_secs(120);
 const LARGE_CHECKPOINT_TIMEOUT: Duration = Duration::from_secs(180);
 
 /// Test if `zebrad` can sync the first checkpoint on mainnet.


### PR DESCRIPTION
## Motivation

Occasionally, an acceptance test fails because it gets bad peers.

For example, `restart_stop_at_height` was really slow in PR #1877, but it was still making progress:
https://github.com/ZcashFoundation/zebra/runs/2071085335

## Solution

- Increase the short acceptance test timeout to 120 seconds (was 30 seconds)
- Make sure Zebra crawls for new peers multiple times within the short test timeout, by making the crawl interval 30 seconds (default 60 seconds)

## Review

@oxarbitrage has done a lot of work on these tests. This review isn't urgent.

## Related Issues

Fixes an unrelated CI failure in #1877
