### PR TITLE
Add `zebra_state::init_test` helper function for tests

### DIFF
--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -42,4 +42,5 @@ tracing-error = "0.1.2"
 tracing-subscriber = "0.2.19"
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/" }

--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -117,10 +117,7 @@ async fn check_transcripts() -> Result<(), Report> {
     zebra_test::init();
 
     let network = Network::Mainnet;
-    let state_service = Buffer::new(
-        zebra_state::init(zebra_state::Config::ephemeral(), network),
-        1,
-    );
+    let state_service = zebra_state::init_test(network);
 
     let block_verifier = Buffer::new(BlockVerifier::new(network, state_service.clone()), 1);
 

--- a/zebra-consensus/src/chain/tests.rs
+++ b/zebra-consensus/src/chain/tests.rs
@@ -4,7 +4,7 @@ use std::{sync::Arc, time::Duration};
 
 use color_eyre::eyre::Report;
 use once_cell::sync::Lazy;
-use tower::{layer::Layer, timeout::TimeoutLayer, Service, ServiceBuilder};
+use tower::{layer::Layer, timeout::TimeoutLayer, Service};
 
 use zebra_chain::{
     block::{self, Block},
@@ -63,9 +63,7 @@ async fn verifiers_from_network(
         + Clone
         + 'static,
 ) {
-    let state_service = ServiceBuilder::new()
-        .buffer(1)
-        .service(zs::init(zs::Config::ephemeral(), network));
+    let state_service = zs::init_test(network);
     let chain_verifier =
         crate::chain::init(Config::default(), network, state_service.clone()).await;
 
@@ -155,14 +153,7 @@ async fn verify_checkpoint(config: Config) -> Result<(), Report> {
 
     // Test that the chain::init function works. Most of the other tests use
     // init_from_verifiers.
-    let chain_verifier = super::init(
-        config.clone(),
-        network,
-        ServiceBuilder::new()
-            .buffer(1)
-            .service(zs::init(zs::Config::ephemeral(), network)),
-    )
-    .await;
+    let chain_verifier = super::init(config.clone(), network, zs::init_test(network)).await;
 
     // Add a timeout layer
     let chain_verifier =

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -9,7 +9,7 @@ use color_eyre::eyre::{eyre, Report};
 use futures::{future::TryFutureExt, stream::FuturesUnordered};
 use std::{cmp::min, convert::TryInto, mem::drop, time::Duration};
 use tokio::{stream::StreamExt, time::timeout};
-use tower::{Service, ServiceBuilder, ServiceExt};
+use tower::{Service, ServiceExt};
 use tracing_futures::Instrument;
 
 use zebra_chain::parameters::Network::*;
@@ -45,9 +45,7 @@ async fn single_item_checkpoint_list() -> Result<(), Report> {
             .cloned()
             .collect();
 
-    let state_service = ServiceBuilder::new()
-        .buffer(1)
-        .service(zebra_state::init(zebra_state::Config::ephemeral(), Mainnet));
+    let state_service = zebra_state::init_test(Mainnet);
     let mut checkpoint_verifier =
         CheckpointVerifier::from_list(genesis_checkpoint_list, Mainnet, None, state_service)
             .map_err(|e| eyre!(e))?;
@@ -129,9 +127,7 @@ async fn multi_item_checkpoint_list() -> Result<(), Report> {
         .map(|(_block, height, hash)| (*height, *hash))
         .collect();
 
-    let state_service = ServiceBuilder::new()
-        .buffer(1)
-        .service(zebra_state::init(zebra_state::Config::ephemeral(), Mainnet));
+    let state_service = zebra_state::init_test(Mainnet);
     let mut checkpoint_verifier =
         CheckpointVerifier::from_list(checkpoint_list, Mainnet, None, state_service)
             .map_err(|e| eyre!(e))?;
@@ -277,9 +273,7 @@ async fn continuous_blockchain(
         let initial_tip = restart_height.map(|block::Height(height)| {
             (blockchain[height as usize].1, blockchain[height as usize].2)
         });
-        let state_service = ServiceBuilder::new()
-            .buffer(1)
-            .service(zebra_state::init(zebra_state::Config::ephemeral(), Mainnet));
+        let state_service = zebra_state::init_test(Mainnet);
         let mut checkpoint_verifier = CheckpointVerifier::from_list(
             checkpoint_list,
             network,
@@ -457,9 +451,7 @@ async fn block_higher_than_max_checkpoint_fail() -> Result<(), Report> {
             .cloned()
             .collect();
 
-    let state_service = ServiceBuilder::new()
-        .buffer(1)
-        .service(zebra_state::init(zebra_state::Config::ephemeral(), Mainnet));
+    let state_service = zebra_state::init_test(Mainnet);
     let mut checkpoint_verifier =
         CheckpointVerifier::from_list(genesis_checkpoint_list, Mainnet, None, state_service)
             .map_err(|e| eyre!(e))?;
@@ -536,9 +528,7 @@ async fn wrong_checkpoint_hash_fail() -> Result<(), Report> {
             .cloned()
             .collect();
 
-    let state_service = ServiceBuilder::new()
-        .buffer(1)
-        .service(zebra_state::init(zebra_state::Config::ephemeral(), Mainnet));
+    let state_service = zebra_state::init_test(Mainnet);
     let mut checkpoint_verifier =
         CheckpointVerifier::from_list(genesis_checkpoint_list, Mainnet, None, state_service)
             .map_err(|e| eyre!(e))?;
@@ -720,9 +710,7 @@ async fn checkpoint_drop_cancel() -> Result<(), Report> {
         .map(|(_block, height, hash)| (*height, *hash))
         .collect();
 
-    let state_service = ServiceBuilder::new()
-        .buffer(1)
-        .service(zebra_state::init(zebra_state::Config::ephemeral(), Mainnet));
+    let state_service = zebra_state::init_test(Mainnet);
     let mut checkpoint_verifier =
         CheckpointVerifier::from_list(checkpoint_list, Mainnet, None, state_service)
             .map_err(|e| eyre!(e))?;
@@ -808,9 +796,7 @@ async fn hard_coded_mainnet() -> Result<(), Report> {
         Arc::<Block>::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..])?;
     let hash0 = block0.hash();
 
-    let state_service = ServiceBuilder::new()
-        .buffer(1)
-        .service(zebra_state::init(zebra_state::Config::ephemeral(), Mainnet));
+    let state_service = zebra_state::init_test(Mainnet);
     // Use the hard-coded checkpoint list
     let mut checkpoint_verifier = CheckpointVerifier::new(Network::Mainnet, None, state_service);
 

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -37,5 +37,7 @@ pub use error::{BoxError, CloneError, CommitBlockError, ValidateContextError};
 pub use request::{FinalizedBlock, HashOrHeight, PreparedBlock, Request};
 pub use response::Response;
 pub use service::init;
+#[cfg(any(test, feature = "proptest-impl"))]
+pub use service::init_test;
 
 pub(crate) use request::ContextuallyValidBlock;

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -10,6 +10,8 @@ use check::difficulty::POW_MEDIAN_BLOCK_SPAN;
 use futures::future::FutureExt;
 use non_finalized_state::{NonFinalizedState, QueuedBlocks};
 use tokio::sync::oneshot;
+#[cfg(any(test, feature = "proptest-impl"))]
+use tower::buffer::Buffer;
 use tower::{util::BoxService, Service};
 use tracing::instrument;
 use zebra_chain::{
@@ -744,6 +746,16 @@ impl Service<Request> for StateService {
 /// probably not what you want.
 pub fn init(config: Config, network: Network) -> BoxService<Request, Response, BoxError> {
     BoxService::new(StateService::new(config, network))
+}
+
+/// Initialize a state service with an ephemeral [`Config`] and a buffer with a single slot.
+///
+/// This can be used to create a state service for testing. See also [`init`].
+#[cfg(any(test, feature = "proptest-impl"))]
+pub fn init_test(network: Network) -> Buffer<BoxService<Request, Response, BoxError>, Request> {
+    let state_service = StateService::new(Config::ephemeral(), network);
+
+    Buffer::new(BoxService::new(state_service), 1)
 }
 
 /// Check if zebra is following a legacy chain and return an error if so.


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
As part of the work for #1334, the construction of a state service instance will change a bit, because it will return a view to the current best chain tip block height. This will require changes to all tests that create a state service. To streamline these changes and to simplify the test code, this PR introduces an alternative constructor for tests to use.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
The `zebra_state::init_test` function is available to other crates when the `proptest-impl` feature is enabled. The function creates a state service with an ephemeral `Config` and automatically wraps the service in a `Buffer` with one slot. These are the most common defaults for the tests, so it reduces a little the amount of repeated code.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 is reviewing the set of changes that are part of #1334.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
A follow-up PR will actually change the `zebra_state::init` method, but after this PR most tests will not need any extra changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2539)
<!-- Reviewable:end -->
