### PR TITLE
Update librustzcash, change zcash_history to work with it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4414,7 +4414,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git#d88e40113c8dadea751dfcdd72ee90868f9655ff"
+source = "git+https://github.com/zcash/librustzcash.git#0c3ed159985affa774e44d10172d4471d798a85a"
 dependencies = [
  "bigint",
  "blake2b_simd",

--- a/zebra-chain/src/primitives/zcash_history.rs
+++ b/zebra-chain/src/primitives/zcash_history.rs
@@ -21,7 +21,7 @@ use crate::{
 pub struct Tree {
     network: Network,
     network_upgrade: NetworkUpgrade,
-    inner: zcash_history::Tree,
+    inner: zcash_history::Tree<zcash_history::V1>,
 }
 
 /// An encoded tree node data.
@@ -48,9 +48,9 @@ pub struct Entry {
     inner: [u8; zcash_history::MAX_ENTRY_SIZE],
 }
 
-impl From<zcash_history::Entry> for Entry {
+impl From<zcash_history::Entry<zcash_history::V1>> for Entry {
     /// Convert from librustzcash.
-    fn from(inner_entry: zcash_history::Entry) -> Self {
+    fn from(inner_entry: zcash_history::Entry<zcash_history::V1>) -> Self {
         let mut entry = Entry {
             inner: [0; zcash_history::MAX_ENTRY_SIZE],
         };
@@ -66,7 +66,7 @@ impl Entry {
     /// Sapling note commitment tree.
     fn new_leaf(block: Arc<Block>, network: Network, sapling_root: &sapling::tree::Root) -> Self {
         let node_data = block_to_history_node(block, network, sapling_root);
-        let inner_entry: zcash_history::Entry = node_data.into();
+        let inner_entry = zcash_history::Entry::<zcash_history::V1>::new_leaf(node_data);
         inner_entry.into()
     }
 


### PR DESCRIPTION
## Motivation

librustzcash was updated and the ZIP-221 Orchard support added to its `zcash_history` crate broke our wrapper.

### Specifications

N/A

### Designs

N/A

## Solution

For now, hardcode our usage of the `Tree` struct with only V1 (non-Orchard) data. In #2283 we will add proper Orchard support.

## Review

This blocks the ZIP-244 PRs (#2050, #2051) which need to update librustzcash.

@teor2345 might want to review this but anyone else can review it too, it's a simple change

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [x] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

#2283 will change this code to add proper Orchard support, which will be required for the other ZIP-221 PRs