### PR TITLE
Update the RFC process to include drafts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/rfc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/rfc.md
@@ -37,10 +37,10 @@ Fill this in, replacing:
 
 ZcashFoundation/zebra with username/repo (if not making the PR from the Zebra repo)
 my-branch-name with the PR branch
-XXXX-my-feature with the filename of the RFC
+xxxx-my-feature with the filename of the RFC
 
 -->
-[Rendered](https://github.com/ZcashFoundation/zebra/blob/my-branch-name/book/src/dev/rfcs/XXXX-my-feature.md).
+[Rendered](https://github.com/ZcashFoundation/zebra/blob/my-branch-name/book/src/dev/rfcs/drafts/xxxx-my-feature.md).
 
 ## Zebra Team Approval
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ To make a Zebra RFC:
 1. Choose a short feature name like `my-feature`.
 
 2. Copy the `book/src/dev/rfcs/0000-template.md` file to
-`book/src/dev/rfcs/drafts/XXXX-my-feature.md`.
+`book/src/dev/rfcs/drafts/xxxx-my-feature.md`.
 
 3. Edit the template header to add the feature name and the date, but leave
 the other fields blank for now.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ To make a Zebra RFC:
 1. Choose a short feature name like `my-feature`.
 
 2. Copy the `book/src/dev/rfcs/0000-template.md` file to
-`book/src/dev/rfcs/XXXX-my-feature.md`.
+`book/src/dev/rfcs/drafts/XXXX-my-feature.md`.
 
 3. Edit the template header to add the feature name and the date, but leave
 the other fields blank for now.
@@ -67,13 +67,16 @@ useful guide.
 
 5. Create an design PR using the RFC template.
 
-6. Take the next available RFC number (not conflicting with any existing RFCs
-or design PRs) and name the RFC file accordingly, e.g., `0027-my-feature.md`
-for number 27. Make sure that `book/src/SUMMARY.md` links to the numbered RFC.
-
-7. After creating an RFC PR, update the RFC header and the PR description
+6. After creating an RFC PR, update the RFC header and the PR description
 with the PR number.
 
-8. After the RFC is accepted, create an issue for the implementation of the
+7. Make changes to the RFC in collaboration with the Zebra team.
+
+8. When the RFC is merged, take the next available RFC number (not conflicting
+with any existing RFCs or design PRs) and name the RFC file accordingly, e.g.,
+`0027-my-feature.md` for number 27. Make sure that `book/src/SUMMARY.md` links
+to the numbered RFC.
+
+7. After the RFC is accepted, create an issue for the implementation of the
 design, and update the RFC header and PR description with the implementation
 issue number.


### PR DESCRIPTION
## Motivation

Sometimes we get RFC number conflicts when there are multiple open RFC pull requests.

## Solution

1. Make RFC PRs in `rfcs/drafts/xxxx-rfc-name.md`
2. Assign them a number when they merge

## Review

@dconnolly @oxarbitrage this is a RFC process change based on the new `drafts` folder.

## Related Issues

For example `0006-stolon.md` in PR #1006 conflicts with https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0006-contextual-difficulty.md
