### PR TITLE
Replace bespoke source-based coverage config with cargo-llvm-cov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: nightly
           override: true
@@ -30,28 +30,15 @@ jobs:
       - name: Install rustfilt symbol demangler
         run: |
           cargo install rustfilt
-      - name: Rerun tests for coverage
-        env:
-          RUSTFLAGS: -Zinstrument-coverage -C link-dead-code -C debuginfo=2
-          LLVM_PROFILE_FILE: "${{ github.workspace }}/test.%p.profraw"
-          ZEBRA_SKIP_NETWORK_TESTS: 1
-          CARGO_INCREMENTAL: 0
-        run: |
-          cargo test
-          cargo test --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM - > filenames.txt
-      - name: Merge coverage data
-        run: |
-          $(rustc --print target-libdir)/../bin/llvm-profdata merge test.*.profraw -o test.profdata
-      - name: Generate detailed html coverage report for github artifact
-        run: |
-          $(rustc --print target-libdir)/../bin/llvm-cov show -format=html -ignore-filename-regex=".*/.cargo/registry/.*" -ignore-filename-regex=".*/.cargo/git/.*" -ignore-filename-regex=".*/.rustup/.*" -Xdemangler=rustfilt -show-instantiations -output-dir=./coverage -instr-profile=./test.profdata $(printf -- "-object %s " $(cat filenames.txt))
-      - uses: actions/upload-artifact@v2
-        with:
-          name: coverage
-          path: ./coverage
 
-      - name: Generate lcov coverage report for codecov
+      - name: Install cargo-llvm-cov cargo command
         run: |
-          $(rustc --print target-libdir)/../bin/llvm-cov export -format=lcov -instr-profile=test.profdata $(printf -- "-object %s " $(cat filenames.txt)) > "lcov.info"
+          cargo install cargo-llvm-cov --version 0.1.0-alpha.3
+
+      - name: Generate code coverage
+        env:
+          ZEBRA_SKIP_NETWORK_TESTS: 1
+        run: cargo llvm-cov --lcov > lcov.info
+
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1.5.2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install cargo-llvm-cov cargo command
         run: |
-          cargo install cargo-llvm-cov --version 0.1.0-alpha
+          cargo install cargo-llvm-cov --version 0.1.0-alpha.4
 
       - name: Generate code coverage
         env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install cargo-llvm-cov cargo command
         run: |
-          cargo install cargo-llvm-cov --version 0.1.0-alpha.4
+          cargo install cargo-llvm-cov --version ^0.1.0-alpha.4
 
       - name: Generate code coverage
         env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Generate code coverage
         env:
           ZEBRA_SKIP_NETWORK_TESTS: 1
+          CARGO_INCREMENTAL: 0
         run: cargo llvm-cov --lcov > lcov.info
 
       - name: Upload coverage report to Codecov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install cargo-llvm-cov cargo command
         run: |
-          cargo install cargo-llvm-cov --version 0.1.0-alpha.3
+          cargo install cargo-llvm-cov --version 0.1.0-alpha
 
       - name: Generate code coverage
         env:


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

While fixing CI for ristretto255-dh, I found a cargo command that does basically what we have been doing here to collect source-based code coverage.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Use cargo-llvm-cov instead of the bespoke llvm tools.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

Anyone can review.

### Reviewer Checklist

  - [ ] Code coverage metrics basically match what we've been collecting

This is what I see when comparing commits:

![image](https://user-images.githubusercontent.com/552961/121788747-b7452c80-cb9d-11eb-9031-a148b0298ffb.png)




