### PR TITLE
Fix the storage of anchors in the state

### DIFF
--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -25,7 +25,7 @@ pub const MIN_TRANSPARENT_COINBASE_MATURITY: u32 = 100;
 pub const MAX_BLOCK_REORG_HEIGHT: u32 = MIN_TRANSPARENT_COINBASE_MATURITY - 1;
 
 /// The database format version, incremented each time the database format changes.
-pub const DATABASE_FORMAT_VERSION: u32 = 6;
+pub const DATABASE_FORMAT_VERSION: u32 = 7;
 
 /// The maximum number of blocks to check for NU5 transactions,
 /// before we assume we are on a pre-NU5 legacy chain.

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -347,8 +347,8 @@ impl FinalizedState {
             }
 
             // Compute the new anchors and index them
-            batch.zs_insert(sapling_anchors, height, sapling_note_commitment_tree.root());
-            batch.zs_insert(orchard_anchors, height, orchard_note_commitment_tree.root());
+            batch.zs_insert(sapling_anchors, sapling_note_commitment_tree.root(), ());
+            batch.zs_insert(orchard_anchors, orchard_note_commitment_tree.root(), ());
 
             // Update the note commitment trees
             if let Some(h) = finalized_tip_height {


### PR DESCRIPTION
## Motivation

#2407 added note commitment trees and anchors to the state. However I got the storage wrong: we should store the root as a key with an empty value (to make it work as a set) instead of using the height as the key and the root as the value.

This fixes that.

### Specifications

N/A

### Designs

https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0005-state-updates.md#rocksdb-data-structures

## Solution

Use the correct key/value

## Review

Anyone can review this.

This is blocking regenerating the cached state, which in turn is blocking testing other state work.

After this is accepted we can regenerate the cached state.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2563)
<!-- Reviewable:end -->
