### PR TITLE
Adjust the benchmark sample size so all benchmarks finish successfully

### DIFF
--- a/zebra-chain/benches/block.rs
+++ b/zebra-chain/benches/block.rs
@@ -46,7 +46,7 @@ fn block_serialization(c: &mut Criterion) {
 
 criterion_group!(
     name = benches;
-    config = Criterion::default().noise_threshold(0.05);
+    config = Criterion::default().noise_threshold(0.05).sample_size(50);
     targets = block_serialization
 );
 criterion_main!(benches);


### PR DESCRIPTION
## Motivation

Some of our benchmarks don't run, because the default number of cases is too high.

## Solution

Reduce the default number of cases.

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Benchmarks
  - [x] This works on my machine

## Review

Anyone can review this low-priority PR.

## Related Issues

Fixes on #2018 

## Follow Up Work

Maybe we want to fix the time limits instead?
(I tried to do that quickly, but I couldn't get it working.)