### PR TITLE
Design: Fix Transparent Value Sign and Definition

### DIFF
--- a/book/src/dev/rfcs/0012-value-pools.md
+++ b/book/src/dev/rfcs/0012-value-pools.md
@@ -62,13 +62,22 @@ Each of the chain value pools can change its value with every block added to the
 ## Consensus rules
 [consensus-rules]: #consensus-rules
 
+### Shielded Chain Value Pools
+
+Consensus rules:
+> If any of the "Sprout chain value pool balance", "Sapling chain value pool balance", or "Orchard chain value pool balance" would become negative in the block chain created as a result of accepting a block, then all nodes MUST reject the block as invalid.
+>
+> Nodes MAY relay transactions even if one or more of them cannot be mined due to the aforementioned restriction.
+
+https://zips.z.cash/zip-0209#specification
+
 ### Coinbase Transactions
 
 In this design, we assume that all coinbase outputs are valid, to avoid checking the newly created coinbase value, and the miner fees.
 
 The coinbase value and miner feel rules will be checked as part of a future design.
 
-### Remaining Value in the Transparent Transaction Value Pool
+### Remaining Value in the Transaction Value Pool
 
 The sum of unspent *inputs* to the transaction: the *negation* of the sum of the transaction value balances.
 
@@ -100,15 +109,6 @@ Specifically, this rule can be derived from other consensus rules:
 - there must be a non-negative remaining value in the transparent transaction value pool.
 
 Some of these consensus rules are derived from Bitcoin, so they may not be documented in the Zcash Specification.
-
-### Shielded Chain Value Pools
-
-Consensus rules:
-> If any of the "Sprout chain value pool balance", "Sapling chain value pool balance", or "Orchard chain value pool balance" would become negative in the block chain created as a result of accepting a block, then all nodes MUST reject the block as invalid.
->
-> Nodes MAY relay transactions even if one or more of them cannot be mined due to the aforementioned restriction.
-
-https://zips.z.cash/zip-0209#specification
 
 ### Sprout Chain Value Pool
 

--- a/book/src/dev/rfcs/0012-value-pools.md
+++ b/book/src/dev/rfcs/0012-value-pools.md
@@ -62,6 +62,15 @@ Each of the chain value pools can change its value with every block added to the
 ## Consensus rules
 [consensus-rules]: #consensus-rules
 
+### Shielded Chain Value Pools
+
+Consensus rules:
+> If any of the "Sprout chain value pool balance", "Sapling chain value pool balance", or "Orchard chain value pool balance" would become negative in the block chain created as a result of accepting a block, then all nodes MUST reject the block as invalid.
+>
+> Nodes MAY relay transactions even if one or more of them cannot be mined due to the aforementioned restriction.
+
+https://zips.z.cash/zip-0209#specification
+
 ### Transparent Chain Value Pool
 
 Consensus rule:
@@ -78,15 +87,6 @@ Specifically, this rule can be derived from other consensus rules:
 - there must be a non-negative remaining value in the transparent transaction value pool.
 
 Some of these consensus rules are derived from Bitcoin, so they may not be documented in the Zcash Specification.
-
-### Shielded Chain Value Pools
-
-Consensus rules:
-> If any of the "Sprout chain value pool balance", "Sapling chain value pool balance", or "Orchard chain value pool balance" would become negative in the block chain created as a result of accepting a block, then all nodes MUST reject the block as invalid.
->
-> Nodes MAY relay transactions even if one or more of them cannot be mined due to the aforementioned restriction.
-
-https://zips.z.cash/zip-0209#specification
 
 ### Coinbase Transactions
 

--- a/book/src/dev/rfcs/0012-value-pools.md
+++ b/book/src/dev/rfcs/0012-value-pools.md
@@ -77,7 +77,7 @@ In this design, we assume that all coinbase outputs are valid, to avoid checking
 
 The coinbase value and miner feel rules will be checked as part of a future design.
 
-### Remaining Value in the Transaction Value Pool
+### Transparent Transaction Value Pool & Remaining Value
 
 The sum of unspent *inputs* to the transaction: the *negation* of the sum of the transaction value balances.
 

--- a/book/src/dev/rfcs/0012-value-pools.md
+++ b/book/src/dev/rfcs/0012-value-pools.md
@@ -25,8 +25,8 @@ Checking the coins created by coinbase transactions and funding streams is out o
 [definitions]: #definitions
 
 - `value balance` - The change in the chain value pools, caused by a subset of the blockchain.
-- `transparent value balance` - The change the transparent value pool. The sum of newly created outputs in `tx_out` fields, minus the sum of the outputs spent by transparent inputs in `tx_in` fields.
-- `coinbase transparent value balance` - The change the transparent value pool, due to a coinbase transaction. The sum of newly created outputs in `tx_out` fields.
+- `transparent value balance` - The change in the transparent value pool. The sum of newly created outputs in `tx_out` fields, minus the sum of the outputs spent by transparent inputs in `tx_in` fields.
+- `coinbase transparent value balance` - The change in the transparent value pool, due to a coinbase transaction. The sum of newly created outputs in `tx_out` fields.
 - `sprout value balance` - The change in the sprout value pool. The sum of all sprout `v_sprout_old` fields, minus the sum of all `v_sprout_new` fields.
 - `sapling value balance` - The change in the sapling value pool. The negation of the sum of all `valueBalanceSapling` fields.
 - `orchard value balance` - The change in the orchard value pool. The negation of the sum of all `valueBalanceOrchard` fields.

--- a/book/src/dev/rfcs/0012-value-pools.md
+++ b/book/src/dev/rfcs/0012-value-pools.md
@@ -71,29 +71,6 @@ Consensus rules:
 
 https://zips.z.cash/zip-0209#specification
 
-### Transparent Chain Value Pool
-
-Consensus rule:
-> Transfers of transparent value work essentially as in Bitcoin
-
-https://zips.z.cash/protocol/protocol.pdf#overview
-
-There is no explicit Zcash consensus rule that the transparent chain value pool balance must be non-negative.
-But an equivalent rule must be enforced by Zcash implementations, so that each block only creates a fixed amount of coins.
-
-Specifically, this rule can be derived from other consensus rules:
-- a transparent output must have a non-negative value,
-- a transparent input can only spend an unspent transparent output,
-- there must be a non-negative remaining value in the transparent transaction value pool.
-
-Some of these consensus rules are derived from Bitcoin, so they may not be documented in the Zcash Specification.
-
-### Coinbase Transactions
-
-In this design, we assume that all coinbase outputs are valid, to avoid checking the newly created coinbase value, and the miner fees.
-
-The coinbase value and miner feel rules will be checked as part of a future design.
-
 ### Transparent Transaction Value Pool & Remaining Value
 
 The sum of unspent *inputs* to the transaction: the *negation* of the sum of the transaction value balances.
@@ -148,6 +125,29 @@ Consensus rules:
 > If the Orchard chain value pool balance would become negative in the block chain created as a result of accepting a block , then all nodes MUST reject the block as invalid.
 
 https://zips.z.cash/protocol/protocol.pdf#orchardbalance
+
+### Transparent Chain Value Pool
+
+Consensus rule:
+> Transfers of transparent value work essentially as in Bitcoin
+
+https://zips.z.cash/protocol/protocol.pdf#overview
+
+There is no explicit Zcash consensus rule that the transparent chain value pool balance must be non-negative.
+But an equivalent rule must be enforced by Zcash implementations, so that each block only creates a fixed amount of coins.
+
+Specifically, this rule can be derived from other consensus rules:
+- a transparent output must have a non-negative value,
+- a transparent input can only spend an unspent transparent output,
+- there must be a non-negative remaining value in the transparent transaction value pool.
+
+Some of these consensus rules are derived from Bitcoin, so they may not be documented in the Zcash Specification.
+
+### Coinbase Transactions
+
+In this design, we assume that all coinbase outputs are valid, to avoid checking the newly created coinbase value, and the miner fees.
+
+The coinbase value and miner feel rules will be checked as part of a future design.
 
 ### Exceptions and Edge Cases
 

--- a/book/src/dev/rfcs/0012-value-pools.md
+++ b/book/src/dev/rfcs/0012-value-pools.md
@@ -153,7 +153,7 @@ Some of these consensus rules are derived from Bitcoin, so they may not be docum
 
 In this design, we assume that all coinbase outputs are valid, to avoid checking the newly created coinbase value, and the miner fees.
 
-The coinbase value and miner feel rules will be checked as part of a future design.
+The coinbase value and miner fee rules will be checked as part of a future design.
 
 ### Exceptions and Edge Cases
 

--- a/book/src/dev/rfcs/0012-value-pools.md
+++ b/book/src/dev/rfcs/0012-value-pools.md
@@ -62,6 +62,23 @@ Each of the chain value pools can change its value with every block added to the
 ## Consensus rules
 [consensus-rules]: #consensus-rules
 
+### Transparent Chain Value Pool
+
+Consensus rule:
+> Transfers of transparent value work essentially as in Bitcoin
+
+https://zips.z.cash/protocol/protocol.pdf#overview
+
+There is no explicit Zcash consensus rule that the transparent chain value pool balance must be non-negative.
+But an equivalent rule must be enforced by Zcash implementations, so that each block only creates a fixed amount of coins.
+
+Specifically, this rule can be derived from other consensus rules:
+- a transparent output must have a non-negative value,
+- a transparent input can only spend an unspent transparent output,
+- there must be a non-negative remaining value in the transparent transaction value pool.
+
+Some of these consensus rules are derived from Bitcoin, so they may not be documented in the Zcash Specification.
+
 ### Shielded Chain Value Pools
 
 Consensus rules:
@@ -92,23 +109,6 @@ Consensus rules:
 https://zips.z.cash/protocol/protocol.pdf#transactions
 
 In Zebra, the remaining value in non-coinbase transactions is not assigned to any particular pool, until a miner spends it as part of a coinbase output.
-
-### Transparent Chain Value Pool
-
-Consensus rule:
-> Transfers of transparent value work essentially as in Bitcoin
-
-https://zips.z.cash/protocol/protocol.pdf#overview
-
-There is no explicit Zcash consensus rule that the transparent chain value pool balance must be non-negative.
-But an equivalent rule must be enforced by Zcash implementations, so that each block only creates a fixed amount of coins.
-
-Specifically, this rule can be derived from other consensus rules:
-- a transparent output must have a non-negative value,
-- a transparent input can only spend an unspent transparent output,
-- there must be a non-negative remaining value in the transparent transaction value pool.
-
-Some of these consensus rules are derived from Bitcoin, so they may not be documented in the Zcash Specification.
 
 ### Sprout Chain Value Pool
 

--- a/book/src/dev/rfcs/0012-value-pools.md
+++ b/book/src/dev/rfcs/0012-value-pools.md
@@ -65,9 +65,10 @@ Each of the chain value pools can change its value with every block added to the
 ### Shielded Chain Value Pools
 
 Consensus rules:
-> If any of the "Sprout chain value pool balance", "Sapling chain value pool balance", or "Orchard chain value pool balance" would become negative in the block chain created as a result of accepting a block, then all nodes MUST reject the block as invalid.
->
-> Nodes MAY relay transactions even if one or more of them cannot be mined due to the aforementioned restriction.
+
+If any of the "Sprout chain value pool balance", "Sapling chain value pool balance", or "Orchard chain value pool balance" would become negative in the block chain created as a result of accepting a block, then all nodes MUST reject the block as invalid.
+
+Nodes MAY relay transactions even if one or more of them cannot be mined due to the aforementioned restriction.
 
 https://zips.z.cash/zip-0209#specification
 
@@ -76,12 +77,13 @@ https://zips.z.cash/zip-0209#specification
 The sum of unspent *inputs* to the transaction: the *negation* of the sum of the transaction value balances.
 
 Consensus rules:
-> Transparent inputs to a transaction insert value into a transparent transaction value pool associated with the transaction, and transparent outputs remove value from this pool.
->
-> As in Bitcoin, the remaining value in the transparent transaction value pool of a non-coinbase transaction is available to miners as a fee.
-> The remaining value in the transparent transaction value pool of a coinbase transaction is destroyed.
->
-> The remaining value in the transparent transaction value pool MUST be nonnegative.
+
+Transparent inputs to a transaction insert value into a transparent transaction value pool associated with the transaction, and transparent outputs remove value from this pool.
+
+As in Bitcoin, the remaining value in the transparent transaction value pool of a non-coinbase transaction is available to miners as a fee.
+The remaining value in the transparent transaction value pool of a coinbase transaction is destroyed.
+
+The remaining value in the transparent transaction value pool MUST be nonnegative.
 
 https://zips.z.cash/protocol/protocol.pdf#transactions
 
@@ -90,46 +92,50 @@ In Zebra, the remaining value in non-coinbase transactions is not assigned to an
 ### Sprout Chain Value Pool
 
 Consensus rules:
-> Each JoinSplit transfer can be seen, from the perspective of the transparent transaction value pool, as an input and an output simultaneously.
->
-> `vold` takes value from the transparent transaction value pool and `vnew` adds value to the transparent transaction value pool . As a result, `vold` is treated like an output value, whereas `vnew` is treated like an input value.
->
-> As defined in [ZIP-209], the Sprout chain value pool balance for a given block chain is the sum of all `vold` field values for transactions in the block chain, minus the sum of all `vnew` fields values for transactions in the block chain.
->
-> If the Sprout chain value pool balance would become negative in the block chain created as a result of accepting a block, then all nodes MUST reject the block as invalid.
+
+Each JoinSplit transfer can be seen, from the perspective of the transparent transaction value pool, as an input and an output simultaneously.
+
+`vold` takes value from the transparent transaction value pool and `vnew` adds value to the transparent transaction value pool . As a result, `vold` is treated like an output value, whereas `vnew` is treated like an input value.
+
+As defined in [ZIP-209], the Sprout chain value pool balance for a given block chain is the sum of all `vold` field values for transactions in the block chain, minus the sum of all `vnew` fields values for transactions in the block chain.
+
+If the Sprout chain value pool balance would become negative in the block chain created as a result of accepting a block, then all nodes MUST reject the block as invalid.
 
 https://zips.z.cash/protocol/protocol.pdf#joinsplitbalance
 
 ### Sapling Chain Value Pool
 
 Consensus rules:
-> A positive Sapling balancing value takes value from the Sapling transaction value pool and adds it to the transparent transaction value pool. A negative Sapling balancing value does the reverse. As a result, positive `vbalanceSapling` is treated like an input to the transparent transaction value pool, whereas negative `vbalanceSapling` is treated like an output from that pool.
->
-> As defined in [ZIP-209], the Sapling chain value pool balance for a given block chain is the negation of the sum of all `valueBalanceSapling` field values for transactions in the block chain.
->
-> If the Sapling chain value pool balance would become negative in the block chain created as a result of accepting a block, then all nodes MUST reject the block as invalid.
+
+A positive Sapling balancing value takes value from the Sapling transaction value pool and adds it to the transparent transaction value pool. A negative Sapling balancing value does the reverse. As a result, positive `vbalanceSapling` is treated like an input to the transparent transaction value pool, whereas negative `vbalanceSapling` is treated like an output from that pool.
+
+As defined in [ZIP-209], the Sapling chain value pool balance for a given block chain is the negation of the sum of all `valueBalanceSapling` field values for transactions in the block chain.
+
+If the Sapling chain value pool balance would become negative in the block chain created as a result of accepting a block, then all nodes MUST reject the block as invalid.
 
 https://zips.z.cash/protocol/protocol.pdf#saplingbalance
 
 ### Orchard Chain Value Pool
 
 Consensus rules:
-> Orchard introduces Action transfers, each of which can optionally perform a spend, and optionally perform an output. Similarly to Sapling, the net value of Orchard spends minus outputs in a transaction is called the Orchard balancing value, measured in zatoshi as a signed integer `vbalanceOrchard`.
->
-> `vbalanceOrchard` is encoded in a transaction as the field `valueBalanceOrchard`. If a transaction has no Action descriptions, `vbalanceOrchard` is implicitly zero. Transaction fields are described in § 7.1 ‘Transaction Encoding and Consensus’ on p. 116.
->
-> A positive Orchard balancing value takes value from the Orchard transaction value pool and adds it to the transparent transaction value pool. A negative Orchard balancing value does the reverse. As a result, positive `vbalanceOrchard` is treated like an input to the transparent transaction value pool, whereas negative `vbalanceOrchard` is treated like an output from that pool.
->
-> Similarly to the Sapling chain value pool balance defined in [ZIP-209], the Orchard chain value pool balance for a given block chain is the negation of the sum of all `valueBalanceOrchard` field values for transactions in the block chain.
->
-> If the Orchard chain value pool balance would become negative in the block chain created as a result of accepting a block , then all nodes MUST reject the block as invalid.
+
+Orchard introduces Action transfers, each of which can optionally perform a spend, and optionally perform an output. Similarly to Sapling, the net value of Orchard spends minus outputs in a transaction is called the Orchard balancing value, measured in zatoshi as a signed integer `vbalanceOrchard`.
+
+`vbalanceOrchard` is encoded in a transaction as the field `valueBalanceOrchard`. If a transaction has no Action descriptions, `vbalanceOrchard` is implicitly zero. Transaction fields are described in § 7.1 ‘Transaction Encoding and Consensus’ on p. 116.
+
+A positive Orchard balancing value takes value from the Orchard transaction value pool and adds it to the transparent transaction value pool. A negative Orchard balancing value does the reverse. As a result, positive `vbalanceOrchard` is treated like an input to the transparent transaction value pool, whereas negative `vbalanceOrchard` is treated like an output from that pool.
+
+Similarly to the Sapling chain value pool balance defined in [ZIP-209], the Orchard chain value pool balance for a given block chain is the negation of the sum of all `valueBalanceOrchard` field values for transactions in the block chain.
+
+If the Orchard chain value pool balance would become negative in the block chain created as a result of accepting a block , then all nodes MUST reject the block as invalid.
 
 https://zips.z.cash/protocol/protocol.pdf#orchardbalance
 
 ### Transparent Chain Value Pool
 
 Consensus rule:
-> Transfers of transparent value work essentially as in Bitcoin
+
+Transfers of transparent value work essentially as in Bitcoin
 
 https://zips.z.cash/protocol/protocol.pdf#overview
 

--- a/book/src/dev/rfcs/0012-value-pools.md
+++ b/book/src/dev/rfcs/0012-value-pools.md
@@ -95,9 +95,9 @@ Consensus rules:
 
 Each JoinSplit transfer can be seen, from the perspective of the transparent transaction value pool, as an input and an output simultaneously.
 
-`vold` takes value from the transparent transaction value pool and `vnew` adds value to the transparent transaction value pool . As a result, `vold` is treated like an output value, whereas `vnew` is treated like an input value.
+`v_sprout_old` takes value from the transparent transaction value pool and `v_sprout_new` adds value to the transparent transaction value pool . As a result, `v_sprout_old` is treated like an output value, whereas `v_sprout_new` is treated like an input value.
 
-As defined in [ZIP-209], the Sprout chain value pool balance for a given block chain is the sum of all `vold` field values for transactions in the block chain, minus the sum of all `vnew` fields values for transactions in the block chain.
+As defined in [ZIP-209], the Sprout chain value pool balance for a given block chain is the sum of all `v_sprout_old` field values for transactions in the block chain, minus the sum of all `v_sprout_new` fields values for transactions in the block chain.
 
 If the Sprout chain value pool balance would become negative in the block chain created as a result of accepting a block, then all nodes MUST reject the block as invalid.
 


### PR DESCRIPTION
## Motivation

- The signs of some transparent values are inconsistent with other pools
- The concepts and definitions in the current design are unclear and complex
- The transparent consensus rules are not documented in the Zcash specification

### Specifications & Designs

See the RFC for the relevant consensus rules.

## Solution

Fix inconsistent transparent value signs:
* make the transparent value pool the sum of unspent output values, like other pools
* swap the sign of the transparent value balance
* make the remaining transaction value balance the sum of unspent input values

Consensus rule updates:
* update the remaining value in the transparent transaction value pool based on recent spec changes

Improve concepts and explanations:
* explain why the transparent chain value pool balance can't be negative
* clarify the definitions, guide, and consensus rules sections

## Review

@oxarbitrage can review this PR, because it's blocking PR #2554.

### Reviewer Checklist

  - [ ] Design is consistent with consensus rules
  - [ ] Design changes make sense

## Follow Up Work

We'll need to swap the sign of the transparent value balance, and swap its sign in the "remaining value in the transparent transaction value pool" calculation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2555)
<!-- Reviewable:end -->
