### PR TITLE
Validate spends of transparent coinbase outputs

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -10,7 +10,7 @@ mod serialize;
 pub mod merkle;
 
 #[cfg(any(test, feature = "proptest-impl"))]
-mod arbitrary;
+pub mod arbitrary;
 #[cfg(any(test, feature = "bench"))]
 pub mod tests;
 

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -381,15 +381,18 @@ impl Block {
                                 .unwrap_or_else(orchard::Flags::empty)
                                 .contains(orchard::Flags::ENABLE_SPENDS))
                     {
-                        // add the created UTXOs
-                        // these outputs can be spent from the next transaction in this block onwards
-                        // see `new_outputs` for details
-                        let hash = transaction.hash();
-                        for output_index_in_transaction in 0..transaction.outputs().len() {
-                            utxos.insert(transparent::OutPoint {
-                                hash,
-                                index: output_index_in_transaction.try_into().unwrap(),
-                            });
+                        // skip genesis created UTXOs, just like the state does
+                        if block.header.previous_block_hash != GENESIS_PREVIOUS_BLOCK_HASH {
+                            // add the created UTXOs
+                            // these outputs can be spent from the next transaction in this block onwards
+                            // see `new_outputs` for details
+                            let hash = transaction.hash();
+                            for output_index_in_transaction in 0..transaction.outputs().len() {
+                                utxos.insert(transparent::OutPoint {
+                                    hash,
+                                    index: output_index_in_transaction.try_into().unwrap(),
+                                });
+                            }
                         }
 
                         // and keep the transaction

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -1,4 +1,4 @@
-//! Randomised property testing for [`Block`]s
+//! Randomised property testing for [`Block`]s.
 
 use proptest::{
     arbitrary::{any, Arbitrary},

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -1,3 +1,5 @@
+//! Randomised property testing for [`Block`]s
+
 use proptest::{
     arbitrary::{any, Arbitrary},
     prelude::*,
@@ -331,7 +333,7 @@ impl Arbitrary for Block {
 }
 
 /// Skip checking transparent coinbase spends in [`Block::partial_chain_strategy`].
-#[allow(dead_code)]
+#[allow(clippy::result_unit_err)]
 pub fn allow_all_transparent_coinbase_spends(
     _: transparent::OutPoint,
     _: transparent::CoinbaseSpendRestriction,

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -364,7 +364,6 @@ impl Block {
                 if let Some(previous_block_hash) = previous_block_hash {
                     block.header.previous_block_hash = previous_block_hash;
                 }
-                previous_block_hash = Some(block.hash());
 
                 // fixup the transparent spends
                 let mut new_transactions = Vec::new();
@@ -482,6 +481,10 @@ impl Block {
                 block.transactions = new_transactions;
 
                 // TODO: fixup the history and authorizing data commitments, if needed
+
+                // now that we've made all the changes, calculate our block hash,
+                // so the next block can use it
+                previous_block_hash = Some(block.hash());
             }
             SummaryDebug(
                 vec.into_iter()

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -32,7 +32,8 @@ use super::*;
 /// shielded_input = shielded_pool_count / pool_count
 /// expected_transactions = expected_inputs = MAX_ARBITRARY_ITEMS/2
 /// proptest_cases = 256
-/// shielded_input^(expected_transactions * expected_inputs * PREVOUTS_CHAIN_HEIGHT) * proptest_cases
+/// number_of_proptests = 5 as of July 2021 (PREVOUTS_CHAIN_HEIGHT and PartialChain tests)
+/// shielded_input^(expected_transactions * expected_inputs * PREVOUTS_CHAIN_HEIGHT) * proptest_cases * number_of_proptests
 /// ```
 ///
 /// `PREVOUTS_CHAIN_HEIGHT` should be increased, and `proptest_cases` should be reduced,

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -21,6 +21,23 @@ use crate::{
 
 use super::*;
 
+/// The chain height used to test for prevout inputs.
+///
+/// This impacts the probability of `has_prevouts` failures in
+/// `arbitrary_height_partial_chain_strategy`.
+///
+/// The failure probability calculation is:
+/// ```text
+/// shielded_input = shielded_pool_count / pool_count
+/// expected_transactions = expected_inputs = MAX_ARBITRARY_ITEMS/2
+/// proptest_cases = 256
+/// shielded_input^(expected_transactions * expected_inputs * PREVOUTS_CHAIN_HEIGHT) * proptest_cases
+/// ```
+///
+/// `PREVOUTS_CHAIN_HEIGHT` should be increased, and `proptest_cases` should be reduced,
+/// so that the failure probability is less than 1 in 1 million.
+pub const PREVOUTS_CHAIN_HEIGHT: usize = 20;
+
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 /// The configuration data for proptest when generating arbitrary chains

--- a/zebra-chain/src/block/tests/prop.rs
+++ b/zebra-chain/src/block/tests/prop.rs
@@ -11,7 +11,9 @@ use crate::{
     LedgerState,
 };
 
-use super::super::{serialize::MAX_BLOCK_BYTES, *};
+use super::super::{
+    arbitrary::allow_all_transparent_coinbase_spends, serialize::MAX_BLOCK_BYTES, *,
+};
 
 const DEFAULT_BLOCK_ROUNDTRIP_PROPTEST_CASES: u32 = 16;
 
@@ -163,8 +165,13 @@ fn block_genesis_strategy() -> Result<()> {
 fn partial_chain_strategy() -> Result<()> {
     zebra_test::init();
 
-    let strategy = LedgerState::genesis_strategy(None, None, false)
-        .prop_flat_map(|init| Block::partial_chain_strategy(init, MAX_ARBITRARY_ITEMS));
+    let strategy = LedgerState::genesis_strategy(None, None, false).prop_flat_map(|init| {
+        Block::partial_chain_strategy(
+            init,
+            MAX_ARBITRARY_ITEMS,
+            allow_all_transparent_coinbase_spends,
+        )
+    });
 
     proptest!(|(chain in strategy)| {
         let mut height = Height(0);
@@ -188,7 +195,13 @@ fn arbitrary_height_partial_chain_strategy() -> Result<()> {
 
     let strategy = any::<Height>()
         .prop_flat_map(|height| LedgerState::height_strategy(height, None, None, false))
-        .prop_flat_map(|init| Block::partial_chain_strategy(init, MAX_ARBITRARY_ITEMS));
+        .prop_flat_map(|init| {
+            Block::partial_chain_strategy(
+                init,
+                MAX_ARBITRARY_ITEMS,
+                allow_all_transparent_coinbase_spends,
+            )
+        });
 
     proptest!(|(chain in strategy)| {
         let mut height = None;

--- a/zebra-chain/src/block/tests/prop.rs
+++ b/zebra-chain/src/block/tests/prop.rs
@@ -12,7 +12,9 @@ use crate::{
 };
 
 use super::super::{
-    arbitrary::allow_all_transparent_coinbase_spends, serialize::MAX_BLOCK_BYTES, *,
+    arbitrary::{allow_all_transparent_coinbase_spends, PREVOUTS_CHAIN_HEIGHT},
+    serialize::MAX_BLOCK_BYTES,
+    *,
 };
 
 const DEFAULT_BLOCK_ROUNDTRIP_PROPTEST_CASES: u32 = 16;
@@ -159,10 +161,12 @@ fn block_genesis_strategy() -> Result<()> {
     Ok(())
 }
 
-/// Make sure our partial chain strategy generates a chain with the correct coinbase
-/// heights and previous block hashes.
+/// Make sure our genesis partial chain strategy generates a chain with:
+/// - correct coinbase heights
+/// - correct previous block hashes
+/// - no transparent spends in the genesis block, because genesis transparent outputs are ignored
 #[test]
-fn partial_chain_strategy() -> Result<()> {
+fn genesis_partial_chain_strategy() -> Result<()> {
     zebra_test::init();
 
     let strategy = LedgerState::genesis_strategy(None, None, false).prop_flat_map(|init| {
@@ -176,9 +180,27 @@ fn partial_chain_strategy() -> Result<()> {
     proptest!(|(chain in strategy)| {
         let mut height = Height(0);
         let mut previous_block_hash = GENESIS_PREVIOUS_BLOCK_HASH;
+
         for block in chain {
             prop_assert_eq!(block.coinbase_height(), Some(height));
             prop_assert_eq!(block.header.previous_block_hash, previous_block_hash);
+
+            // block 1 can have spends of transparent outputs
+            // of previous transactions in the same block
+            if height == Height(0) {
+                prop_assert_eq!(
+                    block
+                        .transactions
+                        .iter()
+                        .flat_map(|t| t.inputs())
+                        .filter_map(|i| i.outpoint())
+                        .count(),
+                    0,
+                    "unexpected transparent prevout inputs at height {:?}: genesis transparent outputs are ignored",
+                    height,
+                );
+            }
+
             height = Height(height.0 + 1);
             previous_block_hash = block.hash();
         }
@@ -187,8 +209,10 @@ fn partial_chain_strategy() -> Result<()> {
     Ok(())
 }
 
-/// Make sure our block height strategy generates a chain with the correct coinbase
-/// heights and hashes.
+/// Make sure our block height strategy generates a chain with:
+/// - correct coinbase heights
+/// - correct previous block hashes
+/// - at least one transparent PrevOut input in the entire chain
 #[test]
 fn arbitrary_height_partial_chain_strategy() -> Result<()> {
     zebra_test::init();
@@ -198,7 +222,7 @@ fn arbitrary_height_partial_chain_strategy() -> Result<()> {
         .prop_flat_map(|init| {
             Block::partial_chain_strategy(
                 init,
-                MAX_ARBITRARY_ITEMS,
+                PREVOUTS_CHAIN_HEIGHT,
                 allow_all_transparent_coinbase_spends,
             )
         });
@@ -206,6 +230,8 @@ fn arbitrary_height_partial_chain_strategy() -> Result<()> {
     proptest!(|(chain in strategy)| {
         let mut height = None;
         let mut previous_block_hash = None;
+        let mut has_prevouts = false;
+
         for block in chain {
             if height.is_none() {
                 prop_assert!(block.coinbase_height().is_some());
@@ -215,8 +241,19 @@ fn arbitrary_height_partial_chain_strategy() -> Result<()> {
                 prop_assert_eq!(block.coinbase_height(), height);
                 prop_assert_eq!(Some(block.header.previous_block_hash), previous_block_hash);
             }
+
+            has_prevouts |= block
+                .transactions
+                .iter()
+                .flat_map(|t| t.inputs())
+                .find_map(|i| i.outpoint())
+                .is_some();
+
             previous_block_hash = Some(block.hash());
         }
+
+        // this assertion checks that we're covering transparent spends
+        prop_assert!(has_prevouts, "unexpected missing prevouts in entire chain");
     });
 
     Ok(())

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -27,7 +27,11 @@ use crate::{
     amount, block, orchard,
     parameters::NetworkUpgrade,
     primitives::{Bctv14Proof, Groth16Proof},
-    sapling, sprout, transparent,
+    sapling, sprout,
+    transparent::{
+        self,
+        CoinbaseSpendRestriction::{self, *},
+    },
 };
 
 /// A Zcash transaction.
@@ -269,6 +273,19 @@ impl Transaction {
         self.inputs()
             .iter()
             .any(|input| matches!(input, transparent::Input::PrevOut { .. }))
+    }
+
+    /// Returns the [`CoinbaseSpendRestriction`] for this transaction,
+    /// assuming it is mined at `spend_height`.
+    pub fn coinbase_spend_restriction(
+        &self,
+        spend_height: block::Height,
+    ) -> CoinbaseSpendRestriction {
+        if self.outputs().is_empty() {
+            OnlyShieldedOutputs { spend_height }
+        } else {
+            SomeTransparentOutputs
+        }
     }
 
     // sprout

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -250,6 +250,28 @@ impl Transaction {
         }
     }
 
+    /// Modify the transparent outputs of this transaction, regardless of version.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn outputs_mut(&mut self) -> &mut Vec<transparent::Output> {
+        match self {
+            Transaction::V1 {
+                ref mut outputs, ..
+            } => outputs,
+            Transaction::V2 {
+                ref mut outputs, ..
+            } => outputs,
+            Transaction::V3 {
+                ref mut outputs, ..
+            } => outputs,
+            Transaction::V4 {
+                ref mut outputs, ..
+            } => outputs,
+            Transaction::V5 {
+                ref mut outputs, ..
+            } => outputs,
+        }
+    }
+
     /// Returns `true` if this transaction is a coinbase transaction.
     pub fn is_coinbase(&self) -> bool {
         self.inputs().len() == 1

--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -9,7 +9,10 @@ mod utxo;
 
 pub use address::Address;
 pub use script::Script;
-pub use utxo::{new_ordered_outputs, new_outputs, utxos_from_ordered_utxos, OrderedUtxo, Utxo};
+pub use utxo::{
+    new_ordered_outputs, new_outputs, utxos_from_ordered_utxos, CoinbaseSpendRestriction,
+    OrderedUtxo, Utxo,
+};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;

--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -15,6 +15,9 @@ pub use utxo::{
 };
 
 #[cfg(any(test, feature = "proptest-impl"))]
+pub(crate) use utxo::new_transaction_ordered_outputs;
+
+#[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
 
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/zebra-chain/src/transparent/utxo.rs
+++ b/zebra-chain/src/transparent/utxo.rs
@@ -68,6 +68,26 @@ impl OrderedUtxo {
     }
 }
 
+/// A restriction that must be checked before spending a transparent output of a
+/// coinbase transaction.
+///
+/// See [`CoinbaseSpendRestriction::check_spend`] for the consensus rules.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    any(test, feature = "proptest-impl"),
+    derive(proptest_derive::Arbitrary)
+)]
+pub enum CoinbaseSpendRestriction {
+    /// The UTXO is spent in a transaction with one or more transparent outputs
+    SomeTransparentOutputs,
+
+    /// The UTXO is spent in a transaction which only has shielded outputs
+    OnlyShieldedOutputs {
+        /// The height at which the UTXO is spent
+        spend_height: block::Height,
+    },
+}
+
 /// Compute an index of [`Utxo`]s, given an index of [`OrderedUtxo`]s.
 pub fn utxos_from_ordered_utxos(
     ordered_utxos: HashMap<transparent::OutPoint, OrderedUtxo>,

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -31,28 +31,9 @@ use std::convert::TryFrom;
 ///
 /// https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
 pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> {
-    let tx_in_count = tx.inputs().len();
-    let tx_out_count = tx.outputs().len();
-    let n_joinsplit = tx.joinsplit_count();
-    let n_spends_sapling = tx.sapling_spends_per_anchor().count();
-    let n_outputs_sapling = tx.sapling_outputs().count();
-    let n_actions_orchard = tx.orchard_actions().count();
-    let flags_orchard = tx.orchard_flags().unwrap_or_else(Flags::empty);
-
-    // TODO: Improve the code to express the spec rules better #2410.
-    if tx_in_count
-        + n_spends_sapling
-        + n_joinsplit
-        + (n_actions_orchard > 0 && flags_orchard.contains(Flags::ENABLE_SPENDS)) as usize
-        == 0
-    {
+    if !tx.has_transparent_or_shielded_inputs() {
         Err(TransactionError::NoInputs)
-    } else if tx_out_count
-        + n_outputs_sapling
-        + n_joinsplit
-        + (n_actions_orchard > 0 && flags_orchard.contains(Flags::ENABLE_OUTPUTS)) as usize
-        == 0
-    {
+    } else if !tx.has_transparent_or_shielded_outputs() {
         Err(TransactionError::NoOutputs)
     } else {
         Ok(())

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -2,15 +2,6 @@
 
 /// The maturity threshold for transparent coinbase outputs.
 ///
-/// This threshold uses the relevant chain for the block being verified by the
-/// non-finalized state.
-///
-/// For the best chain, coinbase spends are only allowed from blocks at or below
-/// the finalized tip. For other chains, coinbase spends can use outputs from
-/// early non-finalized blocks, or finalized blocks. But if that chain becomes
-/// the best chain, all non-finalized blocks past the [`MAX_BLOCK_REORG_HEIGHT`]
-/// will be finalized. This includes all mature coinbase outputs.
-///
 /// "A transaction MUST NOT spend a transparent output of a coinbase transaction
 /// from a block less than 100 blocks prior to the spend. Note that transparent
 /// outputs of coinbase transactions include Founders' Reward outputs and
@@ -21,8 +12,16 @@ pub const MIN_TRANSPARENT_COINBASE_MATURITY: u32 = 100;
 /// The maximum chain reorganisation height.
 ///
 /// This threshold determines the maximum length of the best non-finalized chain.
-///
 /// Larger reorganisations would allow double-spends of coinbase transactions.
+///
+/// This threshold uses the relevant chain for the block being verified by the
+/// non-finalized state.
+///
+/// For the best chain, coinbase spends are only allowed from blocks at or below
+/// the finalized tip. For other chains, coinbase spends can use outputs from
+/// early non-finalized blocks, or finalized blocks. But if that chain becomes
+/// the best chain, all non-finalized blocks past the [`MAX_BLOCK_REORG_HEIGHT`]
+/// will be finalized. This includes all mature coinbase outputs.
 pub const MAX_BLOCK_REORG_HEIGHT: u32 = MIN_TRANSPARENT_COINBASE_MATURITY - 1;
 
 /// The database format version, incremented each time the database format changes.

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -27,7 +27,6 @@ mod response;
 mod service;
 mod util;
 
-// TODO: move these to integration tests.
 #[cfg(test)]
 mod tests;
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -26,12 +26,14 @@ use crate::{
     PreparedBlock, Request, Response, ValidateContextError,
 };
 
-#[cfg(any(test, feature = "proptest-impl"))]
-pub mod arbitrary;
-mod check;
+pub(crate) mod check;
 mod finalized_state;
 mod non_finalized_state;
 mod pending_utxos;
+
+#[cfg(any(test, feature = "proptest-impl"))]
+pub mod arbitrary;
+
 #[cfg(test)]
 mod tests;
 

--- a/zebra-state/src/service/arbitrary.rs
+++ b/zebra-state/src/service/arbitrary.rs
@@ -7,13 +7,22 @@ use proptest::{
     test_runner::TestRunner,
 };
 
-use zebra_chain::{block::Block, fmt::SummaryDebug, parameters::NetworkUpgrade, LedgerState};
+use zebra_chain::{
+    block::{self, Block},
+    fmt::SummaryDebug,
+    parameters::NetworkUpgrade,
+    LedgerState,
+};
 
-use crate::arbitrary::Prepare;
+use crate::{arbitrary::Prepare, constants};
 
 use super::*;
 
-const MAX_PARTIAL_CHAIN_BLOCKS: usize = 102;
+/// The minimum height required for reliable non-finalized state property tests.
+///
+/// See [`block::arbitrary::PREVOUTS_CHAIN_HEIGHT`] for details.
+pub const MAX_PARTIAL_CHAIN_BLOCKS: usize =
+    constants::MIN_TRANSPARENT_COINBASE_MATURITY as usize + block::arbitrary::PREVOUTS_CHAIN_HEIGHT;
 
 #[derive(Debug)]
 pub struct PreparedChainTree {

--- a/zebra-state/src/service/arbitrary.rs
+++ b/zebra-state/src/service/arbitrary.rs
@@ -62,7 +62,11 @@ impl Strategy for PreparedChain {
                 .prop_flat_map(|ledger| {
                     (
                         Just(ledger.network),
-                        Block::partial_chain_strategy(ledger, MAX_PARTIAL_CHAIN_BLOCKS),
+                        Block::partial_chain_strategy(
+                            ledger,
+                            MAX_PARTIAL_CHAIN_BLOCKS,
+                            check::utxo::transparent_coinbase_spend,
+                        ),
                     )
                 })
                 .prop_map(|(network, vec)| {

--- a/zebra-state/src/service/arbitrary.rs
+++ b/zebra-state/src/service/arbitrary.rs
@@ -18,7 +18,9 @@ use crate::{arbitrary::Prepare, constants};
 
 use super::*;
 
-/// The minimum height required for reliable non-finalized state property tests.
+/// The chain length for state proptests.
+///
+/// Shorter lengths increase the probability of proptest failures.
 ///
 /// See [`block::arbitrary::PREVOUTS_CHAIN_HEIGHT`] for details.
 pub const MAX_PARTIAL_CHAIN_BLOCKS: usize =

--- a/zebra-state/src/service/check/utxo.rs
+++ b/zebra-state/src/service/check/utxo.rs
@@ -2,40 +2,36 @@
 
 use std::collections::{HashMap, HashSet};
 
-use zebra_chain::transparent;
+use zebra_chain::{
+    block,
+    transparent::{self, CoinbaseSpendRestriction::*},
+};
 
 use crate::{
+    constants::MIN_TRANSPARENT_COINBASE_MATURITY,
     service::finalized_state::FinalizedState,
     PreparedBlock,
     ValidateContextError::{
-        self, DuplicateTransparentSpend, EarlyTransparentSpend, MissingTransparentOutput,
+        self, DuplicateTransparentSpend, EarlyTransparentSpend, ImmatureTransparentCoinbaseSpend,
+        MissingTransparentOutput, UnshieldedTransparentCoinbaseSpend,
     },
 };
 
-/// Reject double-spends of transparent outputs:
+/// Reject invalid spends of transparent outputs.
+///
+/// Double-spends:
 /// - duplicate spends that are both in this block,
+/// - spends of an output that was spent by a previous block,
+///
+/// Missing spends:
 /// - spends of an output that hasn't been created yet,
-///   (in linear chain and transaction order), and
-/// - spends of an output that was spent by a previous block.
+///   (in linear chain and transaction order),
+/// - spends of UTXOs that were never created in this chain,
 ///
-/// Also rejects attempts to spend UTXOs that were never created (in this chain).
-///
-/// "each output of a particular transaction
-/// can only be used as an input once in the block chain.
-/// Any subsequent reference is a forbidden double spend-
-/// an attempt to spend the same satoshis twice."
-///
-/// https://developer.bitcoin.org/devguide/block_chain.html#introduction
-///
-/// "Any input within this block can spend an output which also appears in this block
-/// (assuming the spend is otherwise valid).
-/// However, the TXID corresponding to the output must be placed at some point
-/// before the TXID corresponding to the input.
-/// This ensures that any program parsing block chain transactions linearly
-/// will encounter each output before it is used as an input."
-///
-/// https://developer.bitcoin.org/reference/block_chain.html#merkle-trees
-pub fn transparent_double_spends(
+/// Invalid spends:
+/// - spends of an immature transparent coinbase output,
+/// - unshielded spends of a transparent coinbase output.
+pub fn transparent_spend(
     prepared: &PreparedBlock,
     non_finalized_chain_unspent_utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
     non_finalized_chain_spent_utxos: &HashSet<transparent::OutPoint>,
@@ -52,6 +48,7 @@ pub fn transparent_double_spends(
         });
 
         for spend in spends {
+            // see `transparent_spend_chain_order` for the consensus rule
             if !block_spends.insert(*spend) {
                 // reject in-block duplicate spends
                 return Err(DuplicateTransparentSpend {
@@ -60,52 +57,150 @@ pub fn transparent_double_spends(
                 });
             }
 
-            // check spends occur in chain order
+            let utxo = transparent_spend_chain_order(
+                *spend,
+                spend_tx_index_in_block,
+                &prepared.new_outputs,
+                non_finalized_chain_unspent_utxos,
+                non_finalized_chain_spent_utxos,
+                finalized_state,
+            )?;
+
+            // The state service returns UTXOs from pending blocks,
+            // which can be rejected by later contextual checks.
+            // This is a particular issue for v5 transactions,
+            // because their authorizing data is only bound to the block data
+            // during contextual validation (#2336).
             //
-            // because we are in the non-finalized state, we need to check spends within the same block,
-            // spent non-finalized UTXOs, and unspent non-finalized and finalized UTXOs.
+            // We don't want to use UTXOs from invalid pending blocks,
+            // so we check transparent coinbase maturity and shielding
+            // using known valid UTXOs during non-finalized chain validation.
 
-            if let Some(output) = prepared.new_outputs.get(spend) {
-                // reject the spend if it uses an output from this block,
-                // but the output was not created by an earlier transaction
-                //
-                // we know the spend is invalid, because transaction IDs are unique
-                //
-                // (transaction IDs also commit to transaction inputs,
-                // so it should be cryptographically impossible for a transaction
-                // to spend its own outputs)
-                if output.tx_index_in_block >= spend_tx_index_in_block {
-                    return Err(EarlyTransparentSpend { outpoint: *spend });
-                } else {
-                    // a unique spend of a previous transaction's output is ok
-                    continue;
-                }
-            }
-
-            if non_finalized_chain_spent_utxos.contains(spend) {
-                // reject the spend if its UTXO is already spent in the
-                // non-finalized parent chain
-                return Err(DuplicateTransparentSpend {
-                    outpoint: *spend,
-                    location: "the non-finalized chain",
-                });
-            }
-
-            if !non_finalized_chain_unspent_utxos.contains_key(spend)
-                && finalized_state.utxo(spend).is_none()
-            {
-                // we don't keep spent UTXOs in the finalized state,
-                // so all we can say is that it's missing from both
-                // the finalized and non-finalized chains
-                // (it might have been spent in the finalized state,
-                // or it might never have existed in this chain)
-                return Err(MissingTransparentOutput {
-                    outpoint: *spend,
-                    location: "the non-finalized and finalized chain",
-                });
+            let spend_restriction = transaction.coinbase_spend_restriction(prepared.height);
+            if cfg!(not(test)) {
+                // TODO: fix proptests to produce valid UTXO spends (#ticket TODO)
+                //       and unconditionally enable this check
+                transparent_coinbase_spend(*spend, spend_restriction, utxo)?;
             }
         }
     }
 
     Ok(())
+}
+
+/// Check that transparent spends occur in chain order.
+///
+/// Because we are in the non-finalized state, we need to check spends within the same block,
+/// spent non-finalized UTXOs, and unspent non-finalized and finalized UTXOs.
+///
+/// "Any input within this block can spend an output which also appears in this block
+/// (assuming the spend is otherwise valid).
+/// However, the TXID corresponding to the output must be placed at some point
+/// before the TXID corresponding to the input.
+/// This ensures that any program parsing block chain transactions linearly
+/// will encounter each output before it is used as an input."
+///
+/// https://developer.bitcoin.org/reference/block_chain.html#merkle-trees
+///
+/// "each output of a particular transaction
+/// can only be used as an input once in the block chain.
+/// Any subsequent reference is a forbidden double spend-
+/// an attempt to spend the same satoshis twice."
+///
+/// https://developer.bitcoin.org/devguide/block_chain.html#introduction
+fn transparent_spend_chain_order(
+    spend: transparent::OutPoint,
+    spend_tx_index_in_block: usize,
+    block_new_outputs: &HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
+    non_finalized_chain_unspent_utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
+    non_finalized_chain_spent_utxos: &HashSet<transparent::OutPoint>,
+    finalized_state: &FinalizedState,
+) -> Result<transparent::Utxo, ValidateContextError> {
+    if let Some(output) = block_new_outputs.get(&spend) {
+        // reject the spend if it uses an output from this block,
+        // but the output was not created by an earlier transaction
+        //
+        // we know the spend is invalid, because transaction IDs are unique
+        //
+        // (transaction IDs also commit to transaction inputs,
+        // so it should be cryptographically impossible for a transaction
+        // to spend its own outputs)
+        if output.tx_index_in_block >= spend_tx_index_in_block {
+            return Err(EarlyTransparentSpend { outpoint: spend });
+        } else {
+            // a unique spend of a previous transaction's output is ok
+            return Ok(output.utxo.clone());
+        }
+    }
+
+    if non_finalized_chain_spent_utxos.contains(&spend) {
+        // reject the spend if its UTXO is already spent in the
+        // non-finalized parent chain
+        return Err(DuplicateTransparentSpend {
+            outpoint: spend,
+            location: "the non-finalized chain",
+        });
+    }
+
+    match (
+        non_finalized_chain_unspent_utxos.get(&spend),
+        finalized_state.utxo(&spend),
+    ) {
+        (None, None) => {
+            // we don't keep spent UTXOs in the finalized state,
+            // so all we can say is that it's missing from both
+            // the finalized and non-finalized chains
+            // (it might have been spent in the finalized state,
+            // or it might never have existed in this chain)
+            Err(MissingTransparentOutput {
+                outpoint: spend,
+                location: "the non-finalized and finalized chain",
+            })
+        }
+
+        (Some(utxo), _) => Ok(utxo.clone()),
+        (_, Some(utxo)) => Ok(utxo),
+    }
+}
+
+/// Check that `utxo` is spendable, based on the coinbase `spend_restriction`.
+///
+/// "A transaction with one or more transparent inputs from coinbase transactions
+/// MUST have no transparent outputs (i.e.tx_out_count MUST be 0)."
+///
+/// "A transaction MUST NOT spend a transparent output of a coinbase transaction
+/// from a block less than 100 blocks prior to the spend.
+///
+/// Note that transparent outputs of coinbase transactions include Founders’
+/// Reward outputs and transparent funding stream outputs."
+///
+/// https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
+pub fn transparent_coinbase_spend(
+    outpoint: transparent::OutPoint,
+    spend_restriction: transparent::CoinbaseSpendRestriction,
+    utxo: transparent::Utxo,
+) -> Result<transparent::Utxo, ValidateContextError> {
+    if !utxo.from_coinbase {
+        return Ok(utxo);
+    }
+
+    match spend_restriction {
+        OnlyShieldedOutputs { spend_height } => {
+            let min_spend_height = utxo.height + block::Height(MIN_TRANSPARENT_COINBASE_MATURITY);
+            // TODO: allow full u32 range of block heights (#1113)
+            let min_spend_height =
+                min_spend_height.expect("valid UTXOs have coinbase heights far below Height::MAX");
+            if spend_height >= min_spend_height {
+                Ok(utxo)
+            } else {
+                Err(ImmatureTransparentCoinbaseSpend {
+                    outpoint,
+                    spend_height,
+                    min_spend_height,
+                    created_height: utxo.height,
+                })
+            }
+        }
+        SomeTransparentOutputs => Err(UnshieldedTransparentCoinbaseSpend { outpoint }),
+    }
 }

--- a/zebra-state/src/service/check/utxo.rs
+++ b/zebra-state/src/service/check/utxo.rs
@@ -77,11 +77,7 @@ pub fn transparent_spend(
             // using known valid UTXOs during non-finalized chain validation.
 
             let spend_restriction = transaction.coinbase_spend_restriction(prepared.height);
-            if cfg!(not(test)) {
-                // TODO: fix proptests to produce valid UTXO spends (#ticket TODO)
-                //       and unconditionally enable this check
-                transparent_coinbase_spend(*spend, spend_restriction, utxo)?;
-            }
+            transparent_coinbase_spend(*spend, spend_restriction, utxo)?;
         }
     }
 

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -172,7 +172,7 @@ impl NonFinalizedState {
         prepared: PreparedBlock,
         finalized_state: &FinalizedState,
     ) -> Result<Chain, ValidateContextError> {
-        check::utxo::transparent_double_spends(
+        check::utxo::transparent_spend(
             &prepared,
             &parent_chain.unspent_utxos(),
             &parent_chain.spent_utxos,

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -2,7 +2,12 @@ use std::{env, sync::Arc};
 
 use zebra_test::prelude::*;
 
-use zebra_chain::{block::Block, fmt::DisplayToDebug, parameters::NetworkUpgrade::*, LedgerState};
+use zebra_chain::{
+    block::{self, Block},
+    fmt::DisplayToDebug,
+    parameters::NetworkUpgrade::*,
+    LedgerState,
+};
 
 use crate::{
     arbitrary::Prepare,
@@ -17,6 +22,10 @@ use crate::{
 const DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES: u32 = 16;
 
 /// Check that a forked chain is the same as a chain that had the same blocks appended.
+///
+/// Also check for:
+/// - no transparent spends in the genesis block, because genesis transparent outputs are ignored
+/// - at least one transparent PrevOut input in the entire chain
 #[test]
 fn forked_equals_pushed() -> Result<()> {
     zebra_test::init();
@@ -30,12 +39,37 @@ fn forked_equals_pushed() -> Result<()> {
             let fork_tip_hash = chain[fork_at_count - 1].hash;
             let mut full_chain = Chain::default();
             let mut partial_chain = Chain::default();
+            let mut has_prevouts = false;
 
             for block in chain.iter().take(fork_at_count) {
                 partial_chain = partial_chain.push(block.clone())?;
             }
             for block in chain.iter() {
                 full_chain = full_chain.push(block.clone())?;
+
+                // check some other properties of generated chains
+                if block.height == block::Height(0) {
+                    prop_assert_eq!(
+                        block
+                            .block
+                            .transactions
+                            .iter()
+                            .flat_map(|t| t.inputs())
+                            .filter_map(|i| i.outpoint())
+                            .count(),
+                        0,
+                        "unexpected transparent prevout inputs at height {:?}: genesis transparent outputs are ignored",
+                        block.height,
+                    );
+                }
+
+                has_prevouts |= block
+                    .block
+                    .transactions
+                    .iter()
+                    .flat_map(|t| t.inputs())
+                    .find_map(|i| i.outpoint())
+                    .is_some();
             }
 
             let forked = full_chain.fork(fork_tip_hash).expect("fork works").expect("hash is present");
@@ -43,6 +77,10 @@ fn forked_equals_pushed() -> Result<()> {
             // the first check is redundant, but it's useful for debugging
             prop_assert_eq!(forked.blocks.len(), partial_chain.blocks.len());
             prop_assert!(forked.eq_internal_state(&partial_chain));
+
+            // this assertion checks that we're still generating some transparent spends,
+            // after proptests remove unshielded and immature transparent coinbase spends
+            prop_assert!(has_prevouts, "no blocks in chain had prevouts");
         });
 
     Ok(())

--- a/zebra-state/src/tests/setup.rs
+++ b/zebra-state/src/tests/setup.rs
@@ -12,7 +12,10 @@ use zebra_chain::{
     transaction::Transaction,
 };
 
-use crate::{service::StateService, Config, FinalizedBlock};
+use crate::{
+    service::{check, StateService},
+    Config, FinalizedBlock,
+};
 
 /// Generate a chain that allows us to make tests for the legacy chain rules.
 ///
@@ -63,7 +66,11 @@ pub(crate) fn partial_nu5_chain_strategy(
                 transaction_has_valid_network_upgrade,
             )
             .prop_flat_map(move |init| {
-                Block::partial_chain_strategy(init, blocks_after_nu_activation as usize)
+                Block::partial_chain_strategy(
+                    init,
+                    blocks_after_nu_activation as usize,
+                    check::utxo::transparent_coinbase_spend,
+                )
             })
             .prop_map(move |partial_chain| (network, nu_activation, partial_chain))
         })


### PR DESCRIPTION
## Motivation

Zebra needs to check the consensus rules that restrict how transparent outputs of coinbase transactions can be spent.

### Specifications

See #2329 and #2330.

### Designs

These designs are more complex than we actually need:

https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0004-asynchronous-script-verification.md , particularly the changes in PR #1970 

https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0005-state-updates.md#requestawaitspendableutxo--outpoint-outpoint-spend_height-height-spend_restriction-spendrestriction-

## Solution

Implementation:
- Add a `CoinbaseSpendRestriction` enum and `Transaction` method
- Check UTXO spendability during contextual validation, using known valid UTXOs

Test fixes:
- Skip created UTXOs in the genesis block in arbitrary block chains
- Refactor out a new_transaction_ordered_outputs function
- Add Transaction::outputs_mut for tests
- Only spend valid UTXOs in arbitrary block chains

Closes #2329
Closes #2330
Closes #2410

### WIP Tests

Skip
  - [x] non-coinbase UTXOs
    - existing unit tests, acceptance tests, and cached state tests

Success
  - [x] coinbase UTXO spent to shielded outputs after 100 or more blocks 
    - existing unit tests, acceptance tests, and cached state tests
  - [x] coinbase UTXO spent to shielded outputs after exactly 100 blocks
    - modified existing state request test

Failure
  - [ ] coinbase UTXO spent to non-shielded outputs after 100 or more blocks
  - [x] coinbase UTXO spent to shielded outputs after less than 100 blocks

Test coverage
  - [x] make the proptest chain lengths slightly longer (ideally using a single constant)
  - [x] make sure that restriction-checked and unchecked proptest chains contain UTXO prevout spends

We could also do tests for finalized/non-finalized state, and both non-shielded and immature. But these tests are the essential ones.

I'm also running a full sync test locally on mainnet and testnet.

## Review

I'd like an initial review from @jvff while I'm working on the rest of the tests.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Move the design changes in PR #1970 to an "alternatives" section, and explain how the simpler design works.
(Or just revert most of PR #1970.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2525)
<!-- Reviewable:end -->
