### PR TITLE
Security: Stop panicking on invalid reserved orchard::Flags bits

### DIFF
--- a/book/src/dev/rfcs/0010-v5-transaction.md
+++ b/book/src/dev/rfcs/0010-v5-transaction.md
@@ -416,7 +416,8 @@ bitflags! {
 
 This type is also defined in `orchard/shielded_data.rs`.
 
-Note: A [consensus rule](https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus) was added to the protocol specification stating that the reserved bits (2..7) of the flags must be all zero in transactions V5.
+Note: A [consensus rule](https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus) was added to the protocol specification stating that:
+> In a version 5 transaction, the reserved bits 2..7 of the flagsOrchard field MUST be zero.
 
 ## Test Plan
 [test-plan]: #test-plan

--- a/book/src/dev/rfcs/0010-v5-transaction.md
+++ b/book/src/dev/rfcs/0010-v5-transaction.md
@@ -416,6 +416,8 @@ bitflags! {
 
 This type is also defined in `orchard/shielded_data.rs`.
 
+Note: A [consensus rule](https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus) was added to the protocol specification stating that the reserved bits (2..7) of the flags must be all zero in transactions V5.
+
 ## Test Plan
 [test-plan]: #test-plan
 

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -155,8 +155,12 @@ impl ZcashSerialize for Flags {
 
 impl ZcashDeserialize for Flags {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let flags = Flags::from_bits(reader.read_u8()?).unwrap();
-
-        Ok(flags)
+        // Consensus rule: In a version 5 transaction,
+        // the reserved bits 2..7 of the flagsOrchard field MUST be zero.
+        // https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
+        match Flags::from_bits(reader.read_u8()?) {
+            Some(flags) => Ok(flags),
+            None => Err(SerializationError::Parse("invalid orchard flags")),
+        }
     }
 }

--- a/zebra-chain/src/orchard/tests.rs
+++ b/zebra-chain/src/orchard/tests.rs
@@ -1,1 +1,2 @@
 mod preallocate;
+mod prop;

--- a/zebra-chain/src/orchard/tests/prop.rs
+++ b/zebra-chain/src/orchard/tests/prop.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 
 proptest! {
+    /// Make sure only valid flags deserialize
     #[test]
-    // Make sure only valid flags deserialize
     fn flags_roundtrip(flags in any::<u8>()) {
 
         let mut serialized = Cursor::new(Vec::new());
@@ -26,7 +26,7 @@ proptest! {
             None => {
                 prop_assert_eq!(
                     maybe_deserialized.err().unwrap().to_string(),
-                    "parse error: invalid orchard flags"
+                    "parse error: invalid reserved orchard flags"
                 );
                 prop_assert_ne!(flags & invalid_bits_mask, 0);
             }

--- a/zebra-chain/src/orchard/tests/prop.rs
+++ b/zebra-chain/src/orchard/tests/prop.rs
@@ -9,7 +9,7 @@ use crate::{
 proptest! {
     /// Make sure only valid flags deserialize
     #[test]
-    fn flags_roundtrip(flags in any::<u8>()) {
+    fn flag_roundtrip_bytes(flags in any::<u8>()) {
 
         let mut serialized = Cursor::new(Vec::new());
         flags.zcash_serialize(&mut serialized)?;

--- a/zebra-chain/src/orchard/tests/prop.rs
+++ b/zebra-chain/src/orchard/tests/prop.rs
@@ -1,0 +1,43 @@
+use proptest::prelude::*;
+use std::io::Cursor;
+
+use super::super::super::*;
+
+use crate::serialization::{ZcashDeserializeInto, ZcashSerialize};
+
+proptest! {
+    #[test]
+    // Make sure only valid flags deserialize
+    fn flags_roundtrip(flags in any::<u8>()) {
+
+        let mut serialized = Cursor::new(Vec::new());
+        flags.zcash_serialize(&mut serialized)?;
+
+        serialized.set_position(0);
+        let maybe_deserialized = (&mut serialized).zcash_deserialize_into();
+
+        let mut error_catch = String::new();
+        let maybe_deserialized: Option<orchard::Flags> = match maybe_deserialized {
+            Ok(deserialized) => Some(deserialized),
+            Err(e) => {
+                error_catch = e.to_string();
+                None
+            },
+        };
+
+        let binary_repr = format!("{:b}", flags);
+        if maybe_deserialized.is_some() {
+            let flag = maybe_deserialized.unwrap();
+            prop_assert!(binary_repr.len() <= 2);
+            prop_assert!(
+                flag == orchard::Flags::empty()
+                || flag == orchard::Flags::ENABLE_SPENDS
+                || flag == orchard::Flags::ENABLE_OUTPUTS
+                || flag == orchard::Flags::ENABLE_SPENDS | orchard::Flags::ENABLE_OUTPUTS);
+        }
+        else {
+            prop_assert!(binary_repr.len() > 2);
+            prop_assert_eq!(error_catch, "parse error: invalid orchard flags");
+        }
+    }
+}

--- a/zebra-chain/src/orchard/tests/prop.rs
+++ b/zebra-chain/src/orchard/tests/prop.rs
@@ -19,11 +19,14 @@ proptest! {
         let invalid_bits_mask = !orchard::Flags::all().bits();
         match orchard::Flags::from_bits(flags) {
             Some(valid_flags) => {
-                prop_assert_eq!(maybe_deserialized, Ok(valid_flags));
+                prop_assert_eq!(maybe_deserialized.ok(), Some(valid_flags));
                 prop_assert_eq!(flags & invalid_bits_mask, 0);
             }
             None => {
-                prop_assert_eq!(maybe_deserialized, Err(SerializationError::Parse("invalid orchard flags")));
+                prop_assert_eq!(
+                    maybe_deserialized.err().unwrap().to_string(),
+                    "parse error: invalid orchard flags"
+                );
                 prop_assert_ne!(flags & invalid_bits_mask, 0);
             }
         }

--- a/zebra-chain/src/orchard/tests/prop.rs
+++ b/zebra-chain/src/orchard/tests/prop.rs
@@ -1,7 +1,7 @@
 use proptest::prelude::*;
 use std::io::Cursor;
 
-use super::super::super::*;
+use crate::orchard;
 
 use crate::serialization::{ZcashDeserializeInto, ZcashSerialize};
 

--- a/zebra-chain/src/orchard/tests/prop.rs
+++ b/zebra-chain/src/orchard/tests/prop.rs
@@ -1,9 +1,10 @@
 use proptest::prelude::*;
 use std::io::Cursor;
 
-use crate::orchard;
-
-use crate::serialization::{ZcashDeserializeInto, ZcashSerialize};
+use crate::{
+    orchard,
+    serialization::{ZcashDeserializeInto, ZcashSerialize},
+};
 
 proptest! {
     #[test]


### PR DESCRIPTION
## Motivation

We need to make sure the consensus rule about the reserved bits of the `orchard::Flags` for transactions V5 is present in Zebra. https://github.com/ZcashFoundation/zebra/issues/2263

In addition there is an `unwrap()` in the deserialization of the `orchard::Flags` that needs to be fixed. 

### Specifications

https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus

"In a version 5 transaction, the reserved bits 2..7 of the flagsOrchard field MUST be zero."

### Designs

Also in this PR a note about this consensus rule is added to the orchard flags section: https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0010-v5-transaction.md#adding-orchard-flags 

## Solution

Only deserialize valid flags and prop test them. 

## Review

As it is a consensus rule will be good if @teor2345 can review, the code in general can be reviewed by anyone.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
