### PR TITLE
Fix clippy::cmp_owned for (sapling, orchard)::keys with `ConstantTimeEq`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3407,9 +3407,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
@@ -4442,6 +4442,7 @@ dependencies = [
  "serde-big-array",
  "sha2",
  "spandoc",
+ "subtle",
  "thiserror",
  "tracing",
  "x25519-dalek",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -41,6 +41,7 @@ secp256k1 = { version = "0.20.2", features = ["serde"] }
 serde = { version = "1", features = ["serde_derive", "rc"] }
 serde-big-array = "0.3.2"
 sha2 = { version = "0.9.5", features=["compress"] }
+subtle = "2.4"
 thiserror = "1"
 x25519-dalek = { version = "1.1", features = ["serde"] }
 

--- a/zebra-chain/src/orchard/keys.rs
+++ b/zebra-chain/src/orchard/keys.rs
@@ -317,6 +317,7 @@ impl From<SpendAuthorizingKey> for SpendValidatingKey {
 impl PartialEq for SpendValidatingKey {
     #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &Self) -> bool {
+        // XXX: These redpallas::VerificationKey(Bytes) fields are pub(crate)
         self.0.bytes.bytes == other.0.bytes.bytes
     }
 }
@@ -324,6 +325,7 @@ impl PartialEq for SpendValidatingKey {
 impl PartialEq<[u8; 32]> for SpendValidatingKey {
     #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
+        // XXX: These redpallas::VerificationKey(Bytes) fields are pub(crate)
         self.0.bytes.bytes == *other
     }
 }

--- a/zebra-chain/src/sapling/keys.rs
+++ b/zebra-chain/src/sapling/keys.rs
@@ -24,6 +24,7 @@ use std::{
 
 use bech32::{self, FromBase32, ToBase32, Variant};
 use rand_core::{CryptoRng, RngCore};
+use subtle::{Choice, ConstantTimeEq};
 
 use crate::{
     parameters::Network,
@@ -194,10 +195,10 @@ mod sk_hrp {
 /// §4.2.2][ps].
 ///
 /// Our root secret key of the Sapling key derivation tree. All other
-/// Sapling key types derive from the SpendingKey value.
+/// Sapling key types derive from the `SpendingKey` value.
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#saplingkeycomponents
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug)]
 #[cfg_attr(
     any(test, feature = "proptest-impl"),
     derive(proptest_derive::Arbitrary)
@@ -207,10 +208,42 @@ pub struct SpendingKey {
     bytes: [u8; 32],
 }
 
+impl SpendingKey {
+    /// Generate a new _SpendingKey_.
+    pub fn new<T>(csprng: &mut T) -> Self
+    where
+        T: RngCore + CryptoRng,
+    {
+        let mut bytes = [0u8; 32];
+        csprng.fill_bytes(&mut bytes);
+
+        Self::from(bytes)
+    }
+}
+
+impl ConstantTimeEq for SpendingKey {
+    /// Check whether two `SpendingKey`s are equal, runtime independent of the
+    /// value of the secret.
+    ///
+    /// # Note
+    ///
+    /// This function short-circuits if the networks of the keys are different.
+    /// Otherwise, it should execute in time independent of the `bytes` value.
+    fn ct_eq(&self, other: &Self) -> Choice {
+        if self.network != other.network {
+            return Choice::from(0);
+        }
+
+        self.bytes.ct_eq(&other.bytes)
+    }
+}
+
+impl Eq for SpendingKey {}
+
 // TODO: impl a From that accepts a Network?
 
 impl From<[u8; 32]> for SpendingKey {
-    /// Generate a _SpendingKey_ from existing bytes.
+    /// Generate a `SpendingKey` from existing bytes.
     fn from(bytes: [u8; 32]) -> Self {
         Self {
             network: Network::default(),
@@ -254,16 +287,9 @@ impl FromStr for SpendingKey {
     }
 }
 
-impl SpendingKey {
-    /// Generate a new _SpendingKey_.
-    pub fn new<T>(csprng: &mut T) -> Self
-    where
-        T: RngCore + CryptoRng,
-    {
-        let mut bytes = [0u8; 32];
-        csprng.fill_bytes(&mut bytes);
-
-        Self::from(bytes)
+impl PartialEq for SpendingKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).unwrap_u8() == 1u8
     }
 }
 
@@ -274,8 +300,16 @@ impl SpendingKey {
 /// _Spend Description_, proving ownership of notes.
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#saplingkeycomponents
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct SpendAuthorizingKey(pub Scalar);
+#[derive(Copy, Clone)]
+pub struct SpendAuthorizingKey(pub(crate) Scalar);
+
+impl ConstantTimeEq for SpendAuthorizingKey {
+    /// Check whether two `SpendAuthorizingKey`s are equal, runtime independent
+    /// of the value of the secret.
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.to_bytes().ct_eq(&other.0.to_bytes())
+    }
+}
 
 impl fmt::Debug for SpendAuthorizingKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -284,6 +318,8 @@ impl fmt::Debug for SpendAuthorizingKey {
             .finish()
     }
 }
+
+impl Eq for SpendAuthorizingKey {}
 
 impl From<SpendAuthorizingKey> for [u8; 32] {
     fn from(sk: SpendAuthorizingKey) -> Self {
@@ -304,11 +340,15 @@ impl From<SpendingKey> for SpendAuthorizingKey {
     }
 }
 
+impl PartialEq for SpendAuthorizingKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).unwrap_u8() == 1u8
+    }
+}
+
 impl PartialEq<[u8; 32]> for SpendAuthorizingKey {
-    // TODO: do we want to use constant-time comparison here?
-    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
-        <[u8; 32]>::from(*self) == *other
+        self.0.to_bytes().ct_eq(other).unwrap_u8() == 1u8
     }
 }
 
@@ -319,7 +359,7 @@ impl PartialEq<[u8; 32]> for SpendAuthorizingKey {
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#saplingkeycomponents
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct ProofAuthorizingKey(pub Scalar);
+pub struct ProofAuthorizingKey(pub(crate) Scalar);
 
 impl fmt::Debug for ProofAuthorizingKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -349,7 +389,7 @@ impl From<SpendingKey> for ProofAuthorizingKey {
 
 impl PartialEq<[u8; 32]> for ProofAuthorizingKey {
     // TODO: do we want to use constant-time comparison here?
-    #[allow(clippy::cmp_owned)]
+
     fn eq(&self, other: &[u8; 32]) -> bool {
         <[u8; 32]>::from(*self) == *other
     }
@@ -362,7 +402,7 @@ impl PartialEq<[u8; 32]> for ProofAuthorizingKey {
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#saplingkeycomponents
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct OutgoingViewingKey(pub [u8; 32]);
+pub struct OutgoingViewingKey(pub(crate) [u8; 32]);
 
 impl fmt::Debug for OutgoingViewingKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -414,7 +454,7 @@ impl PartialEq<[u8; 32]> for OutgoingViewingKey {
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#saplingkeycomponents
 #[derive(Copy, Clone, Debug)]
-pub struct AuthorizingKey(pub redjubjub::VerificationKey<SpendAuth>);
+pub struct AuthorizingKey(pub(crate) redjubjub::VerificationKey<SpendAuth>);
 
 impl Eq for AuthorizingKey {}
 
@@ -452,11 +492,19 @@ impl PartialEq<[u8; 32]> for AuthorizingKey {
 /// A _Nullifier Deriving Key_, as described in [protocol
 /// specification §4.2.2][ps].
 ///
-/// Used to create a _Nullifier_ per note.
+/// Used to create a `Nullifier` per note.
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#saplingkeycomponents
-#[derive(Copy, Clone, PartialEq)]
-pub struct NullifierDerivingKey(pub jubjub::AffinePoint);
+#[derive(Copy, Clone)]
+pub struct NullifierDerivingKey(pub(crate) jubjub::AffinePoint);
+
+impl ConstantTimeEq for NullifierDerivingKey {
+    /// Check whether two `NullifierDerivingKey`s are equal, runtime independent
+    /// of the value of the secret.
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.to_bytes().ct_eq(&other.0.to_bytes())
+    }
+}
 
 impl fmt::Debug for NullifierDerivingKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -508,11 +556,15 @@ impl From<ProofAuthorizingKey> for NullifierDerivingKey {
     }
 }
 
+impl PartialEq for NullifierDerivingKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).unwrap_u8() == 1u8
+    }
+}
+
 impl PartialEq<[u8; 32]> for NullifierDerivingKey {
-    // TODO: do we want to use constant-time comparison here?
-    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
-        <[u8; 32]>::from(*self) == *other
+        self.0.to_bytes().ct_eq(other).unwrap_u8() == 1u8
     }
 }
 
@@ -638,7 +690,7 @@ impl PartialEq<[u8; 32]> for IncomingViewingKey {
     any(test, feature = "proptest-impl"),
     derive(proptest_derive::Arbitrary)
 )]
-pub struct Diversifier(pub [u8; 11]);
+pub struct Diversifier(pub(crate) [u8; 11]);
 
 impl fmt::Debug for Diversifier {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -758,7 +810,7 @@ impl Diversifier {
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#concretediversifyhash
 #[derive(Copy, Clone, PartialEq)]
-pub struct TransmissionKey(pub jubjub::AffinePoint);
+pub struct TransmissionKey(pub(crate) jubjub::AffinePoint);
 
 impl fmt::Debug for TransmissionKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -802,8 +854,6 @@ impl From<(IncomingViewingKey, Diversifier)> for TransmissionKey {
 }
 
 impl PartialEq<[u8; 32]> for TransmissionKey {
-    // TODO: do we want to use constant-time comparison here?
-    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         <[u8; 32]>::from(*self) == *other
     }
@@ -899,7 +949,7 @@ impl FromStr for FullViewingKey {
 /// https://zips.z.cash/protocol/protocol.pdf#concretesaplingkeyagreement
 #[derive(Copy, Clone, Deserialize, PartialEq, Serialize)]
 pub struct EphemeralPublicKey(
-    #[serde(with = "serde_helpers::AffinePoint")] pub jubjub::AffinePoint,
+    #[serde(with = "serde_helpers::AffinePoint")] pub(crate) jubjub::AffinePoint,
 );
 
 impl fmt::Debug for EphemeralPublicKey {
@@ -926,8 +976,6 @@ impl From<&EphemeralPublicKey> for [u8; 32] {
 }
 
 impl PartialEq<[u8; 32]> for EphemeralPublicKey {
-    // TODO: do we want to use constant-time comparison here?
-    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         <[u8; 32]>::from(self) == *other
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->

`orchard::keys` and `sapling::keys` types violated the clippy::cmp_owned lint.

## Solution

Fix clippy::cmp_owned for (sapling, orchard)::keys Eq/PartialEq by impl'ing ConstantTimeEq for those types where leaks of the value would compromise access or privacy, and using that in `PartialEq` and `Eq` implementations.

This also adds `subtle` as a dependency for `zebra-chain`, this is a small, well-known dependency from the authors of `zeroize` and other `-dalek` crates that we already use.

The code in this pull request has:
  - [x] Documentation Comments
  - [ ] Unit Tests and Property Tests

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

Low urgency.

## Related Issues

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
