### PR TITLE
Decrease number of tests in finalized state

### DIFF
--- a/zebra-state/src/service/finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/tests/prop.rs
@@ -12,7 +12,7 @@ use crate::{
     ContextuallyValidBlock,
 };
 
-const DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES: u32 = 32;
+const DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES: u32 = 16;
 
 #[test]
 fn blocks_with_v5_transactions() -> Result<()> {


### PR DESCRIPTION
## Motivation

In https://github.com/zcashfoundation/zebra/pull/2513 we decreased the default number of prop tests for non_finalized_state for speed purposes when running the test suite. I think we should do the same in the finalized tests ones. 

## Solution

Change the `DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES` from 32 to 16.

## Review

Anyone can review, is minor and not a priority.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2521)
<!-- Reviewable:end -->
