### PR TITLE
Add extra crate dependencies to the proptest docs

### DIFF
--- a/book/src/dev/proptests.md
+++ b/book/src/dev/proptests.md
@@ -5,5 +5,12 @@ Zebra uses the [proptest](https://docs.rs/proptest/) crate for randomised proper
 Most types in `zebra-chain` have an `Arbitrary` implementation, which generates randomised test cases.
 
 When we want to use those `Arbitrary` impls in proptests in other crates, we use the `proptest-impl` feature as a dev dependency:
-* in `zebra-chain`: make the `Arbitrary` impl depend on `#[cfg(any(test, feature = "proptest-impl"))]`
-* in the other crate: add zebra-chain as a dev dependency: `zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }`
+1. in `zebra-chain`: make the `Arbitrary` impl depend on `#[cfg(any(test, feature = "proptest-impl"))]`
+2. in the other crate: add zebra-chain as a dev dependency: `zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }`
+
+If we need to add another dependency as part of the `proptest-impl` feature:
+1. Add the crate name to the list of crates in the `proptest-impl` `features` entry
+2. Add the crate as an optional `dependencies` entry
+3. Add the crate as a required `dev-dependencies` entry
+
+For an example of these changes, see [PR 2070](https://github.com/ZcashFoundation/zebra/pull/2070/files).


### PR DESCRIPTION
## Motivation

Explain how to add extra crate dependencies as part of a feature.

## Review

@oxarbitrage can check that these docs match PR #2070.

This is a low-priority doc update.
