### PR TITLE
Canopy activation state

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,10 +51,8 @@ jobs:
           --boot-disk-type pd-ssd \
           --container-image rust:buster \
           --container-mount-disk mount-path='/mainnet',name="zebrad-cache-$SHORT_SHA-mainnet-1046400" \
-          --container-mount-disk mount-path='/testnet',name="zebrad-cache-$SHORT_SHA-testnet-1028500" \
           --container-restart-policy never \
-          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-1046400" \
-          --create-disk name="zebrad-cache-$SHORT_SHA-testnet-1028500" \
+          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-1046400",image=zebrad-cache-8690a39-mainnet-1046400 \
           --machine-type n2-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
@@ -70,7 +68,6 @@ jobs:
           docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test .;
           docker run -i zebrad-test cargo test --workspace --no-fail-fast -- -Zunstable-options --include-ignored;
           docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-1046400,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_canopy_mainnet --manifest-path zebrad/Cargo.toml sync_to_canopy_mainnet;
-          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-testnet-1028500,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_canopy_testnet --manifest-path zebrad/Cargo.toml sync_to_canopy_testnet;
           "
       # Clean up
       - name: Delete test instance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,8 @@ jobs:
           --container-mount-disk mount-path='/mainnet',name="zebrad-cache-$SHORT_SHA-mainnet-1046400" \
           --container-mount-disk mount-path='/testnet',name="zebrad-cache-$SHORT_SHA-testnet-1028500" \
           --container-restart-policy never \
-          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-1046400",image=zebrad-cache-fbca3c7-mainnet-1046400 \
-          --create-disk name="zebrad-cache-$SHORT_SHA-testnet-1028500",image=zebrad-cache-fbca3c7-testnet-1028500 \
+          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-1046400" \
+          --create-disk name="zebrad-cache-$SHORT_SHA-testnet-1028500" \
           --machine-type n2-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
           cd zebra/;
           docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test .;
           docker run -i zebrad-test cargo test --workspace --no-fail-fast -- -Zunstable-options --include-ignored;
-          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-1046400,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_canopy_mainnet --manifest-path zebrad/Cargo.toml sync_to_canopy_mainnet;
+          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-1046400,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_past_canopy_mainnet --manifest-path zebrad/Cargo.toml sync_past_canopy_mainnet;
           "
       # Clean up
       - name: Delete test instance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,11 +50,11 @@ jobs:
           --boot-disk-size 100GB \
           --boot-disk-type pd-ssd \
           --container-image rust:buster \
-          --container-mount-disk mount-path='/mainnet',name="zebrad-cache-$SHORT_SHA-mainnet-419200" \
-          --container-mount-disk mount-path='/testnet',name="zebrad-cache-$SHORT_SHA-testnet-280000" \
+          --container-mount-disk mount-path='/mainnet',name="zebrad-cache-$SHORT_SHA-mainnet-1046400" \
+          --container-mount-disk mount-path='/testnet',name="zebrad-cache-$SHORT_SHA-testnet-1028500" \
           --container-restart-policy never \
-          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-419200",image=zebrad-cache-fbca3c7-mainnet-419200 \
-          --create-disk name="zebrad-cache-$SHORT_SHA-testnet-280000",image=zebrad-cache-fbca3c7-testnet-280000 \
+          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-1046400",image=zebrad-cache-fbca3c7-mainnet-1046400 \
+          --create-disk name="zebrad-cache-$SHORT_SHA-testnet-1028500",image=zebrad-cache-fbca3c7-testnet-1028500 \
           --machine-type n2-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
@@ -69,8 +69,8 @@ jobs:
           cd zebra/;
           docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test .;
           docker run -i zebrad-test cargo test --workspace --no-fail-fast -- -Zunstable-options --include-ignored;
-          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-419200,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_past_canopy_mainnet --manifest-path zebrad/Cargo.toml sync_past_canopy_mainnet;
-          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-testnet-280000,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_past_canopy_testnet --manifest-path zebrad/Cargo.toml sync_past_canopy_testnet;
+          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-1046400,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_canopy_mainnet --manifest-path zebrad/Cargo.toml sync_to_canopy_mainnet;
+          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-testnet-1028500,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_canopy_testnet --manifest-path zebrad/Cargo.toml sync_to_canopy_testnet;
           "
       # Clean up
       - name: Delete test instance


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

We are now checkpointing up through Canopy activation. Our stateful sync tests assume cached state up through the Sapling activation on mainnet and testnet to run the test.yml workflow. Without updated state cache, the new `sync_past_canopy_*` will take much longer to run and usually timeout.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->

Update the test.yml workflow to use a new disk image to create test instance disks containing cached state up to Canopy activation for mainnet. When the testnet sync is complete, that will also be added in a separate PR.

The code in this pull request has:
  - [ ] Documentation Comments
  - [ ] Unit Tests and Property Tests

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

Anyone

## Related Issues

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->

#1918

## Follow Up Work

When testnet state cache through Canopy is available, resolve #1918 with that PR.