### PR TITLE
Make acceptance test `zebrad` output matching more robust

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-03-24
+          toolchain: nightly
           override: true
           profile: minimal
           components: llvm-tools-preview

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "once_cell",
  "regex",
  "secrecy",
- "semver",
+ "semver 0.9.0",
  "serde",
  "signal-hook",
  "termcolor",
@@ -2954,7 +2954,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -3063,6 +3063,12 @@ dependencies = [
  "semver-parser",
  "serde",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "semver-parser"
@@ -4622,6 +4628,8 @@ dependencies = [
  "once_cell",
  "pin-project 0.4.27",
  "rand 0.8.1",
+ "regex",
+ "semver 1.0.3",
  "sentry",
  "sentry-tracing",
  "serde",

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -133,7 +133,7 @@ lazy_static! {
     /// OS-specific error when the port attempting to be opened is already in use.
     pub static ref PORT_IN_USE_ERROR: Regex = if cfg!(unix) {
         #[allow(clippy::trivial_regex)]
-        Regex::new("already in use")
+        Regex::new(&regex::escape("already in use"))
     } else {
         Regex::new("(access a socket in a way forbidden by its access permissions)|(Only one usage of each socket address)")
     }.expect("regex is valid");

--- a/zebra-test/tests/command.rs
+++ b/zebra-test/tests/command.rs
@@ -63,9 +63,11 @@ fn kill_on_timeout_output_continuous_lines() -> Result<()> {
         .spawn_child_with_command(TEST_CMD, &["-v", "/dev/zero"])?
         .with_timeout(Duration::from_secs(2));
 
-    // We need to use expect_stdout, because wait_with_output ignores timeouts.
+    // We need to use expect_stdout_line_matches, because wait_with_output ignores timeouts.
     // We use a non-matching regex, to trigger the timeout.
-    assert!(child.expect_stdout("this regex should not match").is_err());
+    assert!(child
+        .expect_stdout_line_matches("this regex should not match")
+        .is_err());
 
     Ok(())
 }
@@ -88,9 +90,11 @@ fn finish_before_timeout_output_single_line() -> Result<()> {
         .spawn_child_with_command(TEST_CMD, &["zebra_test_output"])?
         .with_timeout(Duration::from_secs(2));
 
-    // We need to use expect_stdout, because wait_with_output ignores timeouts.
+    // We need to use expect_stdout_line_matches, because wait_with_output ignores timeouts.
     // We use a non-matching regex, to trigger the timeout.
-    assert!(child.expect_stdout("this regex should not match").is_err());
+    assert!(child
+        .expect_stdout_line_matches("this regex should not match")
+        .is_err());
 
     Ok(())
 }
@@ -115,9 +119,11 @@ fn kill_on_timeout_continuous_output_no_newlines() -> Result<()> {
         .spawn_child_with_command(TEST_CMD, &["/dev/zero"])?
         .with_timeout(Duration::from_secs(2));
 
-    // We need to use expect_stdout, because wait_with_output ignores timeouts.
+    // We need to use expect_stdout_line_matches, because wait_with_output ignores timeouts.
     // We use a non-matching regex, to trigger the timeout.
-    assert!(child.expect_stdout("this regex should not match").is_err());
+    assert!(child
+        .expect_stdout_line_matches("this regex should not match")
+        .is_err());
 
     Ok(())
 }
@@ -141,9 +147,11 @@ fn finish_before_timeout_short_output_no_newlines() -> Result<()> {
         .spawn_child_with_command(TEST_CMD, &["zebra_test_output"])?
         .with_timeout(Duration::from_secs(2));
 
-    // We need to use expect_stdout, because wait_with_output ignores timeouts.
+    // We need to use expect_stdout_line_matches, because wait_with_output ignores timeouts.
     // We use a non-matching regex, to trigger the timeout.
-    assert!(child.expect_stdout("this regex should not match").is_err());
+    assert!(child
+        .expect_stdout_line_matches("this regex should not match")
+        .is_err());
 
     Ok(())
 }
@@ -167,9 +175,11 @@ fn kill_on_timeout_no_output() -> Result<()> {
         .spawn_child_with_command(TEST_CMD, &["120"])?
         .with_timeout(Duration::from_secs(2));
 
-    // We need to use expect_stdout, because wait_with_output ignores timeouts.
+    // We need to use expect_stdout_line_matches, because wait_with_output ignores timeouts.
     // We use a non-matching regex, to trigger the timeout.
-    assert!(child.expect_stdout("this regex should not match").is_err());
+    assert!(child
+        .expect_stdout_line_matches("this regex should not match")
+        .is_err());
 
     Ok(())
 }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -53,6 +53,8 @@ vergen = { version = "5.1.8", default-features = false, features = ["cargo", "gi
 [dev-dependencies]
 abscissa_core = { version = "0.5", features = ["testing"] }
 once_cell = "1.7"
+regex = "1.4.6"
+semver = "1.0.3"
 tempdir = "0.3.7"
 zebra-test = { path = "../zebra-test" }
 


### PR DESCRIPTION
## Motivation

`zebrad`'s acceptance tests match launched process output. Sometimes matches are too specific. Other matches aren't actually testing what we want to test.

### Specifications

`zebrad`'s acceptance tests use Semantic Versioning: https://semver.org/

We use the `semver` crate to parse these versions: https://docs.rs/semver/1.0.3/semver/struct.Version.html#method.parse

## Solution

Rewrite acceptance test output matching:
- Add a custom semver match for `zebrad` versions
  - adds a dev dependency on the `semver` crate, it's already a transitive dependency
- Prefer "line contains string" matches, so tests ignore minor changes
- Escape regex meta-characters when a literal string match is intended
- Rewrite match internals to remove duplicate code and enable custom matches
- Rename output match functions so they are more precise
- Document output match functions

This PR will need a manual rebase after #2250 merges.

## Review

This is a low-priority improvement that anyone can review. Some of these changes will eventually be required for the tests to pass.

### Reviewer Checklist

  - [x] Code implements specs
  - [x] Test changes are improvements
