### PR TITLE
Update to google-github-actions/setup-gcloud in workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
 
     # Setup gcloud CLI
     - name: Set up gcloud SDK environment
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@master
       with:
         version: '295.0.0'
         project_id: ${{ env.PROJECT_ID }}
@@ -69,7 +69,7 @@ jobs:
 
       # Setup gcloud CLI
       - name: Set up gcloud SDK environment
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           version: '295.0.0'
           project_id: ${{ env.PROJECT_ID }}

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -31,7 +31,7 @@ jobs:
         echo "REPOSITORY=$REPOSITORY" >> $GITHUB_ENV
 
     - name: Set up gcloud
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@master
       with:
         version: '295.0.0'
         project_id: ${{ env.PROJECT_ID }}

--- a/.github/workflows/regenerate-stateful-test-disks.yml
+++ b/.github/workflows/regenerate-stateful-test-disks.yml
@@ -26,7 +26,7 @@ jobs:
           echo "SHORT_SHA=$(git rev-parse --short=7 $GITHUB_SHA)" >> $GITHUB_ENV && \
           echo "REPOSITORY=$REPOSITORY" >> $GITHUB_ENV
       - name: Set up gcloud
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           version: '295.0.0'
           project_id: ${{ env.PROJECT_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           echo "REPOSITORY=$REPOSITORY" >> $GITHUB_ENV
 
       - name: Set up gcloud
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           version: '295.0.0'
           project_id: ${{ env.PROJECT_ID }}

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Setup gcloud CLI
       - name: Set up gcloud SDK environment
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           version: '295.0.0'
           project_id: ${{ env.PROJECT_ID }}


### PR DESCRIPTION
## Motivation

Google Cloud just got rid of some deprecated GitHub action names.

> Warning: Thank you for using setup-gcloud Action. GoogleCloudPlatform/github-actions/setup-gcloud has been deprecated, please switch to google-github-actions/setup-gcloud.

https://github.com/ZcashFoundation/zebra/runs/3145563888#step:4:14

### API Reference

See https://github.com/google-github-actions/setup-gcloud#use-google-github-actionssetup-gcloud

## Solution

- Use the new action names

## Review

Anyone can review this PR.

This change is urgent because every `main` merge will fail until it is fixed.

I manually launched the Google Cloud workflows:
* CD: https://github.com/ZcashFoundation/zebra/actions/runs/1069389490
* Test: https://github.com/ZcashFoundation/zebra/actions/runs/1069392928

The first CD run tests creating the instance group & deploying. We can test deploying CD updates by merging to the `main` branch.

### Reviewer Checklist

  - [ ] CI works before merge
  - [ ] CI works after merge on `main`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2533)
<!-- Reviewable:end -->
