### PR TITLE
Enable more Transaction v5 tests

### DIFF
--- a/zebra-chain/src/block/tests/prop.rs
+++ b/zebra-chain/src/block/tests/prop.rs
@@ -5,7 +5,7 @@ use proptest::{arbitrary::any, prelude::*, test_runner::Config};
 use zebra_test::prelude::*;
 
 use crate::serialization::{SerializationError, ZcashDeserializeInto, ZcashSerialize};
-use crate::{block, parameters::Network, LedgerState};
+use crate::{parameters::Network, LedgerState};
 
 use super::super::{serialize::MAX_BLOCK_BYTES, *};
 
@@ -121,13 +121,7 @@ proptest! {
 fn blocks_have_coinbase() -> Result<()> {
     zebra_test::init();
 
-    let strategy = any::<block::Height>()
-        .prop_map(|tip_height| LedgerState {
-            tip_height,
-            is_coinbase: true,
-            network: Network::Mainnet,
-        })
-        .prop_flat_map(Block::arbitrary_with);
+    let strategy = LedgerState::coinbase_strategy().prop_flat_map(Block::arbitrary_with);
 
     proptest!(|(block in strategy)| {
         let has_coinbase = block.coinbase_height().is_some();

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -130,7 +130,7 @@ impl Transaction {
         len: usize,
     ) -> BoxedStrategy<Vec<Arc<Self>>> {
         let coinbase = Transaction::arbitrary_with(ledger_state).prop_map(Arc::new);
-        ledger_state.is_coinbase = false;
+        ledger_state.has_coinbase = false;
         let remainder = vec(
             Transaction::arbitrary_with(ledger_state).prop_map(Arc::new),
             len,
@@ -302,16 +302,7 @@ impl Arbitrary for Transaction {
     type Parameters = LedgerState;
 
     fn arbitrary_with(ledger_state: Self::Parameters) -> Self::Strategy {
-        let LedgerState {
-            tip_height,
-            network,
-            ..
-        } = ledger_state;
-
-        let height = block::Height(tip_height.0 + 1);
-        let network_upgrade = NetworkUpgrade::current(network, height);
-
-        match network_upgrade {
+        match ledger_state.network_upgrade() {
             NetworkUpgrade::Genesis | NetworkUpgrade::BeforeOverwinter => {
                 Self::v1_strategy(ledger_state)
             }

--- a/zebra-chain/src/transparent/arbitrary.rs
+++ b/zebra-chain/src/transparent/arbitrary.rs
@@ -5,9 +5,9 @@ use crate::{block, LedgerState};
 use super::{CoinbaseData, Input, OutPoint, Script};
 
 impl Input {
-    /// Construct a strategy for creating validish vecs of Inputs.
+    /// Construct a strategy for creating valid-ish vecs of Inputs.
     pub fn vec_strategy(ledger_state: LedgerState, max_size: usize) -> BoxedStrategy<Vec<Self>> {
-        if ledger_state.is_coinbase {
+        if ledger_state.has_coinbase {
             let height = block::Height(ledger_state.tip_height.0 + 1);
             Self::arbitrary_with(Some(height))
                 .prop_map(|input| vec![input])

--- a/zebra-chain/src/transparent/prop.rs
+++ b/zebra-chain/src/transparent/prop.rs
@@ -1,6 +1,6 @@
 use zebra_test::prelude::*;
 
-use crate::{block, parameters::Network, LedgerState};
+use crate::{block, LedgerState};
 
 use super::Input;
 
@@ -24,12 +24,7 @@ fn input_coinbase_vecs_only_have_coinbase_input() -> Result<()> {
     zebra_test::init();
 
     let max_size = 100;
-    let strategy = any::<block::Height>()
-        .prop_map(|tip_height| LedgerState {
-            tip_height,
-            is_coinbase: true,
-            network: Network::Mainnet,
-        })
+    let strategy = LedgerState::coinbase_strategy()
         .prop_flat_map(|ledger_state| Input::vec_strategy(ledger_state, max_size));
 
     proptest!(|(inputs in strategy)| {

--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -13,7 +13,7 @@ use tower::buffer::Buffer;
 
 use zebra_chain::{
     block::{self, Block, Height},
-    parameters::{Network, NetworkUpgrade},
+    parameters::Network,
     serialization::{ZcashDeserialize, ZcashDeserializeInto},
     work::difficulty::{ExpandedDifficulty, INVALID_COMPACT_DIFFICULTY},
 };
@@ -283,9 +283,7 @@ fn subsidy_is_valid_for_network(network: Network) -> Result<(), Report> {
             .expect("block is structurally valid");
 
         // TODO: first halving, second halving, third halving, and very large halvings
-        if block::Height(height) > SLOW_START_INTERVAL
-            && block::Height(height) < NetworkUpgrade::Canopy.activation_height(network).unwrap()
-        {
+        if block::Height(height) > SLOW_START_INTERVAL {
             check::subsidy_is_valid(&block, network).expect("subsidies should pass for this block");
         }
     }

--- a/zebra-state/src/service/non_finalized_state/arbitrary.rs
+++ b/zebra-state/src/service/non_finalized_state/arbitrary.rs
@@ -49,11 +49,21 @@ impl Strategy for PreparedChain {
     fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
         let mut chain = self.chain.lock().unwrap();
         if chain.is_none() {
-            let blocks =
-                Block::partial_chain_strategy(LedgerState::default(), MAX_PARTIAL_CHAIN_BLOCKS)
-                    .prop_map(|vec| vec.into_iter().map(|blk| blk.prepare()).collect::<Vec<_>>())
-                    .new_tree(runner)?
-                    .current();
+            let ledger_strategy = LedgerState::coinbase_strategy();
+
+            // Disable the NU5 override until UpdateWith is implemented for Tx v5 (#1982)
+            let ledger_strategy = ledger_strategy.prop_map(|mut ledger_state| {
+                ledger_state.network_upgrade_override = None;
+                ledger_state
+            });
+
+            let blocks = ledger_strategy
+                .prop_flat_map(|ledger_state| {
+                    Block::partial_chain_strategy(ledger_state, MAX_PARTIAL_CHAIN_BLOCKS)
+                })
+                .prop_map(|vec| vec.into_iter().map(|blk| blk.prepare()).collect::<Vec<_>>())
+                .new_tree(runner)?
+                .current();
             *chain = Some(Arc::new(blocks));
         }
 


### PR DESCRIPTION
## Motivation

Currently, most of Zebra's proptests are testing Transaction v4, but we also want to test Transaction v5 (and NU5).

## Solution

- make NU5 the default network upgrade for proptests
- use arbitrary `LedgerState`s in more tests
- stop skipping Canopy (and later) blocks in some tests

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Property Tests

This is a replacement of https://github.com/ZcashFoundation/zebra/pull/2061

The automatic rebase didn't worked as expected, there are conflicts so i cherry picked the 2 commits involved and made a new PR.

## Review

@oxarbitrage can review. These tests don't pass without his fixes to #2023.

These fixes also depend on #2060.

## Follow Up Work

#2059 Use arbitrary LedgerStates in more tests to increase test coverage