### PR TITLE
Security: Handle small numbers of initial peers better, Credit: Equilibrium

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -67,6 +67,11 @@ impl Config {
     async fn resolve_peers(peers: &HashSet<String>) -> HashSet<SocketAddr> {
         use futures::stream::StreamExt;
 
+        if peers.is_empty() {
+            error!("no initial peers in the network config. Hint: you must configure at least one peer or DNS seeder to run Zebra");
+            return HashSet::new();
+        }
+
         loop {
             // We retry each peer individually, as well as retrying if there are
             // no peers in the combined list. DNS failures are correlated, so all


### PR DESCRIPTION
## Motivation

1. Zebra can appear to hang if there are a small number of initial peers. (It eventually continues after `3*75` seconds, but that's a long time to wait.)

Reported by Niklas Long of Equilibrium.

2. Zebra does not do anything if it has zero initial peers.

## Solution

- Limit the fanout on the initial candidate set update to the number of initial peers.
- Log an explicit error if there are zero initial peers. Do not attempt DNS resolution at all.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Existing Integration Tests

## Review

@dconnolly or @conradoplg can review. This PR blocks #1849, so it would be nice to get it in soon.

## Follow Up Work

It would be nice to avoid the initial update entirely. But it's a workaround for a `zcashd` network protocol choice, so there's not much we can do here.