### PR TITLE
Upgrade to pin_project 1.0.7 to resolve nightly warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.2",
+ "pin-project 1.0.7",
  "socket2",
  "tokio 0.2.23",
  "tower-service",
@@ -1651,7 +1651,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.2",
+ "pin-project 1.0.7",
  "socket2",
  "tokio 0.3.6",
  "tower-service",
@@ -2327,27 +2327,27 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
 dependencies = [
- "pin-project-internal 0.4.27",
+ "pin-project-internal 0.4.28",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.0.2"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
 dependencies = [
- "pin-project-internal 1.0.2",
+ "pin-project-internal 1.0.7",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -2356,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.2"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -3681,7 +3681,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram 6.3.4",
- "pin-project 1.0.2",
+ "pin-project 1.0.7",
  "tokio 0.3.6",
  "tower-layer 0.3.0",
  "tower-service",
@@ -3696,7 +3696,7 @@ dependencies = [
  "ed25519-zebra",
  "futures 0.3.15",
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 1.0.7",
  "rand 0.8.4",
  "tokio 0.3.6",
  "tokio-test",
@@ -3713,7 +3713,7 @@ name = "tower-fallback"
 version = "0.2.8"
 dependencies = [
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "tokio 0.3.6",
  "tower",
  "tracing",
@@ -3744,7 +3744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4546773ffeab9e4ea02b8872faa49bb616a80a7da66afc2f32688943f97efa7"
 dependencies = [
  "futures-util",
- "pin-project 1.0.2",
+ "pin-project 1.0.7",
  "tokio 1.3.0",
  "tokio-test",
  "tower-layer 0.3.1",
@@ -3811,7 +3811,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.2",
+ "pin-project 1.0.7",
  "tracing",
 ]
 
@@ -4479,7 +4479,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "metrics",
- "pin-project 0.4.27",
+ "pin-project 1.0.7",
  "proptest",
  "proptest-derive",
  "rand 0.8.4",
@@ -4596,7 +4596,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "once_cell",
- "pin-project 0.4.27",
+ "pin-project 1.0.7",
  "rand 0.8.4",
  "regex",
  "semver 1.0.3",

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 futures = "0.3.15"
 futures-core = "0.3.13"
-pin-project = "0.4.27"
+pin-project = "1.0.7"
 tokio = { version = "0.3.6", features = ["time", "sync", "stream", "tracing", "macros"] }
 tower = { version = "0.4", features = ["util", "buffer"] }
 tracing = "0.1.26"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -17,7 +17,7 @@ hex = "0.4"
 # which we don't use, so disable it to drop the dependencies.
 indexmap = { version = "1.6", default-features = false }
 lazy_static = "1.4.0"
-pin-project = "0.4"
+pin-project = "1.0.7"
 rand = "0.8"
 regex = "1"
 serde = { version = "1", features = ["serde_derive"] }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -26,7 +26,7 @@ hyper = { version = "0.14.0-dev", features = ["full"] }
 futures = "0.3"
 tokio = { version = "0.3.6", features = ["time", "rt-multi-thread", "stream", "macros", "tracing", "signal"] }
 tower = { version = "0.4", features = ["hedge", "limit"] }
-pin-project = "0.4.23"
+pin-project = "1.0.7"
 
 color-eyre = { version = "0.5.11", features = ["issue-url"] }
 thiserror = "1"


### PR DESCRIPTION
## Motivation

`rustc` nightly warns about `unused_borrow`s in `pin_project` derives in `tower-batch` and `zebra-network`.

## Solution

- Upgrade to `pin_project` 1.0.7
- Leave `tower-fallback` on `pin_project` 0.4.28, because it has code that is incompatible with `pin_project` 1.0 (see #2355)

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [x] New dependencies compile and pass tests

## Follow Up Work

Upgrade pin_project dependency in tower-fallback to 1.0 #2355