### PR TITLE
Move already in state check

### DIFF
--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -121,22 +121,6 @@ where
         // TODO(jlusby): Error = Report, handle errors from state_service.
         async move {
             let hash = block.hash();
-            // Check that this block is actually a new block.
-            tracing::trace!("checking that block is not already in state");
-            match state_service
-                .ready_and()
-                .await
-                .map_err(|source| VerifyBlockError::Depth { source, hash })?
-                .call(zs::Request::Depth(hash))
-                .await
-                .map_err(|source| VerifyBlockError::Depth { source, hash })?
-            {
-                zs::Response::Depth(Some(depth)) => {
-                    return Err(BlockError::AlreadyInChain(hash, depth).into())
-                }
-                zs::Response::Depth(None) => {}
-                _ => unreachable!("wrong response to Request::Depth"),
-            }
 
             tracing::trace!("performing block checks");
             let height = block

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -199,7 +199,7 @@ where
         let fut = async move {
             // Check if the block is already in the state.
             // BUG: check if the hash is in any chain (#862).
-            // Depth only checks the main chain.
+            // Depth only checks the best chain.
             match state.oneshot(zs::Request::Depth(hash)).await {
                 Ok(zs::Response::Depth(None)) => Ok(()),
                 Ok(zs::Response::Depth(Some(_))) => Err("already present".into()),

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -184,7 +184,7 @@ where
 
                 // Check if the block is already in the state.
                 // BUG: check if the hash is in any chain (#862).
-                // Depth only checks the main chain.
+                // Depth only checks the best chain.
                 match state.oneshot(zs::Request::Depth(hash)).await {
                     Ok(zs::Response::Depth(None)) => Ok(()),
                     Ok(zs::Response::Depth(Some(_))) => Err("already present".into()),

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -187,7 +187,8 @@ where
                 // Depth only checks the best chain.
                 match state.oneshot(zs::Request::Depth(hash)).await {
                     Ok(zs::Response::Depth(None)) => Ok(()),
-                    Ok(zs::Response::Depth(Some(_))) => Err("already present".into()),
+                    // TODO: use an error enum here, and update the syncer AlreadyVerified check (#2338, #2339)
+                    Ok(zs::Response::Depth(Some(_))) => Err("AlreadyVerified { }".into()),
                     Ok(_) => unreachable!("wrong response"),
                     Err(e) => Err(e),
                 }?;


### PR DESCRIPTION
## Motivation

We want to move an already in the state check from the zebra-consensus into the downloaders. Will close https://github.com/ZcashFoundation/zebra/issues/2307 when done.

This change also implements part of #862.

## Solution

We have 2 very similar downloaders in zebrad:

- In the inbound: https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/inbound/downloads.rs
- In the sync: https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/downloads.rs

The inbound one already have this check in https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/inbound/downloads.rs#L200-L208
For the sync we bring the state and use the same check as the inbound, we then remove the check from zebra-consensus.

I used the check from inbound to sync instead of https://github.com/ZcashFoundation/zebra/blob/main/zebra-consensus/src/block.rs#L125-L139 because it looks simpler.

## Review

This is currently a draft to ask @teor2345 some questions i added to the code as comments.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
