### PR TITLE
Update docs for coinbase maturity for Canopy

### DIFF
--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -2,15 +2,27 @@
 
 /// The maturity threshold for transparent coinbase outputs.
 ///
-/// A transaction MUST NOT spend a transparent output of a coinbase transaction
+/// This threshold uses the relevant chain for the block being verified by the
+/// non-finalized state.
+///
+/// For the best chain, coinbase spends are only allowed from blocks at or below
+/// the finalized tip. For other chains, coinbase spends can use outputs from
+/// early non-finalized blocks, or finalized blocks. But if that chain becomes
+/// the best chain, all non-finalized blocks past the [`MAX_BLOCK_REORG_HEIGHT`]
+/// will be finalized. This includes all mature coinbase outputs.
+///
+/// "A transaction MUST NOT spend a transparent output of a coinbase transaction
 /// from a block less than 100 blocks prior to the spend. Note that transparent
-/// outputs of coinbase transactions include Founders' Reward outputs.
+/// outputs of coinbase transactions include Founders' Reward outputs and
+/// transparent Funding Stream outputs."
+/// [7.1](https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus)
 pub const MIN_TRANSPARENT_COINBASE_MATURITY: u32 = 100;
 
 /// The maximum chain reorganisation height.
 ///
-/// Allowing reorganisations past this height could allow double-spends of
-/// coinbase transactions.
+/// This threshold determines the maximum length of the best non-finalized chain.
+///
+/// Larger reorganisations would allow double-spends of coinbase transactions.
 pub const MAX_BLOCK_REORG_HEIGHT: u32 = MIN_TRANSPARENT_COINBASE_MATURITY - 1;
 
 /// The database format version, incremented each time the database format changes.


### PR DESCRIPTION
## Motivation

Zebra's coinbase maturity documentation is outdated: it doesn't include spec changes for shielded coinbase or funding streams.

### Specifications

> A transaction MUST NOT spend a transparent output of a coinbase transaction from a block less than 100 blocks prior to the spend. Note that transparent outputs of coinbase transactions include Founders’ Reward outputs and transparent funding stream outputs.

https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus

### Designs

> State data from blocks above the reorg limit (non-finalized state) is stored in-memory and handles multiple chains. State data from blocks below the reorg limit (finalized state) is stored persistently using rocksdb and only tracks a single chain. This allows a simplification of our state handling, because only finalized data is persistent and the logic for finalized data handles less invariants.

https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0005-state-updates.md#state-components

## Solution

- Copy the updated spec into a rustdoc comment
- Update the rest of the comment based on the design

## Review

This is a low-priority change that anyone can review.

### Reviewer Checklist

  - [x] Docs match Specs and Designs

## Follow Up Work

We actually have to implement these checks, see #1970 