### PR TITLE
Security: Spawn a separate task for each initial handshake, Credit: Equilibrium

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -22,8 +22,22 @@ use zebra_chain::parameters::NetworkUpgrade;
 /// buffer adds up to 6 seconds worth of blocks to the queue.
 pub const PEERSET_BUFFER_SIZE: usize = 3;
 
-/// The timeout for requests made to a remote peer.
-pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+/// The timeout for DNS lookups.
+///
+/// [6.1.3.3 Efficient Resource Usage] from [RFC 1123: Requirements for Internet Hosts]
+/// suggest no less than 5 seconds for resolving timeout.
+///
+/// [RFC 1123: Requirements for Internet Hosts] https://tools.ietf.org/rfcmarkup?doc=1123
+/// [6.1.3.3  Efficient Resource Usage] https://tools.ietf.org/rfcmarkup?doc=1123#page-77
+pub const DNS_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The minimum time between connections to initial or candidate peers.
+///
+/// ## Security
+///
+/// Zebra resists distributed denial of service attacks by making sure that new peer connections
+/// are initiated at least `MIN_PEER_CONNECTION_INTERVAL` apart.
+pub const MIN_PEER_CONNECTION_INTERVAL: Duration = Duration::from_millis(100);
 
 /// The timeout for handshakes when connecting to new peers.
 ///
@@ -31,6 +45,9 @@ pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 /// into the peer set. This is particularly important for network-constrained
 /// nodes, and on testnet.
 pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(4);
+
+/// The timeout for requests made to a remote peer.
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// We expect to receive a message from a live peer at least once in this time duration.
 ///
@@ -122,15 +139,6 @@ lazy_static! {
         Regex::new("(access a socket in a way forbidden by its access permissions)|(Only one usage of each socket address)")
     }.expect("regex is valid");
 }
-
-/// The timeout for DNS lookups.
-///
-/// [6.1.3.3 Efficient Resource Usage] from [RFC 1123: Requirements for Internet Hosts]
-/// suggest no less than 5 seconds for resolving timeout.
-///
-/// [RFC 1123: Requirements for Internet Hosts] https://tools.ietf.org/rfcmarkup?doc=1123
-/// [6.1.3.3  Efficient Resource Usage] https://tools.ietf.org/rfcmarkup?doc=1123#page-77
-pub const DNS_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Magic numbers used to identify different Zcash networks.
 pub mod magics {

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -137,7 +137,7 @@ pub struct MetaAddr {
 }
 
 impl MetaAddr {
-    /// Create a new seed [`MetaAddr`, based on the configured seed addresses.
+    /// Create a new seed [`MetaAddr`], based on the configured seed addresses.
     pub fn new_seed_meta_addr(addr: SocketAddr) -> MetaAddr {
         MetaAddr {
             addr,

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -137,6 +137,20 @@ pub struct MetaAddr {
 }
 
 impl MetaAddr {
+    /// Create a new seed [`MetaAddr`, based on the configured seed addresses.
+    pub fn new_seed_meta_addr(addr: SocketAddr) -> MetaAddr {
+        MetaAddr {
+            addr,
+            // TODO: stop guessing this field
+            services: PeerServices::NODE_NETWORK,
+            // TODO: remove this time, it's far too optimistic. Using `now` can
+            // keep invalid peers in the consensus peer set for a long time.
+            last_seen: Utc::now(),
+            // TODO: replace with NeverAttemptedSeed
+            last_connection_state: NeverAttemptedGossiped,
+        }
+    }
+
     /// Create a new gossiped [`MetaAddr`], based on the deserialized fields from
     /// a gossiped peer [`Addr`][crate::protocol::external::Message::Addr] message.
     pub fn new_gossiped_meta_addr(

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -115,14 +115,6 @@ where
     S: Service<Request, Response = Response, Error = BoxError>,
     S::Future: Send + 'static,
 {
-    /// The minimum time between successive calls to `CandidateSet::next()`.
-    ///
-    /// ## Security
-    ///
-    /// Zebra resists distributed denial of service attacks by making sure that new peer connections
-    /// are initiated at least `MIN_PEER_CONNECTION_INTERVAL` apart.
-    const MIN_PEER_CONNECTION_INTERVAL: Duration = Duration::from_millis(100);
-
     /// Uses `address_book` and `peer_service` to manage a [`CandidateSet`] of peers.
     pub fn new(
         address_book: Arc<std::sync::Mutex<AddressBook>>,
@@ -313,7 +305,7 @@ where
         // If we recently had a connection, and we're about to sleep, base the
         // next time off our sleep time. Otherwise, use the current time.
         self.next_peer_sleep_until = max(self.next_peer_sleep_until, Instant::now());
-        self.next_peer_sleep_until += Self::MIN_PEER_CONNECTION_INTERVAL;
+        self.next_peer_sleep_until += constants::MIN_PEER_CONNECTION_INTERVAL;
         sleep_until(current_deadline).await;
 
         Some(reconnect)

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -261,7 +261,7 @@ where
         handshakes.push(Box::pin(hs_join));
 
         // 2. Check if any peers have finished their handshakes
-        while let Some(handshake_action) = handshakes.next().await {
+        while let Some(handshake_action) = handshakes.next().now_or_never().flatten() {
             use CrawlerAction::*;
             match handshake_action {
                 HandshakeConnected { peer_set_change } => {


### PR DESCRIPTION
## Motivation

This fix prevents hangs and deadlocks during initialization, particularly when there are a small number of valid peers in the initial peer config (or from the DNS seeders).

It also cleans up some variable names and error handling, so it's easier to understand what the code is doing.

Reported by Equilibrium.

## Solution

- Spawn a separate task for each initial handshake, using the existing `dial` function
  - Sleep for MIN_PEER_CONNECTION_INTERVAL between each handshake
- Correctly use `MIN_PEER_CONNECTION_INTERVAL` in `CandidateSet`
  - Previously, we would allow a lot of connections if we hadn't connected for a while

Also:
- rename some variables for clarity
- provide errors as part of the `HandshakeFailed` crawler action
- add extra progress logging to help diagnose hangs

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Integration Tests

## Review

I'd like @dconnolly to review this security fix. Or @jvff might like to take a look.

It's blocking the rest of #2160, so it would be great to have it reviewed before my Monday.

## Related Issues

Part of #2163

Blocks #2160

## Follow Up Work

Rest of #2160