### PR TITLE
Optimize build used when regenerating the state to hopefully make it faster

### DIFF
--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -12,6 +12,9 @@ ENV SHORT_SHA $SHORT_SHA
 
 ENV RUST_BACKTRACE full
 ENV CARGO_HOME /zebra/.cargo/
+# Optimize builds. In particular, regenerate-stateful-test-disks.yml was reaching the
+# GitHub Actions time limit (6 hours), so we needed to make it faster.
+ENV RUSTFLAGS -O
 
 RUN rustc -V; cargo -V; rustup -V
 


### PR DESCRIPTION
## Motivation

Regenerating the test state is taking more than 6 hours which is the GitHub Actions limit, and it's getting killed. This may be caused by the note commitment trees recently added that are a bit slow. This adds the `-O` flag to optimize the build and make the resulting binary faster.

(We could also want to just add it to every test? Let me know if it makes sense)

### Specifications

N/A

### Designs

N/A

## Solution

Add `RUSTFLAGS-O` to optimize the build.

## Review

I have run this but we still get a timeout :( https://github.com/ZcashFoundation/zebra/actions/workflows/regenerate-stateful-test-disks.yml

But analyzing the logs it seems it got further in the sync which would indicate it's really faster.

@dconnolly might want to review this since she usually handles this workflow.

### Reviewer Checklist

  - [ ] Changes make sense
  - [ ] Run the workflow and make sure it works

## Follow Up Work

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2552)
<!-- Reviewable:end -->
