### PR TITLE
Fix a nightly compile error by patching lexical-core to 0.7.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,12 +1633,11 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 [[package]]
 name = "lexical-core"
 version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
+source = "git+https://github.com/Alexhuszagh/rust-lexical?rev=601c9bfe16c944948d4c4a07e3c67878d72f6445#601c9bfe16c944948d4c4a07e3c67878d72f6445"
 dependencies = [
  "arrayvec 0.5.2",
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,8 @@ hyper = { git = "https://github.com/hyperium/hyper", rev = "ed2b22a7f66899d33869
 metrics = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
 metrics-exporter-prometheus = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
 tower = { git = "https://github.com/tower-rs/tower", rev = "d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39" }
+
+# lexical-core 0.7.4 is incompatible with rustc nightly >= ~2021-03-24
+# https://github.com/rust-lang/rust/issues/81654
+# remove when zcash_script and rocksdb transitively depend on lexical-core >= 0.7.5
+lexical-core = { git = "https://github.com/Alexhuszagh/rust-lexical", rev = "601c9bfe16c944948d4c4a07e3c67878d72f6445" }


### PR DESCRIPTION
## Motivation

lexical-core 0.7.4 is incompatible with rustc nightly > 2021-03-24, see https://github.com/rust-lang/rust/issues/81654

## Solution

While we're waiting for zcash_script, rocksdb, and their dependencies to
upgrade, patch lexical-core to 0.7.5 in the zebra workspace.

## Review

~This is urgent, because it will cause our nightly coverage CI to fail.~ This fix isn't urgent, because we pinned the rust version in our coverage builds.


## Follow Up Work

Remove the git dependency when dependent crates have updated #1086 