### PR TITLE
Rename RootHash to Commitment based on ZIP-244

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -4,7 +4,7 @@
 mod hash;
 mod header;
 mod height;
-mod root_hash;
+mod commitment;
 mod serialize;
 
 pub mod merkle;
@@ -20,7 +20,7 @@ pub use hash::Hash;
 pub use header::BlockTimeError;
 pub use header::{CountedHeader, Header};
 pub use height::Height;
-pub use root_hash::RootHash;
+pub use commitment::Commitment;
 
 use serde::{Deserialize, Serialize};
 
@@ -69,9 +69,9 @@ impl Block {
     /// configured `network`, and this block's height.
     ///
     /// Returns None if this block does not have a block height.
-    pub fn root_hash(&self, network: Network) -> Option<RootHash> {
+    pub fn commitment(&self, network: Network) -> Option<Commitment> {
         self.coinbase_height()
-            .map(|height| RootHash::from_bytes(self.header.root_bytes, network, height))
+            .map(|height| Commitment::from_bytes(self.header.commitment_bytes, network, height))
     }
 }
 

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -1,10 +1,10 @@
 //! Blocks and block-related structures (heights, headers, etc.)
 #![allow(clippy::unit_arg)]
 
+mod commitment;
 mod hash;
 mod header;
 mod height;
-mod commitment;
 mod serialize;
 
 pub mod merkle;
@@ -16,11 +16,11 @@ mod tests;
 
 use std::fmt;
 
+pub use commitment::Commitment;
 pub use hash::Hash;
 pub use header::BlockTimeError;
 pub use header::{CountedHeader, Header};
 pub use height::Height;
-pub use commitment::Commitment;
 
 use serde::{Deserialize, Serialize};
 

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -47,13 +47,13 @@ impl Block {
     }
 }
 
-impl Arbitrary for RootHash {
+impl Arbitrary for Commitment {
     type Parameters = ();
 
     fn arbitrary_with(_args: ()) -> Self::Strategy {
         (any::<[u8; 32]>(), any::<Network>(), any::<Height>())
-            .prop_map(|(root_bytes, network, block_height)| {
-                RootHash::from_bytes(root_bytes, network, block_height)
+            .prop_map(|(commitment_bytes, network, block_height)| {
+                Commitment::from_bytes(commitment_bytes, network, block_height)
             })
             .boxed()
     }
@@ -82,7 +82,7 @@ impl Arbitrary for Header {
                     version,
                     previous_block_hash,
                     merkle_root,
-                    root_bytes,
+                    commitment_bytes,
                     timestamp,
                     difficulty_threshold,
                     nonce,
@@ -91,7 +91,7 @@ impl Arbitrary for Header {
                     version,
                     previous_block_hash,
                     merkle_root,
-                    root_bytes,
+                    commitment_bytes,
                     time: Utc.timestamp(timestamp, 0),
                     difficulty_threshold,
                     nonce,

--- a/zebra-chain/src/block/commitment.rs
+++ b/zebra-chain/src/block/commitment.rs
@@ -1,4 +1,4 @@
-//! The RootHash enum, used for the corresponding block header field.
+//! The Commitment enum, used for the corresponding block header field.
 
 use crate::parameters::{Network, NetworkUpgrade, NetworkUpgrade::*};
 use crate::sapling::tree::Root;
@@ -7,11 +7,11 @@ use super::Height;
 
 /// Zcash blocks contain different kinds of root hashes, depending on the network upgrade.
 ///
-/// The `BlockHeader.root_bytes` field is interpreted differently,
+/// The `BlockHeader.commitment_bytes` field is interpreted differently,
 /// based on the current block height. The interpretation changes at or after
 /// network upgrades.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum RootHash {
+pub enum Commitment {
     /// [Pre-Sapling] Reserved field.
     ///
     /// All zeroes.
@@ -43,10 +43,10 @@ pub enum RootHash {
     ChainHistoryRoot(ChainHistoryMmrRootHash),
 }
 
-impl RootHash {
-    /// Returns `bytes` as the RootHash variant for `network` and `height`.
-    pub(super) fn from_bytes(bytes: [u8; 32], network: Network, height: Height) -> RootHash {
-        use RootHash::*;
+impl Commitment {
+    /// Returns `bytes` as the Commitment variant for `network` and `height`.
+    pub(super) fn from_bytes(bytes: [u8; 32], network: Network, height: Height) -> Commitment {
+        use Commitment::*;
 
         match NetworkUpgrade::current(network, height) {
             Genesis | BeforeOverwinter | Overwinter => PreSaplingReserved(bytes),
@@ -59,10 +59,10 @@ impl RootHash {
         }
     }
 
-    /// Returns the serialized bytes for this RootHash.
+    /// Returns the serialized bytes for this Commitment.
     #[allow(dead_code)]
     pub(super) fn to_bytes(self) -> [u8; 32] {
-        use RootHash::*;
+        use Commitment::*;
 
         match self {
             PreSaplingReserved(b) => b,

--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -44,9 +44,9 @@ pub struct Header {
     ///
     /// Unfortunately, the interpretation of this field was changed without
     /// incrementing the version, so it cannot be parsed without the block height
-    /// and network. Use [`Block::root_hash`](super::Block::root_hash) to get the
-    /// parsed [`RootHash`](super::RootHash).
-    pub root_bytes: [u8; 32],
+    /// and network. Use [`Block::commitment`](super::Block::commitment) to get the
+    /// parsed [`Commitment`](super::Commitment).
+    pub commitment_bytes: [u8; 32],
 
     /// The block timestamp is a Unix epoch time (UTC) when the miner
     /// started hashing the header (according to the miner).

--- a/zebra-chain/src/block/serialize.rs
+++ b/zebra-chain/src/block/serialize.rs
@@ -26,7 +26,7 @@ impl ZcashSerialize for Header {
         writer.write_u32::<LittleEndian>(self.version)?;
         self.previous_block_hash.zcash_serialize(&mut writer)?;
         writer.write_all(&self.merkle_root.0[..])?;
-        writer.write_all(&self.root_bytes[..])?;
+        writer.write_all(&self.commitment_bytes[..])?;
         // this is a truncating cast, rather than a saturating cast
         // but u32 times are valid until 2106, and our block verification time
         // checks should detect any truncation.
@@ -74,7 +74,7 @@ impl ZcashDeserialize for Header {
             version,
             previous_block_hash: Hash::zcash_deserialize(&mut reader)?,
             merkle_root: merkle::Root(reader.read_32_bytes()?),
-            root_bytes: reader.read_32_bytes()?,
+            commitment_bytes: reader.read_32_bytes()?,
             // This can't panic, because all u32 values are valid `Utc.timestamp`s
             time: Utc.timestamp(reader.read_u32::<LittleEndian>()? as i64, 0),
             difficulty_threshold: CompactDifficulty(reader.read_u32::<LittleEndian>()?),

--- a/zebra-chain/src/block/tests/prop.rs
+++ b/zebra-chain/src/block/tests/prop.rs
@@ -40,15 +40,15 @@ proptest! {
     }
 
     #[test]
-    fn root_hash_roundtrip(
+    fn commitment_roundtrip(
         bytes in any::<[u8; 32]>(),
         network in any::<Network>(),
         block_height in any::<Height>()
     ) {
         zebra_test::init();
 
-        let root_hash = RootHash::from_bytes(bytes, network, block_height);
-        let other_bytes = root_hash.to_bytes();
+        let commitment = Commitment::from_bytes(bytes, network, block_height);
+        let other_bytes = commitment.to_bytes();
 
         prop_assert_eq![bytes, other_bytes];
     }
@@ -70,10 +70,10 @@ proptest! {
         let bytes = &mut bytes.as_slice();
 
         // Check the root hash
-        let root_hash = block.root_hash(network);
-        if let Some(root_hash) = root_hash {
-            let root_hash_bytes = root_hash.to_bytes();
-            prop_assert_eq![block.header.root_bytes, root_hash_bytes];
+        let commitment = block.commitment(network);
+        if let Some(commitment) = commitment {
+            let commitment_bytes = commitment.to_bytes();
+            prop_assert_eq![block.header.commitment_bytes, commitment_bytes];
         } else {
             prop_assert_eq![block.coinbase_height(), None];
         }


### PR DESCRIPTION
## Motivation

The goal of this PR is to **make progress** on the outstanding cleanups on the block commitment field from #881.

In ZIP-244, the root hash field is renamed to block commitment. This name is more generic, and will probably stay the same going forward.

## Solution

Interactive replace using:
```sh
fastmod RootHash Commitment
fastmod root_hash commitment
fastmod root_bytes commitment_bytes
git mv zebra-chain/src/block/root_hash.rs zebra-chain/src/block/commitment.rs
```

All replacements were accepted.

## Review

@dconnolly or @oxarbitrage just a quick search and replace PR that's blocking other issues.

## Related Issues

Implements part of #1874 and #881, but doesn't finish either of them.

## Follow Up Work

Finish #881
Do design for #1874