### PR TITLE
Make MetaAddr.last_seen into a private field and fix sanitize security risk

### DIFF
--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -105,7 +105,7 @@ impl AddressBook {
         );
 
         if let Some(prev) = self.get_by_addr(new.addr) {
-            if prev.last_seen > new.last_seen {
+            if prev.get_last_seen() > new.get_last_seen() {
                 return;
             }
         }
@@ -160,7 +160,7 @@ impl AddressBook {
             // NeverAttempted, Failed, and AttemptPending peers should never be live
             Some(peer) => {
                 peer.last_connection_state == PeerAddrState::Responded
-                    && peer.last_seen > AddressBook::liveness_cutoff_time()
+                    && peer.get_last_seen() > AddressBook::liveness_cutoff_time()
             }
         }
     }

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -70,7 +70,10 @@ impl AddressBook {
     pub fn sanitized(&self) -> Vec<MetaAddr> {
         use rand::seq::SliceRandom;
         let _guard = self.span.enter();
-        let mut peers = self.peers().map(MetaAddr::sanitize).collect::<Vec<_>>();
+        let mut peers = self
+            .peers()
+            .map(|a| MetaAddr::sanitize(&a))
+            .collect::<Vec<_>>();
         peers.shuffle(&mut rand::thread_rng());
         peers
     }

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -124,13 +124,18 @@ pub struct MetaAddr {
 }
 
 impl MetaAddr {
-    /// Sanitize this `MetaAddr` before sending it to a remote peer.
-    pub fn sanitize(mut self) -> MetaAddr {
+    /// Return a sanitized version of this `MetaAddr`, for sending to a remote peer.
+    pub fn sanitize(&self) -> MetaAddr {
         let interval = crate::constants::TIMESTAMP_TRUNCATION_SECONDS;
         let ts = self.last_seen.timestamp();
-        self.last_seen = Utc.timestamp(ts - ts.rem_euclid(interval), 0);
-        self.last_connection_state = Default::default();
-        self
+        let last_seen = Utc.timestamp(ts - ts.rem_euclid(interval), 0);
+        MetaAddr {
+            addr: self.addr,
+            services: self.services,
+            last_seen,
+            // the state isn't sent to the remote peer, but sanitize it anyway
+            last_connection_state: Default::default(),
+        }
     }
 }
 

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -106,6 +106,42 @@ pub struct MetaAddr {
 
     /// The last time we interacted with this peer.
     ///
+    /// See `get_last_seen` for details.
+    last_seen: DateTime<Utc>,
+
+    /// The outcome of our most recent communication attempt with this peer.
+    pub last_connection_state: PeerAddrState,
+}
+
+impl MetaAddr {
+    /// Create a new `MetaAddr` from the deserialized fields in an `Addr`
+    /// message.
+    pub fn new_gossiped(
+        addr: &SocketAddr,
+        services: &PeerServices,
+        last_seen: &DateTime<Utc>,
+    ) -> MetaAddr {
+        MetaAddr {
+            addr: *addr,
+            services: *services,
+            last_seen: *last_seen,
+            // the state is Zebra-specific, it isn't part of the Zcash network protocol
+            last_connection_state: NeverAttempted,
+        }
+    }
+
+    /// Create a new `MetaAddr` for a peer that has just `Responded`.
+    pub fn new_responded(addr: &SocketAddr, services: &PeerServices) -> MetaAddr {
+        MetaAddr {
+            addr: *addr,
+            services: *services,
+            last_seen: Utc::now(),
+            last_connection_state: Responded,
+        }
+    }
+
+    /// The last time we interacted with this peer.
+    ///
     /// The exact meaning depends on `last_connection_state`:
     ///   - `Responded`: the last time we processed a message from this peer
     ///   - `NeverAttempted`: the unverified time provided by the remote peer
@@ -118,17 +154,19 @@ pub struct MetaAddr {
     ///
     /// `last_seen` times from `NeverAttempted` peers may be invalid due to
     /// clock skew, or buggy or malicious peers.
-    pub last_seen: DateTime<Utc>,
+    pub fn get_last_seen(&self) -> DateTime<Utc> {
+        self.last_seen
+    }
 
-    /// The outcome of our most recent communication attempt with this peer.
-    pub last_connection_state: PeerAddrState,
-}
+    /// Update the last time we interacted with this peer to the current time.
+    pub fn update_last_seen(&mut self) {
+        self.last_seen = Utc::now();
+    }
 
-impl MetaAddr {
     /// Return a sanitized version of this `MetaAddr`, for sending to a remote peer.
     pub fn sanitize(&self) -> MetaAddr {
         let interval = crate::constants::TIMESTAMP_TRUNCATION_SECONDS;
-        let ts = self.last_seen.timestamp();
+        let ts = self.get_last_seen().timestamp();
         let last_seen = Utc.timestamp(ts - ts.rem_euclid(interval), 0);
         MetaAddr {
             addr: self.addr,
@@ -151,7 +189,7 @@ impl Ord for MetaAddr {
     fn cmp(&self, other: &Self) -> Ordering {
         use std::net::IpAddr::{V4, V6};
 
-        let oldest_first = self.last_seen.cmp(&other.last_seen);
+        let oldest_first = self.get_last_seen().cmp(&other.get_last_seen());
         let newest_first = oldest_first.reverse();
 
         let connection_state = self.last_connection_state.cmp(&other.last_connection_state);
@@ -187,7 +225,7 @@ impl PartialOrd for MetaAddr {
 
 impl ZcashSerialize for MetaAddr {
     fn zcash_serialize<W: Write>(&self, mut writer: W) -> Result<(), std::io::Error> {
-        writer.write_u32::<LittleEndian>(self.last_seen.timestamp() as u32)?;
+        writer.write_u32::<LittleEndian>(self.get_last_seen().timestamp() as u32)?;
         writer.write_u64::<LittleEndian>(self.services.bits())?;
         writer.write_socket_addr(self.addr)?;
         Ok(())
@@ -196,13 +234,11 @@ impl ZcashSerialize for MetaAddr {
 
 impl ZcashDeserialize for MetaAddr {
     fn zcash_deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
-        Ok(MetaAddr {
-            last_seen: Utc.timestamp(reader.read_u32::<LittleEndian>()? as i64, 0),
-            // Discard unknown service bits.
-            services: PeerServices::from_bits_truncate(reader.read_u64::<LittleEndian>()?),
-            addr: reader.read_socket_addr()?,
-            last_connection_state: Default::default(),
-        })
+        let last_seen = Utc.timestamp(reader.read_u32::<LittleEndian>()? as i64, 0);
+        let services = PeerServices::from_bits_truncate(reader.read_u64::<LittleEndian>()?);
+        let addr = reader.read_socket_addr()?;
+
+        Ok(MetaAddr::new_gossiped(&addr, &services, &last_seen))
     }
 }
 
@@ -227,7 +263,7 @@ mod tests {
 
         // We want the sanitized timestamp to be a multiple of the truncation interval.
         assert_eq!(
-            entry.last_seen.timestamp() % crate::constants::TIMESTAMP_TRUNCATION_SECONDS,
+            entry.get_last_seen().timestamp() % crate::constants::TIMESTAMP_TRUNCATION_SECONDS,
             0
         );
         // We want the state to be the default

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -15,6 +15,8 @@ use zebra_chain::serialization::{
 
 use crate::protocol::types::PeerServices;
 
+use PeerAddrState::*;
+
 /// Peer connection state, based on our interactions with the peer.
 ///
 /// Zebra also tracks how recently a peer has sent us messages, and derives peer
@@ -44,7 +46,7 @@ pub enum PeerAddrState {
 
 impl Default for PeerAddrState {
     fn default() -> Self {
-        PeerAddrState::NeverAttempted
+        NeverAttempted
     }
 }
 
@@ -54,7 +56,6 @@ impl Ord for PeerAddrState {
     ///
     /// See [`CandidateSet`] and [`MetaAddr::cmp`] for more details.
     fn cmp(&self, other: &Self) -> Ordering {
-        use PeerAddrState::*;
         match (self, other) {
             (Responded, Responded)
             | (NeverAttempted, NeverAttempted)
@@ -149,7 +150,6 @@ impl Ord for MetaAddr {
     /// See [`CandidateSet`] for more details.
     fn cmp(&self, other: &Self) -> Ordering {
         use std::net::IpAddr::{V4, V6};
-        use PeerAddrState::*;
 
         let oldest_first = self.last_seen.cmp(&other.last_seen);
         let newest_first = oldest_first.reverse();
@@ -221,7 +221,7 @@ mod tests {
             services,
             addr,
             last_seen: Utc.timestamp(1_573_680_222, 0),
-            last_connection_state: PeerAddrState::Responded,
+            last_connection_state: Responded,
         }
         .sanitize();
 

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -140,6 +140,33 @@ impl MetaAddr {
         }
     }
 
+    /// Create a new `MetaAddr` for a peer that we want to reconnect to.
+    pub fn new_reconnect(addr: &SocketAddr, services: &PeerServices) -> MetaAddr {
+        MetaAddr {
+            addr: *addr,
+            services: *services,
+            last_seen: Utc::now(),
+            last_connection_state: AttemptPending,
+        }
+    }
+
+    /// Create a new `MetaAddr` for a peer that has just had an error.
+    pub fn new_errored(addr: &SocketAddr, services: &PeerServices) -> MetaAddr {
+        MetaAddr {
+            addr: *addr,
+            services: *services,
+            last_seen: Utc::now(),
+            last_connection_state: Failed,
+        }
+    }
+
+    /// Create a new `MetaAddr` for a peer that has just shut down.
+    pub fn new_shutdown(addr: &SocketAddr, services: &PeerServices) -> MetaAddr {
+        // TODO: if the peer shut down in the Responded state, preserve that
+        // state. All other states should be treated as (timeout) errors.
+        MetaAddr::new_errored(addr, services)
+    }
+
     /// The last time we interacted with this peer.
     ///
     /// The exact meaning depends on `last_connection_state`:
@@ -156,11 +183,6 @@ impl MetaAddr {
     /// clock skew, or buggy or malicious peers.
     pub fn get_last_seen(&self) -> DateTime<Utc> {
         self.last_seen
-    }
-
-    /// Update the last time we interacted with this peer to the current time.
-    pub fn update_last_seen(&mut self) {
-        self.last_seen = Utc::now();
     }
 
     /// Return a sanitized version of this `MetaAddr`, for sending to a remote peer.

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -27,7 +27,7 @@ use crate::{
         internal::{Request, Response},
     },
     types::MetaAddr,
-    BoxError, Config, PeerAddrState,
+    BoxError, Config,
 };
 
 use super::{Client, Connection, ErrorSlot, HandshakeError, PeerError};
@@ -390,12 +390,7 @@ where
                             );
                             use futures::sink::SinkExt;
                             let _ = timestamp_collector
-                                .send(MetaAddr {
-                                    addr,
-                                    services: remote_services,
-                                    last_seen: Utc::now(),
-                                    last_connection_state: PeerAddrState::Responded,
-                                })
+                                .send(MetaAddr::new_responded(&addr, &remote_services))
                                 .await;
                         }
                         msg

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -4,7 +4,6 @@ use std::{
     time::Duration,
 };
 
-use chrono::Utc;
 use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::time::{sleep, sleep_until, Sleep};
 use tower::{Service, ServiceExt};
@@ -221,7 +220,7 @@ where
             // instead of yielding the next connection.
             let mut reconnect = peer_set_guard.reconnection_peers().next()?;
 
-            reconnect.last_seen = Utc::now();
+            reconnect.update_last_seen();
             reconnect.last_connection_state = PeerAddrState::AttemptPending;
             peer_set_guard.update(reconnect);
             reconnect
@@ -235,7 +234,7 @@ where
 
     /// Mark `addr` as a failed peer.
     pub fn report_failed(&mut self, mut addr: MetaAddr) {
-        addr.last_seen = Utc::now();
+        addr.update_last_seen();
         addr.last_connection_state = PeerAddrState::Failed;
         self.peer_set.lock().unwrap().update(addr);
     }

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -365,7 +365,7 @@ where
             }
             Right((Some(Err(candidate)), _)) => {
                 debug!(?candidate.addr, "marking candidate as failed");
-                candidates.report_failed(candidate);
+                candidates.report_failed(&candidate);
                 // The demand signal that was taken out of the queue
                 // to attempt to connect to the failed candidate never
                 // turned into a connection, so add it back:


### PR DESCRIPTION
## Motivation

In #1849, we want to replace the `MetaAddr.last_seen` field with 3 more specific time fields.

This PR prepares for this change by making `last_seen` into a private field.
It also modifies the `sanitize` function so it's harder to misuse.

## Solution

- Make MetaAddr.last_seen into a private field b9cf9ac346aa3d67e7e21310eb71aa68da35e803
- Rewrite MetaAddr::sanitize so it's harder to misuse 9bcfb4402257a411334e24bae16561c17a83137e

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Existing Unit Tests, Property Tests, and Sync Tests

## Security

In 9bcfb4402257a411334e24bae16561c17a83137e, this PR fixes a security risk when using `sanitize`, where new code could:
- forget to sanitize new fields, or
- modify the peers in the address book.

See my comment for details https://github.com/ZcashFoundation/zebra/pull/1942/files#discussion_r601212080

## Review

@oxarbitrage can review this PR. It's urgent because the rest of #1849 depends on it.

This PR is mostly interactive renames and code movement. I've added review comments in the two places that actually change Zebra's behaviour.

## Related Issues

First part of #1849

## Follow Up Work

Rest of #1849