### PR TITLE
Create workflow to regenerate cached state disks for tests

### DIFF
--- a/.github/workflows/regenerate-stateful-test-disks.yml
+++ b/.github/workflows/regenerate-stateful-test-disks.yml
@@ -49,6 +49,7 @@ jobs:
           --boot-disk-type pd-ssd \
           --container-image rust:buster \
           --container-mount-disk mount-path='/mainnet',name="zebrad-cache-$SHORT_SHA-mainnet-1046400" \
+          --container-mount-disk mount-path='/testnet',name="zebrad-cache-$SHORT_SHA-testnet-1028500" \
           --container-restart-policy never \
           --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-1046400",size=100GB,type=pd-balanced,auto-delete=no \
           --create-disk name="zebrad-cache-$SHORT_SHA-testnet-1028500",size=100GB,type=pd-balanced,auto-delete=no \
@@ -57,7 +58,7 @@ jobs:
           --scopes cloud-platform \
           --tags zebrad \
           --zone "$ZONE"
-      # Build and run test container to sync up to activation and no further, for mainnet and then tesnet
+      # Build and run test container to sync up to activation and no further, for mainnet and then testnet
       - name: Run all tests
         run: |
           gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --zone "$ZONE" --command \

--- a/.github/workflows/regenerate-stateful-test-disks.yml
+++ b/.github/workflows/regenerate-stateful-test-disks.yml
@@ -1,0 +1,75 @@
+name: Regenerate test state
+
+on:
+  workflow_dispatch:
+
+env:
+  PROJECT_ID: zealous-zebra
+  ZONE: europe-west1-b
+
+jobs:
+
+  regenerate:
+    name: Regenerate test state
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          persist-credentials: false
+        
+      - name: Set project and image names
+        run: |
+          BRANCH_NAME=$(expr $GITHUB_REF : '.*/\(.*\)') && \
+          BRANCH_NAME=${BRANCH_NAME,,} && \
+          REPOSITORY=${GITHUB_REPOSITORY,,} && \
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV && \
+          echo "SHORT_SHA=$(git rev-parse --short=7 $GITHUB_SHA)" >> $GITHUB_ENV && \
+          echo "REPOSITORY=$REPOSITORY" >> $GITHUB_ENV
+      - name: Set up gcloud
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '295.0.0'
+          project_id: ${{ env.PROJECT_ID }}
+          service_account_key: ${{ secrets.GCLOUD_AUTH }}
+
+      # Run once: create firewall rule to allow incoming traffic to the nodes
+      # - name: Create Zcash incoming traffic firewall rule
+      #   run: |
+      #     gcloud compute firewall-rules create "allow-zcash" \
+      #     --target-tags zebrad \
+      #     --allow tcp:8233,tcp:18233 \
+      #     --source-ranges 0.0.0.0/0 \
+      #     --description="Allow incoming Zcash traffic from anywhere" \
+
+      # Creates Compute Engine virtual machine instance w/ disks
+      - name: Create instance
+        run: |
+          gcloud compute instances create-with-container "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" \
+          --boot-disk-size 100GB \
+          --boot-disk-type pd-ssd \
+          --container-image rust:buster \
+          --container-mount-disk mount-path='/mainnet',name="zebrad-cache-$SHORT_SHA-mainnet-1046400" \
+          --container-restart-policy never \
+          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-1046400",size=100GB,type=pd-balanced,auto-delete=no \
+          --create-disk name="zebrad-cache-$SHORT_SHA-testnet-1028500",size=100GB,type=pd-balanced,auto-delete=no \
+          --machine-type n2-standard-4 \
+          --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
+          --scopes cloud-platform \
+          --tags zebrad \
+          --zone "$ZONE"
+      # Build and run test container to sync up to activation and no further, for mainnet and then tesnet
+      - name: Run all tests
+        run: |
+          gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --zone "$ZONE" --command \
+          "git clone -b $BRANCH_NAME https://github.com/ZcashFoundation/zebra.git;
+          cd zebra/;
+          docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test .;
+          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-1046400,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_past_canopy_mainnet --manifest-path zebrad/Cargo.toml sync_past_canopy_mainnet;
+          docker run -i --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-testnet-1028500,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_past_canopy_testnet --manifest-path zebrad/Cargo.toml sync_past_canopy_testnet;
+          "
+      # Clean up
+      - name: Delete test instance
+        # Always run even if the earlier step fails
+        if: ${{ always() }}
+        run: |
+          gcloud compute instances delete "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --delete-disks boot --zone "$ZONE"


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->

Every time we make a change to our state format, we need to regenerate cached database disks that are used by tests that assume state synced up to Canopy activation height and no further. Previously this has been a bit of an ad-hoc, mostly manual process.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->

Create a manually-triggered GitHub Actions Workflow that will:
- spin up a Google Cloud VM with fresh disks
- build zebra in a docker image with the appropriate feature flags for running these tests
- run the `test_sync_to_canopy_mainnet`, writing mainnet state to one disk
- run the `test_sync_to_canopy_testnet`, writing testnet state to another disk
- clean up the instance without deleting the disks with the mainnet and testnet states

After one runs this workflow, those disks are then available for image snapshotting, and then those images can be used to update the `test.yml` workflow that is run after every merge to #main. This is still a manual task. 

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

Not urgent, anyone @ZcashFoundation/zebra-team can review.

## Related Issues

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->

Currently mainnet is synced followed in serial by testnet. Mainnet has been more reliable in syncing to tip within a reasonable amount of time. Testnet has not, and occasionally just never finishes. Would be nice to run these in parallel, especially since the workflow max is 6 hours.