### PR TITLE
Disable incremental compilation in coverage builds

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,6 +32,7 @@ jobs:
           RUSTFLAGS: -Zinstrument-coverage -C link-dead-code -C debuginfo=2
           LLVM_PROFILE_FILE: "${{ github.workspace }}/test.%p.profraw"
           ZEBRA_SKIP_NETWORK_TESTS: 1
+          CARGO_INCREMENTAL: 0
         run: |
           cargo test
           cargo test --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM - > filenames.txt


### PR DESCRIPTION
## Motivation

Zebra's coverage builds are too large for CI disks.

## Solution

Disable incremental compilation, to reduce the size of the build outputs.

## Review

CI failures are urgent.

## Related Issues

#1922 is an alternative fix, this fix is better, because it gives more accurate coverage statistics.

## Follow Up Work

Work out how to reduce Zebra's binary size.