### PR TITLE
Verify proof-of-work in the checkpoint verifier

### DIFF
--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -33,7 +33,7 @@ use zebra_state as zs;
 use crate::{error::*, transaction as tx};
 use crate::{script, BoxError};
 
-mod check;
+pub mod check;
 mod subsidy;
 #[cfg(test)]
 mod tests;

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -183,10 +183,22 @@ pub fn merkle_root_validity(
 
     // Bitcoin's transaction Merkle trees are malleable, allowing blocks with
     // duplicate transactions to have the same Merkle root as blocks without
-    // duplicate transactions. Duplicate transactions should cause a block to be
+    // duplicate transactions.
+    //
+    // Collecting into a HashSet deduplicates, so this checks that there are no
+    // duplicate transaction hashes, preventing Merkle root malleability.
+    //
+    // ## Full Block Validation
+    //
+    // Duplicate transactions should cause a block to be
     // rejected, as duplicate transactions imply that the block contains a
     // double-spend.  As a defense-in-depth, however, we also check that there
-    // are no duplicate transaction hashes, by collecting into a HashSet.
+    // are no duplicate transaction hashes.
+    //
+    // ## Checkpoint Validation
+    //
+    // To prevent malleability (CVE-2012-2459), we also need to check
+    // whether the transaction hashes are unique.
     use std::collections::HashSet;
     if transaction_hashes.len() != transaction_hashes.iter().collect::<HashSet<_>>().len() {
         return Err(BlockError::DuplicateTransaction);

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -153,7 +153,7 @@ where
     tracing::info!(?tip, ?max_checkpoint_height, "initializing chain verifier");
 
     let block = BlockVerifier::new(network, state_service.clone());
-    let checkpoint = CheckpointVerifier::from_checkpoint_list(list, tip, state_service);
+    let checkpoint = CheckpointVerifier::from_checkpoint_list(list, network, tip, state_service);
 
     Buffer::new(
         BoxService::new(ChainVerifier {

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -108,6 +108,9 @@ where
     /// The checkpoint list for this verifier.
     checkpoint_list: CheckpointList,
 
+    /// The network rules used by this verifier.
+    network: Network,
+
     /// The hash of the initial tip, if any.
     initial_tip_hash: Option<block::Hash>,
 
@@ -164,11 +167,11 @@ where
             ?initial_tip,
             "initialising CheckpointVerifier"
         );
-        Self::from_checkpoint_list(checkpoint_list, initial_tip, state_service)
+        Self::from_checkpoint_list(checkpoint_list, network, initial_tip, state_service)
     }
 
-    /// Return a checkpoint verification service using `list`, `initial_tip`,
-    /// and `state_service`.
+    /// Return a checkpoint verification service using `list`, `network`,
+    /// `initial_tip`, and `state_service`.
     ///
     /// Assumes that the provided genesis checkpoint is correct.
     ///
@@ -181,18 +184,20 @@ where
     #[allow(dead_code)]
     pub(crate) fn from_list(
         list: impl IntoIterator<Item = (block::Height, block::Hash)>,
+        network: Network,
         initial_tip: Option<(block::Height, block::Hash)>,
         state_service: S,
     ) -> Result<Self, VerifyCheckpointError> {
         Ok(Self::from_checkpoint_list(
             CheckpointList::from_list(list).map_err(VerifyCheckpointError::CheckpointList)?,
+            network,
             initial_tip,
             state_service,
         ))
     }
 
     /// Return a checkpoint verification service using `checkpoint_list`,
-    /// `initial_tip`, and `state_service`.
+    /// `network`, `initial_tip`, and `state_service`.
     ///
     /// Assumes that the provided genesis checkpoint is correct.
     ///
@@ -200,6 +205,7 @@ where
     /// hard-coded checkpoint lists. See that function for more details.
     pub(crate) fn from_checkpoint_list(
         checkpoint_list: CheckpointList,
+        network: Network,
         initial_tip: Option<(block::Height, block::Hash)>,
         state_service: S,
     ) -> Self {
@@ -220,6 +226,7 @@ where
         };
         CheckpointVerifier {
             checkpoint_list,
+            network,
             initial_tip_hash,
             state_service,
             queued: BTreeMap::new(),

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -49,7 +49,7 @@ async fn single_item_checkpoint_list() -> Result<(), Report> {
         .buffer(1)
         .service(zebra_state::init(zebra_state::Config::ephemeral(), Mainnet));
     let mut checkpoint_verifier =
-        CheckpointVerifier::from_list(genesis_checkpoint_list, None, state_service)
+        CheckpointVerifier::from_list(genesis_checkpoint_list, Mainnet, None, state_service)
             .map_err(|e| eyre!(e))?;
 
     assert_eq!(
@@ -133,7 +133,7 @@ async fn multi_item_checkpoint_list() -> Result<(), Report> {
         .buffer(1)
         .service(zebra_state::init(zebra_state::Config::ephemeral(), Mainnet));
     let mut checkpoint_verifier =
-        CheckpointVerifier::from_list(checkpoint_list, None, state_service)
+        CheckpointVerifier::from_list(checkpoint_list, Mainnet, None, state_service)
             .map_err(|e| eyre!(e))?;
 
     assert_eq!(
@@ -280,9 +280,13 @@ async fn continuous_blockchain(
         let state_service = ServiceBuilder::new()
             .buffer(1)
             .service(zebra_state::init(zebra_state::Config::ephemeral(), Mainnet));
-        let mut checkpoint_verifier =
-            CheckpointVerifier::from_list(checkpoint_list, initial_tip, state_service.clone())
-                .map_err(|e| eyre!(e))?;
+        let mut checkpoint_verifier = CheckpointVerifier::from_list(
+            checkpoint_list,
+            network,
+            initial_tip,
+            state_service.clone(),
+        )
+        .map_err(|e| eyre!(e))?;
 
         // Setup checks
         if restart_height.is_some() {
@@ -457,7 +461,7 @@ async fn block_higher_than_max_checkpoint_fail() -> Result<(), Report> {
         .buffer(1)
         .service(zebra_state::init(zebra_state::Config::ephemeral(), Mainnet));
     let mut checkpoint_verifier =
-        CheckpointVerifier::from_list(genesis_checkpoint_list, None, state_service)
+        CheckpointVerifier::from_list(genesis_checkpoint_list, Mainnet, None, state_service)
             .map_err(|e| eyre!(e))?;
 
     assert_eq!(
@@ -536,7 +540,7 @@ async fn wrong_checkpoint_hash_fail() -> Result<(), Report> {
         .buffer(1)
         .service(zebra_state::init(zebra_state::Config::ephemeral(), Mainnet));
     let mut checkpoint_verifier =
-        CheckpointVerifier::from_list(genesis_checkpoint_list, None, state_service)
+        CheckpointVerifier::from_list(genesis_checkpoint_list, Mainnet, None, state_service)
             .map_err(|e| eyre!(e))?;
 
     assert_eq!(
@@ -720,7 +724,7 @@ async fn checkpoint_drop_cancel() -> Result<(), Report> {
         .buffer(1)
         .service(zebra_state::init(zebra_state::Config::ephemeral(), Mainnet));
     let mut checkpoint_verifier =
-        CheckpointVerifier::from_list(checkpoint_list, None, state_service)
+        CheckpointVerifier::from_list(checkpoint_list, Mainnet, None, state_service)
             .map_err(|e| eyre!(e))?;
 
     assert_eq!(


### PR DESCRIPTION
## Motivation

Processing some malicious blocks can take a lot of resources (RAM or CPU).

Checking the proof of work makes these attacks harder, because malicious blocks are rejected earlier. (Or malicious blocks take a lot of work to generate.)

## Solution

- Check the difficulty threshold and equihash in the checkpoint verifier
- Re-use some BlockVerifier checks in the checkpoint verifier
- Convert errors as needed

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Existing Unit Tests

## Review

@dconnolly or @yaahc might want to check this out. It's not particularly urgent, but it is important.

## Related Issues

#1880 detailed analysis of a resource exhaustion attack
