### PR TITLE
Refactor and document correctness for std::sync::Mutex<AddressBook>

### DIFF
--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -15,7 +15,7 @@ use crate::{constants, types::MetaAddr, PeerAddrState};
 
 /// A database of peers, their advertised services, and information on when they
 /// were last seen.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AddressBook {
     /// Each known peer address has a matching `MetaAddr`
     by_addr: HashMap<SocketAddr, MetaAddr>,

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -3,10 +3,7 @@
 // Portions of this submodule were adapted from tower-balance,
 // which is (c) 2019 Tower Contributors (MIT licensed).
 
-use std::{
-    net::SocketAddr,
-    sync::{Arc, Mutex},
-};
+use std::{net::SocketAddr, sync::Arc};
 
 use futures::{
     channel::mpsc,
@@ -65,7 +62,7 @@ pub async fn init<S>(
     inbound_service: S,
 ) -> (
     Buffer<BoxService<Request, Response, BoxError>, Request>,
-    Arc<Mutex<AddressBook>>,
+    Arc<std::sync::Mutex<AddressBook>>,
 )
 where
     S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -5,7 +5,7 @@ use std::{
     future::Future,
     marker::PhantomData,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::Arc,
     task::{Context, Poll},
     time::Instant,
 };
@@ -106,7 +106,7 @@ where
     /// A shared list of peer addresses.
     ///
     /// Used for logging diagnostics.
-    address_book: Arc<Mutex<AddressBook>>,
+    address_book: Arc<std::sync::Mutex<AddressBook>>,
 }
 
 impl<D> PeerSet<D>
@@ -124,7 +124,7 @@ where
         demand_signal: mpsc::Sender<()>,
         handle_rx: tokio::sync::oneshot::Receiver<Vec<JoinHandle<Result<(), BoxError>>>>,
         inv_stream: broadcast::Receiver<(InventoryHash, SocketAddr)>,
-        address_book: Arc<Mutex<AddressBook>>,
+        address_book: Arc<std::sync::Mutex<AddressBook>>,
     ) -> Self {
         Self {
             discover,
@@ -379,8 +379,13 @@ where
         }
 
         self.last_peer_log = Some(Instant::now());
+
+        // # Correctness
+        //
         // Only log address metrics in exceptional circumstances, to avoid lock contention.
-        // TODO: replace with a watch channel that is updated in `AddressBook::update_metrics()`.
+        //
+        // TODO: replace with a watch channel that is updated in `AddressBook::update_metrics()`,
+        //       or turn the address book into a service (#1976)
         let address_metrics = self.address_book.lock().unwrap().address_metrics();
         if unready_services_len == 0 {
             warn!(

--- a/zebra-network/src/timestamp_collector.rs
+++ b/zebra-network/src/timestamp_collector.rs
@@ -1,6 +1,6 @@
 //! The timestamp collector collects liveness information from peers.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use futures::{channel::mpsc, prelude::*};
 
@@ -14,11 +14,11 @@ impl TimestampCollector {
     /// Spawn a new [`TimestampCollector`] task, and return handles for the
     /// transmission channel for timestamp events and for the [`AddressBook`] it
     /// updates.
-    pub fn spawn() -> (Arc<Mutex<AddressBook>>, mpsc::Sender<MetaAddr>) {
+    pub fn spawn() -> (Arc<std::sync::Mutex<AddressBook>>, mpsc::Sender<MetaAddr>) {
         use tracing::Level;
         const TIMESTAMP_WORKER_BUFFER_SIZE: usize = 100;
         let (worker_tx, mut worker_rx) = mpsc::channel(TIMESTAMP_WORKER_BUFFER_SIZE);
-        let address_book = Arc::new(Mutex::new(AddressBook::new(span!(
+        let address_book = Arc::new(std::sync::Mutex::new(AddressBook::new(span!(
             Level::TRACE,
             "timestamp collector"
         ))));
@@ -26,6 +26,10 @@ impl TimestampCollector {
 
         let worker = async move {
             while let Some(event) = worker_rx.next().await {
+                // # Correctness
+                //
+                // Briefly hold the address book threaded mutex, to update the
+                // state for a single address.
                 worker_address_book
                     .lock()
                     .expect("mutex should be unpoisoned")

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -1,7 +1,7 @@
 use std::{
     future::Future,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -31,7 +31,7 @@ type State = Buffer<BoxService<zs::Request, zs::Response, zs::BoxError>, zs::Req
 type Verifier = Buffer<BoxService<Arc<Block>, block::Hash, VerifyChainError>, Arc<Block>>;
 type InboundDownloads = Downloads<Timeout<Outbound>, Timeout<Verifier>, State>;
 
-pub type NetworkSetupData = (Outbound, Arc<Mutex<AddressBook>>);
+pub type NetworkSetupData = (Outbound, Arc<std::sync::Mutex<AddressBook>>);
 
 /// Tracks the internal state of the [`Inbound`] service during network setup.
 pub enum Setup {
@@ -54,7 +54,7 @@ pub enum Setup {
     /// All requests are answered.
     Initialized {
         /// A shared list of peer addresses.
-        address_book: Arc<Mutex<zn::AddressBook>>,
+        address_book: Arc<std::sync::Mutex<zn::AddressBook>>,
 
         /// A `futures::Stream` that downloads and verifies gossipped blocks.
         downloads: Pin<Box<InboundDownloads>>,
@@ -228,11 +228,20 @@ impl Service<zn::Request> for Inbound {
         match req {
             zn::Request::Peers => {
                 if let Setup::Initialized { address_book, .. } = &self.network_setup {
+                    // # Security
+                    //
                     // We could truncate the list to try to not reveal our entire
                     // peer set. But because we don't monitor repeated requests,
                     // this wouldn't actually achieve anything, because a crawler
                     // could just repeatedly query it.
-                    let mut peers = address_book.lock().unwrap().sanitized();
+                    //
+                    // # Correctness
+                    //
+                    // Briefly hold the address book threaded mutex while
+                    // cloning the address book. Then sanitize after releasing
+                    // the lock.
+                    let peers = address_book.lock().unwrap().clone();
+                    let mut peers = peers.sanitized();
                     const MAX_ADDR: usize = 1000; // bitcoin protocol constant
                     peers.truncate(MAX_ADDR);
                     async { Ok(zn::Response::Peers(peers)) }.boxed()


### PR DESCRIPTION
## Motivation

The shared peer address book uses a threaded mutex. So when we're waiting for the lock in async code, we need to be careful to avoid blocking all the tasks on that thread for too long.

## Solution

- Refactor to make correct usage easier
- Document correctness

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Integration Tests

## Review

@oxarbitrage can review once I've tested it locally.

## Related Issues

Implements part of #1995

## Follow Up Work

The address book and candidate set code is really complex. It would be easier to avoid hang bugs if they were rewritten as services (#1976).