### PR TITLE
Clarify CandidateSet state diagram

### DIFF
--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -43,7 +43,7 @@ use crate::{constants, types::MetaAddr, AddressBook, BoxError, Request, Response
 ///  │                               │
 ///  │                               │
 ///  │ ┌──────────────────┐          │
-///  │ │  Listener Port   │          │
+///  │ │     Inbound      │          │
 ///  │ │ Peer Connections │          │
 ///  │ └──────────────────┘          │
 ///  │          │                    │
@@ -68,7 +68,7 @@ use crate::{constants, types::MetaAddr, AddressBook, BoxError, Request, Response
 ///          ╲ ╱      to remove live                                  │
 ///           V      `Responded` peers                                │
 ///           │                                                       │
-///           │                                                       │
+///           │ Try outbound connection                               │
 ///           ▼                                                       │
 ///    ┌────────────────┐                                             │
 ///    │`AttemptPending`│                                             │


### PR DESCRIPTION
We get inbound connections on the listener port, but the important part is the inbound connection itself.