### PR TITLE
Update multiple crates to ensure bitvec 0.22.3 is being used 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
+
+[[package]]
 name = "async-stream"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,10 +272,11 @@ checksum = "474a626a67200bd107d44179bb3d4fc61891172d11696609264589be6a0e6a43"
 
 [[package]]
 name = "bellman"
-version = "0.9.0"
-source = "git+https://github.com/zkcrypto/bellman?rev=bd4af09f50a4d020a3672aff37c4f3f2da2bb36b#bd4af09f50a4d020a3672aff37c4f3f2da2bb36b"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db9a104adfbc817ea09dec27d616c32dbf1d56fd741dcdc2444a3dfa1b9fffd"
 dependencies = [
- "bitvec 0.20.1",
+ "bitvec",
  "blake2s_simd",
  "byteorder",
  "crossbeam",
@@ -376,22 +383,12 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "0.17.4"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
-dependencies = [
- "either",
- "radium 0.3.0",
-]
-
-[[package]]
-name = "bitvec"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5011ffc90248764d7005b0e10c7294f5aa1bd87d9dd7248f4ad475b347c294d"
+checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
 dependencies = [
  "funty",
- "radium 0.6.2",
+ "radium",
  "tap",
  "wyz",
 ]
@@ -445,9 +442,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bls12_381"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c56609cc42c628848e7b18e0baf42a4ef626b8c50442dc08b8094bd21d8ad32"
+checksum = "54757888b09a69be70b5ec303e382a74227392086ba808cb01eeca29233a2397"
 dependencies = [
  "ff",
  "group",
@@ -902,6 +899,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto_api"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f855e87e75a4799e18b8529178adcde6fd4f97c1449ff4821e747ff728bb102"
+
+[[package]]
+name = "crypto_api_chachapoly"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d930b6a026ce9d358a17f9c9046c55d90b14bb847f36b6ebb6b19365d4feffb8"
+dependencies = [
+ "crypto_api",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +1134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "equihash"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0c3ed159985affa774e44d10172d4471d798a85a#0c3ed159985affa774e44d10172d4471d798a85a"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,11 +1154,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
+checksum = "63eec06c61e487eecf0f7e6e6372e596a81922c28d33e645d6983ca6493a1af0"
 dependencies = [
- "bitvec 0.20.1",
+ "bitvec",
  "rand_core 0.6.3",
  "subtle",
 ]
@@ -1207,9 +1228,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "funty"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "futures"
@@ -1414,9 +1435,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "group"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3c1e8b4f1ca07e6605ea1be903a5f6956aec5c8a67fd44d56076631675ed8"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "byteorder",
  "ff",
@@ -1492,12 +1513,11 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 [[package]]
 name = "halo2"
 version = "0.0.1"
-source = "git+https://github.com/zcash/halo2.git?rev=dda60a363001373d564156ad0334e2022d85a5b4#dda60a363001373d564156ad0334e2022d85a5b4"
+source = "git+https://github.com/zcash/halo2.git?rev=236115917df9db45282fec24d1e1e36f275f71ab#236115917df9db45282fec24d1e1e36f275f71ab"
 dependencies = [
  "blake2b_simd",
  "crossbeam-utils 0.8.0",
  "ff",
- "funty",
  "group",
  "num_cpus",
  "pasta_curves",
@@ -1807,11 +1827,11 @@ dependencies = [
 
 [[package]]
 name = "jubjub"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7e7fef85ae7b26dd89f34175b7f3c5ace64067a110c2ac86cf92407a6666ca"
+checksum = "593fc4726ca80edb47ee18ab4d826719e25c2096991a79308b44fb915c6014ef"
 dependencies = [
- "bitvec 0.20.1",
+ "bitvec",
  "bls12_381",
  "ff",
  "group",
@@ -2150,6 +2170,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fa586da3e43cc7df44aae0e21ed2e743218b876de3f38035683d30bd8a3828e"
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,6 +2259,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "orchard"
+version = "0.0.0"
+source = "git+https://github.com/zcash/orchard.git?rev=37b1b7f357cd34d93f9c55bb96efd05ab4e84408#37b1b7f357cd34d93f9c55bb96efd05ab4e84408"
+dependencies = [
+ "aes",
+ "arrayvec 0.7.1",
+ "bitvec",
+ "blake2b_simd",
+ "ff",
+ "fpe",
+ "group",
+ "halo2",
+ "lazy_static",
+ "nonempty",
+ "pasta_curves",
+ "rand 0.8.4",
+ "reddsa",
+ "subtle",
+ "zcash_note_encryption",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,11 +2312,10 @@ checksum = "f2fe43bf372b08cc9ccee5144715db59c79ab00168bbe4cf0d274dc0d5f64d7f"
 
 [[package]]
 name = "pairing"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be899ebf10363f018353dba1baabb7e83145f3683c7b83b73b93b563e3167cc"
+checksum = "7de9d09263c9966e8196fe0380c9dbbc7ea114b5cf371ba29004bc1f9c6db7f3"
 dependencies = [
- "ff",
  "group",
 ]
 
@@ -2300,12 +2347,12 @@ dependencies = [
 
 [[package]]
 name = "pasta_curves"
-version = "0.0.0"
-source = "git+https://github.com/zcash/pasta_curves.git?rev=b55a6960dfafd7f767e2820ddf1adaa499322f98#b55a6960dfafd7f767e2820ddf1adaa499322f98"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "179df750e20069669699f537ec0c4bcb248283f45a78b8c66d797fb73dbbb455"
 dependencies = [
  "blake2b_simd",
  "ff",
- "funty",
  "group",
  "lazy_static",
  "rand 0.8.4",
@@ -2555,12 +2602,6 @@ dependencies = [
 
 [[package]]
 name = "radium"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
-
-[[package]]
-name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
@@ -2727,15 +2768,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "redjubjub"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcf30702f15c157e348b4ccef28b1224fc7da8f8430d553bdc47b2d6599107b"
+name = "reddsa"
+version = "0.0.0"
+source = "git+https://github.com/str4d/redjubjub.git?rev=d5d8c5f3bb704bad8ae88fe4a29ae1f744774cb2#d5d8c5f3bb704bad8ae88fe4a29ae1f744774cb2"
 dependencies = [
  "blake2b_simd",
  "byteorder",
  "digest",
- "funty",
+ "group",
+ "jubjub",
+ "pasta_curves",
+ "rand_core 0.6.3",
+ "serde",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "redjubjub"
+version = "0.4.0"
+source = "git+https://github.com/ZcashFoundation/redjubjub.git?rev=f772176560b0b7daf25eff2460e08dc127ac8407#f772176560b0b7daf25eff2460e08dc127ac8407"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "digest",
  "jubjub",
  "rand_core 0.6.3",
  "serde",
@@ -3413,9 +3469,9 @@ dependencies = [
 
 [[package]]
 name = "tap"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempdir"
@@ -4339,9 +4395,12 @@ dependencies = [
 
 [[package]]
 name = "wyz"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x25519-dalek"
@@ -4366,6 +4425,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_note_encryption"
+version = "0.0.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0c3ed159985affa774e44d10172d4471d798a85a#0c3ed159985affa774e44d10172d4471d798a85a"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "crypto_api_chachapoly",
+ "ff",
+ "group",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.5.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0c3ed159985affa774e44d10172d4471d798a85a#0c3ed159985affa774e44d10172d4471d798a85a"
+dependencies = [
+ "aes",
+ "bitvec",
+ "blake2b_simd",
+ "blake2s_simd",
+ "bls12_381",
+ "byteorder",
+ "crypto_api_chachapoly",
+ "equihash 0.1.0 (git+https://github.com/zcash/librustzcash.git?rev=0c3ed159985affa774e44d10172d4471d798a85a)",
+ "ff",
+ "fpe",
+ "group",
+ "hex",
+ "jubjub",
+ "lazy_static",
+ "log",
+ "nonempty",
+ "orchard",
+ "pasta_curves",
+ "rand 0.8.4",
+ "rand_core 0.6.3",
+ "sha2",
+ "subtle",
+ "zcash_note_encryption",
+]
+
+[[package]]
 name = "zcash_script"
 version = "0.1.6-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4386,7 +4489,7 @@ dependencies = [
  "bigint",
  "bincode",
  "bitflags",
- "bitvec 0.17.4",
+ "bitvec",
  "blake2b_simd",
  "blake2s_simd",
  "bs58",
@@ -4396,9 +4499,8 @@ dependencies = [
  "criterion",
  "displaydoc",
  "ed25519-zebra",
- "equihash",
+ "equihash 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fpe",
- "funty",
  "futures 0.3.15",
  "group",
  "halo2",
@@ -4424,6 +4526,7 @@ dependencies = [
  "uint",
  "x25519-dalek",
  "zcash_history",
+ "zcash_primitives",
  "zebra-test",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,4 @@ tower = { git = "https://github.com/tower-rs/tower", rev = "d4d1c67c6a0e4213a52a
 # These are librustzcash requirements specified in its workspace Cargo.toml that we must replicate here
 halo2 = { git = "https://github.com/zcash/halo2.git", rev = "236115917df9db45282fec24d1e1e36f275f71ab" }
 orchard = { git = "https://github.com/zcash/orchard.git", rev = "37b1b7f357cd34d93f9c55bb96efd05ab4e84408" }
-# Must point to the same revision used in zebra-chain/Cargo.toml
 zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "0c3ed159985affa774e44d10172d4471d798a85a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,10 @@ hyper = { git = "https://github.com/hyperium/hyper", rev = "ed2b22a7f66899d33869
 metrics = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
 metrics-exporter-prometheus = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
 tower = { git = "https://github.com/tower-rs/tower", rev = "d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39" }
+
+# TODO: remove these after a new librustzcash release.
+# These are librustzcash requirements specified in its workspace Cargo.toml that we must replicate here
+halo2 = { git = "https://github.com/zcash/halo2.git", rev = "236115917df9db45282fec24d1e1e36f275f71ab" }
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "37b1b7f357cd34d93f9c55bb96efd05ab4e84408" }
+# Must point to the same revision used in zebra-chain/Cargo.toml
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "0c3ed159985affa774e44d10172d4471d798a85a" }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -16,7 +16,7 @@ bench = ["zebra-test"]
 aes = "0.6"
 bech32 = "0.8.0"
 bitflags = "1.2.1"
-bitvec = "0.17.4"
+bitvec = "0.22"
 blake2b_simd = "0.5.11"
 blake2s_simd = "0.5.11"
 bs58 = { version = "0.4", features = ["check"] }
@@ -24,15 +24,13 @@ byteorder = "1.4"
 chrono = { version = "0.4", features = ["serde"] }
 displaydoc = "0.2.1"
 fpe = "0.4"
-# Temporary workaround for https://github.com/myrrlyn/funty/issues/3
-# TODO: remove: https://github.com/ZcashFoundation/zebra/issues/2082
-funty = "=1.1.0"
 futures = "0.3"
-group = "0.9"
+group = "0.10"
 # TODO: replace w/ crate version when released: https://github.com/ZcashFoundation/zebra/issues/2083
-halo2 = { git = "https://github.com/zcash/halo2.git", rev = "dda60a363001373d564156ad0334e2022d85a5b4"}
+# Note: if updating this, also update the workspace Cargo.toml to match.
+halo2 = { git = "https://github.com/zcash/halo2.git", rev = "236115917df9db45282fec24d1e1e36f275f71ab" }
 hex = "0.4"
-jubjub = "0.6.0"
+jubjub = "0.7.0"
 lazy_static = "1.4.0"
 rand_core = "0.6"
 ripemd160 = "0.9"
@@ -44,6 +42,7 @@ subtle = "2.4"
 thiserror = "1"
 x25519-dalek = { version = "1.1", features = ["serde"] }
 zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "0c3ed159985affa774e44d10172d4471d798a85a" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0c3ed159985affa774e44d10172d4471d798a85a" }
 bigint = "4"
 uint = "0.9.0"
 
@@ -54,7 +53,8 @@ itertools = { version = "0.10.1", optional = true }
 # ZF deps
 ed25519-zebra = "2"
 equihash = "0.1"
-redjubjub = "0.4"
+# TODO: Update to 0.5 release when published
+redjubjub = { git = "https://github.com/ZcashFoundation/redjubjub.git", rev = "f772176560b0b7daf25eff2460e08dc127ac8407" }
 
 zebra-test = { path = "../zebra-test/", optional = true }
 

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -11,6 +11,8 @@
 #![allow(clippy::try_err)]
 #![deny(clippy::await_holding_lock)]
 #![forbid(unsafe_code)]
+// Required by bitvec! macro
+#![recursion_limit = "256"]
 
 #[macro_use]
 extern crate serde;

--- a/zebra-chain/src/orchard/commitment.rs
+++ b/zebra-chain/src/orchard/commitment.rs
@@ -151,11 +151,25 @@ impl NoteCommitment {
         let psi_bytes: [u8; 32] = psi.into();
 
         // g*d || pk*d || I2LEBSP_64(v) || I2LEBSP_l^Orchard_Base(ρ) || I2LEBSP_l^Orchard_base(ψ)
-        s.append(&mut BitVec::<Lsb0, u8>::from_slice(&g_d_bytes[..]));
-        s.append(&mut BitVec::<Lsb0, u8>::from_slice(&pk_d_bytes[..]));
-        s.append(&mut BitVec::<Lsb0, u8>::from_slice(&v_bytes[..]));
-        s.append(&mut BitVec::<Lsb0, u8>::from_slice(&rho_bytes[..]));
-        s.append(&mut BitVec::<Lsb0, u8>::from_slice(&psi_bytes[..]));
+        s.append(
+            &mut BitVec::<Lsb0, u8>::from_slice(&g_d_bytes[..])
+                .expect("must work for small slices"),
+        );
+        s.append(
+            &mut BitVec::<Lsb0, u8>::from_slice(&pk_d_bytes[..])
+                .expect("must work for small slices"),
+        );
+        s.append(
+            &mut BitVec::<Lsb0, u8>::from_slice(&v_bytes[..]).expect("must work for small slices"),
+        );
+        s.append(
+            &mut BitVec::<Lsb0, u8>::from_slice(&rho_bytes[..])
+                .expect("must work for small slices"),
+        );
+        s.append(
+            &mut BitVec::<Lsb0, u8>::from_slice(&psi_bytes[..])
+                .expect("must work for small slices"),
+        );
 
         let rcm = CommitmentRandomness(generate_trapdoor(csprng));
 

--- a/zebra-chain/src/orchard/commitment.rs
+++ b/zebra-chain/src/orchard/commitment.rs
@@ -151,25 +151,11 @@ impl NoteCommitment {
         let psi_bytes: [u8; 32] = psi.into();
 
         // g*d || pk*d || I2LEBSP_64(v) || I2LEBSP_l^Orchard_Base(ρ) || I2LEBSP_l^Orchard_base(ψ)
-        s.append(
-            &mut BitVec::<Lsb0, u8>::from_slice(&g_d_bytes[..])
-                .expect("must work for small slices"),
-        );
-        s.append(
-            &mut BitVec::<Lsb0, u8>::from_slice(&pk_d_bytes[..])
-                .expect("must work for small slices"),
-        );
-        s.append(
-            &mut BitVec::<Lsb0, u8>::from_slice(&v_bytes[..]).expect("must work for small slices"),
-        );
-        s.append(
-            &mut BitVec::<Lsb0, u8>::from_slice(&rho_bytes[..])
-                .expect("must work for small slices"),
-        );
-        s.append(
-            &mut BitVec::<Lsb0, u8>::from_slice(&psi_bytes[..])
-                .expect("must work for small slices"),
-        );
+        s.extend(g_d_bytes);
+        s.extend(pk_d_bytes);
+        s.extend(v_bytes);
+        s.extend(rho_bytes);
+        s.extend(psi_bytes);
 
         let rcm = CommitmentRandomness(generate_trapdoor(csprng));
 

--- a/zebra-chain/src/orchard/keys.rs
+++ b/zebra-chain/src/orchard/keys.rs
@@ -554,12 +554,14 @@ impl From<FullViewingKey> for IncomingViewingKey {
     fn from(fvk: FullViewingKey) -> Self {
         let mut M: BitVec<Lsb0, u8> = BitVec::new();
 
-        M.append(&mut BitVec::<Lsb0, u8>::from_slice(
-            &<[u8; 32]>::from(fvk.spend_validating_key)[..],
-        ));
-        M.append(&mut BitVec::<Lsb0, u8>::from_slice(
-            &<[u8; 32]>::from(fvk.nullifier_deriving_key)[..],
-        ));
+        M.append(
+            &mut BitVec::<Lsb0, u8>::from_slice(&<[u8; 32]>::from(fvk.spend_validating_key)[..])
+                .expect("must work for small slices"),
+        );
+        M.append(
+            &mut BitVec::<Lsb0, u8>::from_slice(&<[u8; 32]>::from(fvk.nullifier_deriving_key)[..])
+                .expect("must work for small slices"),
+        );
 
         // Commit^ivk_rivk
         let commit_x = sinsemilla_short_commit(

--- a/zebra-chain/src/orchard/keys.rs
+++ b/zebra-chain/src/orchard/keys.rs
@@ -554,14 +554,8 @@ impl From<FullViewingKey> for IncomingViewingKey {
     fn from(fvk: FullViewingKey) -> Self {
         let mut M: BitVec<Lsb0, u8> = BitVec::new();
 
-        M.append(
-            &mut BitVec::<Lsb0, u8>::from_slice(&<[u8; 32]>::from(fvk.spend_validating_key)[..])
-                .expect("must work for small slices"),
-        );
-        M.append(
-            &mut BitVec::<Lsb0, u8>::from_slice(&<[u8; 32]>::from(fvk.nullifier_deriving_key)[..])
-                .expect("must work for small slices"),
-        );
+        M.extend(<[u8; 32]>::from(fvk.spend_validating_key));
+        M.extend(<[u8; 32]>::from(fvk.nullifier_deriving_key));
 
         // Commit^ivk_rivk
         let commit_x = sinsemilla_short_commit(

--- a/zebra-chain/src/orchard/sinsemilla.rs
+++ b/zebra-chain/src/orchard/sinsemilla.rs
@@ -56,7 +56,7 @@ fn S(j: &BitSlice<Lsb0, u8>) -> pallas::Point {
     // value.
     assert_eq!(j.len(), 10);
 
-    pallas_group_hash(b"z.cash:SinsemillaS", j.as_slice())
+    pallas_group_hash(b"z.cash:SinsemillaS", j.as_raw_slice())
 }
 
 /// "...an algebraic hash function with collision resistance (for fixed input
@@ -88,8 +88,9 @@ pub fn sinsemilla_hash_to_point(D: &[u8], M: &BitVec<Lsb0, u8>) -> pallas::Point
     for chunk in M.chunks(k) {
         // Pad each chunk with zeros.
         let mut store = [0u8; 2];
-        let bits = store.bits_mut::<Lsb0>();
-        bits[..chunk.len()].copy_from_slice(chunk);
+        let bits =
+            BitSlice::<Lsb0, _>::from_slice_mut(&mut store).expect("must work for small slices");
+        bits[..chunk.len()].copy_from_bitslice(chunk);
 
         acc = acc + acc + S(&bits[..k]);
     }

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -42,9 +42,13 @@ fn merkle_crh_orchard(layer: u8, left: [u8; 32], right: [u8; 32]) -> [u8; 32] {
     let mut s = bitvec![Lsb0, u8;];
 
     // Prefix: l = I2LEBSP_10(MerkleDepth^Orchard − 1 − layer)
-    s.extend_from_slice(&layer.bits::<Lsb0>()[0..10]);
-    s.extend_from_slice(&left.bits::<Lsb0>()[0..255]);
-    s.extend_from_slice(&right.bits::<Lsb0>()[0..255]);
+    s.extend_from_bitslice(&BitSlice::<Lsb0, _>::from_element(&layer)[0..10]);
+    s.extend_from_bitslice(
+        &BitSlice::<Lsb0, _>::from_slice(&left).expect("must work for small slices")[0..255],
+    );
+    s.extend_from_bitslice(
+        &BitSlice::<Lsb0, _>::from_slice(&right).expect("must work for small slices")[0..255],
+    );
 
     sinsemilla_hash(b"z.cash:Orchard-MerkleCRH", &s).to_bytes()
 }

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -42,13 +42,9 @@ fn merkle_crh_orchard(layer: u8, left: [u8; 32], right: [u8; 32]) -> [u8; 32] {
     let mut s = bitvec![Lsb0, u8;];
 
     // Prefix: l = I2LEBSP_10(MerkleDepth^Orchard − 1 − layer)
-    s.extend_from_bitslice(&BitSlice::<Lsb0, _>::from_element(&layer)[0..10]);
-    s.extend_from_bitslice(
-        &BitSlice::<Lsb0, _>::from_slice(&left).expect("must work for small slices")[0..255],
-    );
-    s.extend_from_bitslice(
-        &BitSlice::<Lsb0, _>::from_slice(&right).expect("must work for small slices")[0..255],
-    );
+    s.extend_from_bitslice(&BitArray::<Lsb0, _>::from([layer, 0])[0..10]);
+    s.extend_from_bitslice(&BitArray::<Lsb0, _>::from(left)[0..255]);
+    s.extend_from_bitslice(&BitArray::<Lsb0, _>::from(right)[0..255]);
 
     sinsemilla_hash(b"z.cash:Orchard-MerkleCRH", &s).to_bytes()
 }

--- a/zebra-chain/src/sapling.rs
+++ b/zebra-chain/src/sapling.rs
@@ -1,4 +1,14 @@
 //! Sapling-related functionality.
+//!
+//! These data structures enforce the *structural validity* of Sapling-related
+//! consensus-critical objects.
+//!
+//! **Consensus rule**:
+//!
+//! These data structures ensure that [ZIP-216](https://zips.z.cash/zip-0216),
+//! canonical Jubjub point encodings, are enforced everywhere where Jubjub
+//! points occur, and non-canonical point encodings are rejected. This is
+//! enforced by the jubjub crate, which is also used by the redjubjub crate.
 
 mod address;
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/zebra-chain/src/sapling/commitment.rs
+++ b/zebra-chain/src/sapling/commitment.rs
@@ -126,9 +126,17 @@ impl NoteCommitment {
         let pk_d_bytes = <[u8; 32]>::from(transmission_key);
         let v_bytes = value.to_bytes();
 
-        s.append(&mut BitVec::<Lsb0, u8>::from_slice(&g_d_bytes[..]));
-        s.append(&mut BitVec::<Lsb0, u8>::from_slice(&pk_d_bytes[..]));
-        s.append(&mut BitVec::<Lsb0, u8>::from_slice(&v_bytes[..]));
+        s.append(
+            &mut BitVec::<Lsb0, u8>::from_slice(&g_d_bytes[..])
+                .expect("must work for small slices"),
+        );
+        s.append(
+            &mut BitVec::<Lsb0, u8>::from_slice(&pk_d_bytes[..])
+                .expect("must work for small slices"),
+        );
+        s.append(
+            &mut BitVec::<Lsb0, u8>::from_slice(&v_bytes[..]).expect("must work for small slices"),
+        );
 
         let rcm = CommitmentRandomness(generate_trapdoor(csprng));
 

--- a/zebra-chain/src/sapling/commitment.rs
+++ b/zebra-chain/src/sapling/commitment.rs
@@ -126,17 +126,9 @@ impl NoteCommitment {
         let pk_d_bytes = <[u8; 32]>::from(transmission_key);
         let v_bytes = value.to_bytes();
 
-        s.append(
-            &mut BitVec::<Lsb0, u8>::from_slice(&g_d_bytes[..])
-                .expect("must work for small slices"),
-        );
-        s.append(
-            &mut BitVec::<Lsb0, u8>::from_slice(&pk_d_bytes[..])
-                .expect("must work for small slices"),
-        );
-        s.append(
-            &mut BitVec::<Lsb0, u8>::from_slice(&v_bytes[..]).expect("must work for small slices"),
-        );
+        s.extend(g_d_bytes);
+        s.extend(pk_d_bytes);
+        s.extend(v_bytes);
 
         let rcm = CommitmentRandomness(generate_trapdoor(csprng));
 

--- a/zebra-chain/src/sapling/commitment/pedersen_hashes.rs
+++ b/zebra-chain/src/sapling/commitment/pedersen_hashes.rs
@@ -26,7 +26,7 @@ fn M_i(segment: &BitSlice<Lsb0, u8>) -> jubjub::Fr {
     for (j, chunk) in segment.chunks(3).enumerate() {
         // Pad each chunk with zeros.
         let mut store = 0u8;
-        let bits = store.bits_mut::<Lsb0>();
+        let bits = BitSlice::<Lsb0, _>::from_element_mut(&mut store);
         chunk
             .iter()
             .enumerate()

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -38,12 +38,8 @@ fn merkle_crh_sapling(layer: u8, left: [u8; 32], right: [u8; 32]) -> [u8; 32] {
 
     // Prefix: l = I2LEBSP_6(MerkleDepth^Sapling − 1 − layer)
     s.extend_from_bitslice(&BitSlice::<Lsb0, _>::from_element(&layer)[0..6]);
-    s.extend_from_bitslice(
-        &BitSlice::<Lsb0, _>::from_slice(&left).expect("must work for small slices")[0..255],
-    );
-    s.extend_from_bitslice(
-        &BitSlice::<Lsb0, _>::from_slice(&right).expect("must work for small slices")[0..255],
-    );
+    s.extend_from_bitslice(&BitArray::<Lsb0, _>::from(left)[0..255]);
+    s.extend_from_bitslice(&BitArray::<Lsb0, _>::from(right)[0..255]);
 
     pedersen_hash(*b"Zcash_PH", &s).to_bytes()
 }

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -37,9 +37,13 @@ fn merkle_crh_sapling(layer: u8, left: [u8; 32], right: [u8; 32]) -> [u8; 32] {
     let mut s = bitvec![Lsb0, u8;];
 
     // Prefix: l = I2LEBSP_6(MerkleDepth^Sapling − 1 − layer)
-    s.extend_from_slice(&layer.bits::<Lsb0>()[0..6]);
-    s.extend_from_slice(&left.bits::<Lsb0>()[0..255]);
-    s.extend_from_slice(&right.bits::<Lsb0>()[0..255]);
+    s.extend_from_bitslice(&BitSlice::<Lsb0, _>::from_element(&layer)[0..6]);
+    s.extend_from_bitslice(
+        &BitSlice::<Lsb0, _>::from_slice(&left).expect("must work for small slices")[0..255],
+    );
+    s.extend_from_bitslice(
+        &BitSlice::<Lsb0, _>::from_slice(&right).expect("must work for small slices")[0..255],
+    );
 
     pedersen_hash(*b"Zcash_PH", &s).to_bytes()
 }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -7,12 +7,11 @@ edition = "2018"
 
 [dependencies]
 blake2b_simd = "0.5.11"
-#bellman = "0.8"
-bellman = { git = "https://github.com/zkcrypto/bellman", rev = "bd4af09f50a4d020a3672aff37c4f3f2da2bb36b" }
-bls12_381 = "0.4.0"
+bellman = "0.10.0"
+bls12_381 = "0.5.0"
 chrono = "0.4.19"
 displaydoc = "0.2.1"
-jubjub = "0.6.0"
+jubjub = "0.7.0"
 lazy_static = "1.4.0"
 once_cell = "1.8"
 rand = "0.8"


### PR DESCRIPTION
## Motivation

`librustzcash` was updated to use `bitvec` 0.22 and due to a package conflict with funty, we need to update _all_ crates that use `bitvec` in order to use the recent `librustzcash` (in particular its `zcash_primitives` crate which will be used by the ZIP-244 PRs).

This will also solve issues with the updated `zcash_script`.

## Solution

Update all crates that use `bitvec` to versions that use `bitvec` 0.22.

This required fixing some of Zebra code that directly uses `bitvec` since its API changed since 0.17 which was being used before. I added a lot of `expects` because `bitvec` now can return an error when instantiating from slices; but per its documentation that can only happen if the slice is too big, and all of our usages are with fixed-size small slices.

Note: I've included the `zcash_primitives` reference in `Cargo.toml` but it's not being actively used right now, but it will be used soon with the ZIP-244 PRs; I wanted to make sure everything works with it.

The jubjub upgrade also resolves #1798 
## Review

This blocks the ZIP-244 PRs (#2129 and #2165).
(Spoiler: I've tested this code with #2129 and it works :tada: )

@jvff might want to review since he had to make pretty much the same changes while updating `zcash_script`
@dconnolly might want to review the `bitvec` usage changes to make sure I haven't accidentally changed the behavior

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Update redjubjub when it's released: https://github.com/ZcashFoundation/zebra/issues/2352
Update librustzcash when it's released: https://github.com/ZcashFoundation/zebra/issues/2353
