### PR TITLE
Improve CI speed by removing redundant build jobs and Rust components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,13 +112,10 @@ jobs:
         run: cargo build --verbose --no-default-features
 
   build:
-    name: Build (+${{ matrix.rust }}) on ${{ matrix.os }}
+    name: Build (+stable) on ubuntu-latest
     timeout-minutes: 60
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [stable, beta]
+    runs-on: ubuntu-latest
+
     env:
       CARGO_INCREMENTAL: 0
       RUST_BACKTRACE: full
@@ -127,15 +124,9 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           profile: minimal
           override: true
-      - name: Install LLVM on Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          choco install llvm -y
-          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: cargo fetch
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+          profile: minimal
           override: true
       - name: cargo fetch
         uses: actions-rs/cargo@v1
@@ -95,6 +96,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+          profile: minimal
           override: true
       - name: cargo fetch
         uses: actions-rs/cargo@v1
@@ -126,6 +128,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+          profile: minimal
           override: true
       - name: Install LLVM on Windows
         if: matrix.os == 'windows-latest'
@@ -188,6 +191,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          components: rustfmt
           override: true
       - run: rustup component add rustfmt
       - name: Show env vars

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: beta
+        components: rust-docs
         override: true
 
     - name: Install mdbook


### PR DESCRIPTION
## Motivation

CI can be slow, particularly if a lot of PRs (or PR changes) are submitted at the same time.

## Solution

- just run builds on ubuntu Rust stable
  - any failures on other platforms or on Rust beta will turn up in the tests
  - we also run clippy and rustfmt on ubuntu stable
- remove some redundant rust component installs

## Review

This routine CI change can be reviewed by @dconnolly.

## Follow Up Work

Maybe we can use the "skip redundant jobs" CI action to skip:
- old jobs on the same PR when a run for a new commit is waiting
- jobs on main that have already run on exactly the same commit in a PR
- jobs in a PR that have already run on exactly the same commit in a ZF branch

But that's a much more intrusive change that would require careful testing.