### PR TITLE
Refactor: Return errors from state update methods to prepare for contextual validation

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -178,9 +178,9 @@ impl StateService {
         let parent_hash = prepared.block.header.previous_block_hash;
 
         if self.disk.finalized_tip_hash() == parent_hash {
-            self.mem.commit_new_chain(prepared);
+            self.mem.commit_new_chain(prepared)?;
         } else {
-            self.mem.commit_block(prepared);
+            self.mem.commit_block(prepared)?;
         }
 
         Ok(())

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -20,13 +20,13 @@ fn forked_equals_pushed() -> Result<()> {
             let mut partial_chain = Chain::default();
 
             for block in chain.iter().take(count) {
-                partial_chain.push(block.clone());
+                partial_chain.push(block.clone())?;
             }
             for block in chain.iter() {
-                full_chain.push(block.clone());
+                full_chain.push(block.clone())?;
             }
 
-            let forked = full_chain.fork(fork_tip_hash).expect("hash is present");
+            let forked = full_chain.fork(fork_tip_hash).expect("fork works").expect("hash is present");
 
             prop_assert_eq!(forked.blocks.len(), partial_chain.blocks.len());
         });
@@ -48,10 +48,10 @@ fn finalized_equals_pushed() -> Result<()> {
         let mut partial_chain = Chain::default();
 
         for block in chain.iter().skip(finalized_count) {
-            partial_chain.push(block.clone());
+            partial_chain.push(block.clone())?;
         }
         for block in chain.iter() {
-            full_chain.push(block.clone());
+            full_chain.push(block.clone())?;
         }
 
         for _ in 0..finalized_count {

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -23,7 +23,7 @@ fn construct_single() -> Result<()> {
         zebra_test::vectors::BLOCK_MAINNET_434873_BYTES.zcash_deserialize_into()?;
 
     let mut chain = Chain::default();
-    chain.push(block.prepare());
+    chain.push(block.prepare())?;
 
     assert_eq!(1, chain.blocks.len());
 
@@ -47,7 +47,7 @@ fn construct_many() -> Result<()> {
     let mut chain = Chain::default();
 
     for block in blocks {
-        chain.push(block.prepare());
+        chain.push(block.prepare())?;
     }
 
     assert_eq!(100, chain.blocks.len());
@@ -64,10 +64,10 @@ fn ord_matches_work() -> Result<()> {
     let more_block = less_block.clone().set_work(10);
 
     let mut lesser_chain = Chain::default();
-    lesser_chain.push(less_block.prepare());
+    lesser_chain.push(less_block.prepare())?;
 
     let mut bigger_chain = Chain::default();
-    bigger_chain.push(more_block.prepare());
+    bigger_chain.push(more_block.prepare())?;
 
     assert!(bigger_chain > lesser_chain);
 
@@ -100,8 +100,8 @@ fn best_chain_wins_for_network(network: Network) -> Result<()> {
     let expected_hash = block2.hash();
 
     let mut state = NonFinalizedState::default();
-    state.commit_new_chain(block2.prepare());
-    state.commit_new_chain(child.prepare());
+    state.commit_new_chain(block2.prepare())?;
+    state.commit_new_chain(child.prepare())?;
 
     let best_chain = state.best_chain().unwrap();
     assert!(best_chain.height_by_hash.contains_key(&expected_hash));
@@ -133,9 +133,9 @@ fn finalize_pops_from_best_chain_for_network(network: Network) -> Result<()> {
     let child = block1.make_fake_child().set_work(1);
 
     let mut state = NonFinalizedState::default();
-    state.commit_new_chain(block1.clone().prepare());
-    state.commit_block(block2.clone().prepare());
-    state.commit_block(child.prepare());
+    state.commit_new_chain(block1.clone().prepare())?;
+    state.commit_block(block2.clone().prepare())?;
+    state.commit_block(child.prepare())?;
 
     let finalized = state.finalize();
     assert_eq!(block1, finalized.block);
@@ -177,13 +177,13 @@ fn commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(
 
     let mut state = NonFinalizedState::default();
     assert_eq!(0, state.chain_set.len());
-    state.commit_new_chain(block1.prepare());
+    state.commit_new_chain(block1.prepare())?;
     assert_eq!(1, state.chain_set.len());
-    state.commit_block(block2.prepare());
+    state.commit_block(block2.prepare())?;
     assert_eq!(1, state.chain_set.len());
-    state.commit_block(child1.prepare());
+    state.commit_block(child1.prepare())?;
     assert_eq!(2, state.chain_set.len());
-    state.commit_block(child2.prepare());
+    state.commit_block(child2.prepare())?;
     assert_eq!(2, state.chain_set.len());
 
     Ok(())
@@ -215,10 +215,10 @@ fn shorter_chain_can_be_best_chain_for_network(network: Network) -> Result<()> {
     let short_chain_block = block1.make_fake_child().set_work(3);
 
     let mut state = NonFinalizedState::default();
-    state.commit_new_chain(block1.prepare());
-    state.commit_block(long_chain_block1.prepare());
-    state.commit_block(long_chain_block2.prepare());
-    state.commit_block(short_chain_block.prepare());
+    state.commit_new_chain(block1.prepare())?;
+    state.commit_block(long_chain_block1.prepare())?;
+    state.commit_block(long_chain_block2.prepare())?;
+    state.commit_block(short_chain_block.prepare())?;
     assert_eq!(2, state.chain_set.len());
 
     assert_eq!(2, state.best_chain_len());
@@ -254,12 +254,12 @@ fn longer_chain_with_more_work_wins_for_network(network: Network) -> Result<()> 
     let short_chain_block = block1.make_fake_child().set_work(3);
 
     let mut state = NonFinalizedState::default();
-    state.commit_new_chain(block1.prepare());
-    state.commit_block(long_chain_block1.prepare());
-    state.commit_block(long_chain_block2.prepare());
-    state.commit_block(long_chain_block3.prepare());
-    state.commit_block(long_chain_block4.prepare());
-    state.commit_block(short_chain_block.prepare());
+    state.commit_new_chain(block1.prepare())?;
+    state.commit_block(long_chain_block1.prepare())?;
+    state.commit_block(long_chain_block2.prepare())?;
+    state.commit_block(long_chain_block3.prepare())?;
+    state.commit_block(long_chain_block4.prepare())?;
+    state.commit_block(short_chain_block.prepare())?;
     assert_eq!(2, state.chain_set.len());
 
     assert_eq!(5, state.best_chain_len());
@@ -291,9 +291,9 @@ fn equal_length_goes_to_more_work_for_network(network: Network) -> Result<()> {
     let expected_hash = more_work_child.hash();
 
     let mut state = NonFinalizedState::default();
-    state.commit_new_chain(block1.prepare());
-    state.commit_block(less_work_child.prepare());
-    state.commit_block(more_work_child.prepare());
+    state.commit_new_chain(block1.prepare())?;
+    state.commit_block(less_work_child.prepare())?;
+    state.commit_block(more_work_child.prepare())?;
     assert_eq!(2, state.chain_set.len());
 
     let tip_hash = state.best_tip().unwrap().1;


### PR DESCRIPTION
## Motivation

In #2301 some methods of the non-finalized state and `Chain` were changed to return errors. However, #2230 and #2231 will also require this. Therefore this PR was split off, with just the addition of the error return.

### Specifications

N/A

### Designs

N/A

## Solution

Change some methods to return `ValidateContextError`. A small refactoring that creates a `NonFinalizedState::parent_chain` method was also ported to this PR since it makes error handling easier.

Note that in this PR errors won't actually be returned, this is just paving the way for that to happen.

## Review

Anyone could review this, but @dconnolly may be particularly interested.

This blocks the PRs mentioned, so it's important to review it soon.

### Reviewer Checklist

Nothing new was implemented so we just need to make sure that no bugs were introduced.

  - [ ] Check if overall behavior stays the same

## Follow Up Work

Paves the way for the PRs mentioned above