### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4459,7 +4459,6 @@ dependencies = [
  "displaydoc",
  "futures 0.3.14",
  "futures-util",
- "halo2",
  "jubjub",
  "lazy_static",
  "metrics",


### PR DESCRIPTION
## Motivation

When I compile `main` on a recent nightly, it makes this tiny change to `Cargo.lock`.

We should clean it up now, because it could cause merge conflicts or dependency confusion in future PRs.