### PR TITLE
Document that the listed address is also advertised to peers

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -13,6 +13,10 @@ const MAX_SINGLE_PEER_RETRIES: usize = 2;
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
     /// The address on which this node should listen for connections.
+    ///
+    /// Zebra will also advertise this address to other nodes. Advertising a
+    /// different external IP address is currently not supported, see #1890
+    /// for details.
     pub listen_addr: SocketAddr,
 
     /// The network to connect to.


### PR DESCRIPTION
## Motivation

Document a potential privacy leak, and a missing feature.

## Review

This is a routine documentation fix.

## Follow Up Work

#1890 Zebra should support separate local bind and external advertise addresses
