### PR TITLE
Document that the mandatory checkpoint can change

### DIFF
--- a/zebra-consensus/src/config.rs
+++ b/zebra-consensus/src/config.rs
@@ -8,6 +8,9 @@ pub struct Config {
     ///
     /// Setting this option to true enables post-Canopy checkpoints.
     /// (Zebra always checkpoints on Canopy activation.)
+    ///
+    /// Future versions of Zebra may change the mandatory checkpoint
+    /// height.
     pub checkpoint_sync: bool,
 }
 


### PR DESCRIPTION
## Motivation

We don't want users relying on the exact height of Zebra's mandatory checkpoint.

We've already changed it once from Sapling to Canopy, and it might change again in future.

## Solution

In the zebra-consensus config, document that the mandatory checkpoint can change.

## Review

Anyone can review, it's not urgent at all.