### PR TITLE
Security: Zebra should stop gossiping unreachable addresses to other nodes, Action: re-deploy all nodes

### DIFF
--- a/zebra-chain/src/serialization.rs
+++ b/zebra-chain/src/serialization.rs
@@ -22,7 +22,7 @@ pub mod sha256d;
 pub mod arbitrary;
 
 pub use constraint::AtLeastOne;
-pub use date_time::DateTime32;
+pub use date_time::{DateTime32, Duration32};
 pub use error::SerializationError;
 pub use read_zcash::{canonical_socket_addr, ReadZcashExt};
 pub use write_zcash::WriteZcashExt;

--- a/zebra-chain/src/serialization/date_time.rs
+++ b/zebra-chain/src/serialization/date_time.rs
@@ -117,6 +117,27 @@ impl Duration32 {
     /// The latest possible `Duration32` value.
     pub const MAX: Duration32 = Duration32 { seconds: u32::MAX };
 
+    /// Creates a new [`Duration32`] to represent the given amount of seconds.
+    pub const fn from_seconds(seconds: u32) -> Self {
+        Duration32 { seconds }
+    }
+
+    /// Creates a new [`Duration32`] to represent the given amount of minutes.
+    ///
+    /// If the resulting number of seconds does not fit in a [`u32`], [`Duration32::MAX`] is
+    /// returned.
+    pub const fn from_minutes(minutes: u32) -> Self {
+        Duration32::from_seconds(minutes.saturating_mul(60))
+    }
+
+    /// Creates a new [`Duration32`] to represent the given amount of hours.
+    ///
+    /// If the resulting number of seconds does not fit in a [`u32`], [`Duration32::MAX`] is
+    /// returned.
+    pub const fn from_hours(hours: u32) -> Self {
+        Duration32::from_minutes(hours.saturating_mul(60))
+    }
+
     /// Returns the number of seconds in this duration.
     pub fn seconds(&self) -> u32 {
         self.seconds

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -256,7 +256,8 @@ impl AddressBook {
             None => false,
             // NeverAttempted, Failed, and AttemptPending peers should never be live
             Some(peer) => {
-                peer.last_connection_state == PeerAddrState::Responded && peer.was_recently_live()
+                peer.last_connection_state == PeerAddrState::Responded
+                    && peer.has_connection_recently_responded()
             }
         }
     }
@@ -291,7 +292,7 @@ impl AddressBook {
         // Skip live peers, and peers pending a reconnect attempt, then sort using BTreeSet
         self.by_addr
             .values()
-            .filter(|peer| peer.is_ready_for_attempt())
+            .filter(|peer| peer.is_ready_for_connection_attempt())
             .collect::<BTreeSet<_>>()
             .into_iter()
             .cloned()
@@ -314,7 +315,7 @@ impl AddressBook {
 
         self.by_addr
             .values()
-            .filter(|peer| !peer.is_ready_for_attempt())
+            .filter(|peer| !peer.is_ready_for_connection_attempt())
             .cloned()
     }
 

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -159,6 +159,14 @@ impl AddressBook {
         let mut peers = peers
             .values()
             .filter_map(MetaAddr::sanitize)
+            // Security: remove peers that:
+            //   - last responded more than three hours ago, or
+            //   - haven't responded yet but were reported last seen more than three hours ago
+            //
+            // This prevents Zebra from gossiping nodes that are likely unreachable. Gossiping such
+            // nodes impacts the network health, because connection attempts end up being wasted on
+            // peers that are less likely to respond.
+            .filter(MetaAddr::is_active_for_gossip)
             .collect::<Vec<_>>();
         peers.shuffle(&mut rand::thread_rng());
         peers

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -14,6 +14,9 @@ use zebra_chain::serialization::canonical_socket_addr;
 
 use crate::{meta_addr::MetaAddrChange, types::MetaAddr, PeerAddrState};
 
+#[cfg(test)]
+mod tests;
+
 /// A database of peer listener addresses, their advertised services, and
 /// information on when they were last seen.
 ///

--- a/zebra-network/src/address_book/tests.rs
+++ b/zebra-network/src/address_book/tests.rs
@@ -1,0 +1,1 @@
+mod prop;

--- a/zebra-network/src/address_book/tests/prop.rs
+++ b/zebra-network/src/address_book/tests/prop.rs
@@ -1,0 +1,36 @@
+use std::net::SocketAddr;
+
+use proptest::{collection::vec, prelude::*};
+use tracing::Span;
+
+use zebra_chain::serialization::Duration32;
+
+use super::super::AddressBook;
+use crate::{
+    constants::MAX_PEER_ACTIVE_FOR_GOSSIP,
+    meta_addr::{arbitrary::MAX_META_ADDR, MetaAddr},
+};
+
+const TIME_ERROR_MARGIN: Duration32 = Duration32::from_seconds(1);
+
+proptest! {
+    #[test]
+    fn only_recently_reachable_are_gossiped(
+        local_listener in any::<SocketAddr>(),
+        addresses in vec(any::<MetaAddr>(), 0..MAX_META_ADDR),
+    ) {
+        zebra_test::init();
+
+        let address_book = AddressBook::new_with_addrs(local_listener, Span::none(), addresses);
+
+        for gossiped_address in address_book.sanitized() {
+            let duration_since_last_seen = gossiped_address
+                .last_seen()
+                .expect("Peer that was never seen before is being gossiped")
+                .saturating_elapsed()
+                .saturating_sub(TIME_ERROR_MARGIN);
+
+            prop_assert!(duration_since_last_seen <= MAX_PEER_ACTIVE_FOR_GOSSIP);
+        }
+    }
+}

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -43,7 +43,7 @@ pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(4);
 /// This avoids explicit synchronization, but relies on the peer
 /// connector actually setting up channels and these heartbeats in a
 /// specific manner that matches up with this math.
-pub const LIVE_PEER_DURATION: Duration = Duration::from_secs(60 + 20 + 20 + 20);
+pub const MIN_PEER_RECONNECTION_DELAY: Duration = Duration::from_secs(60 + 20 + 20 + 20);
 
 /// Regular interval for sending keepalive `Ping` messages to each
 /// connected peer.
@@ -170,7 +170,7 @@ mod tests {
     use super::*;
 
     /// This assures that the `Duration` value we are computing for
-    /// LIVE_PEER_DURATION actually matches the other const values it
+    /// MIN_PEER_RECONNECTION_DELAY actually matches the other const values it
     /// relies on.
     #[test]
     fn ensure_live_peer_duration_value_matches_others() {
@@ -179,7 +179,7 @@ mod tests {
         let constructed_live_peer_duration =
             HEARTBEAT_INTERVAL + REQUEST_TIMEOUT + REQUEST_TIMEOUT + REQUEST_TIMEOUT;
 
-        assert_eq!(LIVE_PEER_DURATION, constructed_live_peer_duration);
+        assert_eq!(MIN_PEER_RECONNECTION_DELAY, constructed_live_peer_duration);
     }
 
     /// Make sure that the timeout values are consistent with each other.

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 // XXX should these constants be split into protocol also?
 use crate::protocol::external::types::*;
 
-use zebra_chain::parameters::NetworkUpgrade;
+use zebra_chain::{parameters::NetworkUpgrade, serialization::Duration32};
 
 /// The buffer size for the peer set.
 ///
@@ -44,6 +44,18 @@ pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(4);
 /// connector actually setting up channels and these heartbeats in a
 /// specific manner that matches up with this math.
 pub const MIN_PEER_RECONNECTION_DELAY: Duration = Duration::from_secs(60 + 20 + 20 + 20);
+
+/// The maximum duration since a peer was last seen to consider it reachable.
+///
+/// This is used to prevent Zebra from gossiping networks that are likely unreachable. Peers that
+/// have last been seen more than this duration ago will not be gossiped.
+///
+/// This is determined as a tradeoff between network health and network view leakage. From the
+/// [Bitcoin protocol documentation](https://en.bitcoin.it/wiki/Protocol_documentation#getaddr):
+///
+/// "The typical presumption is that a node is likely to be active if it has been sending a message
+/// within the last three hours."
+pub const MAX_PEER_ACTIVE_FOR_GOSSIP: Duration32 = Duration32::from_hours(3);
 
 /// Regular interval for sending keepalive `Ping` messages to each
 /// connected peer.

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -47,7 +47,7 @@ pub const MIN_PEER_RECONNECTION_DELAY: Duration = Duration::from_secs(60 + 20 + 
 
 /// The maximum duration since a peer was last seen to consider it reachable.
 ///
-/// This is used to prevent Zebra from gossiping networks that are likely unreachable. Peers that
+/// This is used to prevent Zebra from gossiping addresses that are likely unreachable. Peers that
 /// have last been seen more than this duration ago will not be gossiped.
 ///
 /// This is determined as a tradeoff between network health and network view leakage. From the

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -28,7 +28,7 @@ use proptest_derive::Arbitrary;
 #[cfg(any(test, feature = "proptest-impl"))]
 use zebra_chain::serialization::arbitrary::canonical_socket_addr_strategy;
 #[cfg(any(test, feature = "proptest-impl"))]
-mod arbitrary;
+pub(crate) mod arbitrary;
 
 #[cfg(test)]
 mod tests;

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -438,8 +438,7 @@ impl MetaAddr {
             // Recent times and future times are considered live.
             // Instants are monotonic, so `now` should always be later than `last_attempt`,
             // except for synthetic data in tests.
-            Instant::now().saturating_duration_since(last_attempt)
-                <= constants::MIN_PEER_RECONNECTION_DELAY
+            last_attempt.elapsed() <= constants::MIN_PEER_RECONNECTION_DELAY
         } else {
             // If there has never been any attempt, it can't possibly be live
             false
@@ -452,8 +451,7 @@ impl MetaAddr {
     pub fn has_connection_recently_failed(&self) -> bool {
         if let Some(last_failure) = self.last_failure {
             // Recent times and future times are considered live
-            Instant::now().saturating_duration_since(last_failure)
-                <= constants::MIN_PEER_RECONNECTION_DELAY
+            last_failure.elapsed() <= constants::MIN_PEER_RECONNECTION_DELAY
         } else {
             // If there has never been any failure, it can't possibly be recent
             false

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -458,6 +458,25 @@ impl MetaAddr {
         }
     }
 
+    /// Has this peer been seen recently?
+    ///
+    /// Returns `true` if this peer has responded recently or if the peer was gossiped with a
+    /// recent reported last seen time.
+    ///
+    /// [`constants::MAX_PEER_ACTIVE_FOR_GOSSIP`] represents the maximum time since a peer was seen
+    /// to still be considered reachable.
+    pub fn is_active_for_gossip(&self) -> bool {
+        if let Some(last_seen) = self.last_seen() {
+            // Correctness: `last_seen` shouldn't ever be in the future, either because we set the
+            // time or because another peer's future time was sanitized when it was added to the
+            // address book
+            last_seen.saturating_elapsed() <= constants::MAX_PEER_ACTIVE_FOR_GOSSIP
+        } else {
+            // Peer has never responded and does not have a gossiped last seen time
+            false
+        }
+    }
+
     /// Is this address ready for a new outbound connection attempt?
     pub fn is_ready_for_connection_attempt(&self) -> bool {
         self.last_known_info_is_valid_for_outbound()

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -539,6 +539,16 @@ impl MetaAddr {
     }
 }
 
+#[cfg(test)]
+impl MetaAddr {
+    /// Forcefully change the time this peer last responded.
+    ///
+    /// This method is for test-purposes only.
+    pub(crate) fn set_last_response(&mut self, last_response: DateTime32) {
+        self.last_response = Some(last_response);
+    }
+}
+
 impl MetaAddrChange {
     /// Return the address for this change.
     pub fn addr(&self) -> SocketAddr {

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -133,3 +133,21 @@ fn gossiped_peer_reportedly_seen_long_ago_is_not_gossipable() {
 
     assert!(!peer.is_active_for_gossip());
 }
+
+/// Test that peer that has just responded is gossipable.
+#[test]
+fn recently_responded_peer_is_gossipable() {
+    zebra_test::init();
+
+    let address = SocketAddr::from(([192, 168, 180, 9], 10_000));
+    let peer_seed = MetaAddr::new_alternate(&address, &PeerServices::NODE_NETWORK)
+        .into_new_meta_addr()
+        .expect("MetaAddrChange can't create a new MetaAddr");
+
+    // Create a peer that has responded
+    let peer = MetaAddr::new_responded(&address, &PeerServices::NODE_NETWORK)
+        .apply_to_meta_addr(peer_seed)
+        .expect("Failed to create MetaAddr for responded peer");
+
+    assert!(peer.is_active_for_gossip());
+}

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -113,3 +113,23 @@ fn gossiped_peer_reportedly_seen_in_the_future_is_gossipable() {
 
     assert!(peer.is_active_for_gossip());
 }
+
+/// Test if gossiped peer that was reported last seen a long time ago is not gossipable.
+#[test]
+fn gossiped_peer_reportedly_seen_long_ago_is_not_gossipable() {
+    zebra_test::init();
+
+    let address = SocketAddr::from(([192, 168, 180, 9], 10_000));
+
+    // Report last seen just outside the reachable interval.
+    let offset = MAX_PEER_ACTIVE_FOR_GOSSIP
+        .checked_add(TEST_TIME_ERROR_MARGIN)
+        .expect("Test margin is too large");
+    let last_seen = DateTime32::now()
+        .checked_sub(offset)
+        .expect("Offset is too large");
+
+    let peer = MetaAddr::new_gossiped_meta_addr(address, PeerServices::NODE_NETWORK, last_seen);
+
+    assert!(!peer.is_active_for_gossip());
+}

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -96,3 +96,20 @@ fn gossiped_peer_reportedly_to_be_seen_recently_is_gossipable() {
 
     assert!(peer.is_active_for_gossip());
 }
+
+/// Test if received gossiped peer that was reportedly last seen in the future is gossipable.
+#[test]
+fn gossiped_peer_reportedly_seen_in_the_future_is_gossipable() {
+    zebra_test::init();
+
+    let address = SocketAddr::from(([192, 168, 180, 9], 10_000));
+
+    // Report last seen in the future
+    let last_seen = DateTime32::now()
+        .checked_add(MAX_PEER_ACTIVE_FOR_GOSSIP)
+        .expect("Reachable peer duration is too large");
+
+    let peer = MetaAddr::new_gossiped_meta_addr(address, PeerServices::NODE_NETWORK, last_seen);
+
+    assert!(peer.is_active_for_gossip());
+}

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -40,6 +40,21 @@ fn sanitize_extremes() {
     }
 }
 
+/// Test if a newly created local listening address is gossipable.
+///
+/// The local listener [`MetaAddr`] is always considered gossipable.
+#[test]
+fn new_local_listener_is_gossipable() {
+    zebra_test::init();
+
+    let address = SocketAddr::from(([192, 168, 180, 9], 10_000));
+    let peer = MetaAddr::new_local_listener_change(&address)
+        .into_new_meta_addr()
+        .expect("MetaAddrChange can't create a new MetaAddr");
+
+    assert!(peer.is_active_for_gossip());
+}
+
 /// Test if a recently received alternate peer address is not gossipable.
 ///
 /// Such [`MetaAddr`] is only considered gossipable after Zebra has tried to connect to it and

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -2,10 +2,16 @@
 
 use std::net::SocketAddr;
 
-use zebra_chain::serialization::Duration32;
+use zebra_chain::serialization::{DateTime32, Duration32};
 
 use super::{super::MetaAddr, check};
-use crate::protocol::types::PeerServices;
+use crate::{constants::MAX_PEER_ACTIVE_FOR_GOSSIP, protocol::types::PeerServices};
+
+/// Margin of error for time-based tests.
+///
+/// This is a short duration to consider as error due to a test's execution time when comparing
+/// [`DateTime32`]s.
+const TEST_TIME_ERROR_MARGIN: Duration32 = Duration32::from_seconds(1);
 
 /// Make sure that the sanitize function handles minimum and maximum times.
 #[test]
@@ -69,4 +75,24 @@ fn new_alternate_peer_address_is_not_gossipable() {
         .expect("MetaAddrChange can't create a new MetaAddr");
 
     assert!(!peer.is_active_for_gossip());
+}
+
+/// Test if recently received gossiped peer is gossipable.
+#[test]
+fn gossiped_peer_reportedly_to_be_seen_recently_is_gossipable() {
+    zebra_test::init();
+
+    let address = SocketAddr::from(([192, 168, 180, 9], 10_000));
+
+    // Report last seen within the reachable interval.
+    let offset = MAX_PEER_ACTIVE_FOR_GOSSIP
+        .checked_sub(TEST_TIME_ERROR_MARGIN)
+        .expect("Test margin is too large");
+    let last_seen = DateTime32::now()
+        .checked_sub(offset)
+        .expect("Offset is too large");
+
+    let peer = MetaAddr::new_gossiped_meta_addr(address, PeerServices::NODE_NETWORK, last_seen);
+
+    assert!(peer.is_active_for_gossip());
 }

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -179,3 +179,31 @@ fn not_so_recently_responded_peer_is_still_gossipable() {
 
     assert!(peer.is_active_for_gossip());
 }
+
+/// Test that peer that responded long ago is not gossipable.
+#[test]
+fn responded_long_ago_peer_is_not_gossipable() {
+    zebra_test::init();
+
+    let address = SocketAddr::from(([192, 168, 180, 9], 10_000));
+    let peer_seed = MetaAddr::new_alternate(&address, &PeerServices::NODE_NETWORK)
+        .into_new_meta_addr()
+        .expect("MetaAddrChange can't create a new MetaAddr");
+
+    // Create a peer that has responded
+    let mut peer = MetaAddr::new_responded(&address, &PeerServices::NODE_NETWORK)
+        .apply_to_meta_addr(peer_seed)
+        .expect("Failed to create MetaAddr for responded peer");
+
+    // Tweak the peer's last response time to be outside the limits of the reachable duration
+    let offset = MAX_PEER_ACTIVE_FOR_GOSSIP
+        .checked_add(TEST_TIME_ERROR_MARGIN)
+        .expect("Test margin is too large");
+    let last_response = DateTime32::now()
+        .checked_sub(offset)
+        .expect("Offset is too large");
+
+    peer.set_last_response(last_response);
+
+    assert!(!peer.is_active_for_gossip());
+}

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -1,6 +1,11 @@
 //! Test vectors for MetaAddr.
 
+use std::net::SocketAddr;
+
+use zebra_chain::serialization::Duration32;
+
 use super::{super::MetaAddr, check};
+use crate::protocol::types::PeerServices;
 
 /// Make sure that the sanitize function handles minimum and maximum times.
 #[test]
@@ -33,4 +38,20 @@ fn sanitize_extremes() {
     if let Some(max_sanitized) = max_time_entry.sanitize() {
         check::sanitize_avoids_leaks(&max_time_entry, &max_sanitized);
     }
+}
+
+/// Test if a recently received alternate peer address is not gossipable.
+///
+/// Such [`MetaAddr`] is only considered gossipable after Zebra has tried to connect to it and
+/// confirmed that the address is reachable.
+#[test]
+fn new_alternate_peer_address_is_not_gossipable() {
+    zebra_test::init();
+
+    let address = SocketAddr::from(([192, 168, 180, 9], 10_000));
+    let peer = MetaAddr::new_alternate(&address, &PeerServices::NODE_NETWORK)
+        .into_new_meta_addr()
+        .expect("MetaAddrChange can't create a new MetaAddr");
+
+    assert!(!peer.is_active_for_gossip());
 }

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -70,7 +70,7 @@ mod tests;
 /// ││        ▼                                                      ││
 /// ││        Λ                                                      ││
 /// ││       ╱ ╲              filter by                              ││
-/// ││      ▕   ▏        is_ready_for_attempt                        ││
+/// ││      ▕   ▏        is_ready_for_connection_attempt             ││
 /// ││       ╲ ╱    to remove recent `Responded`,                    ││
 /// ││        V  `AttemptPending`, and `Failed` peers                ││
 /// ││        │                                                      ││


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
Zebra was relay all the nodes it knew about, even those that had not been seen in a while (or had never been seen). This leads to propagating peers that are likely unreachable, and can impact the network by wasting connection attempts.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->
"The typical presumption is that a node is likely to be active if it has been sending a message within the last three hours."

https://en.bitcoin.it/wiki/Protocol_documentation#getaddr

This time period is a network health / network view leakage design tradeoff.

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
The solution was outlined in #1867. The summary is to change `AddressBook::sanitized` to filter out `MetaAddr`s that have a `last_seen()` time more than 3 hours ago (stored in a `REACHABLE_PEER_DURATION` constant).

`MetaAddr::last_seen()` returns the time a last response was received. If no response has ever been received, then it returns the untrusted last seen time reported by another peer. If that returned time is more than three hours ago, or if the peer has no `last_seen` time, it is removed from the returned list of peers.

Last seen times in the future shouldn't happen, either because we set the time to `now()` at some point, or because the `MetaAddr`'s reported last seen time is sanitized to not be in the future before it is added to the address book. The current solution uses `saturating_elapsed` which means that if a future time is returned for some reason, it is considered reachable.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 should review this PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
