### PR TITLE
Parse `MSG_WTX` inventory type (part of ZIP-239)

### DIFF
--- a/zebra-network/proptest-regressions/protocol/external/tests/prop.txt
+++ b/zebra-network/proptest-regressions/protocol/external/tests/prop.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 62951c0bf7f003f29184881befbd1e8144493b3b14a6dd738ecef9e4c8c06148 # shrinks to inventory_hash = Wtx

--- a/zebra-network/src/protocol/external/arbitrary.rs
+++ b/zebra-network/src/protocol/external/arbitrary.rs
@@ -96,4 +96,11 @@ impl Message {
     pub fn inv_strategy() -> BoxedStrategy<Self> {
         any::<Vec<InventoryHash>>().prop_map(Message::Inv).boxed()
     }
+
+    /// Create a strategy that only generates [`Message::GetData`] messages.
+    pub fn get_data_strategy() -> BoxedStrategy<Self> {
+        any::<Vec<InventoryHash>>()
+            .prop_map(Message::GetData)
+            .boxed()
+    }
 }

--- a/zebra-network/src/protocol/external/arbitrary.rs
+++ b/zebra-network/src/protocol/external/arbitrary.rs
@@ -35,6 +35,22 @@ impl InventoryHash {
             .prop_map(InventoryHash::FilteredBlock)
             .boxed()
     }
+
+    /// Generate a proptest strategy for [`InventoryHash`] variants of the smallest serialized size.
+    pub fn smallest_types_strategy() -> BoxedStrategy<Self> {
+        InventoryHash::arbitrary()
+            .prop_filter(
+                "inventory type is not one of the smallest",
+                |inventory_hash| match inventory_hash {
+                    InventoryHash::Error
+                    | InventoryHash::Tx(_)
+                    | InventoryHash::Block(_)
+                    | InventoryHash::FilteredBlock(_) => true,
+                    InventoryHash::Wtx(_) => false,
+                },
+            )
+            .boxed()
+    }
 }
 
 impl Arbitrary for InventoryHash {

--- a/zebra-network/src/protocol/external/arbitrary.rs
+++ b/zebra-network/src/protocol/external/arbitrary.rs
@@ -79,7 +79,6 @@ impl Arbitrary for InventoryHash {
     type Strategy = BoxedStrategy<Self>;
 }
 
-#[cfg(any(test, feature = "proptest-impl"))]
 impl Arbitrary for PeerServices {
     type Parameters = ();
 

--- a/zebra-network/src/protocol/external/arbitrary.rs
+++ b/zebra-network/src/protocol/external/arbitrary.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 
 use proptest::{arbitrary::any, arbitrary::Arbitrary, collection::vec, prelude::*};
 
-use super::{types::PeerServices, InventoryHash};
+use super::{types::PeerServices, InventoryHash, Message};
 
 use zebra_chain::{block, transaction};
 
@@ -89,4 +89,11 @@ impl Arbitrary for PeerServices {
     }
 
     type Strategy = BoxedStrategy<Self>;
+}
+
+impl Message {
+    /// Create a strategy that only generates [`Message::Inv`] messages.
+    pub fn inv_strategy() -> BoxedStrategy<Self> {
+        any::<Vec<InventoryHash>>().prop_map(Message::Inv).boxed()
+    }
 }

--- a/zebra-network/src/protocol/external/arbitrary.rs
+++ b/zebra-network/src/protocol/external/arbitrary.rs
@@ -5,12 +5,12 @@ use super::{types::PeerServices, InventoryHash};
 use zebra_chain::{block, transaction};
 
 impl InventoryHash {
-    /// Generate a proptest strategy for Inv Errors
+    /// Generate a proptest strategy for [`InventoryHash::Error`]s.
     pub fn error_strategy() -> BoxedStrategy<Self> {
         Just(InventoryHash::Error).boxed()
     }
 
-    /// Generate a proptest strategy for Inv Tx hashes
+    /// Generate a proptest strategy for [`InventoryHash::Tx`] hashes.
     pub fn tx_strategy() -> BoxedStrategy<Self> {
         // using any::<transaction::Hash> causes a trait impl error
         // when building the zebra-network crate separately
@@ -20,7 +20,7 @@ impl InventoryHash {
             .boxed()
     }
 
-    /// Generate a proptest strategy for Inv Block hashes
+    /// Generate a proptest strategy for [`InventotryHash::Block`] hashes.
     pub fn block_strategy() -> BoxedStrategy<Self> {
         (any::<[u8; 32]>())
             .prop_map(block::Hash)
@@ -28,7 +28,7 @@ impl InventoryHash {
             .boxed()
     }
 
-    /// Generate a proptest strategy for Inv FilteredBlock hashes
+    /// Generate a proptest strategy for [`InventoryHash::FilteredBlock`] hashes.
     pub fn filtered_block_strategy() -> BoxedStrategy<Self> {
         (any::<[u8; 32]>())
             .prop_map(block::Hash)

--- a/zebra-network/src/protocol/external/arbitrary.rs
+++ b/zebra-network/src/protocol/external/arbitrary.rs
@@ -1,4 +1,6 @@
-use proptest::{arbitrary::any, arbitrary::Arbitrary, prelude::*};
+use std::convert::TryInto;
+
+use proptest::{arbitrary::any, arbitrary::Arbitrary, collection::vec, prelude::*};
 
 use super::{types::PeerServices, InventoryHash};
 
@@ -36,6 +38,13 @@ impl InventoryHash {
             .boxed()
     }
 
+    /// Generate a proptest strategy for [`InventoryHash::Wtx`] hashes.
+    pub fn wtx_strategy() -> BoxedStrategy<Self> {
+        vec(any::<u8>(), 64)
+            .prop_map(|bytes| InventoryHash::Wtx(bytes.try_into().unwrap()))
+            .boxed()
+    }
+
     /// Generate a proptest strategy for [`InventoryHash`] variants of the smallest serialized size.
     pub fn smallest_types_strategy() -> BoxedStrategy<Self> {
         InventoryHash::arbitrary()
@@ -62,6 +71,7 @@ impl Arbitrary for InventoryHash {
             Self::tx_strategy(),
             Self::block_strategy(),
             Self::filtered_block_strategy(),
+            Self::wtx_strategy(),
         ]
         .boxed()
     }

--- a/zebra-network/src/protocol/external/inv.rs
+++ b/zebra-network/src/protocol/external/inv.rs
@@ -82,13 +82,14 @@ impl ZcashDeserialize for InventoryHash {
     }
 }
 
-/// The serialized size of an [`InventoryHash`].
-pub(crate) const INV_HASH_SIZE: usize = 36;
+/// The minimum serialized size of an [`InventoryHash`].
+pub(crate) const MIN_INV_HASH_SIZE: usize = 36;
 
 impl TrustedPreallocate for InventoryHash {
     fn max_allocation() -> u64 {
-        // An Inventory hash takes 36 bytes, and we reserve at least one byte for the Vector length
-        // so we can never receive more than ((MAX_PROTOCOL_MESSAGE_LEN - 1) / 36) in a single message
-        ((MAX_PROTOCOL_MESSAGE_LEN - 1) / INV_HASH_SIZE) as u64
+        // An Inventory hash takes at least 36 bytes, and we reserve at least one byte for the
+        // Vector length so we can never receive more than ((MAX_PROTOCOL_MESSAGE_LEN - 1) / 36) in
+        // a single message
+        ((MAX_PROTOCOL_MESSAGE_LEN - 1) / MIN_INV_HASH_SIZE) as u64
     }
 }

--- a/zebra-network/src/protocol/external/tests.rs
+++ b/zebra-network/src/protocol/external/tests.rs
@@ -1,1 +1,2 @@
 mod preallocate;
+mod vectors;

--- a/zebra-network/src/protocol/external/tests.rs
+++ b/zebra-network/src/protocol/external/tests.rs
@@ -1,2 +1,3 @@
 mod preallocate;
+mod prop;
 mod vectors;

--- a/zebra-network/src/protocol/external/tests/preallocate.rs
+++ b/zebra-network/src/protocol/external/tests/preallocate.rs
@@ -1,6 +1,6 @@
 //! Tests for trusted preallocation during deserialization.
 
-use super::super::inv::{InventoryHash, INV_HASH_SIZE};
+use super::super::inv::{InventoryHash, MIN_INV_HASH_SIZE};
 
 use zebra_chain::serialization::{TrustedPreallocate, ZcashSerialize, MAX_PROTOCOL_MESSAGE_LEN};
 
@@ -15,7 +15,7 @@ proptest! {
         let serialized_inv = inv
             .zcash_serialize_to_vec()
             .expect("Serialization to vec must succeed");
-        assert!(serialized_inv.len() == INV_HASH_SIZE);
+        assert!(serialized_inv.len() == MIN_INV_HASH_SIZE);
     }
 
     /// Verifies that...

--- a/zebra-network/src/protocol/external/tests/preallocate.rs
+++ b/zebra-network/src/protocol/external/tests/preallocate.rs
@@ -22,7 +22,7 @@ proptest! {
     /// 1. The smallest disallowed vector of `InventoryHash`s is too large to fit in a legal Zcash message
     /// 2. The largest allowed vector is small enough to fit in a legal Zcash message
     #[test]
-    fn inv_hash_max_allocation_is_correct(inv in InventoryHash::arbitrary()) {
+    fn inv_hash_max_allocation_is_correct(inv in InventoryHash::smallest_types_strategy()) {
         let max_allocation: usize = InventoryHash::max_allocation().try_into().unwrap();
         let mut smallest_disallowed_vec = Vec::with_capacity(max_allocation + 1);
         for _ in 0..(InventoryHash::max_allocation() + 1) {

--- a/zebra-network/src/protocol/external/tests/prop.rs
+++ b/zebra-network/src/protocol/external/tests/prop.rs
@@ -1,0 +1,22 @@
+use proptest::prelude::*;
+
+use zebra_chain::serialization::{ZcashDeserializeInto, ZcashSerialize};
+
+use super::super::InventoryHash;
+
+proptest! {
+    /// Test if [`InventoryHash`] is not changed after serializing and deserializing it.
+    #[test]
+    fn inventory_hash_roundtrip(inventory_hash in any::<InventoryHash>()) {
+        let mut bytes = Vec::new();
+
+        let serialization_result = inventory_hash.zcash_serialize(&mut bytes);
+
+        prop_assert!(serialization_result.is_ok());
+
+        let deserialized: Result<InventoryHash, _> = bytes.zcash_deserialize_into();
+
+        prop_assert!(deserialized.is_ok());
+        prop_assert_eq!(deserialized.unwrap(), inventory_hash);
+    }
+}

--- a/zebra-network/src/protocol/external/tests/prop.rs
+++ b/zebra-network/src/protocol/external/tests/prop.rs
@@ -1,8 +1,13 @@
-use proptest::prelude::*;
+use proptest::{collection::vec, prelude::*};
 
-use zebra_chain::serialization::{ZcashDeserializeInto, ZcashSerialize};
+use zebra_chain::serialization::{SerializationError, ZcashDeserializeInto, ZcashSerialize};
 
 use super::super::InventoryHash;
+
+/// Maximum number of random input bytes to try to deserialize an [`InventoryHash`] from.
+///
+/// This is two bytes larger than the maximum [`InventoryHash`] size.
+const MAX_INVENTORY_HASH_BYTES: usize = 70;
 
 proptest! {
     /// Test if [`InventoryHash`] is not changed after serializing and deserializing it.
@@ -13,10 +18,52 @@ proptest! {
         let serialization_result = inventory_hash.zcash_serialize(&mut bytes);
 
         prop_assert!(serialization_result.is_ok());
+        prop_assert!(bytes.len() < MAX_INVENTORY_HASH_BYTES);
 
         let deserialized: Result<InventoryHash, _> = bytes.zcash_deserialize_into();
 
         prop_assert!(deserialized.is_ok());
         prop_assert_eq!(deserialized.unwrap(), inventory_hash);
+    }
+
+    /// Test attempting to deserialize an [`InventoryHash`] from random bytes.
+    #[test]
+    fn inventory_hash_from_random_bytes(input in vec(any::<u8>(), 0..MAX_INVENTORY_HASH_BYTES)) {
+        let deserialized: Result<InventoryHash, _> = input.zcash_deserialize_into();
+
+        if input.len() < 36 {
+            // Not enough bytes for any inventory hash
+            prop_assert!(deserialized.is_err());
+            prop_assert_eq!(
+                deserialized.unwrap_err().to_string(),
+                "io error: failed to fill whole buffer"
+            );
+        } else if input[1..4] != [0u8; 3] || input[0] > 5 || input[0] == 4 {
+            // Invalid inventory code
+            prop_assert!(matches!(
+                deserialized,
+                Err(SerializationError::Parse("invalid inventory code"))
+            ));
+        } else if input[0] == 5 && input.len() < 68 {
+            // Not enough bytes for a WTX inventory hash
+            prop_assert!(deserialized.is_err());
+            prop_assert_eq!(
+                deserialized.unwrap_err().to_string(),
+                "io error: failed to fill whole buffer"
+            );
+        } else {
+            // Deserialization should have succeeded
+            prop_assert!(deserialized.is_ok());
+
+            // Reserialize inventory hash
+            let mut bytes = Vec::new();
+            let serialization_result = deserialized.unwrap().zcash_serialize(&mut bytes);
+
+            prop_assert!(serialization_result.is_ok());
+
+            // Check that the reserialization produces the same bytes as the input
+            prop_assert!(bytes.len() <= input.len());
+            prop_assert_eq!(&bytes, &input[..bytes.len()]);
+        }
     }
 }

--- a/zebra-network/src/protocol/external/tests/vectors.rs
+++ b/zebra-network/src/protocol/external/tests/vectors.rs
@@ -1,0 +1,26 @@
+use std::io::Write;
+
+use byteorder::{LittleEndian, WriteBytesExt};
+
+use zebra_chain::serialization::ZcashDeserializeInto;
+
+use super::super::InventoryHash;
+
+/// Test if deserializing [`InventoryHash::Wtx`] does not produce an error.
+#[test]
+fn parses_msg_wtx_inventory_type() {
+    let mut input = Vec::new();
+
+    input
+        .write_u32::<LittleEndian>(5)
+        .expect("Failed to write MSG_WTX code");
+    input
+        .write_all(&[0u8; 64])
+        .expect("Failed to write dummy inventory data");
+
+    let deserialized: InventoryHash = input
+        .zcash_deserialize_into()
+        .expect("Failed to deserialize dummy `InventoryHash::Wtx`");
+
+    assert_eq!(deserialized, InventoryHash::Wtx([0; 64]));
+}


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
ZIP-239 describes a new inv type (`MSG_WTX`), to be applied from the NU5 network upgrade onward. This message type is to be used for both `inv` messages and `getdata` requests for relaying mempool transactions.

Even though a mempool implementation is not the current focus, Zebra could close connections to peers that send these messages. This could lead to Zebra not having enough peers to function properly after the NU5 activation.

### Specifications

> A transaction has a transaction ID that can be used to refer to it. ... Version 5 transactions also have a wtxid , which is used instead of the transaction ID when gossiping transactions in the peer-to-peer protocol

https://zips.z.cash/protocol/protocol.pdf#transactions

> The transaction ID of a version 4 or earlier transaction is the SHA-256d hash of the transaction encoding in the
pre-v5 format described above.
> 
> The transaction ID of a version 5 transaction is as defined in [ZIP-244]. A v5 transaction also has a wtxid (used for example in the peer-to-peer protocol) as defined in [ZIP-239].

https://zips.z.cash/protocol/protocol.pdf#txnidentifiers

> A new inv type MSG_WTX (0x00000005) is added, for use in both inv messages and getdata requests, indicating that the hash being referenced is the wtxid (i.e. the 64-byte value txid || auth_digest). This inv type MUST be used when announcing v5 transactions. The txid and auth_digest are as defined in 4.
> 
> An inv or getdata message MUST NOT use the MSG_WTX inv type for v4 or earlier transactions, or on peer connections that have not negotiated at least the peer protocol version specified in Deployment.
> 
> Note that MSG_WTX might also be used for future transaction versions after v5. Since such versions are not currently consensus-valid, this is left unspecified for now.
> 
> MSG_TX and MSG_WTX entries may be mixed in arbitrary order in an inv message or a getdata message. Since these entry types are of different lengths (36 bytes or 68 bytes respectively including the 4-byte type field), this implies that the size of the message is not determined by its initial count field, and has to be determined by parsing the whole message.

> it is possible for a node to receive an inv or getdata message with a MSG_WTX inv type, on a peer connection that has negotiated protocol version 170014 or later, before NU5 has activated. The node MUST handle this case in the same way that it would after NU5 activation when it has no v5 transactions to relay. Receiving a MSG_WTX inv type on a peer connection that has negotiated a protocol version before 170014, on the other hand, SHOULD be treated as a protocol error.

[ZIP-239](https://zips.z.cash/zip-0239#specification)

[Bitcoin equivalent](https://developer.bitcoin.org/reference/p2p_networking.html#inv)

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
This PR adds an `InventoryHash::Wtx` variant. This variant is currently assumed to not be used and simply stores the raw bytes of the data it contains. This is currently not an issue because Zebra does not have a mempool implementation.

A test vector was added to make sure that the deserialization completes successfully. Some property tests were also added:

- a serialization roundtrip of arbitrary `InventoryHash` variants
- an encoding roundtrip of `Message::Inv` and `Message::GetData` (I tried including all variants, but that led to some issues with the strategy used, which required more work, so I decided to limit the scope for now)
- a deserialization of an `InventoryHash` from random bytes (this ended up being less useful than expected, but maybe it can be converted into some sort of fuzz test in the future?)

Also included in the PR is an update to two existing preallocation tests, because now the `InventoryHash` no longer has a constant size.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 and @oxarbitrage 

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->

## Related issues

This PR closes #2233.
