### PR TITLE
Reduce inbound concurrency to limit memory usage

### DIFF
--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -23,10 +23,27 @@ type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// The maximum number of concurrent inbound download and verify tasks.
 ///
-/// Set to one and a half checkpoint intervals, so that the inbound queue can
-/// hold a complete checkpoint interval, if needed. We expect the syncer to
-/// download and verify checkpoints, so this bound might never be reached.
-const MAX_INBOUND_CONCURRENCY: usize = zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP * 3 / 2;
+/// We expect the syncer to download and verify checkpoints, so this bound
+/// can be small.
+///
+/// ## Security
+///
+/// We use a small concurrency limit, to prevent memory denial-of-service
+/// attacks.
+///
+/// The maximum block size is 2 million bytes. A deserialized malicious
+/// block with ~225_000 transparent outputs can take up 9MB of RAM. As of
+/// February 2021, a growing `Vec` can allocate up to 2x its current length,
+/// leading to an overall memory usage of 18MB per malicious block. (See
+/// #1880 for more details.)
+///
+/// Malicious blocks will eventually timeout or fail contextual validation.
+/// Once validation fails, the block is dropped, and its memory is deallocated.
+///
+/// Since Zebra keeps an `inv` index, inbound downloads for malicious blocks
+/// will be directed to the malicious node that originally gossiped the hash.
+/// Therefore, this attack can be carried out by a single malicious node.
+const MAX_INBOUND_CONCURRENCY: usize = 10;
 
 /// The action taken in response to a peer's gossipped block hash.
 pub enum DownloadAction {

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -40,6 +40,21 @@ const BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 2;
 ///
 /// Set to two checkpoint intervals, so that we're sure that the lookahead
 /// limit always contains at least one complete checkpoint.
+///
+/// ## Security
+///
+/// If a malicious node is chosen for an ObtainTips or ExtendTips request, it can
+/// provide up to 500 malicious block hashes. These block hashes will be
+/// distributed across all available peers. Assuming there are around 50 connected
+/// peers, the malicious node will receive approximately 10 of those block requests.
+///
+/// Malicious deserialized blocks can take up a large amount of RAM, see
+/// [`super::inbound::downloads::MAX_INBOUND_CONCURRENCY`] and #1880 for details.
+/// So we want to keep the lookahead limit reasonably small.
+///
+/// Once these malicious blocks start failing validation, the syncer will cancel all
+/// the pending download and verify tasks, drop all the blocks, and start a new
+/// ObtainTips with a new set of peers.
 const MIN_LOOKAHEAD_LIMIT: usize = zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP * 2;
 
 /// Controls how long we wait for a tips response to return.


### PR DESCRIPTION
## Motivation

Inbound malicious blocks can use a large amount of RAM when deserialized. See #1880 for details.

## Solution

Limit inbound concurrency, so that the total amount of RAM remains small.

The code in this pull request has:
  - [x] Documentation Comments
  - [ ] Unit Tests and Property Tests

## Review

This is a security issue, so @dconnolly should review somewhat urgently.

## Related Issues

Detailed analysis in #1880, thanks to @preston-evans98.

## Follow Up Work

We should verify proof of work in the checkpoint verifier, to make malicious blocks fail validation earlier. (Or make them very hard to generate.)