### PR TITLE
Stop using the wrong name for the coverage action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Coverage
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Motivation

We might want to disable the coverage action if it keeps failing, but it's currently called `CI`.

That risks disabling all our CI, rather than just coverage.

## Solution

- Stop using a duplicate name

## Review

Anyone can review. This change is urgent if coverage keeps failing.

### Reviewer Checklist

  - [x] YAML name matches file name
