### PR TITLE
Prevent burst of reconnection attempts

### DIFF
--- a/zebra-network/src/meta_addr/arbitrary.rs
+++ b/zebra-network/src/meta_addr/arbitrary.rs
@@ -16,6 +16,12 @@ impl MetaAddr {
             })
             .boxed()
     }
+
+    pub fn alternate_node_strategy() -> BoxedStrategy<Self> {
+        canonical_socket_addr()
+            .prop_map(|address| MetaAddr::new_alternate(&address, &PeerServices::NODE_NETWORK))
+            .boxed()
+    }
 }
 
 impl Arbitrary for MetaAddr {

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -1,7 +1,7 @@
 use std::{cmp::min, mem, sync::Arc, time::Duration};
 
 use futures::stream::{FuturesUnordered, StreamExt};
-use tokio::time::{sleep, sleep_until, timeout, Sleep};
+use tokio::time::{sleep, sleep_until, timeout, Instant, Sleep};
 use tower::{Service, ServiceExt};
 
 use zebra_chain::serialization::DateTime32;
@@ -282,7 +282,7 @@ where
     /// new peer connections are initiated at least
     /// `MIN_PEER_CONNECTION_INTERVAL` apart.
     pub async fn next(&mut self) -> Option<MetaAddr> {
-        let current_deadline = self.next_peer_min_wait.deadline();
+        let current_deadline = self.next_peer_min_wait.deadline().max(Instant::now());
         let mut sleep = sleep_until(current_deadline + Self::MIN_PEER_CONNECTION_INTERVAL);
         mem::swap(&mut self.next_peer_min_wait, &mut sleep);
 

--- a/zebra-network/src/peer_set/candidate_set/tests/prop.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/prop.rs
@@ -1,9 +1,19 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
 use proptest::{collection::vec, prelude::*};
+use tokio::{
+    runtime::Runtime,
+    time::{sleep, timeout},
+};
+use tracing::Span;
 
 use zebra_chain::serialization::DateTime32;
 
-use super::super::validate_addrs;
-use crate::types::MetaAddr;
+use super::super::{validate_addrs, CandidateSet};
+use crate::{types::MetaAddr, AddressBook, BoxError, Config, Request, Response};
 
 proptest! {
     /// Test that validated gossiped peers never have a `last_seen` time that's in the future.
@@ -19,5 +29,64 @@ proptest! {
         for peer in validated_peers {
             prop_assert![peer.get_last_seen() <= last_seen_limit];
         }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(16))]
+
+    /// Test that new outbound peer connections are rate-limited.
+    #[test]
+    fn new_outbound_peer_connections_are_rate_limited(
+        peers in vec(MetaAddr::alternate_node_strategy(), 10),
+        initial_candidates in 0..4usize,
+        extra_candidates in 0..4usize,
+    ) {
+        zebra_test::init();
+
+        let runtime = Runtime::new().expect("Failed to create Tokio runtime");
+        let _guard = runtime.enter();
+
+        let peer_service = tower::service_fn(|_| async {
+            unreachable!("Mock peer service is never used");
+        });
+
+        let mut address_book = AddressBook::new(&Config::default(), Span::none());
+        address_book.extend(peers);
+
+        let mut candidate_set = CandidateSet::new(Arc::new(Mutex::new(address_book)), peer_service);
+
+        let checks = async move {
+            // Check rate limiting for initial peers
+            check_candidates_rate_limiting(&mut candidate_set, initial_candidates).await;
+            // Sleep more than the rate limiting delay
+            sleep(Duration::from_millis(400)).await;
+            // Check that the next peers are still respecting the rate limiting, without causing a
+            // burst of reconnections
+            check_candidates_rate_limiting(&mut candidate_set, extra_candidates).await;
+        };
+
+        assert!(runtime.block_on(timeout(Duration::from_secs(10), checks)).is_ok());
+    }
+}
+
+/// Check if obtaining a certain number of reconnection peers is rate limited.
+///
+/// # Panics
+///
+/// Will panic if a reconnection peer is returned too quickly, or if no reconnection peer is
+/// returned.
+async fn check_candidates_rate_limiting<S>(candidate_set: &mut CandidateSet<S>, candidates: usize)
+where
+    S: tower::Service<Request, Response = Response, Error = BoxError>,
+    S::Future: Send + 'static,
+{
+    let mut minimum_reconnect_instant = Instant::now();
+
+    for _ in 0..candidates {
+        assert!(candidate_set.next().await.is_some());
+        assert!(Instant::now() > minimum_reconnect_instant);
+
+        minimum_reconnect_instant += CandidateSet::<S>::MIN_PEER_CONNECTION_INTERVAL;
     }
 }

--- a/zebra-network/src/peer_set/candidate_set/tests/prop.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/prop.rs
@@ -85,7 +85,7 @@ where
 
     for _ in 0..candidates {
         assert!(candidate_set.next().await.is_some());
-        assert!(Instant::now() > minimum_reconnect_instant);
+        assert!(Instant::now() >= minimum_reconnect_instant);
 
         minimum_reconnect_instant += CandidateSet::<S>::MIN_PEER_CONNECTION_INTERVAL;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request.
Please provide a description above and fill in the information below.

Contributors guide: https://zebra.zfnd.org/CONTRIBUTING.html
-->

## Motivation

<!--
Explain the context and why you're making that change.
What is the problem you're trying to solve?
If there's no specific problem, what is the motivation for your change?
-->
In some certain cases, there could be a burst of reconnection attempts. This happened because the rate limiting code could fall-back in time and permit a burst of reconnections until it caught back to the current time. The issue is further described in #2216.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
If this PR implements parts of a design RFC or ticket, list those parts here.
-->
Implement the solution described in #2216:

- [x] Set the `current_deadline` to the maximum of the current time and the `next_peer_min_wait.deadline()`:
https://github.com/ZcashFoundation/zebra/blob/5cdcc5255f8c66fe0fc0f2a41b6e7b37e8530b1f/zebra-network/src/peer_set/candidate_set.rs#L281-L282

This makes sure that the next sleep is at least 100 milliseconds from the current time. (It can be be up to 200 milliseconds, if there's just been a connection, and we're about to sleep for 100 milliseconds.)

- [x] Write proptests with random attempts and waits
  - 10 random addresses in an arbitrary `AddressBook`
  - `0..4` initial candidates, an async sleep from `0..400` milliseconds, and then `0..4` extra candidates
  - the first candidate should yield immediately, but we can't really test for that due to VM delays
  - each subsequent candidate should yield at least 100 milliseconds after the last candidate
  - the whole test should complete within 10 seconds (use a timeout and select)

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests

## Review

<!--
How urgent is this code review?
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 outlined the solution.

## Related Issues

<!--
Please link to any existing GitHub issues pertaining to this PR.
-->
Closes #2216

## Follow Up Work

<!--
Is there anything missing from the solution?
What still needs to be done?
-->
