### PR TITLE
Update `has_inputs_and_outputs` to check V5 transactions

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -112,7 +112,7 @@ pub enum Transaction {
         outputs: Vec<transparent::Output>,
         /// The sapling shielded data for this transaction, if any.
         sapling_shielded_data: Option<sapling::ShieldedData<sapling::SharedAnchor>>,
-        // The orchard data for this transaction, if any.
+        /// The orchard data for this transaction, if any.
         orchard_shielded_data: Option<orchard::ShieldedData>,
     },
 }

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -395,7 +395,7 @@ impl Transaction {
 
     // orchard
 
-    /// Access the orchard::Nullifiers in this transaction, regardless of version.
+    /// Access the [`orchard::Nullifier`]s in this transaction, regardless of version.
     pub fn orchard_nullifiers(&self) -> Box<dyn Iterator<Item = &orchard::Nullifier> + '_> {
         // This function returns a boxed iterator because the different
         // transaction variants can have different iterator types

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -395,6 +395,27 @@ impl Transaction {
 
     // orchard
 
+    /// Iterate over the [`orchard::Action`]s in this transaction, if there are any.
+    pub fn orchard_actions(&self) -> Box<dyn Iterator<Item = &orchard::Action> + '_> {
+        match self {
+            // Actions
+            Transaction::V5 {
+                orchard_shielded_data: Some(orchard_shielded_data),
+                ..
+            } => Box::new(orchard_shielded_data.actions()),
+
+            // No Actions
+            Transaction::V1 { .. }
+            | Transaction::V2 { .. }
+            | Transaction::V3 { .. }
+            | Transaction::V4 { .. }
+            | Transaction::V5 {
+                orchard_shielded_data: None,
+                ..
+            } => Box::new(std::iter::empty()),
+        }
+    }
+
     /// Access the [`orchard::Nullifier`]s in this transaction, regardless of version.
     pub fn orchard_nullifiers(&self) -> Box<dyn Iterator<Item = &orchard::Nullifier> + '_> {
         // This function returns a boxed iterator because the different

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -28,15 +28,11 @@ pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> 
     let n_joinsplit = tx.joinsplit_count();
     let n_spends_sapling = tx.sapling_spends_per_anchor().count();
     let n_outputs_sapling = tx.sapling_outputs().count();
+    let n_actions_orchard = tx.orchard_actions().count();
 
-    // TODO: Orchard validation (#1980)
-    // For `Transaction::V5`:
-    // * at least one of `tx_in_count`, `nSpendsSapling`, and `nActionsOrchard` MUST be non-zero.
-    // * at least one of `tx_out_count`, `nOutputsSapling`, and `nActionsOrchard` MUST be non-zero.
-
-    if tx_in_count + n_spends_sapling + n_joinsplit == 0 {
+    if tx_in_count + n_spends_sapling + n_joinsplit + n_actions_orchard == 0 {
         Err(TransactionError::NoInputs)
-    } else if tx_out_count + n_outputs_sapling + n_joinsplit == 0 {
+    } else if tx_out_count + n_outputs_sapling + n_joinsplit + n_actions_orchard == 0 {
         Err(TransactionError::NoOutputs)
     } else {
         Ok(())

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -52,3 +52,25 @@ fn v5_fake_transactions() -> Result<(), Report> {
 
     Ok(())
 }
+
+#[test]
+fn v5_transaction_with_no_inputs_fails_validation() {
+    let transaction = fake_v5_transactions_for_network(
+        Network::Mainnet,
+        zebra_test::vectors::MAINNET_BLOCKS.iter(),
+    )
+    .rev()
+    .find(|transaction| {
+        transaction.inputs().is_empty()
+            && transaction.sapling_spends_per_anchor().next().is_none()
+            && transaction.orchard_actions().next().is_none()
+            && transaction.joinsplit_count() == 0
+            && (!transaction.outputs().is_empty() || transaction.sapling_outputs().next().is_some())
+    })
+    .expect("At least one transaction with no inputs in the test vectors");
+
+    assert_eq!(
+        check::has_inputs_and_outputs(&transaction),
+        Err(TransactionError::NoInputs)
+    );
+}

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -67,7 +67,7 @@ fn v5_transaction_with_no_inputs_fails_validation() {
             && transaction.joinsplit_count() == 0
             && (!transaction.outputs().is_empty() || transaction.sapling_outputs().next().is_some())
     })
-    .expect("At least one transaction with no inputs in the test vectors");
+    .expect("At least one fake v5 transaction with no inputs in the test vectors");
 
     assert_eq!(
         check::has_inputs_and_outputs(&transaction),
@@ -90,7 +90,7 @@ fn v5_transaction_with_no_outputs_fails_validation() {
             && (!transaction.inputs().is_empty()
                 || transaction.sapling_spends_per_anchor().next().is_some())
     })
-    .expect("At least one transaction with no outputs in the test vectors");
+    .expect("At least one fake v5 transaction with no outputs in the test vectors");
 
     assert_eq!(
         check::has_inputs_and_outputs(&transaction),

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -1,8 +1,6 @@
 use zebra_chain::{
-    block::{Block, Height},
     parameters::Network,
-    serialization::ZcashDeserializeInto,
-    transaction::{arbitrary::transaction_to_fake_v5, Transaction},
+    transaction::{arbitrary::fake_v5_transactions_for_network, Transaction},
 };
 
 use super::check;
@@ -53,21 +51,4 @@ fn v5_fake_transactions() -> Result<(), Report> {
     }
 
     Ok(())
-}
-
-fn fake_v5_transactions_for_network<'b>(
-    network: Network,
-    blocks: impl DoubleEndedIterator<Item = (&'b u32, &'b &'static [u8])> + 'b,
-) -> impl DoubleEndedIterator<Item = Transaction> + 'b {
-    blocks.flat_map(move |(height, original_bytes)| {
-        let original_block = original_bytes
-            .zcash_deserialize_into::<Block>()
-            .expect("block is structurally valid");
-
-        original_block
-            .transactions
-            .into_iter()
-            .map(move |transaction| transaction_to_fake_v5(&*transaction, network, Height(*height)))
-            .map(Transaction::from)
-    })
 }

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -5,55 +5,30 @@ use zebra_chain::{
     transaction::{arbitrary::transaction_to_fake_v5, Transaction},
 };
 
-use crate::error::TransactionError::*;
+use super::check;
+
+use crate::error::TransactionError;
 use color_eyre::eyre::Report;
 
 #[test]
 fn v5_fake_transactions() -> Result<(), Report> {
     zebra_test::init();
 
-    v5_fake_transactions_for_network(Network::Mainnet)?;
-    v5_fake_transactions_for_network(Network::Testnet)?;
+    let networks = vec![
+        (Network::Mainnet, zebra_test::vectors::MAINNET_BLOCKS.iter()),
+        (Network::Testnet, zebra_test::vectors::TESTNET_BLOCKS.iter()),
+    ];
 
-    Ok(())
-}
-
-fn v5_fake_transactions_for_network(network: Network) -> Result<(), Report> {
-    zebra_test::init();
-
-    // get all the blocks we have available
-    let block_iter = match network {
-        Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
-    };
-
-    for (height, original_bytes) in block_iter {
-        let original_block = original_bytes
-            .zcash_deserialize_into::<Block>()
-            .expect("block is structurally valid");
-
-        // convert all transactions from the block to V5
-        let transactions: Vec<Transaction> = original_block
-            .transactions
-            .iter()
-            .map(AsRef::as_ref)
-            .map(|t| transaction_to_fake_v5(t, network, Height(*height)))
-            .map(Into::into)
-            .collect();
-
-        // after the conversion some transactions end up with no inputs nor outputs.
-        for transaction in transactions {
-            match super::check::has_inputs_and_outputs(&transaction) {
-                Err(e) => {
-                    if e != NoInputs && e != NoOutputs {
-                        panic!("error must be NoInputs or NoOutputs")
-                    }
-                }
+    for (network, blocks) in networks {
+        for transaction in fake_v5_transactions_for_network(network, blocks) {
+            match check::has_inputs_and_outputs(&transaction) {
                 Ok(()) => (),
+                Err(TransactionError::NoInputs) | Err(TransactionError::NoOutputs) => (),
+                Err(_) => panic!("error must be NoInputs or NoOutputs"),
             };
 
             // make sure there are no joinsplits nor spends in coinbase
-            super::check::coinbase_tx_no_prevout_joinsplit_spend(&transaction)?;
+            check::coinbase_tx_no_prevout_joinsplit_spend(&transaction)?;
 
             // validate the sapling shielded data
             match transaction {
@@ -62,13 +37,13 @@ fn v5_fake_transactions_for_network(network: Network) -> Result<(), Report> {
                     ..
                 } => {
                     if let Some(s) = sapling_shielded_data {
-                        super::check::sapling_balances_match(&s)?;
+                        check::sapling_balances_match(&s)?;
 
                         for spend in s.spends_per_anchor() {
-                            super::check::spend_cv_rk_not_small_order(&spend)?
+                            check::spend_cv_rk_not_small_order(&spend)?
                         }
                         for output in s.outputs() {
-                            super::check::output_cv_epk_not_small_order(&output)?;
+                            check::output_cv_epk_not_small_order(&output)?;
                         }
                     }
                 }
@@ -76,5 +51,23 @@ fn v5_fake_transactions_for_network(network: Network) -> Result<(), Report> {
             }
         }
     }
+
     Ok(())
+}
+
+fn fake_v5_transactions_for_network<'b>(
+    network: Network,
+    blocks: impl DoubleEndedIterator<Item = (&'b u32, &'b &'static [u8])> + 'b,
+) -> impl DoubleEndedIterator<Item = Transaction> + 'b {
+    blocks.flat_map(move |(height, original_bytes)| {
+        let original_block = original_bytes
+            .zcash_deserialize_into::<Block>()
+            .expect("block is structurally valid");
+
+        original_block
+            .transactions
+            .into_iter()
+            .map(move |transaction| transaction_to_fake_v5(&*transaction, network, Height(*height)))
+            .map(Transaction::from)
+    })
 }

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -74,3 +74,26 @@ fn v5_transaction_with_no_inputs_fails_validation() {
         Err(TransactionError::NoInputs)
     );
 }
+
+#[test]
+fn v5_transaction_with_no_outputs_fails_validation() {
+    let transaction = fake_v5_transactions_for_network(
+        Network::Mainnet,
+        zebra_test::vectors::MAINNET_BLOCKS.iter(),
+    )
+    .rev()
+    .find(|transaction| {
+        transaction.outputs().is_empty()
+            && transaction.sapling_outputs().next().is_none()
+            && transaction.orchard_actions().next().is_none()
+            && transaction.joinsplit_count() == 0
+            && (!transaction.inputs().is_empty()
+                || transaction.sapling_spends_per_anchor().next().is_some())
+    })
+    .expect("At least one transaction with no outputs in the test vectors");
+
+    assert_eq!(
+        check::has_inputs_and_outputs(&transaction),
+        Err(TransactionError::NoOutputs)
+    );
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->
For Network Update 5, the consensus checks will have to consider the new V5 transaction and Orchard transactions. A few things needs to be changed to support this, but this PR focuses on the `transaction::check::has_inputs_and_outputs()` function.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->
The solution implemented follows the solution outlined in #1980.

To test the solution, two test vectors were written to find transactions in the mainnet and check that they fail the check as expected. I'm not sure if I did the right thing, or if the refactor to support the test vectors was optimal, so feedback is more than welcome!

I'm also not sure how to generate an `orchard::Action` in order to try to test the success scenario when there's at least one action.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 outlined the solution, and @oxarbitrage helped with some test planning.

## Related Issues

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->
Part of #1980. 

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
- [ ] Proptests?
- [ ] Test if `check::has_inputs_and_outputs` with V4 transactions?
