### PR TITLE
Don't trust reported last seen times

### DIFF
--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -238,6 +238,11 @@ impl MetaAddr {
         self.last_seen
     }
 
+    /// Set the last time we interacted with this peer.
+    pub(crate) fn set_last_seen(&mut self, last_seen: DateTime32) {
+        self.last_seen = last_seen;
+    }
+
     /// Is this address a directly connected client?
     pub fn is_direct_client(&self) -> bool {
         match self.last_connection_state {

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -355,9 +355,7 @@ fn validate_addrs(
 
     let mut addrs: Vec<_> = addrs.into_iter().collect();
 
-    if !addrs.is_empty() {
-        limit_last_seen_times(&mut addrs, last_seen_limit);
-    }
+    limit_last_seen_times(&mut addrs, last_seen_limit);
 
     addrs.into_iter()
 }

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -366,18 +366,17 @@ fn validate_addrs(
 ///
 /// If the `addrs` list is empty.
 fn limit_last_seen_times(addrs: &mut Vec<MetaAddr>, last_seen_limit: DateTime32) {
-    let most_recent_reported_seen_time = addrs
+    let most_recent_reported_seen_timestamp = addrs
         .iter()
-        .map(|addr| addr.get_last_seen())
+        .map(|addr| addr.get_last_seen().timestamp())
         .max()
         .expect("unexpected empty address list");
 
-    let offset = most_recent_reported_seen_time.timestamp() - last_seen_limit.timestamp();
+    if most_recent_reported_seen_timestamp > last_seen_limit.timestamp() {
+        let offset = most_recent_reported_seen_timestamp - last_seen_limit.timestamp();
 
-    for addr in addrs {
-        let old_last_seen = addr.get_last_seen().timestamp();
-
-        if old_last_seen > last_seen_limit.timestamp() {
+        for addr in addrs {
+            let old_last_seen = addr.get_last_seen().timestamp();
             let new_last_seen = old_last_seen - offset;
 
             addr.set_last_seen(new_last_seen.into());

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -1,9 +1,10 @@
 use std::{cmp::min, mem, sync::Arc, time::Duration};
 
-use chrono::{DateTime, Utc};
 use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::time::{sleep, sleep_until, timeout, Sleep};
 use tower::{Service, ServiceExt};
+
+use zebra_chain::serialization::DateTime32;
 
 use crate::{constants, types::MetaAddr, AddressBook, BoxError, Request, Response};
 
@@ -229,7 +230,7 @@ where
                         ?addrs,
                         "got response to GetPeers"
                     );
-                    let addrs = validate_addrs(addrs, Utc::now());
+                    let addrs = validate_addrs(addrs, DateTime32::now());
                     self.send_addrs(addrs);
                 }
                 Err(e) => {
@@ -334,7 +335,7 @@ where
 #[allow(unused_variables)]
 fn validate_addrs(
     addrs: impl IntoIterator<Item = MetaAddr>,
-    last_seen_limit: DateTime<Utc>,
+    last_seen_limit: DateTime32,
 ) -> impl Iterator<Item = MetaAddr> {
     // Note: The address book handles duplicate addresses internally,
     // so we don't need to de-duplicate addresses here.

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -8,6 +8,9 @@ use zebra_chain::serialization::DateTime32;
 
 use crate::{constants, types::MetaAddr, AddressBook, BoxError, Request, Response};
 
+#[cfg(test)]
+mod tests;
+
 /// The `CandidateSet` manages the `PeerSet`'s peer reconnection attempts.
 ///
 /// It divides the set of all possible candidate peers into disjoint subsets,

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -372,6 +372,7 @@ fn limit_last_seen_times(addrs: &mut Vec<MetaAddr>, last_seen_limit: DateTime32)
         .max()
         .expect("unexpected empty address list");
 
+    // If any time is in the future, adjust all times, to compensate for clock skew on honest peers
     if most_recent_reported_seen_timestamp > last_seen_limit.timestamp() {
         let offset = most_recent_reported_seen_timestamp - last_seen_limit.timestamp();
 

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -331,9 +331,11 @@ where
 /// - modify the address data, or
 /// - delete the address.
 ///
-/// Currently, this method will offset the reported `last_seen` time to prevent clock skews
-/// from causing the peers to be placed too far back or in the front of the reconnection queue
-/// incorrectly.
+/// # Security
+///
+/// Adjusts untrusted last seen times so they are not in the future. This stops
+/// malicious peers keeping all their addresses at the front of the connection
+/// queue. Honest peers with future clock skew also get adjusted.
 fn validate_addrs(
     addrs: impl IntoIterator<Item = MetaAddr>,
     last_seen_limit: DateTime32,
@@ -360,7 +362,9 @@ fn validate_addrs(
 
 /// Ensure all reported `last_seen` times are less than or equal to `last_seen_limit`.
 ///
-/// This function assumes there is at least one address in the `addrs` list.
+/// # Panics
+///
+/// If the `addrs` list is empty.
 fn limit_last_seen_times(addrs: &mut Vec<MetaAddr>, last_seen_limit: DateTime32) {
     let most_recent_reported_seen_time = addrs
         .iter()

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -337,9 +337,7 @@ where
 /// malicious peers keeping all their addresses at the front of the connection
 /// queue. Honest peers with future clock skew also get adjusted.
 ///
-/// Rejects all addresses if there are at least two that have reported
-/// last_seen` times where one is so far in the future and another is so far in
-/// the past that they cause an overflow when offsetting the times.
+/// Rejects all addresses if any calculated times overflow or underflow.
 fn validate_addrs(
     addrs: impl IntoIterator<Item = MetaAddr>,
     last_seen_limit: DateTime32,

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -335,7 +335,7 @@ where
 fn validate_addrs(
     addrs: impl IntoIterator<Item = MetaAddr>,
     last_seen_limit: DateTime<Utc>,
-) -> impl IntoIterator<Item = MetaAddr> {
+) -> impl Iterator<Item = MetaAddr> {
     // Note: The address book handles duplicate addresses internally,
     // so we don't need to de-duplicate addresses here.
 
@@ -348,5 +348,5 @@ fn validate_addrs(
     // - Zebra should limit the number of addresses it uses from a single Addrs
     //   response (#1869)
 
-    addrs
+    addrs.into_iter()
 }

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -375,7 +375,12 @@ fn limit_last_seen_times(addrs: &mut Vec<MetaAddr>, last_seen_limit: DateTime32)
     let offset = most_recent_reported_seen_time.timestamp() - last_seen_limit.timestamp();
 
     for addr in addrs {
-        let last_seen = addr.get_last_seen().timestamp() - offset;
-        addr.set_last_seen(last_seen.into());
+        let old_last_seen = addr.get_last_seen().timestamp();
+
+        if old_last_seen > last_seen_limit.timestamp() {
+            let new_last_seen = old_last_seen - offset;
+
+            addr.set_last_seen(new_last_seen.into());
+        }
     }
 }

--- a/zebra-network/src/peer_set/candidate_set/tests.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests.rs
@@ -1,3 +1,4 @@
 //! [`CandidateSet`] tests.
 
+mod prop;
 mod vectors;

--- a/zebra-network/src/peer_set/candidate_set/tests.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests.rs
@@ -1,0 +1,3 @@
+//! [`CandidateSet`] tests.
+
+mod vectors;

--- a/zebra-network/src/peer_set/candidate_set/tests/prop.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/prop.rs
@@ -1,0 +1,23 @@
+use proptest::{collection::vec, prelude::*};
+
+use zebra_chain::serialization::DateTime32;
+
+use super::super::validate_addrs;
+use crate::types::MetaAddr;
+
+proptest! {
+    /// Test that validated gossiped peers never have a `last_seen` time that's in the future.
+    #[test]
+    fn no_last_seen_times_are_in_the_future(
+        gossiped_peers in vec(MetaAddr::gossiped_strategy(), 1..10),
+        last_seen_limit in any::<DateTime32>(),
+    ) {
+        zebra_test::init();
+
+        let validated_peers = validate_addrs(gossiped_peers, last_seen_limit);
+
+        for peer in validated_peers {
+            prop_assert![peer.get_last_seen() <= last_seen_limit];
+        }
+    }
+}

--- a/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
@@ -34,6 +34,25 @@ fn offsets_last_seen_times_in_the_future() {
     assert_eq!(validated_peers, expected_peers);
 }
 
+/// Test that offset is not applied if all addresses have `last_seen` times that are in the past.
+#[test]
+fn doesnt_offset_last_seen_times_in_the_past() {
+    let last_seen_limit = DateTime32::now();
+    let last_seen_limit_chrono = last_seen_limit.to_chrono();
+
+    let input_peers = mock_gossiped_peers(vec![
+        last_seen_limit_chrono - Duration::minutes(30),
+        last_seen_limit_chrono - Duration::minutes(45),
+        last_seen_limit_chrono - Duration::days(1),
+    ]);
+
+    let validated_peers: Vec<_> = validate_addrs(input_peers.clone(), last_seen_limit).collect();
+
+    let expected_peers = input_peers;
+
+    assert_eq!(validated_peers, expected_peers);
+}
+
 /// Create a mock list of gossiped [`MetaAddr`]s with the specified `last_seen_times`.
 ///
 /// The IP address and port of the generated ports should not matter for the test.

--- a/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
@@ -1,0 +1,56 @@
+use std::{
+    convert::TryInto,
+    net::{IpAddr, SocketAddr},
+};
+
+use chrono::{DateTime, Duration, Utc};
+
+use zebra_chain::serialization::DateTime32;
+
+use super::super::validate_addrs;
+use crate::types::{MetaAddr, PeerServices};
+
+/// Test that offset is applied when all addresses have `last_seen` times in the future.
+#[test]
+fn offsets_last_seen_times_in_the_future() {
+    let last_seen_limit = DateTime32::now();
+    let last_seen_limit_chrono = last_seen_limit.to_chrono();
+
+    let input_peers = mock_gossiped_peers(vec![
+        last_seen_limit_chrono + Duration::minutes(30),
+        last_seen_limit_chrono + Duration::minutes(15),
+        last_seen_limit_chrono + Duration::minutes(45),
+    ]);
+
+    let validated_peers: Vec<_> = validate_addrs(input_peers, last_seen_limit).collect();
+
+    let expected_offset = Duration::minutes(45);
+    let expected_peers = mock_gossiped_peers(vec![
+        last_seen_limit_chrono + Duration::minutes(30) - expected_offset,
+        last_seen_limit_chrono + Duration::minutes(15) - expected_offset,
+        last_seen_limit_chrono + Duration::minutes(45) - expected_offset,
+    ]);
+
+    assert_eq!(validated_peers, expected_peers);
+}
+
+/// Create a mock list of gossiped [`MetaAddr`]s with the specified `last_seen_times`.
+///
+/// The IP address and port of the generated ports should not matter for the test.
+fn mock_gossiped_peers(last_seen_times: impl IntoIterator<Item = DateTime<Utc>>) -> Vec<MetaAddr> {
+    last_seen_times
+        .into_iter()
+        .enumerate()
+        .map(|(index, last_seen_chrono)| {
+            let last_seen = last_seen_chrono
+                .try_into()
+                .expect("`last_seen` time doesn't fit in a `DateTime32`");
+
+            MetaAddr::new_gossiped_meta_addr(
+                SocketAddr::new(IpAddr::from([192, 168, 1, index as u8]), 20_000),
+                PeerServices::NODE_NETWORK,
+                last_seen,
+            )
+        })
+        .collect()
+}

--- a/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
@@ -99,6 +99,22 @@ fn doesnt_offsets_if_most_recent_last_seen_times_is_exactly_the_limit() {
     assert_eq!(validated_peers, expected_peers);
 }
 
+/// Rejects all addresses if underflow occurs when applying the offset.
+#[test]
+fn rejects_all_addresses_if_applying_offset_causes_an_underflow() {
+    let last_seen_limit = DateTime32::now();
+
+    let input_peers = mock_gossiped_peers(vec![
+        DateTime32::from(u32::MIN).to_chrono(),
+        last_seen_limit.to_chrono(),
+        DateTime32::from(u32::MAX).to_chrono(),
+    ]);
+
+    let validated_peers: Vec<_> = validate_addrs(input_peers.clone(), last_seen_limit).collect();
+
+    assert!(validated_peers.is_empty());
+}
+
 /// Create a mock list of gossiped [`MetaAddr`]s with the specified `last_seen_times`.
 ///
 /// The IP address and port of the generated ports should not matter for the test.

--- a/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
@@ -80,6 +80,25 @@ fn offsets_all_last_seen_times_if_one_is_in_the_future() {
     assert_eq!(validated_peers, expected_peers);
 }
 
+/// Test that offset is not applied if the most recent `last_seen` time is equal to the limit.
+#[test]
+fn doesnt_offsets_if_most_recent_last_seen_times_is_exactly_the_limit() {
+    let last_seen_limit = DateTime32::now();
+    let last_seen_limit_chrono = last_seen_limit.to_chrono();
+
+    let input_peers = mock_gossiped_peers(vec![
+        last_seen_limit_chrono,
+        last_seen_limit_chrono - Duration::minutes(3),
+        last_seen_limit_chrono - Duration::hours(1),
+    ]);
+
+    let validated_peers: Vec<_> = validate_addrs(input_peers.clone(), last_seen_limit).collect();
+
+    let expected_peers = input_peers;
+
+    assert_eq!(validated_peers, expected_peers);
+}
+
 /// Create a mock list of gossiped [`MetaAddr`]s with the specified `last_seen_times`.
 ///
 /// The IP address and port of the generated ports should not matter for the test.

--- a/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
@@ -110,9 +110,9 @@ fn rejects_all_addresses_if_applying_offset_causes_an_underflow() {
         DateTime32::from(u32::MAX).to_chrono(),
     ]);
 
-    let validated_peers: Vec<_> = validate_addrs(input_peers.clone(), last_seen_limit).collect();
+    let mut validated_peers = validate_addrs(input_peers, last_seen_limit);
 
-    assert!(validated_peers.is_empty());
+    assert!(validated_peers.next().is_none());
 }
 
 /// Create a mock list of gossiped [`MetaAddr`]s with the specified `last_seen_times`.


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

Zebra would previously trust the `last_seen` time reported on a gossiped peer. However, if that time is in the future, it could take precedence over all other peers in the reconnection queue. This could happen intentionally by a malicious peer or unintentionally due to clock skew. The reporting issue (#1871) has more information.

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->

The proposed solution is to apply an offset to the reported `last_seen` times by a peer if any of them are in the future. To do this, the offset is calculated by subtracting the most advanced reported time (in the remote peer's clock) by the current time (in the local clock).

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

@teor2345 wrote the proposed solution in the original issue.

## Related Issues

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->

Closes #1871 

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
