### PR TITLE
Add the new commit count and git hash to the version

### DIFF
--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -22,6 +22,12 @@ impl From<&Network> for &'static str {
     }
 }
 
+impl From<Network> for &'static str {
+    fn from(network: Network) -> &'static str {
+        (&network).into()
+    }
+}
+
 impl fmt::Display for Network {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.into())

--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -6,7 +6,6 @@ fn main() {
     *config.cargo_mut().features_mut() = false;
     *config.cargo_mut().profile_mut() = false;
 
-    *config.git_mut().semver_mut() = false;
     *config.git_mut().sha_kind_mut() = ShaKind::Short;
 
     match vergen(config) {

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -67,7 +67,7 @@ pub fn app_version() -> Version {
                     )
                 }),
 
-                // it's the "git semver" format, which doesn't quite match Semver 2.0
+                // it's the "git semver" format, which doesn't quite match SemVer 2.0
                 [hash, commit_count, tag] => {
                     let semver_fix = format!("{}+{}.{}", tag, commit_count, hash);
                     semver_fix.parse().unwrap_or_else(|_|

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -52,7 +52,8 @@ pub fn app_version() -> Version {
             // change the git semver format to the semver 2.0 format
             let rparts: Vec<_> = vergen_git_semver.rsplitn(3, '-').collect();
             assert_eq!(rparts.len(), 3,
-                               "git semver format must have at least 3 '-' separated parts: {:?}",
+                               "git semver format {:?} must have at least 3 '-' separated parts: {:?}",
+                               vergen_git_semver
                                rparts);
 
             if let [hash, commit_count, tag] = rparts.as_slice() {

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -53,7 +53,7 @@ pub fn app_version() -> Version {
             let rparts: Vec<_> = vergen_git_semver.rsplitn(3, '-').collect();
             assert_eq!(rparts.len(), 3,
                                "git semver format {:?} must have at least 3 '-' separated parts: {:?}",
-                               vergen_git_semver
+                               vergen_git_semver,
                                rparts);
 
             if let [hash, commit_count, tag] = rparts.as_slice() {

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -51,7 +51,9 @@ pub fn app_version() -> Version {
         Some(vergen_git_semver) => {
             // change the git semver format to the semver 2.0 format
             let rparts: Vec<_> = vergen_git_semver.rsplitn(3, '-').collect();
-            assert_eq!(rparts.len(), 3, "");
+            assert_eq!(rparts.len(), 3,
+                               "git semver format must have at least 3 '-' separated parts: {:?}",
+                               rparts);
 
             if let [hash, commit_count, tag] = rparts.as_slice() {
                 // strip the leading "v"

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -5,7 +5,7 @@ use tracing_subscriber::{
     FmtSubscriber,
 };
 
-use crate::config::TracingSection;
+use crate::{application::app_version, config::TracingSection};
 
 use super::flame;
 
@@ -77,7 +77,7 @@ impl<A: abscissa_core::Application> Component<A> for Tracing {
     }
 
     fn version(&self) -> abscissa_core::Version {
-        abscissa_core::Version::parse(env!("CARGO_PKG_VERSION")).unwrap()
+        app_version()
     }
 
     fn before_shutdown(&self, _kind: Shutdown) -> Result<(), FrameworkError> {


### PR DESCRIPTION
## Motivation

When someone is running on a git branch, sometimes it's hard to tell which version they branched off.

## Solution

Add the following info to the `version` in the panic, ticket template, and sentry report metadata:
* the number of commits since the last git tag
* the git commit hash (a bit repetitive, but it matches the "git semver" format)

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Acceptance Tests

### Manual Test Output

Cause a port/database conflict panic:
```sh
zebrad start 2> /dev/null &
zebrad start
killall zebrad
```

```
Metadata:
version: 1.0.0-alpha.1+332.g3a992dd
branch: vergen-git-tag-count-hash
git commit: 3a992dd
commit timestamp: 2021-04-20T07:09:02+00:00
target triple: x86_64-unknown-linux-gnu
Zcash network: Mainnet
```

## Review

This useful debugging feature can be reviewed by anyone at any time.

## Related Issues

Adds commits to PR #2037

## Follow Up Work

Use the target triple even if there is no `.git` directory, needs rustyhorde/vergen#64