### PR TITLE
Validate V5 transactions with Sapling shielded data

### DIFF
--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -416,10 +416,14 @@ where
     }
 
     /// Verifies a transaction's Sapling shielded data.
-    fn verify_sapling_shielded_data(
-        sapling_shielded_data: &Option<sapling::ShieldedData<sapling::PerSpendAnchor>>,
+    fn verify_sapling_shielded_data<A>(
+        sapling_shielded_data: &Option<sapling::ShieldedData<A>>,
         shielded_sighash: &blake2b_simd::Hash,
-    ) -> Result<AsyncChecks, TransactionError> {
+    ) -> Result<AsyncChecks, TransactionError>
+    where
+        A: sapling::AnchorVariant + Clone,
+        sapling::Spend<sapling::PerSpendAnchor>: From<(sapling::Spend<A>, A::Shared)>,
+    {
         let mut async_checks = AsyncChecks::new();
 
         if let Some(sapling_shielded_data) = sapling_shielded_data {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -328,6 +328,7 @@ where
         // - ZIP-244 (#1874)
         // - validate bindingSigOrchard (#2103)
         // - remaining consensus rules (#2379)
+        // - remove `should_panic` from tests
 
         unimplemented!("V5 transaction validation is not yet complete");
     }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -326,6 +326,8 @@ where
         // - verify orchard shielded pool (ZIP-224) (#2105)
         // - ZIP-216 (#1798)
         // - ZIP-244 (#1874)
+        // - validate bindingSigOrchard (#2103)
+        // - remaining consensus rules (#2379)
 
         unimplemented!("V5 transaction validation is not yet complete");
     }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -323,7 +323,6 @@ where
         )?);
 
         // TODO:
-        // - verify sapling shielded pool (#1981)
         // - verify orchard shielded pool (ZIP-224) (#2105)
         // - ZIP-216 (#1798)
         // - ZIP-244 (#1874)

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -201,6 +201,8 @@ fn v5_coinbase_transaction_with_enable_spends_flag_fails_validation() {
 }
 
 #[tokio::test]
+// TODO: Remove `should_panic` once V5 transaction sighash is implemened.
+#[should_panic]
 async fn v5_transaction_is_rejected_before_nu5_activation() {
     const V5_TRANSACTION_VERSION: u32 = 5;
 

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -751,7 +751,7 @@ fn v4_with_sapling_outputs_and_no_spends() {
                 transaction.sapling_spends_per_anchor().next().is_none()
                     && transaction.sapling_outputs().next().is_some()
             })
-            .expect("No transaction found with Sapling spends");
+            .expect("No transaction found with Sapling outputs and no Sapling spends");
 
         let expected_hash = transaction.hash();
 

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -775,6 +775,47 @@ fn v4_with_sapling_outputs_and_no_spends() {
     });
 }
 
+/// Test if a V5 transaction with Sapling spends is accepted by the verifier.
+#[test]
+// TODO: Remove `should_panic` once V5 transaction verification is complete.
+#[should_panic]
+fn v5_with_sapling_spends() {
+    zebra_test::init();
+    zebra_test::RUNTIME.block_on(async {
+        let network = Network::Mainnet;
+
+        let transaction =
+            fake_v5_transactions_for_network(network, zebra_test::vectors::MAINNET_BLOCKS.iter())
+                .rev()
+                .filter(|transaction| !transaction.is_coinbase() && transaction.inputs().is_empty())
+                .find(|transaction| transaction.sapling_spends_per_anchor().next().is_some())
+                .expect("No transaction found with Sapling spends");
+
+        let expected_hash = transaction.hash();
+        let height = transaction
+            .expiry_height()
+            .expect("Transaction is missing expiry height");
+
+        // Initialize the verifier
+        let state_service =
+            service_fn(|_| async { unreachable!("State service should not be called") });
+        let script_verifier = script::Verifier::new(state_service);
+        let verifier = Verifier::new(network, script_verifier);
+
+        // Test the transaction verifier
+        let result = verifier
+            .clone()
+            .oneshot(Request::Block {
+                transaction: Arc::new(transaction),
+                known_utxos: Arc::new(HashMap::new()),
+                height,
+            })
+            .await;
+
+        assert_eq!(result, Ok(expected_hash));
+    });
+}
+
 // Utility functions
 
 /// Create a mock transparent transfer to be included in a transaction.

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -201,7 +201,7 @@ fn v5_coinbase_transaction_with_enable_spends_flag_fails_validation() {
 }
 
 #[tokio::test]
-// TODO: Remove `should_panic` once V5 transaction sighash is implemened.
+// TODO: Remove `should_panic` once V5 transaction sighash is implemened by the merge of #2165.
 #[should_panic]
 async fn v5_transaction_is_rejected_before_nu5_activation() {
     const V5_TRANSACTION_VERSION: u32 = 5;


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
As part of NU5, there is a [new transaction format and consensus rules (version 5)](https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus). Zebra already had initial support for the new transaction, but the consensus rules aren't fully implemented.

This is the sixth and final PR that's part of #1981, and therefore this PR closes #1981.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->
The new transaction encoding and consensus rules are detailed in the [specification](https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus).

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
The `verify_v5_transaction` method now also includes the checks generated by calling the `verify_sapling_shielded_data` method.

Only one test is included, even though there are two tests for V4 transactions. Unfortunately, the test where there are no Sapling spends but at least one Sapling output can't be implemented because there are no fake V5 transactions that satisfy this condition. The transactions that satisfy this for V4 have Sprout joinsplits as inputs, which are then removed when converted into a V5 transaction, making the verifier reject them due to missing inputs.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 has already reviewed the other PRs that were part of #1981.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors