### PR TITLE
Delete dead code in coverage binaries

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,8 @@ jobs:
           cargo install rustfilt
       - name: Rerun tests for coverage
         env:
-          RUSTFLAGS: -Zinstrument-coverage -C link-dead-code -C debuginfo=2
+          # We don't use "-C link-dead-code", because the resulting binaries are too big for the CI disk
+          RUSTFLAGS: -Zinstrument-coverage -C debuginfo=2
           LLVM_PROFILE_FILE: "${{ github.workspace }}/test.%p.profraw"
           ZEBRA_SKIP_NETWORK_TESTS: 1
         run: |


### PR DESCRIPTION
## Motivation

Our coverage binaries are currently too large for the CI disks, causing our coverage CI to hang and fail.

## Solution

Delete dead code, so the binaries are smaller.

Since we're deleting dead code, our coverage statistics might appear higher than they actually are.

## Review

CI failures are urgent fixes.

## Related Issues

#1923 is a better fix, because it gives more accurate coverage statistics.

## Follow Up Work

Investigate ways to make Zebra's binaries smaller.