### PR TITLE
Release Blocker? Disable IPv6 tests when $ZEBRA_SKIP_IPV6_TESTS is set

### DIFF
--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -34,7 +34,7 @@ use Network::*;
 async fn local_listener_unspecified_port_unspecified_addr() {
     zebra_test::init();
 
-    if env::var_os("ZEBRA_SKIP_NETWORK_TESTS").is_some() {
+    if env::var_os(zebra_test::net::ZEBRA_SKIP_NETWORK_TESTS).is_some() {
         // This message is captured by the test runner, use
         // `cargo test -- --nocapture` to see it.
         eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
@@ -46,7 +46,7 @@ async fn local_listener_unspecified_port_unspecified_addr() {
     local_listener_port_with("0.0.0.0:0".parse().unwrap(), Mainnet).await;
     local_listener_port_with("0.0.0.0:0".parse().unwrap(), Testnet).await;
 
-    if env::var_os("ZEBRA_SKIP_IPV6_TESTS").is_some() {
+    if env::var_os(zebra_test::net::ZEBRA_SKIP_IPV6_TESTS).is_some() {
         eprintln!("Skipping IPv6 test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");
         return;
     }
@@ -62,7 +62,7 @@ async fn local_listener_unspecified_port_unspecified_addr() {
 async fn local_listener_unspecified_port_localhost_addr() {
     zebra_test::init();
 
-    if env::var_os("ZEBRA_SKIP_NETWORK_TESTS").is_some() {
+    if env::var_os(zebra_test::net::ZEBRA_SKIP_NETWORK_TESTS).is_some() {
         eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
         return;
     }
@@ -71,7 +71,7 @@ async fn local_listener_unspecified_port_localhost_addr() {
     local_listener_port_with("127.0.0.1:0".parse().unwrap(), Mainnet).await;
     local_listener_port_with("127.0.0.1:0".parse().unwrap(), Testnet).await;
 
-    if env::var_os("ZEBRA_SKIP_IPV6_TESTS").is_some() {
+    if env::var_os(zebra_test::net::ZEBRA_SKIP_IPV6_TESTS).is_some() {
         eprintln!("Skipping IPv6 test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");
         return;
     }
@@ -89,7 +89,7 @@ async fn local_listener_fixed_port_localhost_addr() {
     let localhost_v4 = "127.0.0.1".parse().unwrap();
     let localhost_v6 = "::1".parse().unwrap();
 
-    if env::var_os("ZEBRA_SKIP_NETWORK_TESTS").is_some() {
+    if env::var_os(zebra_test::net::ZEBRA_SKIP_NETWORK_TESTS).is_some() {
         eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
         return;
     }
@@ -97,7 +97,7 @@ async fn local_listener_fixed_port_localhost_addr() {
     local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), Mainnet).await;
     local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), Testnet).await;
 
-    if env::var_os("ZEBRA_SKIP_IPV6_TESTS").is_some() {
+    if env::var_os(zebra_test::net::ZEBRA_SKIP_IPV6_TESTS).is_some() {
         eprintln!("Skipping IPv6 test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");
         return;
     }

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -34,7 +34,7 @@ use Network::*;
 async fn local_listener_unspecified_port_unspecified_addr() {
     zebra_test::init();
 
-    if env::var_os(zebra_test::net::ZEBRA_SKIP_NETWORK_TESTS).is_some() {
+    if zebra_test::net::zebra_skip_network_tests() {
         // This message is captured by the test runner, use
         // `cargo test -- --nocapture` to see it.
         eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
@@ -46,7 +46,7 @@ async fn local_listener_unspecified_port_unspecified_addr() {
     local_listener_port_with("0.0.0.0:0".parse().unwrap(), Mainnet).await;
     local_listener_port_with("0.0.0.0:0".parse().unwrap(), Testnet).await;
 
-    if env::var_os(zebra_test::net::ZEBRA_SKIP_IPV6_TESTS).is_some() {
+    if zebra_test::net::zebra_skip_ipv6_tests() {
         eprintln!("Skipping IPv6 test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");
         return;
     }
@@ -62,7 +62,7 @@ async fn local_listener_unspecified_port_unspecified_addr() {
 async fn local_listener_unspecified_port_localhost_addr() {
     zebra_test::init();
 
-    if env::var_os(zebra_test::net::ZEBRA_SKIP_NETWORK_TESTS).is_some() {
+    if zebra_test::net::zebra_skip_network_tests() {
         eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
         return;
     }
@@ -71,7 +71,7 @@ async fn local_listener_unspecified_port_localhost_addr() {
     local_listener_port_with("127.0.0.1:0".parse().unwrap(), Mainnet).await;
     local_listener_port_with("127.0.0.1:0".parse().unwrap(), Testnet).await;
 
-    if env::var_os(zebra_test::net::ZEBRA_SKIP_IPV6_TESTS).is_some() {
+    if zebra_test::net::zebra_skip_ipv6_tests() {
         eprintln!("Skipping IPv6 test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");
         return;
     }
@@ -89,7 +89,7 @@ async fn local_listener_fixed_port_localhost_addr() {
     let localhost_v4 = "127.0.0.1".parse().unwrap();
     let localhost_v6 = "::1".parse().unwrap();
 
-    if env::var_os(zebra_test::net::ZEBRA_SKIP_NETWORK_TESTS).is_some() {
+    if zebra_test::net::zebra_skip_network_tests() {
         eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
         return;
     }
@@ -97,7 +97,7 @@ async fn local_listener_fixed_port_localhost_addr() {
     local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), Mainnet).await;
     local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), Testnet).await;
 
-    if env::var_os(zebra_test::net::ZEBRA_SKIP_IPV6_TESTS).is_some() {
+    if zebra_test::net::zebra_skip_ipv6_tests() {
         eprintln!("Skipping IPv6 test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");
         return;
     }

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -13,7 +13,7 @@
 //! If it does not have any IPv4 interfaces, or IPv4 localhost is not on `127.0.0.1`,
 //! skip all the network tests by setting the `ZEBRA_SKIP_NETWORK_TESTS` environmental variable.
 
-use std::{collections::HashSet, env, net::SocketAddr};
+use std::{collections::HashSet, net::SocketAddr};
 
 use tower::service_fn;
 
@@ -35,9 +35,6 @@ async fn local_listener_unspecified_port_unspecified_addr() {
     zebra_test::init();
 
     if zebra_test::net::zebra_skip_network_tests() {
-        // This message is captured by the test runner, use
-        // `cargo test -- --nocapture` to see it.
-        eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
         return;
     }
 
@@ -47,7 +44,6 @@ async fn local_listener_unspecified_port_unspecified_addr() {
     local_listener_port_with("0.0.0.0:0".parse().unwrap(), Testnet).await;
 
     if zebra_test::net::zebra_skip_ipv6_tests() {
-        eprintln!("Skipping IPv6 test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");
         return;
     }
 
@@ -63,7 +59,6 @@ async fn local_listener_unspecified_port_localhost_addr() {
     zebra_test::init();
 
     if zebra_test::net::zebra_skip_network_tests() {
-        eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
         return;
     }
 
@@ -72,7 +67,6 @@ async fn local_listener_unspecified_port_localhost_addr() {
     local_listener_port_with("127.0.0.1:0".parse().unwrap(), Testnet).await;
 
     if zebra_test::net::zebra_skip_ipv6_tests() {
-        eprintln!("Skipping IPv6 test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");
         return;
     }
 
@@ -90,7 +84,6 @@ async fn local_listener_fixed_port_localhost_addr() {
     let localhost_v6 = "::1".parse().unwrap();
 
     if zebra_test::net::zebra_skip_network_tests() {
-        eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
         return;
     }
 
@@ -98,7 +91,6 @@ async fn local_listener_fixed_port_localhost_addr() {
     local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), Testnet).await;
 
     if zebra_test::net::zebra_skip_ipv6_tests() {
-        eprintln!("Skipping IPv6 test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");
         return;
     }
 

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -1,11 +1,19 @@
 //! Specific configs used for zebra-network initialization tests.
 //!
-//! ### Note on port conflict
+//! ## Failures due to Port Conflicts
 //!
 //! If the test has a port conflict with another test, or another process, then it will fail.
 //! If these conflicts cause test failures, run the tests in an isolated environment.
+//!
+//! ## Failures due to Configured Network Interfaces
+//!
+//! If your test environment does not have any IPv6 interfaces configured, skip IPv6 tests
+//! by setting the `ZEBRA_SKIP_IPV6_TESTS` environmental variable.
+//!
+//! If it does not have any IPv4 interfaces, or IPv4 localhost is not on `127.0.0.1`,
+//! skip all the network tests by setting the `ZEBRA_SKIP_NETWORK_TESTS` environmental variable.
 
-use std::{collections::HashSet, net::SocketAddr};
+use std::{collections::HashSet, env, net::SocketAddr};
 
 use tower::service_fn;
 
@@ -26,10 +34,24 @@ use Network::*;
 async fn local_listener_unspecified_port_unspecified_addr() {
     zebra_test::init();
 
+    if env::var_os("ZEBRA_SKIP_NETWORK_TESTS").is_some() {
+        // This message is captured by the test runner, use
+        // `cargo test -- --nocapture` to see it.
+        eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
+        return;
+    }
+
+    // these tests might fail on machines with no configured IPv4 addresses
+    // (localhost should be enough)
     local_listener_port_with("0.0.0.0:0".parse().unwrap(), Mainnet).await;
     local_listener_port_with("0.0.0.0:0".parse().unwrap(), Testnet).await;
 
-    // these tests might fail on machines without IPv6
+    if env::var_os("ZEBRA_SKIP_IPV6_TESTS").is_some() {
+        eprintln!("Skipping IPv6 test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");
+        return;
+    }
+
+    // these tests might fail on machines with no configured IPv6 addresses
     local_listener_port_with("[::]:0".parse().unwrap(), Mainnet).await;
     local_listener_port_with("[::]:0".parse().unwrap(), Testnet).await;
 }
@@ -40,11 +62,21 @@ async fn local_listener_unspecified_port_unspecified_addr() {
 async fn local_listener_unspecified_port_localhost_addr() {
     zebra_test::init();
 
+    if env::var_os("ZEBRA_SKIP_NETWORK_TESTS").is_some() {
+        eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
+        return;
+    }
+
     // these tests might fail on machines with unusual IPv4 localhost configs
     local_listener_port_with("127.0.0.1:0".parse().unwrap(), Mainnet).await;
     local_listener_port_with("127.0.0.1:0".parse().unwrap(), Testnet).await;
 
-    // these tests might fail on machines without IPv6
+    if env::var_os("ZEBRA_SKIP_IPV6_TESTS").is_some() {
+        eprintln!("Skipping IPv6 test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");
+        return;
+    }
+
+    // these tests might fail on machines with no configured IPv6 addresses
     local_listener_port_with("[::1]:0".parse().unwrap(), Mainnet).await;
     local_listener_port_with("[::1]:0".parse().unwrap(), Testnet).await;
 }
@@ -57,11 +89,19 @@ async fn local_listener_fixed_port_localhost_addr() {
     let localhost_v4 = "127.0.0.1".parse().unwrap();
     let localhost_v6 = "::1".parse().unwrap();
 
-    // these tests might fail on machines with unusual IPv4 localhost configs
+    if env::var_os("ZEBRA_SKIP_NETWORK_TESTS").is_some() {
+        eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
+        return;
+    }
+
     local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), Mainnet).await;
     local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), Testnet).await;
 
-    // these tests might fail on machines without IPv6
+    if env::var_os("ZEBRA_SKIP_IPV6_TESTS").is_some() {
+        eprintln!("Skipping IPv6 test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");
+        return;
+    }
+
     local_listener_port_with(SocketAddr::new(localhost_v6, random_known_port()), Mainnet).await;
     local_listener_port_with(SocketAddr::new(localhost_v6, random_known_port()), Testnet).await;
 }

--- a/zebra-test/src/net.rs
+++ b/zebra-test/src/net.rs
@@ -8,14 +8,12 @@ use rand::Rng;
 /// fast network connectivity.
 ///
 /// We use a constant so that the compiler detects typos.
-//
-// TODO: separate "good and reliable" from "any network"?
-pub const ZEBRA_SKIP_NETWORK_TESTS: &str = "ZEBRA_SKIP_NETWORK_TESTS";
+const ZEBRA_SKIP_NETWORK_TESTS: &str = "ZEBRA_SKIP_NETWORK_TESTS";
 
 /// The name of the env var that skips Zebra's IPv6 tests.
 ///
 /// We use a constant so that the compiler detects typos.
-pub const ZEBRA_SKIP_IPV6_TESTS: &str = "ZEBRA_SKIP_IPV6_TESTS";
+const ZEBRA_SKIP_IPV6_TESTS: &str = "ZEBRA_SKIP_IPV6_TESTS";
 
 /// Should we skip Zebra tests which need reliable, fast network connectivity?
 //

--- a/zebra-test/src/net.rs
+++ b/zebra-test/src/net.rs
@@ -1,5 +1,7 @@
 //! Network testing utility functions for Zebra.
 
+use std::env;
+
 use rand::Rng;
 
 /// The name of the env var that skips Zebra tests which need reliable,
@@ -14,6 +16,35 @@ pub const ZEBRA_SKIP_NETWORK_TESTS: &str = "ZEBRA_SKIP_NETWORK_TESTS";
 ///
 /// We use a constant so that the compiler detects typos.
 pub const ZEBRA_SKIP_IPV6_TESTS: &str = "ZEBRA_SKIP_IPV6_TESTS";
+
+/// Should we skip Zebra tests which need reliable, fast network connectivity?
+//
+// TODO: separate "good and reliable" from "any network"?
+pub fn zebra_skip_network_tests() -> bool {
+    if env::var_os(ZEBRA_SKIP_NETWORK_TESTS).is_some() {
+        // This message is captured by the test runner, use
+        // `cargo test -- --nocapture` to see it.
+        eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
+        return true;
+    }
+
+    false
+}
+
+/// Should we skip Zebra tests which need a local IPv6 network stack and
+/// IPv6 interface addresses?
+///
+/// If we are skipping network tests, we also skip IPv6 tests.
+pub fn zebra_skip_ipv6_tests() -> bool {
+    if env::var_os(ZEBRA_SKIP_IPV6_TESTS).is_some() {
+        eprintln!("Skipping IPv6 network test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");
+        return true;
+    }
+
+    // TODO: if we separate "good and reliable" from "any network",
+    //       also skip IPv6 tests when we're skipping all network tests.
+    false
+}
 
 /// Returns a random port number from the ephemeral port range.
 ///

--- a/zebra-test/src/net.rs
+++ b/zebra-test/src/net.rs
@@ -2,6 +2,19 @@
 
 use rand::Rng;
 
+/// The name of the env var that skips Zebra tests which need reliable,
+/// fast network connectivity.
+///
+/// We use a constant so that the compiler detects typos.
+//
+// TODO: separate "good and reliable" from "any network"?
+pub const ZEBRA_SKIP_NETWORK_TESTS: &str = "ZEBRA_SKIP_NETWORK_TESTS";
+
+/// The name of the env var that skips Zebra's IPv6 tests.
+///
+/// We use a constant so that the compiler detects typos.
+pub const ZEBRA_SKIP_IPV6_TESTS: &str = "ZEBRA_SKIP_IPV6_TESTS";
+
 /// Returns a random port number from the ephemeral port range.
 ///
 /// Does not check if the port is already in use. It's impossible to do this

--- a/zebra-test/src/net.rs
+++ b/zebra-test/src/net.rs
@@ -32,7 +32,8 @@ pub fn zebra_skip_network_tests() -> bool {
 /// Should we skip Zebra tests which need a local IPv6 network stack and
 /// IPv6 interface addresses?
 ///
-/// If we are skipping network tests, we also skip IPv6 tests.
+/// Since `zebra_skip_network_tests` only disables tests which need reliable network connectivity,
+/// we allow IPv6 tests even when `ZEBRA_SKIP_NETWORK_TESTS` is set.
 pub fn zebra_skip_ipv6_tests() -> bool {
     if env::var_os(ZEBRA_SKIP_IPV6_TESTS).is_some() {
         eprintln!("Skipping IPv6 network test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -33,7 +33,7 @@ use color_eyre::{
 };
 use tempdir::TempDir;
 
-use std::{collections::HashSet, convert::TryInto, env, path::Path, path::PathBuf, time::Duration};
+use std::{collections::HashSet, convert::TryInto, path::Path, path::PathBuf, time::Duration};
 
 use zebra_chain::{
     block::Height,
@@ -814,9 +814,6 @@ fn sync_until(
     zebra_test::init();
 
     if zebra_test::net::zebra_skip_network_tests() {
-        // This message is captured by the test runner, use
-        // `cargo test -- --nocapture` to see it.
-        eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");
         return testdir();
     }
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -813,7 +813,7 @@ fn sync_until(
 ) -> Result<TempDir> {
     zebra_test::init();
 
-    if env::var_os(zebra_test::net::ZEBRA_SKIP_NETWORK_TESTS).is_some() {
+    if zebra_test::net::zebra_skip_network_tests() {
         // This message is captured by the test runner, use
         // `cargo test -- --nocapture` to see it.
         eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1,7 +1,7 @@
 //! Acceptance test: runs zebrad as a subprocess and asserts its
 //! output for given argument combinations matches what is expected.
 //!
-//! ### Note on port conflict
+//! ## Note on port conflict
 //!
 //! If the test child has a cache or port conflict with another test, or a
 //! running zebrad or zcashd, then it will panic. But the acceptance tests
@@ -11,6 +11,15 @@
 //!   - run the tests in an isolated environment,
 //!   - run zebrad on a custom cache path and port,
 //!   - run zcashd on a custom port.
+//!
+//! ## Failures due to Configured Network Interfaces
+//!
+//! If your test environment does not have any IPv6 interfaces configured, skip IPv6 tests
+//! by setting the `ZEBRA_SKIP_IPV6_TESTS` environmental variable.
+//!
+//! If it does not have any IPv4 interfaces, IPv4 localhost is not on `127.0.0.1`,
+//! or you have poor network connectivity,
+//! skip all the network tests by setting the `ZEBRA_SKIP_NETWORK_TESTS` environmental variable.
 
 // Standard lints
 #![warn(missing_docs)]

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -813,7 +813,7 @@ fn sync_until(
 ) -> Result<TempDir> {
     zebra_test::init();
 
-    if env::var_os("ZEBRA_SKIP_NETWORK_TESTS").is_some() {
+    if env::var_os(zebra_test::net::ZEBRA_SKIP_NETWORK_TESTS).is_some() {
         // This message is captured by the test runner, use
         // `cargo test -- --nocapture` to see it.
         eprintln!("Skipping network test because '$ZEBRA_SKIP_NETWORK_TESTS' is set.");

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -12,7 +12,7 @@
 //!   - run zebrad on a custom cache path and port,
 //!   - run zcashd on a custom port.
 //!
-//! ## Failures due to Configured Network Interfaces
+//! ## Failures due to Configured Network Interfaces or Network Connectivity
 //!
 //! If your test environment does not have any IPv6 interfaces configured, skip IPv6 tests
 //! by setting the `ZEBRA_SKIP_IPV6_TESTS` environmental variable.


### PR DESCRIPTION
## Motivation

Some of Zebra's new network tests fail in our `main` branch Google Cloud CI, but those failures are hidden due to bug #2403.

We need to fix this bug before we can stop hiding those failures.

## Solution

- disable IPv6 tests when $ZEBRA_SKIP_IPV6_TESTS is set
- disable more network tests when $ZEBRA_SKIP_NETWORK_TESTS is set

This allows users to disable IPv6 tests in environments where IPv6 is not configured.

## Review

@jvff reviewed PR #2277, which introduced these tests. I think this might be urgent, because we don't want to release broken code.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Eventually we'll want to test in IPv6-only and non-standard IPv4 localhost environments.