### PR TITLE
Remove outdated pinned nightly in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-03-24
+          toolchain: nightly
           override: true
           profile: minimal
           components: llvm-tools-preview


### PR DESCRIPTION
## Motivation

To avoid some nightly bugs, we pinned a March 2021 version of nightly Rust in Zebra's coverage CI. But those bugs have since been fixed.

And our pinned `nightly-2021-03-24` is incompatible with `semver` 1.0.2, which we want to use in #2252.

## Solution

- use the latest nightly in Zebra's coverage job

## Review

@dconnolly might want to review this one.

It's not particularly urgent, but I'd like to merge #2252 soon to avoid conflicts.

### Reviewer Checklist

  - [x] Coverage output is similar to the previous output

## Follow Up Work

#2252 should automatically rebase to main once this PR merges. Then we can move #2252 out of draft and merge it.