### PR TITLE
clippy: remove a needless borrow

### DIFF
--- a/zebra-chain/src/orchard/tests/tree.rs
+++ b/zebra-chain/src/orchard/tests/tree.rs
@@ -27,7 +27,7 @@ fn incremental_roots() {
 
     for (i, commitment_set) in test_vectors::COMMITMENTS.iter().enumerate() {
         for cm_x_bytes in commitment_set.iter() {
-            let cm_x = pallas::Base::from_bytes(&cm_x_bytes).unwrap();
+            let cm_x = pallas::Base::from_bytes(cm_x_bytes).unwrap();
 
             leaves.push(cm_x);
 


### PR DESCRIPTION
## Motivation

Nightly clippy warns on needless borrows.

We need to fix them so developers who use nightly can see other important errors.

## Review

@conradoplg can review this tiny fix.

It is not urgent at all.

### Reviewer Checklist

  - [x] Code does the same thing

