### PR TITLE
panic in `NonFinalizedState::commit_block` before Canopy

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -64,7 +64,10 @@ impl StateService {
 
     pub fn new(config: Config, network: Network) -> Self {
         let disk = FinalizedState::new(&config, network);
-        let mem = NonFinalizedState::default();
+        let mem = NonFinalizedState {
+            network,
+            ..Default::default()
+        };
         let queued_blocks = QueuedBlocks::default();
         let pending_utxos = PendingUtxos::default();
 

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -75,11 +75,10 @@ impl NonFinalizedState {
         let parent_hash = prepared.block.header.previous_block_hash;
         let (height, hash) = (prepared.height, prepared.hash);
 
-        let canopy_height = Canopy.activation_height(self.network).unwrap();
-        if height < canopy_height {
+        let canopy_activation_height = Canopy.activation_height(self.network).unwrap();
+        if height < canopy_activation_height {
             panic!(
-                "commit_block can only be applied to block heights that are equal \
-                or greater than canopy network upgrade height"
+                "invalid non-finalized block height: the canopy checkpoint is mandatory, pre-canopy blocks must be committed to the state as finalized blocks"
             );
         }
 

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -286,8 +286,22 @@ mod tests {
     fn best_chain_wins() -> Result<()> {
         zebra_test::init();
 
-        let block1: Arc<Block> =
-            zebra_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
+        best_chain_wins_for_network(Network::Mainnet)?;
+        best_chain_wins_for_network(Network::Testnet)?;
+
+        Ok(())
+    }
+
+    fn best_chain_wins_for_network(network: Network) -> Result<()> {
+        let block1: Arc<Block> = match network {
+            Network::Mainnet => {
+                zebra_test::vectors::BLOCK_MAINNET_1180900_BYTES.zcash_deserialize_into()?
+            }
+            Network::Testnet => {
+                zebra_test::vectors::BLOCK_TESTNET_1326100_BYTES.zcash_deserialize_into()?
+            }
+        };
+
         let block2 = block1.make_fake_child().set_work(10);
         let child = block1.make_fake_child().set_work(1);
 
@@ -307,8 +321,22 @@ mod tests {
     fn finalize_pops_from_best_chain() -> Result<()> {
         zebra_test::init();
 
-        let block1: Arc<Block> =
-            zebra_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
+        finalize_pops_from_best_chain_for_network(Network::Mainnet)?;
+        finalize_pops_from_best_chain_for_network(Network::Testnet)?;
+
+        Ok(())
+    }
+
+    fn finalize_pops_from_best_chain_for_network(network: Network) -> Result<()> {
+        let block1: Arc<Block> = match network {
+            Network::Mainnet => {
+                zebra_test::vectors::BLOCK_MAINNET_1180900_BYTES.zcash_deserialize_into()?
+            }
+            Network::Testnet => {
+                zebra_test::vectors::BLOCK_TESTNET_1326100_BYTES.zcash_deserialize_into()?
+            }
+        };
+
         let block2 = block1.make_fake_child().set_work(10);
         let child = block1.make_fake_child().set_work(1);
 
@@ -333,8 +361,24 @@ mod tests {
     fn commit_block_extending_best_chain_doesnt_drop_worst_chains() -> Result<()> {
         zebra_test::init();
 
-        let block1: Arc<Block> =
-            zebra_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
+        commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(Network::Mainnet)?;
+        commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(Network::Testnet)?;
+
+        Ok(())
+    }
+
+    fn commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(
+        network: Network,
+    ) -> Result<()> {
+        let block1: Arc<Block> = match network {
+            Network::Mainnet => {
+                zebra_test::vectors::BLOCK_MAINNET_1180900_BYTES.zcash_deserialize_into()?
+            }
+            Network::Testnet => {
+                zebra_test::vectors::BLOCK_TESTNET_1326100_BYTES.zcash_deserialize_into()?
+            }
+        };
+
         let block2 = block1.make_fake_child().set_work(10);
         let child1 = block1.make_fake_child().set_work(1);
         let child2 = block2.make_fake_child().set_work(1);
@@ -357,8 +401,21 @@ mod tests {
     fn shorter_chain_can_be_best_chain() -> Result<()> {
         zebra_test::init();
 
-        let block1: Arc<Block> =
-            zebra_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
+        shorter_chain_can_be_best_chain_for_network(Network::Mainnet)?;
+        shorter_chain_can_be_best_chain_for_network(Network::Testnet)?;
+
+        Ok(())
+    }
+
+    fn shorter_chain_can_be_best_chain_for_network(network: Network) -> Result<()> {
+        let block1: Arc<Block> = match network {
+            Network::Mainnet => {
+                zebra_test::vectors::BLOCK_MAINNET_1180900_BYTES.zcash_deserialize_into()?
+            }
+            Network::Testnet => {
+                zebra_test::vectors::BLOCK_TESTNET_1326100_BYTES.zcash_deserialize_into()?
+            }
+        };
 
         let long_chain_block1 = block1.make_fake_child().set_work(1);
         let long_chain_block2 = long_chain_block1.make_fake_child().set_work(1);
@@ -381,8 +438,21 @@ mod tests {
     fn longer_chain_with_more_work_wins() -> Result<()> {
         zebra_test::init();
 
-        let block1: Arc<Block> =
-            zebra_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
+        longer_chain_with_more_work_wins_for_network(Network::Mainnet)?;
+        longer_chain_with_more_work_wins_for_network(Network::Testnet)?;
+
+        Ok(())
+    }
+
+    fn longer_chain_with_more_work_wins_for_network(network: Network) -> Result<()> {
+        let block1: Arc<Block> = match network {
+            Network::Mainnet => {
+                zebra_test::vectors::BLOCK_MAINNET_1180900_BYTES.zcash_deserialize_into()?
+            }
+            Network::Testnet => {
+                zebra_test::vectors::BLOCK_TESTNET_1326100_BYTES.zcash_deserialize_into()?
+            }
+        };
 
         let long_chain_block1 = block1.make_fake_child().set_work(1);
         let long_chain_block2 = long_chain_block1.make_fake_child().set_work(1);
@@ -409,8 +479,20 @@ mod tests {
     fn equal_length_goes_to_more_work() -> Result<()> {
         zebra_test::init();
 
-        let block1: Arc<Block> =
-            zebra_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
+        equal_length_goes_to_more_work_for_network(Network::Mainnet)?;
+        equal_length_goes_to_more_work_for_network(Network::Testnet)?;
+
+        Ok(())
+    }
+    fn equal_length_goes_to_more_work_for_network(network: Network) -> Result<()> {
+        let block1: Arc<Block> = match network {
+            Network::Mainnet => {
+                zebra_test::vectors::BLOCK_MAINNET_1180900_BYTES.zcash_deserialize_into()?
+            }
+            Network::Testnet => {
+                zebra_test::vectors::BLOCK_TESTNET_1326100_BYTES.zcash_deserialize_into()?
+            }
+        };
 
         let less_work_child = block1.make_fake_child().set_work(1);
         let more_work_child = block1.make_fake_child().set_work(3);


### PR DESCRIPTION
## Motivation

Panic for blocks before canopy is required for `NonFinalizedState::commit_block` after https://github.com/ZcashFoundation/zebra/pull/1898 gets merged.

More info at https://github.com/ZcashFoundation/zebra/issues/1903

Blocked on https://github.com/ZcashFoundation/zebra/issues/1099

## Solution

In this PR we add the panic however test cases will fail as we need mainnet blocks after Canopy. https://github.com/ZcashFoundation/zebra/issues/1099

If we decide to also make this tests for the testnet then we also need https://github.com/ZcashFoundation/zebra/issues/1104

If we only test mainnet we just need to replace the test vector numbers in the failing tests by the new ones. If we also do the testnet then a bit of the logic will need to change.

## Related Tickets

Closes #1903

## Review

This is in draft state until unblocked. No review needed yet.

