### PR TITLE
Fix bug in deserialization of V5 tx

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -108,8 +108,7 @@ pub enum Transaction {
         outputs: Vec<transparent::Output>,
         /// The sapling shielded data for this transaction, if any.
         sapling_shielded_data: Option<sapling::ShieldedData<sapling::SharedAnchor>>,
-        /// The rest of the transaction as bytes
-        rest: Vec<u8>,
+        // TODO: The orchard data for this transaction, if any.
     },
 }
 

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -109,17 +109,15 @@ impl Transaction {
             transparent::Input::vec_strategy(ledger_state, 10),
             vec(any::<transparent::Output>(), 0..10),
             option::of(any::<sapling::ShieldedData<sapling::SharedAnchor>>()),
-            any::<Vec<u8>>(),
         )
             .prop_map(
-                |(lock_time, expiry_height, inputs, outputs, sapling_shielded_data, rest)| {
+                |(lock_time, expiry_height, inputs, outputs, sapling_shielded_data)| {
                     Transaction::V5 {
                         lock_time,
                         expiry_height,
                         inputs,
                         outputs,
                         sapling_shielded_data,
-                        rest,
                     }
                 },
             )


### PR DESCRIPTION
## Motivation

During transaction v5 development we created a test that convert all the transactions inside all our test vector blocks into v5 transactions.

This test is failing due to a bug in the `rest` field of transaction V5 serialization, specifically the following line is causing to read all the transactions from the block instead of just the end of the transaction itself:

https://github.com/ZcashFoundation/zebra/blob/v1.0.0-alpha.6/zebra-chain/src/transaction/serialize.rs#L325

Was hard to find the cause of the failure as all the transactions individually serialize/deserialize fine. The bug was introduced by me(sorry about that) in some previous PR.

## Solution

To fix it, this PR proposes to remove the `rest` field from the transaction as it is going to be replaced by orchard data anyway. We also add a `0` at the end of the transaction to represent empty orchard data (empty orchard data will be `None` when we implement). This will allow to remain compatible with blocks with v5 transactions that have sapling shielded data but no orchard data.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

No rush but the issue is in the current sprint.

## Related Issues

Closes https://github.com/ZcashFoundation/zebra/issues/2023

