### PR TITLE
Combine near-duplicate Utxo creation functions

### DIFF
--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -8,7 +8,6 @@
 //! verification, where it may be accepted or rejected.
 
 use std::{
-    collections::HashMap,
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -25,7 +24,6 @@ use tracing::Instrument;
 use zebra_chain::{
     block::{self, Block},
     parameters::Network,
-    transaction, transparent,
     work::equihash,
 };
 use zebra_state as zs;
@@ -175,7 +173,7 @@ where
 
             let mut async_checks = FuturesUnordered::new();
 
-            let known_utxos = new_outputs(&block, &transaction_hashes);
+            let known_utxos = Arc::new(zs::new_outputs(&block, &transaction_hashes));
             for transaction in &block.transactions {
                 let rsp = transaction_verifier
                     .ready_and()
@@ -229,34 +227,4 @@ where
         .instrument(span)
         .boxed()
     }
-}
-
-/// Compute an index of newly created transparent outputs, given a block and a
-/// list of precomputed transaction hashes.
-fn new_outputs(
-    block: &Block,
-    transaction_hashes: &[transaction::Hash],
-) -> Arc<HashMap<transparent::OutPoint, zs::Utxo>> {
-    let mut new_outputs = HashMap::default();
-    let height = block.coinbase_height().expect("block has coinbase height");
-    for (transaction, hash) in block
-        .transactions
-        .iter()
-        .zip(transaction_hashes.iter().cloned())
-    {
-        let from_coinbase = transaction.is_coinbase();
-        for (index, output) in transaction.outputs().iter().cloned().enumerate() {
-            let index = index as u32;
-            new_outputs.insert(
-                transparent::OutPoint { hash, index },
-                zs::Utxo {
-                    output,
-                    height,
-                    from_coinbase,
-                },
-            );
-        }
-    }
-
-    Arc::new(new_outputs)
 }

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -36,4 +36,4 @@ pub use error::{BoxError, CloneError, CommitBlockError, ValidateContextError};
 pub use request::{FinalizedBlock, HashOrHeight, PreparedBlock, Request};
 pub use response::Response;
 pub use service::init;
-pub use utxo::Utxo;
+pub use utxo::{new_outputs, Utxo};

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -117,27 +117,7 @@ impl From<Arc<Block>> for FinalizedBlock {
             .iter()
             .map(|tx| tx.hash())
             .collect::<Vec<_>>();
-
-        let mut new_outputs = HashMap::default();
-
-        for (transaction, hash) in block
-            .transactions
-            .iter()
-            .zip(transaction_hashes.iter().cloned())
-        {
-            let from_coinbase = transaction.is_coinbase();
-            for (index, output) in transaction.outputs().iter().cloned().enumerate() {
-                let index = index as u32;
-                new_outputs.insert(
-                    transparent::OutPoint { hash, index },
-                    Utxo {
-                        output,
-                        height,
-                        from_coinbase,
-                    },
-                );
-            }
-        }
+        let new_outputs = crate::utxo::new_outputs(&block, transaction_hashes.as_slice());
 
         Self {
             block,

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -20,8 +20,8 @@ impl Prepare for Arc<Block> {
         let block = self;
         let hash = block.hash();
         let height = block.coinbase_height().unwrap();
-        let transaction_hashes = block.transactions.iter().map(|tx| tx.hash()).collect();
-        let new_outputs = crate::utxo::new_outputs(&block);
+        let transaction_hashes: Vec<_> = block.transactions.iter().map(|tx| tx.hash()).collect();
+        let new_outputs = crate::utxo::new_outputs(&block, transaction_hashes.as_slice());
 
         PreparedBlock {
             block,

--- a/zebra-state/src/utxo.rs
+++ b/zebra-state/src/utxo.rs
@@ -22,8 +22,6 @@ pub struct Utxo {
     pub from_coinbase: bool,
 }
 
-
-
 /// Compute an index of newly created transparent outputs, given a block and a
 /// list of precomputed transaction hashes.
 pub fn new_outputs(

--- a/zebra-state/src/utxo.rs
+++ b/zebra-state/src/utxo.rs
@@ -1,7 +1,11 @@
-// needed to make clippy happy with derive(Arbitrary)
-#![allow(clippy::unit_arg)]
+//! Unspent transparent output data structures and functions.
 
-use zebra_chain::{block, transparent};
+use std::collections::HashMap;
+
+use zebra_chain::{
+    block::{self, Block},
+    transaction, transparent,
+};
 
 /// An unspent `transparent::Output`, with accompanying metadata.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -18,15 +22,21 @@ pub struct Utxo {
     pub from_coinbase: bool,
 }
 
-#[cfg(test)]
-pub fn new_outputs(block: &block::Block) -> std::collections::HashMap<transparent::OutPoint, Utxo> {
-    use std::collections::HashMap;
 
-    let height = block.coinbase_height().expect("block has coinbase height");
 
+/// Compute an index of newly created transparent outputs, given a block and a
+/// list of precomputed transaction hashes.
+pub fn new_outputs(
+    block: &Block,
+    transaction_hashes: &[transaction::Hash],
+) -> HashMap<transparent::OutPoint, Utxo> {
     let mut new_outputs = HashMap::default();
-    for transaction in &block.transactions {
-        let hash = transaction.hash();
+    let height = block.coinbase_height().expect("block has coinbase height");
+    for (transaction, hash) in block
+        .transactions
+        .iter()
+        .zip(transaction_hashes.iter().cloned())
+    {
         let from_coinbase = transaction.is_coinbase();
         for (index, output) in transaction.outputs().iter().cloned().enumerate() {
             let index = index as u32;


### PR DESCRIPTION
## Motivation

We need to change how `Utxo`s are created as part of #2231.

The deduplicated function will be used in a future PR to check for double-spends.

### Priority and Risk

It is easier and less risky to make the changes required for double-spend validation in a single function.

The alternative is making the same changes at 3 separate places in the code, and trying to keep them all in sync.

## Solution

- Combine 3 similar functions into a common `new_outputs` function

As a side-effect, this change avoids re-calculating some transaction hashes.

This is part of ticket #2231, but it does not close that ticket.

## Review

Anyone can review this PR. It's not urgent.

### Reviewer Checklist

  - [ ] Code works as documented
  - [ ] Existing tests pass

This function will also be tested as part of the double-spend tests in a future PR.

## Follow Up Work

Actually check for double-spends