### PR TITLE
Enable cargo env vars when there is no .git during a build, fix tag lookup, add build profile, add modified flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3941,9 +3941,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "5.1.4"
+version = "5.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575b693376dacf6a9825ab3e61a033cf0e94040e620fca8447b055ef8ce82d2b"
+checksum = "adf0b57f76a4f7e9673db1e7ffa4541d215ae8336fee45f5c1378bdeb22a0314"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,9 +1323,9 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "git2"
-version = "0.13.17"
+version = "0.13.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d250f5f82326884bd39c2853577e70a121775db76818ffa452ed1e80de12986"
+checksum = "b483c6c2145421099df1b4efd50e0f6205479a072199460eff852fa15e5603c7"
 dependencies = [
  "bitflags",
  "libc",
@@ -1784,9 +1784,9 @@ checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.18+1.1.0"
+version = "0.12.19+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da6a42da88fc37ee1ecda212ffa254c25713532980005d5f7c0b0fbe7e6e885"
+checksum = "f322155d574c8b9ebe991a04f6908bb49e68a79463338d24a43d6274cb6443e6"
 dependencies = [
  "cc",
  "libc",
@@ -3941,9 +3941,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "5.1.2"
+version = "5.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0277ffac28b64e449a7a8c369ddd8591647c5a2d1fd513eebd6a153ff4c40ea4"
+checksum = "575b693376dacf6a9825ab3e61a033cf0e94040e620fca8447b055ef8ce82d2b"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -48,7 +48,7 @@ sentry = { version = "0.21.0", default-features = false, features = ["backtrace"
 sentry-tracing = { git = "https://github.com/kellpossible/sentry-tracing.git", rev = "f1a4a4a16b5ff1022ae60be779eb3fb928ce9b0f" }
 
 [build-dependencies]
-vergen = { version = "5.1.2", default-features = false, features = ["cargo", "git"] }
+vergen = { version = "5.1.4", default-features = false, features = ["cargo", "git"] }
 
 [dev-dependencies]
 abscissa_core = { version = "0.5", features = ["testing"] }

--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -28,6 +28,7 @@ fn main() {
     disable_non_reproducible(&mut config);
 
     *config.git_mut().sha_kind_mut() = ShaKind::Short;
+    *config.git_mut().semver_kind_mut() = SemverKind::Lightweight;
 
     // Disable env vars we aren't using right now
     *config.cargo_mut().features_mut() = false;

--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -29,6 +29,10 @@ fn main() {
 
     *config.git_mut().sha_kind_mut() = ShaKind::Short;
     *config.git_mut().semver_kind_mut() = SemverKind::Lightweight;
+    // git typically uses "-dirty", but we change that so:
+    // - we're explicit and direct about source code state
+    // - it matches the SemVer 2.0 format, using dot separators
+    *config.git_mut().semver_dirty_mut() = Some(".modified");
 
     // Disable env vars we aren't using right now
     *config.cargo_mut().features_mut() = false;

--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -1,18 +1,47 @@
-use vergen::{vergen, Config, ShaKind};
+use vergen::{vergen, Config, SemverKind, ShaKind};
+
+/// Disable vergen env vars that could cause spurious reproducible build
+/// failures
+fn disable_non_reproducible(_config: &mut Config) {
+    /*
+    Currently, these features are disabled in `Cargo.toml`
+
+    // We don't use build or host-specific env vars, because they can break
+    // reproducible builds.
+    *config.build_mut().enabled_mut() = false;
+    *config.rustc mut().host_triple_mut() = false;
+
+    // It's ok for reproducible builds to depend on the build OS. But most other
+    // sysinfo should not change reproducible builds, so we disable it.
+    *config.sysinfo mut().user_mut() = false;
+    *config.sysinfo mut().memory_mut() = false;
+    *config.sysinfo mut().cpu_vendor_mut() = false;
+    *config.sysinfo mut().cpu_core_count_mut() = false;
+    *config.sysinfo mut().cpu_name_mut() = false;
+    *config.sysinfo mut().cpu_brand_mut() = false;
+    *config.sysinfo mut().cpu_frequency_mut() = false;
+     */
+}
 
 fn main() {
     let mut config = Config::default();
-
-    *config.cargo_mut().features_mut() = false;
-    *config.cargo_mut().profile_mut() = false;
+    disable_non_reproducible(&mut config);
 
     *config.git_mut().sha_kind_mut() = ShaKind::Short;
 
+    // Disable env vars we aren't using right now
+    *config.cargo_mut().features_mut() = false;
+
+    // Disable git if we're building with an invalid `zebra/.git`
     match vergen(config) {
         Ok(_) => {}
-        Err(e) => eprintln!(
-            "skipping detailed git and target info due to vergen error: {:?}",
-            e
-        ),
+        Err(e) => {
+            eprintln!(
+                "git error in vergen build script: skipping git env vars: {:?}",
+                e
+            );
+            *config.git_mut().enabled_mut() = false;
+            vergen(config).expect("non-git vergen should succeed");
+        }
     }
 }

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -45,7 +45,7 @@ pub fn app_config() -> config::Reader<ZebradApp> {
 /// For details, see https://semver.org/
 pub fn app_version() -> Version {
     const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
-    let vergen_git_semver: Option<&str> = option_env!("VERGEN_GIT_SEMVER");
+    let vergen_git_semver: Option<&str> = option_env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT");
 
     match vergen_git_semver {
         // change the git semver format to the semver 2.0 format

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -231,7 +231,11 @@ impl Application for ZebradApp {
             // build
             (
                 "target triple",
-                option_env!("VERGEN_CARGO_TARGET_TRIPLE").map(Into::into),
+                Some(env!("VERGEN_CARGO_TARGET_TRIPLE")).map(Into::into),
+            ),
+            (
+                "build profile",
+                Some(env!("VERGEN_CARGO_PROFILE")).map(Into::into),
             ),
             // config
             ("Zcash network", Some(config.network.network.to_string())),

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -220,6 +220,8 @@ impl Application for ZebradApp {
             // cargo or git tag + short commit
             ("version", Some(app_version().to_string())),
             // git
+            // git env vars can be skipped if there is no `.git` during the
+            // build, so they must all be optional
             ("branch", option_env!("VERGEN_GIT_BRANCH").map(Into::into)),
             ("git commit", Self::git_commit().map(Into::into)),
             (


### PR DESCRIPTION
## Motivation

In #2037, we disable all metadata if `.git` is missing. Thanks to rustyhorde/vergen#67, we can now disable git env vars, but leave the other env vars enabled.

Also we:
- fix tag lookup
- add a "modified" flag if the source code doesn't match the current commit

## Solution

- enable cargo env vars even when there is no `.git`
  - make sure that git vars are always optional
- add the `profile` cargo env var, so we know if it's a release or debug build
- fix git versions to include lightweight tags (like we use from `1.0.0-alpha.2` onwards)
- add a "modified" flag if the source code doesn't match the current commit

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Manual build tests for missing `.git` 

### Manual Test Output

Cause a port/database conflict panic:
```sh
zebrad start > /dev/null &
zebrad start
killall zebrad
```

#### Without `.git` directory (and no google cloud git commit env var):

```
Metadata:
version: 1.0.0-alpha.7
Zcash network: Mainnet
target triple: x86_64-unknown-linux-gnu
build profile: debug
```

#### With a `.git` directory:

```
Metadata:
version: 1.0.0-alpha.7+8.g9441663.modified
Zcash network: Mainnet
branch: vergen-no-git
git commit: 9441663
commit timestamp: 2021-04-26T03:26:06+00:00
target triple: x86_64-unknown-linux-gnu
build profile: debug
```

## Review

Anyone can review this low-priority fix.
