### PR TITLE
Refactor validation of Sapling shielded data in `transaction::Verifier`

### DIFF
--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [features]
 default = []
-proptest-impl = ["proptest", "proptest-derive", "itertools"]
+proptest-impl = ["proptest", "proptest-derive", "itertools", "zebra-test"]
 bench = ["zebra-test"]
 
 [dependencies]

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -567,6 +567,27 @@ fn sapling_spend_v4_to_fake_v5(
     }
 }
 
+/// Iterate over V4 transactions in the block test vectors for the specified `network`.
+pub fn test_transactions(
+    network: Network,
+) -> impl DoubleEndedIterator<Item = (block::Height, Arc<Transaction>)> {
+    let blocks = match network {
+        Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
+        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+    };
+
+    blocks.flat_map(|(&block_height, &block_bytes)| {
+        let block = block_bytes
+            .zcash_deserialize_into::<block::Block>()
+            .expect("block is structurally valid");
+
+        block
+            .transactions
+            .into_iter()
+            .map(move |transaction| (block::Height(block_height), transaction))
+    })
+}
+
 /// Generate an iterator over fake V5 transactions.
 ///
 /// These transactions are converted from non-V5 transactions that exist in the provided network


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
As part of NU5, there is a [new transaction format and consensus rules (version 5)](https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus). Zebra already had initial support for the new transaction, but the consensus rules aren't fully implemented. In order to properly validate the new transaction version, some validation code related to Sapling shielded data will be shared between V4 and V5 transactions, so this PRs refactors it to prepare for code sharing.

This is the fourth PR that's part of #1981.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->
The new transaction encoding and consensus rules are detailed in the [specification](https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus).

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
A new `verify_sapling_shielded_data` method is created by this PR, and the `verify_v4_transaction` uses it.

Two tests were also added. Both test if transactions from the test vectors are accepted by the verifier.

These tests might need some sort of fix or workaround for the shared batch verifier worker task issue (#2390). If the CI fails with a `Closed` error message, then it is likely the same cause. Can #2397 be merged as a temporary solution?

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
- Rename the `proptest-impl` feature into something clearer (#2424).
- Tests for rejecting invalid transactions according to the transaction rules (#2426).