### PR TITLE
Remove unreliable generated chain prevouts tests

### DIFF
--- a/zebra-state/src/service/arbitrary.rs
+++ b/zebra-state/src/service/arbitrary.rs
@@ -20,7 +20,10 @@ use super::*;
 
 /// The chain length for state proptests.
 ///
-/// Shorter lengths increase the probability of proptest failures.
+/// Most generated chains will contain transparent spends at or before this height.
+///
+/// This height was chosen as a tradeoff between chains with no transparent spends,
+/// and chains which spend outputs created by previous spends.
 ///
 /// See [`block::arbitrary::PREVOUTS_CHAIN_HEIGHT`] for details.
 pub const MAX_PARTIAL_CHAIN_BLOCKS: usize =


### PR DESCRIPTION
## Motivation

PR #2525 added some extra tests for generated chains, but they were unreliable.

(Strangely, these tests passed locally and in the PR, but failed fairly often on `main`.)

## Solution

- Remove unreliable generated chain prevouts tests
- Adjust the chain lengths for better coverage
- Update documentation

## Review

This is blocking PR #2531, so @conradoplg might want to review this to unblock that PR.

@jvff reviewed PR #2525, so he might be able to review this one quickly.

### Reviewer Checklist

  - [x] Tests pass
  - [x] Documentation makes sense

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2548)
<!-- Reviewable:end -->
