### PR TITLE
Move the check in `transaction::check::sapling_balances_match` to `V4` deserialization

### DIFF
--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -227,6 +227,18 @@ impl<C1, C2> PartialEq<Amount<C2>> for Amount<C1> {
     }
 }
 
+impl<C> PartialEq<i64> for Amount<C> {
+    fn eq(&self, other: &i64) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl<C> PartialEq<Amount<C>> for i64 {
+    fn eq(&self, other: &Amount<C>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
 impl Eq for Amount<NegativeAllowed> {}
 impl Eq for Amount<NonNegative> {}
 

--- a/zebra-chain/src/sapling/shielded_data.rs
+++ b/zebra-chain/src/sapling/shielded_data.rs
@@ -86,6 +86,16 @@ where
     AnchorV: AnchorVariant + Clone,
 {
     /// The net value of Sapling spend transfers minus output transfers.
+    ///
+    /// [`ShieldedData`] structurally validates this [value balance consensus
+    /// rule](https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus):
+    /// "If effectiveVersion = 4 and there are no Spend descriptions or Output
+    /// descriptions, then valueBalanceSapling MUST be 0."
+    ///
+    /// `value_balance` is a field in [`ShieldedData`], which must have at least
+    /// one spend or output in its first field, so it is impossible to have a
+    /// [`ShieldedData`] with no spends, no outputs, and a non-zero value
+    /// balance.
     pub value_balance: Amount,
 
     /// A bundle of spends and outputs, containing at least one spend or

--- a/zebra-chain/src/sapling/shielded_data.rs
+++ b/zebra-chain/src/sapling/shielded_data.rs
@@ -93,9 +93,8 @@ where
     /// descriptions, then valueBalanceSapling MUST be 0."
     ///
     /// `value_balance` is a field in [`ShieldedData`], which must have at least
-    /// one spend or output in its first field, so it is impossible to have a
-    /// [`ShieldedData`] with no spends, no outputs, and a non-zero value
-    /// balance.
+    /// one spend or output in its `transfers` field. If [`ShieldedData`] is `None`
+    /// then the `value_balance` is always serialized as zero.
     pub value_balance: Amount,
 
     /// A bundle of spends and outputs, containing at least one spend or

--- a/zebra-chain/src/sapling/shielded_data.rs
+++ b/zebra-chain/src/sapling/shielded_data.rs
@@ -87,14 +87,20 @@ where
 {
     /// The net value of Sapling spend transfers minus output transfers.
     ///
-    /// [`ShieldedData`] structurally validates this [value balance consensus
+    /// [`ShieldedData`] validates this [value balance consensus
     /// rule](https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus):
+    ///
     /// "If effectiveVersion = 4 and there are no Spend descriptions or Output
     /// descriptions, then valueBalanceSapling MUST be 0."
     ///
+    /// During deserialization, this rule is checked when there are no spends and
+    /// no outputs.
+    ///
+    /// During serialization, this rule is structurally validated by [`ShieldedData`].
     /// `value_balance` is a field in [`ShieldedData`], which must have at least
     /// one spend or output in its `transfers` field. If [`ShieldedData`] is `None`
-    /// then the `value_balance` is always serialized as zero.
+    /// then there can not possibly be any spends or outputs, and the
+    /// `value_balance` is always serialized as zero.
     pub value_balance: Amount,
 
     /// A bundle of spends and outputs, containing at least one spend or

--- a/zebra-chain/src/serialization/error.rs
+++ b/zebra-chain/src/serialization/error.rs
@@ -23,4 +23,10 @@ pub enum SerializationError {
         #[from]
         source: crate::amount::Error,
     },
+    /// Invalid transaction with a non-zero balance and no Sapling shielded spends or outputs.
+    ///
+    /// Transaction does not conform to the Sapling [consensus
+    /// rule](https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus).
+    #[error("transaction balance is non-zero but doesn't have Sapling shielded spends or outputs")]
+    BadTransactionBalance,
 }

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -608,6 +608,12 @@ impl ZcashDeserialize for Transaction {
                         outputs: shielded_outputs.try_into().expect("checked for outputs"),
                     })
                 } else {
+                    // There are no shielded outputs and no shielded spends, so the value balance
+                    // MUST be zero:
+                    // https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
+                    if value_balance != 0 {
+                        return Err(SerializationError::BadTransactionBalance);
+                    }
                     None
                 };
 

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -55,7 +55,10 @@ fn doesnt_deserialize_transaction_with_invalid_value_balance() {
         .zcash_serialize(&mut input_bytes)
         .expect("dummy transaction should serialize");
     // Set value balance to non-zero
-    input_bytes[24] = 1;
+    // There are 4 * 4 byte fields and 2 * 1 byte compact sizes = 18 bytes before the 8 byte amount
+    // (Zcash is little-endian unless otherwise specified:
+    // https://zips.z.cash/protocol/nu5.pdf#endian)
+    input_bytes[18] = 1;
 
     let result = Transaction::zcash_deserialize(&input_bytes[..]);
 

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -3,7 +3,7 @@ use super::super::*;
 use crate::{
     block::{Block, Height, MAX_BLOCK_BYTES},
     parameters::{Network, NetworkUpgrade},
-    serialization::{ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
+    serialization::{SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
 };
 
 use std::convert::TryInto;
@@ -35,6 +35,34 @@ fn librustzcash_tx_hash() {
         .expect("hash should parse correctly");
 
     assert_eq!(hash, expected);
+}
+
+#[test]
+fn doesnt_deserialize_transaction_with_invalid_value_balance() {
+    zebra_test::init();
+
+    let dummy_transaction = Transaction::V4 {
+        inputs: vec![],
+        outputs: vec![],
+        lock_time: LockTime::Height(Height(1)),
+        expiry_height: Height(10),
+        joinsplit_data: None,
+        sapling_shielded_data: None,
+    };
+
+    let mut input_bytes = Vec::new();
+    dummy_transaction
+        .zcash_serialize(&mut input_bytes)
+        .expect("dummy transaction should serialize");
+    // Set value balance to non-zero
+    input_bytes[24] = 1;
+
+    let result = Transaction::zcash_deserialize(&input_bytes[..]);
+
+    assert!(matches!(
+        result,
+        Err(SerializationError::BadTransactionBalance)
+    ));
 }
 
 #[test]

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -215,8 +215,6 @@ where
                     }
 
                     if let Some(sapling_shielded_data) = sapling_shielded_data {
-                        check::sapling_balances_match(&sapling_shielded_data)?;
-
                         for spend in sapling_shielded_data.spends_per_anchor() {
                             // Consensus rule: cv and rk MUST NOT be of small
                             // order, i.e. [h_J]cv MUST NOT be 𝒪_J and [h_J]rk

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -4,7 +4,7 @@
 
 use zebra_chain::{
     orchard::Flags,
-    sapling::{AnchorVariant, Output, PerSpendAnchor, ShieldedData, Spend},
+    sapling::{Output, PerSpendAnchor, Spend},
     transaction::Transaction,
 };
 
@@ -37,31 +37,6 @@ pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> 
         Err(TransactionError::NoOutputs)
     } else {
         Ok(())
-    }
-}
-
-/// Check that if there are no Spends or Outputs, the Sapling valueBalance is also 0.
-///
-/// If effectiveVersion = 4 and there are no Spend descriptions or Output descriptions,
-/// then valueBalanceSapling MUST be 0.
-///
-/// This check is redundant for `Transaction::V5`, because the transaction format
-/// omits `valueBalanceSapling` when there are no spends and no outputs. But it's
-/// simpler to just do the redundant check anyway.
-///
-/// https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
-pub fn sapling_balances_match<AnchorV>(
-    sapling_shielded_data: &ShieldedData<AnchorV>,
-) -> Result<(), TransactionError>
-where
-    AnchorV: AnchorVariant + Clone,
-{
-    if (sapling_shielded_data.spends().count() + sapling_shielded_data.outputs().count() != 0)
-        || i64::from(sapling_shielded_data.value_balance) == 0
-    {
-        Ok(())
-    } else {
-        Err(TransactionError::BadBalance)
     }
 }
 

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -35,8 +35,6 @@ fn v5_fake_transactions() -> Result<(), Report> {
                     ..
                 } => {
                     if let Some(s) = sapling_shielded_data {
-                        check::sapling_balances_match(&s)?;
-
                         for spend in s.spends_per_anchor() {
                             check::spend_cv_rk_not_small_order(&spend)?
                         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->
The `sapling::ShieldedData` type structurally validates the `value_balance` [consensus rule](https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus). Therefore, the `transaction::check::sapling_balances_match` function is redundant _for serialization_.

_But we still need to do the check during deserialization._

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->
Remove the redundant `transaction::check::sapling_balances_match` function, and add extra documentation to the `sapling::ShieldedData::value_balance` field to link to the consensus rule and describe how it is structurally validated. This solution was described in #1980.

- [x] during `V4` sapling deserialization, return an error if `ShieldedData` is `None`, and the value balance is non-zero
  - copy the consensus rule into that function?
- [x] create a byte test vector with a non-zero `value_balance`, but no spends or outputs

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 outlined the solution.

## Related Issues

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->
Part of #1980.

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
