### PR TITLE
Try a slightly longer handshake timeout

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -30,7 +30,7 @@ pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 /// This timeout should remain small, because it helps stop slow peers getting
 /// into the peer set. This is particularly important for network-constrained
 /// nodes, and on testnet.
-pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(4);
+pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(6);
 
 /// We expect to receive a message from a live peer at least once in this time duration.
 ///


### PR DESCRIPTION
## Motivation

The large testnet acceptance tests are failing, because sometimes Zebra only gets 1-3 good peers on testnet.

## Solution

Increase the timeout to allow slightly slower peers to connect.

## Review

We need to test this change before it gets reviewed.

## Related Issues

#1877 Restore large testnet tests

## Follow Up Work

We could also:
* increase the testnet acceptance test timeouts
* decrease the number of blocks we sync on testnet
* deploy more testnet peers
* make the security fixes that will improve DNS seeder accuracy, and re-deploy the foundation DNS seeders
* just disable the test and leave it disabled