### PR TITLE
tower-batch: wake waiting workers on close to avoid hangs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-stream"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.60",
+]
+
+[[package]]
 name = "atomic-shim"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +478,12 @@ name = "bytes"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "canonical-path"
@@ -3284,6 +3311,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
+dependencies = [
+ "autocfg",
+ "pin-project-lite 0.2.4",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3304,6 +3341,30 @@ dependencies = [
  "rustls",
  "tokio 0.2.23",
  "webpki",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c535f53c0cfa1acace62995a8994fc9cc1f12d202420da96ff306ee24d576469"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.4",
+ "tokio 1.3.0",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58403903e94d4bc56805e46597fced893410b2e753e229d3f7f22423ea03f67"
+dependencies = [
+ "async-stream",
+ "bytes 1.0.1",
+ "futures-core",
+ "tokio 1.3.0",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -3367,7 +3428,7 @@ dependencies = [
  "hdrhistogram 6.3.4",
  "pin-project 1.0.2",
  "tokio 0.3.6",
- "tower-layer",
+ "tower-layer 0.3.0",
  "tower-service",
  "tracing",
 ]
@@ -3383,8 +3444,10 @@ dependencies = [
  "pin-project 0.4.27",
  "rand 0.7.3",
  "tokio 0.3.6",
+ "tokio-test",
  "tower",
  "tower-fallback",
+ "tower-test",
  "tracing",
  "tracing-futures",
  "zebra-test",
@@ -3408,10 +3471,30 @@ version = "0.3.0"
 source = "git+https://github.com/tower-rs/tower?rev=d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39#d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39"
 
 [[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
 name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+
+[[package]]
+name = "tower-test"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4546773ffeab9e4ea02b8872faa49bb616a80a7da66afc2f32688943f97efa7"
+dependencies = [
+ "futures-util",
+ "pin-project 1.0.2",
+ "tokio 1.3.0",
+ "tokio-test",
+ "tower-layer 0.3.1",
+ "tower-service",
+]
 
 [[package]]
 name = "tracing"

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -22,3 +22,5 @@ tracing = "0.1.25"
 zebra-test = { path = "../zebra-test/" }
 tower-fallback = { path = "../tower-fallback/" }
 color-eyre = "0.5.10"
+tokio-test = "0.4.1"
+tower-test = "0.4.0"

--- a/tower-batch/src/service.rs
+++ b/tower-batch/src/service.rs
@@ -101,9 +101,9 @@ where
         // We choose a bound that allows callers to check readiness for every item in
         // a batch, then actually submit those items.
         let bound = max_items;
-        let semaphore = Semaphore::new(bound);
+        let (semaphore, close) = Semaphore::new_with_close(bound);
 
-        let (handle, worker) = Worker::new(service, rx, max_items, max_latency);
+        let (handle, worker) = Worker::new(service, rx, max_items, max_latency, close);
         let batch = Batch {
             tx,
             semaphore,

--- a/tower-batch/src/service.rs
+++ b/tower-batch/src/service.rs
@@ -73,21 +73,44 @@ where
         T::Error: Send + Sync,
         Request: Send + 'static,
     {
+        let (batch, worker) = Self::pair(service, max_items, max_latency);
+        tokio::spawn(worker.run());
+        batch
+    }
+
+    /// Creates a new `Batch` wrapping `service`, but returns the background worker.
+    ///
+    /// This is useful if you do not want to spawn directly onto the `tokio`
+    /// runtime but instead want to use your own executor. This will return the
+    /// `Batch` and the background `Worker` that you can then spawn.
+    pub fn pair(
+        service: T,
+        max_items: usize,
+        max_latency: std::time::Duration,
+    ) -> (Self, Worker<T, Request>)
+    where
+        T: Send + 'static,
+        T::Error: Send + Sync,
+        Request: Send + 'static,
+    {
+        let (tx, rx) = mpsc::unbounded_channel();
+
         // The semaphore bound limits the maximum number of concurrent requests
         // (specifically, requests which got a `Ready` from `poll_ready`, but haven't
         // used their semaphore reservation in a `call` yet).
         // We choose a bound that allows callers to check readiness for every item in
         // a batch, then actually submit those items.
         let bound = max_items;
-        let (tx, rx) = mpsc::unbounded_channel();
-        let (handle, worker) = Worker::new(service, rx, max_items, max_latency);
-        tokio::spawn(worker.run());
         let semaphore = Semaphore::new(bound);
-        Batch {
+
+        let (handle, worker) = Worker::new(service, rx, max_items, max_latency);
+        let batch = Batch {
             tx,
             semaphore,
             handle,
-        }
+        };
+
+        (batch, worker)
     }
 
     fn get_worker_error(&self) -> crate::BoxError {

--- a/tower-batch/tests/worker.rs
+++ b/tower-batch/tests/worker.rs
@@ -1,0 +1,124 @@
+use std::time::Duration;
+use tokio_test::{assert_pending, assert_ready, assert_ready_err, task};
+use tower::{Service, ServiceExt};
+use tower_batch::{error, Batch};
+use tower_test::mock;
+
+#[tokio::test]
+async fn wakes_pending_waiters_on_close() {
+    zebra_test::init();
+
+    let (service, mut handle) = mock::pair::<_, ()>();
+
+    let (mut service, worker) = Batch::pair(service, 1, Duration::from_secs(1));
+    let mut worker = task::spawn(worker.run());
+
+    // // keep the request in the worker
+    handle.allow(0);
+    let service1 = service.ready_and().await.unwrap();
+    let poll = worker.poll();
+    assert_pending!(poll);
+    let mut response = task::spawn(service1.call(()));
+
+    let mut service1 = service.clone();
+    let mut ready1 = task::spawn(service1.ready_and());
+    assert_pending!(worker.poll());
+    assert_pending!(ready1.poll(), "no capacity");
+
+    let mut service1 = service.clone();
+    let mut ready2 = task::spawn(service1.ready_and());
+    assert_pending!(worker.poll());
+    assert_pending!(ready2.poll(), "no capacity");
+
+    // kill the worker task
+    drop(worker);
+
+    let err = assert_ready_err!(response.poll());
+    assert!(
+        err.is::<error::Closed>(),
+        "response should fail with a Closed, got: {:?}",
+        err
+    );
+
+    assert!(
+        ready1.is_woken(),
+        "dropping worker should wake ready task 1"
+    );
+    let err = assert_ready_err!(ready1.poll());
+    assert!(
+        err.is::<error::Closed>(),
+        "ready 1 should fail with a Closed, got: {:?}",
+        err
+    );
+
+    assert!(
+        ready2.is_woken(),
+        "dropping worker should wake ready task 2"
+    );
+    let err = assert_ready_err!(ready1.poll());
+    assert!(
+        err.is::<error::Closed>(),
+        "ready 2 should fail with a Closed, got: {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn wakes_pending_waiters_on_failure() {
+    zebra_test::init();
+
+    let (service, mut handle) = mock::pair::<_, ()>();
+
+    let (mut service, worker) = Batch::pair(service, 1, Duration::from_secs(1));
+    let mut worker = task::spawn(worker.run());
+
+    // keep the request in the worker
+    handle.allow(0);
+    let service1 = service.ready_and().await.unwrap();
+    assert_pending!(worker.poll());
+    let mut response = task::spawn(service1.call("hello"));
+
+    let mut service1 = service.clone();
+    let mut ready1 = task::spawn(service1.ready_and());
+    assert_pending!(worker.poll());
+    assert_pending!(ready1.poll(), "no capacity");
+
+    let mut service1 = service.clone();
+    let mut ready2 = task::spawn(service1.ready_and());
+    assert_pending!(worker.poll());
+    assert_pending!(ready2.poll(), "no capacity");
+
+    // fail the inner service
+    handle.send_error("foobar");
+    // worker task terminates
+    assert_ready!(worker.poll());
+
+    let err = assert_ready_err!(response.poll());
+    assert!(
+        err.is::<error::ServiceError>(),
+        "response should fail with a ServiceError, got: {:?}",
+        err
+    );
+
+    assert!(
+        ready1.is_woken(),
+        "dropping worker should wake ready task 1"
+    );
+    let err = assert_ready_err!(ready1.poll());
+    assert!(
+        err.is::<error::ServiceError>(),
+        "ready 1 should fail with a ServiceError, got: {:?}",
+        err
+    );
+
+    assert!(
+        ready2.is_woken(),
+        "dropping worker should wake ready task 2"
+    );
+    let err = assert_ready_err!(ready1.poll());
+    assert!(
+        err.is::<error::ServiceError>(),
+        "ready 2 should fail with a ServiceError, got: {:?}",
+        err
+    );
+}


### PR DESCRIPTION
## Motivation

After upgrading tower to use tokio `0.3` the tower maintainers noticed they'd introduced a regression where tasks could fail to get woken up when the background task of a `Buffer` closed. They've since fixed this regression in https://github.com/tower-rs/tower/pull/480. Well before this change we copied `Buffer` into our codebase as the basis of `tower-batch`. Our implementation has this same bug now.

## Solution

To fix this we just need to apply the same fix they did to our implementation, properly notifying semaphore waiters when we drop or close.

The code in this pull request has:
  - [ ] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

@teor2345 originally identified this issue

## Related Issues

https://github.com/ZcashFoundation/zebra/issues/1805

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
