### PR TITLE
Add final job to ci.yml that passes when all other ci.yml jobs pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,18 @@ on:
 
 jobs:
 
+  ci-success:
+    name: 🏁
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - build
+      - build-chain-no-features
+      - clippy
+      - fmt
+    steps:
+      - run: exit 0
+
   test:
     name: Test (+${{ matrix.rust }}) on ${{ matrix.os }}
     # The large timeout is to accommodate Windows builds


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->

Currently we only require the Google Cloud Build check to pass out of our CI jobs before merging branches into #main, partially because you need to add each job of each workflow individually as required or not in the GitHub settings for the branch. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->

Add a job in ci.yml that depends on all the other ci.yml jobs to pass for it to pass. This allows us to require this one job to pass as a proxy for all ci.yml jobs before merging PRs.

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

Anyone, non-urgent.
