### PR TITLE
Metrics renaming to enable node interoperability - breaking change

### DIFF
--- a/grafana/block_verification.json
+++ b/grafana/block_verification.json
@@ -75,7 +75,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "block_verified_block_height{job=\"$job\"}",
+          "expr": "zcash_chain_verified_block_height{job=\"$job\"}",
           "interval": "",
           "legendFormat": "verified block height",
           "refId": "A"
@@ -179,7 +179,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "block_verified_block_height{job=\"$job\"}",
+          "expr": "zcash_chain_verified_block_height{job=\"$job\"}",
           "interval": "",
           "legendFormat": "verified block height",
           "refId": "A"
@@ -283,9 +283,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(block_verified_block_count{job=\"$job\"}[1s])",
+          "expr": "rate(zcash_chain_verified_block_total{job=\"$job\"}[1s])",
           "interval": "",
-          "legendFormat": "block_verified_block_count[1s]",
+          "legendFormat": "zcash_chain_verified_block_total[1s]",
           "refId": "A"
         },
         {
@@ -406,9 +406,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(block_verified_block_count{job=\"$job\"}[1s])",
+          "expr": "rate(zcash_chain_verified_block_total{job=\"$job\"}[1s])",
           "interval": "",
-          "legendFormat": "block_verified_block_count[1s]",
+          "legendFormat": "zcash_chain_verified_block_total[1s]",
           "refId": "A"
         },
         {
@@ -528,9 +528,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(block_verified_block_count{job=\"$job\"}[1s])",
+          "expr": "rate(zcash_chain_verified_block_total{job=\"$job\"}[1s])",
           "interval": "",
-          "legendFormat": "block_verified_block_count[1s]",
+          "legendFormat": "zcash_chain_verified_block_total[1s]",
           "refId": "A"
         },
         {
@@ -651,9 +651,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(block_verified_block_count{job=\"$job\"}[1s])",
+          "expr": "rate(zcash_chain_verified_block_total{job=\"$job\"}[1s])",
           "interval": "",
-          "legendFormat": "block_verified_block_count[1s]",
+          "legendFormat": "zcash_chain_verified_block_total[1s]",
           "refId": "A"
         },
         {
@@ -735,14 +735,14 @@
           ]
         },
         "datasource": "Prometheus-Zebra",
-        "definition": "label_values(block_verified_block_height, job)",
+        "definition": "label_values(zcash_chain_verified_block_height, job)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "job",
         "options": [],
-        "query": "label_values(block_verified_block_height, job)",
+        "query": "label_values(zcash_chain_verified_block_height, job)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/grafana/network_health.json
+++ b/grafana/network_health.json
@@ -76,14 +76,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(bytes_read{job=\"$job\"}[1s]))",
+          "expr": "sum(rate(zcash_net_in_bytes_total{job=\"$job\"}[1s]))",
           "hide": false,
           "interval": "",
           "legendFormat": "bytes read [1s]",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(bytes_written{job=\"$job\"}[1s]))",
+          "expr": "sum(rate(zcash_net_out_bytes_total{job=\"$job\"}[1s]))",
           "interval": "",
           "legendFormat": "bytes written [1s]",
           "refId": "B"
@@ -188,14 +188,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(bytes_read{job=\"$job\"}[1s]))",
+          "expr": "sum(rate(zcash_net_in_bytes_total{job=\"$job\"}[1s]))",
           "hide": false,
           "interval": "",
           "legendFormat": "bytes read [1s]",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(bytes_written{job=\"$job\"}[1s]))",
+          "expr": "sum(rate(zcash_net_out_bytes_total{job=\"$job\"}[1s]))",
           "interval": "",
           "legendFormat": "bytes written [1s]",
           "refId": "B"
@@ -299,7 +299,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pool_num_peers{job=\"$job\"}",
+          "expr": "zcash_net_peers{job=\"$job\"}",
           "interval": "",
           "legendFormat": "total peers",
           "refId": "A"
@@ -416,7 +416,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pool_num_peers{job=\"$job\"}",
+          "expr": "zcash_net_peers{job=\"$job\"}",
           "interval": "",
           "legendFormat": "total peers",
           "refId": "A"
@@ -763,14 +763,14 @@
           ]
         },
         "datasource": "Prometheus-Zebra",
-        "definition": "label_values(bytes_read, job)",
+        "definition": "label_values(zcash_net_in_bytes_total, job)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "job",
         "options": [],
-        "query": "label_values(bytes_read, job)",
+        "query": "label_values(zcash_net_in_bytes_total, job)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -198,8 +198,8 @@ where
 
             // Update the metrics after all the validation is finished
             tracing::trace!("verified block");
-            metrics::gauge!("block.verified.block.height", height.0 as _);
-            metrics::counter!("block.verified.block.count", 1);
+            metrics::gauge!("zcash.chain.verified.block.height", height.0 as _);
+            metrics::counter!("zcash.chain.verified.block.total", 1);
 
             // Finally, submit the block for contextual verification.
             let new_outputs = Arc::try_unwrap(known_utxos)

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -364,7 +364,7 @@ where
             let peer_tx = peer_tx.with(move |msg: Message| {
                 // Add a metric for outbound messages.
                 // XXX add a dimension tagging message metrics by type
-                metrics::counter!("peer.outbound_messages", 1, "addr" => addr.to_string());
+                metrics::counter!("zcash.net.out.messages", 1, "addr" => addr.to_string());
                 // We need to use future::ready rather than an async block here,
                 // because we need the sink to be Unpin, and the With<Fut, ...>
                 // returned by .with is Unpin only if Fut is Unpin, and the
@@ -380,7 +380,7 @@ where
                         if msg.is_ok() {
                             // XXX add a dimension tagging message metrics by type
                             metrics::counter!(
-                                "inbound_messages",
+                                "zcash.net.in.messages",
                                 1,
                                 "addr" => addr.to_string(),
                             );

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -363,8 +363,12 @@ where
 
             let peer_tx = peer_tx.with(move |msg: Message| {
                 // Add a metric for outbound messages.
-                // XXX add a dimension tagging message metrics by type
-                metrics::counter!("zcash.net.out.messages", 1, "addr" => addr.to_string());
+                metrics::counter!(
+                    "zcash.net.out.messages",
+                    1,
+                    "command" => msg.to_string(),
+                    "addr" => addr.to_string(),
+                );
                 // We need to use future::ready rather than an async block here,
                 // because we need the sink to be Unpin, and the With<Fut, ...>
                 // returned by .with is Unpin only if Fut is Unpin, and the
@@ -377,11 +381,11 @@ where
                     // Add a metric for inbound messages and fire a timestamp event.
                     let mut timestamp_collector = timestamp_collector.clone();
                     async move {
-                        if msg.is_ok() {
-                            // XXX add a dimension tagging message metrics by type
+                        if let Ok(msg) = &msg {
                             metrics::counter!(
                                 "zcash.net.in.messages",
                                 1,
+                                "command" => msg.to_string(),
                                 "addr" => addr.to_string(),
                             );
                             use futures::sink::SinkExt;

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -386,7 +386,7 @@ where
         let num_peers = num_ready + num_unready;
         metrics::gauge!("pool.num_ready", num_ready as f64);
         metrics::gauge!("pool.num_unready", num_unready as f64);
-        metrics::gauge!("pool.num_peers", num_peers as f64);
+        metrics::gauge!("zcash.net.peers", num_peers as f64);
     }
 }
 

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -117,7 +117,7 @@ impl Encoder<Message> for Codec {
         }
 
         if let Some(label) = self.builder.metrics_label.clone() {
-            metrics::counter!("bytes.written", (body_length + HEADER_LEN) as u64, "addr" => label);
+            metrics::counter!("zcash.net.out.bytes.total", (body_length + HEADER_LEN) as u64, "addr" => label);
         }
 
         use Message::*;
@@ -366,7 +366,7 @@ impl Decoder for Codec {
                 }
 
                 if let Some(label) = self.builder.metrics_label.clone() {
-                    metrics::counter!("bytes.read", (body_len + HEADER_LEN) as u64, "addr" =>  label);
+                    metrics::counter!("zcash.net.in.bytes.total", (body_len + HEADER_LEN) as u64, "addr" =>  label);
                 }
 
                 // Reserve buffer space for the expected body and the following header.

--- a/zebrad/src/components/metrics.rs
+++ b/zebrad/src/components/metrics.rs
@@ -19,6 +19,28 @@ impl MetricsEndpoint {
             match endpoint_result {
                 Ok(()) => {
                     info!("Opened metrics endpoint at {}", addr);
+
+                    // Expose binary metadata to metrics, using a single time series with
+                    // value 1:
+                    //     https://www.robustperception.io/exposing-the-software-version-to-prometheus
+                    //
+                    // We manually expand the metrics::increment!() macro because it only
+                    // supports string literals for metrics names, preventing us from
+                    // using concat!() to build the name.
+                    static METRIC_NAME: [metrics::SharedString; 2] = [
+                        metrics::SharedString::const_str(env!("CARGO_PKG_NAME")),
+                        metrics::SharedString::const_str("build.info"),
+                    ];
+                    static METRIC_LABELS: [metrics::Label; 1] =
+                        [metrics::Label::from_static_parts(
+                            "version",
+                            env!("CARGO_PKG_VERSION"),
+                        )];
+                    static METRIC_KEY: metrics::KeyData =
+                        metrics::KeyData::from_static_parts(&METRIC_NAME, &METRIC_LABELS);
+                    if let Some(recorder) = metrics::try_recorder() {
+                        recorder.increment_counter(metrics::Key::Borrowed(&METRIC_KEY), 1);
+                    }
                 }
                 Err(e) => panic!(
                     "Opening metrics endpoint listener {:?} failed: {:?}. \


### PR DESCRIPTION
## Motivation

It is likely that there will be node operators who want to run both `zcashd` and `zebrad` nodes, and it would be useful to be able to collect metrics common to the two nodes, as well as slice and aggregate based on the particular node version.

## Solution

This PR makes three changes:
- Existing `zebrad` metrics that `zcashd` is adopting as "common metrics" are renamed to follow a consistent Zcash-global naming pattern.
- Message-counting metrics are now tagged by the message command, matching `zcashd` and fixing a TODO.
- The `zebrad.build.info` metric is added to expose binary data to Prometheus, enabling metrics from `zebrad` nodes to be sliced and aggregated (c/f `zcashd.build.info`).

Closes https://github.com/ZcashFoundation/zebra/issues/1746

## Review

Not urgent, not blocking anything.

## Related Issues

- Overall metrics and logging review: https://github.com/ZcashFoundation/zebra/issues/1381
- `zcashd` metrics PR: https://github.com/zcash/zcash/pull/4947

## Follow Up Work

This PR only renames the specific metrics that are common between `zebrad` and `zcashd`. It would likely be useful to rename the remaining metrics to follow a similar pattern, or at least to be consistent in terms of how they follow Prometheus guidance.

This follow-up is already part of:
- Overall metrics and logging review: https://github.com/ZcashFoundation/zebra/issues/1381