### PR TITLE
Implement ZIP-244 authorizing data commitment (auth_digest)

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -29,6 +29,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     amount::NegativeAllowed,
+    block::merkle::AuthDataRoot,
     fmt::DisplayToDebug,
     orchard,
     parameters::{Network, NetworkUpgrade},
@@ -197,6 +198,14 @@ impl Block {
             .sum::<Result<ValueBalance<NegativeAllowed>, _>>()?;
 
         Ok(transaction_value_balance_total.neg())
+    }
+
+    /// Compute the root of the authorizing data Merkle tree,
+    /// as defined in [ZIP-244].
+    ///
+    /// [ZIP-244]: https://zips.z.cash/zip-0244
+    pub fn auth_data_root(&self) -> AuthDataRoot {
+        self.transactions.iter().collect::<AuthDataRoot>()
     }
 }
 

--- a/zebra-chain/src/block/merkle.rs
+++ b/zebra-chain/src/block/merkle.rs
@@ -83,7 +83,7 @@ fn hash(h1: &[u8; 32], h2: &[u8; 32]) -> [u8; 32] {
     w.finish()
 }
 
-/// Compute the root of a Merke tree as used in Bitcoin.
+/// Compute the root of a Merkle tree as used in Bitcoin.
 /// `hashes` must contain the hashes of the tree leaves.
 /// The root is written to the the first element of the input vector.
 /// See [`Root`] for an important disclaimer.

--- a/zebra-chain/src/block/merkle.rs
+++ b/zebra-chain/src/block/merkle.rs
@@ -83,8 +83,8 @@ fn hash(h1: &[u8; 32], h2: &[u8; 32]) -> [u8; 32] {
     w.finish()
 }
 
-/// Compute the root of a Merkle tree as used in Bitcoin.
-/// `hashes` must contain the hashes of the tree leaves.
+/// Compute the root of a Merkle tree of transactions as used in Bitcoin.
+/// `hashes` must contain the hashes of the tree leaves (transactions) in some form.
 /// The root is written to the the first element of the input vector.
 /// See [`Root`] for an important disclaimer.
 fn root(hashes: &mut Vec<[u8; 32]>) {
@@ -135,7 +135,7 @@ impl std::iter::FromIterator<transaction::Hash> for Root {
 /// [ZIP-244]: https://zips.z.cash/zip-0244
 #[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
-pub struct AuthDataRoot(pub [u8; 32]);
+pub struct AuthDataRoot(pub(crate) [u8; 32]);
 
 impl fmt::Debug for AuthDataRoot {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -208,8 +208,8 @@ mod tests {
     fn auth_digest() {
         for block_bytes in zebra_test::vectors::BLOCKS.iter() {
             let block = Block::zcash_deserialize(&**block_bytes).unwrap();
-            let _merkle_root = block.transactions.iter().collect::<AuthDataRoot>();
-            // No test vectors for now, so just check it works
+            let _auth_digest = block.transactions.iter().collect::<AuthDataRoot>();
+            // No test vectors for now, so just check it computes without panicking
         }
     }
 }

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -11,7 +11,7 @@ use crate::{
     amount::{Amount, NonNegative},
     parameters::NetworkUpgrade,
     serialization::ZcashSerialize,
-    transaction::{HashType, SigHash, Transaction},
+    transaction::{AuthDigest, HashType, SigHash, Transaction},
     transparent::{self, Script},
 };
 
@@ -123,4 +123,24 @@ pub(crate) fn sighash(
         )
         .as_ref(),
     )
+}
+
+/// Compute the authorizing data commitment of this transaction as specified
+/// in [ZIP-244].
+///
+/// # Panics
+///
+/// If passed a pre-v5 transaction.
+///
+/// [ZIP-244]: https://zips.z.cash/zip-0244.
+pub(crate) fn auth_digest(trans: &Transaction) -> AuthDigest {
+    let alt_tx: zcash_primitives::transaction::Transaction = trans
+        .try_into()
+        .expect("zcash_primitives and Zebra transaction formats must be compatible");
+    let digest_bytes: [u8; 32] = alt_tx
+        .auth_commitment()
+        .as_ref()
+        .try_into()
+        .expect("digest has the correct size");
+    AuthDigest(digest_bytes)
 }

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -137,10 +137,12 @@ pub(crate) fn auth_digest(trans: &Transaction) -> AuthDigest {
     let alt_tx: zcash_primitives::transaction::Transaction = trans
         .try_into()
         .expect("zcash_primitives and Zebra transaction formats must be compatible");
+
     let digest_bytes: [u8; 32] = alt_tx
         .auth_commitment()
         .as_ref()
         .try_into()
         .expect("digest has the correct size");
+
     AuthDigest(digest_bytes)
 }

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -3,6 +3,7 @@
 use halo2::pasta::pallas;
 use serde::{Deserialize, Serialize};
 
+mod auth_digest;
 mod hash;
 mod joinsplit;
 mod lock_time;
@@ -16,6 +17,7 @@ pub mod arbitrary;
 #[cfg(test)]
 mod tests;
 
+pub use auth_digest::AuthDigest;
 pub use hash::Hash;
 pub use joinsplit::JoinSplitData;
 pub use lock_time::LockTime;
@@ -158,6 +160,22 @@ impl Transaction {
         input: Option<(u32, transparent::Output)>,
     ) -> SigHash {
         sighash::SigHasher::new(self, hash_type, network_upgrade, input).sighash()
+    }
+
+    /// Compute the authorizing data commitment of this transaction as specified
+    /// in [ZIP-244].
+    ///
+    /// Returns None for pre-v5 transactions.
+    ///
+    /// [ZIP-244]: https://zips.z.cash/zip-0244.
+    pub fn auth_digest(&self) -> Option<AuthDigest> {
+        match self {
+            Transaction::V1 { .. }
+            | Transaction::V2 { .. }
+            | Transaction::V3 { .. }
+            | Transaction::V4 { .. } => None,
+            Transaction::V5 { .. } => Some(AuthDigest::from(self)),
+        }
     }
 
     // other properties

--- a/zebra-chain/src/transaction/auth_digest.rs
+++ b/zebra-chain/src/transaction/auth_digest.rs
@@ -1,0 +1,20 @@
+use crate::primitives::zcash_primitives::auth_digest;
+
+use super::Transaction;
+
+/// An authorizing data commitment hash as specified in [ZIP-244].
+///
+/// [ZIP-244]: https://zips.z.cash/zip-0244..
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct AuthDigest(pub [u8; 32]);
+
+impl<'a> From<&'a Transaction> for AuthDigest {
+    /// Computes the authorizing data commitment for a transaction.
+    ///
+    /// # Panics
+    ///
+    /// If passed a pre-v5 transaction.
+    fn from(transaction: &'a Transaction) -> Self {
+        auth_digest(transaction)
+    }
+}

--- a/zebra-chain/src/transaction/auth_digest.rs
+++ b/zebra-chain/src/transaction/auth_digest.rs
@@ -6,7 +6,7 @@ use super::Transaction;
 ///
 /// [ZIP-244]: https://zips.z.cash/zip-0244..
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct AuthDigest(pub [u8; 32]);
+pub struct AuthDigest(pub(crate) [u8; 32]);
 
 impl<'a> From<&'a Transaction> for AuthDigest {
     /// Computes the authorizing data commitment for a transaction.

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -468,6 +468,24 @@ fn zip244_txid() -> Result<()> {
 }
 
 #[test]
+fn zip244_auth_digest() -> Result<()> {
+    zebra_test::init();
+
+    for test in zip0244::TEST_VECTORS.iter() {
+        let transaction = test.tx.zcash_deserialize_into::<Transaction>()?;
+        let auth_digest = transaction.auth_digest();
+        assert_eq!(
+            auth_digest
+                .expect("must have auth_digest since it must be a V5 transaction")
+                .0,
+            test.auth_digest
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_vec143_1() -> Result<()> {
     zebra_test::init();
 


### PR DESCRIPTION
## Motivation

ZIP-244 specifies a new digest called "authorizing data commitment" or "auth_digest" that binds to authorization data (signatures, proofs). This must be implemented for Nu5.

Part of https://github.com/ZcashFoundation/zebra/issues/2048

### Specifications

https://zips.z.cash/zip-0244
https://zips.z.cash/zip-0225#modifications-to-zip-244

### Designs

N/A

## Solution

This adds a new method in `Transaction` to compute the auth_digest. It uses librustzcash to compute it, just like we do for the transaction ID and sighash.

## Review

This is a requirement for ZIP-221 work, but since that's ongoing it's not urgent.

@dconnolly or @teor2345 might want to review, but I think anyone else can review it too.

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [x] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2547)
<!-- Reviewable:end -->
