### PR TITLE
Security: stop panicking on out-of-range version timestamps, Credit: Equilibrium

### DIFF
--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -741,7 +741,7 @@ mod tests {
 
             let old_bytes = bytes.clone();
 
-            // tweak the version bytes so they're out of range
+            // tweak the version bytes so the timestamp is set to `time`
             // Version serialization is specified at:
             // https://developer.bitcoin.org/reference/p2p_networking.html#version
             bytes[36..44].copy_from_slice(&time.to_le_bytes());


### PR DESCRIPTION
## Motivation

If Zebra receives an out-of-range time in a version message, it will panic.

This issue was reported by Niklas Long of Equilibrium.

## Solution

Instead, return a deserialization error, and close the connection.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests

## Root Causes

`chrono`'s `timestamp` function panics, and the `timestamp_opt` function returns a `Result`-like enum. But most other Rust APIs have an explicit `*_unwrap` suffix on functions that panic.

Bitcoin's network protocol uses `u32` for most times, but `i64` for times in the version message. All `u32`s are valid `chrono` times, but some `i64`s are invalid.

## Review

@conradoplg would you like to review this fix? It's not particularly urgent, because it doesn't affect other nodes.

@niklaslong how would you like to be credited in the Zebra release notes?

## Related Issues

I'm just about to post a cleanup PR for Zebra's other time serialization.
