### PR TITLE
Clarify a duplicate log message

### DIFF
--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -54,7 +54,7 @@ impl StartCmd {
             config.network.network,
         ));
 
-        info!("initializing chain verifier");
+        info!("initializing verifiers");
         let verifier = zebra_consensus::chain::init(
             config.consensus.clone(),
             config.network.network,
@@ -63,7 +63,6 @@ impl StartCmd {
         .await;
 
         info!("initializing network");
-
         // The service that our node uses to respond to requests by peers. The
         // load_shed middleware ensures that we reduce the size of the peer set
         // in response to excess load.


### PR DESCRIPTION
## Motivation

While testing #2034, I noticed two log messages that looked like duplicates, but they were actually from very different parts of the code.

## Solution

Change one of the log messages to make it more accurate, to avoid confusion.

## Review

This is a low-priority fix that anyone can review.
