### PR TITLE
Clippy: remove needless borrows

### DIFF
--- a/zebra-chain/src/block/tests/vectors.rs
+++ b/zebra-chain/src/block/tests/vectors.rs
@@ -233,7 +233,7 @@ fn block_commitment(network: Network) {
 
         if let FinalSaplingRoot(final_sapling_root) = commitment {
             let expected_final_sapling_root = *sapling_roots
-                .get(&height)
+                .get(height)
                 .expect("unexpected missing final sapling root test vector");
             assert_eq!(
                 final_sapling_root,

--- a/zebra-chain/src/orchard/keys.rs
+++ b/zebra-chain/src/orchard/keys.rs
@@ -110,7 +110,7 @@ fn prf_ock(ovk: [u8; 32], cv: [u8; 32], cm_x: [u8; 32], ephemeral_key: [u8; 32])
 ///
 /// <https://zips.z.cash/protocol/nu5.pdf#concretediversifyhash>
 fn diversify_hash(d: &[u8]) -> pallas::Point {
-    let p = pallas_group_hash(b"z.cash:Orchard-gd", &d);
+    let p = pallas_group_hash(b"z.cash:Orchard-gd", d);
 
     if <bool>::from(p.is_identity()) {
         pallas_group_hash(b"z.cash:Orchard-gd", b"")

--- a/zebra-chain/src/orchard/sinsemilla.rs
+++ b/zebra-chain/src/orchard/sinsemilla.rs
@@ -89,7 +89,7 @@ pub fn sinsemilla_hash_to_point(D: &[u8], M: &BitVec<Lsb0, u8>) -> pallas::Point
         // Pad each chunk with zeros.
         let mut store = [0u8; 2];
         let bits = store.bits_mut::<Lsb0>();
-        bits[..chunk.len()].copy_from_slice(&chunk);
+        bits[..chunk.len()].copy_from_slice(chunk);
 
         acc = acc + acc + S(&bits[..k]);
     }

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -198,7 +198,7 @@ impl NetworkUpgrade {
     ///
     /// Returns None if this network upgrade has no consensus branch id.
     pub fn branch_id(&self) -> Option<ConsensusBranchId> {
-        NetworkUpgrade::branch_id_list().get(&self).cloned()
+        NetworkUpgrade::branch_id_list().get(self).cloned()
     }
 
     /// Returns the target block spacing for the network upgrade.

--- a/zebra-chain/src/sapling/commitment/pedersen_hashes.rs
+++ b/zebra-chain/src/sapling/commitment/pedersen_hashes.rs
@@ -82,7 +82,7 @@ pub fn pedersen_hash_to_point(domain: [u8; 8], M: &BitVec<Lsb0, u8>) -> jubjub::
         .enumerate()
         .map(|(i, segment)| (i + 1, segment))
     {
-        result += I_i(domain, i as u32) * M_i(&segment);
+        result += I_i(domain, i as u32) * M_i(segment);
     }
 
     result
@@ -124,5 +124,5 @@ pub fn mixing_pedersen_hash(P: jubjub::ExtendedPoint, x: jubjub::Fr) -> jubjub::
 pub fn windowed_pedersen_commitment(r: jubjub::Fr, s: &BitVec<Lsb0, u8>) -> jubjub::ExtendedPoint {
     const D: [u8; 8] = *b"Zcash_PH";
 
-    pedersen_hash_to_point(D, &s) + find_group_hash(D, b"r") * r
+    pedersen_hash_to_point(D, s) + find_group_hash(D, b"r") * r
 }

--- a/zebra-chain/src/serialization/zcash_serialize.rs
+++ b/zebra-chain/src/serialization/zcash_serialize.rs
@@ -112,7 +112,7 @@ pub fn zcash_serialize_bytes_external_count<W: io::Write>(
     vec: &Vec<u8>,
     mut writer: W,
 ) -> Result<(), io::Error> {
-    writer.write_all(&vec)
+    writer.write_all(vec)
 }
 
 /// Write a Bitcoin-encoded UTF-8 `&str`.

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -90,7 +90,7 @@ pub fn difficulty_is_valid(
 
 /// Returns `Ok(())` if the `EquihashSolution` is valid for `header`
 pub fn equihash_solution_is_valid(header: &Header) -> Result<(), equihash::Error> {
-    header.solution.check(&header)
+    header.solution.check(header)
 }
 
 /// Returns `Ok(())` if the block subsidy and miner fees in `block` are valid for `network`

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -464,7 +464,7 @@ where
             .map(|tx| tx.hash())
             .collect::<Vec<_>>();
 
-        crate::block::check::merkle_root_validity(self.network, &block, &transaction_hashes)?;
+        crate::block::check::merkle_root_validity(self.network, block, &transaction_hashes)?;
 
         Ok(height)
     }

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -43,7 +43,7 @@ fn v5_fake_transactions() -> Result<(), Report> {
                             check::spend_cv_rk_not_small_order(&spend)?
                         }
                         for output in s.outputs() {
-                            check::output_cv_epk_not_small_order(&output)?;
+                            check::output_cv_epk_not_small_order(output)?;
                         }
                     }
                 }

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -1018,7 +1018,7 @@ where
 
             if let Some(book_addr) = connected_addr.get_address_book_addr() {
                 let _ = timestamp_collector
-                    .send(MetaAddr::new_errored(&book_addr, &remote_services))
+                    .send(MetaAddr::new_errored(&book_addr, remote_services))
                     .await;
             }
             Err(err)

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -339,7 +339,7 @@ impl FinalizedState {
     /// Returns the height of the given block if it exists.
     pub fn height(&self, hash: block::Hash) -> Option<block::Height> {
         let height_by_hash = self.db.cf_handle("height_by_hash").unwrap();
-        self.db.zs_get(&height_by_hash, &hash)
+        self.db.zs_get(height_by_hash, &hash)
     }
 
     /// Returns the given block if it exists.

--- a/zebra-state/src/service/non_finalized_state/queued_blocks.rs
+++ b/zebra-state/src/service/non_finalized_state/queued_blocks.rs
@@ -135,7 +135,7 @@ impl QueuedBlocks {
 
     /// Return the queued block if it has already been registered
     pub fn get_mut(&mut self, hash: &block::Hash) -> Option<&mut QueuedBlock> {
-        self.blocks.get_mut(&hash)
+        self.blocks.get_mut(hash)
     }
 
     /// Update metrics after the queue is modified


### PR DESCRIPTION
## Motivation

Sometimes we borrow variables, then Rust's auto-deref immediately dereferences them.

This is a clippy nightly lint.

## Solution

- remove needless borrows

## Review

Anyone can review this low-priority fixup.

### Reviewer Checklist

  - [x] Code does the same thing as previous code

