### PR TITLE
Enable joinsplit and spend auth sighash verification

### DIFF
--- a/grafana/errors.json
+++ b/grafana/errors.json
@@ -1,0 +1,421 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 6,
+  "iteration": 1616480577841,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "job",
+      "scopedVars": {
+        "job": {
+          "selected": true,
+          "text": "zebrad-mainnet",
+          "value": "zebrad-mainnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "zebra_error_sapling_binding{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "expr": "zebra_sighash_error_sapling_spend{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "expr": "zebra_sighash_error_sprout_joinsplit{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Sighash Errors - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1616480577841,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "job": {
+          "selected": true,
+          "text": "zebrad-mainnet-tmp-1",
+          "value": "zebrad-mainnet-tmp-1"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "zebra_error_sapling_binding{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "expr": "zebra_sighash_error_sapling_spend{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "expr": "zebra_sighash_error_sprout_joinsplit{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Sighash Errors - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1616480577841,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "job": {
+          "selected": true,
+          "text": "zebrad-testnet-tmp-1",
+          "value": "zebrad-testnet-tmp-1"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "zebra_error_sapling_binding{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "expr": "zebra_sighash_error_sapling_spend{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "expr": "zebra_sighash_error_sprout_joinsplit{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Sighash Errors - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": [
+            "zebrad-mainnet",
+            "zebrad-mainnet-tmp-1",
+            "zebrad-testnet-tmp-1"
+          ],
+          "value": [
+            "zebrad-mainnet",
+            "zebrad-mainnet-tmp-1",
+            "zebrad-testnet-tmp-1"
+          ]
+        },
+        "datasource": "Prometheus-Zebra",
+        "definition": "label_values(zcash_net_peers, job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": "label_values(zcash_net_peers, job)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "errors",
+  "uid": "IhbO11wGk",
+  "version": 4
+}

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -178,11 +178,10 @@ where
                         }
                     }
 
-                    // TODO: rework this code #1377
-                    let sighash = tx.sighash(
+                    let shielded_sighash = tx.sighash(
                         upgrade,
-                        HashType::ALL, // TODO: check these
-                        None,          // TODO: check these
+                        HashType::ALL,
+                        None,
                     );
 
                     if let Some(joinsplit_data) = joinsplit_data {
@@ -192,9 +191,7 @@ where
                         // correctly.
 
                         // Then, pass those items to self.joinsplit to verify them.
-
-                        // Ignore pending sighash check #1377
-                        let _ = check::validate_joinsplit_sig(joinsplit_data, sighash.as_bytes());
+                        check::validate_joinsplit_sig(joinsplit_data, shielded_sighash.as_bytes())?;
                     }
 
                     if let Some(shielded_data) = shielded_data {
@@ -233,13 +230,12 @@ where
                             // description while adding the resulting future to
                             // our collection of async checks that (at a
                             // minimum) must pass for the transaction to verify.
-                            let _rsp = redjubjub_verifier
+                            let rsp = redjubjub_verifier
                                 .ready_and()
                                 .await?
-                                .call((spend.rk, spend.spend_auth_sig, &sighash).into());
+                                .call((spend.rk, spend.spend_auth_sig, &shielded_sighash).into());
 
-                            // Disable pending sighash check #1377
-                            // async_checks.push(rsp.boxed());
+                            async_checks.push(rsp.boxed());
                         }
 
                         for output in shielded_data.outputs() {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -155,13 +155,14 @@ where
                     // We finish by waiting on these below.
                     let mut async_checks = FuturesUnordered::new();
 
+                    // Do basic checks first
+                    check::has_inputs_and_outputs(&tx)?;
+
                     // Handle transparent inputs and outputs.
                     if tx.is_coinbase() {
                         check::coinbase_tx_no_joinsplit_or_spend(&tx)?;
                     } else {
-                        // TODO: check no coinbase inputs
-
-                        // feed all of the inputs to the script verifier
+                        // feed all of the inputs to the script and shielded verifiers
                         let cached_ffi_transaction =
                             Arc::new(CachedFfiTransaction::new(tx.clone()));
 
@@ -176,8 +177,6 @@ where
                             async_checks.push(rsp);
                         }
                     }
-
-                    check::has_inputs_and_outputs(&tx)?;
 
                     // TODO: rework this code #1377
                     let sighash = tx.sighash(

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -163,6 +163,7 @@ where
                         check::coinbase_tx_no_joinsplit_or_spend(&tx)?;
                     } else {
                         // feed all of the inputs to the script and shielded verifiers
+                        // the script_verifier also checks transparent sighashes, using its own implementation
                         let cached_ffi_transaction =
                             Arc::new(CachedFfiTransaction::new(tx.clone()));
 

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -21,6 +21,7 @@ pub fn validate_joinsplit_sig(
     joinsplit_data: &JoinSplitData<Groth16Proof>,
     sighash: &[u8],
 ) -> Result<(), TransactionError> {
+    // TODO: batch verify ed25519
     ed25519::VerificationKey::try_from(joinsplit_data.pub_key)
         .and_then(|vk| vk.verify(&joinsplit_data.sig, sighash))
         .map_err(TransactionError::Ed25519)

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -21,7 +21,7 @@ pub fn validate_joinsplit_sig(
     joinsplit_data: &JoinSplitData<Groth16Proof>,
     sighash: &[u8],
 ) -> Result<(), TransactionError> {
-    // TODO: batch verify ed25519
+    // TODO: batch verify ed25519: https://github.com/ZcashFoundation/zebra/issues/1944
     ed25519::VerificationKey::try_from(joinsplit_data.pub_key)
         .and_then(|vk| vk.verify(&joinsplit_data.sig, sighash))
         .map_err(TransactionError::Ed25519)


### PR DESCRIPTION
## Motivation

In #1377, we thought our sighash implementation was broken. But investigation showed that it was actually the binding signature implementation.

## Solution

- re-enable joinsplit and sapling spend auth verification
- add a metric for binding signature errors
- add a warning log for binding signature errors
- add an error grafana dashboard
- minor cleanups

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Sync Tests

## Review

This is a routine review, @dconnolly just modified this code.

## Related Issues

Closes #1377

## Follow Up Work

#1939 Fix binding signature errors
#1944 Use Ed25519 async batch verification