### PR TITLE
Update the GitHub and RFC templates based on retrospectives

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,48 +7,63 @@ assignees: ''
 
 ---
 
-**Version**
+## Description
 
-For bugs in `zebrad`, run
-
-`zebrad version`
-
-For bugs in the `zebra` libraries, list the versions of all `zebra` crates you
-are using. The easiest way to get this information is using `cargo-tree`.
-
-`cargo install cargo-tree`
-(see install here: https://github.com/sfackler/cargo-tree)
-
-Then:
-
-`cargo tree | grep zebra`
-
-
-**Platform**
-
-The output of `uname -a` (UNIX), or version and 32 or 64-bit (Windows)
-
-**Description**
-
+<!--
 Enter your issue details here.
-One way to structure the description:
+-->
 
 [short summary of the bug]
+
+### Steps to Reproduce
 
 I tried this:
 
 [behavior or code sample that causes the bug]
 
+```sh
+copy and paste the exact commands or code here
+```
+
+### Expected Behaviour
+
 I expected to see this happen: [explanation]
+
+### Actual Behaviour
 
 Instead, this happened: [explanation]
 
-**Commands**
+### Zebra Logs
 
-Copy and paste the exact commands you used, so the team can try to reproduce the issue.
-
-**Logs**
-
+<!--
 Copy and paste the last 100 Zebra log lines.
+Or upload the full logs to https://gist.github.com/ and add a link to them here.
+-->
 
-If you can, upload the full logs to [Gist](https://gist.github.com/), and add a link to them here.
+<details>
+
+```
+copy and paste the logs here
+```
+
+</details>
+
+## Environment
+
+### Zebra Version
+
+<!--
+For bugs in `zebrad`, run `zebrad version`.
+
+For bugs in the `zebra` libraries, list the `zebra` crate versions.
+You can get this information using cargo-tree:
+cargo install cargo-tree
+cargo tree | grep zebra
+-->
+
+### Operating System
+
+<!--
+Linux, macOS, BSD: the output of `uname -a`
+Windows: Windows version and 32-bit or 64-bit
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,49 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
+name: Change request
+about: Suggest a feature or change for this project
 title: ''
 labels: C-enhancement, S-needs-triage
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Motivation
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!--
+Is your feature request related to a problem?
+How does this change improve Zebra?
+-->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+### Specifications
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+<!--
+If this change is based on consensus rules, quote them, and link to the Zcash spec or ZIP:
+https://zips.z.cash/#nu5-zips
+If this changes network behaviour, quote and link to the Bitcoin network reference:
+https://developer.bitcoin.org/reference/p2p_networking.html
+-->
+
+### Designs
+
+<!--
+If this change is part of a Zebra design, quote and link to the RFC:
+https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
+-->
+
+## Solution
+
+<!--
+Summarize the changes that you want to happen
+-->
+
+### Alternatives
+
+<!--
+Are there any alternative solutions?
+-->
+
+## Related Work
+
+<!--
+Is this change related to other features or tickets?
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/rfc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/rfc.md
@@ -4,23 +4,20 @@ about: A design RFC for Zebra
 title: ''
 labels: C-design
 assignees: ''
-
 ---
 
 <!--
 This template is for design RFCs.
-
-The RFC process is documented in CONTRIBUTING.md.
-
-Please see the checklist there: https://zebra.zfnd.org/CONTRIBUTING.html
+Please see the checklist in: https://zebra.zfnd.org/CONTRIBUTING.html
 -->
 
+## RFC Summary
 
-### Summary
+**Please copy the RFC summary here.**
 
-Please copy the RFC summary over here. 
+### Context
 
-### More information
+**Please copy the RFC header here.**
 
 Feature Name: `my_feature`
 
@@ -30,22 +27,23 @@ Design PR: [ZcashFoundation/zebra#0000](https://github.com/ZcashFoundation/zebra
 
 Zebra Issue: [ZcashFoundation/zebra#0000](https://github.com/ZcashFoundation/zebra/issues/0000)
 
-### Document
+### Rendered
 
 <!--
-Fill this in, replacing:
-
+Replace:
 ZcashFoundation/zebra with username/repo (if not making the PR from the Zebra repo)
 my-branch-name with the PR branch
 xxxx-my-feature with the filename of the RFC
-
 -->
 [Rendered](https://github.com/ZcashFoundation/zebra/blob/my-branch-name/book/src/dev/rfcs/drafts/xxxx-my-feature.md).
 
 ## Zebra Team Approval
 
-Everyone on the Zebra team should review design RFCs:
+Most of the Zebra team should review design RFCs:
 
+- [ ] @conradoplg
 - [ ] @dconnolly
 - [ ] @oxarbitrage
+- [ ] @jvff
+- [ ] @mpguerra
 - [ ] @teor2345

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,47 +1,48 @@
-<!--
-Thank you for your Pull Request.
-Please provide a description above and fill in the information below.
-
-Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
--->
-
 ## Motivation
 
 <!--
-Explain the context and why you're making that change.
-What is the problem you're trying to solve?
-If there's no specific problem, what is the motivation for your change?
+Thank you for your Pull Request.
+How does this change improve Zebra?
+-->
+
+### Specifications
+
+<!--
+If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
+https://zips.z.cash/#nu5-zips
+If this PR changes network behaviour, quote and link to the Bitcoin network reference:
+https://developer.bitcoin.org/reference/p2p_networking.html
+-->
+
+### Designs
+
+<!--
+If this PR implements a Zebra design, quote and link to the RFC:
+https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
 -->
 
 ## Solution
 
 <!--
-Summarize the solution and provide any necessary context needed to understand
-the code change.
-If this PR implements parts of a design RFC or ticket, list those parts here.
+Summarize the changes in this PR.
+Does it close any issues?
 -->
-
-The code in this pull request has:
-  - [ ] Documentation Comments
-  - [ ] Unit Tests and Property Tests
 
 ## Review
 
 <!--
-How urgent is this code review?
 Is this PR blocking any other work?
 If you want a specific reviewer for this PR, tag them here.
 -->
 
-## Related Issues
+### Reviewer Checklist
 
-<!--
-Please link to any existing GitHub issues pertaining to this PR.
--->
+  - [ ] Code implements Specs and Designs
+  - [ ] Tests for Expected Behaviour
+  - [ ] Tests for Errors
 
 ## Follow Up Work
 
 <!--
 Is there anything missing from the solution?
-What still needs to be done?
 -->

--- a/book/src/dev/rfcs/0000-template.md
+++ b/book/src/dev/rfcs/0000-template.md
@@ -25,11 +25,12 @@ Explain the proposal as if it was already included in the project and you were t
 
 - Introducing new named concepts.
 - Explaining the feature largely in terms of examples.
-- Explaining how Zebra programmers should *think* about the feature, and how it should impact the way they use Zebra. It should explain the impact as concretely as possible.
-- If applicable, provide sample error messages, deprecation warnings, migration guidance, or test strategies.
-- If applicable, describe the differences between teaching this to existing Zebra programmers and new Zebra programmers.
+- Explaining how Zebra users should *think* about the feature, and how it should impact the way they use Zebra. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages or test strategies.
 
-For implementation-oriented RFCs (e.g. for Zebra internals), this section should focus on how Zebra contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+For implementation-oriented RFCs (e.g. for Zebra internals), this section should focus on how Zebra contributors should think about the change, and give examples of its concrete impact.
+
+For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -41,6 +42,17 @@ This is the technical portion of the RFC. Explain the design in sufficient detai
 - Corner cases are dissected by example.
 
 The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+## Specifications
+[specifications]: #specifications
+
+If this design is based on Zcash consensus rules, quote them, and link to the Zcash spec or ZIP:
+https://zips.z.cash/protocol/nu5.pdf#contents
+https://zips.z.cash/#nu5-zips
+
+If this design changes network behaviour, quote and link to the Bitcoin network reference or wiki:
+https://developer.bitcoin.org/reference/p2p_networking.html
+https://en.bitcoin.it/wiki/Protocol_documentation
 
 ## Module Structure
 [module-structure]: #module-structure


### PR DESCRIPTION
## Motivation

We've talked about focusing on consensus rules and tests in recent retrospectives.

We can remind ourselves to make these changes by updating our templates.

## Solution

Update the GitHub and RFC templates based on retrospectives:
- GitHub Issue templates
- GitHub PR templates
- RFC template

Change them to focus on:
- consensus rule / network reference sections
- design sections
- review/test checklist

Make some process changes:
- add new team members to RFC approval
- change RFC approval to "most of the team"
- make the PR checklist into a reviewer checklist

And general cleanup:
- delete links to the contributor guide, GitHub already links to it for new contributors
- delete docs from the checklist, because we now `warn(missing_docs)`
- shorter explanations
- consistent headings
- consistent order and formatting

## Review

@mpguerra and @dconnolly, you'll probably want to check these changes.
Anyone else is welcome to review as well.

### Reviewer Checklist
  - [ ] Template Changes match Retrospective Discussions

## Follow Up Work

We should gradually automate more checks using GitHub, clippy, seamare, and property testing.