### PR TITLE
Use a channel in sync timing test

### DIFF
--- a/zebrad/src/components/sync/tests/timing.rs
+++ b/zebrad/src/components/sync/tests/timing.rs
@@ -78,6 +78,8 @@ fn request_genesis_is_rate_limited() {
     let mut state_requests_counter = 0;
     let (peer_requests_sender, peer_requests_receiver) = watch::channel(peer_requests_counter);
     let (state_requests_sender, state_requests_receiver) = watch::channel(state_requests_counter);
+    let peer_requests_sender = Arc::new(peer_requests_sender);
+    let state_requests_sender = Arc::new(state_requests_sender);
 
     let runtime = Runtime::new().expect("Failed to create Tokio runtime");
     let _guard = runtime.enter();


### PR DESCRIPTION
## Motivation

We are trying to get rid of `Atomic`s, including in test cases. https://github.com/ZcashFoundation/zebra/issues/2268

### Designs

[link to async coding rfc - atomics section]

## Solution

Use a `tokio::watch` for this test.

## Review
By now this is a draft for sharing with @jvff 

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
