### PR TITLE
Redesign Sapling data model for V5 shared anchor and spends

### DIFF
--- a/book/src/dev/rfcs/0010-v5-transaction.md
+++ b/book/src/dev/rfcs/0010-v5-transaction.md
@@ -171,19 +171,21 @@ enum sapling::TransferData<AnchorV: AnchorVariant> {
     /// there must also be a shared spend anchor.
     SpendsAndMaybeOutputs {
         shared_anchor: AnchorV::Shared,
-        first_spend: Spend<AnchorV>,
-        rest_spends: Vec<Spend<AnchorV>>,
+        spends: AtLeastOne<Spend<AnchorV>>,
         maybe_outputs: Vec<Output>,
     }
 
     /// If there are no spends, there must not be a shared
     /// anchor.
     JustOutputs {
-        first_output: Output,
-        rest_outputs: Vec<Output>,
+        outputs: AtLeastOne<Output>,
     }
 }
 ```
+
+The `AtLeastOne` type is a vector wrapper which always contains at least one
+element. For more details, see [its documentation](https://github.com/ZcashFoundation/zebra/blob/673b95dea5f0b057c11f2f450943b012fec75c00/zebra-chain/src/serialization/constraint.rs).
+<!-- TODO: update link to main branch when PR #2021 merges -->
 
 Some of these fields are in a different order to the serialized data, see
 [the V4 and V5 transaction specs](https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus)
@@ -343,12 +345,7 @@ struct orchard::ShieldedData {
     value_balance: Amount,
     shared_anchor: tree::Root,
     proof: Halo2Proof,
-    /// An authorized action description.
-    ///
-    /// Storing this separately ensures that it is impossible to construct
-    /// an invalid `ShieldedData` with no actions.
-    first: AuthorizedAction,
-    rest: Vec<AuthorizedAction>,
+    actions: AtLeastOne<AuthorizedAction>,
     binding_sig: redpallas::Signature<Binding>,
 }
 ```

--- a/book/src/dev/rfcs/0010-v5-transaction.md
+++ b/book/src/dev/rfcs/0010-v5-transaction.md
@@ -169,7 +169,7 @@ struct sapling::ShieldedData<AnchorV: AnchorVariant> {
 enum sapling::TransferData<AnchorV: AnchorVariant> {
     /// In Transaction::V5, if there are any spends,
     /// there must also be a shared spend anchor.
-    Spends {
+    SpendsAndMaybeOutputs {
         shared_anchor: AnchorV::Shared,
         first_spend: Spend<AnchorV>,
         rest_spends: Vec<Spend<AnchorV>>,
@@ -178,7 +178,7 @@ enum sapling::TransferData<AnchorV: AnchorVariant> {
 
     /// If there are no spends, there must not be a shared
     /// anchor.
-    NoSpends {
+    JustOutputs {
         first_output: Output,
         rest_outputs: Vec<Output>,
     }

--- a/zebra-chain/src/sapling.rs
+++ b/zebra-chain/src/sapling.rs
@@ -22,6 +22,6 @@ pub use keys::Diversifier;
 pub use note::{EncryptedNote, Note, Nullifier, WrappedNoteKey};
 pub use output::{Output, OutputInTransactionV4, OutputPrefixInTransactionV5};
 pub use shielded_data::{
-    AnchorVariant, FieldNotPresent, PerSpendAnchor, SharedAnchor, ShieldedData,
+    AnchorVariant, FieldNotPresent, PerSpendAnchor, SharedAnchor, ShieldedData, TransferData,
 };
 pub use spend::{Spend, SpendPrefixInTransactionV5};

--- a/zebra-chain/src/sapling/shielded_data.rs
+++ b/zebra-chain/src/sapling/shielded_data.rs
@@ -122,7 +122,7 @@ where
     ///
     /// In Transaction::V5, if there are any spends, there must also be a shared
     /// spend anchor.
-    Spends {
+    SpendsAndMaybeOutputs {
         /// The shared anchor for all `Spend`s in this transaction.
         ///
         /// The anchor is the root of the Sapling note commitment tree in a previous
@@ -150,7 +150,7 @@ where
 
         /// Maybe some outputs (can be empty).
         ///
-        /// See [`NoSpends::first_output`] for details.
+        /// See [`JustOutputs::first_output`] for details.
         maybe_outputs: Vec<Output>,
     },
 
@@ -159,7 +159,7 @@ where
     ///
     /// In Transaction::V5, if there are no spends, there must not be a shared
     /// anchor.
-    NoSpends {
+    JustOutputs {
         /// At least one output.
         ///
         /// Storing this separately ensures that it is impossible to construct
@@ -282,13 +282,13 @@ where
         use TransferData::*;
 
         let first = match self {
-            Spends { first_spend, .. } => Some(first_spend),
-            NoSpends { .. } => None,
+            SpendsAndMaybeOutputs { first_spend, .. } => Some(first_spend),
+            JustOutputs { .. } => None,
         };
 
         let rest = match self {
-            Spends { rest_spends, .. } => Some(rest_spends),
-            NoSpends { .. } => None,
+            SpendsAndMaybeOutputs { rest_spends, .. } => Some(rest_spends),
+            JustOutputs { .. } => None,
         };
 
         // this slightly awkward construction avoids returning a newtype struct
@@ -301,13 +301,13 @@ where
         use TransferData::*;
 
         let first = match self {
-            Spends { .. } => None,
-            NoSpends { first_output, .. } => Some(first_output),
+            SpendsAndMaybeOutputs { .. } => None,
+            JustOutputs { first_output, .. } => Some(first_output),
         };
 
         let rest_or_maybe = match self {
-            Spends { maybe_outputs, .. } => Some(maybe_outputs),
-            NoSpends { rest_outputs, .. } => Some(rest_outputs),
+            SpendsAndMaybeOutputs { maybe_outputs, .. } => Some(maybe_outputs),
+            JustOutputs { rest_outputs, .. } => Some(rest_outputs),
         };
 
         first.into_iter().chain(rest_or_maybe.into_iter().flatten())
@@ -322,8 +322,8 @@ where
         use TransferData::*;
 
         match self {
-            Spends { shared_anchor, .. } => Some(shared_anchor.clone()),
-            NoSpends { .. } => None,
+            SpendsAndMaybeOutputs { shared_anchor, .. } => Some(shared_anchor.clone()),
+            JustOutputs { .. } => None,
         }
     }
 }

--- a/zebra-chain/src/sapling/shielded_data.rs
+++ b/zebra-chain/src/sapling/shielded_data.rs
@@ -4,7 +4,6 @@
 //! The `value_balance` change is handled using the default zero value.
 //! The anchor change is handled using the `AnchorVariant` type trait.
 
-use futures::future::Either;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
@@ -17,12 +16,13 @@ use crate::{
         output::OutputPrefixInTransactionV5, spend::SpendPrefixInTransactionV5, tree, Nullifier,
         Output, Spend, ValueCommitment,
     },
-    serialization::{serde_helpers, TrustedPreallocate},
+    serialization::TrustedPreallocate,
 };
 
 use std::{
     cmp::{max, Eq, PartialEq},
     fmt::Debug,
+    iter,
 };
 
 /// Per-Spend Sapling anchors, used in Transaction V4 and the
@@ -74,52 +74,106 @@ pub trait AnchorVariant {
 ///
 /// The Sapling `value_balance` field is optional in `Transaction::V5`, but
 /// required in `Transaction::V4`. In both cases, if there is no `ShieldedData`,
-/// then the field value must be zero. Therefore, only need to store
+/// then the field value must be zero. Therefore, we only need to store
 /// `value_balance` when there is some Sapling `ShieldedData`.
 ///
 /// In `Transaction::V4`, each `Spend` has its own anchor. In `Transaction::V5`,
-/// there is a single `shared_anchor` for the entire transaction. This
-/// structural difference is modeled using the `AnchorVariant` type trait.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+/// there is a single `shared_anchor` for the entire transaction, which is only
+/// present when there is at least one spend. These structural differences are
+/// modeled using the `AnchorVariant` type trait and `TransferData` enum.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ShieldedData<AnchorV>
 where
     AnchorV: AnchorVariant + Clone,
 {
     /// The net value of Sapling spend transfers minus output transfers.
     pub value_balance: Amount,
-    /// The shared anchor for all `Spend`s in this transaction.
+
+    /// A bundle of spends and outputs, containing at least one spend or
+    /// output.
     ///
-    /// The anchor is the root of the Sapling note commitment tree in a previous
-    /// block. This root should be in the best chain for a transaction to be
-    /// mined, and it must be in the relevant chain for a transaction to be
-    /// valid.
-    ///
-    /// Some transaction versions have a per-spend anchor, rather than a shared
-    /// anchor.
-    pub shared_anchor: AnchorV::Shared,
-    /// Either a spend or output description.
-    ///
-    /// Storing this separately ensures that it is impossible to construct
-    /// an invalid `ShieldedData` with no spends or outputs.
-    ///
-    /// However, it's not necessary to access or process `first` and `rest`
-    /// separately, as the [`ShieldedData::spends`] and [`ShieldedData::outputs`]
-    /// methods provide iterators over all of the [`Spend`]s and
-    /// [`Output`]s.
-    #[serde(with = "serde_helpers::Either")]
-    pub first: Either<Spend<AnchorV>, Output>,
-    /// The rest of the [`Spend`]s for this transaction.
-    ///
-    /// Note that the [`ShieldedData::spends`] method provides an iterator
-    /// over all spend descriptions.
-    pub rest_spends: Vec<Spend<AnchorV>>,
-    /// The rest of the [`Output`]s for this transaction.
-    ///
-    /// Note that the [`ShieldedData::outputs`] method provides an iterator
-    /// over all output descriptions.
-    pub rest_outputs: Vec<Output>,
+    /// In V5 transactions, also contains a shared anchor, if there are any
+    /// spends.
+    pub transfers: TransferData<AnchorV>,
+
     /// A signature on the transaction hash.
     pub binding_sig: Signature<Binding>,
+}
+
+/// A bundle of [`Spend`] and [`Output`] descriptions, and a shared anchor.
+///
+/// This wrapper type bundles at least one Spend or Output description with
+/// the required anchor data, so that an `Option<ShieldedData>` (which contains
+/// this type) correctly models the presence or absence of any spends and
+/// shielded data, across both V4 and V5 transactions.
+///
+/// Specifically, TransferData ensures that:
+/// * there is at least one spend or output, and
+/// * the shared anchor is only present when there are spends.
+//
+// clippy warns because Outputs are a lot larger than Spends
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TransferData<AnchorV>
+where
+    AnchorV: AnchorVariant + Clone,
+{
+    /// A bundle containing at least one spend, and the shared spend anchor.
+    /// There can also be zero or more outputs.
+    ///
+    /// In Transaction::V5, if there are any spends, there must also be a shared
+    /// spend anchor.
+    Spends {
+        /// The shared anchor for all `Spend`s in this transaction.
+        ///
+        /// The anchor is the root of the Sapling note commitment tree in a previous
+        /// block. This root should be in the best chain for a transaction to be
+        /// mined, and it must be in the relevant chain for a transaction to be
+        /// valid.
+        ///
+        /// Some transaction versions have a per-spend anchor, rather than a shared
+        /// anchor.
+        ///
+        /// Use the `shared_anchor` method to access this field.
+        shared_anchor: AnchorV::Shared,
+
+        /// At least one spend.
+        ///
+        /// Storing this separately ensures that it is impossible to construct
+        /// an invalid `ShieldedData` with no spends or outputs.
+        ///
+        /// However, it's not necessary to access or process `first_spend` and
+        /// `rest_spends` separately, as the [`ShieldedData::spends`] method
+        /// provides an iterator over all of the [`Spend`]s.
+        first_spend: Spend<AnchorV>,
+        /// The rest of the spends, if any.
+        rest_spends: Vec<Spend<AnchorV>>,
+
+        /// Maybe some outputs (can be empty).
+        ///
+        /// See [`NoSpends::first_output`] for details.
+        maybe_outputs: Vec<Output>,
+    },
+
+    /// A bundle containing at least one output, with no spends and no shared
+    /// spend anchor.
+    ///
+    /// In Transaction::V5, if there are no spends, there must not be a shared
+    /// anchor.
+    NoSpends {
+        /// At least one output.
+        ///
+        /// Storing this separately ensures that it is impossible to construct
+        /// an invalid `ShieldedData` with no spends or outputs.
+        ///
+        /// However, it's not necessary to access or process `first_output`,
+        /// `rest_outputs`, and `maybe_outputs` separately, as the
+        /// [`ShieldedData::outputs`] method provides an iterator over all of the
+        /// [`Outputs`]s.
+        first_output: Output,
+        /// The rest of the outputs, if any.
+        rest_outputs: Vec<Output>,
+    },
 }
 
 impl<AnchorV> ShieldedData<AnchorV>
@@ -136,9 +190,13 @@ where
     ///
     /// Do not use this function for serialization.
     pub fn spends_per_anchor(&self) -> impl Iterator<Item = Spend<PerSpendAnchor>> + '_ {
-        self.spends()
-            .cloned()
-            .map(move |spend| Spend::<PerSpendAnchor>::from((spend, self.shared_anchor.clone())))
+        self.spends().cloned().map(move |spend| {
+            Spend::<PerSpendAnchor>::from((
+                spend,
+                self.shared_anchor()
+                    .expect("shared anchor must be Some if there are any spends"),
+            ))
+        })
     }
 }
 
@@ -153,22 +211,21 @@ where
     ///
     /// Use this function for serialization.
     pub fn spends(&self) -> impl Iterator<Item = &Spend<AnchorV>> {
-        match self.first {
-            Either::Left(ref spend) => Some(spend),
-            Either::Right(_) => None,
-        }
-        .into_iter()
-        .chain(self.rest_spends.iter())
+        self.transfers.spends()
     }
 
     /// Iterate over the [`Output`]s for this transaction.
     pub fn outputs(&self) -> impl Iterator<Item = &Output> {
-        match self.first {
-            Either::Left(_) => None,
-            Either::Right(ref output) => Some(output),
-        }
-        .into_iter()
-        .chain(self.rest_outputs.iter())
+        self.transfers.outputs()
+    }
+
+    /// Provide the shared anchor for this transaction, if present.
+    ///
+    /// The shared anchor is only present if:
+    /// * there is at least one spend, and
+    /// * this is a `V5` transaction.
+    pub fn shared_anchor(&self) -> Option<AnchorV::Shared> {
+        self.transfers.shared_anchor()
     }
 
     /// Collect the [`Nullifier`]s for this transaction, if it contains
@@ -216,39 +273,60 @@ where
     }
 }
 
-// Technically, it's possible to construct two equivalent representations
-// of a ShieldedData with at least one spend and at least one output, depending
-// on which goes in the `first` slot.  This is annoying but a smallish price to
-// pay for structural validity.
-//
-// A `ShieldedData<PerSpendAnchor>` can never be equal to a
-// `ShieldedData<SharedAnchor>`, even if they have the same effects.
-
-impl<AnchorV> std::cmp::PartialEq for ShieldedData<AnchorV>
+impl<AnchorV> TransferData<AnchorV>
 where
-    AnchorV: AnchorVariant + Clone + PartialEq,
+    AnchorV: AnchorVariant + Clone,
 {
-    fn eq(&self, other: &Self) -> bool {
-        // First check that the lengths match, so we know it is safe to use zip,
-        // which truncates to the shorter of the two iterators.
-        if self.spends().count() != other.spends().count() {
-            return false;
-        }
-        if self.outputs().count() != other.outputs().count() {
-            return false;
-        }
+    /// Iterate over the [`Spend`]s for this transaction, returning them as
+    /// their generic type.
+    pub fn spends(&self) -> impl Iterator<Item = &Spend<AnchorV>> {
+        use TransferData::*;
 
-        // Now check that all the fields match
-        self.value_balance == other.value_balance
-            && self.shared_anchor == other.shared_anchor
-            && self.binding_sig == other.binding_sig
-            && self.spends().zip(other.spends()).all(|(a, b)| a == b)
-            && self.outputs().zip(other.outputs()).all(|(a, b)| a == b)
+        // TODO: replace with Box<dyn IntoIterator ...> for efficiency?
+        match self {
+            Spends {
+                first_spend,
+                rest_spends,
+                ..
+            } => iter::once(first_spend).chain(rest_spends.iter()).collect(),
+            NoSpends { .. } => Vec::new(),
+        }
+        .into_iter()
+    }
+
+    /// Iterate over the [`Output`]s for this transaction.
+    pub fn outputs(&self) -> impl Iterator<Item = &Output> {
+        use TransferData::*;
+
+        // TODO: replace with Box<dyn IntoIterator ...> for efficiency?
+        let outputs: Vec<_> = match self {
+            Spends { maybe_outputs, .. } => maybe_outputs.iter().collect(),
+            NoSpends {
+                first_output,
+                rest_outputs,
+                ..
+            } => iter::once(first_output)
+                .chain(rest_outputs.iter())
+                .collect(),
+        };
+
+        outputs.into_iter()
+    }
+
+    /// Provide the shared anchor for this transaction, if present.
+    ///
+    /// The shared anchor is only present if:
+    /// * there is at least one spend, and
+    /// * this is a `V5` transaction.
+    pub fn shared_anchor(&self) -> Option<AnchorV::Shared> {
+        use TransferData::*;
+
+        match self {
+            Spends { shared_anchor, .. } => Some(shared_anchor.clone()),
+            NoSpends { .. } => None,
+        }
     }
 }
-
-impl<AnchorV> std::cmp::Eq for ShieldedData<AnchorV> where AnchorV: AnchorVariant + Clone + PartialEq
-{}
 
 impl TrustedPreallocate for Groth16Proof {
     fn max_allocation() -> u64 {

--- a/zebra-chain/src/sapling/tests/prop.rs
+++ b/zebra-chain/src/sapling/tests/prop.rs
@@ -6,6 +6,7 @@ use crate::{
     serialization::{ZcashDeserializeInto, ZcashSerialize},
     transaction::{LockTime, Transaction},
 };
+use std::convert::TryInto;
 
 proptest! {
     /// Serialize and deserialize `Spend<PerSpendAnchor>`
@@ -169,10 +170,9 @@ proptest! {
 
         // TODO: modify the strategy, rather than the shielded data
         let mut shielded_v4 = shielded_v4;
-        let mut outputs: Vec<_> = shielded_v4.outputs().cloned().collect();
+        let outputs: Vec<_> = shielded_v4.outputs().cloned().collect();
         shielded_v4.transfers = sapling::TransferData::JustOutputs {
-            first_output: outputs.remove(0),
-            rest_outputs: outputs,
+            outputs: outputs.try_into().unwrap(),
         };
 
         // shielded data doesn't serialize by itself, so we have to stick it in
@@ -209,10 +209,9 @@ proptest! {
 
         // TODO: modify the strategy, rather than the shielded data
         let mut shielded_v5 = shielded_v5;
-        let mut outputs: Vec<_> = shielded_v5.outputs().cloned().collect();
+        let outputs: Vec<_> = shielded_v5.outputs().cloned().collect();
         shielded_v5.transfers = sapling::TransferData::JustOutputs {
-            first_output: outputs.remove(0),
-            rest_outputs: outputs,
+            outputs: outputs.try_into().unwrap(),
         };
 
         let data = shielded_v5.zcash_serialize_to_vec().expect("shielded_v5 should serialize");

--- a/zebra-chain/src/sapling/tests/prop.rs
+++ b/zebra-chain/src/sapling/tests/prop.rs
@@ -170,7 +170,7 @@ proptest! {
         // TODO: modify the strategy, rather than the shielded data
         let mut shielded_v4 = shielded_v4;
         let mut outputs: Vec<_> = shielded_v4.outputs().cloned().collect();
-        shielded_v4.transfers = sapling::TransferData::NoSpends {
+        shielded_v4.transfers = sapling::TransferData::JustOutputs {
             first_output: outputs.remove(0),
             rest_outputs: outputs,
         };
@@ -210,7 +210,7 @@ proptest! {
         // TODO: modify the strategy, rather than the shielded data
         let mut shielded_v5 = shielded_v5;
         let mut outputs: Vec<_> = shielded_v5.outputs().cloned().collect();
-        shielded_v5.transfers = sapling::TransferData::NoSpends {
+        shielded_v5.transfers = sapling::TransferData::JustOutputs {
             first_output: outputs.remove(0),
             rest_outputs: outputs,
         };

--- a/zebra-chain/src/sapling/tests/prop.rs
+++ b/zebra-chain/src/sapling/tests/prop.rs
@@ -2,13 +2,10 @@ use proptest::prelude::*;
 
 use crate::{
     block,
-    sapling::{self, PerSpendAnchor, SharedAnchor},
+    sapling::{self, OutputInTransactionV4, PerSpendAnchor, SharedAnchor},
     serialization::{ZcashDeserializeInto, ZcashSerialize},
     transaction::{LockTime, Transaction},
 };
-
-use futures::future::Either;
-use sapling::OutputInTransactionV4;
 
 proptest! {
     /// Serialize and deserialize `Spend<PerSpendAnchor>`
@@ -165,8 +162,6 @@ proptest! {
     fn shielded_data_v4_outputs_only(
         shielded_v4 in any::<sapling::ShieldedData<PerSpendAnchor>>(),
     ) {
-        use Either::*;
-
         zebra_test::init();
 
         // we need at least one output to delete all the spends
@@ -175,9 +170,10 @@ proptest! {
         // TODO: modify the strategy, rather than the shielded data
         let mut shielded_v4 = shielded_v4;
         let mut outputs: Vec<_> = shielded_v4.outputs().cloned().collect();
-        shielded_v4.rest_spends = Vec::new();
-        shielded_v4.first = Right(outputs.remove(0));
-        shielded_v4.rest_outputs = outputs;
+        shielded_v4.transfers = sapling::TransferData::NoSpends {
+            first_output: outputs.remove(0),
+            rest_outputs: outputs,
+        };
 
         // shielded data doesn't serialize by itself, so we have to stick it in
         // a transaction
@@ -206,8 +202,6 @@ proptest! {
     fn shielded_data_v5_outputs_only(
         shielded_v5 in any::<sapling::ShieldedData<SharedAnchor>>(),
     ) {
-        use Either::*;
-
         zebra_test::init();
 
         // we need at least one output to delete all the spends
@@ -216,11 +210,10 @@ proptest! {
         // TODO: modify the strategy, rather than the shielded data
         let mut shielded_v5 = shielded_v5;
         let mut outputs: Vec<_> = shielded_v5.outputs().cloned().collect();
-        shielded_v5.rest_spends = Vec::new();
-        shielded_v5.first = Right(outputs.remove(0));
-        shielded_v5.rest_outputs = outputs;
-        // TODO: delete the shared anchor when there are no spends
-        shielded_v5.shared_anchor = Default::default();
+        shielded_v5.transfers = sapling::TransferData::NoSpends {
+            first_output: outputs.remove(0),
+            rest_outputs: outputs,
+        };
 
         let data = shielded_v5.zcash_serialize_to_vec().expect("shielded_v5 should serialize");
         let shielded_v5_parsed = data.zcash_deserialize_into().expect("randomized shielded_v5 should deserialize");
@@ -236,252 +229,5 @@ proptest! {
         } else {
             panic!("unexpected parsing error: ShieldedData should be Some(_)");
         }
-    }
-
-    /// Check that ShieldedData<PerSpendAnchor> is equal when `first` is swapped
-    /// between a spend and an output
-    #[test]
-    fn shielded_data_per_spend_swap_first_eq(
-        shielded1 in any::<sapling::ShieldedData<PerSpendAnchor>>()
-    ) {
-        use Either::*;
-
-        zebra_test::init();
-
-        // we need at least one spend and one output to swap them
-        prop_assume!(shielded1.spends().count() > 0 && shielded1.outputs().count() > 0);
-
-        let mut shielded2 = shielded1.clone();
-        let mut spends: Vec<_> = shielded2.spends().cloned().collect();
-        let mut outputs: Vec<_> = shielded2.outputs().cloned().collect();
-        match shielded2.first {
-            Left(_spend) => {
-                shielded2.first = Right(outputs.remove(0));
-                shielded2.rest_outputs = outputs;
-                shielded2.rest_spends = spends;
-            }
-            Right(_output) => {
-                shielded2.first = Left(spends.remove(0));
-                shielded2.rest_spends = spends;
-                shielded2.rest_outputs = outputs;
-            }
-        }
-
-        prop_assert_eq![&shielded1, &shielded2];
-
-        // shielded data doesn't serialize by itself, so we have to stick it in
-        // a transaction
-        let tx1 = Transaction::V4 {
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            lock_time: LockTime::min_lock_time(),
-            expiry_height: block::Height(0),
-            joinsplit_data: None,
-            sapling_shielded_data: Some(shielded1),
-        };
-        let tx2 = Transaction::V4 {
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            lock_time: LockTime::min_lock_time(),
-            expiry_height: block::Height(0),
-            joinsplit_data: None,
-            sapling_shielded_data: Some(shielded2),
-        };
-
-        prop_assert_eq![&tx1, &tx2];
-
-        let data1 = tx1.zcash_serialize_to_vec().expect("tx1 should serialize");
-        let data2 = tx2.zcash_serialize_to_vec().expect("tx2 should serialize");
-
-        prop_assert_eq![data1, data2];
-    }
-
-    /// Check that ShieldedData<SharedAnchor> is equal when `first` is swapped
-    /// between a spend and an output
-    #[test]
-    fn shielded_data_shared_swap_first_eq(
-        shielded1 in any::<sapling::ShieldedData<SharedAnchor>>()
-    ) {
-        use Either::*;
-
-        zebra_test::init();
-
-        // we need at least one spend and one output to swap them
-        prop_assume!(shielded1.spends().count() > 0 && shielded1.outputs().count() > 0);
-
-        let mut shielded2 = shielded1.clone();
-        let mut spends: Vec<_> = shielded2.spends().cloned().collect();
-        let mut outputs: Vec<_> = shielded2.outputs().cloned().collect();
-        match shielded2.first {
-            Left(_spend) => {
-                shielded2.first = Right(outputs.remove(0));
-                shielded2.rest_outputs = outputs;
-                shielded2.rest_spends = spends;
-            }
-            Right(_output) => {
-                shielded2.first = Left(spends.remove(0));
-                shielded2.rest_spends = spends;
-                shielded2.rest_outputs = outputs;
-            }
-        }
-
-        prop_assert_eq![&shielded1, &shielded2];
-
-        let data1 = shielded1.zcash_serialize_to_vec().expect("shielded1 should serialize");
-        let data2 = shielded2.zcash_serialize_to_vec().expect("shielded2 should serialize");
-
-        prop_assert_eq![data1, data2];
-    }
-
-    /// Check that ShieldedData<PerSpendAnchor> serialization is equal if
-    /// `shielded1 == shielded2`
-    #[test]
-    fn shielded_data_per_spend_serialize_eq(
-        shielded1 in any::<sapling::ShieldedData<PerSpendAnchor>>(),
-        shielded2 in any::<sapling::ShieldedData<PerSpendAnchor>>()
-    ) {
-        zebra_test::init();
-
-        let shielded_eq = shielded1 == shielded2;
-
-        // shielded data doesn't serialize by itself, so we have to stick it in
-        // a transaction
-        let tx1 = Transaction::V4 {
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            lock_time: LockTime::min_lock_time(),
-            expiry_height: block::Height(0),
-            joinsplit_data: None,
-            sapling_shielded_data: Some(shielded1),
-        };
-        let tx2 = Transaction::V4 {
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            lock_time: LockTime::min_lock_time(),
-            expiry_height: block::Height(0),
-            joinsplit_data: None,
-            sapling_shielded_data: Some(shielded2),
-        };
-
-        if shielded_eq {
-            prop_assert_eq![&tx1, &tx2];
-        } else {
-            prop_assert_ne![&tx1, &tx2];
-        }
-
-        let data1 = tx1.zcash_serialize_to_vec().expect("tx1 should serialize");
-        let data2 = tx2.zcash_serialize_to_vec().expect("tx2 should serialize");
-
-        if shielded_eq {
-            prop_assert_eq![data1, data2];
-        } else {
-            prop_assert_ne![data1, data2];
-        }
-    }
-
-    /// Check that ShieldedData<SharedAnchor> serialization is equal if
-    /// `shielded1 == shielded2`
-    #[test]
-    fn shielded_data_shared_serialize_eq(
-        shielded1 in any::<sapling::ShieldedData<SharedAnchor>>(),
-        shielded2 in any::<sapling::ShieldedData<SharedAnchor>>()
-    ) {
-        zebra_test::init();
-
-        let shielded_eq = shielded1 == shielded2;
-
-        let data1 = shielded1.zcash_serialize_to_vec().expect("shielded1 should serialize");
-        let data2 = shielded2.zcash_serialize_to_vec().expect("shielded2 should serialize");
-
-        if shielded_eq {
-            prop_assert_eq![data1, data2];
-        } else {
-            prop_assert_ne![data1, data2];
-        }
-    }
-
-    /// Check that ShieldedData<PerSpendAnchor> serialization is equal when we
-    /// replace all the known fields.
-    ///
-    /// This test checks for extra fields that are not in `ShieldedData::eq`.
-    #[test]
-    fn shielded_data_per_spend_field_assign_eq(
-        shielded1 in any::<sapling::ShieldedData<PerSpendAnchor>>(),
-        shielded2 in any::<sapling::ShieldedData<PerSpendAnchor>>()
-    ) {
-        zebra_test::init();
-
-        let mut shielded2 = shielded2;
-
-        // these fields must match ShieldedData::eq
-        // the spends() and outputs() checks cover first, rest_spends, and rest_outputs
-        shielded2.first = shielded1.first.clone();
-        shielded2.rest_spends = shielded1.rest_spends.clone();
-        shielded2.rest_outputs = shielded1.rest_outputs.clone();
-        // now for the fields that are checked literally
-        shielded2.value_balance = shielded1.value_balance;
-        shielded2.shared_anchor = shielded1.shared_anchor;
-        shielded2.binding_sig = shielded1.binding_sig;
-
-        prop_assert_eq![&shielded1, &shielded2];
-
-        // shielded data doesn't serialize by itself, so we have to stick it in
-        // a transaction
-        let tx1 = Transaction::V4 {
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            lock_time: LockTime::min_lock_time(),
-            expiry_height: block::Height(0),
-            joinsplit_data: None,
-            sapling_shielded_data: Some(shielded1),
-        };
-        let tx2 = Transaction::V4 {
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            lock_time: LockTime::min_lock_time(),
-            expiry_height: block::Height(0),
-            joinsplit_data: None,
-            sapling_shielded_data: Some(shielded2),
-        };
-
-        prop_assert_eq![&tx1, &tx2];
-
-        let data1 = tx1.zcash_serialize_to_vec().expect("tx1 should serialize");
-        let data2 = tx2.zcash_serialize_to_vec().expect("tx2 should serialize");
-
-        prop_assert_eq![data1, data2];
-    }
-
-    /// Check that ShieldedData<SharedAnchor> serialization is equal when we
-    /// replace all the known fields.
-    ///
-    /// This test checks for extra fields that are not in `ShieldedData::eq`.
-    #[test]
-    fn shielded_data_shared_field_assign_eq(
-        shielded1 in any::<sapling::ShieldedData<SharedAnchor>>(),
-        shielded2 in any::<sapling::ShieldedData<SharedAnchor>>()
-    ) {
-        zebra_test::init();
-
-        let mut shielded2 = shielded2;
-
-        // TODO: modify the strategy, rather than the shielded data
-        //
-        // these fields must match ShieldedData::eq
-        // the spends() and outputs() checks cover first, rest_spends, and rest_outputs
-        shielded2.first = shielded1.first.clone();
-        shielded2.rest_spends = shielded1.rest_spends.clone();
-        shielded2.rest_outputs = shielded1.rest_outputs.clone();
-        // now for the fields that are checked literally
-        shielded2.value_balance = shielded1.value_balance;
-        shielded2.shared_anchor = shielded1.shared_anchor;
-        shielded2.binding_sig = shielded1.binding_sig;
-
-        prop_assert_eq![&shielded1, &shielded2];
-
-        let data1 = shielded1.zcash_serialize_to_vec().expect("shielded1 should serialize");
-        let data2 = shielded2.zcash_serialize_to_vec().expect("shielded2 should serialize");
-
-        prop_assert_eq![data1, data2];
     }
 }

--- a/zebra-chain/src/serialization.rs
+++ b/zebra-chain/src/serialization.rs
@@ -6,6 +6,7 @@
 //! `ReadZcashExt`, extension traits for `io::Read` and `io::Write` with utility functions
 //! for reading and writing data (e.g., the Bitcoin variable-integer format).
 
+mod constraint;
 mod error;
 mod read_zcash;
 mod write_zcash;
@@ -16,6 +17,7 @@ pub(crate) mod serde_helpers;
 
 pub mod sha256d;
 
+pub use constraint::AtLeastOne;
 pub use error::SerializationError;
 pub use read_zcash::ReadZcashExt;
 pub use write_zcash::WriteZcashExt;

--- a/zebra-chain/src/serialization/constraint.rs
+++ b/zebra-chain/src/serialization/constraint.rs
@@ -1,0 +1,180 @@
+//! Serialization constraint helpers.
+
+use std::{
+    convert::{TryFrom, TryInto},
+    ops::Deref,
+};
+
+use crate::serialization::SerializationError;
+
+/// A `Vec<T>` wrapper that ensures there is at least one `T` in the vector.
+///
+/// You can initialize `AtLeastOne` using:
+/// ```
+/// # use zebra_chain::serialization::{AtLeastOne, SerializationError};
+/// # use std::convert::{TryFrom, TryInto};
+/// #
+/// let v: AtLeastOne<u32> = vec![42].try_into()?;
+/// assert_eq!(v.as_slice(), [42]);
+///
+/// let v: AtLeastOne<u32> = vec![42].as_slice().try_into()?;
+/// assert_eq!(v.as_slice(), [42]);
+///
+/// let v: AtLeastOne<u32> = [42].try_into()?;
+/// assert_eq!(v.as_slice(), [42]);
+///
+/// let v = AtLeastOne::<u32>::try_from(&[42])?;
+/// assert_eq!(v.as_slice(), [42]);
+/// #
+/// # Ok::<(), SerializationError>(())
+/// ```
+///
+/// And access the inner vector via [deref coercion](https://doc.rust-lang.org/std/ops/trait.Deref.html#more-on-deref-coercion),
+/// an explicit conversion, or as a slice:
+/// ```
+/// # use zebra_chain::serialization::AtLeastOne;
+/// # use std::convert::TryInto;
+/// #
+/// # let v: AtLeastOne<u32> = vec![42].try_into().unwrap();
+/// #
+/// let first = v.iter().next().expect("AtLeastOne always has a first element");
+/// assert_eq!(*first, 42);
+///
+/// let s = v.as_slice();
+/// #
+/// # assert_eq!(s, [42]);
+///
+/// let mut m = v.into_vec();
+/// #
+/// # assert_eq!(m.as_slice(), [42]);
+///
+/// ```
+///
+/// `AtLeastOne` also re-implements some slice methods with different return
+/// types, to avoid redundant unwraps:
+/// ```
+/// # use zebra_chain::serialization::AtLeastOne;
+/// # use std::convert::TryInto;
+/// #
+/// # let v: AtLeastOne<u32> = vec![42].try_into().unwrap();
+/// #
+/// let first = v.first();
+/// assert_eq!(*first, 42);
+///
+/// let (first, rest) = v.split_first();
+/// assert_eq!(*first, 42);
+/// assert!(rest.is_empty());
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct AtLeastOne<T> {
+    /// The inner vector, which must have at least one element.
+    ///
+    /// `inner` is private, so that it can't be modified in ways that break the
+    /// type constraint.
+    inner: Vec<T>,
+}
+
+// CORRECTNESS
+//
+// All conversions to `AtLeastOne<T>` must go through `TryFrom<Vec<T>>`,
+// so that the type constraint is satisfied.
+
+impl<T> TryFrom<Vec<T>> for AtLeastOne<T> {
+    type Error = SerializationError;
+
+    fn try_from(vec: Vec<T>) -> Result<Self, Self::Error> {
+        if vec.is_empty() {
+            Err(SerializationError::Parse("expected at least one item"))
+        } else {
+            Ok(AtLeastOne { inner: vec })
+        }
+    }
+}
+
+impl<T> TryFrom<&[T]> for AtLeastOne<T>
+where
+    T: Clone,
+{
+    type Error = SerializationError;
+
+    fn try_from(slice: &[T]) -> Result<Self, Self::Error> {
+        slice.to_vec().try_into()
+    }
+}
+
+// TODO:
+// - reject [T; 0] at compile time and impl From instead?
+impl<T, const N: usize> TryFrom<[T; N]> for AtLeastOne<T>
+where
+    T: Clone,
+{
+    type Error = SerializationError;
+
+    fn try_from(slice: [T; N]) -> Result<Self, Self::Error> {
+        slice.to_vec().try_into()
+    }
+}
+
+// TODO:
+// - reject [T; 0] at compile time and impl From instead?
+// - remove when std is updated so that `TryFrom<&U>` is always implemented when
+//   `TryFrom<U>`
+impl<T, const N: usize> TryFrom<&[T; N]> for AtLeastOne<T>
+where
+    T: Clone,
+{
+    type Error = SerializationError;
+
+    fn try_from(slice: &[T; N]) -> Result<Self, Self::Error> {
+        slice.to_vec().try_into()
+    }
+}
+
+// Deref (but not DerefMut, because that could break the constraint)
+
+impl<T> Deref for AtLeastOne<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+// Extracting one or more items
+
+impl<T> From<AtLeastOne<T>> for Vec<T> {
+    fn from(vec1: AtLeastOne<T>) -> Self {
+        vec1.inner
+    }
+}
+
+impl<T> AtLeastOne<T> {
+    /// Returns a reference to the inner vector.
+    pub fn as_vec(&self) -> &Vec<T> {
+        &self.inner
+    }
+
+    /// Converts `self` into a vector without clones or allocation.
+    ///
+    /// The resulting vector can be converted back into `AtLeastOne` via `try_into`.
+    pub fn into_vec(self) -> Vec<T> {
+        self.inner
+    }
+
+    /// Returns the first element.
+    ///
+    /// Unlike `Vec` or slice, `AtLeastOne` always has a first element.
+    pub fn first(&self) -> &T {
+        &self.inner[0]
+    }
+
+    /// Returns the first and all the rest of the elements of the vector.
+    ///
+    /// Unlike `Vec` or slice, `AtLeastOne` always has a first element.
+    pub fn split_first(&self) -> (&T, &[T]) {
+        (&self.inner[0], &self.inner[1..])
+    }
+}
+
+// TODO: consider implementing `push`, `append`, and `Extend`,
+// because adding elements can't break the constraint.

--- a/zebra-chain/src/serialization/serde_helpers.rs
+++ b/zebra-chain/src/serialization/serde_helpers.rs
@@ -35,10 +35,3 @@ impl From<Fq> for jubjub::Fq {
         jubjub::Fq::from_bytes(&local.bytes).unwrap()
     }
 }
-
-#[derive(Deserialize, Serialize)]
-#[serde(remote = "futures::future::Either")]
-pub enum Either<A, B> {
-    Left(A),
-    Right(B),
-}

--- a/zebra-chain/src/serialization/zcash_deserialize.rs
+++ b/zebra-chain/src/serialization/zcash_deserialize.rs
@@ -3,7 +3,7 @@ use std::{
     io,
 };
 
-use super::{ReadZcashExt, SerializationError, MAX_PROTOCOL_MESSAGE_LEN};
+use super::{AtLeastOne, ReadZcashExt, SerializationError, MAX_PROTOCOL_MESSAGE_LEN};
 
 /// Consensus-critical serialization for Zcash.
 ///
@@ -29,6 +29,15 @@ impl<T: ZcashDeserialize + TrustedPreallocate> ZcashDeserialize for Vec<T> {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
         let len = reader.read_compactsize()?.try_into()?;
         zcash_deserialize_external_count(len, reader)
+    }
+}
+
+/// Deserialize an `AtLeastOne` vector, where the number of items is set by a
+/// compactsize prefix in the data. This is the most common format in Zcash.
+impl<T: ZcashDeserialize + TrustedPreallocate> ZcashDeserialize for AtLeastOne<T> {
+    fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let v: Vec<T> = (&mut reader).zcash_deserialize_into()?;
+        v.try_into()
     }
 }
 

--- a/zebra-chain/src/serialization/zcash_serialize.rs
+++ b/zebra-chain/src/serialization/zcash_serialize.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use super::WriteZcashExt;
+use super::{AtLeastOne, WriteZcashExt};
 
 /// Consensus-critical serialization for Zcash.
 ///
@@ -37,6 +37,14 @@ impl<T: ZcashSerialize> ZcashSerialize for Vec<T> {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         writer.write_compactsize(self.len() as u64)?;
         zcash_serialize_external_count(self, writer)
+    }
+}
+
+/// Serialize an `AtLeastOne` vector as a compactsize number of items, then the
+/// items. This is the most common format in Zcash.
+impl<T: ZcashSerialize> ZcashSerialize for AtLeastOne<T> {
+    fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        self.as_vec().zcash_serialize(&mut writer)
     }
 }
 

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -167,6 +167,8 @@ impl Transaction {
     pub fn sprout_nullifiers(&self) -> Box<dyn Iterator<Item = &sprout::Nullifier> + '_> {
         // This function returns a boxed iterator because the different
         // transaction variants end up having different iterator types
+        // (we could extract bctv and groth as separate iterators, then chain
+        // them together, but that would be much harder to read and maintain)
         match self {
             // JoinSplits with Bctv14 Proofs
             Transaction::V2 {
@@ -176,20 +178,12 @@ impl Transaction {
             | Transaction::V3 {
                 joinsplit_data: Some(joinsplit_data),
                 ..
-            } => Box::new(
-                joinsplit_data
-                    .joinsplits()
-                    .flat_map(|joinsplit| joinsplit.nullifiers.iter()),
-            ),
+            } => Box::new(joinsplit_data.nullifiers()),
             // JoinSplits with Groth Proofs
             Transaction::V4 {
                 joinsplit_data: Some(joinsplit_data),
                 ..
-            } => Box::new(
-                joinsplit_data
-                    .joinsplits()
-                    .flat_map(|joinsplit| joinsplit.nullifiers.iter()),
-            ),
+            } => Box::new(joinsplit_data.nullifiers()),
             // No JoinSplits
             Transaction::V1 { .. }
             | Transaction::V2 {

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{convert::TryInto, sync::Arc};
 
 use chrono::{TimeZone, Utc};
 use proptest::{arbitrary::any, array, collection::vec, option, prelude::*};
@@ -245,18 +245,16 @@ impl Arbitrary for sapling::TransferData<PerSpendAnchor> {
         )
             .prop_filter_map(
                 "arbitrary v4 transfers with no spends and no outputs",
-                |(mut spends, mut outputs)| {
+                |(spends, outputs)| {
                     if !spends.is_empty() {
                         Some(sapling::TransferData::SpendsAndMaybeOutputs {
                             shared_anchor: FieldNotPresent,
-                            first_spend: spends.remove(0),
-                            rest_spends: spends,
+                            spends: spends.try_into().unwrap(),
                             maybe_outputs: outputs,
                         })
                     } else if !outputs.is_empty() {
                         Some(sapling::TransferData::JustOutputs {
-                            first_output: outputs.remove(0),
-                            rest_outputs: outputs,
+                            outputs: outputs.try_into().unwrap(),
                         })
                     } else {
                         None
@@ -281,18 +279,16 @@ impl Arbitrary for sapling::TransferData<SharedAnchor> {
         )
             .prop_filter_map(
                 "arbitrary v5 transfers with no spends and no outputs",
-                |(shared_anchor, mut spends, mut outputs)| {
+                |(shared_anchor, spends, outputs)| {
                     if !spends.is_empty() {
                         Some(sapling::TransferData::SpendsAndMaybeOutputs {
                             shared_anchor,
-                            first_spend: spends.remove(0),
-                            rest_spends: spends,
+                            spends: spends.try_into().unwrap(),
                             maybe_outputs: outputs,
                         })
                     } else if !outputs.is_empty() {
                         Some(sapling::TransferData::JustOutputs {
-                            first_output: outputs.remove(0),
-                            rest_outputs: outputs,
+                            outputs: outputs.try_into().unwrap(),
                         })
                     } else {
                         None

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -247,14 +247,14 @@ impl Arbitrary for sapling::TransferData<PerSpendAnchor> {
                 "arbitrary v4 transfers with no spends and no outputs",
                 |(mut spends, mut outputs)| {
                     if !spends.is_empty() {
-                        Some(sapling::TransferData::Spends {
+                        Some(sapling::TransferData::SpendsAndMaybeOutputs {
                             shared_anchor: FieldNotPresent,
                             first_spend: spends.remove(0),
                             rest_spends: spends,
                             maybe_outputs: outputs,
                         })
                     } else if !outputs.is_empty() {
-                        Some(sapling::TransferData::NoSpends {
+                        Some(sapling::TransferData::JustOutputs {
                             first_output: outputs.remove(0),
                             rest_outputs: outputs,
                         })
@@ -283,14 +283,14 @@ impl Arbitrary for sapling::TransferData<SharedAnchor> {
                 "arbitrary v5 transfers with no spends and no outputs",
                 |(shared_anchor, mut spends, mut outputs)| {
                     if !spends.is_empty() {
-                        Some(sapling::TransferData::Spends {
+                        Some(sapling::TransferData::SpendsAndMaybeOutputs {
                             shared_anchor,
                             first_spend: spends.remove(0),
                             rest_spends: spends,
                             maybe_outputs: outputs,
                         })
                     } else if !outputs.is_empty() {
-                        Some(sapling::TransferData::NoSpends {
+                        Some(sapling::TransferData::JustOutputs {
                             first_output: outputs.remove(0),
                             rest_outputs: outputs,
                         })

--- a/zebra-chain/src/transaction/joinsplit.rs
+++ b/zebra-chain/src/transaction/joinsplit.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     primitives::{ed25519, ZkSnarkProof},
-    sprout::JoinSplit,
+    sprout::{JoinSplit, Nullifier},
 };
 
 /// A bundle of [`JoinSplit`] descriptions and signature data.
@@ -47,5 +47,11 @@ impl<P: ZkSnarkProof> JoinSplitData<P> {
     /// Iterate over the [`JoinSplit`]s in `self`.
     pub fn joinsplits(&self) -> impl Iterator<Item = &JoinSplit<P>> {
         std::iter::once(&self.first).chain(self.rest.iter())
+    }
+
+    /// Iterate over the [`Nullifier`]s in `self`.
+    pub fn nullifiers(&self) -> impl Iterator<Item = &Nullifier> {
+        self.joinsplits()
+            .flat_map(|joinsplit| joinsplit.nullifiers.iter())
     }
 }

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -198,13 +198,13 @@ impl ZcashDeserialize for Option<sapling::ShieldedData<SharedAnchor>> {
 
         // Create transfers
         let transfers = match shared_anchor {
-            Some(shared_anchor) => sapling::TransferData::Spends {
+            Some(shared_anchor) => sapling::TransferData::SpendsAndMaybeOutputs {
                 shared_anchor,
                 first_spend: spends.remove(0),
                 rest_spends: spends,
                 maybe_outputs: outputs,
             },
-            None => sapling::TransferData::NoSpends {
+            None => sapling::TransferData::JustOutputs {
                 first_output: outputs.remove(0),
                 rest_outputs: outputs,
             },
@@ -449,14 +449,14 @@ impl ZcashDeserialize for Transaction {
                 let joinsplit_data = OptV4Jsd::zcash_deserialize(&mut reader)?;
 
                 let sapling_transfers = if !shielded_spends.is_empty() {
-                    Some(sapling::TransferData::Spends {
+                    Some(sapling::TransferData::SpendsAndMaybeOutputs {
                         shared_anchor: FieldNotPresent,
                         first_spend: shielded_spends.remove(0),
                         rest_spends: shielded_spends,
                         maybe_outputs: shielded_outputs,
                     })
                 } else if !shielded_outputs.is_empty() {
-                    Some(sapling::TransferData::NoSpends {
+                    Some(sapling::TransferData::JustOutputs {
                         first_output: shielded_outputs.remove(0),
                         rest_outputs: shielded_outputs,
                     })

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -120,8 +120,10 @@ impl ZcashSerialize for sapling::ShieldedData<SharedAnchor> {
         self.value_balance.zcash_serialize(&mut writer)?;
 
         // anchorSapling
-        if !spend_prefixes.is_empty() {
-            writer.write_all(&<[u8; 32]>::from(self.shared_anchor)[..])?;
+        // `TransferData` ensures this field is only present when there is at
+        // least one spend.
+        if let Some(shared_anchor) = self.shared_anchor() {
+            writer.write_all(&<[u8; 32]>::from(shared_anchor)[..])?;
         }
 
         // vSpendProofsSapling
@@ -162,10 +164,11 @@ impl ZcashDeserialize for Option<sapling::ShieldedData<SharedAnchor>> {
         let value_balance = (&mut reader).zcash_deserialize_into()?;
 
         // anchorSapling
-        let mut shared_anchor = None;
-        if spends_count > 0 {
-            shared_anchor = Some(reader.read_32_bytes()?.into());
-        }
+        let shared_anchor = if spends_count > 0 {
+            Some(reader.read_32_bytes()?.into())
+        } else {
+            None
+        };
 
         // vSpendProofsSapling
         let spend_proofs = zcash_deserialize_external_count(spends_count, &mut reader)?;
@@ -193,38 +196,25 @@ impl ZcashDeserialize for Option<sapling::ShieldedData<SharedAnchor>> {
             .map(|(prefix, proof)| Output::from_v5_parts(prefix, proof))
             .collect();
 
-        // Create shielded data
-        use futures::future::Either::*;
-        // TODO: Use a Spend for first if both are present, because the first
-        //       spend activates the shared anchor.
-        if spends_count > 0 {
-            Ok(Some(sapling::ShieldedData {
-                value_balance,
-                // TODO: cleanup shared anchor parsing
-                shared_anchor: shared_anchor.expect("present when spends_count > 0"),
-                first: Left(spends.remove(0)),
+        // Create transfers
+        let transfers = match shared_anchor {
+            Some(shared_anchor) => sapling::TransferData::Spends {
+                shared_anchor,
+                first_spend: spends.remove(0),
                 rest_spends: spends,
+                maybe_outputs: outputs,
+            },
+            None => sapling::TransferData::NoSpends {
+                first_output: outputs.remove(0),
                 rest_outputs: outputs,
-                binding_sig,
-            }))
-        } else {
-            assert!(
-                outputs_count > 0,
-                "parsing returns early when there are no spends and no outputs"
-            );
+            },
+        };
 
-            Ok(Some(sapling::ShieldedData {
-                value_balance,
-                // TODO: delete shared anchor when there are no spends
-                shared_anchor: shared_anchor.unwrap_or_default(),
-                first: Right(outputs.remove(0)),
-                // the spends are actually empty here, but we use the
-                // vec for consistency and readability
-                rest_spends: spends,
-                rest_outputs: outputs,
-                binding_sig,
-            }))
-        }
+        Ok(Some(sapling::ShieldedData {
+            value_balance,
+            transfers,
+            binding_sig,
+        }))
     }
 }
 
@@ -458,30 +448,29 @@ impl ZcashDeserialize for Transaction {
 
                 let joinsplit_data = OptV4Jsd::zcash_deserialize(&mut reader)?;
 
-                use futures::future::Either::*;
-                // Arbitraily use a spend for `first`, if both are present
-                let sapling_shielded_data = if !shielded_spends.is_empty() {
-                    Some(sapling::ShieldedData {
-                        value_balance,
+                let sapling_transfers = if !shielded_spends.is_empty() {
+                    Some(sapling::TransferData::Spends {
                         shared_anchor: FieldNotPresent,
-                        first: Left(shielded_spends.remove(0)),
+                        first_spend: shielded_spends.remove(0),
                         rest_spends: shielded_spends,
-                        rest_outputs: shielded_outputs,
-                        binding_sig: reader.read_64_bytes()?.into(),
+                        maybe_outputs: shielded_outputs,
                     })
                 } else if !shielded_outputs.is_empty() {
-                    Some(sapling::ShieldedData {
-                        value_balance,
-                        shared_anchor: FieldNotPresent,
-                        first: Right(shielded_outputs.remove(0)),
-                        // the spends are actually empty here, but we use the
-                        // vec for consistency and readability
-                        rest_spends: shielded_spends,
+                    Some(sapling::TransferData::NoSpends {
+                        first_output: shielded_outputs.remove(0),
                         rest_outputs: shielded_outputs,
-                        binding_sig: reader.read_64_bytes()?.into(),
                     })
                 } else {
                     None
+                };
+
+                let sapling_shielded_data = match sapling_transfers {
+                    Some(transfers) => Some(sapling::ShieldedData {
+                        value_balance,
+                        transfers,
+                        binding_sig: reader.read_64_bytes()?.into(),
+                    }),
+                    None => None,
                 };
 
                 Ok(Transaction::V4 {

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -381,7 +381,7 @@ fn sapling_shielded_v4_to_fake_v5(
         .unique()
         .collect();
 
-    let mut fake_spends: Vec<_> = v4_shielded
+    let fake_spends: Vec<_> = v4_shielded
         .spends()
         .cloned()
         .map(sapling_spend_v4_to_fake_v5)
@@ -397,18 +397,11 @@ fn sapling_shielded_v4_to_fake_v5(
 
             SpendsAndMaybeOutputs {
                 shared_anchor,
-                first_spend: fake_spends.remove(0),
-                rest_spends: fake_spends,
+                spends: fake_spends.try_into().unwrap(),
                 maybe_outputs,
             }
         }
-        JustOutputs {
-            first_output,
-            rest_outputs,
-        } => JustOutputs {
-            first_output,
-            rest_outputs,
-        },
+        JustOutputs { outputs } => JustOutputs { outputs },
     };
 
     let fake_shielded_v5 = ShieldedData::<SharedAnchor> {

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -1,13 +1,13 @@
 use super::super::*;
 
 use crate::{
-    block::Block,
+    block::{Block, MAX_BLOCK_BYTES},
     sapling::{PerSpendAnchor, SharedAnchor},
     serialization::{WriteZcashExt, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
 };
 
-use block::MAX_BLOCK_BYTES;
 use itertools::Itertools;
+
 use std::convert::TryInto;
 
 #[test]
@@ -372,8 +372,8 @@ fn transaction_to_fake_v5(trans: &Transaction) -> Transaction {
 fn sapling_shielded_v4_to_fake_v5(
     v4_shielded: sapling::ShieldedData<PerSpendAnchor>,
 ) -> Option<sapling::ShieldedData<SharedAnchor>> {
-    use futures::future::Either::*;
     use sapling::ShieldedData;
+    use sapling::TransferData::*;
 
     let unique_anchors: Vec<_> = v4_shielded
         .spends()
@@ -381,30 +381,39 @@ fn sapling_shielded_v4_to_fake_v5(
         .unique()
         .collect();
 
-    let shared_anchor = match unique_anchors.as_slice() {
-        [unique_anchor] => *unique_anchor,
-        // TODO: remove shared anchor when there are no spends
-        [] => Default::default(),
-        // Multiple different anchors, can't convert to v5
-        _ => return None,
-    };
+    let mut fake_spends: Vec<_> = v4_shielded
+        .spends()
+        .cloned()
+        .map(sapling_spend_v4_to_fake_v5)
+        .collect();
 
-    let first = match v4_shielded.first {
-        Left(spend) => Left(sapling_spend_v4_to_fake_v5(spend)),
-        Right(output) => Right(output),
+    let transfers = match v4_shielded.transfers {
+        Spends { maybe_outputs, .. } => {
+            let shared_anchor = match unique_anchors.as_slice() {
+                [unique_anchor] => *unique_anchor,
+                // Multiple different anchors, can't convert to v5
+                _ => return None,
+            };
+
+            Spends {
+                shared_anchor,
+                first_spend: fake_spends.remove(0),
+                rest_spends: fake_spends,
+                maybe_outputs,
+            }
+        }
+        NoSpends {
+            first_output,
+            rest_outputs,
+        } => NoSpends {
+            first_output,
+            rest_outputs,
+        },
     };
 
     let fake_shielded_v5 = ShieldedData::<SharedAnchor> {
         value_balance: v4_shielded.value_balance,
-        shared_anchor,
-        first,
-        rest_spends: v4_shielded
-            .rest_spends
-            .iter()
-            .cloned()
-            .map(sapling_spend_v4_to_fake_v5)
-            .collect(),
-        rest_outputs: v4_shielded.rest_outputs,
+        transfers,
         binding_sig: v4_shielded.binding_sig,
     };
 

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -388,24 +388,24 @@ fn sapling_shielded_v4_to_fake_v5(
         .collect();
 
     let transfers = match v4_shielded.transfers {
-        Spends { maybe_outputs, .. } => {
+        SpendsAndMaybeOutputs { maybe_outputs, .. } => {
             let shared_anchor = match unique_anchors.as_slice() {
                 [unique_anchor] => *unique_anchor,
                 // Multiple different anchors, can't convert to v5
                 _ => return None,
             };
 
-            Spends {
+            SpendsAndMaybeOutputs {
                 shared_anchor,
                 first_spend: fake_spends.remove(0),
                 rest_spends: fake_spends,
                 maybe_outputs,
             }
         }
-        NoSpends {
+        JustOutputs {
             first_output,
             rest_outputs,
-        } => NoSpends {
+        } => JustOutputs {
             first_output,
             rest_outputs,
         },


### PR DESCRIPTION
## Motivation

In V5 transactions, the shared anchor is only present if there are any spends.
This requires an extra `TransferData` type to model correctly.

(This change was made after the NU5 spec audit.)

## Solution

Update the design and tests to include:
- a `TransferData` type which makes sure that the shared anchor is only present when there are spends
- an `AtLeastOne` vector wrapper, which makes sure its inner vector always contains at least one element

As part of this change, delete the manual PartialEq impl and its tests, because we can derive PartialEq now.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

Both @oxarbitrage and @dconnolly should have a look at the new design, these changes are pretty major.

## Related Issues

#1829 implement V5 transaction for sapling
#2020 PR for V5 serialization for sapling

## Follow Up Work

#2028 use `AtLeastOne` for other types, like `JoinSplitData`, `Block.transaction`, and some network messages