### PR TITLE
Add a random number of transactions to generated blocks, rather than always 2

### DIFF
--- a/zebra-chain/src/transparent/arbitrary.rs
+++ b/zebra-chain/src/transparent/arbitrary.rs
@@ -12,7 +12,7 @@ impl Input {
                 .prop_map(|input| vec![input])
                 .boxed()
         } else {
-            vec(Self::arbitrary_with(None), max_size).boxed()
+            vec(Self::arbitrary_with(None), 1..=max_size).boxed()
         }
     }
 }


### PR DESCRIPTION
## Motivation

We want to test Zebra's checks with blocks that have different numbers of transactions and transparent inputs.
But currently, we always have 2 transactions, and `max_size` inputs (typically 4).

This change improves test coverage. For example, it will prevent Zebra depending on always having a non-coinbase transaction in every block.

## Solution

- Add 1 to 3 transactions to generated blocks, rather than always having 2
- Add 1 to `max_size` transparent inputs to generated blocks, rather than always having exactly `max_size`

As a side-effect, it reduces the average number of generated transactions and inputs by about half, which should improve performance.

## Review

@oxarbitrage can review this PR.

### Reviewer Checklist

  - [x] Code behaves as documented
  - [x] Existing tests pass

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2567)
<!-- Reviewable:end -->
