### PR TITLE
Make sure each peer heartbeat has a timeout

### DIFF
--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -529,9 +529,8 @@ where
                         // shutting down. so do a heartbeat request.
                         //
                         // TODO: await heartbeat and shutdown. The select
-                        // function has some strict lifetime requirements,
-                        // try the select! macro with a custom enum mapping
-                        // (#1783, #1678)
+                        // function needs pinned types, but pinned generics
+                        // are hard (#1678)
                         let heartbeat = send_one_heartbeat(&mut server_tx);
                         if heartbeat_timeout(
                             heartbeat,

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -526,7 +526,7 @@ where
                         }
 
                         // We've reached another heartbeat interval without
-                        // shutting down. so do a heartbeat request.
+                        // shutting down, so do a heartbeat request.
                         //
                         // TODO: await heartbeat and shutdown. The select
                         // function needs pinned types, but pinned generics


### PR DESCRIPTION
## Motivation

It's hard to have consistent timeouts when we have to add a `timeout()` to the `Ping` and the completion channel during the heartbeat.

If the peer is busy, we want to wait for it to be ready, rather than closing the connection immediately (#1551).

## Solution

- cleanup the heartbeat code, so each heartbeat request/response runs in a future with a single timeout
- just send the message to the peer, which will wait until the timeout if it is busy, then fail and close the connection

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Integration Tests

## Review

@dconnolly reviewed #1850, which this code is based on.

This change blocks some of the upcoming security refactors, so it should be merged soon.


## Related Issues

Closes #1551.

## Follow Up Work

Wait on shutdowns as well as the heartbeat timeout (#1783, #1678)