### PR TITLE
Remove unicode in Zebra's user agent

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -92,8 +92,9 @@ pub const TIMESTAMP_TRUNCATION_SECONDS: u32 = 30 * 60;
 /// This must be a valid [BIP 14] user agent.
 ///
 /// [BIP 14]: https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki
-// XXX can we generate this from crate metadata?
-pub const USER_AGENT: &str = "/🦓Zebra🦓:1.0.0-alpha.11/";
+//
+// TODO: generate this from crate metadata (#2375)
+pub const USER_AGENT: &str = "/Zebra:1.0.0-alpha.11/";
 
 /// The Zcash network protocol version implemented by this crate, and advertised
 /// during connection setup.


### PR DESCRIPTION
## Motivation

Zebra doesn't appear in node explorers like https://blockchair.com/zcash/nodes
(It also doesn't appear in DNS seeders #1904, but recent fixes might have resolved that issue.)

This might be because we use multi-byte UTF-8 in Zebra's user-agent.

Currently, accurate network metrics are more important than encouraging UTF-8 support in the Zcash ecosystem.

### Specifications

User-agents are loosely specified as US-ASCII, but you have to track back through a lot of references and spec grammar to find that restriction:
https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki#proposal
https://datatracker.ietf.org/doc/html/rfc1945#section-10.15
https://datatracker.ietf.org/doc/html/rfc1945#section-3.7
https://datatracker.ietf.org/doc/html/rfc1945#section-2.2

However, it is quite likely that some block explorers do not support multi-byte UTF-8.

## Solution

- Delete multi-byte UTF-8 characters from the Zebra user-agent

## Review

Anyone can review this PR.

### Reviewer Checklist

- [ ] Fix is implemented as described

- Optional: Manually deployed node version appears in the node list
  - We might need to configure `listen_addr` with the external IP address before this works
  - Deploy Job: https://github.com/ZcashFoundation/zebra/actions/runs/963230415
  - Node List: https://blockchair.com/zcash/nodes

## Follow Up Work

Automatically use zebrad version for the zebra-network user agent #2375