### PR TITLE
Replace smart quotes with ascii quotes

### DIFF
--- a/tower-batch/src/lib.rs
+++ b/tower-batch/src/lib.rs
@@ -30,13 +30,13 @@
 //! Sapling-on-Groth16). A single transaction can have multiple proofs or
 //! signatures of different kinds, depending on the transaction version and its
 //! structure. Verification of a transaction conventionally proceeds
-//! “depth-first”, checking that the structure is appropriate and then that all
+//! "depth-first", checking that the structure is appropriate and then that all
 //! the component signatures and proofs are valid.
 //!
 //! Now consider the problem of implementing batch verification in this context,
 //! using conventional batch verification APIs that require passing a list of
 //! signatures or proofs. This is quite complicated, requiring implementing a
-//! second transposed set of validation logic that proceeds “breadth-first”,
+//! second transposed set of validation logic that proceeds "breadth-first",
 //! checking that the structure of each transaction is appropriate while
 //! assembling collections of signatures and proofs to verify. This transposed
 //! validation logic must match the untransposed logic, but there is another

--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -27,7 +27,7 @@ pub struct Header {
     /// the genesis block.
     ///
     /// This ensures no previous block can be changed without also changing this
-    /// block’s header.
+    /// block's header.
     pub previous_block_hash: Hash,
 
     /// The root of the Bitcoin-inherited transaction Merkle tree, binding the
@@ -52,7 +52,7 @@ pub struct Header {
     /// started hashing the header (according to the miner).
     pub time: DateTime<Utc>,
 
-    /// An encoded version of the target threshold this block’s header
+    /// An encoded version of the target threshold this block's header
     /// hash must be less than or equal to, in the same nBits format
     /// used by Bitcoin.
     ///

--- a/zebra-chain/src/sapling/commitment/pedersen_hashes.rs
+++ b/zebra-chain/src/sapling/commitment/pedersen_hashes.rs
@@ -63,9 +63,9 @@ fn M_i(segment: &BitSlice<Lsb0, u8>) -> jubjub::Fr {
 /// the Jubjub curve."
 ///
 /// PedersenHash is used in the definitions of Pedersen commitments (§
-/// 5.4.7.2 ‘Windowed Pedersen commitments’), and of the Pedersen hash for the
-/// Sapling incremental Merkle tree (§ 5.4.1.3 ‘MerkleCRH^Sapling Hash
-/// Function’).
+/// 5.4.7.2 'Windowed Pedersen commitments'), and of the Pedersen hash for the
+/// Sapling incremental Merkle tree (§ 5.4.1.3 'MerkleCRH^Sapling Hash
+/// Function').
 ///
 /// https://zips.z.cash/protocol/protocol.pdf#concretepedersenhash
 #[allow(non_snake_case)]
@@ -105,7 +105,7 @@ pub fn pedersen_hash(domain: [u8; 8], M: &BitVec<Lsb0, u8>) -> jubjub::Fq {
 /// commitment tree.  It takes as input a Pedersen commitment P, and hashes it
 /// with another input x.
 ///
-/// MixingPedersenHash(P, x) := P + [x]FindGroupHash^J^(r)(“Zcash_J_”, “”)
+/// MixingPedersenHash(P, x) := P + [x]FindGroupHash^J^(r)("Zcash_J_", "")
 ///
 /// https://zips.z.cash/protocol/protocol.pdf#concretemixinghash
 #[allow(non_snake_case)]
@@ -119,7 +119,7 @@ pub fn mixing_pedersen_hash(P: jubjub::ExtendedPoint, x: jubjub::Fr) -> jubjub::
 /// construction, and adding a randomized point on the Jubjub curve.
 ///
 /// WindowedPedersenCommit_r (s) := \
-///   PedersenHashToPoint(“Zcash_PH”, s) + [r]FindGroupHash^J^(r)(“Zcash_PH”, “r”)
+///   PedersenHashToPoint("Zcash_PH", s) + [r]FindGroupHash^J^(r)("Zcash_PH", "r")
 ///
 /// https://zips.z.cash/protocol/protocol.pdf#concretewindowedcommit
 pub fn windowed_pedersen_commitment(r: jubjub::Fr, s: &BitVec<Lsb0, u8>) -> jubjub::ExtendedPoint {

--- a/zebra-chain/src/sapling/keys.rs
+++ b/zebra-chain/src/sapling/keys.rs
@@ -666,7 +666,7 @@ impl From<SpendingKey> for Diversifier {
     /// Derives a [_default diversifier_][4.2.2] from a SpendingKey.
     ///
     /// 'For each spending key, there is also a default diversified
-    /// payment address with a “random-looking” diversifier. This
+    /// payment address with a "random-looking" diversifier. This
     /// allows an implementation that does not expose diversified
     /// addresses as a user-visible feature, to use a default address
     /// that cannot be distinguished (without knowledge of the
@@ -795,8 +795,8 @@ mod fvk_hrp {
 /// spend authority.
 ///
 /// For incoming viewing keys on the production network, the
-/// Human-Readable Part is “zviews”. For incoming viewing keys on the
-/// test network, the Human-Readable Part is “zviewtestsapling”.
+/// Human-Readable Part is "zviews". For incoming viewing keys on the
+/// test network, the Human-Readable Part is "zviewtestsapling".
 ///
 /// https://zips.z.cash/protocol/protocol.pdf#saplingfullviewingkeyencoding
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/zebra-chain/src/sapling/note.rs
+++ b/zebra-chain/src/sapling/note.rs
@@ -28,9 +28,9 @@ pub use nullifiers::Nullifier;
 /// address.
 #[derive(Clone, Debug)]
 pub struct Note {
-    /// The diversifer of the recipient’s shielded payment address.
+    /// The diversifer of the recipient's shielded payment address.
     pub diversifier: Diversifier,
-    /// The diversified transmission key of the recipient’s shielded
+    /// The diversified transmission key of the recipient's shielded
     /// payment address.
     pub transmission_key: TransmissionKey,
     /// An integer representing the value of the note in zatoshi.

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -28,7 +28,7 @@ const MERKLE_DEPTH: usize = 32;
 ///
 /// Used to hash incremental Merkle tree hash values for Sapling.
 ///
-/// MerkleCRH^Sapling(layer, left, right) := PedersenHash(“Zcash_PH”, l || left || right)
+/// MerkleCRH^Sapling(layer, left, right) := PedersenHash("Zcash_PH", l || left || right)
 /// where l = I2LEBSP_6(MerkleDepth^Sapling − 1 − layer) and
 /// left, right, and the output are all technically 255 bits (l_MerkleSapling), not 256.
 ///
@@ -62,7 +62,7 @@ lazy_static! {
     };
 }
 
-/// The index of a note’s commitment at the leafmost layer of its Note
+/// The index of a note's commitment at the leafmost layer of its Note
 /// Commitment Tree.
 ///
 /// https://zips.z.cash/protocol/protocol.pdf#merkletree

--- a/zebra-chain/src/sprout/keys.rs
+++ b/zebra-chain/src/sprout/keys.rs
@@ -2,7 +2,7 @@
 //!
 //! "The receiving key sk_enc, the incoming viewing key ivk = (apk,
 //! sk_enc), and the shielded payment address addr_pk = (a_pk, pk_enc) are
-//! derived from a_sk, as described in [‘Sprout Key Components’][ps]
+//! derived from a_sk, as described in ['Sprout Key Components'][ps]
 //!
 //! [ps]: https://zips.z.cash/protocol/protocol.pdf#sproutkeycomponents
 #![allow(clippy::unit_arg)]
@@ -223,7 +223,7 @@ mod ivk_magics {
     pub const TESTNET: [u8; 3] = [0xA8, 0xAC, 0x0C];
 }
 
-/// The recipient’s possession of the associated incoming viewing key
+/// The recipient's possession of the associated incoming viewing key
 /// is used to reconstruct the original note and memo field.
 pub struct IncomingViewingKey {
     network: Network,

--- a/zebra-chain/src/sprout/note.rs
+++ b/zebra-chain/src/sprout/note.rs
@@ -33,7 +33,7 @@ pub use nullifiers::{Nullifier, NullifierSeed};
     derive(proptest_derive::Arbitrary)
 )]
 pub struct Note {
-    /// The paying key of the recipient’s shielded payment address
+    /// The paying key of the recipient's shielded payment address
     pub paying_key: PayingKey,
     /// An integer representing the value of the note in zatoshi (1 ZEC
     /// = 10^8 zatoshi)

--- a/zebra-chain/src/sprout/note/mac.rs
+++ b/zebra-chain/src/sprout/note/mac.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read};
 /// A sequence of message authentication tags ...
 ///
 /// binding h_sig to each a_sk of the JoinSplit description, computed as
-/// described in § 4.10 ‘Non-malleability (Sprout)’ on p. 37
+/// described in § 4.10 'Non-malleability (Sprout)' on p. 37
 #[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(
     any(test, feature = "proptest-impl"),

--- a/zebra-chain/src/sprout/tree.rs
+++ b/zebra-chain/src/sprout/tree.rs
@@ -70,7 +70,7 @@ lazy_static! {
     };
 }
 
-/// The index of a note’s commitment at the leafmost layer of its Note
+/// The index of a note's commitment at the leafmost layer of its Note
 /// Commitment Tree.
 ///
 /// https://zips.z.cash/protocol/protocol.pdf#merkletree

--- a/zebra-chain/src/transparent/address.rs
+++ b/zebra-chain/src/transparent/address.rs
@@ -35,10 +35,10 @@ mod magics {
 /// In Bitcoin a single byte is used for the version field identifying
 /// the address type. In Zcash two bytes are used. For addresses on
 /// the production network, this and the encoded length cause the first
-/// two characters of the Base58Check encoding to be fixed as “t3” for
-/// P2SH addresses, and as “t1” for P2PKH addresses. (This does not
+/// two characters of the Base58Check encoding to be fixed as "t3" for
+/// P2SH addresses, and as "t1" for P2PKH addresses. (This does not
 /// imply that a transparent Zcash address can be parsed identically
-/// to a Bitcoin address just by removing the “t”.)
+/// to a Bitcoin address just by removing the "t".)
 ///
 /// https://zips.z.cash/protocol/protocol.pdf#transparentaddrencoding
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/zebra-consensus/src/block/subsidy.rs
+++ b/zebra-consensus/src/block/subsidy.rs
@@ -2,7 +2,7 @@
 //!
 //! [7.7]: https://zips.z.cash/protocol/protocol.pdf#subsidies
 
-/// Founders’ Reward functions apply for blocks before Canopy.
+/// Founders' Reward functions apply for blocks before Canopy.
 pub mod founders_reward;
 /// General subsidy functions apply for blocks after slow-start mining.
 pub mod general;

--- a/zebra-consensus/src/block/subsidy/founders_reward.rs
+++ b/zebra-consensus/src/block/subsidy/founders_reward.rs
@@ -1,4 +1,4 @@
-//! Founders’ Reward calculations. - [§7.7][7.7]
+//! Founders' Reward calculations. - [§7.7][7.7]
 //!
 //! [7.7]: https://zips.z.cash/protocol/protocol.pdf#subsidies
 

--- a/zebra-consensus/src/block/subsidy/general.rs
+++ b/zebra-consensus/src/block/subsidy/general.rs
@@ -121,7 +121,7 @@ mod test {
         let blossom_height = Blossom.activation_height(network).unwrap();
         let first_halving_height = match network {
             Network::Mainnet => Canopy.activation_height(network).unwrap(),
-            // Based on "7.7 Calculation of Block Subsidy and Founders’ Reward"
+            // Based on "7.7 Calculation of Block Subsidy and Founders' Reward"
             Network::Testnet => Height(1_116_000),
         };
 
@@ -208,7 +208,7 @@ mod test {
         let blossom_height = Blossom.activation_height(network).unwrap();
         let first_halving_height = match network {
             Network::Mainnet => Canopy.activation_height(network).unwrap(),
-            // Based on "7.7 Calculation of Block Subsidy and Founders’ Reward"
+            // Based on "7.7 Calculation of Block Subsidy and Founders' Reward"
             Network::Testnet => Height(1_116_000),
         };
 
@@ -234,7 +234,7 @@ mod test {
         );
 
         // After the 2nd halving, the block subsidy is reduced to 1.5625 ZEC
-        // See "7.7 Calculation of Block Subsidy and Founders’ Reward"
+        // See "7.7 Calculation of Block Subsidy and Founders' Reward"
         assert_eq!(
             Amount::try_from(156_250_000),
             block_subsidy(

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -1,4 +1,4 @@
-//! Constants for Block Subsidy, Funding Streams, and Founders’ Reward
+//! Constants for Block Subsidy, Funding Streams, and Founders' Reward
 
 use zebra_chain::{amount::COIN, block::Height};
 


### PR DESCRIPTION
## Motivation

Some tools don't deal well with unicode text.

And we're not using them consistently in Zebra anyway.

## Solution

Replace "smart" single and double quotes with their ascii equivalents.

## Review

This is a low-priority change.
