### PR TITLE
Rate limit `GetAddr` messages to any peer, Credit: Equilibrium

### DIFF
--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -38,6 +38,7 @@ zebra-chain = { path = "../zebra-chain" }
 [dev-dependencies]
 proptest = "0.10"
 proptest-derive = "0.3"
+tokio = { version = "0.3.6", features = ["test-util"] }
 toml = "0.5"
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -57,6 +57,14 @@ pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 /// are initiated at least `MIN_PEER_CONNECTION_INTERVAL` apart.
 pub const MIN_PEER_CONNECTION_INTERVAL: Duration = Duration::from_millis(100);
 
+/// The minimum time between successive calls to [`CandidateSet::update()`][Self::update].
+///
+/// ## Security
+///
+/// Zebra resists distributed denial of service attacks by making sure that requests for more
+/// peer addresses are sent to the same peer at least `MIN_PEER_GET_ADDR_INTERVAL` apart.
+pub const MIN_PEER_GET_ADDR_INTERVAL: Duration = Duration::from_secs(10);
+
 /// The number of GetAddr requests sent when crawling for new peers.
 ///
 /// ## SECURITY

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -62,7 +62,7 @@ pub const MIN_PEER_CONNECTION_INTERVAL: Duration = Duration::from_millis(100);
 /// ## Security
 ///
 /// Zebra resists distributed denial of service attacks by making sure that requests for more
-/// peer addresses are sent to the same peer at least `MIN_PEER_GET_ADDR_INTERVAL` apart.
+/// peer addresses are sent at least `MIN_PEER_GET_ADDR_INTERVAL` apart.
 pub const MIN_PEER_GET_ADDR_INTERVAL: Duration = Duration::from_secs(10);
 
 /// The number of GetAddr requests sent when crawling for new peers.

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -49,6 +49,14 @@ pub const LIVE_PEER_DURATION: Duration = Duration::from_secs(60 + 20 + 20 + 20);
 /// connected peer.
 pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 
+/// The minimum time between successive calls to [`CandidateSet::next()`][Self::next].
+///
+/// ## Security
+///
+/// Zebra resists distributed denial of service attacks by making sure that new peer connections
+/// are initiated at least `MIN_PEER_CONNECTION_INTERVAL` apart.
+pub const MIN_PEER_CONNECTION_INTERVAL: Duration = Duration::from_millis(100);
+
 /// The number of GetAddr requests sent when crawling for new peers.
 ///
 /// ## SECURITY

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -181,7 +181,7 @@ where
     async fn update_timeout(&mut self, fanout_limit: Option<usize>) -> Result<(), BoxError> {
         // SECURITY
         //
-        // Rate limit sending `GetAddr` messages to random peers.
+        // Rate limit sending `GetAddr` messages to peers.
         if self.min_next_crawl <= Instant::now() {
             // CORRECTNESS
             //

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -108,7 +108,7 @@ mod tests;
 pub(super) struct CandidateSet<S> {
     pub(super) address_book: Arc<std::sync::Mutex<AddressBook>>,
     pub(super) peer_service: S,
-    next_peer_min_wait: Sleep,
+    wait_next_handshake: Sleep,
 }
 
 impl<S> CandidateSet<S>
@@ -132,7 +132,7 @@ where
         CandidateSet {
             address_book,
             peer_service,
-            next_peer_min_wait: sleep(Duration::from_secs(0)),
+            wait_next_handshake: sleep(Duration::from_secs(0)),
         }
     }
 
@@ -282,9 +282,9 @@ where
     /// new peer connections are initiated at least
     /// `MIN_PEER_CONNECTION_INTERVAL` apart.
     pub async fn next(&mut self) -> Option<MetaAddr> {
-        let current_deadline = self.next_peer_min_wait.deadline().max(Instant::now());
+        let current_deadline = self.wait_next_handshake.deadline().max(Instant::now());
         let mut sleep = sleep_until(current_deadline + Self::MIN_PEER_CONNECTION_INTERVAL);
-        mem::swap(&mut self.next_peer_min_wait, &mut sleep);
+        mem::swap(&mut self.wait_next_handshake, &mut sleep);
 
         // # Correctness
         //

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -116,7 +116,7 @@ where
     S: Service<Request, Response = Response, Error = BoxError>,
     S::Future: Send + 'static,
 {
-    /// The minimum time between successive calls to `CandidateSet::next()`.
+    /// The minimum time between successive calls to [`CandidateSet::next()`][Self::next].
     ///
     /// ## Security
     ///

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -272,7 +272,7 @@ where
     ///
     /// Zebra resists distributed denial of service attacks by making sure that
     /// new peer connections are initiated at least
-    /// `MIN_PEER_CONNECTION_INTERVAL` apart.
+    /// [`MIN_PEER_CONNECTION_INTERVAL`][constants::MIN_PEER_CONNECTION_INTERVAL] apart.
     pub async fn next(&mut self) -> Option<MetaAddr> {
         let current_deadline = self.wait_next_handshake.deadline().max(Instant::now());
         let mut sleep = sleep_until(current_deadline + constants::MIN_PEER_CONNECTION_INTERVAL);

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -109,6 +109,7 @@ pub(super) struct CandidateSet<S> {
     pub(super) address_book: Arc<std::sync::Mutex<AddressBook>>,
     pub(super) peer_service: S,
     wait_next_handshake: Sleep,
+    min_next_crawl: Instant,
 }
 
 impl<S> CandidateSet<S>
@@ -125,14 +126,27 @@ where
             address_book,
             peer_service,
             wait_next_handshake: sleep(Duration::from_secs(0)),
+            min_next_crawl: Instant::now(),
         }
     }
 
     /// Update the peer set from the network, using the default fanout limit.
     ///
     /// See [`update_initial`][Self::update_initial] for details.
+    ///
+    /// ## Security
+    ///
+    /// This call is rate-limited to prevent sending a burst of repeated requests for new peer
+    /// addresses to the same peers. Each call will only update the [`CandidateSet`] if more time
+    /// than [`MIN_PEER_GET_ADDR_INTERVAL`][constants::MIN_PEER_GET_ADDR_INTERVAL] has passed since
+    /// the last call.
     pub async fn update(&mut self) -> Result<(), BoxError> {
-        self.update_timeout(None).await
+        if self.min_next_crawl <= Instant::now() {
+            self.update_timeout(None).await?;
+            self.min_next_crawl = Instant::now() + constants::MIN_PEER_GET_ADDR_INTERVAL;
+        }
+
+        Ok(())
     }
 
     /// Update the peer set from the network, limiting the fanout to

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -164,7 +164,7 @@ where
     /// This call is rate-limited to prevent sending a burst of repeated requests for new peer
     /// addresses. Each call will only update the [`CandidateSet`] if more time
     /// than [`MIN_PEER_GET_ADDR_INTERVAL`][constants::MIN_PEER_GET_ADDR_INTERVAL] has passed since
-    /// the last call.
+    /// the last call. Otherwise, the update is skipped.
     ///
     /// [`Responded`]: crate::PeerAddrState::Responded
     /// [`NeverAttemptedGossiped`]: crate::PeerAddrState::NeverAttemptedGossiped

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -116,14 +116,6 @@ where
     S: Service<Request, Response = Response, Error = BoxError>,
     S::Future: Send + 'static,
 {
-    /// The minimum time between successive calls to [`CandidateSet::next()`][Self::next].
-    ///
-    /// ## Security
-    ///
-    /// Zebra resists distributed denial of service attacks by making sure that new peer connections
-    /// are initiated at least `MIN_PEER_CONNECTION_INTERVAL` apart.
-    const MIN_PEER_CONNECTION_INTERVAL: Duration = Duration::from_millis(100);
-
     /// Uses `address_book` and `peer_service` to manage a [`CandidateSet`] of peers.
     pub fn new(
         address_book: Arc<std::sync::Mutex<AddressBook>>,
@@ -283,7 +275,7 @@ where
     /// `MIN_PEER_CONNECTION_INTERVAL` apart.
     pub async fn next(&mut self) -> Option<MetaAddr> {
         let current_deadline = self.wait_next_handshake.deadline().max(Instant::now());
-        let mut sleep = sleep_until(current_deadline + Self::MIN_PEER_CONNECTION_INTERVAL);
+        let mut sleep = sleep_until(current_deadline + constants::MIN_PEER_CONNECTION_INTERVAL);
         mem::swap(&mut self.wait_next_handshake, &mut sleep);
 
         // # Correctness

--- a/zebra-network/src/peer_set/candidate_set/tests/prop.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/prop.rs
@@ -13,7 +13,10 @@ use tracing::Span;
 use zebra_chain::serialization::DateTime32;
 
 use super::super::{validate_addrs, CandidateSet};
-use crate::{types::MetaAddr, AddressBook, BoxError, Config, Request, Response};
+use crate::{
+    constants::MIN_PEER_CONNECTION_INTERVAL, types::MetaAddr, AddressBook, BoxError, Config,
+    Request, Response,
+};
 
 proptest! {
     /// Test that validated gossiped peers never have a `last_seen` time that's in the future.
@@ -87,6 +90,6 @@ where
         assert!(candidate_set.next().await.is_some());
         assert!(Instant::now() >= minimum_reconnect_instant);
 
-        minimum_reconnect_instant += CandidateSet::<S>::MIN_PEER_CONNECTION_INTERVAL;
+        minimum_reconnect_instant += MIN_PEER_CONNECTION_INTERVAL;
     }
 }

--- a/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
@@ -115,6 +115,8 @@ fn rejects_all_addresses_if_applying_offset_causes_an_underflow() {
     assert!(validated_peers.next().is_none());
 }
 
+// Utility functions
+
 /// Create a mock list of gossiped [`MetaAddr`]s with the specified `last_seen_times`.
 ///
 /// The IP address and port of the generated ports should not matter for the test.

--- a/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
@@ -206,7 +206,7 @@ fn candidate_set_update_after_update_initial_is_rate_limited() {
 
         assert_eq!(call_count.load(Ordering::SeqCst), GET_ADDR_FANOUT);
 
-        // After waiting for the minimum interval the call to `update` should succeed
+        // After waiting for at least the minimum interval the call to `update` should succeed
         time::advance(MIN_PEER_GET_ADDR_INTERVAL).await;
         candidate_set
             .update()

--- a/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
@@ -1,14 +1,28 @@
 use std::{
+    collections::VecDeque,
     convert::TryInto,
+    iter,
     net::{IpAddr, SocketAddr},
+    sync::{Arc, Mutex},
+    time::Duration as StdDuration,
 };
 
 use chrono::{DateTime, Duration, Utc};
+use futures::future;
+use tokio::{
+    runtime::Runtime,
+    time::{self, Instant},
+};
+use tracing::Span;
 
 use zebra_chain::serialization::DateTime32;
 
-use super::super::validate_addrs;
-use crate::types::{MetaAddr, PeerServices};
+use super::super::{validate_addrs, CandidateSet};
+use crate::{
+    constants::{GET_ADDR_FANOUT, MIN_PEER_GET_ADDR_INTERVAL},
+    types::{MetaAddr, PeerServices},
+    AddressBook, Config, Request, Response,
+};
 
 /// Test that offset is applied when all addresses have `last_seen` times in the future.
 #[test]
@@ -113,6 +127,62 @@ fn rejects_all_addresses_if_applying_offset_causes_an_underflow() {
     let mut validated_peers = validate_addrs(input_peers, last_seen_limit);
 
     assert!(validated_peers.next().is_none());
+}
+
+/// Test that calls to [`CandidateSet::update`] are rate limited.
+#[test]
+fn candidate_set_updates_are_rate_limited() {
+    // Run the test for enough time for `update` to actually run three times
+    const INTERVALS_TO_RUN: u32 = 3;
+    // How faster should `update` be called than the expected interval
+    const POLL_FREQUENCY_FACTOR: u32 = 3;
+
+    let runtime = Runtime::new().expect("Failed to create Tokio runtime");
+    let _guard = runtime.enter();
+
+    let mut peer_request_tracker: VecDeque<_> =
+        iter::repeat(Instant::now()).take(GET_ADDR_FANOUT).collect();
+
+    let rate_limit_interval = MIN_PEER_GET_ADDR_INTERVAL;
+
+    let peer_service = tower::service_fn(move |request| {
+        match request {
+            Request::Peers => {
+                // Get time from queue that the request is authorized to be sent
+                let authorized_request_time = peer_request_tracker
+                    .pop_front()
+                    .expect("peer_request_tracker should always have GET_ADDR_FANOUT elements");
+                // Check that the request was rate limited
+                assert!(Instant::now() >= authorized_request_time);
+                // Push a new authorization, updated by the rate limit interval
+                peer_request_tracker.push_back(Instant::now() + rate_limit_interval);
+
+                // Return an empty list of peer addresses
+                future::ok(Response::Peers(vec![]))
+            }
+            _ => unreachable!("Received an unexpected internal message: {:?}", request),
+        }
+    });
+
+    let address_book = AddressBook::new(&Config::default(), Span::none());
+    let mut candidate_set = CandidateSet::new(Arc::new(Mutex::new(address_book)), peer_service);
+
+    runtime.block_on(async move {
+        time::pause();
+
+        let time_limit = Instant::now()
+            + INTERVALS_TO_RUN * MIN_PEER_GET_ADDR_INTERVAL
+            + StdDuration::from_secs(1);
+
+        while Instant::now() <= time_limit {
+            candidate_set
+                .update()
+                .await
+                .expect("Call to CandidateSet::update should not fail");
+
+            time::advance(MIN_PEER_GET_ADDR_INTERVAL / POLL_FREQUENCY_FACTOR).await;
+        }
+    });
 }
 
 // Utility functions

--- a/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
@@ -138,7 +138,7 @@ fn rejects_all_addresses_if_applying_offset_causes_an_underflow() {
 fn candidate_set_updates_are_rate_limited() {
     // Run the test for enough time for `update` to actually run three times
     const INTERVALS_TO_RUN: u32 = 3;
-    // How faster should `update` be called than the expected interval
+    // How many times should `update` be called in each rate limit interval
     const POLL_FREQUENCY_FACTOR: u32 = 3;
 
     let runtime = Runtime::new().expect("Failed to create Tokio runtime");


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
If a Zebra node connects to a few peers that answer requests for more peer addresses with an empty list, it ends up sending a burst of repeated requests for more peers.

Closes #2212 

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->
This fixes the network behavior, but I'm not sure if there's a reference about the rate limiting to link to.

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->
No design changes, just a small bug fix.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Add a `next_update_time` field to `CandidateSet`, which tracks when the next `update` call is authorized to execute. It is initialized with `Instant::now()` so that the next call succeeds.

Every call to `CandidateSet::update` will then check that field. If it is set to an instant before the call instant, then the method proceeds normally and in the end updates the `next_update_time` to be `MIN_PEER_GET_ADDR_INTERVAL` in the future.

The PR also includes a test that creates a `CandidateSet` with a mocked `PeerService` and calls the `update` method repeatedly. The mocked `PeerService` then verifies that the instant it receives the `Request::Peers` message is properly rate limited.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 opened the respective issue (#2212)

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [x] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
Should Ziggurat test this fix?
