### PR TITLE
ZIP-211: Validate Disabling Addition of New Value to the Sprout Value Pool

### DIFF
--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, Duration, Utc};
 ///
 /// Network upgrades can change the Zcash network protocol or consensus rules in
 /// incompatible ways.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum NetworkUpgrade {
     /// The Zcash protocol for a Genesis block.
     ///

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, Duration, Utc};
 ///
 /// Network upgrades can change the Zcash network protocol or consensus rules in
 /// incompatible ways.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum NetworkUpgrade {
     /// The Zcash protocol for a Genesis block.
     ///

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -295,7 +295,10 @@ impl Transaction {
     }
 
     /// Returns the `vpub_old` fields from `JoinSplit`s in this transaction, regardless of version.
-    pub fn sprout_pool(
+    ///
+    /// This value is removed from the transparent value pool of this transaction, and added to the
+    /// sprout value pool.
+    pub fn sprout_pool_added_values(
         &self,
     ) -> Box<dyn Iterator<Item = &amount::Amount<amount::NonNegative>> + '_> {
         match self {

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -81,6 +81,9 @@ pub enum TransactionError {
     // temporary error type until #1186 is fixed
     #[error("Downcast from BoxError to redjubjub::Error failed")]
     InternalDowncastError(String),
+
+    #[error("sprout pool can't be used after Canopy")]
+    DisabledSproutPool,
 }
 
 impl From<BoxError> for TransactionError {

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -82,8 +82,8 @@ pub enum TransactionError {
     #[error("Downcast from BoxError to redjubjub::Error failed")]
     InternalDowncastError(String),
 
-    #[error("sprout pool can't be used after Canopy")]
-    DisabledSproutPool,
+    #[error("adding to the sprout pool is disabled after Canopy")]
+    DisabledAddToSproutPool,
 }
 
 impl From<BoxError> for TransactionError {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -169,6 +169,12 @@ where
                 check::coinbase_tx_no_prevout_joinsplit_spend(&tx)?;
             }
 
+            // [Canopy onward]: `vpub_old` MUST be zero.
+            // https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc
+            if req.upgrade(network) >= NetworkUpgrade::Canopy {
+                check::disabled_sprout_pool(&tx)?;
+            }
+
             // "The consensus rules applied to valueBalance, vShieldedOutput, and bindingSig
             // in non-coinbase transactions MUST also be applied to coinbase transactions."
             //

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -176,7 +176,11 @@ where
 
             // [Canopy onward]: `vpub_old` MUST be zero.
             // https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc
-            if req.upgrade(network) >= NetworkUpgrade::Canopy {
+            if req.height()
+                >= NetworkUpgrade::Canopy
+                    .activation_height(network)
+                    .expect("Canopy activation height must be present for both networks")
+            {
                 check::disabled_sprout_pool(&tx)?;
             }
 

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -176,13 +176,7 @@ where
 
             // [Canopy onward]: `vpub_old` MUST be zero.
             // https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc
-            if req.height()
-                >= NetworkUpgrade::Canopy
-                    .activation_height(network)
-                    .expect("Canopy activation height must be present for both networks")
-            {
-                check::disabled_sprout_pool(&tx)?;
-            }
+            check::disabled_add_to_sprout_pool(&tx, req.height(), network)?;
 
             // "The consensus rules applied to valueBalance, vShieldedOutput, and bindingSig
             // in non-coinbase transactions MUST also be applied to coinbase transactions."

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -120,7 +120,7 @@ pub fn output_cv_epk_not_small_order(output: &Output) -> Result<(), TransactionE
 pub fn disabled_sprout_pool(tx: &Transaction) -> Result<(), TransactionError> {
     let zero = Amount::<NonNegative>::try_from(0).expect("an amount of 0");
 
-    let tx_sprout_pool = tx.sprout_pool();
+    let tx_sprout_pool = tx.sprout_pool_added_values();
     for vpub_old in tx_sprout_pool {
         if *vpub_old != zero {
             return Err(TransactionError::DisabledSproutPool);

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -123,7 +123,7 @@ pub fn disabled_sprout_pool(tx: &Transaction) -> Result<(), TransactionError> {
     let tx_sprout_pool = tx.sprout_pool_added_values();
     for vpub_old in tx_sprout_pool {
         if *vpub_old != zero {
-            return Err(TransactionError::DisabledSproutPool);
+            return Err(TransactionError::DisabledAddToSproutPool);
         }
     }
 

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -118,7 +118,7 @@ pub fn output_cv_epk_not_small_order(output: &Output) -> Result<(), TransactionE
 /// https://zips.z.cash/zip-0211
 /// https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc
 pub fn disabled_sprout_pool(tx: &Transaction) -> Result<(), TransactionError> {
-    let zero = Amount::<NonNegative>::try_from(0).expect("an amount of 0");
+    let zero = Amount::<NonNegative>::try_from(0).expect("an amount of 0 is always valid");
 
     let tx_sprout_pool = tx.sprout_pool_added_values();
     for vpub_old in tx_sprout_pool {

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -705,7 +705,7 @@ fn add_to_sprout_pool_after_nu() {
         Err(TransactionError::DisabledAddToSproutPool)
     );
 
-    // the 8th transaction of the same block has joinsplits and `vpub_old` is 0,
+    // the 8th transaction has joinsplits and the `vpub_old` cumulative is 0,
     // should pass the check.
     assert!(block.transactions[7].joinsplit_count() > 0);
     let vpub_old: Amount<NonNegative> = block.transactions[7]

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -660,3 +660,24 @@ fn mock_sprout_join_split_data() -> (JoinSplitData<Groth16Proof>, ed25519::Signi
 
     (joinsplit_data, signing_key)
 }
+
+#[test]
+fn empty_sprout_pool_after_nu() {
+    zebra_test::init();
+
+    // get a block that we know it haves a transaction with `vpub_old` field greater than 0.
+    let block: Arc<_> = zebra_chain::block::Block::zcash_deserialize(
+        &zebra_test::vectors::BLOCK_MAINNET_419199_BYTES[..],
+    )
+    .unwrap()
+    .into();
+
+    // we know the 4th transaction of this block has the`vpub_old` field greater than 0.
+    assert_eq!(
+        check::disabled_sprout_pool(&block.transactions[3]),
+        Err(TransactionError::DisabledSproutPool)
+    );
+
+    // we know the in the 1st transaction of the same block, the `vpub_old` field is 0.
+    assert_eq!(check::disabled_sprout_pool(&block.transactions[0]), Ok(()));
+}

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -675,7 +675,7 @@ fn empty_sprout_pool_after_nu() {
     // we know the 4th transaction of this block has the`vpub_old` field greater than 0.
     assert_eq!(
         check::disabled_sprout_pool(&block.transactions[3]),
-        Err(TransactionError::DisabledSproutPool)
+        Err(TransactionError::DisabledAddToSproutPool)
     );
 
     // we know the in the 1st transaction of the same block, the `vpub_old` field is 0.

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -662,7 +662,7 @@ fn mock_sprout_join_split_data() -> (JoinSplitData<Groth16Proof>, ed25519::Signi
 }
 
 #[test]
-fn empty_sprout_pool_after_nu() {
+fn add_to_sprout_pool_after_nu() {
     zebra_test::init();
 
     // get a block that we know it haves a transaction with `vpub_old` field greater than 0.
@@ -672,14 +672,21 @@ fn empty_sprout_pool_after_nu() {
     .unwrap()
     .into();
 
+    // create a block height at canopy activation
+    let network = Network::Mainnet;
+    let block_height = NetworkUpgrade::Canopy.activation_height(network).unwrap();
+
     // we know the 4th transaction of this block has the`vpub_old` field greater than 0.
     assert_eq!(
-        check::disabled_sprout_pool(&block.transactions[3]),
+        check::disabled_add_to_sprout_pool(&block.transactions[3], block_height, network),
         Err(TransactionError::DisabledAddToSproutPool)
     );
 
     // we know the in the 2nd transaction of the same block, the `vpub_old` field is 0.
     // we don't use the 1st transaction as coinbase transactions are not allowed to have
     // any sprout joinsplits.
-    assert_eq!(check::disabled_sprout_pool(&block.transactions[1]), Ok(()));
+    assert_eq!(
+        check::disabled_add_to_sprout_pool(&block.transactions[1], block_height, network),
+        Ok(())
+    );
 }

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, convert::TryFrom, convert::TryInto, sync::Arc};
 use tower::{service_fn, ServiceExt};
 
 use zebra_chain::{
-    amount::Amount,
+    amount::{Amount, NonNegative},
     block, orchard,
     parameters::{Network, NetworkUpgrade},
     primitives::{ed25519, x25519, Groth16Proof},
@@ -672,21 +672,49 @@ fn add_to_sprout_pool_after_nu() {
     .unwrap()
     .into();
 
-    // create a block height at canopy activation
+    // create a block height at canopy activation.
     let network = Network::Mainnet;
     let block_height = NetworkUpgrade::Canopy.activation_height(network).unwrap();
 
-    // we know the 4th transaction of this block has the`vpub_old` field greater than 0.
+    // create a zero amount.
+    let zero = Amount::<NonNegative>::try_from(0).expect("an amount of 0 is always valid");
+
+    // the coinbase transaction should pass the check.
+    assert_eq!(
+        check::disabled_add_to_sprout_pool(&block.transactions[0], block_height, network),
+        Ok(())
+    );
+
+    // the 2nd transaction has no joinsplits, should pass the check.
+    assert_eq!(block.transactions[1].joinsplit_count(), 0);
+    assert_eq!(
+        check::disabled_add_to_sprout_pool(&block.transactions[1], block_height, network),
+        Ok(())
+    );
+
+    // the 5th transaction has joinsplits and the `vpub_old` cumulative is greater than 0,
+    // should fail the check.
+    assert!(block.transactions[4].joinsplit_count() > 0);
+    let vpub_old: Amount<NonNegative> = block.transactions[4]
+        .sprout_pool_added_values()
+        .fold(zero, |acc, &x| (acc + x).unwrap());
+    assert!(vpub_old > zero);
+
     assert_eq!(
         check::disabled_add_to_sprout_pool(&block.transactions[3], block_height, network),
         Err(TransactionError::DisabledAddToSproutPool)
     );
 
-    // we know the in the 2nd transaction of the same block, the `vpub_old` field is 0.
-    // we don't use the 1st transaction as coinbase transactions are not allowed to have
-    // any sprout joinsplits.
+    // the 8th transaction of the same block has joinsplits and `vpub_old` is 0,
+    // should pass the check.
+    assert!(block.transactions[7].joinsplit_count() > 0);
+    let vpub_old: Amount<NonNegative> = block.transactions[7]
+        .sprout_pool_added_values()
+        .fold(zero, |acc, &x| (acc + x).unwrap());
+    assert_eq!(vpub_old, zero);
+
     assert_eq!(
-        check::disabled_add_to_sprout_pool(&block.transactions[1], block_height, network),
+        check::disabled_add_to_sprout_pool(&block.transactions[7], block_height, network),
         Ok(())
     );
 }

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -678,6 +678,8 @@ fn empty_sprout_pool_after_nu() {
         Err(TransactionError::DisabledAddToSproutPool)
     );
 
-    // we know the in the 1st transaction of the same block, the `vpub_old` field is 0.
-    assert_eq!(check::disabled_sprout_pool(&block.transactions[0]), Ok(()));
+    // we know the in the 2nd transaction of the same block, the `vpub_old` field is 0.
+    // we don't use the 1st transaction as coinbase transactions are not allowed to have
+    // any sprout joinsplits.
+    assert_eq!(check::disabled_sprout_pool(&block.transactions[1]), Ok(()));
 }


### PR DESCRIPTION
## Motivation

We need to add the disabled sprout pool consensus rule. Resolves https://github.com/ZcashFoundation/zebra/issues/1564 when merged.

### Specifications

https://zips.z.cash/zip-0211
https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc

## Solution

Implement the rule, add a test. The test can be improved.

## Review

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
