### PR TITLE
Release Blocker: Depend on a specific git commit for zcash_history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4414,7 +4414,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git#0c3ed159985affa774e44d10172d4471d798a85a"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0c3ed159985affa774e44d10172d4471d798a85a#0c3ed159985affa774e44d10172d4471d798a85a"
 dependencies = [
  "bigint",
  "blake2b_simd",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -44,7 +44,7 @@ sha2 = { version = "0.9.5", features=["compress"] }
 subtle = "2.4"
 thiserror = "1"
 x25519-dalek = { version = "1.1", features = ["serde"] }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "0c3ed159985affa774e44d10172d4471d798a85a" }
 bigint = "4"
 
 proptest = { version = "0.10", optional = true }


### PR DESCRIPTION
## Motivation

If we don't depend on a specific `zcash_history` commit, `librustzcash` changes can break builds of individual Zebra crates.

Only binary builds depend on the lockfile:
https://doc.rust-lang.org/cargo/faq.html#why-do-binaries-have-cargolock-in-version-control-but-not-libraries

This bug happened to me when I had a different version of librustzcash in my cargo cache.

## Solution

- Depend on a specific librustzcash commit in `zebra-chain/Cargo.toml`

## Review

Anyone can review this PR.

This is urgent, because it blocks the Zebra release in PR #2334.

### Reviewer Checklist

  - [ ] Cargo.toml commit matches Cargo.lock commit

