### PR TITLE
Modify UTXO and state designs for transparent coinbase output checks

### DIFF
--- a/book/src/dev/rfcs/0004-asynchronous-script-verification.md
+++ b/book/src/dev/rfcs/0004-asynchronous-script-verification.md
@@ -19,14 +19,20 @@ and in parallel on a thread pool.
 # Definitions
 [definitions]: #definitions
 
-- *UTXO*: unspent transparent output. Transparent transaction outputs are modeled in `zebra-chain` by the [`transparent::Output`][transout] structure.
+- *UTXO*: unspent transparent transaction output.
+  Transparent transaction outputs are modeled in `zebra-chain` by the [`transparent::Output`][transout] structure.
+- outpoint: a reference to an unspent transparent transaction output, including a transaction hash and output index.
+  Outpoints are modeled in `zebra-chain` by the [`transparent::OutPoint`][outpoint] structure.  
 - transparent input: a previous transparent output consumed by a later transaction (the one it is an input to).
   Modeled in `zebra-chain` by the [`transparent::Input::PrevOut`][transin] enum variant.
 - coinbase transaction: the first transaction in each block, which creates new coins.
-- lock script: the script that defines the conditions under which some UTXO can be spent.  Stored in the [`transparent::Output::lock_script`][lock_script] field.
-- unlock script: a script satisfying the conditions of the lock script, allowing a UTXO to be spent.  Stored in the [`transparent::Input::PrevOut::lock_script`][lock_script] field.
+- lock script: the script that defines the conditions under which some UTXO can be spent.
+  Stored in the [`transparent::Output::lock_script`][lock_script] field.
+- unlock script: a script satisfying the conditions of the lock script, allowing a UTXO to be spent.
+  Stored in the [`transparent::Input::PrevOut::lock_script`][lock_script] field.
 
 [transout]: https://doc.zebra.zfnd.org/zebra_chain/transparent/struct.Output.html
+[outpoint]: https://doc.zebra.zfnd.org/zebra_chain/transparent/struct.OutPoint.html
 [lock_script]: https://doc.zebra.zfnd.org/zebra_chain/transparent/struct.Output.html#structfield.lock_script
 [transin]: https://doc.zebra.zfnd.org/zebra_chain/transparent/enum.Input.html
 [unlock_script]: https://doc.zebra.zfnd.org/zebra_chain/transparent/enum.Input.html#variant.PrevOut.field.unlock_script
@@ -36,7 +42,7 @@ and in parallel on a thread pool.
 [guide-level-explanation]: #guide-level-explanation
 
 Zcash's transparent address system is inherited from Bitcoin. Transactions
-spend unspent transaction outputs (UTXOs) from previous transactions. These
+spend unspent transparent transaction outputs (UTXOs) from previous transactions. These
 UTXOs are encumbered by *locking scripts* that define the conditions under
 which they can be spent, e.g., requiring a signature from a certain key.
 Transactions wishing to spend UTXOs supply an *unlocking script* that should

--- a/book/src/dev/rfcs/0004-asynchronous-script-verification.md
+++ b/book/src/dev/rfcs/0004-asynchronous-script-verification.md
@@ -66,7 +66,7 @@ At a high level, this adds a new request/response pair to the state service:
 
 - `Request::AwaitSpendableUtxo { output: OutPoint, ..conditions }`
    requests a spendable `transparent::Output`, looked up using `OutPoint`.
-- `Response::Utxo(Utxo)` supplies the requested `transparent::Output`
+- `Response::SpendableUtxo(Utxo)` supplies the requested `transparent::Output`
    as part of a new `Utxo` type,
    if the output is spendable based on `conditions`;
 
@@ -118,8 +118,6 @@ enum SpendRestriction {
     /// The UTXO is spent in a transaction with all shielded outputs
     AllShieldedOutputs,
 }
-
-enum Response::Utxo(Utxo)
 ```
 
 As described above, the request name is intended to indicate the request's behavior.
@@ -130,6 +128,8 @@ The request does not resolve until:
 The new `Utxo` type adds a coinbase flag and height to `transparent::Output`s
 that we look up in the state, or get from newly commited blocks:
 ```rust
+enum Response::SpendableUtxo(Utxo)
+
 pub struct Utxo {
     /// The output itself.
     pub output: transparent::Output,

--- a/book/src/dev/rfcs/0004-asynchronous-script-verification.md
+++ b/book/src/dev/rfcs/0004-asynchronous-script-verification.md
@@ -376,7 +376,8 @@ The state service should maintain an `Arc<Mutex<PendingUtxos>>`, used as follows
     - `spend_restriction` is `AllShieldedOutputs`, and
     - `spend_height` is greater than or equal to
       `MIN_TRANSPARENT_COINBASE_MATURITY` plus the `Utxo.height`,
-    - then return the utxo.
+    - if both checks pass, return the utxo.
+    - if any check fails, drop the utxo, and let the request timeout.
 
 3. In `Service::call(Request::CommitBlock(block, ..))`, the service should:
   - [check for double-spends of each UTXO in the block](https://github.com/ZcashFoundation/zebra/issues/2231),

--- a/book/src/dev/rfcs/0004-asynchronous-script-verification.md
+++ b/book/src/dev/rfcs/0004-asynchronous-script-verification.md
@@ -173,7 +173,7 @@ We don't mistakenly accept or reject spends to the transparent pool:
 We don't mistakenly accept or reject mature spends:
 - across all chains, the set of coinbase transaction hashes is disjoint from
   the set of non-coinbase transaction hashes; and
-- across all chains, duplicate coinbase transaction hashes only occur at
+- across all chains, duplicate coinbase transaction hashes can only occur at
   exactly the same height.
 
 These properties are implied by the following consensus rules:

--- a/book/src/dev/rfcs/0004-asynchronous-script-verification.md
+++ b/book/src/dev/rfcs/0004-asynchronous-script-verification.md
@@ -150,7 +150,7 @@ There is exactly one coinbase transaction per block, and it must have an index o
 
 Specifically, if the UTXO is a transparent coinbase output,
 the service is not required to return a response if:
-- `spend_height` is less than `MIN_TRANSPARENT_COINBASE_MATURITY` after the `Coinbase.height`, or
+- `spend_height` is less than `MIN_TRANSPARENT_COINBASE_MATURITY` (100) blocks after the `Coinbase.height`, or
 - `spend_restriction` is `SomeTransparentOutputs`.
 
 This implements the following consensus rules:

--- a/book/src/dev/rfcs/0004-asynchronous-script-verification.md
+++ b/book/src/dev/rfcs/0004-asynchronous-script-verification.md
@@ -194,7 +194,7 @@ Transaction versions 1-4:
 > [Sapling onward] If effectiveVersion < 5, then at least one of tx_in_count, nSpendsSapling, and nJoinSplit MUST be nonzero.
 
 > A coinbase transaction for a block at block height greater than 0
-> MUST have a script that, as its first item, encodes the block height height as follows.
+> MUST have a script that, as its first item, encodes the *block height* height as follows.
 >
 > For height in the range {1 .. 16}, the encoding is a single byte of value 0x50 + height.
 >

--- a/book/src/dev/rfcs/0004-asynchronous-script-verification.md
+++ b/book/src/dev/rfcs/0004-asynchronous-script-verification.md
@@ -170,19 +170,40 @@ https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
 [parallel-coinbase-checks]: #parallel-coinbase-checks
 
 We can perform these coinbase checks asynchronously, in the presence of multiple chain forks,
-as long as the following conditions hold.
+as long as the following conditions both hold:
 
-We don't mistakenly accept or reject spends to the transparent pool:
-- across all chains, the set of coinbase transaction hashes is disjoint from
-  the set of non-coinbase transaction hashes.
+1. We don't mistakenly accept or reject spends to the transparent pool.
 
-We don't mistakenly accept or reject mature spends:
-- across all chains, the set of coinbase transaction hashes is disjoint from
-  the set of non-coinbase transaction hashes; and
-- across all chains, duplicate coinbase transaction hashes can only occur at
+2. We don't mistakenly accept or reject mature spends.
+
+### Parallel coinbase justification
+[parallel-coinbase-justification]: #parallel-coinbase-justification
+
+There are two parts to a spend restriction:
+- the `from_coinbase` flag, and
+- if the `from_coinbase` flag is true, the coinbase `height`.
+
+If a particular transaction hash `h` always has the same `from_coinbase` value,
+and `h` exists in multiple chains, then regardless of which `Utxo` arrives first,
+the outputs of `h` always get the same `from_coinbase` value during validation.
+So spends can not be mistakenly accepted or rejected due to a different coinbase flag.
+
+Similarly, if a particular coinbase transaction hash `h` always has the same `height` value,
+and `h` exists in multiple chains, then regardless of which `Utxo` arrives first,
+the outputs of `h` always get the same `height` value during validation.
+So coinbase spends can not be mistakenly accepted or rejected due to a different `height` value.
+(The heights of non-coinbase outputs are irrelevant, because they are never checked.)
+
+These conditions hold as long as the following multi-chain properties are satisfied:
+- `from_coinbase`: across all chains, the set of coinbase transaction hashes is disjoint from
+  the set of non-coinbase transaction hashes, and
+- coinbase `height`: across all chains, duplicate coinbase transaction hashes can only occur at
   exactly the same height.
 
-These properties are implied by the following consensus rules:
+### Parallel coinbase consensus rules
+[parallel-coinbase-consensus]: #parallel-coinbase-consensus
+
+These multi-chain properties can be derived from the following consensus rules:
 
 Transaction versions 1-4:
 

--- a/book/src/dev/rfcs/0004-asynchronous-script-verification.md
+++ b/book/src/dev/rfcs/0004-asynchronous-script-verification.md
@@ -344,8 +344,14 @@ struct PendingUtxos(HashMap<OutPoint, oneshot::Sender<Utxo>>);
 
 impl PendingUtxos {
     // adds the outpoint and returns (wrapped) rx end of oneshot
+    // checks the spend height and restriction before sending the utxo response
     // return can be converted to `Service::Future`
-    pub fn queue(&mut self, outpoint: OutPoint) -> impl Future<Output=Result<Response, ...>>;
+    pub fn queue(
+        &mut self,
+        outpoint: OutPoint,
+        spend_height: Height,
+        spend_restriction: SpendRestriction,
+    ) -> impl Future<Output=Result<Response, ...>>;
 
     // if outpoint is a hashmap key, remove the entry and send output on the channel
     pub fn respond(&mut self, outpoint: OutPoint, output: transparent::Output);

--- a/book/src/dev/rfcs/0004-asynchronous-script-verification.md
+++ b/book/src/dev/rfcs/0004-asynchronous-script-verification.md
@@ -205,8 +205,10 @@ Transaction versions 1-4:
 
 https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
 
-The version 1-4 transaction identifier hash is undocumented:
-it is the SHA-256d hash of the serialized bytes of the transaction.
+> The transaction ID of a version 4 or earlier transaction is the SHA-256d hash of the transaction encoding in the
+> pre-v5 format described above.
+
+https://zips.z.cash/protocol/protocol.pdf#txnidentifiers
 
 Transaction version 5:
 

--- a/book/src/dev/rfcs/0004-asynchronous-script-verification.md
+++ b/book/src/dev/rfcs/0004-asynchronous-script-verification.md
@@ -19,8 +19,10 @@ and in parallel on a thread pool.
 # Definitions
 [definitions]: #definitions
 
-- *UTXO*: unspent transaction output. Transaction outputs are modeled in `zebra-chain` by the [`transparent::Output`][transout] structure.
-- Transaction input: an output of a previous transaction consumed by a later transaction (the one it is an input to).  Modeled in `zebra-chain` by the [`transparent::Input`][transin] structure.
+- *UTXO*: unspent transparent output. Transparent transaction outputs are modeled in `zebra-chain` by the [`transparent::Output`][transout] structure.
+- transparent input: a previous transparent output consumed by a later transaction (the one it is an input to).
+  Modeled in `zebra-chain` by the [`transparent::Input::PrevOut`][transin] enum variant.
+- coinbase transaction: the first transaction in each block, which creates new coins.
 - lock script: the script that defines the conditions under which some UTXO can be spent.  Stored in the [`transparent::Output::lock_script`][lock_script] field.
 - unlock script: a script satisfying the conditions of the lock script, allowing a UTXO to be spent.  Stored in the [`transparent::Input::PrevOut::lock_script`][lock_script] field.
 
@@ -56,16 +58,23 @@ done later, at the point that its containing block is committed to the chain.
 
 At a high level, this adds a new request/response pair to the state service:
 
-- `Request::AwaitUtxo(OutPoint)` requests a `transparent::Output` specified by `OutPoint` from the state layer;
-- `Response::Utxo(transparent::Output)` supplies requested the `transparent::Output`.
+- `Request::AwaitSpendableUtxo { output: OutPoint, ..conditions }`
+   requests a spendable `transparent::Output`, looked up using `OutPoint`.
+- `Response::Utxo(transparent::Output)` supplies the requested `transparent::Output`,
+   if it is spendable based on `conditions`;
 
 Note that this request is named differently from the other requests,
-`AwaitUtxo` rather than `GetUtxo` or similar. This is because the request has
-rather different behavior: the request does not complete until the state
-service learns about a UTXO matching the request, which could be never. For
-instance, if the transaction output was already spent, the service is not
-required to return a response. The caller is responsible for using a timeout
-layer or some other mechanism.
+`AwaitSpendableUtxo` rather than `GetUtxo` or similar. This is because the
+request has rather different behavior:
+- the request does not complete until the state service learns about a UTXO
+  matching the request, which could be never. For instance, if the transaction
+  output was already spent, the service is not required to return a response.
+- the request does not complete until the output is spendable, based on the
+  `conditions` in the request.
+
+The state service does not cancel long-running UTXO requests. Instead, the caller
+is responsible for deciding when a request is unlikely to complete. (For example,
+using a timeout layer.)
 
 This allows a script verifier to asynchronously obtain information about
 previous transaction outputs and start verifying scripts as soon as the data
@@ -82,17 +91,156 @@ parallelism.
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-We add a `Request::AwaitUtxo(OutPoint)` and
-`Response::Utxo(transparent::Output)` to the state protocol. As described
-above, the request name is intended to indicate the request's behavior: the
-request does not resolve until the state layer learns of a UTXO described by
-the request.
+## Data structures
+[data-structures]: #data-structures
+
+We add the following request and response to the state protocol:
+```rust
+enum Request::AwaitSpendableUtxo {
+    outpoint: OutPoint,
+    spend_height: Height,
+    spend_pools: SpendPools,
+}
+
+enum SpendPools {
+    SomeTransparentOutputs,
+    AllShieldedOutputs,
+}
+
+enum Response::Utxo(transparent::Output)
+```
+
+As described above, the request name is intended to indicate the request's behavior.
+The request does not resolve until:
+- the state layer learns of a UTXO described by the request, and
+- the output is spendable at `height`, to `spend_output_pools`.
+
+We also add a coinbase flag and height to `transparent::Output`s that we look up in
+the state, or get from newly commited blocks:
+```rust
+enum TransparentOutputOrigin {
+    Coinbase {
+        output: transparent::Output,
+        coinbase_height: Height,
+    },
+    NonCoinbase {
+        output: transparent::Output,
+    },
+}
+```
+
+The coinbase flag can be derived from the `OutPoint.index`.
+There is exactly one coinbase transaction per block, and it must have an index of `0`.
+
+The coinbase height can be:
+- looked up from the `OutPoint.hash` in `tx_by_hash`, or
+- retrieved from the newly arrived block.
+
+## Transparent coinbase consensus rules
+[transparent-coinbase-consensus-rules]: #transparent-coinbase-consensus-rules
+
+Specifically, if the UTXO is a transparent coinbase output,
+the service is not required to return a response if:
+- `height` is less than `MIN_TRANSPARENT_COINBASE_MATURITY` after the `OutPoint`'s height, or
+- `spend_pools` is `SomeTransparentOutputs`.
+
+This implements the following consensus rules:
+
+> A transaction MUST NOT spend a transparent output of a coinbase transaction
+> from a block less than 100 blocks prior to the spend.
+>
+> Note that transparent outputs of coinbase transactions include Founders’ Reward
+> outputs and transparent funding stream outputs.
+
+> A transaction with one or more transparent inputs from coinbase transactions
+> MUST have no transparent outputs (i.e.tx_out_count MUST be 0).
+>
+> Inputs from coinbase transactions include Founders’ Reward outputs and funding
+> stream outputs.
+
+https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
+
+## Parallel coinbase checks
+[parallel-coinbase-checks]: #parallel-coinbase-checks
+
+We can perform these coinbase checks asynchronously, in the presence of multiple chain forks,
+as long as the following conditions hold.
+
+We don't mistakenly accept or reject spends to the transparent pool:
+- across all chains, the set of coinbase transaction hashes is disjoint from
+  the set of non-coinbase transaction hashes.
+
+We don't mistakenly accept or reject mature spends:
+- across all chains, the set of coinbase transaction hashes is disjoint from
+  the set of non-coinbase transaction hashes; and
+- across all chains, duplicate coinbase transaction hashes only occur at
+  exactly the same height.
+
+These properties are implied by the following consensus rules:
+
+Transaction versions 1-4:
+
+> [Pre-Sapling ] If effectiveVersion = 1 or nJoinSplit = 0, then both tx_in_count and tx_out_count MUST be nonzero.
+> ...
+> [Sapling onward] If effectiveVersion < 5, then at least one of tx_in_count, nSpendsSapling, and nJoinSplit MUST be nonzero.
+
+> A coinbase transaction for a block at block height greater than 0
+> MUST have a script that, as its first item, encodes the block height height as follows.
+>
+> For height in the range {1 .. 16}, the encoding is a single byte of value 0x50 + height.
+>
+> Otherwise, let heightBytes be the signed little-endian representation of height,
+> using the minimum nonzero number of bytes such that the most significant byte is < 0x80.
+> The length of heightBytes MUST be in the range {1 .. 8}.
+> Then the encoding is the length of heightBytes encoded as one byte, followed by heightBytes itself.
+
+https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
+
+The version 1-4 transaction identifier hash is undocumented:
+it is the SHA-256d hash of the serialized bytes of the transaction.
+
+Transaction version 5:
+
+> [NU5 onward] If effectiveVersion ≥ 5, then this condition must hold: tx_in_count > 0 or nSpendsSapling > 0 or (nActionsOrchard > 0 and enableSpendsOrchard = 1).
+> ...
+> [NU5 onward] The nExpiryHeight field of a coinbase transaction MUST be equal to its block height.
+
+https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
+
+> non-malleable transaction identifiers ... commit to all transaction data except for attestations to transaction validity
+> ...
+> A new transaction digest algorithm is defined that constructs the identifier for a transaction from a tree of hashes
+> ...
+> A BLAKE2b-256 hash of the following values:
+> ...
+> T.1e: expiry_height       (4-byte little-endian block height)
+
+https://zips.z.cash/zip-0244#t-1-header-digest
+
+Since:
+- coinbase transaction hashes commit to the block `Height`,
+- non-coinbase transaction hashes commit to their inputs, and
+- double-spends are not allowed;
+
+Therefore:
+- coinbase transaction hashes are unique for distinct heights in any chain,
+- coinbase transaction hashes are unique in a single chain, and
+- non-coinbase transaction hashes are unique in a single chain,
+  because they recursively commit to unique inputs.
+
+So the required parallel verification conditions are satisfied.
+
+## Script verification
+[script-verification]: #script-verification
 
 To verify scripts, a script verifier requests the relevant UTXOs from the
 state service and waits for all of them to resolve, or fails verification
 with a timeout error. Currently, we outsource script verification to
 `zcash_consensus`, which does FFI into the same C++ code as `zcashd` uses.
 **We need to ensure this code is thread-safe**.
+
+## Database implementation
+[database-implementation]: #database-implementation
 
 Implementing the state request correctly requires considering two sets of behaviors:
 
@@ -129,6 +277,9 @@ synchronous or asynchronous, we ensure that writes cannot race each other.
 Asynchronous reads are guaranteed to read at least the state present at the
 time the request was processed, or a later state.
 
+## Lookup states
+[lookup-states]: #lookup-states
+
 Now, returning to the UTXO lookup problem, we can map out the possible states
 with this restriction in mind. This description assumes that UTXO storage is
 split into disjoint sets, one in-memory (e.g., blocks after the reorg limit)
@@ -136,7 +287,7 @@ and the other in rocksdb (e.g., blocks after the reorg limit). The details of
 this storage are not important for this design, only that the two sets are
 disjoint.
 
-When the state service processes a `Request::AwaitUtxo(OutPoint)` referencing
+When the state service processes a `Request::AwaitSpendableUtxo` referencing
 some UTXO `u`, there are three disjoint possibilities:
 
 1. `u` is already contained in an in-memory block storage;
@@ -151,13 +302,16 @@ in the rocksdb UTXO set when the request was processed, the only way that an
 async read would not return `u` is if the UTXO were spent, in which case the
 service is not required to return a response.
 
+## Lookup implementation
+[lookup-implementation]: #lookup-implementation
+
 This behavior can be encapsulated into a `PendingUtxos`
 structure described below.
 
 ```rust
 // sketch
 #[derive(Default, Debug)]
-struct PendingUtxos(HashMap<OutPoint, oneshot::Sender<transparent::Output>>);
+struct PendingUtxos(HashMap<OutPoint, oneshot::Sender<TransparentOutputOrigin>>);
 
 impl PendingUtxos {
     // adds the outpoint and returns (wrapped) rx end of oneshot
@@ -167,6 +321,8 @@ impl PendingUtxos {
     // if outpoint is a hashmap key, remove the entry and send output on the channel
     pub fn respond(&mut self, outpoint: OutPoint, output: transparent::Output);
 
+    /// check the list of pending UTXO requests against the supplied `utxos` from a block at `height`
+    pub fn check_against(&mut self, utxos: &HashMap<transparent::OutPoint, Utxo>, height: Height);
 
     // scans the hashmap and removes any entries with closed senders
     pub fn prune(&mut self);
@@ -175,23 +331,41 @@ impl PendingUtxos {
 
 The state service should maintain an `Arc<Mutex<PendingUtxos>>`, used as follows:
 
-1. In `Service::call(Request::AwaitUtxo(u))`, the service should:
+1. In `Service::call(Request::AwaitSpendableUtxo { outpoint: u, .. }`, the service should:
   - call `PendingUtxos::queue(u)` to get a future `f` to return to the caller;
-  spawn a task that does a rocksdb lookup for `u`, calling `PendingUtxos::respond(u, output)` if present;
+  - spawn a task that does a rocksdb lookup for `u`, calling `PendingUtxos::respond(u, output)` if present;
   - check the in-memory storage for `u`, calling `PendingUtxos::respond(u, output)` if present;
   - return `f` to the caller (it may already be ready).
-  The common case is that `u` references an old UTXO, so spawning the lookup
+  The common case is that `u` references an old spendable UTXO, so spawning the lookup
   task first means that we don't wait to check in-memory storage for `u`
   before starting the rocksdb lookup.
 
-2. In `Service::call(Request::CommitBlock(block, ..))`, the service should:
-  - call `PendingUtxos::check_block(block.as_ref())`;
-  - do any other transactional checks before committing a block as normal.
-  Because the `AwaitUtxo` request is informational, there's no need to do
-  the transactional checks before matching against pending UTXO requests,
-  and doing so upfront potentially notifies other tasks earlier.
+2. In `f`, the future returned by `PendingUtxos::queue(u)`, the service should
+  check that the `TransparentOutputOrigin` is spendable before returning it:
+  - if the `TransparentOutputOrigin` is `NonCoinbase`, return the utxo;
+  - if the `TransparentOutputOrigin` is `Coinbase`, check that:
+    - `spend_pools` is `AllShieldedOutputs`, and
+    - `spend_height` is greater than or equal to
+      `MIN_TRANSPARENT_COINBASE_MATURITY` plus the `Coinbase { height, .. }`,
+    - then return the utxo.
 
-3. In `Service::poll_ready()`, the service should call
+3. In `PendingUtxos::check_against(utxos, height)`, the service should:
+  - return `TransparentOutputOrigin::Coinbase` if `OutPoint.index` is `0`, and
+  - use the block `height` as the `Coinbase { height, .. }`.
+
+4. In `Service::any_utxo(outpoint)`, the service should:
+  - return `TransparentOutputOrigin::Coinbase` if `outpoint.index` is `0`, and
+  - lookup the height of `OutPoint.hash` in `tx_by_hash`,
+    and use it as the `Coinbase { height, .. }`.
+
+5. In `Service::call(Request::CommitBlock(block, ..))`, the service should:
+  - check for double-spends of each UTXO in the block, and
+  - do any other transactional checks before committing a block as normal.
+  Because the `AwaitSpendableUtxo` request is informational, there's no need to do
+  the transactional checks before matching against pending UTXO requests,
+  and doing so upfront can run expensive verification earlier than needed.
+
+6. In `Service::poll_ready()`, the service should call
   `PendingUtxos::prune()` at least *some* of the time. This is required because
   when a consumer uses a timeout layer, the cancelled requests should be
   flushed from the queue to avoid a resource leak. However, doing this on every
@@ -220,3 +394,9 @@ cleaner and the cost is probably not too large.
 - We need to pick a timeout for UTXO lookup. This should be long enough to
 account for the fact that we may start verifying blocks before all of their
 ancestors are downloaded.
+
+- The maturity check can be skipped for UTXOs from the finalized state,
+because Zebra only finalizes mature UTXOs. We could implement this
+optimisation by adding a `TransparentOutputOrigin::MatureCoinbase { output: transparent::Output }`
+variant, which only performs the spend checks. But this optimisation can be
+delayed after the initial implementation is complete and covered by tests.

--- a/book/src/dev/rfcs/0004-asynchronous-script-verification.md
+++ b/book/src/dev/rfcs/0004-asynchronous-script-verification.md
@@ -131,7 +131,7 @@ the state, or get from newly commited blocks:
 enum TransparentOutputOrigin {
     Coinbase {
         output: transparent::Output,
-        coinbase_height: Height,
+        height: Height,
     },
     NonCoinbase {
         output: transparent::Output,
@@ -150,7 +150,7 @@ There is exactly one coinbase transaction per block, and it must have an index o
 
 Specifically, if the UTXO is a transparent coinbase output,
 the service is not required to return a response if:
-- `height` is less than `MIN_TRANSPARENT_COINBASE_MATURITY` after the `OutPoint`'s height, or
+- `spend_height` is less than `MIN_TRANSPARENT_COINBASE_MATURITY` after the `Coinbase.height`, or
 - `spend_restriction` is `SomeTransparentOutputs`.
 
 This implements the following consensus rules:
@@ -356,17 +356,17 @@ The state service should maintain an `Arc<Mutex<PendingUtxos>>`, used as follows
   - if the `TransparentOutputOrigin` is `Coinbase`, check that:
     - `spend_restriction` is `AllShieldedOutputs`, and
     - `spend_height` is greater than or equal to
-      `MIN_TRANSPARENT_COINBASE_MATURITY` plus the `Coinbase { height, .. }`,
+      `MIN_TRANSPARENT_COINBASE_MATURITY` plus the `Coinbase.height`,
     - then return the utxo.
 
 3. In `PendingUtxos::check_against(utxos, height, tx_index)`, the service should:
   - return `TransparentOutputOrigin::Coinbase` if `tx_index == 0`,
-    using `height` as the coinbase height.
+    using `height` as `Coinbase.height`.
 
 4. In `Service::any_utxo(outpoint)`, the service should:
   - lookup `OutPoint.hash` in `tx_by_hash`;
   - return `TransparentOutputOrigin::Coinbase` if `tx_index == 0`,
-    using `height` as the coinbase height.
+    using `height` as `Coinbase.height`.
 
 5. In `Service::call(Request::CommitBlock(block, ..))`, the service should:
   - check for double-spends of each UTXO in the block, and

--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -606,7 +606,7 @@ We use the following rocksdb column families:
 | `height_by_hash`     | `block::Hash`         | `BE32(height)`                      |
 | `block_by_height`    | `BE32(height)`        | `Block`                             |
 | `tx_by_hash`         | `transaction::Hash`   | `(BE32(height) \|\| BE32(tx_index))`|
-| `utxo_by_outpoint`   | `OutPoint`            | `TransparentOutput`               |
+| `utxo_by_outpoint`   | `OutPoint`            | `TransparentOutput`                 |
 | `sprout_nullifiers`  | `sprout::Nullifier`   | `()`                                |
 | `sapling_nullifiers` | `sapling::Nullifier`  | `()`                                |
 | `orchard_nullifiers` | `orchard::Nullifier`  | `()`                                |

--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -606,7 +606,7 @@ We use the following rocksdb column families:
 | `height_by_hash`     | `block::Hash`         | `BE32(height)`                      |
 | `block_by_height`    | `BE32(height)`        | `Block`                             |
 | `tx_by_hash`         | `transaction::Hash`   | `(BE32(height) \|\| BE32(tx_index))`|
-| `utxo_by_outpoint`   | `OutPoint`            | `transparent::Output`               |
+| `utxo_by_outpoint`   | `OutPoint`            | `TransparentOutput`               |
 | `sprout_nullifiers`  | `sprout::Nullifier`   | `()`                                |
 | `sapling_nullifiers` | `sapling::Nullifier`  | `()`                                |
 | `orchard_nullifiers` | `orchard::Nullifier`  | `()`                                |

--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -899,22 +899,23 @@ Implemented by querying:
 - (finalized) the `height_by_hash` tree (to get the block height) and then
     the `block_by_height` tree (to get the block data), if the block is not in any non-finalized chain
 
-### `Request::AwaitSpendableUtxo { outpoint: OutPoint, spend_height: Height, spend_pools: SpendPools }`
+### `Request::AwaitSpendableUtxo { outpoint: OutPoint, spend_height: Height, spend_restriction: SpendRestriction }`
 
 Returns
 
-- `Response::Utxo(transparent::Output)`
+- `Response::SpendableUtxo(transparent::Output)`
 
 Implemented by querying:
-
-- (non-finalized) if any `Chains` contain `OutPoint` in their `created_utxos`
-  get the `transparent::Output` from `OutPoint`'s transaction,
-  and the `height` for `OutPoint.hash`;
+- (non-finalized) if any `Chains` contain `OutPoint` in their `created_utxos`,
+  return the `Utxo` for `OutPoint`;
 - (finalized) else if `OutPoint` is in `utxos_by_outpoint`,
-  return the associated `transparent::Output`,
-  and the `height` for `OutPoint.hash`;
+  return the `Utxo` for `OutPoint`;
 - else wait for `OutPoint` to be created as described in [RFC0004];
-- then perform the coinbase validation specified in [RFC0004].
+
+Then validating:
+- check the transparent coinbase spend restrictions specified in [RFC0004];
+- if the restrictions are satisfied, return the response;
+- if the spend is invalid, drop the request (and the caller will time out).
 
 [RFC0004]: https://zebra.zfnd.org/dev/rfcs/0004-asynchronous-script-verification.html
 


### PR DESCRIPTION
## Motivation

Zebra needs a design for tracking the source of transparent coinbase UTXOs, so we can validate:
- the coinbase maturity rule, and
- the mandatory transparent coinbase shielding rule.

### Scope

Validate spending transparent outputs of coinbase transactions. (If the miner or funding stream receiver choose to receive the ZEC using a transparent address).

Zebra already ignores the genesis coinbase outputs, so they are out of scope.

### Specifications

> A transaction with one or more transparent inputs from coinbase transactions MUST have no transparent outputs (i.e.tx_out_count MUST be 0). Inputs from coinbase transactions include Founders’ Reward outputs and funding stream outputs.

> A transaction MUST NOT spend a transparent output of a coinbase transaction from a block less than 100 blocks prior to the spend. Note that transparent outputs of coinbase transactions include Founders’ Reward outputs and transparent funding stream outputs.

https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus

## Solution

Closes #1970.

### Script verification RFC

#### Data structures

- Add a transparent spends flag and spend height in an `AwaitSpendableUtxo` request
- Add a `SpendPools` enum
- Create a `TransparentOutputOrigin` with a coinbase flag and height, for internal state use
- Lookup the coinbase flag and height

Note: the finalized state format does not change, because it already stores all the information we need.

#### Validation

- Verify the spends flag and spend height
- Explain why we can verify requests in parallel
- Leave some optimisations for later

### State RFC

- Change to using `AwaitSpendableUtxo`

## Review

@jvff and @conradoplg can do the initial review on this design, because everyone else is working on the pool balances design.

@conradoplg can you check my arguments for transaction ID uniqueness?
We need all IDs to be unique in a single chain. And we need some limited uniqueness across any chain.

### Reviewer Checklist

  - [ ] Design implements Specs
  - [ ] Transaction IDs are unique where required

## Follow Up Work

Open a ticket for the optional optimisations, but don't schedule it in a sprint.
