### PR TITLE
Remove redundant cmp_owned and comments

### DIFF
--- a/zebra-chain/src/orchard/keys.rs
+++ b/zebra-chain/src/orchard/keys.rs
@@ -275,8 +275,6 @@ impl PartialEq for SpendAuthorizingKey {
 }
 
 impl PartialEq<[u8; 32]> for SpendAuthorizingKey {
-    // TODO: do we want to use constant-time comparison here?
-    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         self.0.to_bytes().ct_eq(other).unwrap_u8() == 1u8
     }
@@ -315,17 +313,13 @@ impl From<SpendAuthorizingKey> for SpendValidatingKey {
 }
 
 impl PartialEq for SpendValidatingKey {
-    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &Self) -> bool {
-        // XXX: These redpallas::VerificationKey(Bytes) fields are pub(crate)
         self.0.bytes.bytes == other.0.bytes.bytes
     }
 }
 
 impl PartialEq<[u8; 32]> for SpendValidatingKey {
-    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
-        // XXX: These redpallas::VerificationKey(Bytes) fields are pub(crate)
         self.0.bytes.bytes == *other
     }
 }
@@ -400,7 +394,6 @@ impl PartialEq for NullifierDerivingKey {
 }
 
 impl PartialEq<[u8; 32]> for NullifierDerivingKey {
-    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         self.0.to_bytes().ct_eq(other).unwrap_u8() == 1u8
     }
@@ -952,7 +945,6 @@ impl From<(IncomingViewingKey, Diversifier)> for TransmissionKey {
 }
 
 impl PartialEq<[u8; 32]> for TransmissionKey {
-    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         &self.0.to_bytes() == other
     }
@@ -993,7 +985,6 @@ impl From<&EphemeralPublicKey> for [u8; 32] {
 }
 
 impl PartialEq<[u8; 32]> for EphemeralPublicKey {
-    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &[u8; 32]) -> bool {
         &self.0.to_bytes() == other
     }

--- a/zebra-chain/src/orchard/keys.rs
+++ b/zebra-chain/src/orchard/keys.rs
@@ -314,6 +314,7 @@ impl From<SpendAuthorizingKey> for SpendValidatingKey {
 
 impl PartialEq for SpendValidatingKey {
     fn eq(&self, other: &Self) -> bool {
+        // XXX: These redpallas::VerificationKey(Bytes) fields are pub(crate)
         self.0.bytes.bytes == other.0.bytes.bytes
     }
 }

--- a/zebra-chain/src/orchard/keys.rs
+++ b/zebra-chain/src/orchard/keys.rs
@@ -321,6 +321,7 @@ impl PartialEq for SpendValidatingKey {
 
 impl PartialEq<[u8; 32]> for SpendValidatingKey {
     fn eq(&self, other: &[u8; 32]) -> bool {
+        // XXX: These redpallas::VerificationKey(Bytes) fields are pub(crate)
         self.0.bytes.bytes == *other
     }
 }


### PR DESCRIPTION
## Motivation

This is a cleanup after PR #2184, where we forgot to:
- delete some comments resolved by the PR, and
- re-enable some lints resolved by the PR.

## Review

@dconnolly or @oxarbitrage can review this, since they did the original PR.
