### PR TITLE
Clippy nightly: disable owned cmp, stop comparing bool using assert_eq

### DIFF
--- a/zebra-chain/src/sapling/keys.rs
+++ b/zebra-chain/src/sapling/keys.rs
@@ -285,6 +285,8 @@ impl From<SpendingKey> for SpendAuthorizingKey {
 }
 
 impl PartialEq<[u8; 32]> for SpendAuthorizingKey {
+    // TODO: do we want to use constant-time comparison here?
+    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         <[u8; 32]>::from(*self) == *other
     }
@@ -326,6 +328,8 @@ impl From<SpendingKey> for ProofAuthorizingKey {
 }
 
 impl PartialEq<[u8; 32]> for ProofAuthorizingKey {
+    // TODO: do we want to use constant-time comparison here?
+    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         <[u8; 32]>::from(*self) == *other
     }
@@ -485,6 +489,8 @@ impl From<ProofAuthorizingKey> for NullifierDerivingKey {
 }
 
 impl PartialEq<[u8; 32]> for NullifierDerivingKey {
+    // TODO: do we want to use constant-time comparison here?
+    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         <[u8; 32]>::from(*self) == *other
     }
@@ -776,6 +782,8 @@ impl From<(IncomingViewingKey, Diversifier)> for TransmissionKey {
 }
 
 impl PartialEq<[u8; 32]> for TransmissionKey {
+    // TODO: do we want to use constant-time comparison here?
+    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         <[u8; 32]>::from(*self) == *other
     }
@@ -898,6 +906,8 @@ impl From<&EphemeralPublicKey> for [u8; 32] {
 }
 
 impl PartialEq<[u8; 32]> for EphemeralPublicKey {
+    // TODO: do we want to use constant-time comparison here?
+    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         <[u8; 32]>::from(self) == *other
     }

--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -131,7 +131,7 @@ mod tests {
             );
             assert_eq!(user_agent, "");
             assert_eq!(start_height.0, 0);
-            assert_eq!(relay, false);
+            assert!(!relay);
         } else {
             panic!("handshake did not send version message");
         }


### PR DESCRIPTION
## Motivation

The latest nightly clippy has a few new warnings.

## Solution

- disable owned comparison warnings: we need to create a new canonical point to compare JubJub
- stop comparing bool using `assert_eq!()`

## Review

This low-priority cleanup can be reviewed by anyone.
