### PR TITLE
Use fixed genesis coinbase data in generated genesis blocks

### DIFF
--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -9,6 +9,7 @@ mod utxo;
 
 pub use address::Address;
 pub use script::Script;
+pub use serialize::GENESIS_COINBASE_DATA;
 pub use utxo::{
     new_ordered_outputs, new_outputs, utxos_from_ordered_utxos, CoinbaseSpendRestriction,
     OrderedUtxo, Utxo,

--- a/zebra-chain/src/transparent/arbitrary.rs
+++ b/zebra-chain/src/transparent/arbitrary.rs
@@ -2,7 +2,7 @@ use proptest::{arbitrary::any, collection::vec, prelude::*};
 
 use crate::{block, LedgerState};
 
-use super::{CoinbaseData, Input, OutPoint, Script};
+use super::{CoinbaseData, Input, OutPoint, Script, GENESIS_COINBASE_DATA};
 
 impl Input {
     /// Construct a strategy for creating valid-ish vecs of Inputs.
@@ -25,7 +25,11 @@ impl Arbitrary for Input {
             (vec(any::<u8>(), 0..95), any::<u32>())
                 .prop_map(move |(data, sequence)| Input::Coinbase {
                     height,
-                    data: CoinbaseData(data),
+                    data: if height == block::Height(0) {
+                        CoinbaseData(GENESIS_COINBASE_DATA.to_vec())
+                    } else {
+                        CoinbaseData(data)
+                    },
                     sequence,
                 })
                 .boxed()

--- a/zebra-chain/src/transparent/serialize.rs
+++ b/zebra-chain/src/transparent/serialize.rs
@@ -17,7 +17,7 @@ use super::{CoinbaseData, Input, OutPoint, Output, Script};
 ///
 /// Zcash uses the same coinbase data for the Mainnet, Testnet, and Regtest
 /// genesis blocks.
-const GENESIS_COINBASE_DATA: [u8; 77] = [
+pub const GENESIS_COINBASE_DATA: [u8; 77] = [
     4, 255, 255, 7, 31, 1, 4, 69, 90, 99, 97, 115, 104, 48, 98, 57, 99, 52, 101, 101, 102, 56, 98,
     55, 99, 99, 52, 49, 55, 101, 101, 53, 48, 48, 49, 101, 51, 53, 48, 48, 57, 56, 52, 98, 54, 102,
     101, 97, 51, 53, 54, 56, 51, 97, 55, 99, 97, 99, 49, 52, 49, 97, 48, 52, 51, 99, 52, 50, 48,


### PR DESCRIPTION
## Motivation

Zebra serializes genesis blocks with arbitrary coinbase data, but our deserialization checks for fixed mainnet/testnet coinbase bytes.

This causes failures in some proptests.

This is unscheduled work due to a Zebra bug / spec bug.

### Specifications

The current Zcash specification for the genesis coinbase height encoding is incorrect. (https://github.com/zcash/zips/issues/540)

## Solution

- Return an error when trying to serialize a genesis height with non-genesis coinbase data
- Use fixed genesis coinbase data in generated genesis blocks
- Document input, coinbase, and height encoding and decoding functions
- Delete some documentation that is incorrect after recent spec changes

## Review

This fix blocks PR #2519, so @jvff can review it.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

We should get the spec fixed, then implement whatever it says.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2568)
<!-- Reviewable:end -->
