### PR TITLE
Stop generating V1-V3 transactions for non-finalized state proptests

### DIFF
--- a/zebra-state/proptest-regressions/service/non_finalized_state/tests/prop.txt
+++ b/zebra-state/proptest-regressions/service/non_finalized_state/tests/prop.txt
@@ -1,0 +1,1 @@
+cc 693962399f2771634758dccac882604c14751015ac280113fa9127fa96376c3a # entered unreachable code: older transaction versions only exist in finalized blocks pre sapling; PreparedBlock { .. , Block { .. , transactions: [V2 { .. }, .. ] } };


### PR DESCRIPTION
## Motivation

Currently, Zebra generates V1-V3 transactions in its non-finalized state proptests.

These transactions cause a test panic in `UpdateWith`, in the rare cases where the test gets that far.

## Solution

Stop generating V1-V3 transactions for non-finalized state proptests

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Property Tests + Regression Seed

## Review

This bug can cause unrelated CI failures, but they're rare. @dconnolly or @conradoplg  can review.

## Related Issues

Caused a failure in #2122.
