### PR TITLE
Security: Use canonical SocketAddrs to avoid duplicate peer connections, Feature: Send local listener to peers

### DIFF
--- a/zebra-chain/src/serialization.rs
+++ b/zebra-chain/src/serialization.rs
@@ -24,7 +24,7 @@ pub mod arbitrary;
 pub use constraint::AtLeastOne;
 pub use date_time::DateTime32;
 pub use error::SerializationError;
-pub use read_zcash::ReadZcashExt;
+pub use read_zcash::{canonical_socket_addr, ReadZcashExt};
 pub use write_zcash::WriteZcashExt;
 pub use zcash_deserialize::{
     zcash_deserialize_bytes_external_count, zcash_deserialize_external_count, TrustedPreallocate,

--- a/zebra-chain/src/serialization/arbitrary.rs
+++ b/zebra-chain/src/serialization/arbitrary.rs
@@ -1,6 +1,6 @@
 //! Arbitrary data generation for serialization proptests
 
-use super::{read_zcash::canonical_ip_addr, DateTime32};
+use super::{read_zcash::canonical_socket_addr, DateTime32};
 use chrono::{TimeZone, Utc, MAX_DATETIME, MIN_DATETIME};
 use proptest::{arbitrary::any, prelude::*};
 use std::net::SocketAddr;
@@ -59,10 +59,6 @@ pub fn datetime_u32() -> impl Strategy<Value = chrono::DateTime<Utc>> {
 /// Returns a random canonical Zebra `SocketAddr`.
 ///
 /// See [`canonical_ip_addr`] for details.
-pub fn canonical_socket_addr() -> impl Strategy<Value = SocketAddr> {
-    use SocketAddr::*;
-    any::<SocketAddr>().prop_map(|addr| match addr {
-        V4(_) => addr,
-        V6(v6_addr) => SocketAddr::new(canonical_ip_addr(v6_addr.ip()), v6_addr.port()),
-    })
+pub fn canonical_socket_addr_strategy() -> impl Strategy<Value = SocketAddr> {
+    any::<SocketAddr>().prop_map(canonical_socket_addr)
 }

--- a/zebra-chain/src/serialization/date_time.rs
+++ b/zebra-chain/src/serialization/date_time.rs
@@ -44,14 +44,18 @@ impl DateTime32 {
         self.into()
     }
 
-    /// Returns the current time
+    /// Returns the current time.
+    ///
+    /// # Panics
+    ///
+    /// If the number of seconds since the UNIX epoch is greater than `u32::MAX`.
     pub fn now() -> DateTime32 {
         Utc::now()
             .try_into()
             .expect("unexpected out of range chrono::DateTime")
     }
 
-    /// Returns the number of seconds elapsed between `earlier` and this time,
+    /// Returns the duration elapsed between `earlier` and this time,
     /// or `None` if `earlier` is later than this time.
     pub fn checked_duration_since(&self, earlier: DateTime32) -> Option<Duration32> {
         self.timestamp
@@ -59,7 +63,7 @@ impl DateTime32 {
             .map(|seconds| Duration32 { seconds })
     }
 
-    /// Returns the number of seconds elapsed between `earlier` and this time,
+    /// Returns duration elapsed between `earlier` and this time,
     /// or zero if `earlier` is later than this time.
     pub fn saturating_duration_since(&self, earlier: DateTime32) -> Duration32 {
         Duration32 {
@@ -67,19 +71,19 @@ impl DateTime32 {
         }
     }
 
-    /// Returns the number of seconds elapsed since this time,
+    /// Returns the duration elapsed since this time,
     /// or if this time is in the future, returns `None`.
     pub fn checked_elapsed(&self) -> Option<Duration32> {
         DateTime32::now().checked_duration_since(*self)
     }
 
-    /// Returns the number of seconds elapsed since this time,
+    /// Returns the duration elapsed since this time,
     /// or if this time is in the future, returns zero.
     pub fn saturating_elapsed(&self) -> Duration32 {
         DateTime32::now().saturating_duration_since(*self)
     }
 
-    /// Returns the time that is `duration` seconds after this time.
+    /// Returns the time that is `duration` after this time.
     /// If the calculation overflows, returns `None`.
     pub fn checked_add(&self, duration: Duration32) -> Option<DateTime32> {
         self.timestamp
@@ -87,7 +91,7 @@ impl DateTime32 {
             .map(DateTime32::from)
     }
 
-    /// Returns the time that is `duration` seconds after this time.
+    /// Returns the time that is `duration` after this time.
     /// If the calculation overflows, returns `DateTime32::MAX`.
     pub fn saturating_add(&self, duration: Duration32) -> DateTime32 {
         DateTime32 {
@@ -95,7 +99,7 @@ impl DateTime32 {
         }
     }
 
-    /// Returns the time that is `duration` seconds before this time.
+    /// Returns the time that is `duration` before this time.
     /// If the calculation underflows, returns `None`.
     pub fn checked_sub(&self, duration: Duration32) -> Option<DateTime32> {
         self.timestamp
@@ -103,7 +107,7 @@ impl DateTime32 {
             .map(|timestamp| DateTime32 { timestamp })
     }
 
-    /// Returns the time that is `duration` seconds before this time.
+    /// Returns the time that is `duration` before this time.
     /// If the calculation underflows, returns `DateTime32::MIN`.
     pub fn saturating_sub(&self, duration: Duration32) -> DateTime32 {
         DateTime32 {
@@ -119,7 +123,7 @@ impl Duration32 {
     /// The latest possible `Duration32` value.
     pub const MAX: Duration32 = Duration32 { seconds: u32::MAX };
 
-    /// Returns the number of seconds.
+    /// Returns the number of seconds in this duration.
     pub fn seconds(&self) -> u32 {
         self.seconds
     }
@@ -253,7 +257,7 @@ impl TryFrom<chrono::DateTime<Utc>> for DateTime32 {
 
     /// Convert from a [`chrono::DateTime`] to a [`DateTime32`], discarding any nanoseconds.
     ///
-    /// Conversion fails if the number of seconds is outside the `u32` range.
+    /// Conversion fails if the number of seconds since the UNIX epoch is outside the `u32` range.
     fn try_from(value: chrono::DateTime<Utc>) -> Result<Self, Self::Error> {
         Ok(Self {
             timestamp: value.timestamp().try_into()?,
@@ -266,7 +270,7 @@ impl TryFrom<&chrono::DateTime<Utc>> for DateTime32 {
 
     /// Convert from a [`chrono::DateTime`] to a [`DateTime32`], discarding any nanoseconds.
     ///
-    /// Conversion fails if the number of seconds is outside the `u32` range.
+    /// Conversion fails if the number of seconds since the UNIX epoch is outside the `u32` range.
     fn try_from(value: &chrono::DateTime<Utc>) -> Result<Self, Self::Error> {
         (*value).try_into()
     }
@@ -277,7 +281,7 @@ impl TryFrom<chrono::Duration> for Duration32 {
 
     /// Convert from a [`chrono::Duration`] to a [`Duration32`], discarding any nanoseconds.
     ///
-    /// Conversion fails if the number of seconds is outside the `u32` range.
+    /// Conversion fails if the number of seconds since the UNIX epoch is outside the `u32` range.
     fn try_from(value: chrono::Duration) -> Result<Self, Self::Error> {
         Ok(Self {
             seconds: value.num_seconds().try_into()?,
@@ -290,7 +294,7 @@ impl TryFrom<&chrono::Duration> for Duration32 {
 
     /// Convert from a [`chrono::Duration`] to a [`Duration32`], discarding any nanoseconds.
     ///
-    /// Conversion fails if the number of seconds is outside the `u32` range.
+    /// Conversion fails if the number of seconds in the duration is outside the `u32` range.
     fn try_from(value: &chrono::Duration) -> Result<Self, Self::Error> {
         (*value).try_into()
     }
@@ -301,7 +305,7 @@ impl TryFrom<std::time::Duration> for Duration32 {
 
     /// Convert from a [`std::time::Duration`] to a [`Duration32`], discarding any nanoseconds.
     ///
-    /// Conversion fails if the number of seconds is outside the `u32` range.
+    /// Conversion fails if the number of seconds in the duration is outside the `u32` range.
     fn try_from(value: std::time::Duration) -> Result<Self, Self::Error> {
         Ok(Self {
             seconds: value.as_secs().try_into()?,
@@ -314,7 +318,7 @@ impl TryFrom<&std::time::Duration> for Duration32 {
 
     /// Convert from a [`std::time::Duration`] to a [`Duration32`], discarding any nanoseconds.
     ///
-    /// Conversion fails if the number of seconds is outside the `u32` range.
+    /// Conversion fails if the number of seconds in the duration is outside the `u32` range.
     fn try_from(value: &std::time::Duration) -> Result<Self, Self::Error> {
         (*value).try_into()
     }

--- a/zebra-chain/src/serialization/date_time.rs
+++ b/zebra-chain/src/serialization/date_time.rs
@@ -134,7 +134,7 @@ impl Duration32 {
         self.into()
     }
 
-    /// Returns the time that is `duration` seconds after this time.
+    /// Returns a duration that is `duration` longer than this duration.
     /// If the calculation overflows, returns `None`.
     pub fn checked_add(&self, duration: Duration32) -> Option<Duration32> {
         self.seconds
@@ -142,7 +142,7 @@ impl Duration32 {
             .map(|seconds| Duration32 { seconds })
     }
 
-    /// Returns the time that is `duration` seconds after this time.
+    /// Returns a duration that is `duration` longer than this duration.
     /// If the calculation overflows, returns `Duration32::MAX`.
     pub fn saturating_add(&self, duration: Duration32) -> Duration32 {
         Duration32 {
@@ -150,7 +150,7 @@ impl Duration32 {
         }
     }
 
-    /// Returns the time that is `duration` seconds before this time.
+    /// Returns a duration that is `duration` shorter than this duration.
     /// If the calculation underflows, returns `None`.
     pub fn checked_sub(&self, duration: Duration32) -> Option<Duration32> {
         self.seconds
@@ -158,7 +158,7 @@ impl Duration32 {
             .map(|seconds| Duration32 { seconds })
     }
 
-    /// Returns the time that is `duration` seconds before this time.
+    /// Returns a duration that is `duration` shorter than this duration.
     /// If the calculation underflows, returns `Duration32::MIN`.
     pub fn saturating_sub(&self, duration: Duration32) -> Duration32 {
         Duration32 {

--- a/zebra-chain/src/serialization/date_time.rs
+++ b/zebra-chain/src/serialization/date_time.rs
@@ -78,6 +78,38 @@ impl DateTime32 {
     pub fn saturating_elapsed(&self) -> Duration32 {
         DateTime32::now().saturating_duration_since(*self)
     }
+
+    /// Returns the time that is `duration` seconds after this time.
+    /// If the calculation overflows, returns `None`.
+    pub fn checked_add(&self, duration: Duration32) -> Option<DateTime32> {
+        self.timestamp
+            .checked_add(duration.seconds)
+            .map(|timestamp| DateTime32 { timestamp })
+    }
+
+    /// Returns the time that is `duration` seconds after this time.
+    /// If the calculation overflows, returns `DateTime32::MAX`.
+    pub fn saturating_add(&self, duration: Duration32) -> DateTime32 {
+        DateTime32 {
+            timestamp: self.timestamp.saturating_add(duration.seconds),
+        }
+    }
+
+    /// Returns the time that is `duration` seconds before this time.
+    /// If the calculation underflows, returns `None`.
+    pub fn checked_sub(&self, duration: Duration32) -> Option<DateTime32> {
+        self.timestamp
+            .checked_sub(duration.seconds)
+            .map(|timestamp| DateTime32 { timestamp })
+    }
+
+    /// Returns the time that is `duration` seconds before this time.
+    /// If the calculation underflows, returns `DateTime32::MIN`.
+    pub fn saturating_sub(&self, duration: Duration32) -> DateTime32 {
+        DateTime32 {
+            timestamp: self.timestamp.saturating_sub(duration.seconds),
+        }
+    }
 }
 
 impl Duration32 {
@@ -100,6 +132,38 @@ impl Duration32 {
     /// Returns the equivalent [`std::time::Duration`].
     pub fn to_std(self) -> std::time::Duration {
         self.into()
+    }
+
+    /// Returns the time that is `duration` seconds after this time.
+    /// If the calculation overflows, returns `None`.
+    pub fn checked_add(&self, duration: Duration32) -> Option<Duration32> {
+        self.seconds
+            .checked_add(duration.seconds)
+            .map(|seconds| Duration32 { seconds })
+    }
+
+    /// Returns the time that is `duration` seconds after this time.
+    /// If the calculation overflows, returns `Duration32::MAX`.
+    pub fn saturating_add(&self, duration: Duration32) -> Duration32 {
+        Duration32 {
+            seconds: self.seconds.saturating_add(duration.seconds),
+        }
+    }
+
+    /// Returns the time that is `duration` seconds before this time.
+    /// If the calculation underflows, returns `None`.
+    pub fn checked_sub(&self, duration: Duration32) -> Option<Duration32> {
+        self.seconds
+            .checked_sub(duration.seconds)
+            .map(|seconds| Duration32 { seconds })
+    }
+
+    /// Returns the time that is `duration` seconds before this time.
+    /// If the calculation underflows, returns `Duration32::MIN`.
+    pub fn saturating_sub(&self, duration: Duration32) -> Duration32 {
+        Duration32 {
+            seconds: self.seconds.saturating_sub(duration.seconds),
+        }
     }
 }
 

--- a/zebra-chain/src/serialization/date_time.rs
+++ b/zebra-chain/src/serialization/date_time.rs
@@ -84,7 +84,7 @@ impl DateTime32 {
     pub fn checked_add(&self, duration: Duration32) -> Option<DateTime32> {
         self.timestamp
             .checked_add(duration.seconds)
-            .map(|timestamp| DateTime32 { timestamp })
+            .map(DateTime32::from)
     }
 
     /// Returns the time that is `duration` seconds after this time.

--- a/zebra-chain/src/serialization/date_time.rs
+++ b/zebra-chain/src/serialization/date_time.rs
@@ -60,15 +60,13 @@ impl DateTime32 {
     pub fn checked_duration_since(&self, earlier: DateTime32) -> Option<Duration32> {
         self.timestamp
             .checked_sub(earlier.timestamp)
-            .map(|seconds| Duration32 { seconds })
+            .map(Duration32::from)
     }
 
     /// Returns duration elapsed between `earlier` and this time,
     /// or zero if `earlier` is later than this time.
     pub fn saturating_duration_since(&self, earlier: DateTime32) -> Duration32 {
-        Duration32 {
-            seconds: self.timestamp.saturating_sub(earlier.timestamp),
-        }
+        Duration32::from(self.timestamp.saturating_sub(earlier.timestamp))
     }
 
     /// Returns the duration elapsed since this time,
@@ -94,9 +92,7 @@ impl DateTime32 {
     /// Returns the time that is `duration` after this time.
     /// If the calculation overflows, returns `DateTime32::MAX`.
     pub fn saturating_add(&self, duration: Duration32) -> DateTime32 {
-        DateTime32 {
-            timestamp: self.timestamp.saturating_add(duration.seconds),
-        }
+        DateTime32::from(self.timestamp.saturating_add(duration.seconds))
     }
 
     /// Returns the time that is `duration` before this time.
@@ -104,15 +100,13 @@ impl DateTime32 {
     pub fn checked_sub(&self, duration: Duration32) -> Option<DateTime32> {
         self.timestamp
             .checked_sub(duration.seconds)
-            .map(|timestamp| DateTime32 { timestamp })
+            .map(DateTime32::from)
     }
 
     /// Returns the time that is `duration` before this time.
     /// If the calculation underflows, returns `DateTime32::MIN`.
     pub fn saturating_sub(&self, duration: Duration32) -> DateTime32 {
-        DateTime32 {
-            timestamp: self.timestamp.saturating_sub(duration.seconds),
-        }
+        DateTime32::from(self.timestamp.saturating_sub(duration.seconds))
     }
 }
 
@@ -143,15 +137,13 @@ impl Duration32 {
     pub fn checked_add(&self, duration: Duration32) -> Option<Duration32> {
         self.seconds
             .checked_add(duration.seconds)
-            .map(|seconds| Duration32 { seconds })
+            .map(Duration32::from)
     }
 
     /// Returns a duration that is `duration` longer than this duration.
     /// If the calculation overflows, returns `Duration32::MAX`.
     pub fn saturating_add(&self, duration: Duration32) -> Duration32 {
-        Duration32 {
-            seconds: self.seconds.saturating_add(duration.seconds),
-        }
+        Duration32::from(self.seconds.saturating_add(duration.seconds))
     }
 
     /// Returns a duration that is `duration` shorter than this duration.
@@ -159,15 +151,13 @@ impl Duration32 {
     pub fn checked_sub(&self, duration: Duration32) -> Option<Duration32> {
         self.seconds
             .checked_sub(duration.seconds)
-            .map(|seconds| Duration32 { seconds })
+            .map(Duration32::from)
     }
 
     /// Returns a duration that is `duration` shorter than this duration.
     /// If the calculation underflows, returns `Duration32::MIN`.
     pub fn saturating_sub(&self, duration: Duration32) -> Duration32 {
-        Duration32 {
-            seconds: self.seconds.saturating_sub(duration.seconds),
-        }
+        Duration32::from(self.seconds.saturating_sub(duration.seconds))
     }
 }
 

--- a/zebra-chain/src/serialization/read_zcash.rs
+++ b/zebra-chain/src/serialization/read_zcash.rs
@@ -162,3 +162,20 @@ pub fn canonical_ip_addr(v6_addr: &Ipv6Addr) -> IpAddr {
         Some(_) | None => V6(*v6_addr),
     }
 }
+
+/// Transform a `SocketAddr` into a canonical Zebra `SocketAddr`, converting
+/// IPv6-mapped IPv4 addresses, and removing IPv6 scope IDs and flow information.
+///
+/// See [`canonical_ip_addr`] for detailed info on IPv6-mapped IPv4 addresses.
+pub fn canonical_socket_addr(socket_addr: impl Into<SocketAddr>) -> SocketAddr {
+    use SocketAddr::*;
+
+    let mut socket_addr = socket_addr.into();
+    if let V6(v6_socket_addr) = socket_addr {
+        let canonical_ip = canonical_ip_addr(v6_socket_addr.ip());
+        // creating a new SocketAddr removes scope IDs and flow information
+        socket_addr = SocketAddr::new(canonical_ip, socket_addr.port());
+    }
+
+    socket_addr
+}

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -148,8 +148,8 @@ impl AddressBook {
 
         // Then sanitize and shuffle
         let mut peers = peers
-            .into_values()
-            .filter_map(|a| MetaAddr::sanitize(&a))
+            .values()
+            .filter_map(MetaAddr::sanitize)
             .collect::<Vec<_>>();
         peers.shuffle(&mut rand::thread_rng());
         peers

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -136,7 +136,7 @@ impl AddressBook {
     ///
     /// This address contains minimal state, but it is not sanitized.
     pub fn get_local_listener(&self) -> MetaAddr {
-        MetaAddr::new_local_listener(&self.local_listener)
+        MetaAddr::new_local_listener_change(&self.local_listener)
             .into_new_meta_addr()
             .expect("unexpected invalid new local listener addr")
     }

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -482,8 +482,7 @@ impl MetaAddr {
     ///
     /// Returns `None` if this `MetaAddr` should not be sent to remote peers.
     pub fn sanitize(&self) -> Option<MetaAddr> {
-        // Make sure this address is valid for outbound connections
-        if !self.is_valid_for_outbound() {
+        if !self.last_known_info_is_valid_for_outbound() {
             return None;
         }
 

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -318,7 +318,7 @@ impl MetaAddr {
     }
 
     /// Returns a [`MetaAddrChange::NewLocal`] for our own listener address.
-    pub fn new_local_listener(addr: &SocketAddr) -> MetaAddrChange {
+    pub fn new_local_listener_change(addr: &SocketAddr) -> MetaAddrChange {
         NewLocal {
             addr: canonical_socket_addr(*addr),
         }

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -574,7 +574,8 @@ impl MetaAddrChange {
                 ..
             } => Some(*untrusted_last_seen),
             NewAlternate { .. } => None,
-            NewLocal { .. } => None,
+            // We know that our local listener is available
+            NewLocal { .. } => Some(DateTime32::now()),
             UpdateAttempt { .. } => None,
             UpdateResponded { .. } => None,
             UpdateFailed { .. } => None,

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -482,11 +482,18 @@ impl MetaAddr {
     ///
     /// Returns `None` if this `MetaAddr` should not be sent to remote peers.
     pub fn sanitize(&self) -> Option<MetaAddr> {
+        // Make sure this address is valid for outbound connections
+        if !self.is_valid_for_outbound() {
+            return None;
+        }
+
+        // Sanitize time
         let interval = crate::constants::TIMESTAMP_TRUNCATION_SECONDS;
         let ts = self.last_seen()?.timestamp();
         // This can't underflow, because `0 <= rem_euclid < ts`
         let last_seen = ts - ts.rem_euclid(interval);
         let last_seen = DateTime32::from(last_seen);
+
         Some(MetaAddr {
             addr: self.addr,
             // deserialization also sanitizes services to known flags

--- a/zebra-network/src/meta_addr/arbitrary.rs
+++ b/zebra-network/src/meta_addr/arbitrary.rs
@@ -4,7 +4,7 @@ use proptest::{arbitrary::any, collection::vec, prelude::*};
 
 use super::{MetaAddr, MetaAddrChange, PeerServices};
 
-use zebra_chain::serialization::{arbitrary::canonical_socket_addr, DateTime32};
+use zebra_chain::serialization::{arbitrary::canonical_socket_addr_strategy, DateTime32};
 
 /// The largest number of random changes we want to apply to a MetaAddr
 ///
@@ -17,7 +17,7 @@ impl MetaAddr {
     /// [`PeerAddrState::NeverAttemptedGossiped`] state.
     pub fn gossiped_strategy() -> BoxedStrategy<Self> {
         (
-            canonical_socket_addr(),
+            canonical_socket_addr_strategy(),
             any::<PeerServices>(),
             any::<DateTime32>(),
         )
@@ -30,7 +30,7 @@ impl MetaAddr {
     /// Create a strategy that generates [`MetaAddr`]s in the
     /// [`PeerAddrState::NeverAttemptedAlternate`] state.
     pub fn alternate_strategy() -> BoxedStrategy<Self> {
-        (canonical_socket_addr(), any::<PeerServices>())
+        (canonical_socket_addr_strategy(), any::<PeerServices>())
             .prop_map(|(socket_addr, untrusted_services)| {
                 MetaAddr::new_alternate(&socket_addr, &untrusted_services)
                     .into_new_meta_addr()
@@ -78,7 +78,7 @@ impl MetaAddrChange {
     /// TODO: Generate all [`MetaAddrChange`] variants, and give them ready fields.
     ///       (After PR #2276 merges.)
     pub fn ready_outbound_strategy() -> BoxedStrategy<Self> {
-        canonical_socket_addr()
+        canonical_socket_addr_strategy()
             .prop_filter_map("failed MetaAddr::is_valid_for_outbound", |addr| {
                 // Alternate nodes use the current time, so they're always ready
                 //

--- a/zebra-network/src/meta_addr/arbitrary.rs
+++ b/zebra-network/src/meta_addr/arbitrary.rs
@@ -6,11 +6,17 @@ use super::{MetaAddr, MetaAddrChange, PeerServices};
 
 use zebra_chain::serialization::{arbitrary::canonical_socket_addr_strategy, DateTime32};
 
-/// The largest number of random changes we want to apply to a MetaAddr
+/// The largest number of random changes we want to apply to a [`MetaAddr`].
 ///
-/// This should be at least twice the number of [`PeerAddrState`]s, so
-/// the tests can cover multiple transitions through every state.
+/// This should be at least twice the number of [`PeerAddrState`]s, so the tests
+/// can cover multiple transitions through every state.
 pub const MAX_ADDR_CHANGE: usize = 15;
+
+/// The largest number of random addresses we want to add to an [`AddressBook`].
+///
+/// This should be at least the number of [`PeerAddrState`]s, so the tests can
+/// cover interactions between addresses in different states.
+pub const MAX_META_ADDR: usize = 8;
 
 impl MetaAddr {
     /// Create a strategy that generates [`MetaAddr`]s in the

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -201,12 +201,16 @@ where
     S::Future: Send + 'static,
 {
     info!(?initial_peers, "connecting to initial peer set");
-    // ## Correctness:
+    // # Security
     //
-    // Each `CallAll` can hold one `Buffer` or `Batch` reservation for
-    // an indefinite period. We can use `CallAllUnordered` without filling
-    // the underlying `Inbound` buffer, because we immediately drive this
-    // single `CallAll` to completion, and handshakes have a short timeout.
+    // TODO: rate-limit initial seed peer connections (#2326)
+    //
+    // # Correctness
+    //
+    // Each `FuturesUnordered` can hold one `Buffer` or `Batch` reservation for
+    // an indefinite period. We can use `FuturesUnordered` without filling
+    // the underlying network buffers, because we immediately drive this
+    // single `FuturesUnordered` to completion, and handshakes have a short timeout.
     let mut handshakes: FuturesUnordered<_> = initial_peers
         .into_iter()
         .map(|addr| {

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -240,11 +240,7 @@ impl Service<zn::Request> for Inbound {
                     // Briefly hold the address book threaded mutex while
                     // cloning the address book. Then sanitize after releasing
                     // the lock.
-                    let mut peers = address_book.lock().unwrap().clone();
-
-                    // Add our local listener address to the advertised peers
-                    let local_listener = address_book.lock().unwrap().get_local_listener();
-                    peers.update(local_listener);
+                    let peers = address_book.lock().unwrap().clone();
 
                     // Send a sanitized response
                     let mut peers = peers.sanitized();


### PR DESCRIPTION
## Motivation

1. Zebra's seed peers and local listener address can be non-canonical, leading to duplicate peer connections.

2. In PR #2273, Zebra stopped gossiping its local listener address to peers, because it didn't have a last seen time.

3. In PR #2273, Zebra applied its local listener to any existing entry for that address, which could skip the listener, or leak internal state.

4. Since the listener was added to the cloned `AddressBook`, it was briefly included in the address book metrics.

These changes help test PRs #2273 and #2275.

### Specifications

addr.time:
> Nodes advertising their own IP address set this to the current time. 

https://developer.bitcoin.org/reference/p2p_networking.html#addr

## Solution

1. Make Zebra always use canonical seed, listener, `MetaAddr`, and `MetaAddrChange` `SocketAddr`s
2. Give the local listener address a last seen time
3. Replace any existing address book entry for the local listener
4. Get the peer list from the address book, rather than cloning it

As a side-effect, this change also makes sanitization slightly faster, because it avoids some useless peer filtering and sorting.

### Testing

Adds proptests for the following properties:
- regardless of any existing entry for a local listener `MetaAddr`, a sanitized address book contains a copy of the local listener with the current time
  - but listeners that are not valid for outbound connections should be skipped
- Zebra doesn't share invalid listeners (IP addresses or client services) with its peers

## Review

@jvff can review this change.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up

Make MetaAddr.addr a private field #2357, so the constructors can make sure it's canonical
