### PR TITLE
Update test job to use the updated state

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,8 @@ jobs:
           --container-image rust:buster \
           --container-mount-disk mount-path='/mainnet',name="zebrad-cache-$SHORT_SHA-mainnet-1046400" \
           --container-restart-policy never \
-          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-1046400",image=zebrad-cache-8690a39-mainnet-1046400 \
-          --machine-type n2-standard-4 \
+          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-1046400",image=zebrad-cache-9416b5d-mainnet-1046400 \
+          --machine-type n2-standard-8 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
           --tags zebrad \


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

When we updated our state with new Orchard data, we needed to update our cached state disks for our stateful tests.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

After re-running `sync_to_canopy_mainnet` I created an image from that disk, and now update the Test workflow to use that image when running `sync_past_canopy_mainnet`.

Also bump cores from 4 to 8, to see if that makes the jobs a little faster.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

Anyone can review

## Follow Up Work

<!--
Is there anything missing from the solution?
-->

Do the same for testnet, it just takes ages.
Related: https://github.com/ZcashFoundation/zebra/pull/2247