### PR TITLE
Spelling: gossipped -> gossiped

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ especially the ability to make good connections to other Zcash network peers.
 
 Network:
 - synchronize the chain from peers
-- download gossipped blocks from peers
+- download gossiped blocks from peers
 - answer inbound peer requests for hashes, headers, and blocks
 
 State:

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -21,7 +21,7 @@
 //!  * Inbound Service
 //!    * handles requests from peers for network data and chain data
 //!    * performs transaction and block diffusion
-//!    * downloads and verifies gossipped blocks and transactions
+//!    * downloads and verifies gossiped blocks and transactions
 
 use abscissa_core::{config, Command, FrameworkError, Options, Runnable};
 use color_eyre::eyre::{eyre, Report};

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -56,7 +56,7 @@ pub enum Setup {
         /// A shared list of peer addresses.
         address_book: Arc<std::sync::Mutex<zn::AddressBook>>,
 
-        /// A `futures::Stream` that downloads and verifies gossipped blocks.
+        /// A `futures::Stream` that downloads and verifies gossiped blocks.
         downloads: Pin<Box<InboundDownloads>>,
     },
 

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -45,14 +45,14 @@ type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// Therefore, this attack can be carried out by a single malicious node.
 const MAX_INBOUND_CONCURRENCY: usize = 10;
 
-/// The action taken in response to a peer's gossipped block hash.
+/// The action taken in response to a peer's gossiped block hash.
 pub enum DownloadAction {
     /// The block hash was successfully queued for download and verification.
     AddedToQueue,
 
     /// The block hash is already queued, so this request was ignored.
     ///
-    /// Another peer has already gossipped the same hash to us.
+    /// Another peer has already gossiped the same hash to us.
     AlreadyQueued,
 
     /// The queue is at capacity, so this request was ignored.


### PR DESCRIPTION
## Motivation

Fix a spelling mistake