### PR TITLE
Explicitly allow unencrypted disclosures for alpha releases

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,8 +36,14 @@ Specifically, we have agreed to engage in responsible disclosures for security i
 
 ## Deviations from the Standard
 
+### Monetary Base Protection
+
 Zcash is a technology that provides strong privacy. Notes are encrypted to their destination, and then the monetary base is kept via zero-knowledge proofs intended to only be creatable by the real holder of Zcash. If this fails, and a counterfeiting bug results, that counterfeiting bug might be exploited without any way for blockchain analyzers to identify the perpetrator or which data in the blockchain has been used to exploit the bug. Rollbacks before that point, such as have been executed in some other projects in such cases, are therefore impossible.
 
 The standard describes reporters of vulnerabilities including full details of an issue, in order to reproduce it. This is necessary for instance in the case of an external researcher both demonstrating and proving that there really is a security issue, and that security issue really has the impact that they say it has - allowing the development team to accurately prioritize and resolve the issue.
 
 In the case of a counterfeiting bug, we might decide not to include those details with our reports to partners ahead of coordinated release, so long as we are sure that they are vulnerable.
+
+### Alpha Release Disclosures
+
+The Zcash Foundation will generate encryption keys for security disclosures for our first stable release. Until then, disclosures should be sent to security@zfnd.org unencrypted.


### PR DESCRIPTION
## Motivation

We decided to skip generating and securing encryption keys until Zebra's first stable release.

But the policy we reference requires PGP encrypted emails, so we need to explicitly allow unencrypted disclosures for Zebra alpha releases.

## Solution

Explicitly allow unencrypted disclosures for Zebra alpha releases.

## Review

@dconnolly should review this update, it's not urgent.

## Follow Up Work

Getting people in the habit of sending unencrypted disclosures might lead to accidental insecure disclosures. So we should make generating PGP keys a higher priority (#1638).
