### PR TITLE
Add methods for getting block nullifiers

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -120,7 +120,7 @@ impl Block {
         Ok(())
     }
 
-    /// Access the sprout::Nullifiers from all transactions in this block.
+    /// Access the [`sprout::Nullifier`]s from all transactions in this block.
     pub fn sprout_nullifiers(&self) -> impl Iterator<Item = &sprout::Nullifier> {
         self.transactions
             .iter()
@@ -128,7 +128,7 @@ impl Block {
             .flatten()
     }
 
-    /// Access the sapling::Nullifiers from all transactions in this block.
+    /// Access the [`sapling::Nullifier`]s from all transactions in this block.
     pub fn sapling_nullifiers(&self) -> impl Iterator<Item = &sapling::Nullifier> {
         self.transactions
             .iter()
@@ -136,7 +136,7 @@ impl Block {
             .flatten()
     }
 
-    /// Access the orchard::Nullifiers from all transactions in this block.
+    /// Access the [`orchard::Nullifier`]s from all transactions in this block.
     pub fn orchard_nullifiers(&self) -> impl Iterator<Item = &orchard::Nullifier> {
         self.transactions
             .iter()

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -29,8 +29,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     fmt::DisplayToDebug,
+    orchard,
     parameters::{Network, NetworkUpgrade},
+    sapling,
     serialization::{TrustedPreallocate, MAX_PROTOCOL_MESSAGE_LEN},
+    sprout,
     transaction::Transaction,
     transparent,
 };
@@ -115,6 +118,30 @@ impl Block {
         }
 
         Ok(())
+    }
+
+    /// Access the sprout::Nullifiers from all transactions in this block.
+    pub fn sprout_nullifiers(&self) -> impl Iterator<Item = &sprout::Nullifier> {
+        self.transactions
+            .iter()
+            .map(|transaction| transaction.sprout_nullifiers())
+            .flatten()
+    }
+
+    /// Access the sapling::Nullifiers from all transactions in this block.
+    pub fn sapling_nullifiers(&self) -> impl Iterator<Item = &sapling::Nullifier> {
+        self.transactions
+            .iter()
+            .map(|transaction| transaction.sapling_nullifiers())
+            .flatten()
+    }
+
+    /// Access the orchard::Nullifiers from all transactions in this block.
+    pub fn orchard_nullifiers(&self) -> impl Iterator<Item = &orchard::Nullifier> {
+        self.transactions
+            .iter()
+            .map(|transaction| transaction.orchard_nullifiers())
+            .flatten()
     }
 }
 


### PR DESCRIPTION
## Motivation

Add methods for getting block nullifiers.

These methods will be used in a future PR to check for double-spends.

## Solution

This is part of ticket #2231, but it does not close that ticket.

## Review

Anyone can review this PR. It's not urgent.

### Reviewer Checklist

  - [ ] Code works as documented

These methods will be tested as part of the double-spend tests in a future PR.

## Follow Up Work

Actually check for double-spends