### PR TITLE
Fix a deadlock between the crawler and dialer, and other hangs

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -49,6 +49,14 @@ pub const LIVE_PEER_DURATION: Duration = Duration::from_secs(60 + 20 + 20 + 20);
 /// connected peer.
 pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 
+/// The number of GetAddr requests sent when crawling for new peers.
+///
+/// ## SECURITY
+///
+/// The fanout should be greater than 1, to ensure that Zebra's address book is
+/// not dominated by a single peer.
+pub const GET_ADDR_FANOUT: usize = 2;
+
 /// Truncate timestamps in outbound address messages to this time interval.
 ///
 /// This is intended to prevent a peer from learning exactly when we received

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -98,4 +98,13 @@ pub enum HandshakeError {
     /// The remote peer offered a version older than our minimum version.
     #[error("Peer offered obsolete version: {0:?}")]
     ObsoleteVersion(crate::protocol::external::types::Version),
+    /// Sending or receiving a message timed out.
+    #[error("Timeout when sending or receiving a message to peer")]
+    Timeout,
+}
+
+impl From<tokio::time::error::Elapsed> for HandshakeError {
+    fn from(_source: tokio::time::error::Elapsed) -> Self {
+        HandshakeError::Timeout
+    }
 }

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -403,7 +403,6 @@ where
                                     "command" => msg.to_string(),
                                     "addr" => addr.to_string(),
                                 );
-                                use futures::sink::SinkExt;
                                 // the collector doesn't depend on network activity,
                                 // so this await should not hang
                                 let _ = inbound_ts_collector
@@ -417,7 +416,6 @@ where
                                     "error" => err.to_string(),
                                     "addr" => addr.to_string(),
                                 );
-                                use futures::sink::SinkExt;
                                 let _ = inbound_ts_collector
                                     .send(MetaAddr::new_errored(&addr, &remote_services))
                                     .await;
@@ -497,7 +495,6 @@ where
                 async move {
                     use super::ClientRequest;
                     use futures::future::Either;
-                    use futures::sink::SinkExt;
 
                     let mut shutdown_rx = shutdown_rx;
                     let mut server_tx = server_tx;

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -12,7 +12,7 @@ use futures::{
     channel::{mpsc, oneshot},
     prelude::*,
 };
-use tokio::{net::TcpStream, sync::broadcast};
+use tokio::{net::TcpStream, sync::broadcast, time::timeout};
 use tokio_util::codec::Framed;
 use tower::Service;
 use tracing::{span, Level, Span};
@@ -34,6 +34,12 @@ use super::{Client, Connection, ErrorSlot, HandshakeError, PeerError};
 
 /// A [`Service`] that handshakes with a remote peer and constructs a
 /// client/server pair.
+///
+/// CORRECTNESS
+///
+/// To avoid hangs, each handshake (or its connector) should be:
+/// - launched in a separate task, and
+/// - wrapped in a timeout.
 #[derive(Clone)]
 pub struct Handshake<S> {
     config: Config,
@@ -211,6 +217,10 @@ where
         let fut = async move {
             debug!("connecting to remote peer");
 
+            // CORRECTNESS
+            //
+            // As a defence-in-depth against hangs, every send or next on stream
+            // should be wrapped in a timeout.
             let mut stream = Framed::new(
                 tcp_stream,
                 Codec::builder()
@@ -260,11 +270,10 @@ where
             };
 
             debug!(?version, "sending initial version message");
-            stream.send(version).await?;
+            timeout(constants::REQUEST_TIMEOUT, stream.send(version)).await??;
 
-            let remote_msg = stream
-                .next()
-                .await
+            let remote_msg = timeout(constants::REQUEST_TIMEOUT, stream.next())
+                .await?
                 .ok_or(HandshakeError::ConnectionClosed)??;
 
             // Check that we got a Version and destructure its fields into the local scope.
@@ -293,11 +302,10 @@ where
                 return Err(HandshakeError::NonceReuse);
             }
 
-            stream.send(Message::Verack).await?;
+            timeout(constants::REQUEST_TIMEOUT, stream.send(Message::Verack)).await??;
 
-            let remote_msg = stream
-                .next()
-                .await
+            let remote_msg = timeout(constants::REQUEST_TIMEOUT, stream.next())
+                .await?
                 .ok_or(HandshakeError::ConnectionClosed)??;
             if let Message::Verack = remote_msg {
                 debug!("got verack from remote peer");
@@ -376,22 +384,44 @@ where
                 future::ready(Ok(msg))
             });
 
+            // CORRECTNESS
+            //
+            // Every message and error must update the peer address state via
+            // the inbound_ts_collector.
+            let inbound_ts_collector = timestamp_collector.clone();
             let peer_rx = peer_rx
                 .then(move |msg| {
-                    // Add a metric for inbound messages and fire a timestamp event.
-                    let mut timestamp_collector = timestamp_collector.clone();
+                    // Add a metric for inbound messages and errors.
+                    // Fire a timestamp or failure event.
+                    let mut inbound_ts_collector = inbound_ts_collector.clone();
                     async move {
-                        if let Ok(msg) = &msg {
-                            metrics::counter!(
-                                "zcash.net.in.messages",
-                                1,
-                                "command" => msg.to_string(),
-                                "addr" => addr.to_string(),
-                            );
-                            use futures::sink::SinkExt;
-                            let _ = timestamp_collector
-                                .send(MetaAddr::new_responded(&addr, &remote_services))
-                                .await;
+                        match &msg {
+                            Ok(msg) => {
+                                metrics::counter!(
+                                    "zcash.net.in.messages",
+                                    1,
+                                    "command" => msg.to_string(),
+                                    "addr" => addr.to_string(),
+                                );
+                                use futures::sink::SinkExt;
+                                // the collector doesn't depend on network activity,
+                                // so this await should not hang
+                                let _ = inbound_ts_collector
+                                    .send(MetaAddr::new_responded(&addr, &remote_services))
+                                    .await;
+                            }
+                            Err(err) => {
+                                metrics::counter!(
+                                    "zebra.net.in.errors",
+                                    1,
+                                    "error" => err.to_string(),
+                                    "addr" => addr.to_string(),
+                                );
+                                use futures::sink::SinkExt;
+                                let _ = inbound_ts_collector
+                                    .send(MetaAddr::new_errored(&addr, &remote_services))
+                                    .await;
+                            }
                         }
                         msg
                     }
@@ -452,17 +482,35 @@ where
                     .boxed(),
             );
 
+            // CORRECTNESS
+            //
+            // To prevent hangs:
+            // - every await that depends on the network must have a timeout (or interval)
+            // - every error/shutdown must update the address book state and return
+            //
+            // The address book state can be updated via `ClientRequest.tx`, or the
+            // timestamp_collector.
+            //
+            // Returning from the spawned closure terminates the connection's heartbeat task.
             let heartbeat_span = tracing::debug_span!(parent: connection_span, "heartbeat");
             tokio::spawn(
                 async move {
                     use super::ClientRequest;
                     use futures::future::Either;
+                    use futures::sink::SinkExt;
 
                     let mut shutdown_rx = shutdown_rx;
                     let mut server_tx = server_tx;
+                    let mut timestamp_collector = timestamp_collector.clone();
                     let mut interval_stream = tokio::time::interval(constants::HEARTBEAT_INTERVAL);
                     loop {
                         let shutdown_rx_ref = Pin::new(&mut shutdown_rx);
+                        let mut send_addr_err = false;
+
+                        // Currently, select prefers the first future.
+                        // There is no starvation risk here, because
+                        // interval has a limited rate, and shutdown
+                        // is a oneshot.
                         match future::select(interval_stream.next(), shutdown_rx_ref).await {
                             Either::Left(_) => {
                                 let (tx, rx) = oneshot::channel();
@@ -474,19 +522,28 @@ where
                                     span: tracing::Span::current(),
                                 }) {
                                     Ok(()) => {
-                                        match server_tx.flush().await {
-                                            Ok(()) => {}
-                                            Err(e) => {
-                                                // We can't get the client request for this failure,
-                                                // so we can't send an error back here. But that's ok,
-                                                // because:
-                                                //   - this error never happens (or it's very rare)
-                                                //   - if the flush() fails, the server hasn't
-                                                //     received the request
+                                        // TODO: also wait on the shutdown_rx here
+                                        match timeout(
+                                            constants::HEARTBEAT_INTERVAL,
+                                            server_tx.flush(),
+                                        )
+                                        .await
+                                        {
+                                            Ok(Ok(())) => {
+                                            }
+                                            Ok(Err(e)) => {
                                                 tracing::warn!(
-                                                    "flushing client request failed: {:?}",
-                                                    e
+                                                    ?e,
+                                                    "flushing client request failed, shutting down"
                                                 );
+                                                send_addr_err = true;
+                                            }
+                                            Err(e) => {
+                                                tracing::warn!(
+                                                    ?e,
+                                                    "flushing client request timed out, shutting down"
+                                                );
+                                                send_addr_err = true;
                                             }
                                         }
                                     }
@@ -514,17 +571,46 @@ where
                                 // Heartbeats are checked internally to the
                                 // connection logic, but we need to wait on the
                                 // response to avoid canceling the request.
-                                match rx.await {
-                                    Ok(_) => tracing::trace!("got heartbeat response"),
-                                    Err(_) => {
-                                        tracing::trace!(
+                                //
+                                // TODO: also wait on the shutdown_rx here
+                                match timeout(constants::HEARTBEAT_INTERVAL, rx).await {
+                                    Ok(Ok(_)) => tracing::trace!("got heartbeat response"),
+                                    Ok(Err(e)) => {
+                                        tracing::warn!(
+                                            ?e,
                                             "error awaiting heartbeat response, shutting down"
                                         );
-                                        return;
+                                        send_addr_err = true;
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            ?e,
+                                            "heartbeat response timed out, shutting down"
+                                        );
+                                        send_addr_err = true;
                                     }
                                 }
                             }
-                            Either::Right(_) => return, // got shutdown signal
+                            Either::Right(_) => {
+                                tracing::trace!("shutting down due to Client shut down");
+                                // awaiting a local task won't hang
+                                let _ = timestamp_collector
+                                    .send(MetaAddr::new_shutdown(&addr, &remote_services))
+                                    .await;
+                                return;
+                            }
+                        }
+                        if send_addr_err {
+                            // We can't get the client request for this failure,
+                            // so we can't send an error back on `tx`. So
+                            // we just update the address book with a failure.
+                            let _ = timestamp_collector
+                                .send(MetaAddr::new_errored(
+                                    &addr,
+                                    &remote_services,
+                                ))
+                                .await;
+                            return;
                         }
                     }
                 }


### PR DESCRIPTION
## Motivation

In #1905, Zebra gradually loses peer connections, until there are none left. Then it stops making sync progress.

When this issue happens, a large number of peers are stuck in the `attempt_pending` state, despite the handshake timeout.

This issue also impacted the `peer::Connection` refactor in #1817, and a bunch of upcoming zebra-network security fixes.

## Solution

- Stop ignoring inbound message errors
- Add timeouts during handshake setup
- Add a timeout to the candidate set update
- Use the `select!` macro in the crawler to avoid starvation
- Spawn a separate task for each handshake
- Increase the crawl fanout to improve address diversity
- Avoid starvation when using the `select` function
- Fix priority of multiple ready futures in the `select` function
- Add correctness documentation

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Existing Unit Tests and Integration Tests

## Review

@dconnolly or @oxarbitrage can review - whoever is available.

I'd like to get this merged in the next few days. It doesn't directly conflict with the other security fixes, but it will make them harder to test.

## Related Issues

Closes #1905 (based on 3 mainnet and 3 testnet nodes x 3 days of testing).
Closes #1941 (based on 3 testnet nodes x 3 days of testing).
Possibly closes some other related hang or reliability issues.

Deals with part of the #1892 and #1657 refactors.