### PR TITLE
Add value_balance() method to Block

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -149,7 +149,7 @@ impl Block {
     /// Get all the value balances from this block by summing all the value balances
     /// in each transaction the block has.
     ///
-    /// `utxos` must contain the utxos of every input in the transaction,
+    /// `utxos` must contain the utxos of every input in the block,
     /// including UTXOs created by a transaction in this block,
     /// then spent by a later transaction that's also in this block.
     pub fn value_balance(

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -14,7 +14,7 @@ pub mod arbitrary;
 #[cfg(any(test, feature = "bench"))]
 pub mod tests;
 
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 pub use commitment::{ChainHistoryMmrRootHash, Commitment, CommitmentError};
 pub use hash::Hash;
@@ -28,6 +28,7 @@ pub use arbitrary::LedgerState;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    amount::NegativeAllowed,
     fmt::DisplayToDebug,
     orchard,
     parameters::{Network, NetworkUpgrade},
@@ -36,6 +37,7 @@ use crate::{
     sprout,
     transaction::Transaction,
     transparent,
+    value_balance::{ValueBalance, ValueBalanceError},
 };
 
 /// A Zcash block, containing a header and a list of transactions.
@@ -142,6 +144,22 @@ impl Block {
             .iter()
             .map(|transaction| transaction.orchard_nullifiers())
             .flatten()
+    }
+
+    /// Get all the value balances from this block by summing all the value balances
+    /// in each transaction the block has.
+    ///
+    /// `utxos` must contain the utxos of every input in the transaction,
+    /// including UTXOs created by a transaction in this block,
+    /// then spent by a later transaction that's also in this block.
+    pub fn value_balance(
+        &self,
+        utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
+    ) -> Result<ValueBalance<NegativeAllowed>, ValueBalanceError> {
+        self.transactions
+            .iter()
+            .flat_map(|t| t.value_balance(utxos))
+            .sum()
     }
 }
 

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -184,3 +184,28 @@ where
         self? - rhs
     }
 }
+
+impl<C> std::iter::Sum<ValueBalance<C>> for Result<ValueBalance<C>, ValueBalanceError>
+where
+    C: Constraint + Copy,
+{
+    fn sum<I: Iterator<Item = ValueBalance<C>>>(mut iter: I) -> Self {
+        iter.try_fold(ValueBalance::zero(), |acc, value_balance| {
+            Ok(ValueBalance {
+                transparent: (acc.transparent + value_balance.transparent)?,
+                sprout: (acc.sprout + value_balance.sprout)?,
+                sapling: (acc.sapling + value_balance.sapling)?,
+                orchard: (acc.orchard + value_balance.orchard)?,
+            })
+        })
+    }
+}
+
+impl<'amt, C> std::iter::Sum<&'amt ValueBalance<C>> for Result<ValueBalance<C>, ValueBalanceError>
+where
+    C: Constraint + std::marker::Copy + 'amt,
+{
+    fn sum<I: Iterator<Item = &'amt ValueBalance<C>>>(iter: I) -> Self {
+        iter.copied().sum()
+    }
+}

--- a/zebra-chain/src/value_balance/tests/prop.rs
+++ b/zebra-chain/src/value_balance/tests/prop.rs
@@ -60,4 +60,32 @@ proptest! {
             ),
         }
     }
+
+    #[test]
+    fn test_sum(
+        value_balance1 in any::<ValueBalance<NegativeAllowed>>(),
+        value_balance2 in any::<ValueBalance<NegativeAllowed>>(),
+    ) {
+        zebra_test::init();
+
+        let collection = vec![value_balance1, value_balance2];
+
+        let transparent = value_balance1.transparent + value_balance2.transparent;
+        let sprout = value_balance1.sprout + value_balance2.sprout;
+        let sapling = value_balance1.sapling + value_balance2.sapling;
+        let orchard = value_balance1.orchard + value_balance2.orchard;
+
+        match (transparent, sprout, sapling, orchard) {
+            (Ok(transparent), Ok(sprout), Ok(sapling), Ok(orchard)) => prop_assert_eq!(
+                collection.iter().sum::<Result<ValueBalance<NegativeAllowed>, ValueBalanceError>>(),
+                Ok(ValueBalance {
+                    transparent,
+                    sprout,
+                    sapling,
+                    orchard,
+                })
+            ),
+            _ => prop_assert!(matches!(collection.iter().sum(), Err(ValueBalanceError::AmountError(_))))
+        }
+    }
 }


### PR DESCRIPTION
## Motivation

Part of the value pools design.

### Designs

https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0012-value-pools.md#create-a-method-in-block-that-returns-valuebalancenegativeallowed-for-the-block

## Solution

Add `Sum` for `ValueBalance` and create the `value_balance()` method in `Block`.

## Review

This is the same code as https://github.com/oxarbitrage/zebra/pull/126 that already had an initial review from @teor2345 

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2546)
<!-- Reviewable:end -->
