### PR TITLE
Doc: shielded data always contains at least one action

### DIFF
--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -44,8 +44,7 @@ impl ShieldedData {
         self.actions.actions()
     }
 
-    /// Collect the [`Nullifier`]s for this transaction, if it contains
-    /// [`Action`]s.
+    /// Collect the [`Nullifier`]s for this transaction.
     pub fn nullifiers(&self) -> impl Iterator<Item = &Nullifier> {
         self.actions().map(|action| &action.nullifier)
     }


### PR DESCRIPTION
## Motivation

In a recent PR, we merged a comment in orchard::ShieldedData which said "if it contains any Actions".

But a ShieldedData always contains `AtLeastOne<Action>`.

## Solution

Delete the incorrect part of the comment.

## Review

@oxarbitrage can review this low-priority doc fix.