### PR TITLE
Replace primitives_types with uint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,12 +484,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
-name = "byte-slice-cast"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
-
-[[package]]
 name = "bytemuck"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,18 +1143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "byteorder",
- "rand 0.8.4",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,15 +1704,6 @@ dependencies = [
  "sized-chunks",
  "typenum",
  "version_check 0.9.2",
-]
-
-[[package]]
-name = "impl-codec"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df170efa359aebdd5cb7fe78edcc67107748e4737bdca8a8fb40d15ea7a877ed"
-dependencies = [
- "parity-scale-codec",
 ]
 
 [[package]]
@@ -2300,18 +2273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-scale-codec"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c823fdae1bb5ff5708ee61a62697e6296175dc671710876871c853f48592b3"
-dependencies = [
- "arrayvec 0.5.2",
- "bitvec 0.20.1",
- "byte-slice-cast",
- "serde",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2472,17 +2433,6 @@ dependencies = [
  "ctor",
  "diff",
  "output_vt100",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2415937401cb030a2a0a4d922483f945fa068f52a7dbb22ce0fe5f2b6f6adace"
-dependencies = [
- "fixed-hash",
- "impl-codec",
- "uint",
 ]
 
 [[package]]
@@ -2957,12 +2907,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hex"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
@@ -4462,7 +4406,6 @@ dependencies = [
  "itertools 0.10.1",
  "jubjub",
  "lazy_static",
- "primitive-types",
  "proptest",
  "proptest-derive",
  "rand 0.8.4",
@@ -4478,6 +4421,7 @@ dependencies = [
  "subtle",
  "thiserror",
  "tracing",
+ "uint",
  "x25519-dalek",
  "zcash_history",
  "zebra-test",
@@ -4583,7 +4527,6 @@ dependencies = [
  "lazy_static",
  "metrics",
  "once_cell",
- "primitive-types",
  "proptest",
  "proptest-derive",
  "regex",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -34,7 +34,6 @@ halo2 = { git = "https://github.com/zcash/halo2.git", rev = "dda60a363001373d564
 hex = "0.4"
 jubjub = "0.6.0"
 lazy_static = "1.4.0"
-primitive-types = "0.9.0"
 rand_core = "0.6"
 ripemd160 = "0.9"
 secp256k1 = { version = "0.20.2", features = ["serde"] }
@@ -46,6 +45,7 @@ thiserror = "1"
 x25519-dalek = { version = "1.1", features = ["serde"] }
 zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "0c3ed159985affa774e44d10172d4471d798a85a" }
 bigint = "4"
+uint = "0.9.0"
 
 proptest = { version = "0.10", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }

--- a/zebra-chain/src/work.rs
+++ b/zebra-chain/src/work.rs
@@ -2,6 +2,7 @@
 
 pub mod difficulty;
 pub mod equihash;
+mod u256;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 mod arbitrary;

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -23,7 +23,7 @@ use std::{
     ops::Mul,
 };
 
-use primitive_types::U256;
+pub use crate::work::u256::U256;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 mod arbitrary;

--- a/zebra-chain/src/work/difficulty/tests/prop.rs
+++ b/zebra-chain/src/work/difficulty/tests/prop.rs
@@ -1,4 +1,3 @@
-use primitive_types::U256;
 use proptest::{arbitrary::any, prelude::*};
 
 use std::cmp::Ordering;

--- a/zebra-chain/src/work/u256.rs
+++ b/zebra-chain/src/work/u256.rs
@@ -1,0 +1,10 @@
+//! Module for a 256-bit big int structure.
+// This is a separate module to make it easier to disable clippy because
+// it raises a lot of issues in the macro.
+#![allow(clippy::all)]
+
+use uint::construct_uint;
+
+construct_uint! {
+    pub struct U256(4);
+}

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -26,7 +26,6 @@ displaydoc = "0.2.1"
 rocksdb = "0.16.0"
 tempdir = "0.3.7"
 chrono = "0.4.19"
-primitive-types = "0.9.0"
 rlimit = "0.5.4"
 
 [dev-dependencies]
@@ -40,4 +39,3 @@ tempdir = "0.3.7"
 tokio = { version = "0.3.6", features = ["full"] }
 proptest = "0.10.1"
 proptest-derive = "0.3"
-primitive-types = "0.9.0"

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -6,14 +6,17 @@
 //!  * `median-time-past`.
 
 use chrono::{DateTime, Duration, Utc};
-use primitive_types::U256;
 
 use std::{cmp::max, cmp::min, convert::TryInto};
 
 use zebra_chain::{
-    block, block::Block, parameters::Network, parameters::NetworkUpgrade,
-    parameters::POW_AVERAGING_WINDOW, work::difficulty::CompactDifficulty,
+    block,
+    block::Block,
+    parameters::Network,
+    parameters::NetworkUpgrade,
+    parameters::POW_AVERAGING_WINDOW,
     work::difficulty::ExpandedDifficulty,
+    work::difficulty::{CompactDifficulty, U256},
 };
 
 /// The median block span for time median calculations.

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -1,12 +1,11 @@
 use std::{convert::TryFrom, mem, sync::Arc};
 
-use primitive_types::U256;
 use zebra_chain::{
     block::{self, Block},
     transaction::Transaction,
     transparent,
     work::difficulty::ExpandedDifficulty,
-    work::difficulty::Work,
+    work::difficulty::{Work, U256},
 };
 
 use super::*;


### PR DESCRIPTION
## Motivation

We need to use the recent `zcash_primitives` in `librustzcash` for ZIP-244/221 support. However, they have updated their dependencies to use `bitvec` 0.22, while we use 0.17. Due to a package conflict issue with `funty`, we must then update _all_ dependencies that use `bitvec`.

One of those is `primitive-types`, however it hasn't been updated to use `bitvec` 0.22, and was due to being replaced in #829 anyway. That issue proposes replacing it with `bigint`, however that package has a different API and it will take some time to adapt to it.

Until we do that, we can use `uint` instead (which `primitives-types` also uses and therefore does not require any big changes in our code). This will unblock further work on the `librustzcash` update and we can eventually use `bigint` instead per  #829.


### Specifications

N/A

### Designs

N/A

## Solution

Use `uint` to define a `U256` type which is essentially the same as the one defined in `primitive-types`.

Note that this does not prevent the packages conflicts by itself, we keep using `bitvec` 0.17 here. That will be solved in a separated PR because the `bitvec` upgrade is non-trivial and requires some code changes.

## Review

Anyone can review, it's a simple change.

This blocks further work on the `librustzcash` update which is necessary to merge ZIP-244 PRs.

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

In #829 we'll change it again to use `bigint` in order to have the same dependency as `librustzcash`.
