### PR TITLE
Clarify anchor names in V5 transaction RFC

### DIFF
--- a/book/src/dev/rfcs/0010-v5-transaction.md
+++ b/book/src/dev/rfcs/0010-v5-transaction.md
@@ -119,7 +119,7 @@ We use `AnchorVariant` in `ShieldedData` to model the anchor differences between
 ```rust
 struct sapling::ShieldedData<AnchorV: AnchorVariant> {
     value_balance: Amount,
-    anchor: AnchorV::Shared,
+    shared_anchor: AnchorV::Shared,
     first: Either<Spend<AnchorV>, Output>,
     rest_spends: Vec<Spend<AnchorV>>,
     rest_outputs: Vec<Output>,
@@ -135,7 +135,7 @@ Sapling spend code is located at `zebra-chain/src/sapling/spend.rs`. We use `Anc
 ```rust
 struct Spend<AnchorV: AnchorVariant> {
     cv: commitment::ValueCommitment,
-    anchor: AnchorV::PerSpend,
+    per_spend_anchor: AnchorV::PerSpend,
     nullifier: note::Nullifier,
     rk: redjubjub::VerificationKeyBytes<SpendAuth>,
     zkproof: Groth16Proof,
@@ -191,7 +191,7 @@ The new V5 structure will create a new `orchard::ShieldedData` type. This new ty
 struct orchard::ShieldedData {
     flags: Flags,
     value_balance: Amount,
-    anchor: tree::Root,
+    shared_anchor: tree::Root,
     proof: Halo2Proof,
     /// An authorized action description.
     ///


### PR DESCRIPTION
## Motivation

When we're naming the anchors without the corresponding type or struct,
it's not clear if they are shared or per spend.

## Solution

Rename the fields as `shared_anchor` or `per_spend_anchor`.

## Review

@oxarbitrage and maybe @dconnolly should review this very minor field name change.

## Related Issues

The PR review conversation at https://github.com/ZcashFoundation/zebra/pull/1946#pullrequestreview-622031579 

## Follow Up Work

Make these changes in PR #1946 and any other V5 transaction PRs.