### PR TITLE
Move zebra_state::service::check tests to their own module

### DIFF
--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -17,6 +17,8 @@ use super::check;
 use difficulty::{AdjustedDifficulty, POW_MEDIAN_BLOCK_SPAN};
 
 pub(crate) mod difficulty;
+#[cfg(test)]
+mod tests;
 
 /// Check that `block` is contextually valid for `network`, based on the
 /// `finalized_tip_height` and `relevant_chain`.
@@ -166,56 +168,4 @@ fn difficulty_threshold_is_valid(
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use zebra_chain::serialization::ZcashDeserializeInto;
-
-    use super::*;
-
-    #[test]
-    fn test_orphan_consensus_check() {
-        zebra_test::init();
-
-        let height = zebra_test::vectors::BLOCK_MAINNET_347499_BYTES
-            .zcash_deserialize_into::<Arc<Block>>()
-            .unwrap()
-            .coinbase_height()
-            .unwrap();
-
-        block_is_not_orphaned(block::Height(0), height).expect("tip is lower so it should be fine");
-        block_is_not_orphaned(block::Height(347498), height)
-            .expect("tip is lower so it should be fine");
-        block_is_not_orphaned(block::Height(347499), height)
-            .expect_err("tip is equal so it should error");
-        block_is_not_orphaned(block::Height(500000), height)
-            .expect_err("tip is higher so it should error");
-    }
-
-    #[test]
-    fn test_sequential_height_check() {
-        zebra_test::init();
-
-        let height = zebra_test::vectors::BLOCK_MAINNET_347499_BYTES
-            .zcash_deserialize_into::<Arc<Block>>()
-            .unwrap()
-            .coinbase_height()
-            .unwrap();
-
-        height_one_more_than_parent_height(block::Height(0), height)
-            .expect_err("block is much lower, should panic");
-        height_one_more_than_parent_height(block::Height(347497), height)
-            .expect_err("parent height is 2 less, should panic");
-        height_one_more_than_parent_height(block::Height(347498), height)
-            .expect("parent height is 1 less, should be good");
-        height_one_more_than_parent_height(block::Height(347499), height)
-            .expect_err("parent height is equal, should panic");
-        height_one_more_than_parent_height(block::Height(347500), height)
-            .expect_err("parent height is way more, should panic");
-        height_one_more_than_parent_height(block::Height(500000), height)
-            .expect_err("parent height is way more, should panic");
-    }
 }

--- a/zebra-state/src/service/check/tests.rs
+++ b/zebra-state/src/service/check/tests.rs
@@ -1,0 +1,3 @@
+//! Tests for state contextual validation checks.
+
+mod vectors;

--- a/zebra-state/src/service/check/tests/vectors.rs
+++ b/zebra-state/src/service/check/tests/vectors.rs
@@ -1,0 +1,50 @@
+//! Fixed test vectors for state contextual validation checks.
+
+use std::sync::Arc;
+
+use zebra_chain::serialization::ZcashDeserializeInto;
+
+use super::super::*;
+
+#[test]
+fn test_orphan_consensus_check() {
+    zebra_test::init();
+
+    let height = zebra_test::vectors::BLOCK_MAINNET_347499_BYTES
+        .zcash_deserialize_into::<Arc<Block>>()
+        .unwrap()
+        .coinbase_height()
+        .unwrap();
+
+    block_is_not_orphaned(block::Height(0), height).expect("tip is lower so it should be fine");
+    block_is_not_orphaned(block::Height(347498), height)
+        .expect("tip is lower so it should be fine");
+    block_is_not_orphaned(block::Height(347499), height)
+        .expect_err("tip is equal so it should error");
+    block_is_not_orphaned(block::Height(500000), height)
+        .expect_err("tip is higher so it should error");
+}
+
+#[test]
+fn test_sequential_height_check() {
+    zebra_test::init();
+
+    let height = zebra_test::vectors::BLOCK_MAINNET_347499_BYTES
+        .zcash_deserialize_into::<Arc<Block>>()
+        .unwrap()
+        .coinbase_height()
+        .unwrap();
+
+    height_one_more_than_parent_height(block::Height(0), height)
+        .expect_err("block is much lower, should panic");
+    height_one_more_than_parent_height(block::Height(347497), height)
+        .expect_err("parent height is 2 less, should panic");
+    height_one_more_than_parent_height(block::Height(347498), height)
+        .expect("parent height is 1 less, should be good");
+    height_one_more_than_parent_height(block::Height(347499), height)
+        .expect_err("parent height is equal, should panic");
+    height_one_more_than_parent_height(block::Height(347500), height)
+        .expect_err("parent height is way more, should panic");
+    height_one_more_than_parent_height(block::Height(500000), height)
+        .expect_err("parent height is way more, should panic");
+}


### PR DESCRIPTION
## Motivation

I need to add some tests as part of PR #2477, but the existing tests don't follow Zebra's standard module structure.

This PR does not close any tickets, but it is part of creating the tests for ticket #2231.

## Solution

- Create Zebra's standard test module structure for the `service::check` tests
- Put the existing tests in it

## Review

@jvff can review this PR, it blocks PR #2477 due to trivial merge conflicts.

### Reviewer Checklist

  - [ ] Code Movement is Correct
  - [ ] Existing Tests Run

