### PR TITLE
clippy: fix inconsistent struct ordering

### DIFF
--- a/tower-batch/tests/ed25519.rs
+++ b/tower-batch/tests/ed25519.rs
@@ -32,7 +32,7 @@ impl Ed25519Verifier {
         let batch = batch::Verifier::default();
         // XXX(hdevalence) what's a reasonable choice here?
         let (tx, _) = channel(10);
-        Self { tx, batch }
+        Self { batch, tx }
     }
 }
 

--- a/zebra-consensus/src/primitives/groth16.rs
+++ b/zebra-consensus/src/primitives/groth16.rs
@@ -146,7 +146,7 @@ impl VerifierImpl {
         // let batch = batch::Verifier::default();
         let batch = Batch::default();
         let (tx, _) = channel(super::BROADCAST_BUFFER_SIZE);
-        Self { batch, tx, pvk }
+        Self { batch, pvk, tx }
     }
 }
 

--- a/zebra-consensus/src/primitives/redjubjub.rs
+++ b/zebra-consensus/src/primitives/redjubjub.rs
@@ -63,7 +63,7 @@ impl Default for Verifier {
     fn default() -> Self {
         let batch = batch::Verifier::default();
         let (tx, _) = channel(super::BROADCAST_BUFFER_SIZE);
-        Self { tx, batch }
+        Self { batch, tx }
     }
 }
 

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -141,8 +141,8 @@ impl From<Arc<Block>> for FinalizedBlock {
 
         Self {
             block,
-            height,
             hash,
+            height,
             new_outputs,
             transaction_hashes,
         }
@@ -153,15 +153,15 @@ impl From<PreparedBlock> for FinalizedBlock {
     fn from(prepared: PreparedBlock) -> Self {
         let PreparedBlock {
             block,
-            height,
             hash,
+            height,
             new_outputs,
             transaction_hashes,
         } = prepared;
         Self {
             block,
-            height,
             hash,
+            height,
             new_outputs,
             transaction_hashes,
         }


### PR DESCRIPTION
## Motivation

Some of Zebra's struct initializations are in a different order to the struct declarations.

This makes the code harder to read. (And clippy nightly complains about it.)

## Solution

- [x] Make struct initialization order consistent with declaration order
- [x] Also fix a nearby out-of-order destructure

## Review

This is a low-priority code cleanup.