### PR TITLE
Decrease `DEFAULT_NULLIFIER_PROPTEST_CASES`

### DIFF
--- a/zebra-state/src/service/check/tests/nullifier.rs
+++ b/zebra-state/src/service/check/tests/nullifier.rs
@@ -34,7 +34,7 @@ use crate::{
 // because we're only interested in spend validation,
 // (and passing various other state checks).
 
-const DEFAULT_NULLIFIER_PROPTEST_CASES: u32 = 16;
+const DEFAULT_NULLIFIER_PROPTEST_CASES: u32 = 2;
 
 proptest! {
     #![proptest_config(


### PR DESCRIPTION
## Motivation

We want to reduce the amount of time the nullifier tests are taking.

## Solution

Reduce the `DEFAULT_NULLIFIER_PROPTEST_CASES` from 16 to 2.

## Review

Anyone can review

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

[add ticket for the other test cases taking too long]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2574)
<!-- Reviewable:end -->
