### PR TITLE
clippy: remove needless borrows

### DIFF
--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -19,7 +19,7 @@ pub struct Hash(pub [u8; 32]);
 
 impl<'a> From<&'a Transaction> for Hash {
     fn from(transaction: &'a Transaction) -> Self {
-        let hasher = TxIdBuilder::new(&transaction);
+        let hasher = TxIdBuilder::new(transaction);
         hasher
             .txid()
             .expect("zcash_primitives and Zebra transaction formats must be compatible")

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -555,6 +555,6 @@ impl<'a> SigHasher<'a> {
             .input
             .as_ref()
             .map(|(output, input, idx)| (output, *input, *idx));
-        sighash(&self.trans, self.hash_type, self.network_upgrade, input)
+        sighash(self.trans, self.hash_type, self.network_upgrade, input)
     }
 }


### PR DESCRIPTION
## Motivation

Fix a clippy nightly warning, so that any other clippy warnings are obvious to developers.

This fix only impacts developers who use Rust nightly.

### Code Freeze Justification

If we don't fix this warning:
- developers have to stop using nightly Rust,
- we have to disable this warning in Zebra, or
- developers might miss genuine bugs.

Since it's a tiny fix that is low risk, the fix is better than the alternatives.

## Review

Anyone can review this tiny fix.

### Reviewer Checklist

  - [x] Changes are minor
  - [x] Clippy passes
