### PR TITLE
Security: reject compact sizes greater than the protocol message limit

### DIFF
--- a/zebra-chain/src/block/tests/preallocate.rs
+++ b/zebra-chain/src/block/tests/preallocate.rs
@@ -3,7 +3,7 @@
 use crate::{
     block::{
         header::MIN_COUNTED_HEADER_LEN, CountedHeader, Hash, Header, BLOCK_HASH_SIZE,
-        MAX_PROTOCOL_MESSAGE_LEN,
+        MAX_BLOCK_BYTES, MAX_PROTOCOL_MESSAGE_LEN,
     },
     serialization::{TrustedPreallocate, ZcashSerialize},
 };
@@ -51,7 +51,7 @@ proptest! {
     /// Confirm that each counted header takes at least COUNTED_HEADER_LEN bytes when serialized.
     /// This verifies that our calculated `TrustedPreallocate::max_allocation()` is indeed an upper bound.
     #[test]
-    fn counted_header_min_length(header in Header::arbitrary_with(()), transaction_count in (0..std::u32::MAX)) {
+    fn counted_header_min_length(header in Header::arbitrary_with(()), transaction_count in (0..MAX_BLOCK_BYTES)) {
         let header = CountedHeader {
             header,
             transaction_count: transaction_count.try_into().expect("Must run test on platform with at least 32 bit address space"),

--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -108,6 +108,7 @@ impl ZcashDeserialize for Solution {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::block::MAX_BLOCK_BYTES;
 
     static EQUIHASH_SIZE_TESTS: &[u64] = &[
         0,
@@ -115,8 +116,8 @@ mod tests {
         (SOLUTION_SIZE - 1) as u64,
         SOLUTION_SIZE as u64,
         (SOLUTION_SIZE + 1) as u64,
-        u64::MAX - 1,
-        u64::MAX,
+        MAX_BLOCK_BYTES - 1,
+        MAX_BLOCK_BYTES,
     ];
 
     #[test]


### PR DESCRIPTION
## Motivation

Reject compact sizes greater than the protocol message limit.
These sizes should be impossible in valid messages.
This is a defence-in-depth against memory attacks.

During deserialization, they likely represent a memory preallocation attack.
During serialization, they likely represent a bug in Zebra.

## Solution

- Return a `Parse` error when deserializing large compact sizes
- Panic when serializing large compact sizes
- Fix impacted tests

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

This is a routine security defence in depth fix. @conradoplg or @dconnolly can review.

## Context

`zcashd` does something similar with its compactsize decoding.
