### PR TITLE
Fix a test failure due to ' debug format changes in Rust

### DIFF
--- a/zebra-chain/src/transaction/memo.rs
+++ b/zebra-chain/src/transaction/memo.rs
@@ -52,6 +52,10 @@ impl fmt::Debug for Memo {
 fn memo_fmt() {
     zebra_test::init();
 
+    // Rust changed the escaping of ' between 1.52 and 1.53 (nightly-2021-04-14?),
+    // so the memo string can't contain '
+    //
+    // TODO: rewrite this test so it doesn't depend on the exact debug format
     let memo = Memo(Box::new(
         *b"thiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiis \
            iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiis \
@@ -59,11 +63,11 @@ fn memo_fmt() {
            veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeryyyyyyyyyyyyyyyyyyyyyyyyyy \
            looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong \
            meeeeeeeeeeeeeeeeeeemooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo \
-           but it's just short enough",
+           but its just short enough!",
     ));
 
     assert_eq!(format!("{:?}", memo),
-               "Memo(\"thiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiis iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiis aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeryyyyyyyyyyyyyyyyyyyyyyyyyy looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong meeeeeeeeeeeeeeeeeeemooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo but it\\\'s just short enough\")"
+               "Memo(\"thiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiis iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiis aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeryyyyyyyyyyyyyyyyyyyyyyyyyy looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong meeeeeeeeeeeeeeeeeeemooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo but its just short enough!\")"
     );
 
     let mut some_bytes = [0u8; 512];


### PR DESCRIPTION
## Motivation

Rust nightly changes how Debug escapes `'`.

## Solution

Remove the `'` from the affected test.

## Review

~This is a high-priority fix, because our coverage builds will fail without it.~ This fix isn't urgent, because we pinned the rust version in our coverage builds.

@dconnolly or @oxarbitrage can review.
