### PR TITLE
Remove "solution" from the ticket template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -30,18 +30,6 @@ If this change is part of a Zebra design, quote and link to the RFC:
 https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
 -->
 
-## Solution
-
-<!--
-Summarize the changes that you want to happen
--->
-
-### Alternatives
-
-<!--
-Are there any alternative solutions?
--->
-
 ## Related Work
 
 <!--


### PR DESCRIPTION
## Motivation

We want developers to do detailed designs and solutions in RFCs and code comments, rather than tickets.

Also this will stop me writing really detailed solutions on tickets 🤭

## Solution

- Remove the solution and alternatives sections from tickets.

This also makes tickets shorter, which is good.

## Review

@mpguerra and I talked about this change today.

