### PR TITLE
Missed zebra-utils bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "color-eyre",
  "hex",

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zebra-utils"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 edition = "2018"
 # Prevent accidental publication of this utility crate.
 publish = false


### PR DESCRIPTION
zebra-utils depends on the following crates which have changed:
zebra-chain = { path = "../zebra-chain" }
zebra-consensus = { path = "../zebra-consensus" }
zebra-state = { path = "../zebra-state" }

This bump was missed in https://github.com/ZcashFoundation/zebra/pull/1991 and fixed here.