### PR TITLE
Clean up block commitment enum and parsing

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -63,9 +63,9 @@ impl Block {
         Hash::from(self)
     }
 
-    /// Get the parsed root hash for this block.
+    /// Get the parsed block [`Commitment`] for this block.
     ///
-    /// The interpretation of the root hash depends on the
+    /// The interpretation of the commitment depends on the
     /// configured `network`, and this block's height.
     ///
     /// Returns None if this block does not have a block height.

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -53,7 +53,16 @@ impl Arbitrary for Commitment {
     fn arbitrary_with(_args: ()) -> Self::Strategy {
         (any::<[u8; 32]>(), any::<Network>(), any::<Height>())
             .prop_map(|(commitment_bytes, network, block_height)| {
-                Commitment::from_bytes(commitment_bytes, network, block_height)
+                match Commitment::from_bytes(commitment_bytes, network, block_height) {
+                    Ok(commitment) => commitment,
+                    // just fix up the reserved values when they fail
+                    Err(_) => Commitment::from_bytes(
+                        super::commitment::RESERVED_BYTES,
+                        network,
+                        block_height,
+                    )
+                    .expect("from_bytes only fails due to reserved bytes"),
+                }
             })
             .boxed()
     }

--- a/zebra-chain/src/block/commitment.rs
+++ b/zebra-chain/src/block/commitment.rs
@@ -1,7 +1,7 @@
 //! The Commitment enum, used for the corresponding block header field.
 
 use crate::parameters::{Network, NetworkUpgrade, NetworkUpgrade::*};
-use crate::sapling::tree::Root;
+use crate::sapling;
 
 use super::Height;
 
@@ -26,7 +26,7 @@ pub enum Commitment {
     ///
     /// Subsequent `Commitment` variants also commit to the `FinalSaplingRoot`,
     /// via their `EarliestSaplingRoot` and `LatestSaplingRoot` fields.
-    FinalSaplingRoot(Root),
+    FinalSaplingRoot(sapling::tree::Root),
 
     /// [Heartwood activation block] Reserved field.
     ///
@@ -58,7 +58,7 @@ impl Commitment {
 
         match NetworkUpgrade::current(network, height) {
             Genesis | BeforeOverwinter | Overwinter => PreSaplingReserved(bytes),
-            Sapling | Blossom => FinalSaplingRoot(Root(bytes)),
+            Sapling | Blossom => FinalSaplingRoot(sapling::tree::Root(bytes)),
             Heartwood if Some(height) == Heartwood.activation_height(network) => {
                 ChainHistoryActivationReserved(bytes)
             }

--- a/zebra-chain/src/block/commitment.rs
+++ b/zebra-chain/src/block/commitment.rs
@@ -5,11 +5,13 @@ use crate::sapling::tree::Root;
 
 use super::Height;
 
-/// Zcash blocks contain different kinds of root hashes, depending on the network upgrade.
+/// Zcash blocks contain different kinds of commitments to their contents,
+/// depending on the network and height.
 ///
-/// The `BlockHeader.commitment_bytes` field is interpreted differently,
-/// based on the current block height. The interpretation changes at or after
-/// network upgrades.
+/// The `Header.commitment_bytes` field is interpreted differently, based on the
+/// network and height. The interpretation changes in the network upgrade
+/// activation block, or in the block immediately after network upgrade
+/// activation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Commitment {
     /// [Pre-Sapling] Reserved field.
@@ -21,6 +23,9 @@ pub enum Commitment {
     ///
     /// The root LEBS2OSP256(rt) of the Sapling note commitment tree
     /// corresponding to the final Sapling treestate of this block.
+    ///
+    /// Subsequent `Commitment` variants also commit to the `FinalSaplingRoot`,
+    /// via their `EarliestSaplingRoot` and `LatestSaplingRoot` fields.
     FinalSaplingRoot(Root),
 
     /// [Heartwood activation block] Reserved field.
@@ -39,7 +44,10 @@ pub enum Commitment {
     /// The commitment in each block covers the chain history from the most
     /// recent network upgrade, through to the previous block. In particular,
     /// an activation block commits to the entire previous network upgrade, and
-    /// the block after activation commits only to the activation block.
+    /// the block after activation commits only to the activation block. (And
+    /// therefore transitively to all previous network upgrades covered by a
+    /// chain history hash in their activation block, via the previous block
+    /// hash field.)
     ChainHistoryRoot(ChainHistoryMmrRootHash),
 }
 

--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -40,12 +40,14 @@ pub struct Header {
     /// valid.
     pub merkle_root: merkle::Root,
 
-    /// Some kind of root hash.
+    /// Zcash blocks contain different kinds of commitments to their contents,
+    /// depending on the network and height.
     ///
-    /// Unfortunately, the interpretation of this field was changed without
-    /// incrementing the version, so it cannot be parsed without the block height
-    /// and network. Use [`Block::commitment`](super::Block::commitment) to get the
-    /// parsed [`Commitment`](super::Commitment).
+    /// The interpretation of this field has been changed multiple times, without
+    /// incrementing the block [`version`]. Therefore, this field cannot be
+    /// parsed without the network and height. Use
+    /// [`Block::commitment`](super::Block::commitment) to get the parsed
+    /// [`Commitment`](super::Commitment).
     pub commitment_bytes: [u8; 32],
 
     /// The block timestamp is a Unix epoch time (UTC) when the miner

--- a/zebra-chain/src/block/tests/prop.rs
+++ b/zebra-chain/src/block/tests/prop.rs
@@ -47,10 +47,13 @@ proptest! {
     ) {
         zebra_test::init();
 
-        let commitment = Commitment::from_bytes(bytes, network, block_height);
-        let other_bytes = commitment.to_bytes();
+        // just skip the test if the bytes don't parse, because there's nothing
+        // to compare with
+        if let Ok(commitment) = Commitment::from_bytes(bytes, network, block_height) {
+            let other_bytes = commitment.to_bytes();
 
-        prop_assert_eq![bytes, other_bytes];
+            prop_assert_eq![bytes, other_bytes];
+        }
     }
 }
 
@@ -69,13 +72,11 @@ proptest! {
         let bytes = block.zcash_serialize_to_vec()?;
         let bytes = &mut bytes.as_slice();
 
-        // Check the root hash
+        // Check the block commitment
         let commitment = block.commitment(network);
-        if let Some(commitment) = commitment {
+        if let Ok(commitment) = commitment {
             let commitment_bytes = commitment.to_bytes();
             prop_assert_eq![block.header.commitment_bytes, commitment_bytes];
-        } else {
-            prop_assert_eq![block.coinbase_height(), None];
         }
 
         // Check the block size limit


### PR DESCRIPTION
## Motivation

The goal of this PR is to **finish** the outstanding cleanups on the block commitment field from #881.

After they're done, we can create a good design for its `FinalSaplingRoot`, `ChainHistoryRoot`, and `BlockCommitments` variants.

## Solution

- Comment cleanups after interactive replace
- Distinguish `Sapling` tree roots from other tree roots
- Add the `NU5` `BlockCommitmentsHash` variant to `block::Commitment`
- Validate reserved values in `Block::commitment`

This PR is based on #1957.

## Review

@oxarbitrage is going to work on ZIP-244 and ZIP-221 with me, so he can review this.

## Related Issues

Closes #881 
Makes some progress on #1874

## Follow Up Work

Do a design for #1874, #1567, and #958 
