### PR TITLE
Document shared to per-spend anchor conversion

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -323,6 +323,9 @@ impl Transaction {
     /// returning `Spend<PerSpendAnchor>` regardless of the underlying
     /// transaction version.
     ///
+    /// Shared anchors in V5 transactions are copied into each sapling spend.
+    /// This allows the same code to validate spends from V4 and V5 transactions.
+    ///
     /// # Correctness
     ///
     /// Do not use this function for serialization.


### PR DESCRIPTION
## Motivation

The documentation on `sapling_spends_per_anchor` is a bit unclear.

## Review

Anyone can review this doc fix, but @jvff asked for it.

### Reviewer Checklist

  - [ ] Documentation matches Designs and Implementation
