### PR TITLE
Support a minimum protocol version during initial block download

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -100,19 +100,25 @@ pub const USER_AGENT: &str = "/Zebra:1.0.0-alpha.11/";
 /// during connection setup.
 ///
 /// The current protocol version is checked by our peers. If it is too old,
-/// newer peers will refuse to connect to us.
+/// newer peers will disconnect from us.
 ///
 /// The current protocol version typically changes before Mainnet and Testnet
 /// network upgrades.
-pub const CURRENT_VERSION: Version = Version(170_013);
+pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_013);
 
-/// The most recent bilateral consensus upgrade implemented by this crate.
+/// The minimum network protocol version accepted by this crate for each network,
+/// represented as a network upgrade.
 ///
-/// The minimum network upgrade is used to check the protocol versions of our
-/// peers. If their versions are too old, we will disconnect from them.
-//
-// TODO: replace with NetworkUpgrade::current(network, height). (#1334)
-pub const MIN_NETWORK_UPGRADE: NetworkUpgrade = NetworkUpgrade::Canopy;
+/// The minimum protocol version is used to check the protocol versions of our
+/// peers during the initial block download. After the intial block download,
+/// we use the current block height to select the minimum network protocol
+/// version.
+///
+/// If peer versions are too old, we will disconnect from them.
+///
+/// The minimum network protocol version typically changes after Mainnet network
+/// upgrades.
+pub const INITIAL_MIN_NETWORK_PROTOCOL_VERSION: NetworkUpgrade = NetworkUpgrade::Canopy;
 
 /// The default RTT estimate for peer responses.
 ///

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -54,7 +54,7 @@ impl Codec {
     pub fn builder() -> Builder {
         Builder {
             network: Network::Mainnet,
-            version: constants::CURRENT_VERSION,
+            version: constants::CURRENT_NETWORK_PROTOCOL_VERSION,
             max_len: MAX_PROTOCOL_MESSAGE_LEN,
             metrics_addr_label: None,
         }
@@ -650,7 +650,7 @@ mod tests {
             let services = PeerServices::NODE_NETWORK;
             let timestamp = Utc.timestamp(1_568_000_000, 0);
             Message::Version {
-                version: crate::constants::CURRENT_VERSION,
+                version: crate::constants::CURRENT_NETWORK_PROTOCOL_VERSION,
                 services,
                 timestamp,
                 address_recv: (

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -64,13 +64,19 @@ impl Version {
     }
 
     /// Returns the minimum supported network protocol version for `network`.
-    /// This is the minimum peer version during initial block download.
+    ///
+    /// This is the minimum peer version when Zebra is significantly behind current tip:
+    /// - during the initial block download,
+    /// - after Zebra restarts, and
+    /// - after Zebra's local network is slow or shut down.
     fn initial_min_for_network(network: Network) -> Version {
         Version::min_specified_for_upgrade(network, constants::INITIAL_MIN_NETWORK_PROTOCOL_VERSION)
     }
 
     /// Returns the minimum specified network protocol version for `network` and
-    /// `height`. This is the minimum peer version after initial block download.
+    /// `height`.
+    ///
+    /// This is the minimum peer version when Zebra is close to the current tip.
     fn min_specified_for_height(network: Network, height: block::Height) -> Version {
         let network_upgrade = NetworkUpgrade::current(network, height);
         Version::min_specified_for_upgrade(network, network_upgrade)

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -84,7 +84,7 @@ impl Version {
 
     /// Returns the minimum specified network protocol version for `network` and
     /// `network_upgrade`.
-    fn min_specified_for_upgrade(network: Network, network_upgrade: NetworkUpgrade) -> Self {
+    fn min_specified_for_upgrade(network: Network, network_upgrade: NetworkUpgrade) -> Version {
         // TODO: Should we reject earlier protocol versions during our initial
         //       sync? zcashd accepts 170_002 or later during its initial sync.
         Version(match (network, network_upgrade) {


### PR DESCRIPTION
## Motivation

Before we implement #1334 and #2262, we need to support a minimum network protocol during the initial block download.

This PR implements common code for both tickets, but doesn't close either of them.

### Specifications

> For each network (testnet and mainnet), nodes compatible with NU5 activation on that network MUST advertise a network protocol version that is greater than or equal to that network's MIN_NETWORK_PROTOCOL_VERSION (NU5).
> 
> For each network, pre-NU5 nodes are defined as nodes advertising a protocol version less than that network's MIN_NETWORK_PROTOCOL_VERSION (NU5).
> 
> Once NU5 activates on testnet or mainnet, NU5 nodes SHOULD take steps to:
> 
> - reject new connections from pre-NU5 nodes on that network;
> - disconnect any existing connections to pre-NU5 nodes on that network.

https://zips.z.cash/zip-0252#nu5-deployment

> The minimum peer protocol version that NU5-compatible Zebra nodes will connect to is 170002. However, Zebra will immediately disconnect from nodes with a protocol version less than:
> - 170012 on testnet, or
> - 170013 on mainnet.

https://zips.z.cash/zip-0252#backward-compatibility-in-zebra

## Solution

- add a `min_remote_for_height` function that takes a state block height and network, and returns the minimum remote protocol version for that height
  - panic if Zebra doesn't implement its own minimum network protocol version
- add a `initial_min_for_network` function that takes a network, and returns the absolute minimum remote protocol version for the initial block download
- rename some methods and constants
- improve documentation

But don't actually use the state height yet.

The current tests should provide decent coverage for these changes.

## Review

@jvff or @oxarbitrage can review these changes. This change isn't urgent, I can make draft PRs for the follow-up work.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Implement the rest of #1334 and #2262.