### PR TITLE
Reject duplicate Sapling and Orchard nullifiers

### DIFF
--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use thiserror::Error;
 
-use zebra_chain::{block, sprout, work::difficulty::CompactDifficulty};
+use zebra_chain::{block, orchard, sapling, sprout, work::difficulty::CompactDifficulty};
 
 /// A wrapper for type erased errors that is itself clonable and implements the
 /// Error trait
@@ -81,6 +81,20 @@ pub enum ValidateContextError {
         nullifier: sprout::Nullifier,
         in_finalized_state: bool,
     },
+
+    #[error("sapling double-spend: duplicate nullifier: {nullifier:?}, in finalized state: {in_finalized_state:?}")]
+    #[non_exhaustive]
+    DuplicateSaplingNullifier {
+        nullifier: sapling::Nullifier,
+        in_finalized_state: bool,
+    },
+
+    #[error("orchard double-spend: duplicate nullifier: {nullifier:?}, in finalized state: {in_finalized_state:?}")]
+    #[non_exhaustive]
+    DuplicateOrchardNullifier {
+        nullifier: orchard::Nullifier,
+        in_finalized_state: bool,
+    },
 }
 
 /// Trait for creating the corresponding duplicate nullifier error from a nullifier.
@@ -92,6 +106,24 @@ pub(crate) trait DuplicateNullifierError {
 impl DuplicateNullifierError for sprout::Nullifier {
     fn duplicate_nullifier_error(&self, in_finalized_state: bool) -> ValidateContextError {
         ValidateContextError::DuplicateSproutNullifier {
+            nullifier: *self,
+            in_finalized_state,
+        }
+    }
+}
+
+impl DuplicateNullifierError for sapling::Nullifier {
+    fn duplicate_nullifier_error(&self, in_finalized_state: bool) -> ValidateContextError {
+        ValidateContextError::DuplicateSaplingNullifier {
+            nullifier: *self,
+            in_finalized_state,
+        }
+    }
+}
+
+impl DuplicateNullifierError for orchard::Nullifier {
+    fn duplicate_nullifier_error(&self, in_finalized_state: bool) -> ValidateContextError {
+        ValidateContextError::DuplicateOrchardNullifier {
             nullifier: *self,
             in_finalized_state,
         }

--- a/zebra-state/src/service/check/nullifier.rs
+++ b/zebra-state/src/service/check/nullifier.rs
@@ -37,7 +37,17 @@ pub(crate) fn no_duplicates_in_finalized_chain(
         }
     }
 
-    // TODO: sapling and orchard nullifiers (#2231)
+    for nullifier in prepared.block.sapling_nullifiers() {
+        if finalized_state.contains_sapling_nullifier(nullifier) {
+            Err(nullifier.duplicate_nullifier_error(true))?;
+        }
+    }
+
+    for nullifier in prepared.block.orchard_nullifiers() {
+        if finalized_state.contains_orchard_nullifier(nullifier) {
+            Err(nullifier.duplicate_nullifier_error(true))?;
+        }
+    }
 
     Ok(())
 }

--- a/zebra-state/src/service/check/tests/prop.rs
+++ b/zebra-state/src/service/check/tests/prop.rs
@@ -10,14 +10,18 @@ use zebra_chain::{
     fmt::TypeNameToDebug,
     parameters::Network::*,
     primitives::Groth16Proof,
+    sapling::{self, FieldNotPresent, PerSpendAnchor, TransferData::*},
     serialization::ZcashDeserializeInto,
     sprout::JoinSplit,
     transaction::{JoinSplitData, LockTime, Transaction},
 };
 
 use crate::{
-    config::Config, service::StateService, tests::Prepare, FinalizedBlock,
-    ValidateContextError::DuplicateSproutNullifier,
+    config::Config,
+    service::StateService,
+    tests::Prepare,
+    FinalizedBlock,
+    ValidateContextError::{DuplicateSaplingNullifier, DuplicateSproutNullifier},
 };
 
 // These tests use the `Arbitrary` trait to easily generate complex types,
@@ -316,6 +320,258 @@ proptest! {
     }
 }
 
+// sapling
+
+proptest! {
+    /// Make sure an arbitrary sapling nullifier is accepted by state contextual validation.
+    ///
+    /// This test makes sure there are no spurious rejections that might hide bugs in the other tests.
+    /// (And that the test infrastructure generally works.)
+    #[test]
+    fn accept_distinct_arbitrary_sapling_nullifiers(
+        spend in TypeNameToDebug::<sapling::Spend::<PerSpendAnchor>>::arbitrary(),
+        sapling_shielded_data in TypeNameToDebug::<sapling::ShieldedData::<PerSpendAnchor>>::arbitrary(),
+        use_finalized_state in any::<bool>(),
+    ) {
+        zebra_test::init();
+
+        let mut block1 = zebra_test::vectors::BLOCK_MAINNET_1_BYTES
+            .zcash_deserialize_into::<Block>()
+            .expect("block should deserialize");
+
+        let transaction = transaction_v4_with_sapling_shielded_data(
+            sapling_shielded_data.0,
+            &[spend.0]
+        );
+
+        // convert the coinbase transaction to a version that the non-finalized state will accept
+        block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
+
+        block1
+            .transactions
+            .push(transaction.into());
+
+        let (mut state, _genesis) = new_state_with_mainnet_genesis();
+        let previous_mem = state.mem.clone();
+
+        // randomly choose to commit the block to the finalized or non-finalized state
+        if use_finalized_state {
+            let block1 = FinalizedBlock::from(Arc::new(block1));
+            let commit_result = state.disk.commit_finalized_direct(block1.clone(), "test");
+
+            prop_assert_eq!(Some((Height(1), block1.hash)), state.best_tip());
+            prop_assert!(commit_result.is_ok());
+            prop_assert!(state.mem.eq_internal_state(&previous_mem));
+        } else {
+            let block1 = Arc::new(block1).prepare();
+            let commit_result =
+                state.validate_and_commit(block1.clone());
+
+            prop_assert_eq!(commit_result, Ok(()));
+            prop_assert_eq!(Some((Height(1), block1.hash)), state.best_tip());
+            prop_assert!(!state.mem.eq_internal_state(&previous_mem));
+        }
+    }
+
+    /// Make sure duplicate sapling nullifiers are rejected by state contextual validation,
+    /// if they come from different Spends in the same sapling::ShieldedData/Transaction.
+    #[test]
+    fn reject_duplicate_sapling_nullifiers_in_transaction(
+        spend1 in TypeNameToDebug::<sapling::Spend::<PerSpendAnchor>>::arbitrary(),
+        mut spend2 in TypeNameToDebug::<sapling::Spend::<PerSpendAnchor>>::arbitrary(),
+        sapling_shielded_data in TypeNameToDebug::<sapling::ShieldedData::<PerSpendAnchor>>::arbitrary(),
+    ) {
+        zebra_test::init();
+
+        let mut block1 = zebra_test::vectors::BLOCK_MAINNET_1_BYTES
+            .zcash_deserialize_into::<Block>()
+            .expect("block should deserialize");
+
+        make_distinct_nullifiers(&mut [spend1.nullifier, spend2.nullifier]);
+
+        // create a double-spend across two spends
+        let duplicate_nullifier = spend1.nullifier;
+        spend2.nullifier = duplicate_nullifier;
+
+        let transaction = transaction_v4_with_sapling_shielded_data(
+            sapling_shielded_data.0,
+            &[spend1.0, spend2.0],
+        );
+
+        block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
+
+        block1
+            .transactions
+            .push(transaction.into());
+
+        let (mut state, genesis) = new_state_with_mainnet_genesis();
+        let previous_mem = state.mem.clone();
+
+        let block1 = Arc::new(block1).prepare();
+        let commit_result =
+            state.validate_and_commit(block1);
+
+        prop_assert_eq!(
+            commit_result,
+            Err(
+                DuplicateSaplingNullifier {
+                    nullifier: duplicate_nullifier,
+                    in_finalized_state: false,
+                }.into()
+            )
+        );
+        prop_assert_eq!(Some((Height(0), genesis.hash)), state.best_tip());
+        prop_assert!(state.mem.eq_internal_state(&previous_mem));
+    }
+
+    /// Make sure duplicate sapling nullifiers are rejected by state contextual validation,
+    /// if they come from different transactions in the same block.
+    #[test]
+    fn reject_duplicate_sapling_nullifiers_in_block(
+        spend1 in TypeNameToDebug::<sapling::Spend::<PerSpendAnchor>>::arbitrary(),
+        mut spend2 in TypeNameToDebug::<sapling::Spend::<PerSpendAnchor>>::arbitrary(),
+        sapling_shielded_data1 in TypeNameToDebug::<sapling::ShieldedData::<PerSpendAnchor>>::arbitrary(),
+        sapling_shielded_data2 in TypeNameToDebug::<sapling::ShieldedData::<PerSpendAnchor>>::arbitrary(),
+    ) {
+        zebra_test::init();
+
+        let mut block1 = zebra_test::vectors::BLOCK_MAINNET_1_BYTES
+            .zcash_deserialize_into::<Block>()
+            .expect("block should deserialize");
+
+        make_distinct_nullifiers(&mut [spend1.nullifier, spend2.nullifier]);
+
+        // create a double-spend across two transactions
+        let duplicate_nullifier = spend1.nullifier;
+        spend2.nullifier = duplicate_nullifier;
+
+        let transaction1 = transaction_v4_with_sapling_shielded_data(
+            sapling_shielded_data1.0,
+            &[spend1.0]
+        );
+        let transaction2 = transaction_v4_with_sapling_shielded_data(
+            sapling_shielded_data2.0,
+            &[spend2.0]
+        );
+
+        block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
+
+        block1
+            .transactions
+            .push(transaction1.into());
+        block1
+            .transactions
+            .push(transaction2.into());
+
+        let (mut state, genesis) = new_state_with_mainnet_genesis();
+        let previous_mem = state.mem.clone();
+
+        let block1 = Arc::new(block1).prepare();
+        let commit_result =
+            state.validate_and_commit(block1);
+
+        prop_assert_eq!(
+            commit_result,
+            Err(
+                DuplicateSaplingNullifier {
+                    nullifier: duplicate_nullifier,
+                    in_finalized_state: false,
+                }.into()
+            )
+        );
+        prop_assert_eq!(Some((Height(0), genesis.hash)), state.best_tip());
+        prop_assert!(state.mem.eq_internal_state(&previous_mem));
+    }
+
+    /// Make sure duplicate sapling nullifiers are rejected by state contextual validation,
+    /// if they come from different blocks in the same chain.
+    #[test]
+    fn reject_duplicate_sapling_nullifiers_in_chain(
+        spend1 in TypeNameToDebug::<sapling::Spend::<PerSpendAnchor>>::arbitrary(),
+        mut spend2 in TypeNameToDebug::<sapling::Spend::<PerSpendAnchor>>::arbitrary(),
+        sapling_shielded_data1 in TypeNameToDebug::<sapling::ShieldedData::<PerSpendAnchor>>::arbitrary(),
+        sapling_shielded_data2 in TypeNameToDebug::<sapling::ShieldedData::<PerSpendAnchor>>::arbitrary(),
+        duplicate_in_finalized_state in any::<bool>(),
+    ) {
+        zebra_test::init();
+
+        let mut block1 = zebra_test::vectors::BLOCK_MAINNET_1_BYTES
+            .zcash_deserialize_into::<Block>()
+            .expect("block should deserialize");
+        let mut block2 = zebra_test::vectors::BLOCK_MAINNET_2_BYTES
+            .zcash_deserialize_into::<Block>()
+            .expect("block should deserialize");
+
+        make_distinct_nullifiers(&mut [spend1.nullifier, spend2.nullifier]);
+
+        // create a double-spend across two blocks
+        let duplicate_nullifier = spend1.nullifier;
+        spend2.nullifier = duplicate_nullifier;
+
+        let transaction1 = transaction_v4_with_sapling_shielded_data(
+            sapling_shielded_data1.0,
+            &[spend1.0]
+        );
+        let transaction2 = transaction_v4_with_sapling_shielded_data(
+            sapling_shielded_data2.0,
+            &[spend2.0]
+        );
+
+        block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
+        block2.transactions[0] = transaction_v4_from_coinbase(&block2.transactions[0]).into();
+
+        block1
+            .transactions
+            .push(transaction1.into());
+        block2
+            .transactions
+            .push(transaction2.into());
+
+        let (mut state, _genesis) = new_state_with_mainnet_genesis();
+        let mut previous_mem = state.mem.clone();
+
+        let block1_hash;
+        // randomly choose to commit the next block to the finalized or non-finalized state
+        if duplicate_in_finalized_state {
+            let block1 = FinalizedBlock::from(Arc::new(block1));
+            let commit_result = state.disk.commit_finalized_direct(block1.clone(), "test");
+
+            prop_assert_eq!(Some((Height(1), block1.hash)), state.best_tip());
+            prop_assert!(commit_result.is_ok());
+            prop_assert!(state.mem.eq_internal_state(&previous_mem));
+
+            block1_hash = block1.hash;
+        } else {
+            let block1 = Arc::new(block1).prepare();
+            let commit_result =
+                state.validate_and_commit(block1.clone());
+
+            prop_assert_eq!(commit_result, Ok(()));
+            prop_assert_eq!(Some((Height(1), block1.hash)), state.best_tip());
+            prop_assert!(!state.mem.eq_internal_state(&previous_mem));
+
+            block1_hash = block1.hash;
+            previous_mem = state.mem.clone();
+        }
+
+        let block2 = Arc::new(block2).prepare();
+        let commit_result =
+            state.validate_and_commit(block2);
+
+        prop_assert_eq!(
+            commit_result,
+            Err(
+                DuplicateSaplingNullifier {
+                    nullifier: duplicate_nullifier,
+                    in_finalized_state: duplicate_in_finalized_state,
+                }.into()
+            )
+        );
+        prop_assert_eq!(Some((Height(1), block1_hash)), state.best_tip());
+        prop_assert!(state.mem.eq_internal_state(&previous_mem));
+    }
+}
+
 /// Return a new `StateService` containing the mainnet genesis block.
 /// Also returns the finalized genesis block itself.
 fn new_state_with_mainnet_genesis() -> (StateService, FinalizedBlock) {
@@ -403,6 +659,74 @@ fn transaction_v4_with_joinsplit_data<'js>(
         expiry_height: Height(0),
         joinsplit_data,
         sapling_shielded_data: None,
+    }
+}
+
+/// Return a `Transaction::V4` containing `sapling_shielded_data`.
+/// with its `Spend`s replaced by `spends`.
+///
+/// Other fields have empty or default values.
+///
+/// Note: since sapling nullifiers in V5 transactions are identical to V4 transactions,
+/// we just use V4 transactions in the tests.
+///
+/// # Panics
+///
+/// If there are no `Spend`s in `spends`, and no `Output`s in `sapling_shielded_data`.
+fn transaction_v4_with_sapling_shielded_data<'s>(
+    sapling_shielded_data: impl Into<Option<sapling::ShieldedData<PerSpendAnchor>>>,
+    spends: impl IntoIterator<Item = &'s sapling::Spend<PerSpendAnchor>>,
+) -> Transaction {
+    let mut sapling_shielded_data = sapling_shielded_data.into();
+    let spends: Vec<_> = spends.into_iter().cloned().collect();
+
+    if let Some(ref mut sapling_shielded_data) = sapling_shielded_data {
+        // make sure there are no other nullifiers, by replacing all the spends
+        sapling_shielded_data.transfers = match (
+            sapling_shielded_data.transfers.clone(),
+            spends.is_empty(),
+        ) {
+            // old and new spends: replace spends
+            (
+                SpendsAndMaybeOutputs {
+                    shared_anchor,
+                    maybe_outputs,
+                    ..
+                },
+                false,
+            ) => SpendsAndMaybeOutputs {
+                shared_anchor,
+                spends: spends.try_into().expect("just checked at least one spend"),
+                maybe_outputs,
+            },
+            // old spends, but no new spends: delete spends, panic if no outputs
+            (SpendsAndMaybeOutputs { maybe_outputs, .. }, true) => JustOutputs {
+                outputs: maybe_outputs.try_into().expect(
+                    "unexpected invalid TransferData: must have at least one spend or one output",
+                ),
+            },
+            // no old spends, but new spends: add spends
+            (JustOutputs { outputs, .. }, false) => SpendsAndMaybeOutputs {
+                shared_anchor: FieldNotPresent,
+                spends: spends.try_into().expect("just checked at least one spend"),
+                maybe_outputs: outputs.into(),
+            },
+            // no old and no new spends: do nothing
+            (just_outputs @ JustOutputs { .. }, true) => just_outputs,
+        };
+
+        // set value balance to 0 to pass the chain value pool checks
+        let zero_amount = 0.try_into().expect("unexpected invalid zero amount");
+        sapling_shielded_data.value_balance = zero_amount;
+    }
+
+    Transaction::V4 {
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        lock_time: LockTime::min_lock_time(),
+        expiry_height: Height(0),
+        joinsplit_data: None,
+        sapling_shielded_data,
     }
 }
 

--- a/zebra-state/src/service/check/tests/prop.rs
+++ b/zebra-state/src/service/check/tests/prop.rs
@@ -415,8 +415,6 @@ proptest! {
             .zcash_deserialize_into::<Block>()
             .expect("block should deserialize");
 
-        make_distinct_nullifiers(&mut [spend1.nullifier, spend2.nullifier]);
-
         // create a double-spend across two spends
         let duplicate_nullifier = spend1.nullifier;
         spend2.nullifier = duplicate_nullifier;
@@ -466,8 +464,6 @@ proptest! {
         let mut block1 = zebra_test::vectors::BLOCK_MAINNET_1_BYTES
             .zcash_deserialize_into::<Block>()
             .expect("block should deserialize");
-
-        make_distinct_nullifiers(&mut [spend1.nullifier, spend2.nullifier]);
 
         // create a double-spend across two transactions
         let duplicate_nullifier = spend1.nullifier;
@@ -530,9 +526,6 @@ proptest! {
             .zcash_deserialize_into::<Block>()
             .expect("block should deserialize");
 
-        make_distinct_nullifiers(&mut [spend1.nullifier, spend2.nullifier]);
-        let expected_nullifier = spend1.nullifier;
-
         // create a double-spend across two blocks
         let duplicate_nullifier = spend1.nullifier;
         spend2.nullifier = duplicate_nullifier;
@@ -568,7 +561,7 @@ proptest! {
             prop_assert_eq!(Some((Height(1), block1.hash)), state.best_tip());
             prop_assert!(commit_result.is_ok());
             prop_assert!(state.mem.eq_internal_state(&previous_mem));
-            prop_assert!(state.disk.contains_sapling_nullifier(&expected_nullifier));
+            prop_assert!(state.disk.contains_sapling_nullifier(&duplicate_nullifier));
 
             block1_hash = block1.hash;
         } else {
@@ -579,7 +572,7 @@ proptest! {
             prop_assert_eq!(commit_result, Ok(()));
             prop_assert_eq!(Some((Height(1), block1.hash)), state.best_tip());
             prop_assert!(!state.mem.eq_internal_state(&previous_mem));
-            prop_assert!(state.mem.best_contains_sapling_nullifier(&expected_nullifier));
+            prop_assert!(state.mem.best_contains_sapling_nullifier(&duplicate_nullifier));
 
             block1_hash = block1.hash;
             previous_mem = state.mem.clone();
@@ -674,11 +667,6 @@ proptest! {
             .zcash_deserialize_into::<Block>()
             .expect("block should deserialize");
 
-        // we can't reliably make orchard nullifiers distinct,
-        // because they must be valid Pallas points.
-        // So just skip the test if they are the same.
-        prop_assume!(authorized_action1.action.nullifier != authorized_action2.action.nullifier);
-
         // create a double-spend across two authorized_actions
         let duplicate_nullifier = authorized_action1.action.nullifier;
         authorized_action2.action.nullifier = duplicate_nullifier;
@@ -728,8 +716,6 @@ proptest! {
         let mut block1 = zebra_test::vectors::BLOCK_MAINNET_1_BYTES
             .zcash_deserialize_into::<Block>()
             .expect("block should deserialize");
-
-        prop_assume!(authorized_action1.action.nullifier != authorized_action2.action.nullifier);
 
         // create a double-spend across two transactions
         let duplicate_nullifier = authorized_action1.action.nullifier;
@@ -792,9 +778,6 @@ proptest! {
             .zcash_deserialize_into::<Block>()
             .expect("block should deserialize");
 
-        prop_assume!(authorized_action1.action.nullifier != authorized_action2.action.nullifier);
-        let expected_nullifier = authorized_action1.action.nullifier;
-
         // create a double-spend across two blocks
         let duplicate_nullifier = authorized_action1.action.nullifier;
         authorized_action2.action.nullifier = duplicate_nullifier;
@@ -830,7 +813,7 @@ proptest! {
             prop_assert_eq!(Some((Height(1), block1.hash)), state.best_tip());
             prop_assert!(commit_result.is_ok());
             prop_assert!(state.mem.eq_internal_state(&previous_mem));
-            prop_assert!(state.disk.contains_orchard_nullifier(&expected_nullifier));
+            prop_assert!(state.disk.contains_orchard_nullifier(&duplicate_nullifier));
 
             block1_hash = block1.hash;
         } else {
@@ -841,7 +824,7 @@ proptest! {
             prop_assert_eq!(commit_result, Ok(()));
             prop_assert_eq!(Some((Height(1), block1.hash)), state.best_tip());
             prop_assert!(!state.mem.eq_internal_state(&previous_mem));
-            prop_assert!(state.mem.best_contains_orchard_nullifier(&expected_nullifier));
+            prop_assert!(state.mem.best_contains_orchard_nullifier(&duplicate_nullifier));
 
             block1_hash = block1.hash;
             previous_mem = state.mem.clone();

--- a/zebra-state/src/service/check/tests/prop.rs
+++ b/zebra-state/src/service/check/tests/prop.rs
@@ -57,7 +57,7 @@ proptest! {
         make_distinct_nullifiers(&mut joinsplit.nullifiers);
         let expected_nullifiers = joinsplit.nullifiers;
 
-        let transaction = transaction_v4_with_joinsplit_data(joinsplit_data.0, &[joinsplit.0]);
+        let transaction = transaction_v4_with_joinsplit_data(joinsplit_data.0, vec![joinsplit.0]);
 
         // convert the coinbase transaction to a version that the non-finalized state will accept
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -121,7 +121,7 @@ proptest! {
         let duplicate_nullifier = joinsplit.nullifiers[0];
         joinsplit.nullifiers[1] = duplicate_nullifier;
 
-        let transaction = transaction_v4_with_joinsplit_data(joinsplit_data.0, &[joinsplit.0]);
+        let transaction = transaction_v4_with_joinsplit_data(joinsplit_data.0, vec![joinsplit.0]);
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
 
@@ -174,7 +174,7 @@ proptest! {
 
         let transaction = transaction_v4_with_joinsplit_data(
             joinsplit_data.0,
-            &[joinsplit1.0, joinsplit2.0]
+            vec![joinsplit1.0, joinsplit2.0]
         );
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -224,8 +224,8 @@ proptest! {
         let duplicate_nullifier = joinsplit1.nullifiers[0];
         joinsplit2.nullifiers[0] = duplicate_nullifier;
 
-        let transaction1 = transaction_v4_with_joinsplit_data(joinsplit_data1.0, &[joinsplit1.0]);
-        let transaction2 = transaction_v4_with_joinsplit_data(joinsplit_data2.0, &[joinsplit2.0]);
+        let transaction1 = transaction_v4_with_joinsplit_data(joinsplit_data1.0, vec![joinsplit1.0]);
+        let transaction2 = transaction_v4_with_joinsplit_data(joinsplit_data2.0, vec![joinsplit2.0]);
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
 
@@ -282,8 +282,8 @@ proptest! {
         let duplicate_nullifier = joinsplit1.nullifiers[0];
         joinsplit2.nullifiers[0] = duplicate_nullifier;
 
-        let transaction1 = transaction_v4_with_joinsplit_data(joinsplit_data1.0, &[joinsplit1.0]);
-        let transaction2 = transaction_v4_with_joinsplit_data(joinsplit_data2.0, &[joinsplit2.0]);
+        let transaction1 = transaction_v4_with_joinsplit_data(joinsplit_data1.0, vec![joinsplit1.0]);
+        let transaction2 = transaction_v4_with_joinsplit_data(joinsplit_data2.0, vec![joinsplit2.0]);
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
         block2.transactions[0] = transaction_v4_from_coinbase(&block2.transactions[0]).into();
@@ -367,7 +367,7 @@ proptest! {
 
         let transaction = transaction_v4_with_sapling_shielded_data(
             sapling_shielded_data.0,
-            &[spend.0]
+            vec![spend.0]
         );
 
         // convert the coinbase transaction to a version that the non-finalized state will accept
@@ -423,7 +423,7 @@ proptest! {
 
         let transaction = transaction_v4_with_sapling_shielded_data(
             sapling_shielded_data.0,
-            &[spend1.0, spend2.0],
+            vec![spend1.0, spend2.0],
         );
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -475,11 +475,11 @@ proptest! {
 
         let transaction1 = transaction_v4_with_sapling_shielded_data(
             sapling_shielded_data1.0,
-            &[spend1.0]
+            vec![spend1.0]
         );
         let transaction2 = transaction_v4_with_sapling_shielded_data(
             sapling_shielded_data2.0,
-            &[spend2.0]
+            vec![spend2.0]
         );
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -539,11 +539,11 @@ proptest! {
 
         let transaction1 = transaction_v4_with_sapling_shielded_data(
             sapling_shielded_data1.0,
-            &[spend1.0]
+            vec![spend1.0]
         );
         let transaction2 = transaction_v4_with_sapling_shielded_data(
             sapling_shielded_data2.0,
-            &[spend2.0]
+            vec![spend2.0]
         );
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -626,7 +626,7 @@ proptest! {
 
         let transaction = transaction_v5_with_orchard_shielded_data(
             orchard_shielded_data.0,
-            &[authorized_action.0]
+            vec![authorized_action.0]
         );
 
         // convert the coinbase transaction to a version that the non-finalized state will accept
@@ -685,7 +685,7 @@ proptest! {
 
         let transaction = transaction_v5_with_orchard_shielded_data(
             orchard_shielded_data.0,
-            &[authorized_action1.0, authorized_action2.0],
+            vec![authorized_action1.0, authorized_action2.0],
         );
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -737,11 +737,11 @@ proptest! {
 
         let transaction1 = transaction_v5_with_orchard_shielded_data(
             orchard_shielded_data1.0,
-            &[authorized_action1.0]
+            vec![authorized_action1.0]
         );
         let transaction2 = transaction_v5_with_orchard_shielded_data(
             orchard_shielded_data2.0,
-            &[authorized_action2.0]
+            vec![authorized_action2.0]
         );
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -801,11 +801,11 @@ proptest! {
 
         let transaction1 = transaction_v5_with_orchard_shielded_data(
             orchard_shielded_data1.0,
-            &[authorized_action1.0]
+            vec![authorized_action1.0]
         );
         let transaction2 = transaction_v5_with_orchard_shielded_data(
             orchard_shielded_data2.0,
-            &[authorized_action2.0]
+            vec![authorized_action2.0]
         );
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -918,12 +918,12 @@ fn make_distinct_nullifiers<'until_modified, NullifierT>(
 /// # Panics
 ///
 /// If there are no `JoinSplit`s in `joinsplits`.
-fn transaction_v4_with_joinsplit_data<'until_cloned>(
+fn transaction_v4_with_joinsplit_data(
     joinsplit_data: impl Into<Option<JoinSplitData<Groth16Proof>>>,
-    joinsplits: impl IntoIterator<Item = &'until_cloned JoinSplit<Groth16Proof>>,
+    joinsplits: impl IntoIterator<Item = JoinSplit<Groth16Proof>>,
 ) -> Transaction {
     let mut joinsplit_data = joinsplit_data.into();
-    let joinsplits: Vec<_> = joinsplits.into_iter().cloned().collect();
+    let joinsplits: Vec<_> = joinsplits.into_iter().collect();
 
     if let Some(ref mut joinsplit_data) = joinsplit_data {
         // make sure there are no other nullifiers, by replacing all the joinsplits
@@ -966,12 +966,12 @@ fn transaction_v4_with_joinsplit_data<'until_cloned>(
 /// # Panics
 ///
 /// If there are no `Spend`s in `spends`, and no `Output`s in `sapling_shielded_data`.
-fn transaction_v4_with_sapling_shielded_data<'until_cloned>(
+fn transaction_v4_with_sapling_shielded_data(
     sapling_shielded_data: impl Into<Option<sapling::ShieldedData<PerSpendAnchor>>>,
-    spends: impl IntoIterator<Item = &'until_cloned sapling::Spend<PerSpendAnchor>>,
+    spends: impl IntoIterator<Item = sapling::Spend<PerSpendAnchor>>,
 ) -> Transaction {
     let mut sapling_shielded_data = sapling_shielded_data.into();
-    let spends: Vec<_> = spends.into_iter().cloned().collect();
+    let spends: Vec<_> = spends.into_iter().collect();
 
     if let Some(ref mut sapling_shielded_data) = sapling_shielded_data {
         // make sure there are no other nullifiers, by replacing all the spends
@@ -1031,12 +1031,12 @@ fn transaction_v4_with_sapling_shielded_data<'until_cloned>(
 /// # Panics
 ///
 /// If there are no `AuthorizedAction`s in `authorized_actions`.
-fn transaction_v5_with_orchard_shielded_data<'until_cloned>(
+fn transaction_v5_with_orchard_shielded_data(
     orchard_shielded_data: impl Into<Option<orchard::ShieldedData>>,
-    authorized_actions: impl IntoIterator<Item = &'until_cloned orchard::AuthorizedAction>,
+    authorized_actions: impl IntoIterator<Item = orchard::AuthorizedAction>,
 ) -> Transaction {
     let mut orchard_shielded_data = orchard_shielded_data.into();
-    let authorized_actions: Vec<_> = authorized_actions.into_iter().cloned().collect();
+    let authorized_actions: Vec<_> = authorized_actions.into_iter().collect();
 
     if let Some(ref mut orchard_shielded_data) = orchard_shielded_data {
         // make sure there are no other nullifiers, by replacing all the authorized_actions

--- a/zebra-state/src/service/check/tests/prop.rs
+++ b/zebra-state/src/service/check/tests/prop.rs
@@ -972,7 +972,7 @@ fn transaction_v4_with_sapling_shielded_data(
                 Some(spends),
             ) => SpendsAndMaybeOutputs {
                 shared_anchor,
-                spends:,
+                spends,
                 maybe_outputs,
             },
             // old spends, but no new spends: delete spends, panic if no outputs

--- a/zebra-state/src/service/check/tests/prop.rs
+++ b/zebra-state/src/service/check/tests/prop.rs
@@ -57,7 +57,7 @@ proptest! {
         make_distinct_nullifiers(&mut joinsplit.nullifiers);
         let expected_nullifiers = joinsplit.nullifiers;
 
-        let transaction = transaction_v4_with_joinsplit_data(joinsplit_data.0, vec![joinsplit.0]);
+        let transaction = transaction_v4_with_joinsplit_data(joinsplit_data.0, [joinsplit.0]);
 
         // convert the coinbase transaction to a version that the non-finalized state will accept
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -121,7 +121,7 @@ proptest! {
         let duplicate_nullifier = joinsplit.nullifiers[0];
         joinsplit.nullifiers[1] = duplicate_nullifier;
 
-        let transaction = transaction_v4_with_joinsplit_data(joinsplit_data.0, vec![joinsplit.0]);
+        let transaction = transaction_v4_with_joinsplit_data(joinsplit_data.0, [joinsplit.0]);
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
 
@@ -174,7 +174,7 @@ proptest! {
 
         let transaction = transaction_v4_with_joinsplit_data(
             joinsplit_data.0,
-            vec![joinsplit1.0, joinsplit2.0]
+            [joinsplit1.0, joinsplit2.0]
         );
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -224,8 +224,8 @@ proptest! {
         let duplicate_nullifier = joinsplit1.nullifiers[0];
         joinsplit2.nullifiers[0] = duplicate_nullifier;
 
-        let transaction1 = transaction_v4_with_joinsplit_data(joinsplit_data1.0, vec![joinsplit1.0]);
-        let transaction2 = transaction_v4_with_joinsplit_data(joinsplit_data2.0, vec![joinsplit2.0]);
+        let transaction1 = transaction_v4_with_joinsplit_data(joinsplit_data1.0, [joinsplit1.0]);
+        let transaction2 = transaction_v4_with_joinsplit_data(joinsplit_data2.0, [joinsplit2.0]);
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
 
@@ -282,8 +282,8 @@ proptest! {
         let duplicate_nullifier = joinsplit1.nullifiers[0];
         joinsplit2.nullifiers[0] = duplicate_nullifier;
 
-        let transaction1 = transaction_v4_with_joinsplit_data(joinsplit_data1.0, vec![joinsplit1.0]);
-        let transaction2 = transaction_v4_with_joinsplit_data(joinsplit_data2.0, vec![joinsplit2.0]);
+        let transaction1 = transaction_v4_with_joinsplit_data(joinsplit_data1.0, [joinsplit1.0]);
+        let transaction2 = transaction_v4_with_joinsplit_data(joinsplit_data2.0, [joinsplit2.0]);
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
         block2.transactions[0] = transaction_v4_from_coinbase(&block2.transactions[0]).into();
@@ -367,7 +367,7 @@ proptest! {
 
         let transaction = transaction_v4_with_sapling_shielded_data(
             sapling_shielded_data.0,
-            vec![spend.0]
+            [spend.0]
         );
 
         // convert the coinbase transaction to a version that the non-finalized state will accept
@@ -421,7 +421,7 @@ proptest! {
 
         let transaction = transaction_v4_with_sapling_shielded_data(
             sapling_shielded_data.0,
-            vec![spend1.0, spend2.0],
+            [spend1.0, spend2.0],
         );
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -471,11 +471,11 @@ proptest! {
 
         let transaction1 = transaction_v4_with_sapling_shielded_data(
             sapling_shielded_data1.0,
-            vec![spend1.0]
+            [spend1.0]
         );
         let transaction2 = transaction_v4_with_sapling_shielded_data(
             sapling_shielded_data2.0,
-            vec![spend2.0]
+            [spend2.0]
         );
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -532,11 +532,11 @@ proptest! {
 
         let transaction1 = transaction_v4_with_sapling_shielded_data(
             sapling_shielded_data1.0,
-            vec![spend1.0]
+            [spend1.0]
         );
         let transaction2 = transaction_v4_with_sapling_shielded_data(
             sapling_shielded_data2.0,
-            vec![spend2.0]
+            [spend2.0]
         );
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -619,7 +619,7 @@ proptest! {
 
         let transaction = transaction_v5_with_orchard_shielded_data(
             orchard_shielded_data.0,
-            vec![authorized_action.0]
+            [authorized_action.0]
         );
 
         // convert the coinbase transaction to a version that the non-finalized state will accept
@@ -673,7 +673,7 @@ proptest! {
 
         let transaction = transaction_v5_with_orchard_shielded_data(
             orchard_shielded_data.0,
-            vec![authorized_action1.0, authorized_action2.0],
+            [authorized_action1.0, authorized_action2.0],
         );
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -723,11 +723,11 @@ proptest! {
 
         let transaction1 = transaction_v5_with_orchard_shielded_data(
             orchard_shielded_data1.0,
-            vec![authorized_action1.0]
+            [authorized_action1.0]
         );
         let transaction2 = transaction_v5_with_orchard_shielded_data(
             orchard_shielded_data2.0,
-            vec![authorized_action2.0]
+            [authorized_action2.0]
         );
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
@@ -784,11 +784,11 @@ proptest! {
 
         let transaction1 = transaction_v5_with_orchard_shielded_data(
             orchard_shielded_data1.0,
-            vec![authorized_action1.0]
+            [authorized_action1.0]
         );
         let transaction2 = transaction_v5_with_orchard_shielded_data(
             orchard_shielded_data2.0,
-            vec![authorized_action2.0]
+            [authorized_action2.0]
         );
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -9,8 +9,9 @@ use std::{collections::HashMap, convert::TryInto, path::Path, sync::Arc};
 
 use zebra_chain::{
     block::{self, Block},
+    orchard,
     parameters::{Network, GENESIS_PREVIOUS_BLOCK_HASH},
-    sprout,
+    sapling, sprout,
     transaction::{self, Transaction},
     transparent,
 };
@@ -373,6 +374,18 @@ impl FinalizedState {
     pub fn contains_sprout_nullifier(&self, sprout_nullifier: &sprout::Nullifier) -> bool {
         let sprout_nullifiers = self.db.cf_handle("sprout_nullifiers").unwrap();
         self.db.zs_contains(sprout_nullifiers, &sprout_nullifier)
+    }
+
+    /// Returns `true` if the finalized state contains `sapling_nullifier`.
+    pub fn contains_sapling_nullifier(&self, sapling_nullifier: &sapling::Nullifier) -> bool {
+        let sapling_nullifiers = self.db.cf_handle("sapling_nullifiers").unwrap();
+        self.db.zs_contains(sapling_nullifiers, &sapling_nullifier)
+    }
+
+    /// Returns `true` if the finalized state contains `orchard_nullifier`.
+    pub fn contains_orchard_nullifier(&self, orchard_nullifier: &orchard::Nullifier) -> bool {
+        let orchard_nullifiers = self.db.cf_handle("orchard_nullifiers").unwrap();
+        self.db.zs_contains(orchard_nullifiers, &orchard_nullifier)
     }
 
     /// Returns the finalized hash for a given `block::Height` if it is present.

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -14,7 +14,9 @@ use std::{collections::BTreeSet, mem, ops::Deref, sync::Arc};
 
 use zebra_chain::{
     block::{self, Block},
+    orchard,
     parameters::Network,
+    sapling, sprout,
     transaction::{self, Transaction},
     transparent,
 };
@@ -299,6 +301,30 @@ impl NonFinalizedState {
             .tx_by_hash
             .get(&hash)
             .map(|(height, index)| best_chain.blocks[height].block.transactions[*index].clone())
+    }
+
+    /// Returns `true` if the best chain contains `sprout_nullifier`.
+    #[allow(dead_code)]
+    pub fn best_contains_sprout_nullifier(&self, sprout_nullifier: &sprout::Nullifier) -> bool {
+        self.best_chain()
+            .map(|best_chain| best_chain.sprout_nullifiers.contains(sprout_nullifier))
+            .unwrap_or(false)
+    }
+
+    /// Returns `true` if the best chain contains `sapling_nullifier`.
+    #[allow(dead_code)]
+    pub fn best_contains_sapling_nullifier(&self, sapling_nullifier: &sapling::Nullifier) -> bool {
+        self.best_chain()
+            .map(|best_chain| best_chain.sapling_nullifiers.contains(sapling_nullifier))
+            .unwrap_or(false)
+    }
+
+    /// Returns `true` if the best chain contains `orchard_nullifier`.
+    #[allow(dead_code)]
+    pub fn best_contains_orchard_nullifier(&self, orchard_nullifier: &orchard::Nullifier) -> bool {
+        self.best_chain()
+            .map(|best_chain| best_chain.orchard_nullifiers.contains(orchard_nullifier))
+            .unwrap_or(false)
     }
 
     /// Return the non-finalized portion of the current best chain


### PR DESCRIPTION
## Motivation

Zebra needs to reject duplicate sapling and orchard nullifiers, to prevent double-spends.

See #2231 for details.
This PR finishes the shielded part of #2231, but does not close that ticket.

## Solution

This code is almost identical to the sprout code in the previous PR:
- Add sapling and orchard duplicate nullifier errors
- Reject duplicate finalized sapling and orchard nullifiers
- Reject duplicate non-finalized sapling and orchard nullifiers

These tests are based on the previous PR, with sapling and orchard-specific changes:
- Refactor sprout nullifier tests to remove common code
- Add sapling nullifier tests 
- Add orchard nullifier tests

The specific test changes are:
- sapling and orchard only have one nullifier per `Spend`/`Action`, so there is no need for "same `Spend`/`Action`" tests 
- we can't reliably make orchard nullifiers distinct, because they must be valid Pallas points, so we just skip the test case if they are the same
- various minor structural and validation changes

## Review

@jvff can review this PR - it's not urgent at all.
This code is unlikely to conflict with any other code.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Prevent transparent double-spends #2231