### PR TITLE
Add a verification height to mempool transaction verification requests

### DIFF
--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -82,21 +82,22 @@ pub enum Request {
         transaction: Arc<Transaction>,
         /// Additional UTXOs which are known at the time of verification.
         known_utxos: Arc<HashMap<transparent::OutPoint, zs::Utxo>>,
-        /// The height of the block containing this transaction, used to
-        /// determine the applicable network upgrade.
+        /// The height of the block containing this transaction.
         height: block::Height,
     },
     /// Verify the supplied transaction as part of the mempool.
+    ///
+    /// Mempool transactions do not have any additional UTXOs.
     ///
     /// Note: coinbase transactions are invalid in the mempool
     Mempool {
         /// The transaction itself.
         transaction: Arc<Transaction>,
-        /// Additional UTXOs which are known at the time of verification.
-        known_utxos: Arc<HashMap<transparent::OutPoint, zs::Utxo>>,
-        /// Bug: this field should be the next block height, because some
-        /// consensus rules depend on the exact height. See #1683.
-        upgrade: NetworkUpgrade,
+        /// The height of the next block.
+        ///
+        /// The next block is the first block that could possibly contain a
+        /// mempool transaction.
+        height: block::Height,
     },
 }
 
@@ -113,7 +114,14 @@ impl Request {
     pub fn known_utxos(&self) -> Arc<HashMap<transparent::OutPoint, zs::Utxo>> {
         match self {
             Request::Block { known_utxos, .. } => known_utxos.clone(),
-            Request::Mempool { known_utxos, .. } => known_utxos.clone(),
+            Request::Mempool { .. } => HashMap::new().into(),
+        }
+    }
+
+    /// The height used to select the consensus rules for verifying this transaction.
+    pub fn height(&self) -> block::Height {
+        match self {
+            Request::Block { height, .. } | Request::Mempool { height, .. } => *height,
         }
     }
 
@@ -121,10 +129,7 @@ impl Request {
     ///
     /// This is based on the block height from the request, and the supplied `network`.
     pub fn upgrade(&self, network: Network) -> NetworkUpgrade {
-        match self {
-            Request::Block { height, .. } => NetworkUpgrade::current(network, *height),
-            Request::Mempool { upgrade, .. } => *upgrade,
-        }
+        NetworkUpgrade::current(network, self.height())
     }
 }
 


### PR DESCRIPTION
## Motivation

Before we implement height-based transaction checks, we need to add a height to every transaction verification request.

Block transactions already had a height, but mempool transactions didn't.

## Solution

- add a height to mempool transactions
- add an accessor method for block/mempool transaction verification request heights
- delete redundant and unused fields (mempool network upgrade and known UTXOs)

Closes #1683.

### Testing

The existing tests verify block request heights, because the `upgrade` method uses the `height` method.

Mempool request heights will be verified when we do the mempool work.

## Review

@oxarbitrage can review this PR. The missing height method is blocking PR #2399.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Mempool implementation #936 