### PR TITLE
Security: do version checks first, then send a verack response

### DIFF
--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -493,18 +493,6 @@ pub async fn negotiate_version(
         Err(HandshakeError::NonceReuse)?;
     }
 
-    peer_conn.send(Message::Verack).await?;
-
-    let remote_msg = peer_conn
-        .next()
-        .await
-        .ok_or(HandshakeError::ConnectionClosed)??;
-    if let Message::Verack = remote_msg {
-        debug!("got verack from remote peer");
-    } else {
-        Err(HandshakeError::UnexpectedMessage(Box::new(remote_msg)))?;
-    }
-
     // XXX in zcashd remote peer can only send one version message and
     // we would disconnect here if it received a second one. Is it even possible
     // for that to happen to us here?
@@ -530,6 +518,18 @@ pub async fn negotiate_version(
     if remote_version < Version::min_for_upgrade(config.network, constants::MIN_NETWORK_UPGRADE) {
         // Disconnect if peer is using an obsolete version.
         Err(HandshakeError::ObsoleteVersion(remote_version))?;
+    }
+
+    peer_conn.send(Message::Verack).await?;
+
+    let remote_msg = peer_conn
+        .next()
+        .await
+        .ok_or(HandshakeError::ConnectionClosed)??;
+    if let Message::Verack = remote_msg {
+        debug!("got verack from remote peer");
+    } else {
+        Err(HandshakeError::UnexpectedMessage(Box::new(remote_msg)))?;
     }
 
     Ok((remote_version, remote_services, remote_canonical_addr))


### PR DESCRIPTION
## Motivation

As a general rule, Zebra should do local checks first, then send messages to the peer.

This minor security issue was discovered during #2120, but it's not related to that fix. (It just changes nearby code.)

## Review

This is a routine security fix. Anyone can review.

## Related Issues

This fix is based on #2120. GitHub will automatically rebase it to main once #2120 merges.
