### PR TITLE
ZIP-213: Explain how Zebra validates shielded coinbase outputs like other shielded outputs

### DIFF
--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -87,6 +87,8 @@ pub enum Request {
         height: block::Height,
     },
     /// Verify the supplied transaction as part of the mempool.
+    ///
+    /// Note: coinbase transactions are invalid in the mempool
     Mempool {
         /// The transaction itself.
         transaction: Arc<Transaction>,

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -163,6 +163,15 @@ where
             // Do basic checks first
             check::has_inputs_and_outputs(&tx)?;
 
+            // "The consensus rules applied to valueBalance, vShieldedOutput, and bindingSig
+            // in non-coinbase transactions MUST also be applied to coinbase transactions."
+            //
+            // This rule is implicitly implemented during sapling and orchard verification,
+            // because they do not distinguish between coinbase and non-coinbase transactions.
+            //
+            // Note: this rule originally applied to Sapling, but we assume it also applies to Orchard.
+            //
+            // https://zips.z.cash/zip-0213#specification
             let async_checks = match tx.as_ref() {
                 Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
                     tracing::debug!(?tx, "got transaction with wrong version");

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -172,7 +172,7 @@ where
             // "The consensus rules applied to valueBalance, vShieldedOutput, and bindingSig
             // in non-coinbase transactions MUST also be applied to coinbase transactions."
             //
-            // This rule is implicitly implemented during sapling and orchard verification,
+            // This rule is implicitly implemented during Sapling and Orchard verification,
             // because they do not distinguish between coinbase and non-coinbase transactions.
             //
             // Note: this rule originally applied to Sapling, but we assume it also applies to Orchard.


### PR DESCRIPTION
## Motivation

We've split most of the work out of ZIP-213, so we just need to explain how we implement the remaining consensus rules.

Closes #608.

### Specifications

> The consensus rules applied to valueBalance, vShieldedOutput, and bindingSig in non-coinbase transactions MUST also be applied to coinbase transactions.

https://zips.z.cash/zip-0213#specification

Note: this rule originally applied to Sapling, but we assume it also applies to Orchard

## Solution

- Explain how Zebra validates shielded coinbase outputs like other shielded outputs
- Rearrange some code to make the implementation clearer
- Add a note about mempool coinbase transactions

The existing block test vectors and tests include shielded coinbase transactions.

## Review

@jvff is working on the same file.

This PR is not urgent.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

The Sapling and Orchard note consensus rules will be implemented in #2362.

"Only transparent outputs in coinbase transactions are subject to the existing restrictions on spending coinbase funds" will be implemented in #1970: