### PR TITLE
Make nullifier tests faster and consistent with UTXO tests

### DIFF
--- a/zebra-state/src/service/check/tests/nullifier.rs
+++ b/zebra-state/src/service/check/tests/nullifier.rs
@@ -1,6 +1,6 @@
 //! Randomised property tests for state contextual validation
 
-use std::{convert::TryInto, sync::Arc};
+use std::{convert::TryInto, env, sync::Arc};
 
 use itertools::Itertools;
 use proptest::prelude::*;
@@ -35,9 +35,18 @@ use crate::{
 // because we're only interested in spend validation,
 // (and passing various other state checks).
 
-// sprout
+const DEFAULT_NULLIFIER_PROPTEST_CASES: u32 = 16;
 
 proptest! {
+    #![proptest_config(
+        proptest::test_runner::Config::with_cases(env::var("PROPTEST_CASES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_NULLIFIER_PROPTEST_CASES))
+    )]
+
+// sprout
+
     /// Make sure an arbitrary sprout nullifier is accepted by state contextual validation.
     ///
     /// This test makes sure there are no spurious rejections that might hide bugs in the other tests.
@@ -342,11 +351,9 @@ proptest! {
         prop_assert_eq!(Some((Height(1), block1_hash)), state.best_tip());
         prop_assert!(state.mem.eq_internal_state(&previous_mem));
     }
-}
 
 // sapling
 
-proptest! {
     /// Make sure an arbitrary sapling nullifier is accepted by state contextual validation.
     ///
     /// This test makes sure there are no spurious rejections that might hide bugs in the other tests.
@@ -594,11 +601,9 @@ proptest! {
         prop_assert_eq!(Some((Height(1), block1_hash)), state.best_tip());
         prop_assert!(state.mem.eq_internal_state(&previous_mem));
     }
-}
 
 // orchard
 
-proptest! {
     /// Make sure an arbitrary orchard nullifier is accepted by state contextual validation.
     ///
     /// This test makes sure there are no spurious rejections that might hide bugs in the other tests.

--- a/zebra-state/src/service/check/tests/nullifier.rs
+++ b/zebra-state/src/service/check/tests/nullifier.rs
@@ -43,7 +43,7 @@ proptest! {
     /// This test makes sure there are no spurious rejections that might hide bugs in the other tests.
     /// (And that the test infrastructure generally works.)
     #[test]
-    fn accept_distinct_arbitrary_sprout_nullifiers(
+    fn accept_distinct_arbitrary_sprout_nullifiers_in_one_block(
         mut joinsplit in TypeNameToDebug::<JoinSplit::<Groth16Proof>>::arbitrary(),
         joinsplit_data in TypeNameToDebug::<JoinSplitData::<Groth16Proof>>::arbitrary(),
         use_finalized_state in any::<bool>(),
@@ -352,7 +352,7 @@ proptest! {
     /// This test makes sure there are no spurious rejections that might hide bugs in the other tests.
     /// (And that the test infrastructure generally works.)
     #[test]
-    fn accept_distinct_arbitrary_sapling_nullifiers(
+    fn accept_distinct_arbitrary_sapling_nullifiers_in_one_block(
         spend in TypeNameToDebug::<sapling::Spend::<PerSpendAnchor>>::arbitrary(),
         sapling_shielded_data in TypeNameToDebug::<sapling::ShieldedData::<PerSpendAnchor>>::arbitrary(),
         use_finalized_state in any::<bool>(),
@@ -604,7 +604,7 @@ proptest! {
     /// This test makes sure there are no spurious rejections that might hide bugs in the other tests.
     /// (And that the test infrastructure generally works.)
     #[test]
-    fn accept_distinct_arbitrary_orchard_nullifiers(
+    fn accept_distinct_arbitrary_orchard_nullifiers_in_one_block(
         authorized_action in TypeNameToDebug::<orchard::AuthorizedAction>::arbitrary(),
         orchard_shielded_data in TypeNameToDebug::<orchard::ShieldedData>::arbitrary(),
         use_finalized_state in any::<bool>(),

--- a/zebra-state/src/service/check/tests/nullifier.rs
+++ b/zebra-state/src/service/check/tests/nullifier.rs
@@ -240,10 +240,7 @@ proptest! {
 
         block1
             .transactions
-            .push(transaction1.into());
-        block1
-            .transactions
-            .push(transaction2.into());
+            .extend([transaction1.into(), transaction2.into()]);
 
         let (mut state, genesis) = new_state_with_mainnet_genesis();
         let previous_mem = state.mem.clone();
@@ -489,10 +486,7 @@ proptest! {
 
         block1
             .transactions
-            .push(transaction1.into());
-        block1
-            .transactions
-            .push(transaction2.into());
+            .extend([transaction1.into(), transaction2.into()]);
 
         let (mut state, genesis) = new_state_with_mainnet_genesis();
         let previous_mem = state.mem.clone();
@@ -739,10 +733,7 @@ proptest! {
 
         block1
             .transactions
-            .push(transaction1.into());
-        block1
-            .transactions
-            .push(transaction2.into());
+            .extend([transaction1.into(), transaction2.into()]);
 
         let (mut state, genesis) = new_state_with_mainnet_genesis();
         let previous_mem = state.mem.clone();

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -14,12 +14,13 @@ use std::{collections::BTreeSet, mem, ops::Deref, sync::Arc};
 
 use zebra_chain::{
     block::{self, Block},
-    orchard,
     parameters::Network,
-    sapling, sprout,
     transaction::{self, Transaction},
     transparent,
 };
+
+#[cfg(test)]
+use zebra_chain::{orchard, sapling, sprout};
 
 use crate::{FinalizedBlock, HashOrHeight, PreparedBlock, ValidateContextError};
 
@@ -304,7 +305,7 @@ impl NonFinalizedState {
     }
 
     /// Returns `true` if the best chain contains `sprout_nullifier`.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn best_contains_sprout_nullifier(&self, sprout_nullifier: &sprout::Nullifier) -> bool {
         self.best_chain()
             .map(|best_chain| best_chain.sprout_nullifiers.contains(sprout_nullifier))
@@ -312,7 +313,7 @@ impl NonFinalizedState {
     }
 
     /// Returns `true` if the best chain contains `sapling_nullifier`.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn best_contains_sapling_nullifier(&self, sapling_nullifier: &sapling::Nullifier) -> bool {
         self.best_chain()
             .map(|best_chain| best_chain.sapling_nullifiers.contains(sapling_nullifier))
@@ -320,7 +321,7 @@ impl NonFinalizedState {
     }
 
     /// Returns `true` if the best chain contains `orchard_nullifier`.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn best_contains_orchard_nullifier(&self, orchard_nullifier: &orchard::Nullifier) -> bool {
         self.best_chain()
             .map(|best_chain| best_chain.orchard_nullifiers.contains(orchard_nullifier))

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -14,7 +14,7 @@ use crate::{
     Config,
 };
 
-const DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES: u32 = 32;
+const DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES: u32 = 16;
 
 /// Check that a forked chain is the same as a chain that had the same blocks appended.
 #[test]

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -175,17 +175,6 @@ fn state_behaves_when_blocks_are_committed_in_order() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn state_behaves_when_blocks_are_committed_out_of_order() -> Result<()> {
-    zebra_test::init();
-
-    proptest!(|(blocks in out_of_order_committing_strategy())| {
-        populate_and_check(blocks).unwrap();
-    });
-
-    Ok(())
-}
-
 const DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES: u32 = 2;
 const BLOCKS_AFTER_NU5: u32 = 101;
 
@@ -196,6 +185,14 @@ proptest! {
             .and_then(|v| v.parse().ok())
             .unwrap_or(DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES))
     )]
+
+    /// Test out of order commits of continuous block test vectors from genesis onward.
+    #[test]
+    fn state_behaves_when_blocks_are_committed_out_of_order(blocks in out_of_order_committing_strategy()) {
+        zebra_test::init();
+
+        populate_and_check(blocks).unwrap();
+    }
 
     /// Test blocks that are less than the NU5 activation height.
     #[test]


### PR DESCRIPTION
## Motivation

The nullifier tests are a bit slow on some developers' machines.

This PR also makes minor changes to the nullifier test code to match the UTXO tests in  PR #2511.

This PR does not close any tickets.

## Solution

- reduce the number of proptest cases for slow state tests
- rename tests for consistency and clarity
- make some non-finalized state methods test-only

## Review

@oxarbitrage can review this PR. It's not urgent at all.

### Reviewer Checklist

  - [ ] Refactors make sense
  - [ ] Tests are faster

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2513)
<!-- Reviewable:end -->
