### PR TITLE
Use the same value balance sign for transparent and shielded outputs

### DIFF
--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -330,10 +330,10 @@ impl<C> std::ops::Neg for Amount<C>
 where
     C: Constraint,
 {
-    type Output = Result<Amount<C>>;
-
+    type Output = Amount<NegativeAllowed>;
     fn neg(self) -> Self::Output {
-        Amount::<C>::try_from(-self.0)
+        Amount::<NegativeAllowed>::try_from(-self.0)
+            .expect("a negation of any Amount into NegativeAllowed is always valid")
     }
 }
 

--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -326,12 +326,14 @@ where
     }
 }
 
-impl std::ops::Neg for Amount<NegativeAllowed> {
-    type Output = Self;
+impl<C> std::ops::Neg for Amount<C>
+where
+    C: Constraint,
+{
+    type Output = Result<Amount<C>>;
 
     fn neg(self) -> Self::Output {
-        Amount::try_from(-self.0)
-            .expect("a change in sign to any value inside Amount<NegativeAllowed> is always valid")
+        Amount::<C>::try_from(-self.0)
     }
 }
 

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -721,7 +721,7 @@ impl Transaction {
             .sum::<Result<Amount, AmountError>>()?;
 
         Ok(ValueBalance::from_transparent_amount(
-            (input_value_balance - output_value_balance)?,
+            (output_value_balance - input_value_balance)?,
         ))
     }
 

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -778,11 +778,7 @@ impl Transaction {
             .fold(Ok(Amount::zero()), |accumulator, value| {
                 accumulator.and_then(|sum| sum + value)
             })
-            .map(|amount| {
-                ValueBalance::from_sapling_amount((-amount).expect(
-                    "a change in sign to any value inside Amount<NegativeAllowed> is always valid",
-                ))
-            })
+            .map(|amount| ValueBalance::from_sapling_amount(-amount))
     }
 
     /// Return the orchard value balance.
@@ -798,9 +794,7 @@ impl Transaction {
             .map(|o| o.value_balance())
             .sum::<Result<Amount, AmountError>>()?;
 
-        Ok(ValueBalance::from_orchard_amount((-orchard).expect(
-            "a change in sign to any value inside Amount<NegativeAllowed> is always valid",
-        )))
+        Ok(ValueBalance::from_orchard_amount(-orchard))
     }
 
     /// Get all the value balances for this transaction.

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -778,7 +778,11 @@ impl Transaction {
             .fold(Ok(Amount::zero()), |accumulator, value| {
                 accumulator.and_then(|sum| sum + value)
             })
-            .map(|amount| ValueBalance::from_sapling_amount(-amount))
+            .map(|amount| {
+                ValueBalance::from_sapling_amount((-amount).expect(
+                    "a change in sign to any value inside Amount<NegativeAllowed> is always valid",
+                ))
+            })
     }
 
     /// Return the orchard value balance.
@@ -794,7 +798,9 @@ impl Transaction {
             .map(|o| o.value_balance())
             .sum::<Result<Amount, AmountError>>()?;
 
-        Ok(ValueBalance::from_orchard_amount(-orchard))
+        Ok(ValueBalance::from_orchard_amount((-orchard).expect(
+            "a change in sign to any value inside Amount<NegativeAllowed> is always valid",
+        )))
     }
 
     /// Get all the value balances for this transaction.

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -31,8 +31,8 @@ where
         // Calculated in Zebra by negating the sum of the transparent, sprout,
         // sapling, and orchard value balances as specified in
         // https://zebra.zfnd.org/dev/rfcs/0012-value-pools.html#definitions
-        (-(self.transparent + self.sprout + self.sapling + self.orchard)?)?
-            .constrain::<NonNegative>()
+        let value = (self.transparent + self.sprout + self.sapling + self.orchard)?;
+        (-(value)).constrain::<NonNegative>()
     }
 
     /// Creates a [`ValueBalance`] from the given transparent amount.

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -1,6 +1,6 @@
 //! A type that can hold the four types of Zcash value pools.
 
-use crate::amount::{Amount, Constraint, Error, NegativeAllowed, NonNegative};
+use crate::amount::{Amount, Constraint, Error, NonNegative};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 mod arbitrary;
@@ -28,15 +28,11 @@ where
     ///
     /// [Consensus rule]: https://zips.z.cash/protocol/protocol.pdf#transactions
     pub fn remaining_transaction_value(&self) -> Result<Amount<NonNegative>, Error> {
-        // This rule checks the transparent value balance minus the sum of the sprout,
-        // sapling, and orchard value balances in a transaction is nonnegative.
         // Calculated in Zebra by negating the sum of the transparent, sprout,
         // sapling, and orchard value balances as specified in
         // https://zebra.zfnd.org/dev/rfcs/0012-value-pools.html#definitions
-        let amount = -(self.transparent + self.sprout + self.sapling + self.orchard)?
-            .constrain::<NegativeAllowed>()?;
-
-        amount.constrain::<NonNegative>()
+        (-(self.transparent + self.sprout + self.sapling + self.orchard)?)?
+            .constrain::<NonNegative>()
     }
 
     /// Creates a [`ValueBalance`] from the given transparent amount.


### PR DESCRIPTION
## Motivation

We changed the design of the value pools RFC to change some signs.

[#2555 (comment)](https://github.com/ZcashFoundation/zebra/pull/2555#discussion_r680639894)
[#2555 (comment)](https://github.com/ZcashFoundation/zebra/pull/2555#discussion_r680640057)

### Designs

Part of https://zebra.zfnd.org/dev/rfcs/0012-value-pools.html

## Solution

Change the signs needed.

## Review

@teor2345

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2569)
<!-- Reviewable:end -->
