### PR TITLE
Avoid broken nightly cargo by switching to beta

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   coverage:
-    name: Coverage (+nightly)
+    name: Coverage (+beta)
     # The large timeout is to accommodate nightly builds
     timeout-minutes: 45
     runs-on: ubuntu-latest
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1.0.7
         with:
-          toolchain: nightly
+          toolchain: beta
           override: true
           profile: minimal
           components: llvm-tools-preview

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Coverage
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Motivation

Zebra's coverage CI is failing, but the other tests seem fine.

Coverage is the only build that uses nightly Rust.

## Solution

- change coverage from nightly to beta

This solution might not work if coverage still requires nightly features.

## Review

Anyone can review this PR. It's urgent, because checking CI failures takes up time every time a PR changes.

### Reviewer Checklist

  - [ ] CI passes
