### PR TITLE
Add proptest regressions for redpallas::prop::tweak_signature

### DIFF
--- a/zebra-chain/proptest-regressions/primitives/redpallas/tests/prop.txt
+++ b/zebra-chain/proptest-regressions/primitives/redpallas/tests/prop.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 68e194dd66b253f8e9ce1719d48859faee091b599b0eaa28f5565a0cb8dda0d7 # shrinks to tweaks = [ChangePubkey, ChangePubkey, ChangePubkey, ChangePubkey], rng_seed = [123, 133, 115, 59, 239, 12, 212, 123, 117, 56, 130, 93, 113, 174, 68, 31, 112, 35, 70, 148, 60, 142, 15, 200, 183, 123, 209, 36, 75, 164, 166, 174]

--- a/zebra-chain/proptest-regressions/primitives/redpallas/tests/prop.txt
+++ b/zebra-chain/proptest-regressions/primitives/redpallas/tests/prop.txt
@@ -5,3 +5,10 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 68e194dd66b253f8e9ce1719d48859faee091b599b0eaa28f5565a0cb8dda0d7 # shrinks to tweaks = [ChangePubkey, ChangePubkey, ChangePubkey, ChangePubkey], rng_seed = [123, 133, 115, 59, 239, 12, 212, 123, 117, 56, 130, 93, 113, 174, 68, 31, 112, 35, 70, 148, 60, 142, 15, 200, 183, 123, 209, 36, 75, 164, 166, 174]
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc e31ba1ed4703731bee9d445f19eef0b9b3a4b83cf996bfe8f7c31ef199c7a7f5 # shrinks to tweaks = [ChangePubkey, ChangePubkey, ChangePubkey, ChangePubkey], rng_seed = [47, 76, 188, 189, 167, 109, 189, 126, 164, 51, 0, 11, 240, 53, 145, 194, 104, 117, 4, 96, 28, 48, 122, 25, 230, 14, 102, 21, 172, 162, 206, 139]


### PR DESCRIPTION
## Motivation

`redpallas::prop::tweak_signature`'s `spendauth.check()` fails on the proptest seeds in this PR.

## Solution

This cryptographic error seems like a job for @dconnolly or @conradoplg.

## Review

This PR should only be merged once the regressions are fixed.

## Related Issues

Sapling binding signatures fail in #1939. This suggests there might be some bug in the common Orchard/Sapling code, or in the code that was copied from Sapling to Orchard.

(However, binding signatures and spendauth signatures have some differences, so 🤷.)

## Related Issues

Regression PR #2168 
Temporarily disable test PR #2169
Underlying fix ticket #2170

## Follow Up Work

See #2170