### PR TITLE
Rename NU5 to Nu5 to satisfy newly stable clippy::upper-case-acronyms

### DIFF
--- a/zebra-chain/src/block/root_hash.rs
+++ b/zebra-chain/src/block/root_hash.rs
@@ -55,7 +55,7 @@ impl RootHash {
                 ChainHistoryActivationReserved(bytes)
             }
             Heartwood | Canopy => ChainHistoryRoot(ChainHistoryMmrRootHash(bytes)),
-            NU5 => unimplemented!("NU5 uses hashAuthDataRoot as specified in ZIP-244"),
+            Nu5 => unimplemented!("Nu5 uses hashAuthDataRoot as specified in ZIP-244"),
         }
     }
 

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -40,8 +40,8 @@ pub enum NetworkUpgrade {
     /// The Zcash protocol after the NU5 upgrade.
     ///
     /// Note: Network Upgrade 5 includes the Orchard Shielded Protocol, and
-    /// other changes. The NU5 code name has not been chosen yet.
-    NU5,
+    /// other changes. The Nu5 code name has not been chosen yet.
+    Nu5,
 }
 
 /// Mainnet network upgrade activation heights.
@@ -101,7 +101,7 @@ pub(crate) const CONSENSUS_BRANCH_IDS: &[(NetworkUpgrade, ConsensusBranchId)] = 
     (Blossom, ConsensusBranchId(0x2bb40e60)),
     (Heartwood, ConsensusBranchId(0xf5b9230b)),
     (Canopy, ConsensusBranchId(0xe9ff75a6)),
-    (NU5, ConsensusBranchId(0xf919a198)),
+    (Nu5, ConsensusBranchId(0xf919a198)),
 ];
 
 /// The target block spacing before Blossom.
@@ -207,7 +207,7 @@ impl NetworkUpgrade {
     pub fn target_spacing(&self) -> Duration {
         let spacing_seconds = match self {
             Genesis | BeforeOverwinter | Overwinter | Sapling => PRE_BLOSSOM_POW_TARGET_SPACING,
-            Blossom | Heartwood | Canopy | NU5 => POST_BLOSSOM_POW_TARGET_SPACING,
+            Blossom | Heartwood | Canopy | Nu5 => POST_BLOSSOM_POW_TARGET_SPACING,
         };
 
         Duration::seconds(spacing_seconds)

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -256,7 +256,7 @@ impl Arbitrary for Transaction {
             NetworkUpgrade::Blossom | NetworkUpgrade::Heartwood | NetworkUpgrade::Canopy => {
                 Self::v4_strategy(ledger_state)
             }
-            NetworkUpgrade::NU5 => prop_oneof![
+            NetworkUpgrade::Nu5 => prop_oneof![
                 Self::v4_strategy(ledger_state),
                 Self::v5_strategy(ledger_state)
             ]

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -85,8 +85,8 @@ impl<'a> SigHasher<'a> {
             Sapling | Blossom | Heartwood | Canopy => self
                 .hash_sighash_zip243(&mut hash)
                 .expect("serialization into hasher never fails"),
-            NU5 => unimplemented!(
-                "NU5 upgrade uses a new transaction digest algorithm, as specified in ZIP-244"
+            Nu5 => unimplemented!(
+                "Nu5 upgrade uses a new transaction digest algorithm, as specified in ZIP-244"
             ),
         }
 

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -57,8 +57,8 @@ impl Version {
             (Mainnet, Heartwood) => 170_011,
             (Testnet, Canopy) => 170_012,
             (Mainnet, Canopy) => 170_013,
-            (Testnet, NU5) => 170_014,
-            (Mainnet, NU5) => 170_015,
+            (Testnet, Nu5) => 170_014,
+            (Mainnet, Nu5) => 170_015,
         })
     }
 
@@ -189,7 +189,7 @@ mod test {
         zebra_test::init();
 
         let highest_network_upgrade = NetworkUpgrade::current(network, block::Height::MAX);
-        assert!(highest_network_upgrade == NU5 || highest_network_upgrade == Canopy,
+        assert!(highest_network_upgrade == Nu5 || highest_network_upgrade == Canopy,
                 "expected coverage of all network upgrades: add the new network upgrade to the list in this test");
 
         for &network_upgrade in &[
@@ -199,7 +199,7 @@ mod test {
             Blossom,
             Heartwood,
             Canopy,
-            NU5,
+            Nu5,
         ] {
             let height = network_upgrade.activation_height(network);
             if let Some(height) = height {


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

As of Rust 1.51.0, the clippy::upper-case-acronyms lint is now stable and failing CI.

## Solution

Rename NU5 to Nu5 where appropriate.

## Review

Anyone
