### PR TITLE
Reject connections from outdated peers

### DIFF
--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -575,6 +575,8 @@ pub async fn negotiate_version(
         Err(HandshakeError::NonceReuse)?;
     }
 
+    // SECURITY: Reject connections to peers on old versions, because they might not know about all
+    // network upgrades and could lead to chain forks or slower block propagation.
     let height = best_tip_height.and_then(|height| *height.borrow());
     let min_version = Version::min_remote_for_height(config.network, height);
     if remote_version < min_version {

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -575,17 +575,9 @@ pub async fn negotiate_version(
         Err(HandshakeError::NonceReuse)?;
     }
 
-    // TODO: Reject connections with nodes that don't know about the current network upgrade (#1334)
-    //       Use the latest non-finalized block height, rather than the minimum
-    if remote_version
-        < Version::min_remote_for_height(
-            config.network,
-            // This code will be replaced in #1334
-            constants::INITIAL_MIN_NETWORK_PROTOCOL_VERSION
-                .activation_height(config.network)
-                .expect("minimum network protocol network upgrade has an activation height"),
-        )
-    {
+    let height = best_tip_height.and_then(|height| *height.borrow());
+    let min_version = Version::min_remote_for_height(config.network, height);
+    if remote_version < min_version {
         // Disconnect if peer is using an obsolete version.
         Err(HandshakeError::ObsoleteVersion(remote_version))?;
     }

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -454,6 +454,7 @@ where
 ///
 /// We split `Handshake` into its components before calling this function,
 /// to avoid infectious `Sync` bounds on the returned future.
+#[allow(clippy::too_many_arguments)]
 pub async fn negotiate_version(
     peer_conn: &mut Framed<TcpStream, Codec>,
     connected_addr: &ConnectedAddr,
@@ -462,6 +463,7 @@ pub async fn negotiate_version(
     user_agent: String,
     our_services: PeerServices,
     relay: bool,
+    best_tip_height: Option<watch::Receiver<Option<block::Height>>>,
 ) -> Result<(Version, PeerServices, SocketAddr), HandshakeError> {
     // Create a random nonce for this connection
     let local_nonce = Nonce::default();
@@ -638,6 +640,7 @@ where
         let user_agent = self.user_agent.clone();
         let our_services = self.our_services;
         let relay = self.relay;
+        let best_tip_height = self.best_tip_height.clone();
 
         let fut = async move {
             debug!(
@@ -668,6 +671,7 @@ where
                     user_agent,
                     our_services,
                     relay,
+                    best_tip_height,
                 ),
             )
             .await??;

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -12,7 +12,11 @@ use futures::{
     stream::{FuturesUnordered, StreamExt},
     TryFutureExt,
 };
-use tokio::{net::TcpListener, sync::broadcast, time::Instant};
+use tokio::{
+    net::TcpListener,
+    sync::{broadcast, watch},
+    time::Instant,
+};
 use tower::{
     buffer::Buffer, discover::Change, layer::Layer, load::peak_ewma::PeakEwmaDiscover,
     util::BoxService, Service, ServiceExt,
@@ -25,7 +29,7 @@ use crate::{
     BoxError, Config, Request, Response,
 };
 
-use zebra_chain::parameters::Network;
+use zebra_chain::{block, parameters::Network};
 
 use super::CandidateSet;
 use super::PeerSet;
@@ -59,6 +63,7 @@ type PeerChange = Result<Change<SocketAddr, peer::Client>, BoxError>;
 pub async fn init<S>(
     config: Config,
     inbound_service: S,
+    best_tip_height: Option<watch::Receiver<Option<block::Height>>>,
 ) -> (
     Buffer<BoxService<Request, Response, BoxError>, Request>,
     Arc<std::sync::Mutex<AddressBook>>,
@@ -87,6 +92,7 @@ where
             .with_timestamp_collector(timestamp_collector)
             .with_advertised_services(PeerServices::NODE_NETWORK)
             .with_user_agent(crate::constants::USER_AGENT.to_string())
+            .with_best_tip_height(best_tip_height)
             .want_transactions(true)
             .finish()
             .expect("configured all required parameters");

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -110,7 +110,7 @@ async fn local_listener_port_with(listen_addr: SocketAddr, network: Network) {
     let inbound_service =
         service_fn(|_| async { unreachable!("inbound service should never be called") });
 
-    let (_peer_service, address_book) = init(config, inbound_service).await;
+    let (_peer_service, address_book) = init(config, inbound_service, None).await;
     let local_listener = address_book.lock().unwrap().local_listener_meta_addr();
 
     if listen_addr.port() == 0 {

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -48,7 +48,11 @@ impl Version {
     /// # Panics
     ///
     /// If we are incompatible with our own minimum remote protocol version.
-    pub fn min_remote_for_height(network: Network, height: block::Height) -> Version {
+    pub fn min_remote_for_height(
+        network: Network,
+        height: impl Into<Option<block::Height>>,
+    ) -> Version {
+        let height = height.into().unwrap_or(block::Height(0));
         let min_spec = Version::min_specified_for_height(network, height);
 
         // shut down if our own version is too old

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -28,6 +28,7 @@ use crate::{
     FinalizedBlock, PreparedBlock, Request, Response, ValidateContextError,
 };
 
+mod best_tip_height;
 pub(crate) mod check;
 mod finalized_state;
 mod non_finalized_state;

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -171,10 +171,13 @@ impl StateService {
                 );
         }
 
-        self.queued_blocks
-            .prune_by_height(self.disk.finalized_tip_height().expect(
+        let finalized_tip_height = self.disk.finalized_tip_height().expect(
             "Finalized state must have at least one block before committing non-finalized state",
-        ));
+        );
+
+        self.queued_blocks.prune_by_height(finalized_tip_height);
+        self.best_tip_height
+            .set_finalized_height(finalized_tip_height);
 
         tracing::trace!("finished processing queued block");
         rsp_rx

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -678,6 +678,10 @@ impl Service<Request> for StateService {
                 self.pending_utxos.check_against(&finalized.new_outputs);
                 self.disk.queue_and_commit_finalized((finalized, rsp_tx));
 
+                if let Some(finalized_height) = self.disk.finalized_tip_height() {
+                    self.best_tip_height.set_finalized_height(finalized_height);
+                }
+
                 async move {
                     rsp_rx
                         .await

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -174,10 +174,14 @@ impl StateService {
         let finalized_tip_height = self.disk.finalized_tip_height().expect(
             "Finalized state must have at least one block before committing non-finalized state",
         );
+        let non_finalized_tip_height = self.mem.best_tip().map(|(height, _hash)| height);
 
         self.queued_blocks.prune_by_height(finalized_tip_height);
+
         self.best_tip_height
             .set_finalized_height(finalized_tip_height);
+        self.best_tip_height
+            .set_best_non_finalized_height(non_finalized_tip_height);
 
         tracing::trace!("finished processing queued block");
         rsp_rx

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -73,8 +73,12 @@ impl StateService {
     const PRUNE_INTERVAL: Duration = Duration::from_secs(30);
 
     pub fn new(config: Config, network: Network) -> (Self, watch::Receiver<Option<block::Height>>) {
-        let (best_tip_height, best_tip_height_receiver) = BestTipHeight::new();
+        let (mut best_tip_height, best_tip_height_receiver) = BestTipHeight::new();
         let disk = FinalizedState::new(&config, network);
+
+        if let Some(finalized_height) = disk.finalized_tip_height() {
+            best_tip_height.set_finalized_height(finalized_height);
+        }
 
         let mem = NonFinalizedState::new(network);
         let queued_blocks = QueuedBlocks::default();

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -6,7 +6,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use check::difficulty::POW_MEDIAN_BLOCK_SPAN;
 use futures::future::FutureExt;
 use non_finalized_state::{NonFinalizedState, QueuedBlocks};
 use tokio::sync::{oneshot, watch};
@@ -16,7 +15,6 @@ use tower::{util::BoxService, Service};
 use tracing::instrument;
 use zebra_chain::{
     block::{self, Block},
-    parameters::POW_AVERAGING_WINDOW,
     parameters::{Network, NetworkUpgrade},
     transaction,
     transaction::Transaction,
@@ -529,14 +527,6 @@ impl StateService {
             "invalid non-finalized block height: the canopy checkpoint is mandatory, pre-canopy \
             blocks, and the canopy activation block, must be committed to the state as finalized \
             blocks"
-        );
-
-        // required by check_contextual_validity, moved here to make testing easier
-        let relevant_chain = self.any_ancestor_blocks(block.block.header.previous_block_hash);
-        assert!(
-            relevant_chain.len() >= POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN,
-            "contextual validation requires at least 28 \
-            (POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN) blocks"
         );
     }
 }

--- a/zebra-state/src/service/best_tip_height.rs
+++ b/zebra-state/src/service/best_tip_height.rs
@@ -2,6 +2,9 @@ use tokio::sync::watch;
 
 use zebra_chain::block;
 
+#[cfg(test)]
+mod tests;
+
 /// A helper type to determine the best chain tip block height.
 ///
 /// The block height is determined based on the current finalized block height and the current best

--- a/zebra-state/src/service/best_tip_height.rs
+++ b/zebra-state/src/service/best_tip_height.rs
@@ -1,0 +1,67 @@
+use tokio::sync::watch;
+
+use zebra_chain::block;
+
+/// A helper type to determine the best chain tip block height.
+///
+/// The block height is determined based on the current finalized block height and the current best
+/// non-finalized chain's tip block height. The height is made available from a [`watch::Receiver`].
+#[derive(Debug)]
+pub struct BestTipHeight {
+    finalized: Option<block::Height>,
+    non_finalized: Option<block::Height>,
+    sender: watch::Sender<Option<block::Height>>,
+    // TODO: Replace with calls to `watch::Sender::borrow` once Tokio is updated to 1.0.0 (#2573)
+    active_value: Option<block::Height>,
+}
+
+impl BestTipHeight {
+    /// Create a new instance of [`BestTipHeight`] and the [`watch::Receiver`] endpoint for the
+    /// current best tip block height.
+    pub fn new() -> (Self, watch::Receiver<Option<block::Height>>) {
+        let (sender, receiver) = watch::channel(None);
+
+        (
+            BestTipHeight {
+                finalized: None,
+                non_finalized: None,
+                sender,
+                active_value: None,
+            },
+            receiver,
+        )
+    }
+
+    /// Update the current finalized block height.
+    ///
+    /// May trigger an update to best tip height.
+    pub fn set_finalized_height(&mut self, new_height: block::Height) {
+        if self.finalized != Some(new_height) {
+            self.finalized = Some(new_height);
+            self.update();
+        }
+    }
+
+    /// Update the current non-finalized block height.
+    ///
+    /// May trigger an update to the best tip height.
+    pub fn set_best_non_finalized_height(&mut self, new_height: Option<block::Height>) {
+        if self.non_finalized != new_height {
+            self.non_finalized = new_height;
+            self.update();
+        }
+    }
+
+    /// Possibly send an update to listeners.
+    ///
+    /// An update is only sent if the current best tip height is different from the last best tip
+    /// height that was sent.
+    fn update(&mut self) {
+        let new_value = self.non_finalized.max(self.finalized);
+
+        if new_value != self.active_value {
+            let _ = self.sender.send(new_value);
+            self.active_value = new_value;
+        }
+    }
+}

--- a/zebra-state/src/service/best_tip_height/tests.rs
+++ b/zebra-state/src/service/best_tip_height/tests.rs
@@ -1,0 +1,1 @@
+mod vectors;

--- a/zebra-state/src/service/best_tip_height/tests.rs
+++ b/zebra-state/src/service/best_tip_height/tests.rs
@@ -1,1 +1,2 @@
+mod prop;
 mod vectors;

--- a/zebra-state/src/service/best_tip_height/tests/prop.rs
+++ b/zebra-state/src/service/best_tip_height/tests/prop.rs
@@ -1,0 +1,47 @@
+use proptest::prelude::*;
+use proptest_derive::Arbitrary;
+
+use zebra_chain::block;
+
+use super::super::BestTipHeight;
+
+proptest! {
+    #[test]
+    fn best_tip_value_is_heighest_of_latest_finalized_and_non_finalized_heights(
+        height_updates in any::<Vec<HeightUpdate>>(),
+    ) {
+        let (mut best_tip_height, receiver) = BestTipHeight::new();
+
+        let mut latest_finalized_height = None;
+        let mut latest_non_finalized_height = None;
+
+        for update in height_updates {
+            match update {
+                HeightUpdate::Finalized(height) => {
+                    best_tip_height.set_finalized_height(height);
+                    latest_finalized_height = Some(height);
+                }
+                HeightUpdate::NonFinalized(height) => {
+                    best_tip_height.set_best_non_finalized_height(height);
+                    latest_non_finalized_height = height;
+                }
+            }
+        }
+
+        let expected_height = match (latest_finalized_height, latest_non_finalized_height) {
+            (Some(finalized_height), Some(non_finalized_height)) => {
+                Some(finalized_height.max(non_finalized_height))
+            }
+            (finalized_height, None) => finalized_height,
+            (None, non_finalized_height) => non_finalized_height,
+        };
+
+        prop_assert_eq!(*receiver.borrow(), expected_height);
+    }
+}
+
+#[derive(Arbitrary, Clone, Copy, Debug)]
+enum HeightUpdate {
+    Finalized(block::Height),
+    NonFinalized(Option<block::Height>),
+}

--- a/zebra-state/src/service/best_tip_height/tests/vectors.rs
+++ b/zebra-state/src/service/best_tip_height/tests/vectors.rs
@@ -1,0 +1,8 @@
+use super::super::BestTipHeight;
+
+#[test]
+fn best_tip_value_is_initially_empty() {
+    let (_best_tip_height, receiver) = BestTipHeight::new();
+
+    assert_eq!(*receiver.borrow(), None);
+}

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -5,13 +5,16 @@ use tower::{buffer::Buffer, util::BoxService, Service, ServiceExt};
 use zebra_chain::{
     block::Block,
     parameters::{Network, NetworkUpgrade},
-    serialization::ZcashDeserializeInto,
+    serialization::{ZcashDeserialize, ZcashDeserializeInto},
     transaction, transparent,
 };
 use zebra_test::{prelude::*, transcript::Transcript};
 
 use crate::{
-    constants, init_test, tests::setup::partial_nu5_chain_strategy, BoxError, Request, Response,
+    arbitrary::Prepare,
+    constants, init_test,
+    tests::setup::{partial_nu5_chain_strategy, transaction_v4_from_coinbase},
+    BoxError, FinalizedBlock, PreparedBlock, Request, Response,
 };
 
 const LAST_BLOCK_HEIGHT: u32 = 10;
@@ -274,4 +277,50 @@ proptest! {
 
         prop_assert_eq!(response, Ok(()));
     }
+}
+
+/// Test strategy to generate a chain split in two from the test vectors.
+///
+/// Selects either the mainnet or testnet chain test vector and randomly splits the chain in two
+/// lists of blocks. The first containing the blocks to be finalized (which always includes at
+/// least the genesis block) and the blocks to be stored in the non-finalized state.
+fn continuous_empty_blocks_from_test_vectors(
+) -> impl Strategy<Value = (Network, Vec<FinalizedBlock>, Vec<PreparedBlock>)> {
+    any::<Network>()
+        .prop_flat_map(|network| {
+            // Select the test vector based on the network
+            let raw_blocks = match network {
+                Network::Mainnet => &*zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS,
+                Network::Testnet => &*zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS,
+            };
+
+            // Transform the test vector's block bytes into a vector of `PreparedBlock`s.
+            let blocks: Vec<_> = raw_blocks
+                .iter()
+                .map(|(_height, &block_bytes)| {
+                    let mut block_reader: &[u8] = block_bytes;
+                    let mut block = Block::zcash_deserialize(&mut block_reader)
+                        .expect("Failed to deserialize block from test vector");
+
+                    let coinbase = transaction_v4_from_coinbase(&block.transactions[0]);
+                    block.transactions = vec![Arc::new(coinbase)];
+
+                    Arc::new(block).prepare()
+                })
+                .collect();
+
+            // Always finalize the genesis block
+            let finalized_blocks_count = 1..=blocks.len();
+
+            (Just(network), Just(blocks), finalized_blocks_count)
+        })
+        .prop_map(|(network, mut blocks, finalized_blocks_count)| {
+            let non_finalized_blocks = blocks.split_off(finalized_blocks_count);
+            let finalized_blocks: Vec<_> = blocks
+                .into_iter()
+                .map(|prepared_block| FinalizedBlock::from(prepared_block.block))
+                .collect();
+
+            (network, finalized_blocks, non_finalized_blocks)
+        })
 }

--- a/zebra-state/src/tests/setup.rs
+++ b/zebra-state/src/tests/setup.rs
@@ -83,7 +83,7 @@ pub(crate) fn new_state_with_mainnet_genesis() -> (StateService, FinalizedBlock)
         .zcash_deserialize_into::<Arc<Block>>()
         .expect("block should deserialize");
 
-    let mut state = StateService::new(Config::ephemeral(), Mainnet);
+    let (mut state, _) = StateService::new(Config::ephemeral(), Mainnet);
 
     assert_eq!(None, state.best_tip());
 

--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -7,7 +7,6 @@
 use color_eyre::eyre::Report;
 use once_cell::sync::Lazy;
 use std::sync::Arc;
-use tempdir::TempDir;
 use zebra_chain::{block::Block, parameters::Network, serialization::ZcashDeserialize};
 use zebra_test::transcript::{ExpectedTranscriptError, Transcript};
 
@@ -76,20 +75,10 @@ async fn check_transcripts(network: Network) -> Result<(), Report> {
         Network::Mainnet => mainnet_transcript,
         Network::Testnet => testnet_transcript,
     } {
-        let storage_guard = TempDir::new("")?;
-        let cache_dir = storage_guard.path().to_owned();
-        let service = zebra_state::init(
-            Config {
-                cache_dir,
-                ..Config::default()
-            },
-            network,
-        );
+        let service = zebra_state::init_test(network);
         let transcript = Transcript::from(transcript_data.iter().cloned());
         /// SPANDOC: check the on disk service against the transcript
         transcript.check(service).await?;
-        // Delete the contents of the temp directory before going to the next case.
-        std::mem::drop(storage_guard);
     }
 
     Ok(())

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -49,10 +49,8 @@ impl StartCmd {
         info!(?config);
 
         info!("initializing node state");
-        let state = ServiceBuilder::new().buffer(20).service(zebra_state::init(
-            config.state.clone(),
-            config.network.network,
-        ));
+        let (state_service, _) = zebra_state::init(config.state.clone(), config.network.network);
+        let state = ServiceBuilder::new().buffer(20).service(state_service);
 
         info!("initializing verifiers");
         let verifier = zebra_consensus::chain::init(

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -49,7 +49,8 @@ impl StartCmd {
         info!(?config);
 
         info!("initializing node state");
-        let (state_service, _) = zebra_state::init(config.state.clone(), config.network.network);
+        let (state_service, best_tip_height) =
+            zebra_state::init(config.state.clone(), config.network.network);
         let state = ServiceBuilder::new().buffer(20).service(state_service);
 
         info!("initializing verifiers");
@@ -70,7 +71,8 @@ impl StartCmd {
             .buffer(20)
             .service(Inbound::new(setup_rx, state.clone(), verifier.clone()));
 
-        let (peer_set, address_book) = zebra_network::init(config.network.clone(), inbound).await;
+        let (peer_set, address_book) =
+            zebra_network::init(config.network.clone(), inbound, Some(best_tip_height)).await;
         setup_tx
             .send((peer_set.clone(), address_book))
             .map_err(|_| eyre!("could not send setup data to inbound service"))?;


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
When NU5 activates, there may still be peers on the network that are running outdated software. This means that they would be advertising themselves with support for an older network protocol version. In order to incentivize peers to upgrade their software and improve network health, it would be best for Zebra nodes to automatically only accept connections from peers that support NU5 after NU5 is activated.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->
[ZIP-201](https://zips.z.cash/zip-0201#rejecting-pre-overwinter-connections) details how a node rejects connections from peers that are on an older network protocol and therefore don't support a network upgrade when it's activated.

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->
#1334 outlines an initial design.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
The solution implemented here adds a `BestTipHeight` helper type. This type helps to determine the best tip height based on the finalized tip height and the tip height of the best non-finalized chain. It then sends the block height to a `watch` channel. The `zebra-state` now provides the best tip height `watch::Receiver` endpoint when it is initialized.

The `zebra-network` crate can now receive the best tip height `watch::Receiver` endpoint and will determine the minimum supported network protocol version based on its value. It will automatically reject peers that have a network protocol version less than the calculated minimum network protocol version.

The `zebrad` crate was updated to forward the `watch::Receiver` endpoint created by `zebra-state` into `zebra-network`.

The PR includes a few unit tests for the `BestTipHeight` type, as well as a slightly broader property test that checks if the best tip height is updated by the state service.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 has been reviewing and helping with this PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
- After this PR is merged, long running Foundation Zebra nodes have to be redeployed.
- Consider adding tests that use multiple non-finalized chain forks (#2571).
- Add proptest to check the minimum supported network protocol version based on random block heights (#2571)
- Refactor to remove `active_value` once Tokio is updated to version 1.0.0 (#2573)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2519)
<!-- Reviewable:end -->
