### PR TITLE
Add missing `std::sync::Mutex` qualifiers in the unit tests

### DIFF
--- a/zebra-network/src/peer_set/candidate_set/tests/prop.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/prop.rs
@@ -1,6 +1,6 @@
 use std::{
     env,
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -69,7 +69,7 @@ proptest! {
         // Since the address book is empty, there won't be any available peers
         let address_book = AddressBook::new(&Config::default(), Span::none());
 
-        let mut candidate_set = CandidateSet::new(Arc::new(Mutex::new(address_book)), peer_service);
+        let mut candidate_set = CandidateSet::new(Arc::new(std::sync::Mutex::new(address_book)), peer_service);
 
         // Make sure that the rate-limit is never triggered, even after multiple calls
         for _ in 0..next_peer_attempts {
@@ -106,7 +106,7 @@ proptest! {
         let mut address_book = AddressBook::new(&Config::default(), Span::none());
         address_book.extend(peers);
 
-        let mut candidate_set = CandidateSet::new(Arc::new(Mutex::new(address_book)), peer_service);
+        let mut candidate_set = CandidateSet::new(Arc::new(std::sync::Mutex::new(address_book)), peer_service);
 
         let checks = async move {
             // Check rate limiting for initial peers

--- a/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
@@ -3,7 +3,7 @@ use std::{
     convert::TryInto,
     iter,
     net::{IpAddr, SocketAddr},
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::Duration as StdDuration,
 };
 
@@ -139,12 +139,15 @@ fn candidate_set_updates_are_rate_limited() {
     // How many times should `update` be called in each rate limit interval
     const POLL_FREQUENCY_FACTOR: u32 = 3;
 
+    zebra_test::init();
+
     let runtime = Runtime::new().expect("Failed to create Tokio runtime");
     let _guard = runtime.enter();
 
     let address_book = AddressBook::new(&Config::default(), Span::none());
     let (peer_service, call_count) = mock_peer_service();
-    let mut candidate_set = CandidateSet::new(Arc::new(Mutex::new(address_book)), peer_service);
+    let mut candidate_set =
+        CandidateSet::new(Arc::new(std::sync::Mutex::new(address_book)), peer_service);
 
     runtime.block_on(async move {
         time::pause();
@@ -178,7 +181,8 @@ fn candidate_set_update_after_update_initial_is_rate_limited() {
 
     let address_book = AddressBook::new(&Config::default(), Span::none());
     let (peer_service, call_count) = mock_peer_service();
-    let mut candidate_set = CandidateSet::new(Arc::new(Mutex::new(address_book)), peer_service);
+    let mut candidate_set =
+        CandidateSet::new(Arc::new(std::sync::Mutex::new(address_book)), peer_service);
 
     runtime.block_on(async move {
         time::pause();


### PR DESCRIPTION
## Motivation

In the Zebra async RFC, we want to always say `std::sync::Mutex`, so we remember it's a threaded mutex:
> Always qualify ambiguous names like `Mutex` and `sleep`, so that it is obvious when a call will block.

https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0011-async-rust-in-zebra.md#futures-aware-types

## Solution

- add missing `std::sync::Mutex` qualifiers in the unit tests
- add a missing `zebra_test::init()`

## Review

Anyone can review this low priority cleanup.

### Reviewer Checklist

  - [ ] Code implements Coding Standards
