### PR TITLE
Remove broken ci-success check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,6 @@ on:
 
 jobs:
 
-  ci-success:
-    name: 🏁
-    runs-on: ubuntu-latest
-    needs:
-      - test
-      - build
-      - build-chain-no-features
-      - clippy
-      - fmt
-    steps:
-      - run: exit 0
-
   test:
     name: Test (+${{ matrix.rust }}) on ${{ matrix.os }}
     # The large timeout is to accommodate Windows builds


### PR DESCRIPTION
## Motivation

Previously, Zebra made ci-success a required check for merges to main. And then we made ci-success depend on a bunch of other CI checks.

But this doesn't work as expected, because if the dependent checks fail, ci-success is skipped, and the branch protection rules allow the branch to be merged to main.

As a side-effect, CI will be slightly faster, because the number of jobs is reduced by 1. (Even though it is a short job, it still needs an extra VM.)

## Solution

In this PR: delete the broken ci-success check

In the GitHub admin interface: make the branch protection rule depend directly on the 5 CI checks we intended to require

I also opened a GitHub help issue, to get them to update their documentation to includes skipped tasks.

## Review

@dconnolly can review this PR as a routine cleanup.

## Related Issues

We discovered this issue because #2075 unexpectedly merged with broken tests.
