### PR TITLE
ZIP-221: integrate MMR tree from librustcash (without Orchard)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bigint"
+version = "4.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0e8c8a600052b52482eff2cf4d810e462fdff1f656ac1ecb6232132a1ed7def"
+dependencies = [
+ "byteorder",
+ "crunchy 0.1.6",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,6 +894,12 @@ dependencies = [
  "const_fn",
  "lazy_static",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 
 [[package]]
 name = "crunchy"
@@ -3938,7 +3954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
 dependencies = [
  "byteorder",
- "crunchy",
+ "crunchy 0.2.2",
  "hex",
  "static_assertions",
 ]
@@ -4390,6 +4406,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_history"
+version = "0.2.0"
+source = "git+https://github.com/zcash/librustzcash.git#d50bb12a97da768dc8f3ee39b81f84262103e6eb"
+dependencies = [
+ "bigint",
+ "blake2b_simd",
+ "byteorder",
+]
+
+[[package]]
 name = "zcash_script"
 version = "0.1.6-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4446,6 +4472,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "x25519-dalek",
+ "zcash_history",
  "zebra-test",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4433,6 +4433,7 @@ version = "1.0.0-alpha.9"
 dependencies = [
  "aes",
  "bech32",
+ "bigint",
  "bincode",
  "bitflags",
  "bitvec 0.17.4",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -44,7 +44,7 @@ sha2 = { version = "0.9.5", features=["compress"] }
 subtle = "2.4"
 thiserror = "1"
 x25519-dalek = { version = "1.1", features = ["serde"] }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git"}
+zcash_history = { git = "https://github.com/zcash/librustzcash.git" }
 
 proptest = { version = "0.10", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -51,7 +51,6 @@ proptest = { version = "0.10", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 itertools = { version = "0.10.0", optional = true }
 
-
 # ZF deps
 ed25519-zebra = "2"
 equihash = "0.1"

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -44,10 +44,12 @@ sha2 = { version = "0.9.5", features=["compress"] }
 subtle = "2.4"
 thiserror = "1"
 x25519-dalek = { version = "1.1", features = ["serde"] }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git"}
 
 proptest = { version = "0.10", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 itertools = { version = "0.10.0", optional = true }
+
 
 # ZF deps
 ed25519-zebra = "2"

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -45,6 +45,7 @@ subtle = "2.4"
 thiserror = "1"
 x25519-dalek = { version = "1.1", features = ["serde"] }
 zcash_history = { git = "https://github.com/zcash/librustzcash.git" }
+bigint = "4"
 
 proptest = { version = "0.10", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -15,7 +15,7 @@ pub mod tests;
 
 use std::fmt;
 
-pub use commitment::{Commitment, CommitmentError};
+pub use commitment::{ChainHistoryMmrRootHash, Commitment, CommitmentError};
 pub use hash::Hash;
 pub use header::{BlockTimeError, CountedHeader, Header};
 pub use height::Height;

--- a/zebra-chain/src/block/commitment.rs
+++ b/zebra-chain/src/block/commitment.rs
@@ -143,6 +143,12 @@ impl Commitment {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ChainHistoryMmrRootHash([u8; 32]);
 
+impl From<[u8; 32]> for ChainHistoryMmrRootHash {
+    fn from(hash: [u8; 32]) -> Self {
+        ChainHistoryMmrRootHash(hash)
+    }
+}
+
 /// A block commitment to chain history and transaction auth.
 /// - the chain history tree for all ancestors in the current network upgrade,
 ///   and

--- a/zebra-chain/src/primitives.rs
+++ b/zebra-chain/src/primitives.rs
@@ -13,3 +13,5 @@ pub use redjubjub;
 pub use x25519_dalek as x25519;
 
 pub use proofs::{Bctv14Proof, Groth16Proof, Halo2Proof, ZkSnarkProof};
+
+pub mod zcash_history;

--- a/zebra-chain/src/primitives/zcash_history.rs
+++ b/zebra-chain/src/primitives/zcash_history.rs
@@ -4,6 +4,8 @@
 // TODO: remove after this module gets to be used
 #![allow(dead_code)]
 
+mod tests;
+
 use std::{collections::HashMap, convert::TryInto, io, sync::Arc};
 
 use crate::{
@@ -281,93 +283,4 @@ fn count_sapling_transactions(block: Arc<Block>) -> u64 {
         .count()
         .try_into()
         .expect("number of transactions must fit u64")
-}
-
-#[cfg(test)]
-mod test {
-    use crate::{
-        block::Commitment::{self, ChainHistoryActivationReserved},
-        serialization::ZcashDeserializeInto,
-    };
-
-    use super::*;
-    use color_eyre::eyre;
-    use eyre::Result;
-    use zebra_test::vectors::{
-        MAINNET_BLOCKS, MAINNET_FINAL_SAPLING_ROOTS, TESTNET_BLOCKS, TESTNET_FINAL_SAPLING_ROOTS,
-    };
-
-    /// Test the MMR tree using the activation block of a network upgrade
-    /// and its next block.
-    #[test]
-    fn tree() -> Result<()> {
-        tree_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Heartwood)?;
-        tree_for_network_upgrade(Network::Testnet, NetworkUpgrade::Heartwood)?;
-        tree_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Canopy)?;
-        tree_for_network_upgrade(Network::Testnet, NetworkUpgrade::Canopy)?;
-        Ok(())
-    }
-
-    fn tree_for_network_upgrade(network: Network, network_upgrade: NetworkUpgrade) -> Result<()> {
-        let (blocks, sapling_roots) = match network {
-            Network::Mainnet => (&*MAINNET_BLOCKS, &*MAINNET_FINAL_SAPLING_ROOTS),
-            Network::Testnet => (&*TESTNET_BLOCKS, &*TESTNET_FINAL_SAPLING_ROOTS),
-        };
-        let height = network_upgrade.activation_height(network).unwrap().0;
-
-        // Load Block 0 (activation block of the given network upgrade)
-        let block0 = Arc::new(
-            blocks
-                .get(&height)
-                .expect("test vector exists")
-                .zcash_deserialize_into::<Block>()
-                .expect("block is structurally valid"),
-        );
-
-        // Check its commitment
-        let commitment0 = block0.commitment(network)?;
-        if network_upgrade == NetworkUpgrade::Heartwood {
-            // Heartwood is the only upgrade that has a reserved value.
-            // (For other upgrades we could compare with the expected commitment,
-            // but we haven't calculated them.)
-            assert_eq!(commitment0, ChainHistoryActivationReserved);
-        }
-
-        // Build initial MMR tree with only Block 0
-        let sapling_root0 =
-            sapling::tree::Root(**sapling_roots.get(&height).expect("test vector exists"));
-        let mut tree = Tree::new_from_block(network, block0, &sapling_root0)?;
-
-        // Compute root hash of the MMR tree, which will be included in the next block
-        let hash0 = tree.hash();
-
-        // Load Block 1 (activation + 1)
-        let block1 = Arc::new(
-            blocks
-                .get(&(height + 1))
-                .expect("test vector exists")
-                .zcash_deserialize_into::<Block>()
-                .expect("block is structurally valid"),
-        );
-
-        // Check its commitment
-        let commitment1 = block1.commitment(network)?;
-        assert_eq!(commitment1, Commitment::ChainHistoryRoot(hash0));
-
-        // Append Block to MMR tree
-        let sapling_root1 = sapling::tree::Root(
-            **sapling_roots
-                .get(&(height + 1))
-                .expect("test vector exists"),
-        );
-        let append = tree.append_leaf(block1, &sapling_root1).unwrap();
-
-        // Tree how has 3 nodes: two leafs for each block, and one parent node
-        // which is the new root
-        assert_eq!(tree.inner.len(), 3);
-        // Two nodes were appended: the new leaf and the parent node
-        assert_eq!(append.len(), 2);
-
-        Ok(())
-    }
 }

--- a/zebra-chain/src/primitives/zcash_history.rs
+++ b/zebra-chain/src/primitives/zcash_history.rs
@@ -1,0 +1,194 @@
+//! Contains code that interfaces with the zcash_history crate from
+//! librustzcash.
+
+use std::{collections::HashMap, convert::TryInto, io};
+
+use crate::{
+    block::Block,
+    parameters::{ConsensusBranchId, Network},
+    sapling,
+    transaction::Transaction,
+};
+
+/// A MMR Tree using zcash_history::Tree.
+///
+/// Currently it should not be used as a long-term data structure because it
+/// may grow undefinitely.
+pub struct Tree {
+    network: Network,
+    tree: zcash_history::Tree,
+}
+
+/// An encoded tree Node.
+pub struct Node {
+    node: [u8; zcash_history::MAX_NODE_DATA_SIZE],
+}
+
+impl Node {
+    /// Convert a Node into a zcash_history::Entry.
+    fn to_entry(&self, branch_id: ConsensusBranchId) -> Result<zcash_history::Entry, io::Error> {
+        zcash_history::Entry::from_bytes(branch_id.into(), self.node)
+    }
+}
+
+impl Tree {
+    /// Create a MMR tree with the given length.
+    ///
+    /// The `peaks` are the peaks of the MMR tree to build and their position in the
+    /// array representation of the tree.
+    /// The `extra` are extra nodes that enable removing nodes from the tree, and their position.
+    ///
+    /// Note that the length is usually larger than the length of `peaks` and `extra`, since
+    /// you don't need to pass every node, just the peaks of the tree (plus extra).
+    fn new(
+        network: Network,
+        branch_id: ConsensusBranchId,
+        length: u32,
+        peaks: &HashMap<u32, &Node>,
+        extra: &HashMap<u32, &Node>,
+    ) -> Result<Self, io::Error> {
+        let mut peaks_vec = Vec::new();
+        for (idx, node) in peaks {
+            peaks_vec.push((*idx, node.to_entry(branch_id)?));
+        }
+        let mut extra_vec = Vec::new();
+        for (idx, node) in extra {
+            extra_vec.push((*idx, node.to_entry(branch_id)?));
+        }
+        let tree = zcash_history::Tree::new(length, peaks_vec, extra_vec);
+        Ok(Tree { network, tree })
+    }
+
+    /// Append a new block to the tree, as a new leaf.
+    ///
+    /// `sapling_root` is the root of the Sapling note commitment tree of the block.
+    ///
+    /// Returns a vector of nodes added to the tree (leaf + internal nodes).
+    fn append_leaf(&mut self, block: &Block, sapling_root: &sapling::tree::Root) -> Vec<Node> {
+        let node_data = convert_block_to_librustzcash_data(block, self.network, sapling_root);
+        // TODO: handle error
+        let appended = self.tree.append_leaf(node_data).unwrap();
+
+        let mut new_nodes = Vec::new();
+        for entry in appended {
+            let mut node = Node {
+                node: [0; zcash_history::MAX_NODE_DATA_SIZE],
+            };
+            self.tree
+                .resolve_link(entry)
+                .expect("entry was just generated so it must be valid")
+                .data()
+                .write(&mut &mut node.node[..])
+                .expect("buffer was created with enough capacity");
+            new_nodes.push(node);
+        }
+        new_nodes
+    }
+
+    /// Append multiple blocks to the tree.
+    fn append_leaf_iter<'a>(
+        &mut self,
+        vals: impl Iterator<Item = (&'a Block, &'a sapling::tree::Root)>,
+    ) {
+        for (block, root) in vals {
+            self.append_leaf(block, root);
+        }
+    }
+
+    /// Remove the last leaf (block) from the tree.
+    ///
+    /// Returns the number of nodes removed from the tree after the operation.
+    fn truncate_leaf(&mut self) -> u32 {
+        // XXX: handle error
+        self.tree.truncate_leaf().unwrap()
+    }
+
+    /// Return the root hash of the tree, i.e. `hashChainHistoryRoot`.
+    fn hash(&self) -> [u8; 32] {
+        // Both append_leaf() and truncate_leaf() leave a root node, so it should
+        // always exist.
+        self.tree
+            .root_node()
+            .expect("must have root node")
+            .data()
+            .hash()
+    }
+}
+
+/// Convert a Block into a zcash_history::NodeData used in the MMR tree.
+///
+/// `sapling_root` is the root of the Sapling note commitment tree of the block.
+fn convert_block_to_librustzcash_data(
+    block: &Block,
+    network: Network,
+    sapling_root: &sapling::tree::Root,
+) -> zcash_history::NodeData {
+    // XXX: is this expect OK?
+    let height = block
+        .coinbase_height()
+        .expect("block must have coinbase height");
+    // XXX: is this expect OK?
+    let branch_id = ConsensusBranchId::current(network, height).expect("Must have branch ID");
+    let block_hash = block.hash().0;
+    let time: u32 = block
+        .header
+        .time
+        .timestamp()
+        .try_into()
+        .expect("deserialized and generated timestamps are u32 values");
+    let target = block.header.difficulty_threshold.0;
+    let sapling_root: [u8; 32] = (*sapling_root).into();
+    // XXX: is this expect OK?
+    let work = block
+        .header
+        .difficulty_threshold
+        .to_work()
+        .expect("must have work");
+    let work = work.as_u128().to_be_bytes();
+
+    let sapling_tx_count = count_sapling_transactions(block);
+
+    zcash_history::NodeData {
+        consensus_branch_id: branch_id.into(),
+        subtree_commitment: block_hash,
+        start_time: time,
+        end_time: time,
+        start_target: target,
+        end_target: target,
+        start_sapling_root: sapling_root,
+        end_sapling_root: sapling_root,
+        subtree_total_work: (&work[..]).into(),
+        start_height: height.0 as u64,
+        end_height: height.0 as u64,
+        sapling_tx: sapling_tx_count,
+    }
+}
+
+/// Count how many Sapling transactions exist in a block,
+/// i.e. transactions "where either of vSpendsSapling or vOutputsSapling is non-empty"
+/// (https://zips.z.cash/zip-0221#tree-node-specification).
+fn count_sapling_transactions(block: &Block) -> u64 {
+    block
+        .transactions
+        .iter()
+        .map(|tx| -> u64 {
+            match &**tx {
+                Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => 0,
+                Transaction::V4 {
+                    sapling_shielded_data,
+                    ..
+                } => match sapling_shielded_data {
+                    Some(_) => 1,
+                    None => 0,
+                },
+                Transaction::V5 {
+                    sapling_shielded_data,
+                    ..
+                } => match sapling_shielded_data {
+                    Some(_) => 1,
+                    None => 0,
+                },
+            }
+        })
+        .sum()
+}

--- a/zebra-chain/src/primitives/zcash_history.rs
+++ b/zebra-chain/src/primitives/zcash_history.rs
@@ -15,7 +15,7 @@ use crate::{
 /// A MMR Tree using zcash_history::Tree.
 ///
 /// Currently it should not be used as a long-term data structure because it
-/// may grow undefinitely.
+/// may grow without limits.
 pub struct Tree {
     network: Network,
     tree: zcash_history::Tree,
@@ -59,7 +59,7 @@ impl From<zcash_history::Entry> for Entry {
 }
 
 impl Entry {
-    /// Create a leaf Entry for the given block, its netwrok, and the root of its
+    /// Create a leaf Entry for the given block, its network, and the root of its
     /// Sapling note commitment tree.
     fn new_leaf(block: Arc<Block>, network: Network, sapling_root: &sapling::tree::Root) -> Self {
         let node_data = block_to_history_node(block, network, sapling_root);

--- a/zebra-chain/src/primitives/zcash_history.rs
+++ b/zebra-chain/src/primitives/zcash_history.rs
@@ -145,7 +145,8 @@ fn block_to_history_node(
         .difficulty_threshold
         .to_work()
         .expect("work must be valid during contextual verification");
-    let work = work.as_u128().to_be_bytes();
+    // There is no direct `std::primitive::u128` to `bigint::U256` conversion
+    let work = bigint::U256::from_big_endian(work.as_u128().to_be_bytes());
 
     let sapling_tx_count = count_sapling_transactions(block);
 
@@ -158,8 +159,7 @@ fn block_to_history_node(
         end_target: target,
         start_sapling_root: sapling_root,
         end_sapling_root: sapling_root,
-        // Conversion from 128-bit value into 256-bit
-        subtree_total_work: (&work[..]).into(),
+        subtree_total_work: work,
         start_height: height.0 as u64,
         end_height: height.0 as u64,
         sapling_tx: sapling_tx_count,

--- a/zebra-chain/src/primitives/zcash_history/tests.rs
+++ b/zebra-chain/src/primitives/zcash_history/tests.rs
@@ -1,0 +1,4 @@
+//! Tests for Zebra history trees
+
+#[cfg(test)]
+mod vectors;

--- a/zebra-chain/src/primitives/zcash_history/tests/vectors.rs
+++ b/zebra-chain/src/primitives/zcash_history/tests/vectors.rs
@@ -1,0 +1,85 @@
+use crate::{
+    block::Commitment::{self, ChainHistoryActivationReserved},
+    serialization::ZcashDeserializeInto,
+};
+
+use crate::primitives::zcash_history::*;
+use color_eyre::eyre;
+use eyre::Result;
+use zebra_test::vectors::{
+    MAINNET_BLOCKS, MAINNET_FINAL_SAPLING_ROOTS, TESTNET_BLOCKS, TESTNET_FINAL_SAPLING_ROOTS,
+};
+
+/// Test the MMR tree using the activation block of a network upgrade
+/// and its next block.
+#[test]
+fn tree() -> Result<()> {
+    tree_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Heartwood)?;
+    tree_for_network_upgrade(Network::Testnet, NetworkUpgrade::Heartwood)?;
+    tree_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Canopy)?;
+    tree_for_network_upgrade(Network::Testnet, NetworkUpgrade::Canopy)?;
+    Ok(())
+}
+
+fn tree_for_network_upgrade(network: Network, network_upgrade: NetworkUpgrade) -> Result<()> {
+    let (blocks, sapling_roots) = match network {
+        Network::Mainnet => (&*MAINNET_BLOCKS, &*MAINNET_FINAL_SAPLING_ROOTS),
+        Network::Testnet => (&*TESTNET_BLOCKS, &*TESTNET_FINAL_SAPLING_ROOTS),
+    };
+    let height = network_upgrade.activation_height(network).unwrap().0;
+
+    // Load Block 0 (activation block of the given network upgrade)
+    let block0 = Arc::new(
+        blocks
+            .get(&height)
+            .expect("test vector exists")
+            .zcash_deserialize_into::<Block>()
+            .expect("block is structurally valid"),
+    );
+
+    // Check its commitment
+    let commitment0 = block0.commitment(network)?;
+    if network_upgrade == NetworkUpgrade::Heartwood {
+        // Heartwood is the only upgrade that has a reserved value.
+        // (For other upgrades we could compare with the expected commitment,
+        // but we haven't calculated them.)
+        assert_eq!(commitment0, ChainHistoryActivationReserved);
+    }
+
+    // Build initial MMR tree with only Block 0
+    let sapling_root0 =
+        sapling::tree::Root(**sapling_roots.get(&height).expect("test vector exists"));
+    let mut tree = Tree::new_from_block(network, block0, &sapling_root0)?;
+
+    // Compute root hash of the MMR tree, which will be included in the next block
+    let hash0 = tree.hash();
+
+    // Load Block 1 (activation + 1)
+    let block1 = Arc::new(
+        blocks
+            .get(&(height + 1))
+            .expect("test vector exists")
+            .zcash_deserialize_into::<Block>()
+            .expect("block is structurally valid"),
+    );
+
+    // Check its commitment
+    let commitment1 = block1.commitment(network)?;
+    assert_eq!(commitment1, Commitment::ChainHistoryRoot(hash0));
+
+    // Append Block to MMR tree
+    let sapling_root1 = sapling::tree::Root(
+        **sapling_roots
+            .get(&(height + 1))
+            .expect("test vector exists"),
+    );
+    let append = tree.append_leaf(block1, &sapling_root1).unwrap();
+
+    // Tree how has 3 nodes: two leafs for each block, and one parent node
+    // which is the new root
+    assert_eq!(tree.inner.len(), 3);
+    // Two nodes were appended: the new leaf and the parent node
+    assert_eq!(append.len(), 2);
+
+    Ok(())
+}

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -108,6 +108,12 @@ impl From<&Root> for [u8; 32] {
     }
 }
 
+impl From<&Root> for [u8; 32] {
+    fn from(root: &Root) -> Self {
+        root.0
+    }
+}
+
 /// Sapling Note Commitment Tree
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct NoteCommitmentTree {

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -108,12 +108,6 @@ impl From<&Root> for [u8; 32] {
     }
 }
 
-impl From<&Root> for [u8; 32] {
-    fn from(root: &Root) -> Self {
-        root.0
-    }
-}
-
 /// Sapling Note Commitment Tree
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct NoteCommitmentTree {

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -393,6 +393,21 @@ impl Transaction {
         }
     }
 
+    /// Return if the transaction has any Sapling shielded data.
+    pub fn has_sapling_shielded_data(&self) -> bool {
+        match self {
+            Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => false,
+            Transaction::V4 {
+                sapling_shielded_data,
+                ..
+            } => sapling_shielded_data.is_some(),
+            Transaction::V5 {
+                sapling_shielded_data,
+                ..
+            } => sapling_shielded_data.is_some(),
+        }
+    }
+
     // orchard
 
     /// Access the [`orchard::ShieldedData`] in this transaction, if there are any,


### PR DESCRIPTION
## Motivation

ZIP-221 specifies that the `hashFinalSaplingRoot` field of the header is a commitment to the root of a MMR tree, therefore Zebra must support it.

## Solution

librustzcash has code for that in `zcash_history`, though not for the whole logic. It has a Tree class that contains the logic for adding / removing nodes to the tree, but it's not supposed to be used as a long-term data structure - zcashd instantiates it every time a node is added or removed.

This PR creates a wrapper over it.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests
  
(will add tests after moving from draft)

## Review

@teor2345 will probably want to review it.

This draft PR only adds the wrapping over librustzcash; it still does not handle the logic to keep track of what should be stored.

Draft PR points that I'd like feedback on:

- Are some of the `expects` OK? If an error should be returned, how should I wrap it? (I guess I shouldn't return a librustzcash error. I tried using `thiserror` but couldn't get it to work, so I thought it would be better to confirm which approach to use beforehand)
- Is the librustzcash wrapping enough for this PR? (i.e. should I add the remaining logic in a separate PR?)
- Are the method names OK? I copied librustzcash, but I considered using `push`/`pop` (similar to `Vec`)
- Should the remaining logic be added in the same file / class, or maybe in other place of `zebra_chain`?

Questions about the design in #2132

- "use HashMap<u32, Entry>": this is what would be persisted/serialized, and I'd add / remove nodes on it based on the Tree operations, right? Are there any guidelines on how that should be serialized?

## Related Issues

Part of #2132

## Follow Up Work

Needs Orchard support which is blocked by librustzcash: https://github.com/zcash/librustzcash/issues/368