### PR TITLE
Add action methods

### DIFF
--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -52,8 +52,7 @@ impl ShieldedData {
 }
 
 impl AtLeastOne<AuthorizedAction> {
-    /// Iterate over the [`Action`]s of the `AuthorizedAction` for this transaction,
-    /// returning them as their generic type.
+    /// Iterate over the [`Action`]s of each [`AuthorizedAction`].
     pub fn actions(&self) -> impl Iterator<Item = &Action> {
         self.iter()
             .map(|authorized_action| &authorized_action.action)

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -3,7 +3,7 @@
 use crate::{
     amount::Amount,
     block::MAX_BLOCK_BYTES,
-    orchard::{tree, Action},
+    orchard::{tree, Action, Nullifier},
     primitives::{
         redpallas::{Binding, Signature, SpendAuth},
         Halo2Proof,
@@ -36,6 +36,28 @@ pub struct ShieldedData {
     pub actions: AtLeastOne<AuthorizedAction>,
     /// A signature on the transaction `sighash`.
     pub binding_sig: Signature<Binding>,
+}
+
+impl ShieldedData {
+    /// Iterate over the [`Action`]s for the [`AuthorizedAction`]s in this transaction.
+    pub fn actions(&self) -> impl Iterator<Item = &Action> {
+        self.actions.actions()
+    }
+
+    /// Collect the [`Nullifier`]s for this transaction, if it contains
+    /// [`Action`]s.
+    pub fn nullifiers(&self) -> impl Iterator<Item = &Nullifier> {
+        self.actions().map(|action| &action.nullifier)
+    }
+}
+
+impl AtLeastOne<AuthorizedAction> {
+    /// Iterate over the [`Action`]s of the `AuthorizedAction` for this transaction,
+    /// returning them as their generic type.
+    pub fn actions(&self) -> impl Iterator<Item = &Action> {
+        self.iter()
+            .map(|authorized_action| &authorized_action.action)
+    }
 }
 
 /// An authorized action description.


### PR DESCRIPTION
## Motivation

We added some `Action` methods to shielded_data of orchard in https://github.com/ZcashFoundation/zebra/pull/2185 however we might need them before that PR  gets merged for https://github.com/ZcashFoundation/zebra/issues/1980

## Solution

Split that code in a separated PR.

## Review

@teor2345 or @jvff 

## Related Issues

https://github.com/ZcashFoundation/zebra/issues/1980
https://github.com/ZcashFoundation/zebra/issues/1982
https://github.com/ZcashFoundation/zebra/issues/1983
