### PR TITLE
Rollup: Skip invalid addresses, add canonical peer addresses to the address book, send our own listener address, check version before sending verack

### DIFF
--- a/zebra-chain/src/orchard/keys.rs
+++ b/zebra-chain/src/orchard/keys.rs
@@ -233,6 +233,8 @@ impl From<SpendingKey> for SpendAuthorizingKey {
 }
 
 impl PartialEq<[u8; 32]> for SpendAuthorizingKey {
+    // TODO: do we want to use constant-time comparison here?
+    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         <[u8; 32]>::from(*self) == *other
     }
@@ -271,12 +273,14 @@ impl From<SpendAuthorizingKey> for SpendValidatingKey {
 }
 
 impl PartialEq for SpendValidatingKey {
+    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &Self) -> bool {
         <[u8; 32]>::from(self.0) == <[u8; 32]>::from(other.0)
     }
 }
 
 impl PartialEq<[u8; 32]> for SpendValidatingKey {
+    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         <[u8; 32]>::from(self.0) == *other
     }
@@ -338,6 +342,7 @@ impl From<SpendingKey> for NullifierDerivingKey {
 impl Eq for NullifierDerivingKey {}
 
 impl PartialEq<[u8; 32]> for NullifierDerivingKey {
+    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         <[u8; 32]>::from(*self) == *other
     }
@@ -826,6 +831,7 @@ impl From<(IncomingViewingKey, Diversifier)> for TransmissionKey {
 }
 
 impl PartialEq<[u8; 32]> for TransmissionKey {
+    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         <[u8; 32]>::from(*self) == *other
     }
@@ -866,6 +872,7 @@ impl From<&EphemeralPublicKey> for [u8; 32] {
 }
 
 impl PartialEq<[u8; 32]> for EphemeralPublicKey {
+    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         <[u8; 32]>::from(self) == *other
     }

--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -15,6 +15,7 @@ use tower::{
 };
 
 use crate::{peer, BoxError, Config, Request, Response};
+use peer::ConnectedAddr;
 
 /// Use the provided TCP connection to create a Zcash connection completely
 /// isolated from all other node state.
@@ -57,13 +58,11 @@ pub fn connect_isolated(
         .finish()
         .expect("provided mandatory builder parameters");
 
-    // We can't get the remote addr from conn, because it might be a tcp
-    // connection through a socks proxy, not directly to the remote. But it
-    // doesn't seem like zcashd cares if we give a bogus one, and Zebra doesn't
-    // touch it at all.
-    let remote_addr = "0.0.0.0:8233".parse().unwrap();
+    // Don't send any metadata about the connection
+    let connected_addr = ConnectedAddr::new_isolated();
 
-    Oneshot::new(handshake, (conn, remote_addr)).map_ok(|client| BoxService::new(Wrapper(client)))
+    Oneshot::new(handshake, (conn, connected_addr))
+        .map_ok(|client| BoxService::new(Wrapper(client)))
 }
 
 // This can be deleted when a new version of Tower with map_err is released.

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -191,6 +191,17 @@ impl MetaAddr {
         }
     }
 
+    /// Create a new `MetaAddr` for our own listener address.
+    pub fn new_local_listener(addr: &SocketAddr) -> MetaAddr {
+        MetaAddr {
+            addr: *addr,
+            // TODO: create a "local services" constant
+            services: PeerServices::NODE_NETWORK,
+            last_seen: Utc::now(),
+            last_connection_state: Responded,
+        }
+    }
+
     /// Create a new `MetaAddr` for a peer that has just had an error.
     pub fn new_errored(addr: &SocketAddr, services: &PeerServices) -> MetaAddr {
         MetaAddr {
@@ -240,8 +251,8 @@ impl MetaAddr {
         let last_seen = Utc.timestamp(ts - ts.rem_euclid(interval), 0);
         MetaAddr {
             addr: self.addr,
-            // services are sanitized during parsing, so we don't need to make
-            // any changes here
+            // services are sanitized during parsing, or set to a fixed valued by
+            // new_local_listener, so we don't need to sanitize here
             services: self.services,
             last_seen,
             // the state isn't sent to the remote peer, but sanitize it anyway

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -21,4 +21,4 @@ pub use client::Client;
 pub use connection::Connection;
 pub use connector::Connector;
 pub use error::{HandshakeError, PeerError, SharedPeerError};
-pub use handshake::Handshake;
+pub use handshake::{ConnectedAddr, Handshake, HandshakeRequest};

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -11,7 +11,7 @@ use tower::{discover::Change, Service, ServiceExt};
 
 use crate::{BoxError, Request, Response};
 
-use super::{Client, Handshake};
+use super::{Client, ConnectedAddr, Handshake};
 
 /// A wrapper around [`peer::Handshake`] that opens a TCP connection before
 /// forwarding to the inner handshake service. Writing this as its own
@@ -53,7 +53,8 @@ where
         async move {
             let stream = TcpStream::connect(addr).await?;
             hs.ready_and().await?;
-            let client = hs.call((stream, addr)).await?;
+            let connected_addr = ConnectedAddr::new_outbound_direct(addr);
+            let client = hs.call((stream, connected_addr)).await?;
             Ok(Change::Insert(addr, client))
         }
         .boxed()

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -224,6 +224,59 @@ impl ConnectedAddr {
             Isolated => "Isol",
         }
     }
+
+    /// Returns a list of alternate remote peer addresses, which can be used for
+    /// reconnection attempts.
+    ///
+    /// Uses the connected address, and the remote canonical address.
+    ///
+    /// Skips duplicates. If this is an outbound connection, also skips the
+    /// remote address that we're currently connected to.
+    pub fn get_alternate_addrs(
+        &self,
+        mut canonical_remote: SocketAddr,
+    ) -> impl Iterator<Item = SocketAddr> {
+        let addrs = match self {
+            OutboundDirect { addr } => {
+                // Fixup unspecified addresses and ports using known good data
+                if canonical_remote.ip().is_unspecified() {
+                    canonical_remote.set_ip(addr.ip());
+                }
+                if canonical_remote.port() == 0 {
+                    canonical_remote.set_port(addr.port());
+                }
+
+                // Try the canonical remote address, if it is different from the
+                // outbound address (which we already have in our address book)
+                if &canonical_remote != addr {
+                    vec![canonical_remote]
+                } else {
+                    Vec::new()
+                }
+            }
+
+            InboundDirect { maybe_ip, .. } => {
+                // Use the IP from the TCP connection, and the port the peer told us
+                let maybe_addr = SocketAddr::new(*maybe_ip, canonical_remote.port());
+
+                // Try both addresses, but remove one duplicate if they match
+                if canonical_remote != maybe_addr {
+                    vec![canonical_remote, maybe_addr]
+                } else {
+                    vec![canonical_remote]
+                }
+            }
+
+            // Proxy addresses can't be used for reconnection attempts, but we
+            // can try the canonical remote address
+            OutboundProxy { .. } | InboundProxy { .. } => vec![canonical_remote],
+
+            // Hide all metadata for isolated connections
+            Isolated => Vec::new(),
+        };
+
+        addrs.into_iter()
+    }
 }
 
 impl fmt::Debug for ConnectedAddr {
@@ -595,6 +648,30 @@ where
                 ),
             )
             .await??;
+
+            // If we've learned potential peer addresses from an inbound
+            // connection or handshake, add those addresses to our address book.
+            //
+            // # Security
+            //
+            // We must handle alternate addresses separately from connected
+            // addresses. Otherwise, malicious peers could interfere with the
+            // address book state of other peers by providing their addresses in
+            // `Version` messages.
+            let alternate_addrs = connected_addr.get_alternate_addrs(remote_canonical_addr);
+            for alt_addr in alternate_addrs {
+                let alt_addr = MetaAddr::new_alternate(&alt_addr, &remote_services);
+                if alt_addr.is_valid_for_outbound() {
+                    tracing::info!(
+                        ?alt_addr,
+                        "sending valid alternate peer address to the address book"
+                    );
+                    // awaiting a local task won't hang
+                    let _ = timestamp_collector.send(alt_addr).await;
+                } else {
+                    tracing::trace!(?alt_addr, "dropping invalid alternate peer address");
+                }
+            }
 
             // Set the connection's version to the minimum of the received version or our own.
             let negotiated_version = std::cmp::min(remote_version, constants::CURRENT_VERSION);

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -1,7 +1,8 @@
 use std::{
     collections::HashSet,
+    fmt,
     future::Future,
-    net::SocketAddr,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -12,6 +13,7 @@ use futures::{
     channel::{mpsc, oneshot},
     future, FutureExt, SinkExt, StreamExt,
 };
+use lazy_static::lazy_static;
 use tokio::{net::TcpStream, sync::broadcast, task::JoinError, time::timeout};
 use tokio_util::codec::Framed;
 use tower::Service;
@@ -53,6 +55,191 @@ pub struct Handshake<S> {
     parent_span: Span,
 }
 
+/// The peer address that we are handshaking with.
+///
+/// Typically, we can rely on outbound addresses, but inbound addresses don't
+/// give us enough information to reconnect to that peer.
+#[derive(Copy, Clone, PartialEq)]
+pub enum ConnectedAddr {
+    /// The address we used to make a direct outbound connection.
+    ///
+    /// In an honest network, a Zcash peer is listening on this exact address
+    /// and port.
+    OutboundDirect { addr: SocketAddr },
+
+    /// The address we received from the OS, when a remote peer directly
+    /// connected to our Zcash listener port.
+    ///
+    /// In an honest network, a Zcash peer might be listening on this address,
+    /// if its outbound address is the same as its listener address. But the port
+    /// is an ephemeral outbound TCP port, not a listener port.
+    InboundDirect {
+        maybe_ip: IpAddr,
+        transient_port: u16,
+    },
+
+    /// The proxy address we used to make an outbound connection.
+    ///
+    /// The proxy address can be used by many connections, but our own ephemeral
+    /// outbound address and port can be used as an identifier for the duration
+    /// of this connection.
+    OutboundProxy {
+        proxy_addr: SocketAddr,
+        transient_local_addr: SocketAddr,
+    },
+
+    /// The address we received from the OS, when a remote peer connected via an
+    /// inbound proxy.
+    ///
+    /// The proxy's ephemeral outbound address can be used as an identifier for
+    /// the duration of this connection.
+    InboundProxy { transient_addr: SocketAddr },
+
+    /// An isolated connection, where we deliberately don't connect any metadata.
+    Isolated,
+    //
+    // TODO: handle Tor onion addresses
+}
+
+lazy_static! {
+    /// An unspecified IPv4 address
+    pub static ref UNSPECIFIED_IPV4_ADDR: SocketAddr =
+        (Ipv4Addr::UNSPECIFIED, 0).into();
+}
+
+use ConnectedAddr::*;
+
+impl ConnectedAddr {
+    /// Returns a new outbound directly connected addr.
+    pub fn new_outbound_direct(addr: SocketAddr) -> ConnectedAddr {
+        OutboundDirect { addr }
+    }
+
+    /// Returns a new inbound directly connected addr.
+    pub fn new_inbound_direct(addr: SocketAddr) -> ConnectedAddr {
+        InboundDirect {
+            maybe_ip: addr.ip(),
+            transient_port: addr.port(),
+        }
+    }
+
+    /// Returns a new outbound connected addr via `proxy`.
+    ///
+    /// `local_addr` is the ephemeral local address of the connection.
+    #[allow(unused)]
+    pub fn new_outbound_proxy(proxy: SocketAddr, local_addr: SocketAddr) -> ConnectedAddr {
+        OutboundProxy {
+            proxy_addr: proxy,
+            transient_local_addr: local_addr,
+        }
+    }
+
+    /// Returns a new inbound connected addr from `proxy`.
+    //
+    // TODO: distinguish between direct listeners and proxy listeners in the
+    //       rest of zebra-network
+    #[allow(unused)]
+    pub fn new_inbound_proxy(proxy: SocketAddr) -> ConnectedAddr {
+        InboundProxy {
+            transient_addr: proxy,
+        }
+    }
+
+    /// Returns a new isolated connected addr, with no metadata.
+    pub fn new_isolated() -> ConnectedAddr {
+        Isolated
+    }
+
+    /// Returns a `SocketAddr` that can be used to track this connection in the
+    /// `AddressBook`.
+    ///
+    /// `None` for inbound connections, proxy connections, and isolated
+    /// connections.
+    ///
+    /// # Correctness
+    ///
+    /// This address can be used for reconnection attempts, or as a permanent
+    /// identifier.
+    ///
+    /// # Security
+    ///
+    /// This address must not depend on the canonical address from the `Version`
+    /// message. Otherwise, malicious peers could interfere with other peers
+    /// `AddressBook` state.
+    pub fn get_address_book_addr(&self) -> Option<SocketAddr> {
+        match self {
+            OutboundDirect { addr } => Some(*addr),
+            // TODO: consider using the canonical address of the peer to track
+            //       outbound proxy connections
+            InboundDirect { .. } | OutboundProxy { .. } | InboundProxy { .. } | Isolated => None,
+        }
+    }
+
+    /// Returns a `SocketAddr` that can be used to temporarily identify a
+    /// connection.
+    ///
+    /// Isolated connections must not change Zebra's peer set or address book
+    /// state, so they do not have an identifier.
+    ///
+    /// # Correctness
+    ///
+    /// The returned address is only valid while the original connection is
+    /// open. It must not be used in the `AddressBook`, for outbound connection
+    /// attempts, or as a permanent identifier.
+    ///
+    /// # Security
+    ///
+    /// This address must not depend on the canonical address from the `Version`
+    /// message. Otherwise, malicious peers could interfere with other peers'
+    /// `PeerSet` state.
+    pub fn get_transient_addr(&self) -> Option<SocketAddr> {
+        match self {
+            OutboundDirect { addr } => Some(*addr),
+            InboundDirect {
+                maybe_ip,
+                transient_port,
+            } => Some(SocketAddr::new(*maybe_ip, *transient_port)),
+            OutboundProxy {
+                transient_local_addr,
+                ..
+            } => Some(*transient_local_addr),
+            InboundProxy { transient_addr } => Some(*transient_addr),
+            Isolated => None,
+        }
+    }
+
+    /// Returns the metrics label for this connection's address.
+    pub fn get_transient_addr_label(&self) -> String {
+        self.get_transient_addr()
+            .map_or_else(|| "isolated".to_string(), |addr| addr.to_string())
+    }
+
+    /// Returns a short label for the kind of connection.
+    pub fn get_short_kind_label(&self) -> &'static str {
+        match self {
+            OutboundDirect { .. } => "Out",
+            InboundDirect { .. } => "In",
+            OutboundProxy { .. } => "ProxOut",
+            InboundProxy { .. } => "ProxIn",
+            Isolated => "Isol",
+        }
+    }
+}
+
+impl fmt::Debug for ConnectedAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = self.get_short_kind_label();
+        let addr = self.get_transient_addr_label();
+
+        if matches!(self, Isolated) {
+            f.write_str(kind)
+        } else {
+            f.debug_tuple(kind).field(&addr).finish()
+        }
+    }
+}
+
+/// A builder for `Handshake`.
 pub struct Builder<S> {
     config: Option<Config>,
     inbound_service: Option<S>,
@@ -81,6 +268,9 @@ where
     }
 
     /// Provide a channel for registering inventory advertisements. Optional.
+    ///
+    /// This channel takes transient remote addresses, which the `PeerSet` uses
+    /// to look up peers that have specific inventory.
     pub fn with_inventory_collector(
         mut self,
         inv_collector: broadcast::Sender<(InventoryHash, SocketAddr)>,
@@ -91,7 +281,8 @@ where
 
     /// Provide a hook for timestamp collection. Optional.
     ///
-    /// If this is unset, timestamps will not be collected.
+    /// This channel takes `MetaAddr`s, permanent addresses which can be used to
+    /// make outbound connections to peers.
     pub fn with_timestamp_collector(mut self, timestamp_collector: mpsc::Sender<MetaAddr>) -> Self {
         self.timestamp_collector = Some(timestamp_collector);
         self
@@ -181,19 +372,19 @@ where
 }
 
 /// Negotiate the Zcash network protocol version with the remote peer
-/// at `addr`, using the connection `peer_conn`.
+/// at `connected_addr`, using the connection `peer_conn`.
 ///
 /// We split `Handshake` into its components before calling this function,
 /// to avoid infectious `Sync` bounds on the returned future.
 pub async fn negotiate_version(
     peer_conn: &mut Framed<TcpStream, Codec>,
-    addr: &SocketAddr,
+    connected_addr: &ConnectedAddr,
     config: Config,
     nonces: Arc<futures::lock::Mutex<HashSet<Nonce>>>,
     user_agent: String,
     our_services: PeerServices,
     relay: bool,
-) -> Result<(Version, PeerServices), HandshakeError> {
+) -> Result<(Version, PeerServices, SocketAddr), HandshakeError> {
     // Create a random nonce for this connection
     let local_nonce = Nonce::default();
     // # Correctness
@@ -227,7 +418,12 @@ pub async fn negotiate_version(
         version: constants::CURRENT_VERSION,
         services: our_services,
         timestamp,
-        address_recv: (PeerServices::NODE_NETWORK, *addr),
+        address_recv: (
+            PeerServices::NODE_NETWORK,
+            connected_addr
+                .get_transient_addr()
+                .unwrap_or_else(|| *UNSPECIFIED_IPV4_ADDR),
+        ),
         // TODO: detect external address (#1893)
         address_from: (our_services, config.listen_addr),
         nonce: local_nonce,
@@ -248,17 +444,28 @@ pub async fn negotiate_version(
 
     // Check that we got a Version and destructure its fields into the local scope.
     debug!(?remote_msg, "got message from remote peer");
-    let (remote_nonce, remote_services, remote_version) = if let Message::Version {
-        nonce,
-        services,
-        version,
-        ..
-    } = remote_msg
-    {
-        (nonce, services, version)
-    } else {
-        Err(HandshakeError::UnexpectedMessage(Box::new(remote_msg)))?
-    };
+    let (remote_nonce, remote_services, remote_version, remote_canonical_addr) =
+        if let Message::Version {
+            version,
+            services,
+            address_from,
+            nonce,
+            ..
+        } = remote_msg
+        {
+            let (address_services, canonical_addr) = address_from;
+            if address_services != services {
+                info!(
+                    ?services,
+                    ?address_services,
+                    "peer with inconsistent version services and version address services"
+                );
+            }
+
+            (nonce, services, version, canonical_addr)
+        } else {
+            Err(HandshakeError::UnexpectedMessage(Box::new(remote_msg)))?
+        };
 
     // Check for nonce reuse, indicating self-connection
     //
@@ -317,10 +524,12 @@ pub async fn negotiate_version(
         Err(HandshakeError::ObsoleteVersion(remote_version))?;
     }
 
-    Ok((remote_version, remote_services))
+    Ok((remote_version, remote_services, remote_canonical_addr))
 }
 
-impl<S> Service<(TcpStream, SocketAddr)> for Handshake<S>
+pub type HandshakeRequest = (TcpStream, ConnectedAddr);
+
+impl<S> Service<HandshakeRequest> for Handshake<S>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
     S::Future: Send,
@@ -334,19 +543,20 @@ where
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, req: (TcpStream, SocketAddr)) -> Self::Future {
-        let (tcp_stream, addr) = req;
+    fn call(&mut self, req: HandshakeRequest) -> Self::Future {
+        let (tcp_stream, connected_addr) = req;
 
-        let connector_span = span!(Level::INFO, "connector", ?addr);
+        let negotiator_span = span!(Level::INFO, "negotiator", peer = ?connected_addr);
         // set the peer connection span's parent to the global span, as it
         // should exist independently of its creation source (inbound
         // connection, crawler, initial peer, ...)
-        let connection_span = span!(parent: &self.parent_span, Level::INFO, "peer", ?addr);
+        let connection_span =
+            span!(parent: &self.parent_span, Level::INFO, "", peer = ?connected_addr);
 
         // Clone these upfront, so they can be moved into the future.
         let nonces = self.nonces.clone();
         let inbound_service = self.inbound_service.clone();
-        let timestamp_collector = self.timestamp_collector.clone();
+        let mut timestamp_collector = self.timestamp_collector.clone();
         let inv_collector = self.inv_collector.clone();
         let config = self.config.clone();
         let user_agent = self.user_agent.clone();
@@ -354,7 +564,10 @@ where
         let relay = self.relay;
 
         let fut = async move {
-            debug!(?addr, "negotiating protocol version with remote peer");
+            debug!(
+                addr = ?connected_addr,
+                "negotiating protocol version with remote peer"
+            );
 
             // CORRECTNESS
             //
@@ -364,16 +577,16 @@ where
                 tcp_stream,
                 Codec::builder()
                     .for_network(config.network)
-                    .with_metrics_label(addr.ip().to_string())
+                    .with_metrics_addr_label(connected_addr.get_transient_addr_label())
                     .finish(),
             );
 
             // Wrap the entire initial connection setup in a timeout.
-            let (remote_version, remote_services) = timeout(
+            let (remote_version, remote_services, remote_canonical_addr) = timeout(
                 constants::HANDSHAKE_TIMEOUT,
                 negotiate_version(
                     &mut peer_conn,
-                    &addr,
+                    &connected_addr,
                     config,
                     nonces,
                     user_agent,
@@ -418,7 +631,7 @@ where
                     "zcash.net.out.messages",
                     1,
                     "command" => msg.to_string(),
-                    "addr" => addr.to_string(),
+                    "addr" => connected_addr.get_transient_addr_label(),
                 );
                 // We need to use future::ready rather than an async block here,
                 // because we need the sink to be Unpin, and the With<Fut, ...>
@@ -445,24 +658,30 @@ where
                                     "zcash.net.in.messages",
                                     1,
                                     "command" => msg.to_string(),
-                                    "addr" => addr.to_string(),
+                                    "addr" => connected_addr.get_transient_addr_label(),
                                 );
-                                // the collector doesn't depend on network activity,
-                                // so this await should not hang
-                                let _ = inbound_ts_collector
-                                    .send(MetaAddr::new_responded(&addr, &remote_services))
-                                    .await;
+
+                                if let Some(book_addr) = connected_addr.get_address_book_addr() {
+                                    // the collector doesn't depend on network activity,
+                                    // so this await should not hang
+                                    let _ = inbound_ts_collector
+                                        .send(MetaAddr::new_responded(&book_addr, &remote_services))
+                                        .await;
+                                }
                             }
                             Err(err) => {
                                 metrics::counter!(
                                     "zebra.net.in.errors",
                                     1,
                                     "error" => err.to_string(),
-                                    "addr" => addr.to_string(),
+                                    "addr" => connected_addr.get_transient_addr_label(),
                                 );
-                                let _ = inbound_ts_collector
-                                    .send(MetaAddr::new_errored(&addr, &remote_services))
-                                    .await;
+
+                                if let Some(book_addr) = connected_addr.get_address_book_addr() {
+                                    let _ = inbound_ts_collector
+                                        .send(MetaAddr::new_errored(&book_addr, &remote_services))
+                                        .await;
+                                }
                             }
                         }
                         msg
@@ -472,7 +691,9 @@ where
                     let inv_collector = inv_collector.clone();
                     let span = debug_span!("inventory_filter");
                     async move {
-                        if let Ok(Message::Inv(hashes)) = &msg {
+                        if let (Ok(Message::Inv(hashes)), Some(transient_addr)) =
+                            (&msg, connected_addr.get_transient_addr())
+                        {
                             // We ignore inventory messages with more than one
                             // block, because they are most likely replies to a
                             // query, rather than a newly gossiped block.
@@ -487,13 +708,15 @@ where
                             // merged inv messages into separate inv messages. (#1799)
                             match hashes.as_slice() {
                                 [hash @ InventoryHash::Block(_)] => {
-                                    let _ = inv_collector.send((*hash, addr));
+                                    let _ = inv_collector.send((*hash, transient_addr));
                                 }
                                 [hashes @ ..] => {
                                     for hash in hashes {
                                         if matches!(hash, InventoryHash::Tx(_)) {
                                             debug!(?hash, "registering Tx inventory hash");
-                                            let _ = inv_collector.send((*hash, addr));
+                                            // The peer set and inv collector use the peer's remote
+                                            // address as an identifier
+                                            let _ = inv_collector.send((*hash, transient_addr));
                                         } else {
                                             trace!(?hash, "ignoring non Tx inventory hash")
                                         }
@@ -562,10 +785,12 @@ where
                             Either::Left(_)
                         ) {
                             tracing::trace!("shutting down due to Client shut down");
-                            // awaiting a local task won't hang
-                            let _ = timestamp_collector
-                                .send(MetaAddr::new_shutdown(&addr, &remote_services))
-                                .await;
+                            if let Some(book_addr) = connected_addr.get_address_book_addr() {
+                                // awaiting a local task won't hang
+                                let _ = timestamp_collector
+                                    .send(MetaAddr::new_shutdown(&book_addr, &remote_services))
+                                    .await;
+                            }
                             return;
                         }
 
@@ -579,7 +804,7 @@ where
                         if heartbeat_timeout(
                             heartbeat,
                             &mut timestamp_collector,
-                            &addr,
+                            &connected_addr,
                             &remote_services,
                         )
                         .await
@@ -597,7 +822,7 @@ where
         };
 
         // Spawn a new task to drive this handshake.
-        tokio::spawn(fut.instrument(connector_span))
+        tokio::spawn(fut.instrument(negotiator_span))
             .map(|x: Result<Result<Client, HandshakeError>, JoinError>| Ok(x??))
             .boxed()
     }
@@ -652,7 +877,7 @@ async fn send_one_heartbeat(server_tx: &mut mpsc::Sender<ClientRequest>) -> Resu
 async fn heartbeat_timeout<F, T>(
     fut: F,
     timestamp_collector: &mut mpsc::Sender<MetaAddr>,
-    addr: &SocketAddr,
+    connected_addr: &ConnectedAddr,
     remote_services: &PeerServices,
 ) -> Result<T, BoxError>
 where
@@ -660,21 +885,33 @@ where
 {
     let t = match timeout(constants::HEARTBEAT_INTERVAL, fut).await {
         Ok(inner_result) => {
-            handle_heartbeat_error(inner_result, timestamp_collector, addr, remote_services).await?
+            handle_heartbeat_error(
+                inner_result,
+                timestamp_collector,
+                connected_addr,
+                remote_services,
+            )
+            .await?
         }
         Err(elapsed) => {
-            handle_heartbeat_error(Err(elapsed), timestamp_collector, addr, remote_services).await?
+            handle_heartbeat_error(
+                Err(elapsed),
+                timestamp_collector,
+                connected_addr,
+                remote_services,
+            )
+            .await?
         }
     };
 
     Ok(t)
 }
 
-/// If `result.is_err()`, mark `addr` as failed using `timestamp_collector`.
+/// If `result.is_err()`, mark `connected_addr` as failed using `timestamp_collector`.
 async fn handle_heartbeat_error<T, E>(
     result: Result<T, E>,
     timestamp_collector: &mut mpsc::Sender<MetaAddr>,
-    addr: &SocketAddr,
+    connected_addr: &ConnectedAddr,
     remote_services: &PeerServices,
 ) -> Result<T, E>
 where
@@ -685,10 +922,11 @@ where
         Err(err) => {
             tracing::debug!(?err, "heartbeat error, shutting down");
 
-            let _ = timestamp_collector
-                .send(MetaAddr::new_errored(&addr, &remote_services))
-                .await;
-
+            if let Some(book_addr) = connected_addr.get_address_book_addr() {
+                let _ = timestamp_collector
+                    .send(MetaAddr::new_errored(&book_addr, &remote_services))
+                    .await;
+            }
             Err(err)
         }
     }

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -64,7 +64,7 @@ where
     S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
     S::Future: Send + 'static,
 {
-    let (address_book, timestamp_collector) = TimestampCollector::spawn();
+    let (address_book, timestamp_collector) = TimestampCollector::spawn(&config);
     let (inv_sender, inv_receiver) = broadcast::channel(100);
 
     // Construct services that handle inbound handshakes and perform outbound

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -381,15 +381,14 @@ where
             DemandHandshake { candidate } => {
                 // spawn each handshake into an independent task, so it can make
                 // progress independently of the crawls
-                let hs_join =
-                    tokio::spawn(dial(candidate, outbound_connector.clone())).map(move |res| {
-                        match res {
-                            Ok(crawler_action) => crawler_action,
-                            Err(e) => {
-                                panic!("panic during handshaking with {:?}: {:?} ", candidate, e);
-                            }
+                let hs_join = tokio::spawn(dial(candidate, outbound_connector.clone()))
+                    .map(move |res| match res {
+                        Ok(crawler_action) => crawler_action,
+                        Err(e) => {
+                            panic!("panic during handshaking with {:?}: {:?} ", candidate, e);
                         }
-                    });
+                    })
+                    .instrument(Span::current());
                 handshakes.push(Box::pin(hs_join));
             }
             DemandCrawl => {

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -40,6 +40,17 @@ use super::{
 
 /// A [`tower::Service`] that abstractly represents "the rest of the network".
 ///
+/// # Security
+///
+/// The `Discover::Key` must be the transient remote address of each peer. This
+/// address may only be valid for the duration of a single connection. (For
+/// example, inbound connections have an ephemeral remote port, and proxy
+/// connections have an ephemeral local or proxy port.)
+///
+/// Otherwise, malicious peers could interfere with other peers' `PeerSet` state.
+///
+/// # Implementation
+///
 /// This implementation is adapted from the one in `tower-balance`, and as
 /// described in that crate's documentation, it
 ///

--- a/zebra-network/src/timestamp_collector.rs
+++ b/zebra-network/src/timestamp_collector.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use futures::{channel::mpsc, prelude::*};
 
-use crate::{types::MetaAddr, AddressBook};
+use crate::{types::MetaAddr, AddressBook, Config};
 
 /// The timestamp collector hooks into incoming message streams for each peer and
 /// records per-connection last-seen timestamps into an [`AddressBook`].
@@ -14,14 +14,14 @@ impl TimestampCollector {
     /// Spawn a new [`TimestampCollector`] task, and return handles for the
     /// transmission channel for timestamp events and for the [`AddressBook`] it
     /// updates.
-    pub fn spawn() -> (Arc<std::sync::Mutex<AddressBook>>, mpsc::Sender<MetaAddr>) {
+    pub fn spawn(config: &Config) -> (Arc<std::sync::Mutex<AddressBook>>, mpsc::Sender<MetaAddr>) {
         use tracing::Level;
         const TIMESTAMP_WORKER_BUFFER_SIZE: usize = 100;
         let (worker_tx, mut worker_rx) = mpsc::channel(TIMESTAMP_WORKER_BUFFER_SIZE);
-        let address_book = Arc::new(std::sync::Mutex::new(AddressBook::new(span!(
-            Level::TRACE,
-            "timestamp collector"
-        ))));
+        let address_book = Arc::new(std::sync::Mutex::new(AddressBook::new(
+            config,
+            span!(Level::TRACE, "timestamp collector"),
+        )));
         let worker_address_book = address_book.clone();
 
         let worker = async move {

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -240,7 +240,13 @@ impl Service<zn::Request> for Inbound {
                     // Briefly hold the address book threaded mutex while
                     // cloning the address book. Then sanitize after releasing
                     // the lock.
-                    let peers = address_book.lock().unwrap().clone();
+                    let mut peers = address_book.lock().unwrap().clone();
+
+                    // Add our local listener address to the advertised peers
+                    let local_listener = address_book.lock().unwrap().get_local_listener();
+                    peers.update(local_listener);
+
+                    // Send a sanitized response
                     let mut peers = peers.sanitized();
                     const MAX_ADDR: usize = 1000; // bitcoin protocol constant
                     peers.truncate(MAX_ADDR);


### PR DESCRIPTION
## Motivation

As part of the `MetaAddr` refactor (#1849), we need to track alternate addresses for existing peers.

## Solution

Track alternate addresses:
- canonical addresses that differ from the address we're actually connected to
- remote addresses of inbound connections, where we guess the default Zcash port

As part of this change, we also:
- send our own listener address in response to inbound `Peers` requests
  - this change improves integration test coverage
- remove client, inbound peer, and unspecified addresses from the address book, so it only contains the outbound addresses of full nodes
- add the canonical addresses provided by peers in their `Version` messages to the address book
- do some handshake checks earlier, before sending further messages

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Integration Tests
  - [x] Manual Tests

### Manual Tests

Running Zebra locally, I see that:
* `In` and `Out` addresses appear correct in the logs
* alternate addresses appear correct

> `dial{candidate=MetaAddr { addr: 178.140.162.102:8233, services: NODE_NETWORK, last_seen: 2021-05-04T05:15:35.999493016Z, last_connection_state: AttemptPending }}:negotiator{peer=Out("178.140.162.102:8233")}: zebra_network::peer::handshake: sending valid alternate peer address to the address book alt_addr=MetaAddr { addr: [2a02:2168:8b25:800:922b:34ff:fe5a:c38a]:8233, services:
NODE_NETWORK, last_seen: 2021-05-04T05:15:36.694310187Z, last_connection_state: NeverAttemptedAlternate }`

> `{zebrad="8da66f4" net="Main"}:{peer=Out("178.140.162.102:8233")}:msg_as_req{msg=getheaders}:state: zebra_state::service: responding to peer GetBlocks or GetHeaders final_height=
Height(1237279) response_len=36 chain_tip_height=Height(1237279) stop_height=None intersection_height=Some(Height(1237243))`

> ` {zebrad="8da66f4" net="Main"}:{peer=In("127.0.0.1:48778")}:msg_as_req{msg=getblocks}:state: zebra_state::service: responding to peer GetBlocks or GetHeaders final_height=Height(18428) response_len=500 chain_tip_height=Height(1237382) stop_height=None intersection_height=Some(Height(17928))`

## Review

Anyone can review. This is a routine refactor/feature/fix PR.

I might split this PR up into two smaller PRs after testing - but unfortunately most of the code changes are tightly coupled.

## Related Issues

This PR fixes part of #1892

## Follow Up Work

The rest of the #1849 refactor, including some cleanups