### PR TITLE
Revert "Revert "build(deps): bump vergen from 5.1.1 to 5.1.2"" - actually make this change now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3931,11 +3931,12 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "5.1.1"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b12ae3b7d7a942d4698d79e20513c99fb3b6b7b0efc1b1f1fb0aafa31de939"
+checksum = "0277ffac28b64e449a7a8c369ddd8591647c5a2d1fd513eebd6a153ff4c40ea4"
 dependencies = [
  "anyhow",
+ "cfg-if 1.0.0",
  "chrono",
  "enum-iterator",
  "getset",

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -47,7 +47,7 @@ sentry = { version = "0.21.0", default-features = false, features = ["backtrace"
 sentry-tracing = { git = "https://github.com/kellpossible/sentry-tracing.git", rev = "f1a4a4a16b5ff1022ae60be779eb3fb928ce9b0f" }
 
 [build-dependencies]
-vergen = { version = "5.1.1", default-features = false, features = ["cargo", "git"] }
+vergen = { version = "5.1.2", default-features = false, features = ["cargo", "git"] }
 
 [dev-dependencies]
 abscissa_core = { version = "0.5", features = ["testing"] }


### PR DESCRIPTION
Reverts ZcashFoundation/zebra#2040, applying #2039 now that #2037 has merged and passed CD.