### PR TITLE
Benchmark Block struct serialization code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +470,15 @@ name = "canonical-path"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
+
+[[package]]
+name = "cast"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc38c385bfd7e444464011bb24820f40dd1c76bcdfa1b78611cb7c2e5cafab75"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "cc"
@@ -635,6 +656,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools 0.10.0",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+dependencies = [
+ "cast",
+ "itertools 0.9.0",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +834,28 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "ctor"
@@ -1309,6 +1388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +1663,24 @@ name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1975,6 +2078,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2242,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07fffcddc1cb3a1de753caa4e4df03b79922ba43cf882acc1bdd7e8df9f4590"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38a02e23bd9604b842a812063aec4ef702b57989c37b655254bb61c471ad211"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2687,6 +2824,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,6 +3000,16 @@ checksum = "18b20e7752957bbe9661cff4e0bb04d183d0948cdab2ea58cdb9df36a61dfe62"
 dependencies = [
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -3198,6 +3354,16 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3783,6 +3949,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4040,6 +4217,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "color-eyre",
+ "criterion",
  "displaydoc",
  "ed25519-zebra",
  "equihash",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 default = []
 proptest-impl = ["proptest", "proptest-derive"]
+bench = ["zebra-test"]
 
 [dependencies]
 bech32 = "0.8.0"
@@ -43,6 +44,8 @@ proptest-derive = { version = "0.3.0", optional = true }
 # ZF deps
 ed25519-zebra = "2.2.0"
 redjubjub = "0.4"
+
+zebra-test = { path = "../zebra-test/", optional = true }
 
 [dev-dependencies]
 bincode = "1"

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -47,9 +47,14 @@ redjubjub = "0.4"
 [dev-dependencies]
 bincode = "1"
 color-eyre = "0.5.11"
+criterion = { version = "0.3", features = ["html_reports"] }
 spandoc = "0.2"
 tracing = "0.1.25"
 proptest = "0.10"
 proptest-derive = "0.3"
 
 zebra-test = { path = "../zebra-test/" }
+
+[[bench]]
+name = "block"
+harness = false

--- a/zebra-chain/benches/block.rs
+++ b/zebra-chain/benches/block.rs
@@ -3,7 +3,10 @@ use std::io::Cursor;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use zebra_chain::{
-    block::{tests::generate::large_multi_transaction_block, Block},
+    block::{
+        tests::generate::{large_multi_transaction_block, large_single_transaction_block},
+        Block,
+    },
     serialization::{ZcashDeserialize, ZcashSerialize},
 };
 use zebra_test::vectors::BLOCK_TESTNET_141042_BYTES;
@@ -12,32 +15,33 @@ fn block_serialization(c: &mut Criterion) {
     // Biggest block from `zebra-test`.
     let block141042_bytes: &[u8] = BLOCK_TESTNET_141042_BYTES.as_ref();
     let block141042 = Block::zcash_deserialize(Cursor::new(block141042_bytes)).unwrap();
-    // zebra_chain::block::tests::generate::large_multi_transaction_block
-    let block_gen = large_multi_transaction_block();
-    let block_gen_vec = block_gen.zcash_serialize_to_vec().unwrap();
-    let block_gen_bytes: &[u8] = block_gen_vec.as_ref();
 
-    c.bench_with_input(
-        BenchmarkId::new("zcash_serialize_to_vec", "BLOCK_TESTNET_141042"),
-        &block141042,
-        |b, block| b.iter(|| block.zcash_serialize_to_vec().unwrap()),
-    );
-    c.bench_with_input(
-        BenchmarkId::new("zcash_serialize_to_vec", "large_multi_transaction_block"),
-        &block_gen,
-        |b, block| b.iter(|| block.zcash_serialize_to_vec().unwrap()),
-    );
+    let blocks = vec![
+        ("BLOCK_TESTNET_141042", block141042),
+        (
+            "large_multi_transaction_block",
+            large_multi_transaction_block(),
+        ),
+        (
+            "large_single_transaction_block",
+            large_single_transaction_block(),
+        ),
+    ];
 
-    c.bench_with_input(
-        BenchmarkId::new("zcash_deserialize", "BLOCK_TESTNET_141042"),
-        &block141042_bytes,
-        |b, bytes| b.iter(|| Block::zcash_deserialize(Cursor::new(bytes)).unwrap()),
-    );
-    c.bench_with_input(
-        BenchmarkId::new("zcash_deserialize", "large_multi_transaction_block"),
-        &block_gen_bytes,
-        |b, bytes| b.iter(|| Block::zcash_deserialize(Cursor::new(bytes)).unwrap()),
-    );
+    for (name, block) in blocks {
+        c.bench_with_input(
+            BenchmarkId::new("zcash_serialize_to_vec", name),
+            &block,
+            |b, block| b.iter(|| block.zcash_serialize_to_vec().unwrap()),
+        );
+
+        let block_bytes = block.zcash_serialize_to_vec().unwrap();
+        c.bench_with_input(
+            BenchmarkId::new("zcash_deserialize", "BLOCK_TESTNET_141042"),
+            &block_bytes,
+            |b, bytes| b.iter(|| Block::zcash_deserialize(Cursor::new(bytes)).unwrap()),
+        );
+    }
 }
 
 criterion_group!(

--- a/zebra-chain/benches/block.rs
+++ b/zebra-chain/benches/block.rs
@@ -14,6 +14,8 @@ fn block_serialization(c: &mut Criterion) {
     let block141042 = Block::zcash_deserialize(Cursor::new(block141042_bytes)).unwrap();
     // zebra_chain::block::tests::generate::large_multi_transaction_block
     let block_gen = large_multi_transaction_block();
+    let block_gen_vec = block_gen.zcash_serialize_to_vec().unwrap();
+    let block_gen_bytes: &[u8] = block_gen_vec.as_ref();
 
     c.bench_with_input(
         BenchmarkId::new("zcash_serialize_to_vec", "BLOCK_TESTNET_141042"),
@@ -24,6 +26,17 @@ fn block_serialization(c: &mut Criterion) {
         BenchmarkId::new("zcash_serialize_to_vec", "large_multi_transaction_block"),
         &block_gen,
         |b, block| b.iter(|| block.zcash_serialize_to_vec().unwrap()),
+    );
+
+    c.bench_with_input(
+        BenchmarkId::new("zcash_deserialize", "BLOCK_TESTNET_141042"),
+        &block141042_bytes,
+        |b, bytes| b.iter(|| Block::zcash_deserialize(Cursor::new(bytes)).unwrap()),
+    );
+    c.bench_with_input(
+        BenchmarkId::new("zcash_deserialize", "large_multi_transaction_block"),
+        &block_gen_bytes,
+        |b, bytes| b.iter(|| Block::zcash_deserialize(Cursor::new(bytes)).unwrap()),
     );
 }
 

--- a/zebra-chain/benches/block.rs
+++ b/zebra-chain/benches/block.rs
@@ -1,0 +1,28 @@
+use std::io::Cursor;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use zebra_chain::{
+    block::Block,
+    serialization::{ZcashDeserialize, ZcashSerialize},
+};
+use zebra_test::vectors::BLOCK_TESTNET_141042_BYTES;
+
+fn block_serialization(c: &mut Criterion) {
+    // Biggest block from `zebra-test`.
+    let block_bytes: &[u8] = BLOCK_TESTNET_141042_BYTES.as_ref();
+    let block = Block::zcash_deserialize(Cursor::new(block_bytes)).unwrap();
+
+    c.bench_with_input(
+        BenchmarkId::new("zcash_serialize_to_vec", "BLOCK_TESTNET_141042"),
+        &block,
+        |b, block| b.iter(|| block.zcash_serialize_to_vec().unwrap()),
+    );
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().noise_threshold(0.05);
+    targets = block_serialization
+);
+criterion_main!(benches);

--- a/zebra-chain/benches/block.rs
+++ b/zebra-chain/benches/block.rs
@@ -37,7 +37,7 @@ fn block_serialization(c: &mut Criterion) {
 
         let block_bytes = block.zcash_serialize_to_vec().unwrap();
         c.bench_with_input(
-            BenchmarkId::new("zcash_deserialize", "BLOCK_TESTNET_141042"),
+            BenchmarkId::new("zcash_deserialize", name),
             &block_bytes,
             |b, bytes| b.iter(|| Block::zcash_deserialize(Cursor::new(bytes)).unwrap()),
         );

--- a/zebra-chain/benches/block.rs
+++ b/zebra-chain/benches/block.rs
@@ -3,19 +3,26 @@ use std::io::Cursor;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use zebra_chain::{
-    block::Block,
+    block::{tests::generate::large_multi_transaction_block, Block},
     serialization::{ZcashDeserialize, ZcashSerialize},
 };
 use zebra_test::vectors::BLOCK_TESTNET_141042_BYTES;
 
 fn block_serialization(c: &mut Criterion) {
     // Biggest block from `zebra-test`.
-    let block_bytes: &[u8] = BLOCK_TESTNET_141042_BYTES.as_ref();
-    let block = Block::zcash_deserialize(Cursor::new(block_bytes)).unwrap();
+    let block141042_bytes: &[u8] = BLOCK_TESTNET_141042_BYTES.as_ref();
+    let block141042 = Block::zcash_deserialize(Cursor::new(block141042_bytes)).unwrap();
+    // zebra_chain::block::tests::generate::large_multi_transaction_block
+    let block_gen = large_multi_transaction_block();
 
     c.bench_with_input(
         BenchmarkId::new("zcash_serialize_to_vec", "BLOCK_TESTNET_141042"),
-        &block,
+        &block141042,
+        |b, block| b.iter(|| block.zcash_serialize_to_vec().unwrap()),
+    );
+    c.bench_with_input(
+        BenchmarkId::new("zcash_serialize_to_vec", "large_multi_transaction_block"),
+        &block_gen,
         |b, block| b.iter(|| block.zcash_serialize_to_vec().unwrap()),
     );
 }

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -11,8 +11,8 @@ pub mod merkle;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 mod arbitrary;
-#[cfg(test)]
-mod tests;
+#[cfg(any(test, feature = "bench"))]
+pub mod tests;
 
 use std::fmt;
 

--- a/zebra-chain/src/block/tests.rs
+++ b/zebra-chain/src/block/tests.rs
@@ -1,8 +1,6 @@
 // XXX generate should be rewritten as strategies
-#[cfg(feature = "bench")]
+#[cfg(any(test, feature = "bench"))]
 pub mod generate;
-#[cfg(test)]
-mod generate;
 #[cfg(test)]
 mod preallocate;
 #[cfg(test)]

--- a/zebra-chain/src/block/tests.rs
+++ b/zebra-chain/src/block/tests.rs
@@ -1,5 +1,11 @@
 // XXX generate should be rewritten as strategies
+#[cfg(feature = "bench")]
+pub mod generate;
+#[cfg(test)]
 mod generate;
+#[cfg(test)]
 mod preallocate;
+#[cfg(test)]
 mod prop;
+#[cfg(test)]
 mod vectors;


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->

For resolving #1774 there should be a way to determine that improvement was introduced. Benchmark is a good way to see performance changes.
I do not think that it's required to benchmark all structs which implement `ZcashSerialize`. `Block` uses a lot (all?) of structs internally, so only `Block` should be enough.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->

Add a simple benchmark for the biggest block from `zebra-test` created with [criterion](https://crates.io/crates/criterion).

<!--
The code in this pull request has:
  - [ ] Documentation Comments
  - [ ] Unit Tests and Property Tests
-->

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

## Related Issues

Should close https://github.com/ZcashFoundation/zebra/issues/2019.
<!--
Please link to any existing GitHub issues pertaining to this PR.
-->

## Follow Up Work

Create tracking issue for adding benchmarks to CI once this PR is merged.

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
