### PR TITLE
Make debugging easier on proptests with large vectors

### DIFF
--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use crate::{
     block,
+    fmt::SummaryDebug,
     parameters::{Network, NetworkUpgrade, GENESIS_PREVIOUS_BLOCK_HASH},
     serialization,
     work::{difficulty::CompactDifficulty, equihash},
@@ -249,7 +250,7 @@ impl Block {
     pub fn partial_chain_strategy(
         mut current: LedgerState,
         count: usize,
-    ) -> BoxedStrategy<Vec<Arc<Self>>> {
+    ) -> BoxedStrategy<SummaryDebug<Vec<Arc<Self>>>> {
         let mut vec = Vec::with_capacity(count);
 
         // generate block strategies with the correct heights
@@ -267,7 +268,7 @@ impl Block {
                 }
                 previous_block_hash = Some(block.hash());
             }
-            vec.into_iter().map(Arc::new).collect()
+            SummaryDebug(vec.into_iter().map(Arc::new).collect())
         })
         .boxed()
     }

--- a/zebra-chain/src/fmt.rs
+++ b/zebra-chain/src/fmt.rs
@@ -1,7 +1,8 @@
 //! Format wrappers for Zebra
 
-use std::fmt;
+use std::{fmt, ops};
 
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DisplayToDebug<T>(pub T);
 
 impl<T> fmt::Debug for DisplayToDebug<T>
@@ -13,6 +14,21 @@ where
     }
 }
 
+impl<T> ops::Deref for DisplayToDebug<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> From<T> for DisplayToDebug<T> {
+    fn from(t: T) -> Self {
+        Self(t)
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SummaryDebug<T>(pub T);
 
 impl<T> fmt::Debug for SummaryDebug<Vec<T>> {
@@ -24,5 +40,29 @@ impl<T> fmt::Debug for SummaryDebug<Vec<T>> {
 impl<T> fmt::Debug for SummaryDebug<&Vec<T>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}, len={}", std::any::type_name::<T>(), self.0.len())
+    }
+}
+
+impl<T> ops::Deref for SummaryDebug<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> From<T> for SummaryDebug<T> {
+    fn from(t: T) -> Self {
+        Self(t)
+    }
+}
+
+impl<T> IntoIterator for SummaryDebug<Vec<T>> {
+    type Item = T;
+
+    type IntoIter = <Vec<T> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }

--- a/zebra-chain/src/fmt.rs
+++ b/zebra-chain/src/fmt.rs
@@ -2,6 +2,7 @@
 
 use std::{fmt, ops};
 
+/// Wrapper to override `Debug`, redirecting it to the `Display` impl.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DisplayToDebug<T>(pub T);
 

--- a/zebra-chain/src/fmt.rs
+++ b/zebra-chain/src/fmt.rs
@@ -28,39 +28,49 @@ impl<T> From<T> for DisplayToDebug<T> {
     }
 }
 
+/// Wrapper to override `Debug` to display a shorter summary of the type.
+///
+/// For collections and exact size iterators, it only displays the
+/// collection/iterator type, the item type, and the length.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SummaryDebug<T>(pub T);
+pub struct SummaryDebug<CollectionOrIter>(pub CollectionOrIter);
 
-impl<T> fmt::Debug for SummaryDebug<Vec<T>> {
+impl<CollectionOrIter> fmt::Debug for SummaryDebug<CollectionOrIter>
+where
+    CollectionOrIter: IntoIterator + Clone,
+    <CollectionOrIter as IntoIterator>::IntoIter: ExactSizeIterator,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}, len={}", std::any::type_name::<T>(), self.0.len())
+        write!(
+            f,
+            "{}<{}>, len={}",
+            std::any::type_name::<CollectionOrIter>(),
+            std::any::type_name::<<CollectionOrIter as IntoIterator>::Item>(),
+            self.0.clone().into_iter().len()
+        )
     }
 }
 
-impl<T> fmt::Debug for SummaryDebug<&Vec<T>> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}, len={}", std::any::type_name::<T>(), self.0.len())
-    }
-}
-
-impl<T> ops::Deref for SummaryDebug<T> {
-    type Target = T;
+impl<CollectionOrIter> ops::Deref for SummaryDebug<CollectionOrIter> {
+    type Target = CollectionOrIter;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<T> From<T> for SummaryDebug<T> {
-    fn from(t: T) -> Self {
-        Self(t)
+impl<CollectionOrIter> From<CollectionOrIter> for SummaryDebug<CollectionOrIter> {
+    fn from(collection: CollectionOrIter) -> Self {
+        Self(collection)
     }
 }
 
-impl<T> IntoIterator for SummaryDebug<Vec<T>> {
-    type Item = T;
-
-    type IntoIter = <Vec<T> as IntoIterator>::IntoIter;
+impl<CollectionOrIter> IntoIterator for SummaryDebug<CollectionOrIter>
+where
+    CollectionOrIter: IntoIterator,
+{
+    type Item = <CollectionOrIter as IntoIterator>::Item;
+    type IntoIter = <CollectionOrIter as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -23,14 +23,14 @@ use sapling::{AnchorVariant, PerSpendAnchor, SharedAnchor};
 ///
 /// This size is chosen to provide interesting behaviour, but not be too large
 /// for debugging.
-pub const MAX_ARBITRARY_TRANSACTIONS: usize = 4;
+pub const MAX_ARBITRARY_ITEMS: usize = 4;
 
 impl Transaction {
     /// Generate a proptest strategy for V1 Transactions
     pub fn v1_strategy(ledger_state: LedgerState) -> BoxedStrategy<Self> {
         (
-            transparent::Input::vec_strategy(ledger_state, MAX_ARBITRARY_TRANSACTIONS),
-            vec(any::<transparent::Output>(), 0..MAX_ARBITRARY_TRANSACTIONS),
+            transparent::Input::vec_strategy(ledger_state, MAX_ARBITRARY_ITEMS),
+            vec(any::<transparent::Output>(), 0..MAX_ARBITRARY_ITEMS),
             any::<LockTime>(),
         )
             .prop_map(|(inputs, outputs, lock_time)| Transaction::V1 {
@@ -44,8 +44,8 @@ impl Transaction {
     /// Generate a proptest strategy for V2 Transactions
     pub fn v2_strategy(ledger_state: LedgerState) -> BoxedStrategy<Self> {
         (
-            transparent::Input::vec_strategy(ledger_state, MAX_ARBITRARY_TRANSACTIONS),
-            vec(any::<transparent::Output>(), 0..MAX_ARBITRARY_TRANSACTIONS),
+            transparent::Input::vec_strategy(ledger_state, MAX_ARBITRARY_ITEMS),
+            vec(any::<transparent::Output>(), 0..MAX_ARBITRARY_ITEMS),
             any::<LockTime>(),
             option::of(any::<JoinSplitData<Bctv14Proof>>()),
         )
@@ -63,8 +63,8 @@ impl Transaction {
     /// Generate a proptest strategy for V3 Transactions
     pub fn v3_strategy(ledger_state: LedgerState) -> BoxedStrategy<Self> {
         (
-            transparent::Input::vec_strategy(ledger_state, MAX_ARBITRARY_TRANSACTIONS),
-            vec(any::<transparent::Output>(), 0..MAX_ARBITRARY_TRANSACTIONS),
+            transparent::Input::vec_strategy(ledger_state, MAX_ARBITRARY_ITEMS),
+            vec(any::<transparent::Output>(), 0..MAX_ARBITRARY_ITEMS),
             any::<LockTime>(),
             any::<block::Height>(),
             option::of(any::<JoinSplitData<Bctv14Proof>>()),
@@ -84,8 +84,8 @@ impl Transaction {
     /// Generate a proptest strategy for V4 Transactions
     pub fn v4_strategy(ledger_state: LedgerState) -> BoxedStrategy<Self> {
         (
-            transparent::Input::vec_strategy(ledger_state, MAX_ARBITRARY_TRANSACTIONS),
-            vec(any::<transparent::Output>(), 0..MAX_ARBITRARY_TRANSACTIONS),
+            transparent::Input::vec_strategy(ledger_state, MAX_ARBITRARY_ITEMS),
+            vec(any::<transparent::Output>(), 0..MAX_ARBITRARY_ITEMS),
             any::<LockTime>(),
             any::<block::Height>(),
             option::of(any::<JoinSplitData<Groth16Proof>>()),
@@ -117,8 +117,8 @@ impl Transaction {
             NetworkUpgrade::branch_id_strategy(),
             any::<LockTime>(),
             any::<block::Height>(),
-            transparent::Input::vec_strategy(ledger_state, MAX_ARBITRARY_TRANSACTIONS),
-            vec(any::<transparent::Output>(), 0..MAX_ARBITRARY_TRANSACTIONS),
+            transparent::Input::vec_strategy(ledger_state, MAX_ARBITRARY_ITEMS),
+            vec(any::<transparent::Output>(), 0..MAX_ARBITRARY_ITEMS),
             option::of(any::<sapling::ShieldedData<sapling::SharedAnchor>>()),
             option::of(any::<orchard::ShieldedData>()),
         )
@@ -206,7 +206,7 @@ impl<P: ZkSnarkProof + Arbitrary + 'static> Arbitrary for JoinSplitData<P> {
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         (
             any::<sprout::JoinSplit<P>>(),
-            vec(any::<sprout::JoinSplit<P>>(), 0..MAX_ARBITRARY_TRANSACTIONS),
+            vec(any::<sprout::JoinSplit<P>>(), 0..MAX_ARBITRARY_ITEMS),
             array::uniform32(any::<u8>()),
             vec(any::<u8>(), 64),
         )
@@ -262,9 +262,9 @@ impl Arbitrary for sapling::TransferData<PerSpendAnchor> {
         (
             vec(
                 any::<sapling::Spend<PerSpendAnchor>>(),
-                0..MAX_ARBITRARY_TRANSACTIONS,
+                0..MAX_ARBITRARY_ITEMS,
             ),
-            vec(any::<sapling::Output>(), 0..MAX_ARBITRARY_TRANSACTIONS),
+            vec(any::<sapling::Output>(), 0..MAX_ARBITRARY_ITEMS),
         )
             .prop_filter_map(
                 "arbitrary v4 transfers with no spends and no outputs",
@@ -299,9 +299,9 @@ impl Arbitrary for sapling::TransferData<SharedAnchor> {
             any::<sapling::tree::Root>(),
             vec(
                 any::<sapling::Spend<SharedAnchor>>(),
-                0..MAX_ARBITRARY_TRANSACTIONS,
+                0..MAX_ARBITRARY_ITEMS,
             ),
-            vec(any::<sapling::Output>(), 0..MAX_ARBITRARY_TRANSACTIONS),
+            vec(any::<sapling::Output>(), 0..MAX_ARBITRARY_ITEMS),
         )
             .prop_filter_map(
                 "arbitrary v5 transfers with no spends and no outputs",
@@ -338,7 +338,7 @@ impl Arbitrary for orchard::ShieldedData {
             any::<Halo2Proof>(),
             vec(
                 any::<orchard::shielded_data::AuthorizedAction>(),
-                1..MAX_ARBITRARY_TRANSACTIONS,
+                1..MAX_ARBITRARY_ITEMS,
             ),
             any::<Signature<Binding>>(),
         )

--- a/zebra-chain/src/transparent/prop.rs
+++ b/zebra-chain/src/transparent/prop.rs
@@ -4,9 +4,7 @@
 
 use zebra_test::prelude::*;
 
-use crate::{
-    block, fmt::SummaryDebug, transaction::arbitrary::MAX_ARBITRARY_TRANSACTIONS, LedgerState,
-};
+use crate::{block, fmt::SummaryDebug, transaction::arbitrary::MAX_ARBITRARY_ITEMS, LedgerState};
 
 use super::Input;
 
@@ -29,9 +27,8 @@ fn coinbase_has_height() -> Result<()> {
 fn input_coinbase_vecs_only_have_coinbase_input() -> Result<()> {
     zebra_test::init();
 
-    let strategy = LedgerState::coinbase_strategy(None).prop_flat_map(|ledger_state| {
-        Input::vec_strategy(ledger_state, MAX_ARBITRARY_TRANSACTIONS)
-    });
+    let strategy = LedgerState::coinbase_strategy(None)
+        .prop_flat_map(|ledger_state| Input::vec_strategy(ledger_state, MAX_ARBITRARY_ITEMS));
 
     proptest!(|(inputs in strategy.prop_map(SummaryDebug))| {
         let len = inputs.len();

--- a/zebra-chain/src/transparent/prop.rs
+++ b/zebra-chain/src/transparent/prop.rs
@@ -5,7 +5,7 @@
 use zebra_test::prelude::*;
 
 use crate::{
-    block, fmt::SummaryDebug, LedgerState,
+    block, fmt::SummaryDebug, transaction::arbitrary::MAX_ARBITRARY_TRANSACTIONS, LedgerState,
 };
 
 use super::Input;
@@ -29,9 +29,9 @@ fn coinbase_has_height() -> Result<()> {
 fn input_coinbase_vecs_only_have_coinbase_input() -> Result<()> {
     zebra_test::init();
 
-    let max_size = 100;
-    let strategy = LedgerState::coinbase_strategy(None)
-        .prop_flat_map(|ledger_state| Input::vec_strategy(ledger_state, max_size));
+    let strategy = LedgerState::coinbase_strategy(None).prop_flat_map(|ledger_state| {
+        Input::vec_strategy(ledger_state, MAX_ARBITRARY_TRANSACTIONS)
+    });
 
     proptest!(|(inputs in strategy.prop_map(SummaryDebug))| {
         let len = inputs.len();

--- a/zebra-chain/src/transparent/prop.rs
+++ b/zebra-chain/src/transparent/prop.rs
@@ -4,7 +4,9 @@
 
 use zebra_test::prelude::*;
 
-use crate::{block, LedgerState};
+use crate::{
+    block, fmt::SummaryDebug, LedgerState,
+};
 
 use super::Input;
 
@@ -31,7 +33,7 @@ fn input_coinbase_vecs_only_have_coinbase_input() -> Result<()> {
     let strategy = LedgerState::coinbase_strategy(None)
         .prop_flat_map(|ledger_state| Input::vec_strategy(ledger_state, max_size));
 
-    proptest!(|(inputs in strategy)| {
+    proptest!(|(inputs in strategy.prop_map(SummaryDebug))| {
         let len = inputs.len();
         for (ind, input) in inputs.into_iter().enumerate() {
             let is_coinbase = matches!(input, Input::Coinbase { .. });


### PR DESCRIPTION
## Motivation

It's hard to diagnose a proptest failure when you get hundreds of pages of log output.

## Solution

- Wrap large proptest vectors in the `SummaryDebug` type
- Make that type easier to use
- Reduce the size of random vectors that are embedded in other types

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Existing Property Tests

## Review

This code can be reviewed by anyone, but we'll all want it next time a block or chain test fails :-)

## Related Issues

Some of this code was accidentally deleted in PR #2012.

I really needed it when the chain proptests in #2185 were failing. (But they're fixed now.)
