### PR TITLE
Update `transaction::check::coinbase_tx_no_joinsplit_or_spend` to validate V5 coinbase transactions with Orchard shielded data

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -438,22 +438,9 @@ impl Transaction {
     pub fn orchard_nullifiers(&self) -> Box<dyn Iterator<Item = &orchard::Nullifier> + '_> {
         // This function returns a boxed iterator because the different
         // transaction variants can have different iterator types
-        match self {
-            // Actions
-            Transaction::V5 {
-                orchard_shielded_data: Some(orchard_shielded_data),
-                ..
-            } => Box::new(orchard_shielded_data.nullifiers()),
-
-            // No Actions
-            Transaction::V1 { .. }
-            | Transaction::V2 { .. }
-            | Transaction::V3 { .. }
-            | Transaction::V4 { .. }
-            | Transaction::V5 {
-                orchard_shielded_data: None,
-                ..
-            } => Box::new(std::iter::empty()),
+        match self.orchard_shielded_data() {
+            Some(orchard_shielded_data) => Box::new(orchard_shielded_data.nullifiers()),
+            None => Box::new(std::iter::empty()),
         }
     }
 }

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -395,7 +395,7 @@ impl Transaction {
 
     // orchard
 
-    /// Access the [`orchard::ShieldedData`] in this transaction, if the transaction has it,
+    /// Access the [`orchard::ShieldedData`] in this transaction, if there are any,
     /// regardless of version.
     pub fn orchard_shielded_data(&self) -> Option<&orchard::ShieldedData> {
         match self {
@@ -413,7 +413,8 @@ impl Transaction {
         }
     }
 
-    /// Iterate over the [`orchard::Action`]s in this transaction, if there are any.
+    /// Iterate over the [`orchard::Action`]s in this transaction, if there are any,
+    /// regardless of version.
     pub fn orchard_actions(&self) -> impl Iterator<Item = &orchard::Action> {
         self.orchard_shielded_data()
             .into_iter()
@@ -421,7 +422,8 @@ impl Transaction {
             .flatten()
     }
 
-    /// Access the [`orchard::Nullifier`]s in this transaction, regardless of version.
+    /// Access the [`orchard::Nullifier`]s in this transaction, if there are any,
+    /// regardless of version.
     pub fn orchard_nullifiers(&self) -> impl Iterator<Item = &orchard::Nullifier> {
         self.orchard_shielded_data()
             .into_iter()

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -414,33 +414,18 @@ impl Transaction {
     }
 
     /// Iterate over the [`orchard::Action`]s in this transaction, if there are any.
-    pub fn orchard_actions(&self) -> Box<dyn Iterator<Item = &orchard::Action> + '_> {
-        match self {
-            // Actions
-            Transaction::V5 {
-                orchard_shielded_data: Some(orchard_shielded_data),
-                ..
-            } => Box::new(orchard_shielded_data.actions()),
-
-            // No Actions
-            Transaction::V1 { .. }
-            | Transaction::V2 { .. }
-            | Transaction::V3 { .. }
-            | Transaction::V4 { .. }
-            | Transaction::V5 {
-                orchard_shielded_data: None,
-                ..
-            } => Box::new(std::iter::empty()),
-        }
+    pub fn orchard_actions(&self) -> impl Iterator<Item = &orchard::Action> {
+        self.orchard_shielded_data()
+            .into_iter()
+            .map(orchard::ShieldedData::actions)
+            .flatten()
     }
 
     /// Access the [`orchard::Nullifier`]s in this transaction, regardless of version.
-    pub fn orchard_nullifiers(&self) -> Box<dyn Iterator<Item = &orchard::Nullifier> + '_> {
-        // This function returns a boxed iterator because the different
-        // transaction variants can have different iterator types
-        match self.orchard_shielded_data() {
-            Some(orchard_shielded_data) => Box::new(orchard_shielded_data.nullifiers()),
-            None => Box::new(std::iter::empty()),
-        }
+    pub fn orchard_nullifiers(&self) -> impl Iterator<Item = &orchard::Nullifier> {
+        self.orchard_shielded_data()
+            .into_iter()
+            .map(orchard::ShieldedData::nullifiers)
+            .flatten()
     }
 }

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -395,6 +395,24 @@ impl Transaction {
 
     // orchard
 
+    /// Access the [`orchard::ShieldedData`] in this transaction, if the transaction has it,
+    /// regardless of version.
+    pub fn orchard_shielded_data(&self) -> Option<&orchard::ShieldedData> {
+        match self {
+            // Maybe Orchard shielded data
+            Transaction::V5 {
+                orchard_shielded_data,
+                ..
+            } => orchard_shielded_data.as_ref(),
+
+            // No Orchard shielded data
+            Transaction::V1 { .. }
+            | Transaction::V2 { .. }
+            | Transaction::V3 { .. }
+            | Transaction::V4 { .. } => None,
+        }
+    }
+
     /// Iterate over the [`orchard::Action`]s in this transaction, if there are any.
     pub fn orchard_actions(&self) -> Box<dyn Iterator<Item = &orchard::Action> + '_> {
         match self {

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -38,6 +38,9 @@ pub enum TransactionError {
     #[error("coinbase transaction MUST NOT have any Output descriptions pre-Heartwood")]
     CoinbaseHasOutputPreHeartwood,
 
+    #[error("coinbase transaction MUST NOT have the EnableSpendsOrchard flag set")]
+    CoinbaseHasEnableSpendsOrchard,
+
     #[error("coinbase transaction failed subsidy validation")]
     Subsidy(#[from] SubsidyError),
 

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -3,6 +3,7 @@
 //! Code in this file can freely assume that no pre-V4 transactions are present.
 
 use zebra_chain::{
+    orchard::Flags,
     sapling::{AnchorVariant, Output, PerSpendAnchor, ShieldedData, Spend},
     transaction::Transaction,
 };
@@ -84,8 +85,11 @@ pub fn coinbase_tx_no_prevout_joinsplit_spend(tx: &Transaction) -> Result<(), Tr
             return Err(TransactionError::CoinbaseHasSpend);
         }
 
-        // TODO: Orchard validation (#1980)
-        // In a version 5 coinbase transaction, the enableSpendsOrchard flag MUST be 0.
+        if let Some(orchard_shielded_data) = tx.orchard_shielded_data() {
+            if orchard_shielded_data.flags.contains(Flags::ENABLE_SPENDS) {
+                return Err(TransactionError::CoinbaseHasEnableSpendsOrchard);
+            }
+        }
     }
 
     Ok(())


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->
NU5 has the consensus rule that V5 coinbase transactions must not have the enableSpendsOrchard flag set.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->
Implement the consensus rule in the `coinbase_tx_no_joinsplit_or_spend` function, as described in #1980.

The code in this pull request has:
  - [x] Documentation Comments
  - [ ] Unit Tests and Property Tests

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 outlined the solution, and @oxarbitrage is working on similar Orchard issues.

## Related Issues

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->
Part of #1980.

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
- [ ] What test vectors are needed?
- [ ] What kind of property tests should be written?