### PR TITLE
Security: Stop panicking when serializing out-of-range times

### DIFF
--- a/zebra-chain/src/serialization/arbitrary.rs
+++ b/zebra-chain/src/serialization/arbitrary.rs
@@ -1,5 +1,7 @@
+use super::read_zcash::canonical_ip_addr;
 use chrono::{TimeZone, Utc, MAX_DATETIME, MIN_DATETIME};
 use proptest::{arbitrary::any, prelude::*};
+use std::net::SocketAddr;
 
 /// Returns a strategy that produces an arbitrary [`chrono::DateTime<Utc>`],
 /// based on the full valid range of the type.
@@ -38,4 +40,15 @@ pub fn datetime_full() -> impl Strategy<Value = chrono::DateTime<Utc>> {
 /// [`Version`] message.
 pub fn datetime_u32() -> impl Strategy<Value = chrono::DateTime<Utc>> {
     any::<u32>().prop_map(|secs| Utc.timestamp(secs.into(), 0))
+}
+
+/// Returns a random canonical Zebra `SocketAddr`.
+///
+/// See [`canonical_ip_addr`] for details.
+pub fn canonical_socket_addr() -> impl Strategy<Value = SocketAddr> {
+    use SocketAddr::*;
+    any::<SocketAddr>().prop_map(|addr| match addr {
+        V4(_) => addr,
+        V6(v6_addr) => SocketAddr::new(canonical_ip_addr(v6_addr.ip()), v6_addr.port()),
+    })
 }

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -262,9 +262,8 @@ impl MetaAddr {
         let last_seen = Utc.timestamp(ts - ts.rem_euclid(interval), 0);
         MetaAddr {
             addr: self.addr,
-            // services are sanitized during parsing, or set to a fixed valued by
-            // new_local_listener, so we don't need to sanitize here
-            services: self.services,
+            // deserialization also sanitizes services to known flags
+            services: self.services & PeerServices::all(),
             last_seen,
             // the state isn't sent to the remote peer, but sanitize it anyway
             last_connection_state: NeverAttemptedGossiped,

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -325,7 +325,7 @@ impl ZcashSerialize for MetaAddr {
             self.get_last_seen()
                 .timestamp()
                 .try_into()
-                .expect("time is in range"),
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?,
         )?;
         writer.write_u64::<LittleEndian>(self.services.bits())?;
         writer.write_socket_addr(self.addr)?;

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -106,7 +106,7 @@ impl PartialOrd for PeerAddrState {
 /// An address with metadata on its advertised services and last-seen time.
 ///
 /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#Network_address)
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug)]
 pub struct MetaAddr {
     /// The peer's address.
     pub addr: SocketAddr,
@@ -318,6 +318,14 @@ impl PartialOrd for MetaAddr {
         Some(self.cmp(other))
     }
 }
+
+impl PartialEq for MetaAddr {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for MetaAddr {}
 
 impl ZcashSerialize for MetaAddr {
     fn zcash_serialize<W: Write>(&self, mut writer: W) -> Result<(), std::io::Error> {

--- a/zebra-network/src/meta_addr/arbitrary.rs
+++ b/zebra-network/src/meta_addr/arbitrary.rs
@@ -2,15 +2,30 @@ use proptest::{arbitrary::any, arbitrary::Arbitrary, prelude::*};
 
 use super::{MetaAddr, PeerAddrState, PeerServices};
 
+use zebra_chain::serialization::arbitrary::{canonical_socket_addr, datetime_u32};
+
 use chrono::{TimeZone, Utc};
-use std::net::SocketAddr;
+
+impl MetaAddr {
+    pub fn gossiped_strategy() -> BoxedStrategy<Self> {
+        (
+            canonical_socket_addr(),
+            any::<PeerServices>(),
+            datetime_u32(),
+        )
+            .prop_map(|(address, services, untrusted_last_seen)| {
+                MetaAddr::new_gossiped_meta_addr(address, services, untrusted_last_seen)
+            })
+            .boxed()
+    }
+}
 
 impl Arbitrary for MetaAddr {
     type Parameters = ();
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         (
-            any::<SocketAddr>(),
+            canonical_socket_addr(),
             any::<PeerServices>(),
             any::<u32>(),
             any::<PeerAddrState>(),

--- a/zebra-network/src/meta_addr/tests/prop.rs
+++ b/zebra-network/src/meta_addr/tests/prop.rs
@@ -4,6 +4,8 @@ use super::{super::MetaAddr, check};
 
 use proptest::prelude::*;
 
+use zebra_chain::serialization::{ZcashDeserialize, ZcashSerialize};
+
 proptest! {
     /// Make sure that the sanitize function reduces time and state metadata
     /// leaks.
@@ -12,5 +14,69 @@ proptest! {
         zebra_test::init();
 
         check::sanitize_avoids_leaks(&entry);
+    }
+
+    /// Test round-trip serialization for gossiped MetaAddrs
+    #[test]
+    fn gossiped_roundtrip(
+        mut gossiped_addr in MetaAddr::gossiped_strategy()
+    ) {
+        zebra_test::init();
+
+        // Zebra's deserialization sanitizes `services` to known flags
+        gossiped_addr.services &= PeerServices::all();
+
+        // Check that malicious peers can't make Zebra's serialization fail
+        let addr_bytes = gossiped_addr.zcash_serialize_to_vec();
+        prop_assert!(
+            addr_bytes.is_ok(),
+            "unexpected serialization error: {:?}, addr: {:?}",
+            addr_bytes,
+            gossiped_addr
+        );
+        let addr_bytes = addr_bytes.unwrap();
+
+        // Assume other implementations deserialize like Zebra
+        let deserialized_addr = MetaAddr::zcash_deserialize(addr_bytes.as_slice());
+        prop_assert!(
+            deserialized_addr.is_ok(),
+            "unexpected deserialization error: {:?}, addr: {:?}, bytes: {:?}",
+            deserialized_addr,
+            gossiped_addr,
+            hex::encode(addr_bytes),
+        );
+        let deserialized_addr = deserialized_addr.unwrap();
+
+        // Check that the addrs are equal
+        prop_assert_eq!(
+            gossiped_addr,
+            deserialized_addr,
+            "unexpected round-trip mismatch with bytes: {:?}",
+            hex::encode(addr_bytes),
+        );
+
+        // Now check that the re-serialized bytes are equal
+        // (`impl PartialEq for MetaAddr` might not match serialization equality)
+        let addr_bytes2 = deserialized_addr.zcash_serialize_to_vec();
+        prop_assert!(
+            addr_bytes2.is_ok(),
+            "unexpected serialization error after round-trip: {:?}, original addr: {:?}, bytes: {:?}, deserialized addr: {:?}",
+            addr_bytes2,
+            gossiped_addr,
+            hex::encode(addr_bytes),
+            deserialized_addr,
+        );
+        let addr_bytes2 = addr_bytes2.unwrap();
+
+        prop_assert_eq!(
+            &addr_bytes,
+            &addr_bytes2,
+            "unexpected round-trip bytes mismatch: original addr: {:?}, bytes: {:?}, deserialized addr: {:?}, bytes: {:?}",
+            gossiped_addr,
+            hex::encode(&addr_bytes),
+            deserialized_addr,
+            hex::encode(&addr_bytes2),
+        );
+
     }
 }

--- a/zebra-network/src/meta_addr/tests/prop.rs
+++ b/zebra-network/src/meta_addr/tests/prop.rs
@@ -1,6 +1,7 @@
 //! Randomised property tests for MetaAddr.
 
-use super::{super::MetaAddr, check};
+use super::check;
+use crate::{meta_addr::MetaAddr, types::PeerServices};
 
 use proptest::prelude::*;
 
@@ -10,10 +11,10 @@ proptest! {
     /// Make sure that the sanitize function reduces time and state metadata
     /// leaks.
     #[test]
-    fn sanitized_fields(entry in MetaAddr::arbitrary()) {
+    fn sanitize_avoids_leaks(addr in MetaAddr::arbitrary()) {
         zebra_test::init();
 
-        check::sanitize_avoids_leaks(&entry);
+        check::sanitize_avoids_leaks(&addr, &addr.sanitize());
     }
 
     /// Test round-trip serialization for gossiped MetaAddrs
@@ -79,4 +80,73 @@ proptest! {
         );
 
     }
+
+    /// Test round-trip serialization for all MetaAddr variants after sanitization
+    #[test]
+    fn sanitized_roundtrip(
+        addr in any::<MetaAddr>()
+    ) {
+        zebra_test::init();
+
+        let sanitized_addr = addr.sanitize();
+        // Make sure sanitization avoids leaks on this address, to avoid spurious errors
+        check::sanitize_avoids_leaks(&addr, &sanitized_addr);
+
+        // Check that sanitization doesn't make Zebra's serialization fail
+        let addr_bytes = sanitized_addr.zcash_serialize_to_vec();
+        prop_assert!(
+            addr_bytes.is_ok(),
+            "unexpected serialization error: {:?}, addr: {:?}",
+            addr_bytes,
+            sanitized_addr
+        );
+        let addr_bytes = addr_bytes.unwrap();
+
+        // Assume other implementations deserialize like Zebra
+        let deserialized_addr = MetaAddr::zcash_deserialize(addr_bytes.as_slice());
+        prop_assert!(
+            deserialized_addr.is_ok(),
+            "unexpected deserialization error: {:?}, addr: {:?}, bytes: {:?}",
+            deserialized_addr,
+            sanitized_addr,
+            hex::encode(addr_bytes),
+        );
+        let deserialized_addr = deserialized_addr.unwrap();
+
+        // Check that the addrs are equal
+        prop_assert_eq!(
+            sanitized_addr,
+            deserialized_addr,
+            "unexpected round-trip mismatch with bytes: {:?}",
+            hex::encode(addr_bytes),
+        );
+
+        // Check that serialization hasn't de-sanitized anything
+        check::sanitize_avoids_leaks(&addr, &deserialized_addr);
+
+        // Now check that the re-serialized bytes are equal
+        // (`impl PartialEq for MetaAddr` might not match serialization equality)
+        let addr_bytes2 = deserialized_addr.zcash_serialize_to_vec();
+        prop_assert!(
+            addr_bytes2.is_ok(),
+            "unexpected serialization error after round-trip: {:?}, original addr: {:?}, bytes: {:?}, deserialized addr: {:?}",
+            addr_bytes2,
+            sanitized_addr,
+            hex::encode(addr_bytes),
+            deserialized_addr,
+        );
+        let addr_bytes2 = addr_bytes2.unwrap();
+
+        prop_assert_eq!(
+            &addr_bytes,
+            &addr_bytes2,
+            "unexpected round-trip bytes mismatch: original addr: {:?}, bytes: {:?}, deserialized addr: {:?}, bytes: {:?}",
+            sanitized_addr,
+            hex::encode(&addr_bytes),
+            deserialized_addr,
+            hex::encode(&addr_bytes2),
+        );
+
+    }
+
 }

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -23,6 +23,6 @@ fn sanitize_extremes() {
         last_connection_state: Default::default(),
     };
 
-    check::sanitize_avoids_leaks(&min_time_entry);
-    check::sanitize_avoids_leaks(&max_time_entry);
+    check::sanitize_avoids_leaks(&min_time_entry, &min_time_entry.sanitize());
+    check::sanitize_avoids_leaks(&max_time_entry, &max_time_entry.sanitize());
 }


### PR DESCRIPTION
## Motivation

Zebra assumes that deserialized times are never modified, and so they are always valid for serialization.

We think that this works for Zebra's current:
* `MetaAddr` sanitization, and
* generated "local listener" `MetaAddr`.

But it probably won't keep working as we modify times more. (For example, in #2178.)

## Solution

- Security: Stop panicking when serializing out-of-range times
  - The security fix is on line https://github.com/ZcashFoundation/zebra/pull/2203/files#r639426014
- Add property tests for round-trip serialization
- Add property tests for sanitization and round-trip serialization
- Do a bunch of smaller fixes to make these tests work

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

@jvff can review this PR, I think it blocks #2178.
