### PR TITLE
Move network_upgrade check into zebra-chain

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -88,7 +88,7 @@ impl Block {
         }
     }
 
-    /// Check if the `branch_id` field from the transactions match block height.
+    /// Check if the `network_upgrade` field from the transactions match block height.
     ///
     /// # Consensus rule:
     ///
@@ -97,7 +97,7 @@ impl Block {
     ///
     /// [ZIP-244]: https://zips.z.cash/zip-0244
     /// [7.1]: https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus
-    pub fn check_consensus_branch_id_consistency(
+    pub fn check_transaction_network_upgrades(
         &self,
         network: Network,
     ) -> Result<(), error::BlockError> {

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -88,7 +88,8 @@ impl Block {
         }
     }
 
-    /// Check if the `network_upgrade` field from the transactions match block height.
+    /// Check if the `network_upgrade` fields from each transaction in the block matches
+    /// the network upgrade calculated from the `network` and block height.
     ///
     /// # Consensus rule:
     ///
@@ -97,7 +98,7 @@ impl Block {
     ///
     /// [ZIP-244]: https://zips.z.cash/zip-0244
     /// [7.1]: https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus
-    pub fn check_transaction_network_upgrades(
+    pub fn check_transaction_network_upgrade_consistency(
         &self,
         network: Network,
     ) -> Result<(), error::BlockError> {
@@ -110,7 +111,7 @@ impl Block {
             .filter_map(|trans| trans.as_ref().network_upgrade())
             .any(|trans_nu| trans_nu != block_nu)
         {
-            return Err(error::BlockError::InvalidNetworkUpgrade);
+            return Err(error::BlockError::WrongTransactionConsensusBranchId);
         }
 
         Ok(())

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -88,7 +88,7 @@ impl Block {
         }
     }
 
-    /// Check if the `network_upgrade` fields from the transactions match block height.
+    /// Check if the `branch_id` field from the transactions match block height.
     ///
     /// # Consensus rule:
     ///
@@ -97,7 +97,7 @@ impl Block {
     ///
     /// [ZIP-244]: https://zips.z.cash/zip-0244
     /// [7.1]: https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus
-    pub fn check_transaction_network_upgrade(
+    pub fn check_consensus_branch_id_consistency(
         &self,
         network: Network,
     ) -> Result<(), error::BlockError> {

--- a/zebra-chain/src/block/error.rs
+++ b/zebra-chain/src/block/error.rs
@@ -5,6 +5,6 @@ use thiserror::Error;
 #[allow(dead_code, missing_docs)]
 #[derive(Error, Debug, PartialEq)]
 pub enum BlockError {
-    #[error("invalid network upgrade")]
-    InvalidNetworkUpgrade,
+    #[error("transaction has wrong consensus branch id for block network upgrade")]
+    WrongTransactionConsensusBranchId,
 }

--- a/zebra-chain/src/block/error.rs
+++ b/zebra-chain/src/block/error.rs
@@ -1,0 +1,10 @@
+//! Errors that can occur when checking Block consensus rules.
+
+use thiserror::Error;
+
+#[allow(dead_code, missing_docs)]
+#[derive(Error, Debug, PartialEq)]
+pub enum BlockError {
+    #[error("invalid network upgrade")]
+    InvalidNetworkUpgrade,
+}

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -192,7 +192,7 @@ impl Transaction {
         }
     }
 
-    /// Get this transaction network_upgrade, if any.
+    /// Get this transaction's network_upgrade, if any.
     pub fn network_upgrade(&self) -> Option<NetworkUpgrade> {
         match self {
             Transaction::V1 { .. }

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -192,7 +192,10 @@ impl Transaction {
         }
     }
 
-    /// Get this transaction's network_upgrade, if any.
+    /// Get this transaction's network upgrade field, if any.
+    /// This field is serialized as `nConsensusBranchId` ([7.1]).
+    ///
+    /// [7.1]: https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus
     pub fn network_upgrade(&self) -> Option<NetworkUpgrade> {
         match self {
             Transaction::V1 { .. }

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -192,6 +192,19 @@ impl Transaction {
         }
     }
 
+    /// Get this transaction network_upgrade, if any.
+    pub fn network_upgrade(&self) -> Option<NetworkUpgrade> {
+        match self {
+            Transaction::V1 { .. }
+            | Transaction::V2 { .. }
+            | Transaction::V3 { .. }
+            | Transaction::V4 { .. } => None,
+            Transaction::V5 {
+                network_upgrade, ..
+            } => Some(*network_upgrade),
+        }
+    }
+
     // transparent
 
     /// Access the transparent inputs of this transaction, regardless of version.

--- a/zebra-chain/src/transaction/tests/prop.rs
+++ b/zebra-chain/src/transaction/tests/prop.rs
@@ -97,7 +97,7 @@ fn transaction_valid_network_upgrade_strategy() -> Result<()> {
     });
 
     proptest!(|((network, block) in strategy)| {
-        block.check_transaction_network_upgrade(network)?;
+        block.check_consensus_branch_id_consistency(network)?;
     });
 
     Ok(())

--- a/zebra-chain/src/transaction/tests/prop.rs
+++ b/zebra-chain/src/transaction/tests/prop.rs
@@ -97,7 +97,7 @@ fn transaction_valid_network_upgrade_strategy() -> Result<()> {
     });
 
     proptest!(|((network, block) in strategy)| {
-        block.check_consensus_branch_id_consistency(network)?;
+        block.check_transaction_network_upgrades(network)?;
     });
 
     Ok(())

--- a/zebra-chain/src/transaction/tests/prop.rs
+++ b/zebra-chain/src/transaction/tests/prop.rs
@@ -97,13 +97,7 @@ fn transaction_valid_network_upgrade_strategy() -> Result<()> {
     });
 
     proptest!(|((network, block) in strategy)| {
-        // TODO: replace with check_transaction_network_upgrade from #2343
-        let block_network_upgrade = NetworkUpgrade::current(network, block.coinbase_height().unwrap());
-        for transaction in block.transactions {
-            if let Transaction::V5 { network_upgrade, .. } = transaction.as_ref() {
-                prop_assert_eq!(network_upgrade, &block_network_upgrade);
-            }
-        }
+        block.check_transaction_network_upgrade(network)?;
     });
 
     Ok(())

--- a/zebra-chain/src/transaction/tests/prop.rs
+++ b/zebra-chain/src/transaction/tests/prop.rs
@@ -97,7 +97,7 @@ fn transaction_valid_network_upgrade_strategy() -> Result<()> {
     });
 
     proptest!(|((network, block) in strategy)| {
-        block.check_transaction_network_upgrades(network)?;
+        block.check_transaction_network_upgrade_consistency(network)?;
     });
 
     Ok(())

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -189,10 +189,7 @@ pub fn merkle_root_validity(
     block: &Block,
     transaction_hashes: &[transaction::Hash],
 ) -> Result<(), BlockError> {
-    if block
-        .check_consensus_branch_id_consistency(network)
-        .is_err()
-    {
+    if block.check_transaction_network_upgrades(network).is_err() {
         return Err(BlockError::WrongTransactionConsensusBranchId);
     }
 

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -189,24 +189,7 @@ pub fn merkle_root_validity(
     block: &Block,
     transaction_hashes: &[transaction::Hash],
 ) -> Result<(), BlockError> {
-    use transaction::Transaction;
-    let block_nu =
-        NetworkUpgrade::current(network, block.coinbase_height().expect("a valid height"));
-
-    if block
-        .transactions
-        .iter()
-        .filter_map(|trans| match *trans.as_ref() {
-            Transaction::V5 {
-                network_upgrade, ..
-            } => Some(network_upgrade),
-            Transaction::V1 { .. }
-            | Transaction::V2 { .. }
-            | Transaction::V3 { .. }
-            | Transaction::V4 { .. } => None,
-        })
-        .any(|trans_nu| trans_nu != block_nu)
-    {
+    if block.check_transaction_network_upgrade(network).is_err() {
         return Err(BlockError::WrongTransactionConsensusBranchId);
     }
 

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -189,7 +189,10 @@ pub fn merkle_root_validity(
     block: &Block,
     transaction_hashes: &[transaction::Hash],
 ) -> Result<(), BlockError> {
-    if block.check_transaction_network_upgrade(network).is_err() {
+    if block
+        .check_consensus_branch_id_consistency(network)
+        .is_err()
+    {
         return Err(BlockError::WrongTransactionConsensusBranchId);
     }
 

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -189,7 +189,10 @@ pub fn merkle_root_validity(
     block: &Block,
     transaction_hashes: &[transaction::Hash],
 ) -> Result<(), BlockError> {
-    if block.check_transaction_network_upgrades(network).is_err() {
+    if block
+        .check_transaction_network_upgrade_consistency(network)
+        .is_err()
+    {
         return Err(BlockError::WrongTransactionConsensusBranchId);
     }
 


### PR DESCRIPTION
## Motivation

Resolves https://github.com/ZcashFoundation/zebra/issues/2343

### Specifications

This PR moves the code of a consensus rule check from zebra-consensus into zebra-chain

## Solution

Moved check to zebra-chain.

## Review

Anyone can review but i am working on this among others related with @teor2345 

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
