### PR TITLE
CI: Clarify duplicate Clippy job name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         uses: actions-rs/clippy-check@v1.0.7
         with:
           # GitHub displays the clippy job and its results as separate entries
-          name: ${{ jobs.clippy.name }} Results
+          name: Clippy (stable) Results
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,8 @@ jobs:
       - name: Run clippy
         uses: actions-rs/clippy-check@v1.0.7
         with:
+          # GitHub displays the clippy job and its results as separate entries
+          name: ${{ jobs.clippy.name }} Results
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,6 @@ jobs:
       - name: Run clippy
         uses: actions-rs/clippy-check@v1.0.7
         with:
-          name: Clippy (stable)
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
 


### PR DESCRIPTION
## Motivation

Two clippy jobs show up in the GitHub PR status list.

## Solution

Remove the extra name config from the last clippy step.

## Review

Anyone can review this low-priority cleanup.

### Reviewer Checklist

  - [ ] Clippy job and clippy results have different names

