### PR TITLE
Document some consensus-critical finalized state behaviour

### DIFF
--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -239,9 +239,10 @@ impl FinalizedState {
 
             // TODO: sprout and sapling anchors (per block)
 
-            // Consensus-critical bug in zcashd: transactions in the
-            // genesis block are ignored.
-            if block.header.previous_block_hash == block::Hash([0; 32]) {
+            // "A transaction MUST NOT spend an output of the genesis block coinbase transaction.
+            // (There is one such zero-valued output, on each of Testnet and Mainnet .)"
+            // https://zips.z.cash/protocol/protocol.pdf#txnconsensus
+            if block.header.previous_block_hash == GENESIS_PREVIOUS_BLOCK_HASH {
                 return batch;
             }
 
@@ -251,7 +252,6 @@ impl FinalizedState {
             }
 
             // Index each transaction, spent inputs, nullifiers
-            // TODO: move computation into FinalizedBlock as with transparent outputs
             for (transaction_index, (transaction, transaction_hash)) in block
                 .transactions
                 .iter()

--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -237,7 +237,8 @@ impl IntoDisk for transparent::OutPoint {
 /// Helper trait for inserting (Key, Value) pairs into rocksdb with a consistently
 /// defined format
 pub trait DiskSerialize {
-    /// Serialize and insert the given key and value into a rocksdb column family.
+    /// Serialize and insert the given key and value into a rocksdb column family,
+    /// overwriting any existing `value` for `key`.
     fn zs_insert<K, V>(&mut self, cf: &rocksdb::ColumnFamily, key: K, value: V)
     where
         K: IntoDisk + Debug,


### PR DESCRIPTION
## Motivation

We need to update some state documentation for:
- a new genesis consensus rule
- RocksDB double-insert behaviour

### Specifications

> A transaction MUST NOT spend an output of the genesis block coinbase transaction.
> (There is one such zero-valued output, on each of Testnet and Mainnet .)

https://zips.z.cash/protocol/protocol.pdf#txnconsensus

### API Reference

> A Put API inserts a single key-value to the database.
> If the key already exists in the database, the previous value will be overwritten.

https://github.com/facebook/rocksdb/wiki/RocksDB-Overview#updates

## Review

Anyone can review this PR, it's not urgent.

### Reviewer Checklist

  - [ ] Comments match spec / API

