### PR TITLE
Security: Remove checkout credentials from GitHub actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4
+      with:
+        persist-credentials: false
 
     - name: Set project and image names
       run: |
@@ -53,6 +55,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2.3.4
+        with:
+          persist-credentials: false
 
       - name: Set project and image names
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.4
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
@@ -81,6 +83,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.4
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
@@ -110,6 +114,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.4
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -140,6 +146,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.4
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -167,6 +175,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.4
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
+        with:
+          persist-credentials: false
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,9 @@ jobs:
     steps:
     - name: Checkout the source code
       uses: actions/checkout@v2.3.4
-
+      with:
+        persist-credentials: false
+        
     - name: Install latest beta
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -18,7 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4
-
+      with:
+        persist-credentials: false
+        
     - name: Set project and image names
       run: |
         BRANCH_NAME=$(expr $GITHUB_REF : '.*/\(.*\)') && \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-
+        with:
+          persist-credentials: false
+        
       - name: Set project and image names
         run: |
           BRANCH_NAME=$(expr $GITHUB_REF : '.*/\(.*\)') && \

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -20,7 +20,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2.3.4
-
+        with:
+          persist-credentials: false
+        
       - name: Set project and image names
         run: |
           BRANCH_NAME=$(expr $GITHUB_REF : '.*/\(.*\)') && \


### PR DESCRIPTION
## Motivation

The GitHub checkout action gives scripts access to the user's GitHub or SSH credentials by default.

As a defence-in-depth, remove those credentials after checkout.

## Review

Anyone can review this security fix.
