### PR TITLE
Temporarily pin coverage CI to nightly-2021-03-17

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   coverage:
-    name: Coverage (+nightly)
+    name: Coverage (+nightly-2021-03-17)
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2021-03-17
           override: true
           profile: minimal
           components: llvm-tools-preview


### PR DESCRIPTION
## Motivation

nightly-2021-03-18 hangs when launching the coverage tests, without any output.

## Solution

Temporarily pin coverage CI to nightly-2021-03-17, to avoid this bug.

## Review

CI failures are urgent, so we should review and merge as soon as it passes.

## Follow Up Work

Open a ticket/PR to revert this PR, as soon as nightly is fixed.