### PR TITLE
Update tower-batch tests to rand 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,20 +929,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-zebra"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a128b76af6dd4b427e34a6fd43dc78dbfe73672ec41ff615a2414c1a0ad0409"
-dependencies = [
- "curve25519-dalek",
- "hex",
- "rand_core 0.5.1",
- "serde",
- "sha2",
- "thiserror",
-]
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3399,11 +3385,11 @@ name = "tower-batch"
 version = "0.2.3"
 dependencies = [
  "color-eyre",
- "ed25519-zebra 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-zebra",
  "futures 0.3.13",
  "futures-core",
  "pin-project 0.4.27",
- "rand 0.7.3",
+ "rand 0.8.1",
  "tokio 0.3.6",
  "tokio-test",
  "tower",
@@ -4056,7 +4042,7 @@ dependencies = [
  "chrono",
  "color-eyre",
  "displaydoc",
- "ed25519-zebra 2.2.0 (git+https://github.com/ZcashFoundation/ed25519-zebra?rev=539fad040c443302775b0f508e616418825e6c22)",
+ "ed25519-zebra",
  "equihash",
  "futures 0.3.13",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ panic = "abort"
 
 [patch.crates-io]
 
+# TODO: upgrade ed25510-zebra to 3 when released: https://github.com/ZcashFoundation/ed25519-zebra/issues/45
+ed25519-zebra = {git = "https://github.com/ZcashFoundation/ed25519-zebra", rev = "539fad040c443302775b0f508e616418825e6c22"}
 
 # awaiting stable versions which all depend on tokio 1.0, see #1086 for details
 hyper = { git = "https://github.com/hyperium/hyper", rev = "ed2b22a7f66899d338691552fbcb6c0f2f4e06b9" }

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -16,8 +16,8 @@ tracing-futures = "0.2.5"
 
 [dev-dependencies]
 color-eyre = "0.5.10"
-ed25519-zebra = "2.1.0"
-rand = "0.7"
+ed25519-zebra = "2.2.0"
+rand = "0.8"
 tokio = { version = "0.3.6", features = ["full"]}
 tokio-test = "0.4.1"
 tower-fallback = { path = "../tower-fallback/" }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -41,8 +41,7 @@ proptest = { version = "0.10", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 
 # ZF deps
-# TODO: upgrade ed25510-zebra to 3 when released: https://github.com/ZcashFoundation/ed25519-zebra/issues/45
-ed25519-zebra = {git = "https://github.com/ZcashFoundation/ed25519-zebra", rev = "539fad040c443302775b0f508e616418825e6c22"}
+ed25519-zebra = "2.2.0"
 redjubjub = "0.4"
 
 [dev-dependencies]


### PR DESCRIPTION
## Motivation

Zebra currently depends on a git version of ed25519-zebra in zebra-chain, but the crates.io version in the tower-batch tests.

This seems to cause some Cargo.lock instability.

## Solution

- Update tower-batch tests to rand 0.8
- Move the ed25519-zebra git patch to the workspace Cargo.toml

## Review

@dconnolly can review. This fix isn't urgent.

## Related Issues

Caused by #1952.

## Follow Up Work

Remove the ed25519-zebra git patch in the workspace Cargo.toml, as part of ZcashFoundation/ed25519-zebra#45.