### PR TITLE
Make Zcash string serialization consistent with deserialization

### DIFF
--- a/zebra-chain/src/serialization/write_zcash.rs
+++ b/zebra-chain/src/serialization/write_zcash.rs
@@ -71,13 +71,6 @@ pub trait WriteZcashExt: io::Write {
         self.write_u16::<BigEndian>(addr.port())
     }
 
-    /// Write a string in Bitcoin format.
-    #[inline]
-    fn write_string(&mut self, string: &str) -> io::Result<()> {
-        self.write_compactsize(string.len() as u64)?;
-        self.write_all(string.as_bytes())
-    }
-
     /// Convenience method to write exactly 32 u8's.
     #[inline]
     fn write_32_bytes(&mut self, bytes: &[u8; 32]) -> io::Result<()> {

--- a/zebra-chain/src/serialization/zcash_serialize.rs
+++ b/zebra-chain/src/serialization/zcash_serialize.rs
@@ -99,6 +99,22 @@ pub fn zcash_serialize_bytes_external_count<W: io::Write>(
     writer.write_all(&vec)
 }
 
+/// Write a Bitcoin-encoded UTF-8 `&str`.
+impl ZcashSerialize for &str {
+    fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        let str_bytes = self.as_bytes();
+        writer.write_compactsize(str_bytes.len() as u64)?;
+        writer.write_all(str_bytes)
+    }
+}
+
+/// Write a Bitcoin-encoded UTF-8 `String`.
+impl ZcashSerialize for String {
+    fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        self.as_str().zcash_serialize(&mut writer)
+    }
+}
+
 /// The maximum length of a Zcash message, in bytes.
 ///
 /// This value is used to calculate safe preallocation limits for some types

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -228,7 +228,7 @@ impl Codec {
                 writer.write_socket_addr(*from_addr)?;
 
                 writer.write_u64::<LittleEndian>(nonce.0)?;
-                writer.write_string(&user_agent)?;
+                user_agent.zcash_serialize(&mut writer)?;
                 writer.write_u32::<LittleEndian>(start_height.0)?;
                 writer.write_u8(*relay as u8)?;
             }
@@ -245,9 +245,9 @@ impl Codec {
                 reason,
                 data,
             } => {
-                writer.write_string(&message)?;
+                message.zcash_serialize(&mut writer)?;
                 writer.write_u8(*ccode as u8)?;
-                writer.write_string(&reason)?;
+                reason.zcash_serialize(&mut writer)?;
                 if let Some(data) = data {
                     writer.write_all(data)?;
                 }


### PR DESCRIPTION
## Motivation

After recent changes, `String` serialization was `write_string`, but deserialization was `zcash_deserialize`.

## Solution

Make them both into `zcash_{de,}serialize` methods.

## Review

This is a tiny low-priority cleanup. Anyone can review.

## Related Issues

#1925 Stop untrusted preallocation during deserialization