### PR TITLE
Zebra Client RFC: add mandatory sweep fast startup option

### DIFF
--- a/book/src/dev/rfcs/0009-zebra-client.md
+++ b/book/src/dev/rfcs/0009-zebra-client.md
@@ -296,6 +296,20 @@ Supporting a wallet assumes risk.  Effort required to implement wallet functiona
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
+- mandatory sweeps for legacy keys
+    - blazingly fast wallet startup, to match `zebrad`'s blazingly fast sync
+    - generate unified address from a new seed phrase (or one provided by the user)
+    - user can just backup seed phrase rather than a set of private keys
+    - handles arbitrary keys from `zcashd` and other wallets, even if they weren't generated from a seed phrase
+    - handles Sprout funds without `zebra-client` having to support Sprout balances
+    - startup is incredibly fast
+        - sweep takes a few minutes to be confirmed
+        - scanning the entire chain could take hours
+        - if we know when the seed phrase was created, we can skip millions of blocks during scanning
+    - sweeps can also be initiated by the user for non-linkability / performance / refresh
+    - sweeps should handle the "block reward recipient" case where there are a lot of small outputs
+    - initial release could support mandatory sweeps, and future releases could support legacy keys
+
 - split `Client` component into subprocess
     - this helps somewhat but the benefit is reduced by our prexisting memory safety, thanks to Rust
     - not meaningful without other isolation (need to restrict `zebrad` from accessing viewing keys on disk, etc)


### PR DESCRIPTION
## Motivation

A mandatory sweep would help `zebra-client` match `zebrad`'s blazingly fast speeds.

## Solution

Update the Zebra Client RFC to include this design idea, and some of its benefits and drawbacks.

## Review

@dconnolly and I talked about this design. The review isn't urgent at all.
