### PR TITLE
Fix failing legacy chain tests

### DIFF
--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -47,7 +47,7 @@ pub struct LedgerState {
 
     /// Every V5 and later transaction has a valid `network_upgrade` field.
     ///
-    /// If `false`, some transactions have invalid network upgrades.
+    /// If `false`, zero or more transactions may have invalid network upgrades.
     transaction_has_valid_network_upgrade: bool,
 
     /// Generate coinbase transactions.
@@ -79,7 +79,7 @@ pub struct LedgerStateOverride {
 
     /// Every V5 and later transaction has a valid `network_upgrade` field.
     ///
-    /// If `false`, some transactions have invalid network upgrades.
+    /// If `false`, zero or more transactions may have invalid network upgrades.
     pub transaction_has_valid_network_upgrade: bool,
 
     /// Every block has exactly one coinbase transaction.

--- a/zebra-state/proptest-regressions/service/tests.txt
+++ b/zebra-state/proptest-regressions/service/tests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 37aea4b0880d7d9029ea4fad0136bd8553f81eea0435122737ec513f4f6fb73c # shrinks to (network, nu_activation_height, chain) = (Mainnet, Height(1046400), alloc::vec::Vec<alloc::sync::Arc<zebra_chain::block::Block>><alloc::sync::Arc<zebra_chain::block::Block>>, len=101)

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -315,7 +315,7 @@ impl StateService {
     }
 
     /// Return an iterator over the relevant chain of the block identified by
-    /// `hash`.
+    /// `hash`, in order from the largest height to the genesis block.
     ///
     /// The block identified by `hash` is included in the chain of blocks yielded
     /// by the iterator. `hash` can come from any chain.

--- a/zebra-state/src/service/arbitrary.rs
+++ b/zebra-state/src/service/arbitrary.rs
@@ -97,6 +97,7 @@ impl Strategy for PreparedChain {
 /// Arguments:
 /// - `transaction_version_override`: See `LedgerState::height_strategy` for details.
 /// - `transaction_has_valid_network_upgrade`: See `LedgerState::height_strategy` for details.
+///    Note: `false` allows zero or more invalid network upgrades.
 /// - `blocks_after_nu_activation`: The number of blocks the strategy will generate
 /// after the provided `network_upgrade`.
 /// - `network_upgrade` - The network upgrade that we are using to simulate from where the

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -202,7 +202,7 @@ proptest! {
     fn some_block_less_than_network_upgrade(
         (network, nu_activation_height, chain) in arbitrary::partial_nu5_chain_strategy(4, true, BLOCKS_AFTER_NU5/2, NetworkUpgrade::Canopy)
     ) {
-        let response = crate::service::legacy_chain_check(nu_activation_height, chain.into_iter(), network)
+        let response = crate::service::legacy_chain_check(nu_activation_height, chain.into_iter().rev(), network)
             .map_err(|error| error.to_string());
 
         prop_assert_eq!(response, Ok(()));
@@ -213,7 +213,7 @@ proptest! {
     fn no_transaction_with_network_upgrade(
         (network, nu_activation_height, chain) in arbitrary::partial_nu5_chain_strategy(4, true, BLOCKS_AFTER_NU5, NetworkUpgrade::Canopy)
     ) {
-        let response = crate::service::legacy_chain_check(nu_activation_height, chain.into_iter(), network)
+        let response = crate::service::legacy_chain_check(nu_activation_height, chain.into_iter().rev(), network)
             .map_err(|error| error.to_string());
 
         prop_assert_eq!(
@@ -235,6 +235,7 @@ proptest! {
         // we must check at least one block, and the first checked block must be invalid
         let first_checked_block = chain
             .iter()
+            .rev()
             .take_while(|block| block.coinbase_height().unwrap() >= nu_activation_height)
             .take(100)
             .next();
@@ -248,7 +249,7 @@ proptest! {
 
         let response = crate::service::legacy_chain_check(
             nu_activation_height,
-            chain.clone().into_iter(),
+            chain.clone().into_iter().rev(),
             network
         ).map_err(|error| error.to_string());
 
@@ -266,7 +267,7 @@ proptest! {
     fn at_least_one_transaction_with_valid_network_upgrade(
         (network, nu_activation_height, chain) in arbitrary::partial_nu5_chain_strategy(5, true, BLOCKS_AFTER_NU5/2, NetworkUpgrade::Canopy)
     ) {
-        let response = crate::service::legacy_chain_check(nu_activation_height, chain.into_iter(), network)
+        let response = crate::service::legacy_chain_check(nu_activation_height, chain.into_iter().rev(), network)
             .map_err(|error| error.to_string());
 
         prop_assert_eq!(response, Ok(()));


### PR DESCRIPTION
## Motivation

1. In some rare cases, a legacy chain proptest will fail, because it expects blocks that are always invalid.
2. The legacy chain tests check the blocks in the wrong order.

## Solution

- skip test cases that are unexpectedly valid, in tests that require invalid blocks
- use the correct order for the block iterators in the tests
- add proptest seeds
- improve unclear documentation that might have caused these bugs

## Review

@oxarbitrage can review this code, because he wrote the original legacy chain checks.

This fix is not urgent, unless CI starts failing with these bugs.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

We might want to add a proptest enum with `AlwaysValid`, `MaybeInvalid`, and `AlwaysInvalid` variants.