### PR TITLE
Add notes about note commitment trees storage

### DIFF
--- a/book/src/dev/rfcs/drafts/0005-treestate.md
+++ b/book/src/dev/rfcs/drafts/0005-treestate.md
@@ -191,7 +191,7 @@ IMPORTANT: we need to save the incremental merkle tree / serialized nodes for:
 - When finalizing a block, the finalized tip is updated with a serialization of the Sapling Note Commitment Tree. (The previous tree should be deleted as part of the same database transaction.)
 - When non-finalized state is being updated, each non-finalized chain gets its own copy of the Sapling Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Sapling note commitments are discovered when processing blocks.
 
-All Sprout blocks:
+### Sprout
 - Every finalized block needs its own copy of the Sprout note commitment tree accurate to that block (😿)
 - When non-finalized state is being updated, each non-finalized chain gets its own copy of the Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Sprout note commitments are discovered when processing blocks.
 

--- a/book/src/dev/rfcs/drafts/0005-treestate.md
+++ b/book/src/dev/rfcs/drafts/0005-treestate.md
@@ -179,11 +179,16 @@ time).
 
 IMPORTANT: we need to save the incremental merkle tree / serialized nodes for:
 
+Orchard tip: 
+- When finalizing state, for Orchard, the tip of the chain (latest finalized block) saves a serialization of the Orchard Note Commitment Tree
+- When non-finalized state is being updated, each non-finalized chain gets its own copy of the Orchard Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Orchard note commitments are discovered when processing blocks.
+
 Sapling tip: 
-- When finalizing state, for Sapling, the tip saves a serialization of the Sapling Note Commitment Tree
-- 
+- When finalizing state, for Sapling, the tip of the chain (latest finalized block) saves a serialization of the Sapling Note Commitment Tree
+- When non-finalized state is being updated, each non-finalized chain gets its own copy of the Sapling Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Sapling note commitments are discovered when processing blocks.
+
 All Sprout blocks:
-- Every finalized block needs its own copy of the Sprout note commitment tree (😿)
+- Every finalized block needs its own copy of the Sprout note commitment tree accurate to that block (😿)
 - When non-finalized state is being updated, each non-finalized chain gets its own copy of the Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Sprout note commitments are discovered when processing blocks.
 
 We can't just compute a fresh tree with just the note commitments within a block, we are adding them to the tree referenced by the anchor, but we cannot update that tree with just the anchor, we need the 'frontier' nodes and leaves of the incremental merkle tree.

--- a/book/src/dev/rfcs/drafts/0005-treestate.md
+++ b/book/src/dev/rfcs/drafts/0005-treestate.md
@@ -179,7 +179,9 @@ time).
 
 IMPORTANT: we need to save the incremental merkle tree / serialized nodes for:
 
-Orchard tip: 
+## State Management
+
+### Orchard
 - There is a single copy of the latest Orchard Note Commitment Tree for the finalized tip.
 - When finalizing a block, the finalized tip is updated with a serialization of the latest Orchard Note Commitment Tree. (The previous tree should be deleted as part of the same database transaction.)
 - When non-finalized state is being updated, each non-finalized chain gets its own copy of the Orchard Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Orchard note commitments are discovered when processing blocks.

--- a/book/src/dev/rfcs/drafts/0005-treestate.md
+++ b/book/src/dev/rfcs/drafts/0005-treestate.md
@@ -186,7 +186,7 @@ IMPORTANT: we need to save the incremental merkle tree / serialized nodes for:
 - When finalizing a block, the finalized tip is updated with a serialization of the latest Orchard Note Commitment Tree. (The previous tree should be deleted as part of the same database transaction.)
 - When non-finalized state is being updated, each non-finalized chain gets its own copy of the Orchard Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Orchard note commitments are discovered when processing blocks.
 
-Sapling tip: 
+### Sapling
 - There is a single copy of the latest Sapling Note Commitment Tree for the finalized tip.
 - When finalizing a block, the finalized tip is updated with a serialization of the Sapling Note Commitment Tree. (The previous tree should be deleted as part of the same database transaction.)
 - When non-finalized state is being updated, each non-finalized chain gets its own copy of the Sapling Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Sapling note commitments are discovered when processing blocks.

--- a/book/src/dev/rfcs/drafts/0005-treestate.md
+++ b/book/src/dev/rfcs/drafts/0005-treestate.md
@@ -179,9 +179,13 @@ time).
 
 IMPORTANT: we need to save the incremental merkle tree / serialized nodes for:
 
-Sapling tip block
-~all Sprout blocks
-chains we're tracking in memory within the reorg limit, for both
+Sapling tip: 
+- When finalizing state, for Sapling, the tip saves a serialization of the Sapling Note Commitment Tree
+- 
+All Sprout blocks:
+- Every finalized block needs its own copy of the Sprout note commitment tree (😿)
+- When non-finalized state is being updated, each non-finalized chain gets its own copy of the Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Sprout note commitments are discovered when processing blocks.
+
 We can't just compute a fresh tree with just the note commitments within a block, we are adding them to the tree referenced by the anchor, but we cannot update that tree with just the anchor, we need the 'frontier' nodes and leaves of the incremental merkle tree.
 
 # Reference-level explanation

--- a/book/src/dev/rfcs/drafts/0005-treestate.md
+++ b/book/src/dev/rfcs/drafts/0005-treestate.md
@@ -189,7 +189,9 @@ time).
 ### Sapling
 - There is a single copy of the latest Sapling Note Commitment Tree for the finalized tip.
 - When finalizing a block, the finalized tip is updated with a serialization of the Sapling Note Commitment Tree. (The previous tree should be deleted as part of the same database transaction.)
-- When non-finalized state is being updated, each non-finalized chain gets its own copy of the Sapling Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Sapling note commitments are discovered when processing blocks.
+- Each non-finalized chain gets its own copy of the Sapling note commitment tree, cloned from the note commitment tree of the finalized tip or fork root.
+- When a block is added to a non-finalized chain tip, the Sapling note commitment tree is updated with the note commitments from that block.
+- When a block is rolled back from a non-finalized chain tip... (TODO)
 
 ### Sprout
 - Every finalized block needs its own copy of the Sprout note commitment tree accurate to that block (😿)

--- a/book/src/dev/rfcs/drafts/0005-treestate.md
+++ b/book/src/dev/rfcs/drafts/0005-treestate.md
@@ -194,7 +194,8 @@ time).
 - When a block is rolled back from a non-finalized chain tip... (TODO)
 
 ### Sprout
-- Every finalized block needs its own copy of the Sprout note commitment tree accurate to that block (😿)
+- Every finalized block stores a separate copy of the Sprout note commitment tree (😿), as of that block.
+- When finalizing a block, the Sprout note commitment tree for that block is stored in the state. (The trees for previous blocks also remain in the state.)
 - Every block in each non-finalized chain gets its own copy of the Sprout note commitment tree. The initial tree is cloned from the note commitment tree of the finalized tip or fork root.
 - When a block is added to a non-finalized chain tip, the Sprout note commitment tree is cloned, then updated with the note commitments from that block.
 - When a block is rolled back from a non-finalized chain tip, the trees for each block are deleted, along with that block.

--- a/book/src/dev/rfcs/drafts/0005-treestate.md
+++ b/book/src/dev/rfcs/drafts/0005-treestate.md
@@ -195,7 +195,9 @@ time).
 
 ### Sprout
 - Every finalized block needs its own copy of the Sprout note commitment tree accurate to that block (😿)
-- When non-finalized state is being updated, each non-finalized chain gets its own copy of the Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Sprout note commitments are discovered when processing blocks.
+- Every block in each non-finalized chain gets its own copy of the Sprout note commitment tree. The initial tree is cloned from the note commitment tree of the finalized tip or fork root.
+- When a block is added to a non-finalized chain tip, the Sprout note commitment tree is cloned, then updated with the note commitments from that block.
+- When a block is rolled back from a non-finalized chain tip, the trees for each block are deleted, along with that block.
 
 We can't just compute a fresh tree with just the note commitments within a block, we are adding them to the tree referenced by the anchor, but we cannot update that tree with just the anchor, we need the 'frontier' nodes and leaves of the incremental merkle tree.
 

--- a/book/src/dev/rfcs/drafts/0005-treestate.md
+++ b/book/src/dev/rfcs/drafts/0005-treestate.md
@@ -177,8 +177,6 @@ state. The Sprout and Sapling nullifiers revealed in the block will be merged
 with the exising ones in our finalized state (ie, it should strictly grow over
 time).
 
-IMPORTANT: we need to save the incremental merkle tree / serialized nodes for:
-
 ## State Management
 
 ### Orchard

--- a/book/src/dev/rfcs/drafts/0005-treestate.md
+++ b/book/src/dev/rfcs/drafts/0005-treestate.md
@@ -180,7 +180,8 @@ time).
 IMPORTANT: we need to save the incremental merkle tree / serialized nodes for:
 
 Orchard tip: 
-- When finalizing state, for Orchard, the tip of the chain (latest finalized block) saves a serialization of the Orchard Note Commitment Tree
+- There is a single copy of the latest Orchard Note Commitment Tree for the finalized tip.
+- When finalizing a block, the finalized tip is updated with a serialization of the latest Orchard Note Commitment Tree. (The previous tree should be deleted as part of the same database transaction.)
 - When non-finalized state is being updated, each non-finalized chain gets its own copy of the Orchard Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Orchard note commitments are discovered when processing blocks.
 
 Sapling tip: 

--- a/book/src/dev/rfcs/drafts/0005-treestate.md
+++ b/book/src/dev/rfcs/drafts/0005-treestate.md
@@ -182,7 +182,9 @@ time).
 ### Orchard
 - There is a single copy of the latest Orchard Note Commitment Tree for the finalized tip.
 - When finalizing a block, the finalized tip is updated with a serialization of the latest Orchard Note Commitment Tree. (The previous tree should be deleted as part of the same database transaction.)
-- When non-finalized state is being updated, each non-finalized chain gets its own copy of the Orchard Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Orchard note commitments are discovered when processing blocks.
+- Each non-finalized chain gets its own copy of the Orchard note commitment tree, cloned from the note commitment tree of the finalized tip or fork root.
+- When a block is added to a non-finalized chain tip, the Orchard note commitment tree is updated with the note commitments from that block.
+- When a block is rolled back from a non-finalized chain tip... (TODO)
 
 ### Sapling
 - There is a single copy of the latest Sapling Note Commitment Tree for the finalized tip.

--- a/book/src/dev/rfcs/drafts/0005-treestate.md
+++ b/book/src/dev/rfcs/drafts/0005-treestate.md
@@ -185,7 +185,8 @@ Orchard tip:
 - When non-finalized state is being updated, each non-finalized chain gets its own copy of the Orchard Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Orchard note commitments are discovered when processing blocks.
 
 Sapling tip: 
-- When finalizing state, for Sapling, the tip of the chain (latest finalized block) saves a serialization of the Sapling Note Commitment Tree
+- There is a single copy of the latest Sapling Note Commitment Tree for the finalized tip.
+- When finalizing a block, the finalized tip is updated with a serialization of the Sapling Note Commitment Tree. (The previous tree should be deleted as part of the same database transaction.)
 - When non-finalized state is being updated, each non-finalized chain gets its own copy of the Sapling Note Commitment Tree, cloned from the finalized block note commitment tree of its parent block, and then subsequently updated/extended as new Sapling note commitments are discovered when processing blocks.
 
 All Sprout blocks:


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

Need to write down prelim design of how the Sapling (and Orchard) and Sprout note commitment trees are being handled in non-finalized state and finalized state.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->
"A transaction that contains one or more JoinSplit descriptions or Spend descriptions or Action descriptions, when entered into the block chain, appends to the note commitment tree with all constituent note commitments."

https://zips.z.cash/protocol/protocol.pdf#merkletree

## Solution

[Rendered (Full RFC)](https://github.com/ZcashFoundation/zebra/blob/treestate-rfc-updates/book/src/dev/rfcs/drafts/0005-treestate.md)

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

@teor2345 @jvff @conradoplg @oxarbitrage 

### Reviewer Checklist

  - [ ] Does this cohere with how we model data in our state service?

## Follow Up Work

Finish implementing as part of https://github.com/ZcashFoundation/zebra/issues/1287
