### PR TITLE
Stop assuming there will always be a git commit

### DIFF
--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -9,5 +9,11 @@ fn main() {
     *config.git_mut().semver_mut() = false;
     *config.git_mut().sha_kind_mut() = ShaKind::Short;
 
-    vergen(config).expect("Unable to generate the cargo keys!");
+    match vergen(config) {
+        Ok(_) => {}
+        Err(e) => eprintln!(
+            "skipping detailed git and target info due to vergen error: {:?}",
+            e
+        ),
+    }
 }


### PR DESCRIPTION
## Motivation

Since #1741, Zebra assumes that there will always be a `.git` directory. Even before that, Zebra assumed that there would always be some kind of git commit hash available.

## Solution

Enable builds where:
* there is no google cloud git commit env var, and
* there is no `.git` directory.

By making all `vergen` env vars optional, and skipping any env vars that don't exist.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Acceptance Tests


### Manual Test Output

Cause a port/database conflict panic:
```sh
zebrad start > /dev/null &
zebrad start
killall zebrad
```

#### Without `.git` directory (and no google cloud git commit env var):

```                                                                                                                                                                                               
Metadata:                                                                                                                                                                                      
version: 1.0.0-alpha.6                                                                                                                                                                         Zcash network: Mainnet                                                                                                                                                                                                                                                                                                                                                                          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━                                                                                                                                                                                                                                                                                                            
   0: zebrad::application:: with net="Main"                                                                                                                                                    
      at zebrad/src/application.rs:292   
```

Note that the target triple is also skipped, even though we can discover it directly from cargo. See rustyhorde/vergen#64.

#### With a `.git` directory:

```
Metadata:                                
version: 1.0.0-alpha.6
branch: vergen-no-git-fix
git commit: 102e465                                                                                                                                                                            
commit timestamp: 2021-04-20T07:05:45+00:00
target triple: x86_64-unknown-linux-gnu                                                        
Zcash network: Mainnet

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                                                                                                                                                                               
   0: zebrad::application:: with zebrad="102e465" net="Main"                                                                                                                                   
      at zebrad/src/application.rs:290    
```

## Review

This fix is urgent because the CD task is failing.

## Related Issues

Caused by PR #2029.

## Follow Up Work

Fix the cargo target triple and supply a better git commit version.