### PR TITLE
Fix missing blake2b_simd::Hash -> SigHash replacement

### DIFF
--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -546,7 +546,7 @@ where
     /// Verifies a transaction's Orchard shielded data.
     fn verify_orchard_shielded_data(
         orchard_shielded_data: &Option<orchard::ShieldedData>,
-        shielded_sighash: &blake2b_simd::Hash,
+        shielded_sighash: &SigHash,
     ) -> Result<AsyncChecks, TransactionError> {
         let mut async_checks = AsyncChecks::new();
 


### PR DESCRIPTION
## Motivation

We missed a blake2b_simd::Hash -> SigHash replacement replacement in  #2442 which is breaking `main`. It worked in the PR because it wasn't up-to-date with `main`

### Specifications

N/A

### Designs

N/A

## Solution

Just rename it

## Review

Anyone can review, this is critical beacause it's breaking all the builds

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

N/A
