### PR TITLE
Make the RFC TOC into a separate step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,9 +74,10 @@ with the PR number.
 
 8. When the RFC is merged, take the next available RFC number (not conflicting
 with any existing RFCs or design PRs) and name the RFC file accordingly, e.g.,
-`0027-my-feature.md` for number 27. Make sure that `book/src/SUMMARY.md` links
-to the numbered RFC.
+`0027-my-feature.md` for number 27.
 
-7. After the RFC is accepted, create an issue for the implementation of the
+9. Make sure that `book/src/SUMMARY.md` links to the new number for the RFC.
+
+10. After the RFC is accepted, create an issue for the implementation of the
 design, and update the RFC header and PR description with the implementation
 issue number.


### PR DESCRIPTION
## Motivation

We've forgotten to add the last few RFCs to SUMMARY.md.

## Solution

Make the RFC TOC into a separate step.

We might remember it better that way.

## Review

Anyone can review this minor change. It's not urgent.

## Related Issues

Follow up for #2124

## Follow Up Work

Maybe we can automate this step, or check for it in our tests, see #2125