### PR TITLE
Improve docs and panic messages for zebra_test::command

### DIFF
--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -212,7 +212,7 @@ impl<T> TestChild<T> {
     /// Checks each line of the child's stdout against `regex`, and returns Ok
     /// if a line matches.
     ///
-    /// Kills the child after the configured timeout has elapsed.
+    /// Kills the child on error, or after the configured timeout has elapsed.
     /// See `expect_line_matching` for details.
     #[instrument(skip(self))]
     pub fn expect_stdout_line_matches(&mut self, regex: &str) -> Result<&mut Self> {
@@ -228,7 +228,7 @@ impl<T> TestChild<T> {
         let mut lines = self
             .stdout
             .take()
-            .expect("child must capture stdout to call expect_stdout_line_matches");
+            .expect("child must capture stdout to call expect_stdout_line_matches, and it can't be called again after an error");
 
         match self.expect_line_matching(&mut lines, regex, "stdout") {
             Ok(()) => {
@@ -242,7 +242,7 @@ impl<T> TestChild<T> {
     /// Checks each line of the child's stderr against `regex`, and returns Ok
     /// if a line matches.
     ///
-    /// Kills the child after the configured timeout has elapsed.
+    /// Kills the child on error, or after the configured timeout has elapsed.
     /// See `expect_line_matching` for details.
     #[instrument(skip(self))]
     pub fn expect_stderr_line_matches(&mut self, regex: &str) -> Result<&mut Self> {
@@ -258,7 +258,7 @@ impl<T> TestChild<T> {
         let mut lines = self
             .stderr
             .take()
-            .expect("child must capture stderr to call expect_stderr_line_matches");
+            .expect("child must capture stderr to call expect_stderr_line_matches, and it can't be called again after an error");
 
         match self.expect_line_matching(&mut lines, regex, "stderr") {
             Ok(()) => {
@@ -272,7 +272,7 @@ impl<T> TestChild<T> {
     /// Checks each line in `lines` against `regex`, and returns Ok if a line
     /// matches. Uses `stream_name` as the name for `lines` in error reports.
     ///
-    /// Kills the child after the configured timeout has elapsed.
+    /// Kills the child on error, or after the configured timeout has elapsed.
     /// Note: the timeout is only checked after each full line is received from
     /// the child.
     #[instrument(skip(self, lines))]


### PR DESCRIPTION
## Motivation

We need accurate docs and panic messages to make progress on PR #2366.

## Solution

- Improve docs and panic messages

## Review

@oxarbitrage can review this PR. It's not urgent.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

It would be good to have a way to check for optional test command output.