### PR TITLE
Update panics by `todo!` and `unimplemented!` macros

### DIFF
--- a/zebra-chain/src/orchard/note/nullifiers.rs
+++ b/zebra-chain/src/orchard/note/nullifiers.rs
@@ -21,7 +21,7 @@ use super::super::{
 /// [poseidonhash]: https://zips.z.cash/protocol/nu5.pdf#poseidonhash
 fn poseidon_hash(_x: pallas::Base, _y: pallas::Base) -> pallas::Base {
     // TODO: implement: #2064
-    unimplemented!()
+    unimplemented!("PoseidonHash is not yet implemented (#2064)")
 }
 
 /// Used as part of deriving the _nullifier_ for a Orchard _note_.

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -43,9 +43,6 @@ mod tests;
 pub struct Verifier<ZS> {
     network: Network,
     script_verifier: script::Verifier<ZS>,
-    // spend_verifier: groth16::Verifier,
-    // output_verifier: groth16::Verifier,
-    // joinsplit_verifier: groth16::Verifier,
 }
 
 impl<ZS> Verifier<ZS>
@@ -53,16 +50,10 @@ where
     ZS: Service<zs::Request, Response = zs::Response, Error = BoxError> + Send + Clone + 'static,
     ZS::Future: Send + 'static,
 {
-    // XXX: how should this struct be constructed?
     pub fn new(network: Network, script_verifier: script::Verifier<ZS>) -> Self {
-        // let (spend_verifier, output_verifier, joinsplit_verifier) = todo!();
-
         Self {
             network,
             script_verifier,
-            // spend_verifier,
-            // output_verifier,
-            // joinsplit_verifier,
         }
     }
 }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -153,7 +153,7 @@ where
         };
         if is_mempool {
             // XXX determine exactly which rules apply to mempool transactions
-            unimplemented!();
+            unimplemented!("Zebra does not yet have a mempool (#2309)");
         }
 
         let script_verifier = self.script_verifier.clone();


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
When NU5 activates, Zebra must not panic unexpectedly. This can happen for example if execution reaches a code that's not complete and has a `todo!` or `unimplemented!` panicking placeholder.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
I executed the command:

```
grep -RI '\(todo\|unimplemented\)!' zebra*/src
```

and went through each occurrence.

- Some I was able to remove;
- Some were changed to `unreachable` if I figured that there was no code missing but the condition could be reached due a coding mistake;
- Others were updated to have a reference to a tracking issue nearby.

Closes #2369 

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Go through all `TODO`, `FIXME` and `XXX` comments to see if there are any missing pieces that aren't tracked by issues.
