### PR TITLE
Update `has_inputs_and_outputs()` for new consensus rules

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -483,4 +483,14 @@ impl Transaction {
             .map(orchard::ShieldedData::nullifiers)
             .flatten()
     }
+
+    /// Access the [`orchard::Flags`] in this transaction, if there is any,
+    /// regardless of version.
+    pub fn orchard_flags(&self) -> Option<orchard::shielded_data::Flags> {
+        if let Some(orchard_shielded_data) = self.orchard_shielded_data() {
+            Some(orchard_shielded_data.flags)
+        } else {
+            None
+        }
+    }
 }

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -487,10 +487,7 @@ impl Transaction {
     /// Access the [`orchard::Flags`] in this transaction, if there is any,
     /// regardless of version.
     pub fn orchard_flags(&self) -> Option<orchard::shielded_data::Flags> {
-        if let Some(orchard_shielded_data) = self.orchard_shielded_data() {
-            Some(orchard_shielded_data.flags)
-        } else {
-            None
-        }
+        self.orchard_shielded_data()
+            .map(|orchard_shielded_data| orchard_shielded_data.flags)
     }
 }

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -32,7 +32,7 @@ pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> 
     let n_spends_sapling = tx.sapling_spends_per_anchor().count();
     let n_outputs_sapling = tx.sapling_outputs().count();
     let n_actions_orchard = tx.orchard_actions().count();
-    let flags_orchard = tx.orchard_flags().unwrap_or(Flags::empty());
+    let flags_orchard = tx.orchard_flags().unwrap_or_else(Flags::empty);
 
     if tx_in_count
         + n_spends_sapling

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -34,6 +34,7 @@ pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> 
     let n_actions_orchard = tx.orchard_actions().count();
     let flags_orchard = tx.orchard_flags().unwrap_or_else(Flags::empty);
 
+    // TODO: Improve the code to express the spec rules better #2410.
     if tx_in_count
         + n_spends_sapling
         + n_joinsplit

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -86,13 +86,14 @@ fn fake_v5_transaction_with_orchard_actions_has_inputs_and_outputs() {
     // guaranteed structurally by `orchard::ShieldedData`)
     insert_fake_orchard_shielded_data(&mut transaction);
 
-    // The check will fail if it haves no flags
+    // The check will fail if the transaction has no flags
     assert_eq!(
         check::has_inputs_and_outputs(&transaction),
         Err(TransactionError::NoInputs)
     );
 
     // If we add ENABLE_SPENDS flag it will pass the inputs check but fails with the outputs
+    // TODO: Avoid new calls to `insert_fake_orchard_shielded_data` for each check #2409.
     let shielded_data = insert_fake_orchard_shielded_data(&mut transaction);
     shielded_data.flags = orchard::Flags::ENABLE_SPENDS;
 

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -86,8 +86,34 @@ fn fake_v5_transaction_with_orchard_actions_has_inputs_and_outputs() {
     // guaranteed structurally by `orchard::ShieldedData`)
     insert_fake_orchard_shielded_data(&mut transaction);
 
-    // If a transaction has at least one Orchard shielded action, it should be considered to have
-    // inputs and/or outputs
+    // The check will fail if it haves no flags
+    assert_eq!(
+        check::has_inputs_and_outputs(&transaction),
+        Err(TransactionError::NoInputs)
+    );
+
+    // If we add ENABLE_SPENDS flag it will pass the inputs check but fails with the outputs
+    let shielded_data = insert_fake_orchard_shielded_data(&mut transaction);
+    shielded_data.flags = orchard::Flags::ENABLE_SPENDS;
+
+    assert_eq!(
+        check::has_inputs_and_outputs(&transaction),
+        Err(TransactionError::NoOutputs)
+    );
+
+    // If we add ENABLE_OUTPUTS flag it will pass the outputs check but fails with the inputs
+    let shielded_data = insert_fake_orchard_shielded_data(&mut transaction);
+    shielded_data.flags = orchard::Flags::ENABLE_OUTPUTS;
+
+    assert_eq!(
+        check::has_inputs_and_outputs(&transaction),
+        Err(TransactionError::NoInputs)
+    );
+
+    // Finally make it valid by adding both required flags
+    let shielded_data = insert_fake_orchard_shielded_data(&mut transaction);
+    shielded_data.flags = orchard::Flags::ENABLE_SPENDS | orchard::Flags::ENABLE_OUTPUTS;
+
     assert!(check::has_inputs_and_outputs(&transaction).is_ok());
 }
 


### PR DESCRIPTION
## Motivation

We need to update Zebra for new consensus rules added to the protocol in regards to orchard flags. Closes https://github.com/ZcashFoundation/zebra/issues/2365

### Specifications

* At least one of `tx_in_count`, `nSpendsSapling`, and `nJoinSplit` MUST be non-zero.
* At least one of `tx_out_count`, `nOutputsSapling`, and `nJoinSplit` MUST be non-zero.
* This condition must hold: `tx_in_count` > 0 or `nSpendsSapling` > 0 or (`nActionsOrchard` > 0 and `enableSpendsOrchard` = 1)
* This condition must hold: `tx_out_count` > 0 or `nOutputsSapling` > 0 or (`nActionsOrchard` > 0 and `enableOutputsOrchard` = 1)

https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus

## Solution

Add the new consensus rules into the `has_inputs_and_outputs` function, update the tests to cover them.

## Review

Anyone can review the code initially, before merging @teor2345 should take a look.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
