### PR TITLE
Document how Zebra does cross-crate proptests

### DIFF
--- a/book/src/dev/proptests.md
+++ b/book/src/dev/proptests.md
@@ -1,0 +1,9 @@
+# Randomised Property Testing in Zebra
+
+Zebra uses the [proptest](https://docs.rs/proptest/) crate for randomised property testing.
+
+Most types in `zebra-chain` have an `Arbitrary` implementation, which generates randomised test cases.
+
+When we want to use those `Arbitrary` impls in proptests in other crates, we use the `proptest-impl` feature as a dev dependency:
+* in `zebra-chain`: make the `Arbitrary` impl depend on `#[cfg(any(test, feature = "proptest-impl"))]`
+* in the other crate: add zebra-chain as a dev dependency: `zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }`


### PR DESCRIPTION
## Motivation

Explain what the `proptest-impl` feature does.

## Solution

Add a page to the book which explains how to use `proptest-impl`

## Review

@oxarbitrage just added a function to this feature.

## Follow Up Work

Maybe we should link to this page from the generated internal docs?
(That's where most crates document their features.)