### PR TITLE
Increase coverage CI timeout

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,8 @@ jobs:
 
   coverage:
     name: Coverage (+nightly)
-    timeout-minutes: 30
+    # The large timeout is to accommodate nightly builds
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Motivation

Since coverage uses nightly, it can be slightly slower than other CI.

## Solution

Increase coverage time limit to 45 minutes.

Coverage finishes in about 30 minutes right now. Other Ubuntu jobs finish in about 23 minutes.

## Review

Urgent because it's blocking #1920.
