### PR TITLE
Try arbitrary leap seconds

### DIFF
--- a/zebra-chain/src/serialization/arbitrary.rs
+++ b/zebra-chain/src/serialization/arbitrary.rs
@@ -5,7 +5,7 @@ use proptest::{arbitrary::any, prelude::*};
 /// based on the full valid range of the type.
 ///
 /// Both the seconds and nanoseconds values are randomised, including leap seconds:
-/// https://docs.rs/chrono/0.4.19/chrono/naive/struct.NaiveTime.html#leap-second-handling
+/// <https://docs.rs/chrono/0.4.19/chrono/naive/struct.NaiveTime.html#leap-second-handling>
 ///
 /// Wherever possible, Zebra should handle leap seconds by:
 /// - making durations and intervals 3 seconds or longer,


### PR DESCRIPTION
## Motivation

Zebra should cope with leap seconds, just in case.

## Solution

Update the arbitrary time implementation with chrono-specific leap seconds. See the docs in the doc comment for details.

## Review

Anyone can review this low priority PR.

## Related Issues

Follow up to PR #2179 