### PR TITLE
Security: stop gossiping temporary inbound remote addresses to peers

### DIFF
--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -1,4 +1,4 @@
-//! The addressbook manages information about what peers exist, when they were
+//! The `AddressBook` manages information about what peers exist, when they were
 //! seen, and what services they provide.
 
 use std::{
@@ -13,8 +13,39 @@ use tracing::Span;
 
 use crate::{constants, types::MetaAddr, PeerAddrState};
 
-/// A database of peers, their advertised services, and information on when they
-/// were last seen.
+/// A database of peer listener addresses, their advertised services, and
+/// information on when they were last seen.
+///
+/// # Security
+///
+/// Address book state must be based on outbound connections to peers.
+///
+/// If the address book is updated incorrectly:
+/// - malicious peers can interfere with other peers' `AddressBook` state,
+///   or
+/// - Zebra can advertise unreachable addresses to its own peers.
+///
+/// ## Adding Addresses
+///
+/// The address book should only contain Zcash listener port addresses from peers
+/// on the configured network. These addresses can come from:
+/// - DNS seeders
+/// - addresses gossiped by other peers
+/// - the canonical address (`Version.address_from`) provided by each peer,
+///   particularly peers on inbound connections.
+///
+/// The remote addresses of inbound connections must not be added to the address
+/// book, because they contain ephemeral outbound ports, not listener ports.
+///
+/// Isolated connections must not add addresses or update the address book.
+///
+/// ## Updating Address State
+///
+/// Updates to address state must be based on outbound connections to peers.
+///
+/// Updates must not be based on:
+/// - the remote addresses of inbound connections, or
+/// - the canonical address of any connection.
 #[derive(Clone, Debug)]
 pub struct AddressBook {
     /// Each known peer address has a matching `MetaAddr`
@@ -33,8 +64,11 @@ pub struct AddressMetrics {
     /// The number of addresses in the `Responded` state.
     responded: usize,
 
-    /// The number of addresses in the `NeverAttempted` state.
-    never_attempted: usize,
+    /// The number of addresses in the `NeverAttemptedGossiped` state.
+    never_attempted_gossiped: usize,
+
+    /// The number of addresses in the `NeverAttemptedAlternate` state.
+    never_attempted_alternate: usize,
 
     /// The number of addresses in the `Failed` state.
     failed: usize,
@@ -93,9 +127,10 @@ impl AddressBook {
     /// Add `new` to the address book, updating the previous entry if `new` is
     /// more recent or discarding `new` if it is stale.
     ///
-    /// ## Note
+    /// # Correctness
     ///
-    /// All changes should go through `update` or `take`, to ensure accurate metrics.
+    /// All new addresses should go through `update`, so that the address book
+    /// only contains valid outbound addresses.
     pub fn update(&mut self, new: MetaAddr) {
         let _guard = self.span.enter();
         trace!(
@@ -103,6 +138,14 @@ impl AddressBook {
             total_peers = self.by_addr.len(),
             recent_peers = self.recently_live_peers().count(),
         );
+
+        // Drop any unspecified or client addresses.
+        //
+        // Communication with these addresses can be monitored via Zebra's
+        // metrics. (The address book is for valid peer addresses.)
+        if !new.is_valid_for_outbound() {
+            return;
+        }
 
         if let Some(prev) = self.get_by_addr(new.addr) {
             if prev.get_last_seen() > new.get_last_seen() {
@@ -117,9 +160,10 @@ impl AddressBook {
 
     /// Removes the entry with `addr`, returning it if it exists
     ///
-    /// ## Note
+    /// # Note
     ///
-    /// All changes should go through `update` or `take`, to ensure accurate metrics.
+    /// All address removals should go through `take`, so that the address
+    /// book metrics are accurate.
     fn take(&mut self, removed_addr: SocketAddr) -> Option<MetaAddr> {
         let _guard = self.span.enter();
         trace!(
@@ -254,7 +298,12 @@ impl AddressBook {
     /// Returns metrics for the addresses in this address book.
     pub fn address_metrics(&self) -> AddressMetrics {
         let responded = self.state_peers(PeerAddrState::Responded).count();
-        let never_attempted = self.state_peers(PeerAddrState::NeverAttempted).count();
+        let never_attempted_gossiped = self
+            .state_peers(PeerAddrState::NeverAttemptedGossiped)
+            .count();
+        let never_attempted_alternate = self
+            .state_peers(PeerAddrState::NeverAttemptedAlternate)
+            .count();
         let failed = self.state_peers(PeerAddrState::Failed).count();
         let attempt_pending = self.state_peers(PeerAddrState::AttemptPending).count();
 
@@ -265,7 +314,8 @@ impl AddressBook {
 
         AddressMetrics {
             responded,
-            never_attempted,
+            never_attempted_gossiped,
+            never_attempted_alternate,
             failed,
             attempt_pending,
             recently_live,
@@ -281,7 +331,11 @@ impl AddressBook {
 
         // TODO: rename to address_book.[state_name]
         metrics::gauge!("candidate_set.responded", m.responded as f64);
-        metrics::gauge!("candidate_set.gossiped", m.never_attempted as f64);
+        metrics::gauge!("candidate_set.gossiped", m.never_attempted_gossiped as f64);
+        metrics::gauge!(
+            "candidate_set.alternate",
+            m.never_attempted_alternate as f64
+        );
         metrics::gauge!("candidate_set.failed", m.failed as f64);
         metrics::gauge!("candidate_set.pending", m.attempt_pending as f64);
 
@@ -327,7 +381,12 @@ impl AddressBook {
 
         self.last_address_log = Some(Instant::now());
         // if all peers have failed
-        if m.responded + m.attempt_pending + m.never_attempted == 0 {
+        if m.responded
+            + m.attempt_pending
+            + m.never_attempted_gossiped
+            + m.never_attempted_alternate
+            == 0
+        {
             warn!(
                 address_metrics = ?m,
                 "all peer addresses have failed. Hint: check your network connection"

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -139,7 +139,15 @@ impl AddressBook {
             recent_peers = self.recently_live_peers().count(),
         );
 
-        // Drop any unspecified or client addresses.
+        // If a node that we are directly connected to has changed to a client,
+        // remove it from the address book.
+        if new.is_direct_client() && self.contains_addr(&new.addr) {
+            std::mem::drop(_guard);
+            self.take(new.addr);
+            return;
+        }
+
+        // Never add unspecified addresses or client services.
         //
         // Communication with these addresses can be monitored via Zebra's
         // metrics. (The address book is for valid peer addresses.)

--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -15,6 +15,7 @@ use tower::{
 };
 
 use crate::{peer, BoxError, Config, Request, Response};
+use peer::ConnectedAddr;
 
 /// Use the provided TCP connection to create a Zcash connection completely
 /// isolated from all other node state.
@@ -57,13 +58,11 @@ pub fn connect_isolated(
         .finish()
         .expect("provided mandatory builder parameters");
 
-    // We can't get the remote addr from conn, because it might be a tcp
-    // connection through a socks proxy, not directly to the remote. But it
-    // doesn't seem like zcashd cares if we give a bogus one, and Zebra doesn't
-    // touch it at all.
-    let remote_addr = "0.0.0.0:8233".parse().unwrap();
+    // Don't send any metadata about the connection
+    let connected_addr = ConnectedAddr::new_isolated();
 
-    Oneshot::new(handshake, (conn, remote_addr)).map_ok(|client| BoxService::new(Wrapper(client)))
+    Oneshot::new(handshake, (conn, connected_addr))
+        .map_ok(|client| BoxService::new(Wrapper(client)))
 }
 
 // This can be deleted when a new version of Tower with map_err is released.

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -156,7 +156,9 @@ impl MetaAddr {
     ///
     /// # Security
     ///
-    /// This address must be the remote address from an outbound connection.
+    /// This address must be the remote address from an outbound connection,
+    /// and the services must be the services from that peer's handshake.
+    ///
     /// Otherwise:
     /// - malicious peers could interfere with other peers' `AddressBook` state,
     ///   or
@@ -224,6 +226,14 @@ impl MetaAddr {
     /// clock skew, or buggy or malicious peers.
     pub fn get_last_seen(&self) -> DateTime<Utc> {
         self.last_seen
+    }
+
+    /// Is this address a directly connected client?
+    pub fn is_direct_client(&self) -> bool {
+        match self.last_connection_state {
+            Responded => !self.services.contains(PeerServices::NODE_NETWORK),
+            NeverAttemptedGossiped | NeverAttemptedAlternate | Failed | AttemptPending => false,
+        }
     }
 
     /// Is this address valid for outbound connections?

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -21,4 +21,4 @@ pub use client::Client;
 pub use connection::Connection;
 pub use connector::Connector;
 pub use error::{HandshakeError, PeerError, SharedPeerError};
-pub use handshake::Handshake;
+pub use handshake::{ConnectedAddr, Handshake, HandshakeRequest};

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -11,7 +11,7 @@ use tower::{discover::Change, Service, ServiceExt};
 
 use crate::{BoxError, Request, Response};
 
-use super::{Client, Handshake};
+use super::{Client, ConnectedAddr, Handshake};
 
 /// A wrapper around [`peer::Handshake`] that opens a TCP connection before
 /// forwarding to the inner handshake service. Writing this as its own
@@ -53,7 +53,8 @@ where
         async move {
             let stream = TcpStream::connect(addr).await?;
             hs.ready_and().await?;
-            let client = hs.call((stream, addr)).await?;
+            let connected_addr = ConnectedAddr::new_outbound_direct(addr);
+            let client = hs.call((stream, connected_addr)).await?;
             Ok(Change::Insert(addr, client))
         }
         .boxed()

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -95,7 +95,7 @@ pub enum ConnectedAddr {
     /// the duration of this connection.
     InboundProxy { transient_addr: SocketAddr },
 
-    /// An isolated connection, where we deliberately don't connect any metadata.
+    /// An isolated connection, where we deliberately don't have any connection metadata.
     Isolated,
     //
     // TODO: handle Tor onion addresses

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -40,6 +40,17 @@ use super::{
 
 /// A [`tower::Service`] that abstractly represents "the rest of the network".
 ///
+/// # Security
+///
+/// The `Discover::Key` must be the transient remote address of each peer. This
+/// address may only be valid for the duration of a single connection. (For
+/// example, inbound connections have an ephemeral remote port, and proxy
+/// connections have an ephemeral local or proxy port.)
+///
+/// Otherwise, malicious peers could interfere with other peers' `PeerSet` state.
+///
+/// # Implementation
+///
 /// This implementation is adapted from the one in `tower-balance`, and as
 /// described in that crate's documentation, it
 ///


### PR DESCRIPTION
## Motivation

When Zebra gets inbound connections from peers, it puts the remote addresses of those connections in its address book. But those addresses are not Zcash listener addresses - the IP address might be correct, but the port is an ephemeral local port.

There are tens of thousands of ephemeral ports for each peer IP address.

This issue is mitigated because:
* Zebra's default config uses an unspecified inbound address
* Zebra does not detect its own IP address
* Zebra does not send its address to other peers

## Solution

- stop putting inbound addresses in the address book
- drop address book entries that can't be used for outbound connections
    - distinguish between temporary inbound and permanent outbound peer
       addresses
    - also create variants to handle proxy connections
       (but don't use them yet)
     - avoid tracking connection state for isolated connections
- make isolated connections more anonymous, add defence-in-depth
- document security constraints for the address book and peer set

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Integration Tests
  - [x] Manual Testing (see #2093)

## Review

This PR is blocking progress on some other security fixes.

But we still have to expire old addresses before the fix is complete, so it will be a release or two before we can get everyone to re-deploy.

## Related Issues

PRs #2121 and #2122 depend on this fix.

This fix blocks #1849.

## Follow Up Work

Stop gossiping failure times as last seen times #1868 
Make Zebra stop sending the incorrect addresses that we've been adding to the network #1867