### PR TITLE
Pin coverage.yml nightly to 2021-03-24 for now

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2021-03-24
           override: true
           profile: minimal
           components: llvm-tools-preview
@@ -53,4 +53,3 @@ jobs:
           $(rustc --print target-libdir)/../bin/llvm-cov export -format=lcov -instr-profile=test.profdata $(printf -- "-object %s " $(cat filenames.txt)) > "lcov.info"
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1
-


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->

Latest nightly is causing build errors on our coverage job.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->

Pin coverage.yml's nightly version to the last known good nightly.

## Follow Up Work

#2015 revert this change to track nightly again
