### PR TITLE
Add ZIP-221 (history tree) to finalized state

### DIFF
--- a/zebra-chain/src/history_tree.rs
+++ b/zebra-chain/src/history_tree.rs
@@ -352,6 +352,11 @@ impl HistoryTree {
     pub fn current_height(&self) -> Height {
         self.current_height
     }
+
+    /// Return the network where this tree is used.
+    pub fn network(&self) -> Network {
+        self.network
+    }
 }
 
 impl Clone for HistoryTree {

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -16,6 +16,8 @@
 
 #[macro_use]
 extern crate serde;
+#[macro_use]
+extern crate serde_big_array;
 
 #[macro_use]
 extern crate bitflags;

--- a/zebra-chain/src/primitives/zcash_history.rs
+++ b/zebra-chain/src/primitives/zcash_history.rs
@@ -3,6 +3,7 @@
 
 // TODO: remove after this module gets to be used
 #![allow(dead_code)]
+#![allow(missing_docs)]
 
 mod tests;
 
@@ -16,6 +17,8 @@ use crate::{
     parameters::{Network, NetworkUpgrade},
     sapling,
 };
+
+big_array! { BigArray; zcash_history::MAX_ENTRY_SIZE }
 
 /// A trait to represent a version of `Tree`.
 pub trait Version: zcash_history::Version {
@@ -59,8 +62,9 @@ impl From<&zcash_history::NodeData> for NodeData {
 /// An encoded entry in the tree.
 ///
 /// Contains the node data and information about its position in the tree.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Entry {
+    #[serde(with = "BigArray")]
     inner: [u8; zcash_history::MAX_ENTRY_SIZE],
 }
 

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -25,7 +25,7 @@ pub const MIN_TRANSPARENT_COINBASE_MATURITY: u32 = 100;
 pub const MAX_BLOCK_REORG_HEIGHT: u32 = MIN_TRANSPARENT_COINBASE_MATURITY - 1;
 
 /// The database format version, incremented each time the database format changes.
-pub const DATABASE_FORMAT_VERSION: u32 = 6;
+pub const DATABASE_FORMAT_VERSION: u32 = 7;
 
 /// The maximum number of blocks to check for NU5 transactions,
 /// before we assume we are on a pre-NU5 legacy chain.

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -25,7 +25,7 @@ pub const MIN_TRANSPARENT_COINBASE_MATURITY: u32 = 100;
 pub const MAX_BLOCK_REORG_HEIGHT: u32 = MIN_TRANSPARENT_COINBASE_MATURITY - 1;
 
 /// The database format version, incremented each time the database format changes.
-pub const DATABASE_FORMAT_VERSION: u32 = 7;
+pub const DATABASE_FORMAT_VERSION: u32 = 8;
 
 /// The maximum number of blocks to check for NU5 transactions,
 /// before we assume we are on a pre-NU5 legacy chain.

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -160,7 +160,9 @@ impl StateService {
             let finalized = self.mem.finalize();
             self.disk
                 .commit_finalized_direct(finalized, "best non-finalized chain root")
-                .expect("expected that disk errors would not occur");
+                .expect(
+                    "expected that errors would not occur when writing to disk or updating note commitment and history trees",
+                );
         }
 
         self.queued_blocks

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -9,8 +9,9 @@ use std::{collections::HashMap, convert::TryInto, path::Path, sync::Arc};
 
 use zebra_chain::{
     block::{self, Block},
+    history_tree::HistoryTree,
     orchard,
-    parameters::{Network, GENESIS_PREVIOUS_BLOCK_HASH},
+    parameters::{Network, NetworkUpgrade, GENESIS_PREVIOUS_BLOCK_HASH},
     sapling, sprout,
     transaction::{self, Transaction},
     transparent,
@@ -36,6 +37,8 @@ pub struct FinalizedState {
     ephemeral: bool,
     /// Commit blocks to the finalized state up to this height, then exit Zebra.
     debug_stop_at_height: Option<block::Height>,
+
+    network: Network,
 }
 
 impl FinalizedState {
@@ -60,6 +63,7 @@ impl FinalizedState {
                 "orchard_note_commitment_tree",
                 db_options.clone(),
             ),
+            rocksdb::ColumnFamilyDescriptor::new("history_tree", db_options.clone()),
         ];
         let db_result = rocksdb::DB::open_cf_descriptors(&db_options, &path, column_families);
 
@@ -83,6 +87,7 @@ impl FinalizedState {
             db,
             ephemeral: config.ephemeral,
             debug_stop_at_height: config.debug_stop_at_height.map(block::Height),
+            network,
         };
 
         if let Some(tip_height) = new_state.finalized_tip_height() {
@@ -225,6 +230,7 @@ impl FinalizedState {
             self.db.cf_handle("sapling_note_commitment_tree").unwrap();
         let orchard_note_commitment_tree_cf =
             self.db.cf_handle("orchard_note_commitment_tree").unwrap();
+        let history_tree_cf = self.db.cf_handle("history_tree").unwrap();
 
         // Assert that callers (including unit tests) get the chain order correct
         if self.is_empty(hash_by_height) {
@@ -259,10 +265,11 @@ impl FinalizedState {
         // state, these will contain the empty trees.
         let mut sapling_note_commitment_tree = self.sapling_note_commitment_tree();
         let mut orchard_note_commitment_tree = self.orchard_note_commitment_tree();
+        let mut history_tree = self.history_tree();
 
         // We use a closure so we can use an early return for control flow in
         // the genesis case
-        let prepare_commit = || -> rocksdb::WriteBatch {
+        let prepare_commit = || -> Result<rocksdb::WriteBatch, BoxError> {
             let mut batch = rocksdb::WriteBatch::default();
 
             // Index the block
@@ -288,7 +295,7 @@ impl FinalizedState {
                     height,
                     orchard_note_commitment_tree,
                 );
-                return batch;
+                return Ok(batch);
             }
 
             // Index all new transparent outputs
@@ -346,14 +353,40 @@ impl FinalizedState {
                 }
             }
 
-            // Compute the new anchors and index them
-            batch.zs_insert(sapling_anchors, height, sapling_note_commitment_tree.root());
-            batch.zs_insert(orchard_anchors, height, orchard_note_commitment_tree.root());
+            let sapling_root = sapling_note_commitment_tree.root();
+            let orchard_root = orchard_note_commitment_tree.root();
 
-            // Update the note commitment trees
+            // Create the history tree if it's the Heartwood activation block.
+            let heartwood_height = NetworkUpgrade::Heartwood
+                .activation_height(self.network)
+                .expect("Heartwood height is known");
+            match height.cmp(&heartwood_height) {
+                std::cmp::Ordering::Less => assert!(history_tree.is_none()),
+                std::cmp::Ordering::Equal => {
+                    history_tree = Some(HistoryTree::from_block(
+                        self.network,
+                        block.clone(),
+                        &sapling_root,
+                        &orchard_root,
+                    )?);
+                }
+                std::cmp::Ordering::Greater => assert!(history_tree.is_some()),
+            }
+
+            // Add block to history tree if applicable
+            if let Some(history_tree) = &mut history_tree {
+                history_tree.push(block.clone(), &sapling_root, &orchard_root)?;
+            }
+
+            // Compute the new anchors and index them
+            batch.zs_insert(sapling_anchors, height, sapling_root);
+            batch.zs_insert(orchard_anchors, height, orchard_root);
+
+            // Update the trees in state
             if let Some(h) = finalized_tip_height {
                 batch.zs_delete(sapling_note_commitment_tree_cf, h);
                 batch.zs_delete(orchard_note_commitment_tree_cf, h);
+                batch.zs_delete(history_tree_cf, h);
             }
             batch.zs_insert(
                 sapling_note_commitment_tree_cf,
@@ -365,11 +398,14 @@ impl FinalizedState {
                 height,
                 orchard_note_commitment_tree,
             );
+            if let Some(history_tree) = history_tree {
+                batch.zs_insert(history_tree_cf, height, history_tree);
+            }
 
-            batch
+            Ok(batch)
         };
 
-        let batch = prepare_commit();
+        let batch = prepare_commit()?;
 
         let result = self.db.write(batch).map(|()| hash);
 
@@ -501,6 +537,14 @@ impl FinalizedState {
         self.db
             .zs_get(orchard_note_commitment_tree, &height)
             .expect("note commitment tree must exist if there is a finalized tip")
+    }
+
+    /// Returns the Orchard note commitment tree of the finalized tip
+    /// or the empty tree if the state is empty.
+    pub fn history_tree(&self) -> Option<HistoryTree> {
+        let height = self.finalized_tip_height()?;
+        let history_tree = self.db.cf_handle("history_tree").unwrap();
+        self.db.zs_get(history_tree, &height)
     }
 
     /// If the database is `ephemeral`, delete it.


### PR DESCRIPTION
## Motivation

ZIP-221 specifies a history tree used Heartwood-onward.

We must store the tree in the state to be able to validate the history tree for each block.

### Specifications

https://zips.z.cash/zip-0221

### Designs

Design was discussed in the issue: https://github.com/ZcashFoundation/zebra/issues/2134

## Solution

Instantiate a History Tree in the state on the Heartwood activation and keep it update with each commited block.

The tree is serialized with `serde`. This is something that I'd like feedback on. It was the simplest and fastest approach, but it seems we want to get rid of `serde` eventually (#2331). We can use `byteorder` and serialize manually instead. It should be fairly straightforward. Let me know if that's desirable.

Depends on https://github.com/ZcashFoundation/zebra/pull/2531

Part of https://github.com/ZcashFoundation/zebra/issues/2134

## Review

ZIP-221 non-finalized state needs this but it does not prevent me from working on it. So it's not urgent, but should be done this sprint.

@teor2345 might want to review this since they already reviewed the (old) ZIP-221 non-finalized state PR.

### Reviewer Checklist

  - [ ] Check if the it syncs correctly using a CI workflow
  - [ ] Provide feedback on the serialization strategy
  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

This does not do any validation. This will be done in a separate ticket (needs to be created).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2553)
<!-- Reviewable:end -->
