### PR TITLE
Add Chain ValueBalance serialization

### DIFF
--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -49,9 +49,12 @@ impl<C> Amount<C> {
     }
 
     /// From little endian byte array
-    pub fn from_bytes(bytes: [u8; 8]) -> Amount<C> {
+    pub fn from_bytes(bytes: [u8; 8]) -> Result<Amount<C>>
+    where
+        C: Constraint,
+    {
         let amount = i64::from_le_bytes(bytes);
-        Amount::<C>(amount, PhantomData)
+        amount.try_into()
     }
 
     /// Create a zero `Amount`

--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -16,6 +16,12 @@ use std::{
 use crate::serialization::{ZcashDeserialize, ZcashSerialize};
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};
 
+#[cfg(any(test, feature = "proptest-impl"))]
+pub mod arbitrary;
+
+#[cfg(test)]
+mod tests;
+
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// A runtime validated type for representing amounts of zatoshis
@@ -459,22 +465,7 @@ impl ZcashDeserialize for Amount<NonNegative> {
     }
 }
 
-#[cfg(any(test, feature = "proptest-impl"))]
-use proptest::prelude::*;
-#[cfg(any(test, feature = "proptest-impl"))]
-impl<C> Arbitrary for Amount<C>
-where
-    C: Constraint + std::fmt::Debug,
-{
-    type Parameters = ();
-
-    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        C::valid_range().prop_map(|v| Self(v, PhantomData)).boxed()
-    }
-
-    type Strategy = BoxedStrategy<Self>;
-}
-
+// TODO: move to tests::vectors after PR #2577 merges
 #[cfg(test)]
 mod test {
     use crate::serialization::ZcashDeserializeInto;

--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -48,6 +48,12 @@ impl<C> Amount<C> {
         buf
     }
 
+    /// From little endian byte array
+    pub fn from_bytes(bytes: [u8; 8]) -> Amount<C> {
+        let amount = i64::from_le_bytes(bytes);
+        Amount::<C>(amount, PhantomData)
+    }
+
     /// Create a zero `Amount`
     pub fn zero() -> Amount<C>
     where

--- a/zebra-chain/src/amount/arbitrary.rs
+++ b/zebra-chain/src/amount/arbitrary.rs
@@ -1,0 +1,18 @@
+//! Randomised test case generation for amounts.
+
+use proptest::prelude::*;
+
+use crate::amount::*;
+
+impl<C> Arbitrary for Amount<C>
+where
+    C: Constraint + std::fmt::Debug,
+{
+    type Parameters = ();
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        C::valid_range().prop_map(|v| Self(v, PhantomData)).boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}

--- a/zebra-chain/src/amount/tests.rs
+++ b/zebra-chain/src/amount/tests.rs
@@ -1,0 +1,3 @@
+//! Tests for amounts
+
+mod prop;

--- a/zebra-chain/src/amount/tests/prop.rs
+++ b/zebra-chain/src/amount/tests/prop.rs
@@ -1,0 +1,27 @@
+//! Randomised property tests for amounts.
+
+use proptest::prelude::*;
+
+use crate::amount::*;
+
+proptest! {
+    #[test]
+    fn amount_serialization(amount in any::<Amount<NegativeAllowed>>()) {
+        zebra_test::init();
+
+        let bytes = amount.to_bytes();
+        let serialized_amount = Amount::<NegativeAllowed>::from_bytes(bytes)?;
+
+        prop_assert_eq!(amount, serialized_amount);
+    }
+
+    #[test]
+    fn amount_deserialization(bytes in any::<[u8; 8]>()) {
+        zebra_test::init();
+
+        if let Ok(deserialized) = Amount::<NegativeAllowed>::from_bytes(bytes) {
+            let bytes2 = deserialized.to_bytes();
+            prop_assert_eq!(bytes, bytes2);
+        }
+    }
+}

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -138,16 +138,34 @@ where
         let orchard = self.orchard.to_bytes();
         match [transparent, sprout, sapling, orchard].concat().try_into() {
             Ok(bytes) => bytes,
-            _ => unreachable!("should be impossible to get here"),
+            _ => unreachable!(
+                "Four [u8; 8] should always concat with no error into a single [u8; 32]"
+            ),
         }
     }
 
     /// From byte array
     pub fn from_bytes(bytes: [u8; 32]) -> Self {
-        let transparent = Amount::from_bytes(bytes[0..8].try_into().unwrap());
-        let sprout = Amount::from_bytes(bytes[8..16].try_into().unwrap());
-        let sapling = Amount::from_bytes(bytes[16..24].try_into().unwrap());
-        let orchard = Amount::from_bytes(bytes[24..32].try_into().unwrap());
+        let transparent = Amount::from_bytes(
+            bytes[0..8]
+                .try_into()
+                .expect("Extracting the first quarter of a [u8; 32] should always succeed"),
+        );
+        let sprout = Amount::from_bytes(
+            bytes[8..16]
+                .try_into()
+                .expect("Extracting the second quarter of a [u8; 32] should always succeed"),
+        );
+        let sapling = Amount::from_bytes(
+            bytes[16..24]
+                .try_into()
+                .expect("Extracting the third quarter of a [u8; 32] should always succeed"),
+        );
+        let orchard = Amount::from_bytes(
+            bytes[24..32]
+                .try_into()
+                .expect("Extracting the last quarter of a [u8; 32] should always succeed"),
+        );
 
         ValueBalance {
             transparent,

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -2,6 +2,8 @@
 
 use crate::amount::{Amount, Constraint, Error, NonNegative};
 
+use std::convert::TryInto;
+
 #[cfg(any(test, feature = "proptest-impl"))]
 mod arbitrary;
 
@@ -125,6 +127,33 @@ where
             sprout: zero,
             sapling: zero,
             orchard: zero,
+        }
+    }
+
+    /// To byte array
+    pub fn to_bytes(self) -> [u8; 32] {
+        let transparent = self.transparent.to_bytes();
+        let sprout = self.sprout.to_bytes();
+        let sapling = self.sapling.to_bytes();
+        let orchard = self.orchard.to_bytes();
+        match [transparent, sprout, sapling, orchard].concat().try_into() {
+            Ok(bytes) => bytes,
+            _ => unreachable!("should be impossible to get here"),
+        }
+    }
+
+    /// From byte array
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        let transparent = Amount::from_bytes(bytes[0..8].try_into().unwrap());
+        let sprout = Amount::from_bytes(bytes[8..16].try_into().unwrap());
+        let sapling = Amount::from_bytes(bytes[16..24].try_into().unwrap());
+        let orchard = Amount::from_bytes(bytes[24..32].try_into().unwrap());
+
+        ValueBalance {
+            transparent,
+            sprout,
+            sapling,
+            orchard,
         }
     }
 }

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -145,34 +145,34 @@ where
     }
 
     /// From byte array
-    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+    pub fn from_bytes(bytes: [u8; 32]) -> Result<ValueBalance<C>, ValueBalanceError> {
         let transparent = Amount::from_bytes(
             bytes[0..8]
                 .try_into()
                 .expect("Extracting the first quarter of a [u8; 32] should always succeed"),
-        );
+        )?;
         let sprout = Amount::from_bytes(
             bytes[8..16]
                 .try_into()
                 .expect("Extracting the second quarter of a [u8; 32] should always succeed"),
-        );
+        )?;
         let sapling = Amount::from_bytes(
             bytes[16..24]
                 .try_into()
                 .expect("Extracting the third quarter of a [u8; 32] should always succeed"),
-        );
+        )?;
         let orchard = Amount::from_bytes(
             bytes[24..32]
                 .try_into()
                 .expect("Extracting the last quarter of a [u8; 32] should always succeed"),
-        );
+        )?;
 
-        ValueBalance {
+        Ok(ValueBalance {
             transparent,
             sprout,
             sapling,
             orchard,
-        }
+        })
     }
 }
 

--- a/zebra-chain/src/value_balance/tests.rs
+++ b/zebra-chain/src/value_balance/tests.rs
@@ -1,1 +1,3 @@
+//! Tests for value balances.
+
 mod prop;

--- a/zebra-chain/src/value_balance/tests/prop.rs
+++ b/zebra-chain/src/value_balance/tests/prop.rs
@@ -94,7 +94,7 @@ proptest! {
         zebra_test::init();
 
         let bytes = value_balance.to_bytes();
-        let serialized_value_balance = ValueBalance::from_bytes(bytes);
+        let serialized_value_balance = ValueBalance::from_bytes(bytes)?;
 
         prop_assert_eq!(value_balance, serialized_value_balance);
     }
@@ -103,9 +103,9 @@ proptest! {
     fn value_balance_deserialization(bytes in any::<[u8; 32]>()) {
         zebra_test::init();
 
-        let deserialized = ValueBalance::<NegativeAllowed>::from_bytes(bytes);
-        let bytes2 = deserialized.to_bytes();
-
-        prop_assert_eq!(bytes, bytes2)
+        if let Ok(deserialized) = ValueBalance::<NegativeAllowed>::from_bytes(bytes) {
+            let bytes2 = deserialized.to_bytes();
+            prop_assert_eq!(bytes, bytes2);
+        }
     }
 }

--- a/zebra-chain/src/value_balance/tests/prop.rs
+++ b/zebra-chain/src/value_balance/tests/prop.rs
@@ -3,7 +3,7 @@ use proptest::prelude::*;
 
 proptest! {
     #[test]
-    fn test_add(
+    fn value_blance_add(
         value_balance1 in any::<ValueBalance<NegativeAllowed>>(),
         value_balance2 in any::<ValueBalance<NegativeAllowed>>())
     {
@@ -32,7 +32,7 @@ proptest! {
         }
     }
     #[test]
-    fn test_sub(
+    fn value_balance_sub(
         value_balance1 in any::<ValueBalance<NegativeAllowed>>(),
         value_balance2 in any::<ValueBalance<NegativeAllowed>>())
     {
@@ -62,7 +62,7 @@ proptest! {
     }
 
     #[test]
-    fn test_sum(
+    fn value_balance_sum(
         value_balance1 in any::<ValueBalance<NegativeAllowed>>(),
         value_balance2 in any::<ValueBalance<NegativeAllowed>>(),
     ) {
@@ -90,7 +90,7 @@ proptest! {
     }
 
     #[test]
-    fn test_serialization(value_balance in any::<ValueBalance<NegativeAllowed>>()) {
+    fn value_balance_serialization(value_balance in any::<ValueBalance<NegativeAllowed>>()) {
         zebra_test::init();
 
         let bytes = value_balance.to_bytes();

--- a/zebra-chain/src/value_balance/tests/prop.rs
+++ b/zebra-chain/src/value_balance/tests/prop.rs
@@ -1,5 +1,8 @@
-use crate::{amount::*, value_balance::*};
+//! Randomised property tests for value balances.
+
 use proptest::prelude::*;
+
+use crate::{amount::*, value_balance::*};
 
 proptest! {
     #[test]
@@ -108,26 +111,4 @@ proptest! {
             prop_assert_eq!(bytes, bytes2);
         }
     }
-
-    #[test]
-    fn amount_serialization(amount in any::<Amount<NegativeAllowed>>()) {
-        zebra_test::init();
-
-        let bytes = amount.to_bytes();
-        let serialized_amount = Amount::<NegativeAllowed>::from_bytes(bytes)?;
-
-        prop_assert_eq!(amount, serialized_amount);
-    }
-
-    #[test]
-    fn amount_deserialization(bytes in any::<[u8; 8]>()) {
-        zebra_test::init();
-
-        if let Ok(deserialized) = Amount::<NegativeAllowed>::from_bytes(bytes) {
-            let bytes2 = deserialized.to_bytes();
-            prop_assert_eq!(bytes, bytes2);
-        }
-    }
-
-
 }

--- a/zebra-chain/src/value_balance/tests/prop.rs
+++ b/zebra-chain/src/value_balance/tests/prop.rs
@@ -88,4 +88,14 @@ proptest! {
             _ => prop_assert!(matches!(collection.iter().sum(), Err(ValueBalanceError::AmountError(_))))
         }
     }
+
+    #[test]
+    fn test_serialization(value_balance in any::<ValueBalance<NegativeAllowed>>()) {
+        zebra_test::init();
+
+        let bytes = value_balance.to_bytes();
+        let serialized_value_balance = ValueBalance::from_bytes(bytes);
+
+        prop_assert_eq!(value_balance, serialized_value_balance);
+    }
 }

--- a/zebra-chain/src/value_balance/tests/prop.rs
+++ b/zebra-chain/src/value_balance/tests/prop.rs
@@ -98,4 +98,14 @@ proptest! {
 
         prop_assert_eq!(value_balance, serialized_value_balance);
     }
+
+    #[test]
+    fn value_balance_deserialization(bytes in any::<[u8; 32]>()) {
+        zebra_test::init();
+
+        let deserialized = ValueBalance::<NegativeAllowed>::from_bytes(bytes);
+        let bytes2 = deserialized.to_bytes();
+
+        prop_assert_eq!(bytes, bytes2)
+    }
 }

--- a/zebra-chain/src/value_balance/tests/prop.rs
+++ b/zebra-chain/src/value_balance/tests/prop.rs
@@ -108,4 +108,26 @@ proptest! {
             prop_assert_eq!(bytes, bytes2);
         }
     }
+
+    #[test]
+    fn amount_serialization(amount in any::<Amount<NegativeAllowed>>()) {
+        zebra_test::init();
+
+        let bytes = amount.to_bytes();
+        let serialized_amount = Amount::<NegativeAllowed>::from_bytes(bytes)?;
+
+        prop_assert_eq!(amount, serialized_amount);
+    }
+
+    #[test]
+    fn amount_deserialization(bytes in any::<[u8; 8]>()) {
+        zebra_test::init();
+
+        if let Ok(deserialized) = Amount::<NegativeAllowed>::from_bytes(bytes) {
+            let bytes2 = deserialized.to_bytes();
+            prop_assert_eq!(bytes, bytes2);
+        }
+    }
+
+
 }

--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -261,7 +261,8 @@ impl IntoDisk for ValueBalance<NonNegative> {
 
 impl FromDisk for ValueBalance<NonNegative> {
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
-        ValueBalance::from_bytes(bytes.as_ref().try_into().unwrap())
+        let array = bytes.as_ref().try_into().unwrap();
+        ValueBalance::from_bytes(array).unwrap()
     }
 }
 


### PR DESCRIPTION
## Motivation

In order to store `ValueBalance` in the database we need to be able to serialize and deserialize the type.

### Designs

This is part of the value pools design:

https://zebra.zfnd.org/dev/rfcs/0012-value-pools.html#serialization-of-valuebalancec

## Solution

- https://github.com/ZcashFoundation/zebra/commit/6de0ef45d6207a3e1e469e48110aaf53c0df2ec6 implements the serialization code.

- https://github.com/ZcashFoundation/zebra/commit/d9964f764ad173fb5716d070b9d8875bbaed5aa3 just change some of the value balance tests so they can be filtered by "value_balance".

## Review

The design specifies the implementation of `IntoDisk` and `FromDisk` for `Amount` however i think this will not be needed.

I added some comments in the code where i have some doubts. Anyone can review.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2554)
<!-- Reviewable:end -->
