### PR TITLE
Document required request timeouts due to data dependencies

### DIFF
--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -32,6 +32,12 @@ mod check;
 mod tests;
 
 /// Asynchronous transaction verification.
+///
+/// # Correctness
+///
+/// Transaction verification requests should be wrapped in a timeout, so that
+/// out-of-order and invalid requests do not hang indefinitely. See the [`chain`](`crate::chain`)
+/// module documentation for details.
 #[derive(Debug, Clone)]
 pub struct Verifier<ZS> {
     network: Network,

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -2,8 +2,9 @@
 //!
 //! # Correctness
 //!
-//! Block commit requests should be wrapped in a timeout, because contextual verification
-//! and state updates wait for all previous blocks.
+//! Await UTXO and block commit requests should be wrapped in a timeout, because:
+//! - await UTXO requests wait for a block containing that UTXO, and
+//! - contextual verification and state updates wait for all previous blocks.
 //!
 //! Otherwise, verification of out-of-order and invalid blocks can hang indefinitely.
 

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -1,4 +1,11 @@
-//! State storage code for Zebra. 🦓
+//! State contextual verification and storage code for Zebra. 🦓
+//!
+//! # Correctness
+//!
+//! Block commit requests should be wrapped in a timeout, because contextual verification
+//! and state updates wait for all previous blocks.
+//!
+//! Otherwise, verification of out-of-order and invalid blocks can hang indefinitely.
 
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -264,8 +264,11 @@ pub enum Request {
     /// whether the UTXO remains unspent or is on the best chain, or any chain.
     /// Its purpose is to allow asynchronous script verification.
     ///
-    /// Code making this request should apply a timeout layer to the service to
-    /// handle missing UTXOs.
+    /// # Correctness
+    ///
+    /// UTXO requests should be wrapped in a timeout, so that
+    /// out-of-order and invalid requests do not hang indefinitely. See the [`crate`]
+    /// documentation for details.
     AwaitUtxo(transparent::OutPoint),
 
     /// Finds the first hash that's in the peer's `known_blocks` and the local best chain.

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -186,6 +186,12 @@ pub enum Request {
     /// future will have no effect on whether it is eventually processed. A
     /// request to commit a block which has been queued internally but not yet
     /// committed will fail the older request and replace it with the newer request.
+    ///
+    /// # Correctness
+    ///
+    /// Block commit requests should be wrapped in a timeout, so that
+    /// out-of-order and invalid requests do not hang indefinitely. See the [`crate`]
+    /// documentation for details.
     CommitBlock(PreparedBlock),
 
     /// Commit a finalized block to the state, skipping all validation.
@@ -202,6 +208,12 @@ pub enum Request {
     /// future will have no effect on whether it is eventually processed.
     /// Duplicate requests should not be made, because it is the caller's
     /// responsibility to ensure that each block is valid and final.
+    ///
+    /// # Correctness
+    ///
+    /// Block commit requests should be wrapped in a timeout, so that
+    /// out-of-order and invalid requests do not hang indefinitely. See the [`crate`]
+    /// documentation for details.
     CommitFinalizedBlock(FinalizedBlock),
 
     /// Computes the depth in the current best chain of the block identified by the given hash.


### PR DESCRIPTION
## Motivation

Some requests to Zebra services need timeouts, otherwise they can hang on invalid blocks or transactions.

### Designs

https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0002-parallel-verification.md
https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0004-asynchronous-script-verification.md
https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0005-state-updates.md

## Solution

- Document block and transaction verification requests that need timeouts

## Review

@jvff was part of the conversation that led to this PR. It's a low priority.

### Reviewer Checklist

  - [x] Documentation matches behaviour of code

