### PR TITLE
Make arbitrary block chains pass some genesis checks

### DIFF
--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -198,8 +198,7 @@ impl FinalizedState {
         // Assert that callers (including unit tests) get the chain order correct
         if self.is_empty(hash_by_height) {
             assert_eq!(
-                block::Hash([0; 32]),
-                block.header.previous_block_hash,
+                GENESIS_PREVIOUS_BLOCK_HASH, block.header.previous_block_hash,
                 "the first block added to an empty state must be a genesis block"
             );
             assert_eq!(


### PR DESCRIPTION
## Motivation

In #2185, we want to commit arbitrary chains to the finalized state.

But the finalized state has some chain order assertions, which the `Block` and `PreparedChain` arbitrary implementations don't satisfy.

## Solution

Use the genesis previous block hash for
- the first arbitrary block in each chain, and
- individual arbitrary blocks.

This setting can be adjusted by individual proptests as needed.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Passes Existing Property Tests
  - [ ] Property Tests that depend on this feature will be written in #2185

## Review

@oxarbitrage should review this PR, so he can write tests for #2185
