### PR TITLE
Minor property test cleanups

### DIFF
--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -313,7 +313,7 @@ pub enum Error {
 /// );
 /// ```
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NegativeAllowed {}
+pub struct NegativeAllowed;
 
 impl Constraint for NegativeAllowed {
     fn valid_range() -> RangeInclusive<i64> {
@@ -331,7 +331,7 @@ impl Constraint for NegativeAllowed {
 /// );
 /// ```
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub struct NonNegative {}
+pub struct NonNegative;
 
 impl Constraint for NonNegative {
     fn valid_range() -> RangeInclusive<i64> {

--- a/zebra-chain/src/parameters.rs
+++ b/zebra-chain/src/parameters.rs
@@ -17,6 +17,9 @@ mod network;
 mod network_upgrade;
 mod transaction;
 
+#[cfg(any(test, feature = "proptest-impl"))]
+pub mod arbitrary;
+
 pub use genesis::*;
 pub use network::Network;
 pub use network_upgrade::*;

--- a/zebra-chain/src/parameters/arbitrary.rs
+++ b/zebra-chain/src/parameters/arbitrary.rs
@@ -1,0 +1,21 @@
+//! Arbitrary implementations for network parameters
+
+use proptest::prelude::*;
+
+use super::NetworkUpgrade;
+
+impl NetworkUpgrade {
+    /// Generates network upgrades with [`BranchId`]s
+    pub fn branch_id_strategy() -> BoxedStrategy<NetworkUpgrade> {
+        prop_oneof![
+            Just(NetworkUpgrade::Overwinter),
+            Just(NetworkUpgrade::Sapling),
+            Just(NetworkUpgrade::Blossom),
+            Just(NetworkUpgrade::Heartwood),
+            Just(NetworkUpgrade::Canopy),
+            Just(NetworkUpgrade::Nu5),
+            // TODO: add future network upgrades (#1974)
+        ]
+        .boxed()
+    }
+}

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -108,7 +108,7 @@ impl Transaction {
     /// Generate a proptest strategy for V5 Transactions
     pub fn v5_strategy(ledger_state: LedgerState) -> BoxedStrategy<Self> {
         (
-            Self::branch_id_strategy(),
+            NetworkUpgrade::branch_id_strategy(),
             any::<LockTime>(),
             any::<block::Height>(),
             transparent::Input::vec_strategy(ledger_state, 10),
@@ -138,20 +138,6 @@ impl Transaction {
                 },
             )
             .boxed()
-    }
-
-    // A custom strategy to use only some of the NetworkUpgrade values
-    fn branch_id_strategy() -> BoxedStrategy<NetworkUpgrade> {
-        prop_oneof![
-            Just(NetworkUpgrade::Overwinter),
-            Just(NetworkUpgrade::Sapling),
-            Just(NetworkUpgrade::Blossom),
-            Just(NetworkUpgrade::Heartwood),
-            Just(NetworkUpgrade::Canopy),
-            Just(NetworkUpgrade::Nu5),
-            // TODO: add future network upgrades
-        ]
-        .boxed()
     }
 
     /// Proptest Strategy for creating a Vector of transactions where the first

--- a/zebra-chain/src/transparent/prop.rs
+++ b/zebra-chain/src/transparent/prop.rs
@@ -1,3 +1,7 @@
+//! Property tests for transparent inputs and outputs.
+//!
+//! TODO: Move this module into a `tests` submodule.
+
 use zebra_test::prelude::*;
 
 use crate::{block, LedgerState};

--- a/zebra-state/src/utxo.rs
+++ b/zebra-state/src/utxo.rs
@@ -5,7 +5,10 @@ use zebra_chain::{block, transparent};
 
 /// An unspent `transparent::Output`, with accompanying metadata.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+#[cfg_attr(
+    any(test, feature = "proptest-impl"),
+    derive(proptest_derive::Arbitrary)
+)]
 pub struct Utxo {
     /// The output itself.
     pub output: transparent::Output,


### PR DESCRIPTION
## Motivation

- Move implementations to more specific modules
- Activate arbitrary impls for the proptest-impl feature
- Note future moves
- Cleanup some unit structs

## Review

Anyone can review this low-priority PR.
