### PR TITLE
Move `Utxo` type to zebra-chain

### DIFF
--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -5,9 +5,11 @@ mod address;
 mod keys;
 mod script;
 mod serialize;
+mod utxo;
 
 pub use address::Address;
 pub use script::Script;
+pub use utxo::{new_outputs, Utxo};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;

--- a/zebra-chain/src/transparent/utxo.rs
+++ b/zebra-chain/src/transparent/utxo.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use zebra_chain::{
+use crate::{
     block::{self, Block},
     transaction, transparent,
 };

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -24,6 +24,7 @@ use tracing::Instrument;
 use zebra_chain::{
     block::{self, Block},
     parameters::Network,
+    transparent,
     work::equihash,
 };
 use zebra_state as zs;
@@ -173,7 +174,7 @@ where
 
             let mut async_checks = FuturesUnordered::new();
 
-            let known_utxos = Arc::new(zs::new_outputs(&block, &transaction_hashes));
+            let known_utxos = Arc::new(transparent::new_outputs(&block, &transaction_hashes));
             for transaction in &block.transactions {
                 let rsp = transaction_verifier
                     .ready_and()

--- a/zebra-consensus/src/script.rs
+++ b/zebra-consensus/src/script.rs
@@ -5,7 +5,6 @@ use tracing::Instrument;
 
 use zebra_chain::{parameters::NetworkUpgrade, transparent};
 use zebra_script::CachedFfiTransaction;
-use zebra_state::Utxo;
 
 use crate::BoxError;
 
@@ -59,7 +58,7 @@ pub struct Request {
     /// A set of additional UTXOs known in the context of this verification request.
     ///
     /// This allows specifying additional UTXOs that are not already known to the chain state.
-    pub known_utxos: Arc<HashMap<transparent::OutPoint, Utxo>>,
+    pub known_utxos: Arc<HashMap<transparent::OutPoint, transparent::Utxo>>,
     /// The network upgrade active in the context of this verification request.
     ///
     /// Because the consensus branch ID changes with each network upgrade,

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -70,7 +70,7 @@ pub enum Request {
         /// The transaction itself.
         transaction: Arc<Transaction>,
         /// Additional UTXOs which are known at the time of verification.
-        known_utxos: Arc<HashMap<transparent::OutPoint, zs::Utxo>>,
+        known_utxos: Arc<HashMap<transparent::OutPoint, transparent::Utxo>>,
         /// The height of the block containing this transaction.
         height: block::Height,
     },
@@ -100,7 +100,7 @@ impl Request {
     }
 
     /// The set of additional known unspent transaction outputs that's in this request.
-    pub fn known_utxos(&self) -> Arc<HashMap<transparent::OutPoint, zs::Utxo>> {
+    pub fn known_utxos(&self) -> Arc<HashMap<transparent::OutPoint, transparent::Utxo>> {
         match self {
             Request::Block { known_utxos, .. } => known_utxos.clone(),
             Request::Mempool { .. } => HashMap::new().into(),

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -17,7 +17,6 @@ use zebra_chain::{
     },
     transparent::{self, CoinbaseData},
 };
-use zebra_state::Utxo;
 
 use super::{check, Request, Verifier};
 
@@ -839,7 +838,7 @@ fn mock_transparent_transfer(
 ) -> (
     transparent::Input,
     transparent::Output,
-    HashMap<transparent::OutPoint, Utxo>,
+    HashMap<transparent::OutPoint, transparent::Utxo>,
 ) {
     // A script with a single opcode that accepts the transaction (pushes true on the stack)
     let accepting_script = transparent::Script::new(&[1, 1]);
@@ -863,7 +862,7 @@ fn mock_transparent_transfer(
         lock_script,
     };
 
-    let previous_utxo = Utxo {
+    let previous_utxo = transparent::Utxo {
         output: previous_output,
         height: previous_utxo_height,
         from_coinbase: false,

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -24,7 +24,6 @@ mod request;
 mod response;
 mod service;
 mod util;
-mod utxo;
 
 // TODO: move these to integration tests.
 #[cfg(test)]
@@ -36,4 +35,3 @@ pub use error::{BoxError, CloneError, CommitBlockError, ValidateContextError};
 pub use request::{FinalizedBlock, HashOrHeight, PreparedBlock, Request};
 pub use response::Response;
 pub use service::init;
-pub use utxo::{new_outputs, Utxo};

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -5,8 +5,6 @@ use zebra_chain::{
     transaction, transparent,
 };
 
-use crate::Utxo;
-
 // Allow *only* this unused import, so that rustdoc link resolution
 // will work with inline links.
 #[allow(unused_imports)]
@@ -73,7 +71,7 @@ pub struct PreparedBlock {
     /// Note: although these transparent outputs are newly created, they may not
     /// be unspent, since a later transaction in a block can spend outputs of an
     /// earlier transaction.
-    pub new_outputs: HashMap<transparent::OutPoint, Utxo>,
+    pub new_outputs: HashMap<transparent::OutPoint, transparent::Utxo>,
     /// A precomputed list of the hashes of the transactions in this block.
     pub transaction_hashes: Vec<transaction::Hash>,
     // TODO: add these parameters when we can compute anchors.
@@ -98,7 +96,7 @@ pub struct FinalizedBlock {
     /// Note: although these transparent outputs are newly created, they may not
     /// be unspent, since a later transaction in a block can spend outputs of an
     /// earlier transaction.
-    pub(crate) new_outputs: HashMap<transparent::OutPoint, Utxo>,
+    pub(crate) new_outputs: HashMap<transparent::OutPoint, transparent::Utxo>,
     /// A precomputed list of the hashes of the transactions in this block.
     pub(crate) transaction_hashes: Vec<transaction::Hash>,
 }
@@ -117,7 +115,7 @@ impl From<Arc<Block>> for FinalizedBlock {
             .iter()
             .map(|tx| tx.hash())
             .collect::<Vec<_>>();
-        let new_outputs = crate::utxo::new_outputs(&block, transaction_hashes.as_slice());
+        let new_outputs = transparent::new_outputs(&block, transaction_hashes.as_slice());
 
         Self {
             block,

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -2,9 +2,8 @@ use std::sync::Arc;
 use zebra_chain::{
     block::{self, Block},
     transaction::Transaction,
+    transparent,
 };
-
-use crate::Utxo;
 
 // Allow *only* this unused import, so that rustdoc link resolution
 // will work with inline links.
@@ -34,7 +33,7 @@ pub enum Response {
     Block(Option<Arc<Block>>),
 
     /// The response to a `AwaitUtxo` request.
-    Utxo(Utxo),
+    Utxo(transparent::Utxo),
 
     /// The response to a `FindBlockHashes` request.
     BlockHashes(Vec<block::Hash>),

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -23,7 +23,7 @@ use zebra_chain::{
 
 use crate::{
     request::HashOrHeight, BoxError, CommitBlockError, Config, FinalizedBlock, PreparedBlock,
-    Request, Response, Utxo, ValidateContextError,
+    Request, Response, ValidateContextError,
 };
 
 #[cfg(any(test, feature = "proptest-impl"))]
@@ -314,7 +314,7 @@ impl StateService {
     }
 
     /// Return the [`Utxo`] pointed to by `outpoint` if it exists in any chain.
-    pub fn any_utxo(&self, outpoint: &transparent::OutPoint) -> Option<Utxo> {
+    pub fn any_utxo(&self, outpoint: &transparent::OutPoint) -> Option<transparent::Utxo> {
         self.mem
             .any_utxo(outpoint)
             .or_else(|| self.queued_blocks.utxo(outpoint))

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -14,7 +14,7 @@ use zebra_chain::{
     transaction::{self, Transaction},
 };
 
-use crate::{BoxError, Config, FinalizedBlock, HashOrHeight, Utxo};
+use crate::{BoxError, Config, FinalizedBlock, HashOrHeight};
 
 use self::disk_format::{DiskDeserialize, DiskSerialize, FromDisk, IntoDisk, TransactionLocation};
 
@@ -363,7 +363,7 @@ impl FinalizedState {
 
     /// Returns the `transparent::Output` pointed to by the given
     /// `transparent::OutPoint` if it is present.
-    pub fn utxo(&self, outpoint: &transparent::OutPoint) -> Option<Utxo> {
+    pub fn utxo(&self, outpoint: &transparent::OutPoint) -> Option<transparent::Utxo> {
         let utxo_by_outpoint = self.db.cf_handle("utxo_by_outpoint").unwrap();
         self.db.zs_get(utxo_by_outpoint, outpoint)
     }

--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -9,8 +9,6 @@ use zebra_chain::{
     sprout, transaction, transparent,
 };
 
-use crate::Utxo;
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TransactionLocation {
     pub height: block::Height,
@@ -195,7 +193,7 @@ impl FromDisk for block::Height {
     }
 }
 
-impl IntoDisk for Utxo {
+impl IntoDisk for transparent::Utxo {
     type Bytes = Vec<u8>;
 
     fn as_bytes(&self) -> Self::Bytes {
@@ -209,7 +207,7 @@ impl IntoDisk for Utxo {
     }
 }
 
-impl FromDisk for Utxo {
+impl FromDisk for transparent::Utxo {
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
         let (meta_bytes, output_bytes) = bytes.as_ref().split_at(5);
         let height = block::Height(u32::from_be_bytes(meta_bytes[0..4].try_into().unwrap()));
@@ -395,6 +393,6 @@ mod tests {
     fn roundtrip_transparent_output() {
         zebra_test::init();
 
-        proptest!(|(val in any::<Utxo>())| assert_value_properties(val));
+        proptest!(|(val in any::<transparent::Utxo>())| assert_value_properties(val));
     }
 }

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -19,7 +19,7 @@ use zebra_chain::{
     transparent,
 };
 
-use crate::{FinalizedBlock, HashOrHeight, PreparedBlock, Utxo, ValidateContextError};
+use crate::{FinalizedBlock, HashOrHeight, PreparedBlock, ValidateContextError};
 
 use self::chain::Chain;
 
@@ -158,7 +158,7 @@ impl NonFinalizedState {
 
     /// Returns the `transparent::Output` pointed to by the given
     /// `transparent::OutPoint` if it is present in any chain.
-    pub fn any_utxo(&self, outpoint: &transparent::OutPoint) -> Option<Utxo> {
+    pub fn any_utxo(&self, outpoint: &transparent::OutPoint) -> Option<transparent::Utxo> {
         for chain in self.chain_set.iter().rev() {
             if let Some(output) = chain.created_utxos.get(outpoint) {
                 return Some(output.clone());

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -10,7 +10,7 @@ use zebra_chain::{
     transaction::Transaction::*, transparent, work::difficulty::PartialCumulativeWork,
 };
 
-use crate::{PreparedBlock, Utxo, ValidateContextError};
+use crate::{PreparedBlock, ValidateContextError};
 
 #[derive(Default, Clone)]
 pub struct Chain {
@@ -18,7 +18,7 @@ pub struct Chain {
     pub height_by_hash: HashMap<block::Hash, block::Height>,
     pub tx_by_hash: HashMap<transaction::Hash, (block::Height, usize)>,
 
-    pub created_utxos: HashMap<transparent::OutPoint, Utxo>,
+    pub created_utxos: HashMap<transparent::OutPoint, transparent::Utxo>,
     spent_utxos: HashSet<transparent::OutPoint>,
     // TODO: add sprout, sapling and orchard anchors (#1320)
     sprout_anchors: HashSet<sprout::tree::Root>,
@@ -303,17 +303,20 @@ impl UpdateWith<PreparedBlock> for Chain {
     }
 }
 
-impl UpdateWith<HashMap<transparent::OutPoint, Utxo>> for Chain {
+impl UpdateWith<HashMap<transparent::OutPoint, transparent::Utxo>> for Chain {
     fn update_chain_state_with(
         &mut self,
-        utxos: &HashMap<transparent::OutPoint, Utxo>,
+        utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
     ) -> Result<(), ValidateContextError> {
         self.created_utxos
             .extend(utxos.iter().map(|(k, v)| (*k, v.clone())));
         Ok(())
     }
 
-    fn revert_chain_state_with(&mut self, utxos: &HashMap<transparent::OutPoint, Utxo>) {
+    fn revert_chain_state_with(
+        &mut self,
+        utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
+    ) {
         self.created_utxos
             .retain(|outpoint, _| !utxos.contains_key(outpoint));
     }

--- a/zebra-state/src/service/non_finalized_state/queued_blocks.rs
+++ b/zebra-state/src/service/non_finalized_state/queued_blocks.rs
@@ -6,7 +6,7 @@ use std::{
 use tracing::instrument;
 use zebra_chain::{block, transparent};
 
-use crate::{service::QueuedBlock, Utxo};
+use crate::service::QueuedBlock;
 
 /// A queue of blocks, awaiting the arrival of parent blocks.
 #[derive(Default)]
@@ -18,7 +18,7 @@ pub struct QueuedBlocks {
     /// Hashes from `queued_blocks`, indexed by block height.
     by_height: BTreeMap<block::Height, HashSet<block::Hash>>,
     /// Known UTXOs.
-    known_utxos: HashMap<transparent::OutPoint, Utxo>,
+    known_utxos: HashMap<transparent::OutPoint, transparent::Utxo>,
 }
 
 impl QueuedBlocks {
@@ -150,7 +150,7 @@ impl QueuedBlocks {
     }
 
     /// Try to look up this UTXO in any queued block.
-    pub fn utxo(&self, outpoint: &transparent::OutPoint) -> Option<Utxo> {
+    pub fn utxo(&self, outpoint: &transparent::OutPoint) -> Option<transparent::Utxo> {
         self.known_utxos.get(outpoint).cloned()
     }
 }

--- a/zebra-state/src/service/pending_utxos.rs
+++ b/zebra-state/src/service/pending_utxos.rs
@@ -5,10 +5,10 @@ use tokio::sync::broadcast;
 
 use zebra_chain::transparent;
 
-use crate::{BoxError, Response, Utxo};
+use crate::{BoxError, Response};
 
 #[derive(Debug, Default)]
-pub struct PendingUtxos(HashMap<transparent::OutPoint, broadcast::Sender<Utxo>>);
+pub struct PendingUtxos(HashMap<transparent::OutPoint, broadcast::Sender<transparent::Utxo>>);
 
 impl PendingUtxos {
     /// Returns a future that will resolve to the `transparent::Output` pointed
@@ -37,7 +37,7 @@ impl PendingUtxos {
 
     /// Notify all requests waiting for the [`Utxo`] pointed to by the given
     /// [`transparent::OutPoint`] that the [`Utxo`] has arrived.
-    pub fn respond(&mut self, outpoint: &transparent::OutPoint, utxo: Utxo) {
+    pub fn respond(&mut self, outpoint: &transparent::OutPoint, utxo: transparent::Utxo) {
         if let Some(sender) = self.0.remove(outpoint) {
             // Adding the outpoint as a field lets us crossreference
             // with the trace of the verification that made the request.
@@ -47,7 +47,7 @@ impl PendingUtxos {
     }
 
     /// Check the list of pending UTXO requests against the supplied UTXO index.
-    pub fn check_against(&mut self, utxos: &HashMap<transparent::OutPoint, Utxo>) {
+    pub fn check_against(&mut self, utxos: &HashMap<transparent::OutPoint, transparent::Utxo>) {
         for (outpoint, utxo) in utxos.iter() {
             if let Some(sender) = self.0.remove(outpoint) {
                 tracing::trace!(?outpoint, "found pending UTXO");

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -10,7 +10,7 @@ use zebra_chain::{
 };
 use zebra_test::{prelude::*, transcript::Transcript};
 
-use crate::{init, service::arbitrary, BoxError, Config, Request, Response, Utxo};
+use crate::{init, service::arbitrary, BoxError, Config, Request, Response};
 
 const LAST_BLOCK_HEIGHT: u32 = 10;
 
@@ -88,7 +88,7 @@ async fn test_populated_state_responds_correctly(
                         hash: transaction_hash,
                         index: index as _,
                     };
-                    let utxo = Utxo {
+                    let utxo = transparent::Utxo {
                         output,
                         height,
                         from_coinbase,

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -21,7 +21,7 @@ impl Prepare for Arc<Block> {
         let hash = block.hash();
         let height = block.coinbase_height().unwrap();
         let transaction_hashes: Vec<_> = block.transactions.iter().map(|tx| tx.hash()).collect();
-        let new_outputs = crate::utxo::new_outputs(&block, transaction_hashes.as_slice());
+        let new_outputs = transparent::new_outputs(&block, transaction_hashes.as_slice());
 
         PreparedBlock {
             block,


### PR DESCRIPTION
## Motivation

In the value pools design we created several methods that receive a `Hashmap` with `Utxo`s, just as:

- https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0012-value-pools.md#create-a-method-in-input-that-returns-valuebalancenegativeallowed
- https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0012-value-pools.md#create-the-transaction-method
- https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0012-value-pools.md#create-a-method-in-block-that-returns-valuebalancenegativeallowed-for-the-block

However, the `Utxo` is a `zebra-state` type. 

Note: `zebra-chain` do not depend on `zebra-state`

### Designs

[Value Pools Design](https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0012-value-pools.md)

## Solution

Move the state `Utxo` type into `zebra-chain::transparent` so we can have it available in method signatures. This is a pretty noisy change so i separated it from the value pool implementation but it is part of https://github.com/ZcashFoundation/zebra/issues/1895

## Review

I am not sure if we have a better alternative but i think this is needed. Anyone can review the code.

### Reviewer Checklist

  - [ ] Current tests pass all.

## Follow Up Work

Continue the implementation of value pools in https://github.com/ZcashFoundation/zebra/issues/1895
