### PR TITLE
Disable Rust beta tests in CI, due to a Rust bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [stable, beta]
+        rust: [stable]
     env:
       CARGO_INCREMENTAL: 0
       RUST_BACKTRACE: full


### PR DESCRIPTION
## Motivation

On 29 July, Zebra's tests started failing on beta Rust (https://github.com/rust-lang/rust/pull/87483).

But the stable CI tests and beta zebra-chain build were fine.

## Solution

Disable the Rust beta tests in the CI matrix, but keep stable tests, and stable and beta zebra-chain builds.

## Follow Up

We should try re-enabling beta tests at some point (#2541).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2542)
<!-- Reviewable:end -->
