### PR TITLE
Stop allowing JoinSplit<Halo2>

### DIFF
--- a/zebra-chain/src/primitives/proofs.rs
+++ b/zebra-chain/src/primitives/proofs.rs
@@ -14,7 +14,7 @@ pub use self::bctv14::Bctv14Proof;
 pub use self::groth16::Groth16Proof;
 pub use self::halo2::Halo2Proof;
 
-/// A marker trait used to abstract over BCTV14, Groth16, or Halo2 proofs.
+/// A marker trait used to abstract over BCTV14 or Groth16 proofs in JoinSplits.
 pub trait ZkSnarkProof:
     Clone
     + Debug
@@ -27,9 +27,9 @@ pub trait ZkSnarkProof:
     + private::Sealed
 {
 }
+
 impl ZkSnarkProof for Bctv14Proof {}
 impl ZkSnarkProof for Groth16Proof {}
-impl ZkSnarkProof for Halo2Proof {}
 
 mod private {
     use super::*;
@@ -37,5 +37,4 @@ mod private {
     pub trait Sealed {}
     impl Sealed for Bctv14Proof {}
     impl Sealed for Groth16Proof {}
-    impl Sealed for Halo2Proof {}
 }


### PR DESCRIPTION
## Motivation

A recent PR implemented the `ZkProof` trait for `Halo2`, but that allows `JoinSplit<Halo2>`, which we don't want.

## Solution

- delete `impl ZkProof for Halo2`

## Review

@dconnolly can review this PR.

It's not urgent at all.

### Reviewer Checklist

  - [x] Code implements Specs and Designs

## Follow Up Work

Maybe we should rename the trait to something `JoinSplit`-specific.