### PR TITLE
Implement Sapling serialization in Transaction V5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,6 +1580,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4044,6 +4053,7 @@ dependencies = [
  "equihash",
  "futures 0.3.14",
  "hex",
+ "itertools",
  "jubjub",
  "lazy_static",
  "primitive-types",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -46,9 +46,13 @@ redjubjub = "0.4"
 
 [dev-dependencies]
 bincode = "1"
+
 color-eyre = "0.5.11"
 spandoc = "0.2"
 tracing = "0.1.25"
+
+itertools = "0.10.0"
+
 proptest = "0.10"
 proptest-derive = "0.3"
 

--- a/zebra-chain/src/block/tests/prop.rs
+++ b/zebra-chain/src/block/tests/prop.rs
@@ -17,7 +17,12 @@ proptest! {
         let bytes = hash.zcash_serialize_to_vec()?;
         let other_hash: Hash = bytes.zcash_deserialize_into()?;
 
-        prop_assert_eq![hash, other_hash];
+        prop_assert_eq![&hash, &other_hash];
+
+        let bytes2 = other_hash
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+        prop_assert_eq![bytes, bytes2, "bytes must be equal if structs are equal"];
     }
 
     #[test]
@@ -36,7 +41,12 @@ proptest! {
         let bytes = header.zcash_serialize_to_vec()?;
         let other_header = bytes.zcash_deserialize_into()?;
 
-        prop_assert_eq![header, other_header];
+        prop_assert_eq![&header, &other_header];
+
+        let bytes2 = other_header
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+        prop_assert_eq![bytes, bytes2, "bytes must be equal if structs are equal"];
     }
 
     #[test]
@@ -70,7 +80,6 @@ proptest! {
         zebra_test::init();
 
         let bytes = block.zcash_serialize_to_vec()?;
-        let bytes = &mut bytes.as_slice();
 
         // Check the block commitment
         let commitment = block.commitment(network);
@@ -84,7 +93,12 @@ proptest! {
             // Check deserialization
             let other_block = bytes.zcash_deserialize_into()?;
 
-            prop_assert_eq![block, other_block];
+            prop_assert_eq![&block, &other_block];
+
+            let bytes2 = other_block
+                .zcash_serialize_to_vec()
+                .expect("vec serialization is infallible");
+            prop_assert_eq![bytes, bytes2, "bytes must be equal if structs are equal"];
         } else {
             let serialization_err = bytes.zcash_deserialize_into::<Block>()
                 .expect_err("blocks larger than the maximum size should fail");

--- a/zebra-chain/src/block/tests/vectors.rs
+++ b/zebra-chain/src/block/tests/vectors.rs
@@ -72,14 +72,15 @@ fn deserialize_blockheader() {
 }
 
 #[test]
-fn deserialize_block() {
+fn round_trip_blocks() {
     zebra_test::init();
 
-    // this one has a bad version field
+    // this one has a bad version field, but it is still valid
     zebra_test::vectors::BLOCK_MAINNET_434873_BYTES
         .zcash_deserialize_into::<Block>()
-        .expect("block test vector should deserialize");
+        .expect("bad version block test vector should deserialize");
 
+    // now do a round-trip test on all the block test vectors
     for block_bytes in zebra_test::vectors::BLOCKS.iter() {
         let block = block_bytes
             .zcash_deserialize_into::<Block>()

--- a/zebra-chain/src/sapling.rs
+++ b/zebra-chain/src/sapling.rs
@@ -24,4 +24,4 @@ pub use output::{Output, OutputInTransactionV4, OutputPrefixInTransactionV5};
 pub use shielded_data::{
     AnchorVariant, FieldNotPresent, PerSpendAnchor, SharedAnchor, ShieldedData,
 };
-pub use spend::Spend;
+pub use spend::{Spend, SpendPrefixInTransactionV5};

--- a/zebra-chain/src/sapling.rs
+++ b/zebra-chain/src/sapling.rs
@@ -5,22 +5,22 @@ mod address;
 mod arbitrary;
 mod commitment;
 mod note;
-mod output;
-mod spend;
 #[cfg(test)]
 mod tests;
 
 // XXX clean up these modules
 
 pub mod keys;
+pub mod output;
 pub mod shielded_data;
+pub mod spend;
 pub mod tree;
 
 pub use address::Address;
 pub use commitment::{CommitmentRandomness, NoteCommitment, ValueCommitment};
 pub use keys::Diversifier;
 pub use note::{EncryptedNote, Note, Nullifier, WrappedNoteKey};
-pub use output::{Output, OutputInTransactionV4};
+pub use output::{Output, OutputInTransactionV4, OutputPrefixInTransactionV5};
 pub use shielded_data::{
     AnchorVariant, FieldNotPresent, PerSpendAnchor, SharedAnchor, ShieldedData,
 };

--- a/zebra-chain/src/sapling/tests/prop.rs
+++ b/zebra-chain/src/sapling/tests/prop.rs
@@ -20,7 +20,12 @@ proptest! {
 
         let data = spend.zcash_serialize_to_vec().expect("spend should serialize");
         let spend_parsed = data.zcash_deserialize_into().expect("randomized spend should deserialize");
-        prop_assert_eq![spend, spend_parsed];
+        prop_assert_eq![&spend, &spend_parsed];
+
+        let data2 = spend_parsed
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+        prop_assert_eq![data, data2, "data must be equal if structs are equal"];
     }
 
     /// Serialize and deserialize `Spend<SharedAnchor>`
@@ -34,15 +39,30 @@ proptest! {
 
         let data = prefix.zcash_serialize_to_vec().expect("spend prefix should serialize");
         let parsed = data.zcash_deserialize_into().expect("randomized spend prefix should deserialize");
-        prop_assert_eq![prefix, parsed];
+        prop_assert_eq![&prefix, &parsed];
+
+        let data2 = parsed
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+        prop_assert_eq![data, data2, "data must be equal if structs are equal"];
 
         let data = zkproof.zcash_serialize_to_vec().expect("spend zkproof should serialize");
         let parsed = data.zcash_deserialize_into().expect("randomized spend zkproof should deserialize");
-        prop_assert_eq![zkproof, parsed];
+        prop_assert_eq![&zkproof, &parsed];
+
+        let data2 = parsed
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+        prop_assert_eq![data, data2, "data must be equal if structs are equal"];
 
         let data = spend_auth_sig.zcash_serialize_to_vec().expect("spend auth sig should serialize");
         let parsed = data.zcash_deserialize_into().expect("randomized spend auth sig should deserialize");
-        prop_assert_eq![spend_auth_sig, parsed];
+        prop_assert_eq![&spend_auth_sig, &parsed];
+
+        let data2 = parsed
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+        prop_assert_eq![data, data2, "data must be equal if structs are equal"];
     }
 
     /// Serialize and deserialize `Output`
@@ -57,17 +77,32 @@ proptest! {
         let output_parsed = data.zcash_deserialize_into::<OutputInTransactionV4>().expect("randomized output should deserialize").into_output();
         prop_assert_eq![&output, &output_parsed];
 
+        let data2 = output_parsed
+            .into_v4()
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+        prop_assert_eq![data, data2, "data must be equal if structs are equal"];
+
         // v5 format
         let (prefix, zkproof) = output.into_v5_parts();
 
         let data = prefix.zcash_serialize_to_vec().expect("output prefix should serialize");
         let parsed = data.zcash_deserialize_into().expect("randomized output prefix should deserialize");
-        prop_assert_eq![prefix, parsed];
+        prop_assert_eq![&prefix, &parsed];
+
+        let data2 = parsed
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+        prop_assert_eq![data, data2, "data must be equal if structs are equal"];
 
         let data = zkproof.zcash_serialize_to_vec().expect("output zkproof should serialize");
         let parsed = data.zcash_deserialize_into().expect("randomized output zkproof should deserialize");
-        prop_assert_eq![zkproof, parsed];
+        prop_assert_eq![&zkproof, &parsed];
 
+        let data2 = parsed
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+        prop_assert_eq![data, data2, "data must be equal if structs are equal"];
     }
 }
 
@@ -94,7 +129,12 @@ proptest! {
         };
         let data = tx.zcash_serialize_to_vec().expect("tx should serialize");
         let tx_parsed = data.zcash_deserialize_into().expect("randomized tx should deserialize");
-        prop_assert_eq![tx, tx_parsed];
+        prop_assert_eq![&tx, &tx_parsed];
+
+        let data2 = tx_parsed
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+        prop_assert_eq![data, data2, "data must be equal if structs are equal"];
     }
 
     /// Serialize and deserialize `SharedAnchor` shielded data by including it
@@ -119,7 +159,12 @@ proptest! {
         };
         let data = tx.zcash_serialize_to_vec().expect("tx should serialize");
         let tx_parsed = data.zcash_deserialize_into().expect("randomized tx should deserialize");
-        prop_assert_eq![tx, tx_parsed];
+        prop_assert_eq![&tx, &tx_parsed];
+
+        let data2 = tx_parsed
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+        prop_assert_eq![data, data2, "data must be equal if structs are equal"];
     }
 
     /// Check that ShieldedData<PerSpendAnchor> is equal when `first` is swapped

--- a/zebra-chain/src/sapling/tests/prop.rs
+++ b/zebra-chain/src/sapling/tests/prop.rs
@@ -74,8 +74,6 @@ proptest! {
 proptest! {
     /// Serialize and deserialize `PerSpendAnchor` shielded data by including it
     /// in a V4 transaction
-    //
-    // TODO: write a similar test for `ShieldedData<SharedAnchor>` (#1829)
     #[test]
     fn shielded_data_v4_roundtrip(
         shielded_v4 in any::<sapling::ShieldedData<PerSpendAnchor>>(),
@@ -99,12 +97,37 @@ proptest! {
         prop_assert_eq![tx, tx_parsed];
     }
 
+    /// Serialize and deserialize `SharedAnchor` shielded data by including it
+    /// in a V5 transaction
+    #[test]
+    fn shielded_data_v5_roundtrip(
+        shielded_v5 in any::<sapling::ShieldedData<SharedAnchor>>(),
+    ) {
+        zebra_test::init();
+
+        // shielded data doesn't serialize by itself, so we have to stick it in
+        // a transaction
+
+        // stick `SharedAnchor` shielded data into a v4 transaction
+        let tx = Transaction::V5 {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            lock_time: LockTime::min_lock_time(),
+            expiry_height: block::Height(0),
+            sapling_shielded_data: Some(shielded_v5),
+            rest: Vec::new(),
+        };
+        let data = tx.zcash_serialize_to_vec().expect("tx should serialize");
+        let tx_parsed = data.zcash_deserialize_into().expect("randomized tx should deserialize");
+        prop_assert_eq![tx, tx_parsed];
+    }
+
     /// Check that ShieldedData<PerSpendAnchor> is equal when `first` is swapped
     /// between a spend and an output
-    //
-    // TODO: write a similar test for `ShieldedData<SharedAnchor>` (#1829)
     #[test]
-    fn shielded_data_per_spend_swap_first_eq(shielded1 in any::<sapling::ShieldedData<PerSpendAnchor>>()) {
+    fn shielded_data_per_spend_swap_first_eq(
+        shielded1 in any::<sapling::ShieldedData<PerSpendAnchor>>()
+    ) {
         use Either::*;
 
         zebra_test::init();
@@ -157,12 +180,71 @@ proptest! {
         prop_assert_eq![data1, data2];
     }
 
+    /// Check that ShieldedData<SharedAnchor> is equal when `first` is swapped
+    /// between a spend and an output
+    #[test]
+    fn shielded_data_shared_swap_first_eq(
+        shielded1 in any::<sapling::ShieldedData<SharedAnchor>>()
+    ) {
+        use Either::*;
+
+        zebra_test::init();
+
+        // we need at least one spend and one output to swap them
+        prop_assume!(shielded1.spends().count() > 0 && shielded1.outputs().count() > 0);
+
+        let mut shielded2 = shielded1.clone();
+        let mut spends: Vec<_> = shielded2.spends().cloned().collect();
+        let mut outputs: Vec<_> = shielded2.outputs().cloned().collect();
+        match shielded2.first {
+            Left(_spend) => {
+                shielded2.first = Right(outputs.remove(0));
+                shielded2.rest_outputs = outputs;
+                shielded2.rest_spends = spends;
+            }
+            Right(_output) => {
+                shielded2.first = Left(spends.remove(0));
+                shielded2.rest_spends = spends;
+                shielded2.rest_outputs = outputs;
+            }
+        }
+
+        prop_assert_eq![&shielded1, &shielded2];
+
+        // shielded data doesn't serialize by itself, so we have to stick it in
+        // a transaction
+        let tx1 = Transaction::V5 {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            lock_time: LockTime::min_lock_time(),
+            expiry_height: block::Height(0),
+            sapling_shielded_data: Some(shielded1),
+            rest: Vec::new()
+        };
+        let tx2 = Transaction::V5 {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            lock_time: LockTime::min_lock_time(),
+            expiry_height: block::Height(0),
+            sapling_shielded_data: Some(shielded2),
+            rest: Vec::new()
+        };
+
+        prop_assert_eq![&tx1, &tx2];
+
+        let data1 = tx1.zcash_serialize_to_vec().expect("tx1 should serialize");
+        let data2 = tx2.zcash_serialize_to_vec().expect("tx2 should serialize");
+
+        prop_assert_eq![data1, data2];
+    }
+
     /// Check that ShieldedData<PerSpendAnchor> serialization is equal if
     /// `shielded1 == shielded2`
-    //
-    // TODO: write a similar test for `ShieldedData<SharedAnchor>` (#1829)
     #[test]
-    fn shielded_data_per_spend_serialize_eq(shielded1 in any::<sapling::ShieldedData<PerSpendAnchor>>(), shielded2 in any::<sapling::ShieldedData<PerSpendAnchor>>()) {
+    fn shielded_data_per_spend_serialize_eq(
+        shielded1 in any::<sapling::ShieldedData<PerSpendAnchor>>(),
+        shielded2 in any::<sapling::ShieldedData<PerSpendAnchor>>()
+    ) {
         zebra_test::init();
 
         let shielded_eq = shielded1 == shielded2;
@@ -202,14 +284,61 @@ proptest! {
         }
     }
 
+    /// Check that ShieldedData<SharedAnchor> serialization is equal if
+    /// `shielded1 == shielded2`
+    #[test]
+    fn shielded_data_shared_serialize_eq(
+        shielded1 in any::<sapling::ShieldedData<SharedAnchor>>(),
+        shielded2 in any::<sapling::ShieldedData<SharedAnchor>>()
+    ) {
+        zebra_test::init();
+
+        let shielded_eq = shielded1 == shielded2;
+
+        // shielded data doesn't serialize by itself, so we have to stick it in
+        // a transaction
+        let tx1 = Transaction::V5 {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            lock_time: LockTime::min_lock_time(),
+            expiry_height: block::Height(0),
+            sapling_shielded_data: Some(shielded1),
+            rest: Vec::new(),
+        };
+        let tx2 = Transaction::V5 {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            lock_time: LockTime::min_lock_time(),
+            expiry_height: block::Height(0),
+            sapling_shielded_data: Some(shielded2),
+            rest: Vec::new(),
+        };
+
+        if shielded_eq {
+            prop_assert_eq![&tx1, &tx2];
+        } else {
+            prop_assert_ne![&tx1, &tx2];
+        }
+
+        let data1 = tx1.zcash_serialize_to_vec().expect("tx1 should serialize");
+        let data2 = tx2.zcash_serialize_to_vec().expect("tx2 should serialize");
+
+        if shielded_eq {
+            prop_assert_eq![data1, data2];
+        } else {
+            prop_assert_ne![data1, data2];
+        }
+    }
+
     /// Check that ShieldedData<PerSpendAnchor> serialization is equal when we
     /// replace all the known fields.
     ///
     /// This test checks for extra fields that are not in `ShieldedData::eq`.
-    //
-    // TODO: write a similar test for `ShieldedData<SharedAnchor>` (#1829)
     #[test]
-    fn shielded_data_per_spend_field_assign_eq(shielded1 in any::<sapling::ShieldedData<PerSpendAnchor>>(), shielded2 in any::<sapling::ShieldedData<PerSpendAnchor>>()) {
+    fn shielded_data_per_spend_field_assign_eq(
+        shielded1 in any::<sapling::ShieldedData<PerSpendAnchor>>(),
+        shielded2 in any::<sapling::ShieldedData<PerSpendAnchor>>()
+    ) {
         zebra_test::init();
 
         let mut shielded2 = shielded2;
@@ -243,6 +372,58 @@ proptest! {
             expiry_height: block::Height(0),
             joinsplit_data: None,
             sapling_shielded_data: Some(shielded2),
+        };
+
+        prop_assert_eq![&tx1, &tx2];
+
+        let data1 = tx1.zcash_serialize_to_vec().expect("tx1 should serialize");
+        let data2 = tx2.zcash_serialize_to_vec().expect("tx2 should serialize");
+
+        prop_assert_eq![data1, data2];
+    }
+
+    /// Check that ShieldedData<SharedAnchor> serialization is equal when we
+    /// replace all the known fields.
+    ///
+    /// This test checks for extra fields that are not in `ShieldedData::eq`.
+    #[test]
+    fn shielded_data_shared_field_assign_eq(
+        shielded1 in any::<sapling::ShieldedData<SharedAnchor>>(),
+        shielded2 in any::<sapling::ShieldedData<SharedAnchor>>()
+    ) {
+        zebra_test::init();
+
+        let mut shielded2 = shielded2;
+
+        // these fields must match ShieldedData::eq
+        // the spends() and outputs() checks cover first, rest_spends, and rest_outputs
+        shielded2.first = shielded1.first.clone();
+        shielded2.rest_spends = shielded1.rest_spends.clone();
+        shielded2.rest_outputs = shielded1.rest_outputs.clone();
+        // now for the fields that are checked literally
+        shielded2.value_balance = shielded1.value_balance;
+        shielded2.shared_anchor = shielded1.shared_anchor;
+        shielded2.binding_sig = shielded1.binding_sig;
+
+        prop_assert_eq![&shielded1, &shielded2];
+
+        // shielded data doesn't serialize by itself, so we have to stick it in
+        // a transaction
+        let tx1 = Transaction::V5 {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            lock_time: LockTime::min_lock_time(),
+            expiry_height: block::Height(0),
+            sapling_shielded_data: Some(shielded1),
+            rest: Vec::new(),
+        };
+        let tx2 = Transaction::V5 {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            lock_time: LockTime::min_lock_time(),
+            expiry_height: block::Height(0),
+            sapling_shielded_data: Some(shielded2),
+            rest: Vec::new(),
         };
 
         prop_assert_eq![&tx1, &tx2];

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -257,7 +257,7 @@ impl Arbitrary for sapling::ShieldedData<sapling::SharedAnchor> {
         )
             .prop_map(
                 |(value_balance, shared_anchor, first, rest_spends, rest_outputs, sig_bytes)| {
-                    Self {
+                    let mut shielded_data = Self {
                         value_balance,
                         shared_anchor,
                         first,
@@ -268,7 +268,12 @@ impl Arbitrary for sapling::ShieldedData<sapling::SharedAnchor> {
                             b.copy_from_slice(sig_bytes.as_slice());
                             b
                         }),
+                    };
+                    if shielded_data.spends().count() == 0 {
+                        // Todo: delete field when there is no spend
+                        shielded_data.shared_anchor = Default::default();
                     }
+                    shielded_data
                 },
             )
             .boxed()

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -117,9 +117,9 @@ impl ZcashSerialize for Option<sapling::ShieldedData<SharedAnchor>> {
                     })
                     .collect::<Vec<_>>();
 
-                // nSpendsSapling - vSpendsSapling
+                // nSpendsSapling and vSpendsSapling
                 spend_prefixes.zcash_serialize(&mut writer)?;
-                // nOutputsSapling - vOutputsSapling
+                // nOutputsSapling and vOutputsSapling
                 output_prefixes.zcash_serialize(&mut writer)?;
 
                 // valueBalanceSapling
@@ -130,15 +130,15 @@ impl ZcashSerialize for Option<sapling::ShieldedData<SharedAnchor>> {
                     writer.write_all(&<[u8; 32]>::from(shielded_data.shared_anchor)[..])?;
                 }
 
-                // vSpendProofSapling
+                // vSpendProofsSapling
                 zcash_serialize_external_count(&spend_proofs, &mut writer)?;
                 // vSpendAuthSigsSapling
                 zcash_serialize_external_count(&spend_sigs, &mut writer)?;
 
-                // vOutputProofSapling
+                // vOutputProofsSapling
                 zcash_serialize_external_count(&output_proofs, &mut writer)?;
 
-                // Serialize binding sig
+                // bindingSigSapling
                 writer.write_all(&<[u8; 64]>::from(shielded_data.binding_sig)[..])?;
             }
         }
@@ -149,11 +149,11 @@ impl ZcashSerialize for Option<sapling::ShieldedData<SharedAnchor>> {
 
 impl ZcashDeserialize for Option<sapling::ShieldedData<SharedAnchor>> {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        // nSpendsSapling - vSpendsSapling
+        // nSpendsSapling and vSpendsSapling
         let spend_prefixes =
             Vec::<sapling::spend::SpendPrefixInTransactionV5>::zcash_deserialize(&mut reader)?;
 
-        // nOutputsSapling - vOutputsSapling
+        // nOutputsSapling and vOutputsSapling
         let output_prefixes =
             Vec::<sapling::output::OutputPrefixInTransactionV5>::zcash_deserialize(&mut reader)?;
 
@@ -173,10 +173,10 @@ impl ZcashDeserialize for Option<sapling::ShieldedData<SharedAnchor>> {
             shared_anchor = Some(sapling::tree::Root(reader.read_32_bytes()?));
         }
 
-        // vSpendsProofSapling
+        // vSpendProofsSapling
         let spend_proofs: Vec<Groth16Proof> =
             zcash_deserialize_external_count(spends_count, &mut reader)?;
-        // vSpendAuthSigSapling
+        // vSpendAuthSigsSapling
         let spend_sigs: Vec<redjubjub::Signature<redjubjub::SpendAuth>> =
             zcash_deserialize_external_count(spends_count, &mut reader)?;
 

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -257,9 +257,10 @@ impl ZcashSerialize for Transaction {
                         shielded_data.value_balance.zcash_serialize(&mut writer)?;
 
                         // anchorSapling
-                        if spend_prefixes.len() > 0 {
+                        if !spend_prefixes.is_empty() {
                             writer.write_all(&<[u8; 32]>::from(shielded_data.shared_anchor)[..])?;
                         }
+
                         // vSpendProofSapling
                         zcash_serialize_external_count(&spend_proofs, &mut writer)?;
                         // vSpendAuthSigsSapling

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -439,8 +439,8 @@ impl ZcashDeserialize for Transaction {
                     for i in 0..spends_count {
                         shielded_spends.push(sapling::Spend::from_v5_parts(
                             spend_prefixes[i].clone(),
-                            spend_proofs[i].clone(),
-                            spend_sigs[i].clone(),
+                            spend_proofs[i],
+                            spend_sigs[i],
                         ));
                     }
                 }
@@ -451,7 +451,7 @@ impl ZcashDeserialize for Transaction {
                     for i in 0..outputs_count {
                         shielded_outputs.push(sapling::Output::from_v5_parts(
                             output_prefixes[i].clone(),
-                            output_proofs[i].clone(),
+                            output_proofs[i],
                         ));
                     }
                 }

--- a/zebra-chain/src/transaction/tests/prop.rs
+++ b/zebra-chain/src/transaction/tests/prop.rs
@@ -13,7 +13,13 @@ proptest! {
         let data = tx.zcash_serialize_to_vec().expect("tx should serialize");
         let tx2 = data.zcash_deserialize_into().expect("randomized tx should deserialize");
 
-        prop_assert_eq![tx, tx2];
+        prop_assert_eq![&tx, &tx2];
+
+        let data2 = tx2
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+
+        prop_assert_eq![data, data2, "data must be equal if structs are equal"];
     }
 
     #[test]

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -6,7 +6,9 @@ use crate::{
     serialization::{WriteZcashExt, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
 };
 
+use block::MAX_BLOCK_BYTES;
 use itertools::Itertools;
+use std::convert::TryInto;
 
 #[test]
 fn librustzcash_tx_deserialize_and_round_trip() {
@@ -156,6 +158,132 @@ fn empty_v4_round_trip() {
     assert_eq!(data, data2, "data must be equal if structs are equal");
 }
 
+/// Do a round-trip test on fake v5 transactions created from v4 transactions
+/// in the block test vectors.
+///
+/// Covers Sapling only, Transparent only, and Sapling/Transparent v5
+/// transactions.
+#[test]
+fn fake_v5_round_trip() {
+    zebra_test::init();
+
+    for original_bytes in zebra_test::vectors::BLOCKS.iter() {
+        let original_block = original_bytes
+            .zcash_deserialize_into::<Block>()
+            .expect("block is structurally valid");
+
+        // skip this block if it only contains v5 transactions,
+        // the block round-trip test covers it already
+        if original_block
+            .transactions
+            .iter()
+            .all(|trans| matches!(trans.as_ref(), &Transaction::V5 { .. }))
+        {
+            continue;
+        }
+
+        let mut fake_block = original_block.clone();
+        fake_block.transactions = fake_block
+            .transactions
+            .iter()
+            .map(AsRef::as_ref)
+            .map(transaction_to_fake_v5)
+            .map(Into::into)
+            .collect();
+
+        // test each transaction
+        for (original_tx, fake_tx) in original_block
+            .transactions
+            .iter()
+            .zip(fake_block.transactions.iter())
+        {
+            assert_ne!(
+                &original_tx, &fake_tx,
+                "v1-v4 transactions must change when converted to fake v5"
+            );
+
+            let fake_bytes = fake_tx
+                .zcash_serialize_to_vec()
+                .expect("vec serialization is infallible");
+
+            assert_ne!(
+                &original_bytes[..],
+                fake_bytes,
+                "v1-v4 transaction data must change when converted to fake v5"
+            );
+
+            let fake_tx2 = fake_bytes
+                .zcash_deserialize_into::<Transaction>()
+                .expect("tx is structurally valid");
+
+            assert_eq!(fake_tx.as_ref(), &fake_tx2);
+
+            let fake_bytes2 = fake_tx2
+                .zcash_serialize_to_vec()
+                .expect("vec serialization is infallible");
+
+            assert_eq!(
+                fake_bytes, fake_bytes2,
+                "data must be equal if structs are equal"
+            );
+        }
+
+        // test full blocks
+        assert_ne!(
+            &original_block, &fake_block,
+            "v1-v4 transactions must change when converted to fake v5"
+        );
+
+        let fake_bytes = fake_block
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+
+        assert_ne!(
+            &original_bytes[..],
+            fake_bytes,
+            "v1-v4 transaction data must change when converted to fake v5"
+        );
+
+        // skip fake blocks which exceed the block size limit
+        // because of the changes we made
+        if fake_bytes.len() > MAX_BLOCK_BYTES.try_into().unwrap() {
+            continue;
+        }
+
+        let fake_block2 = match fake_bytes.zcash_deserialize_into::<Block>() {
+            Ok(fake_block2) => fake_block2,
+            Err(err) => {
+                // TODO: work out why transaction parsing succeeds,
+                //       but block parsing doesn't
+                tracing::info!(
+                    ?err,
+                    ?original_block,
+                    ?fake_block,
+                    hex_original_bytes = ?hex::encode(&original_bytes),
+                    hex_fake_bytes = ?hex::encode(&fake_bytes),
+                    original_bytes_len = %original_bytes.len(),
+                    fake_bytes_len = %fake_bytes.len(),
+                    %MAX_BLOCK_BYTES,
+                    "unexpected structurally invalid block during deserialization"
+                );
+
+                continue;
+            }
+        };
+
+        assert_eq!(fake_block, fake_block2);
+
+        let fake_bytes2 = fake_block2
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+
+        assert_eq!(
+            fake_bytes, fake_bytes2,
+            "data must be equal if structs are equal"
+        );
+    }
+}
+
 // Utility functions
 
 /// Return serialized empty Transaction::V5 Orchard data.
@@ -170,4 +298,131 @@ fn empty_v5_orchard_data() -> Vec<u8> {
 
     // all other orchard fields are only present when `nActionsOrchard > 0`
     buf
+}
+
+/// Convert `trans` into a fake v5 transaction,
+/// converting sapling shielded data from v4 to v5 if possible.
+fn transaction_to_fake_v5(trans: &Transaction) -> Transaction {
+    use Transaction::*;
+
+    match trans {
+        V1 {
+            inputs,
+            outputs,
+            lock_time,
+        } => V5 {
+            inputs: inputs.to_vec(),
+            outputs: outputs.to_vec(),
+            lock_time: *lock_time,
+            expiry_height: block::Height(0),
+            sapling_shielded_data: None,
+            rest: empty_v5_orchard_data(),
+        },
+        V2 {
+            inputs,
+            outputs,
+            lock_time,
+            ..
+        } => V5 {
+            inputs: inputs.to_vec(),
+            outputs: outputs.to_vec(),
+            lock_time: *lock_time,
+            expiry_height: block::Height(0),
+            sapling_shielded_data: None,
+            rest: empty_v5_orchard_data(),
+        },
+        V3 {
+            inputs,
+            outputs,
+            lock_time,
+            expiry_height,
+            ..
+        } => V5 {
+            inputs: inputs.to_vec(),
+            outputs: outputs.to_vec(),
+            lock_time: *lock_time,
+            expiry_height: *expiry_height,
+            sapling_shielded_data: None,
+            rest: empty_v5_orchard_data(),
+        },
+        V4 {
+            inputs,
+            outputs,
+            lock_time,
+            expiry_height,
+            sapling_shielded_data,
+            ..
+        } => V5 {
+            inputs: inputs.to_vec(),
+            outputs: outputs.to_vec(),
+            lock_time: *lock_time,
+            expiry_height: *expiry_height,
+            sapling_shielded_data: sapling_shielded_data
+                .clone()
+                .map(sapling_shielded_v4_to_fake_v5)
+                .flatten(),
+            rest: empty_v5_orchard_data(),
+        },
+        v5 @ V5 { .. } => v5.clone(),
+    }
+}
+
+/// Convert a v4 sapling shielded data into a fake v5 sapling shielded data,
+/// if possible.
+fn sapling_shielded_v4_to_fake_v5(
+    v4_shielded: sapling::ShieldedData<PerSpendAnchor>,
+) -> Option<sapling::ShieldedData<SharedAnchor>> {
+    use futures::future::Either::*;
+    use sapling::ShieldedData;
+
+    let unique_anchors: Vec<_> = v4_shielded
+        .spends()
+        .map(|spend| spend.per_spend_anchor)
+        .unique()
+        .collect();
+
+    let shared_anchor = match unique_anchors.as_slice() {
+        [unique_anchor] => *unique_anchor,
+        // TODO: remove shared anchor when there are no spends
+        [] => Default::default(),
+        // Multiple different anchors, can't convert to v5
+        _ => return None,
+    };
+
+    let first = match v4_shielded.first {
+        Left(spend) => Left(sapling_spend_v4_to_fake_v5(spend)),
+        Right(output) => Right(output),
+    };
+
+    let fake_shielded_v5 = ShieldedData::<SharedAnchor> {
+        value_balance: v4_shielded.value_balance,
+        shared_anchor,
+        first,
+        rest_spends: v4_shielded
+            .rest_spends
+            .iter()
+            .cloned()
+            .map(sapling_spend_v4_to_fake_v5)
+            .collect(),
+        rest_outputs: v4_shielded.rest_outputs,
+        binding_sig: v4_shielded.binding_sig,
+    };
+
+    Some(fake_shielded_v5)
+}
+
+/// Convert a v4 sapling spend into a fake v5 sapling spend.
+fn sapling_spend_v4_to_fake_v5(
+    v4_spend: sapling::Spend<PerSpendAnchor>,
+) -> sapling::Spend<SharedAnchor> {
+    use sapling::Spend;
+
+    Spend::<SharedAnchor> {
+        cv: v4_spend.cv,
+        per_spend_anchor: FieldNotPresent,
+        nullifier: v4_spend.nullifier,
+        rk: v4_spend.rk,
+        zkproof: v4_spend.zkproof,
+        spend_auth_sig: v4_spend.spend_auth_sig,
+    }
 }


### PR DESCRIPTION
## Motivation

Transaction V5 is a required change in NU5.

## Solution

- Cleanup the Transaction V5 sapling serialization code

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

@teor2345 can review @oxarbitrage's commits.
@oxarbitrage can review @teor2345's commits.

## Related Issues

Part of #1829 
Rebased from oxarbitrage/zebra#90

## Follow Up Work

Redesign Sapling data model for V5 shared anchor and spends #2021

TODO - make tickets:
- Work out why the `fake_v5_round_trip` test fails on blocks, but not transactions (re-test on #2021 first)
- Modify proptest strategies, rather than editing the generated data in each test

Orchard in V5 #1979
