### PR TITLE
Add remaining value balance check

### DIFF
--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -181,12 +181,14 @@ impl NonFinalizedState {
         prepared: PreparedBlock,
         finalized_state: &FinalizedState,
     ) -> Result<Chain, ValidateContextError> {
-        check::utxo::transparent_spend(
+        let utxos = check::utxo::transparent_spend(
             &prepared,
             &parent_chain.unspent_utxos(),
             &parent_chain.spent_utxos,
             finalized_state,
         )?;
+
+        check::utxo::remaining_transaction_value(&prepared, &utxos)?;
 
         parent_chain.push(prepared)
     }


### PR DESCRIPTION
## Motivation

After https://github.com/ZcashFoundation/zebra/pull/2561 we are in position to readd the remaining value balance consensus rule.


### Designs

https://zebra.zfnd.org/dev/rfcs/0012-value-pools.html#definitions

## Solution

Readd the check.

## Review

I will like @teor2345 can take a look, we have some tests failing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2565)
<!-- Reviewable:end -->
