### PR TITLE
Add extra arithmetic operations and error details to Amount and ValueBalance

### DIFF
--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -403,8 +403,8 @@ where
 pub enum Error {
     /// input {value} is outside of valid range for zatoshi Amount, valid_range={range:?}
     Contains {
-        range: RangeInclusive<i64>,
         value: i64,
+        range: RangeInclusive<i64>,
     },
 
     /// {value} could not be converted to an i64 Amount
@@ -482,7 +482,7 @@ pub trait Constraint {
         let range = Self::valid_range();
 
         if !range.contains(&value) {
-            Err(Error::Contains { range, value })
+            Err(Error::Contains { value, range })
         } else {
             Ok(value)
         }

--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -363,14 +363,16 @@ impl<C> std::iter::Sum<Amount<C>> for Result<Amount<C>>
 where
     C: Constraint,
 {
-    fn sum<I: Iterator<Item = Amount<C>>>(iter: I) -> Self {
-        let sum = iter
-            .map(|a| a.0)
-            .try_fold(0i64, |acc, amount| acc.checked_add(amount));
+    fn sum<I: Iterator<Item = Amount<C>>>(mut iter: I) -> Self {
+        let sum = iter.try_fold(Amount::zero(), |acc, amount| acc + amount);
 
         match sum {
-            Some(sum) => Amount::try_from(sum),
-            None => Err(Error::SumOverflow),
+            Ok(sum) => Ok(sum),
+            Err(Error::Contains { value, .. }) => Err(Error::SumOverflow {
+                partial_sum: value,
+                remaining_items: iter.count(),
+            }),
+            Err(unexpected_error) => unreachable!("unexpected Add error: {:?}", unexpected_error),
         }
     }
 }
@@ -421,8 +423,11 @@ pub enum Error {
     /// cannot divide amount {amount} by zero
     DivideByZero { amount: i64 },
 
-    /// i64 overflow when summing i64 amounts
-    SumOverflow,
+    /// i64 overflow when summing i64 amounts, partial_sum: {partial_sum}, remaining items: {remaining_items}
+    SumOverflow {
+        partial_sum: i64,
+        remaining_items: usize,
+    },
 }
 
 /// Marker type for `Amount` that allows negative values.
@@ -828,9 +833,9 @@ mod test {
         assert_eq!(sum_ref, sum_value);
         assert_eq!(
             sum_ref,
-            Err(Error::Contains {
-                range: -MAX_MONEY..=MAX_MONEY,
-                value: integer_sum,
+            Err(Error::SumOverflow {
+                partial_sum: integer_sum,
+                remaining_items: 0
             })
         );
 
@@ -845,9 +850,9 @@ mod test {
         assert_eq!(sum_ref, sum_value);
         assert_eq!(
             sum_ref,
-            Err(Error::Contains {
-                range: -MAX_MONEY..=MAX_MONEY,
-                value: integer_sum,
+            Err(Error::SumOverflow {
+                partial_sum: integer_sum,
+                remaining_items: 0
             })
         );
 
@@ -863,7 +868,13 @@ mod test {
         let sum_value = amounts.into_iter().sum::<Result<Amount, Error>>();
 
         assert_eq!(sum_ref, sum_value);
-        assert_eq!(sum_ref, Err(Error::SumOverflow));
+        assert_eq!(
+            sum_ref,
+            Err(Error::SumOverflow {
+                partial_sum: 4200000000000000,
+                remaining_items: 4391
+            })
+        );
 
         // below min of i64 overflow
         let times: usize = (i64::MAX / MAX_MONEY)
@@ -877,7 +888,13 @@ mod test {
         let sum_value = amounts.into_iter().sum::<Result<Amount, Error>>();
 
         assert_eq!(sum_ref, sum_value);
-        assert_eq!(sum_ref, Err(Error::SumOverflow));
+        assert_eq!(
+            sum_ref,
+            Err(Error::SumOverflow {
+                partial_sum: -4200000000000000,
+                remaining_items: 4391
+            })
+        );
 
         Ok(())
     }

--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -368,7 +368,7 @@ where
 
         match sum {
             Ok(sum) => Ok(sum),
-            Err(Error::Contains { value, .. }) => Err(Error::SumOverflow {
+            Err(Error::Constraint { value, .. }) => Err(Error::SumOverflow {
                 partial_sum: value,
                 remaining_items: iter.count(),
             }),
@@ -402,7 +402,7 @@ where
 /// Errors that can be returned when validating `Amount`s
 pub enum Error {
     /// input {value} is outside of valid range for zatoshi Amount, valid_range={range:?}
-    Contains {
+    Constraint {
         value: i64,
         range: RangeInclusive<i64>,
     },
@@ -482,7 +482,7 @@ pub trait Constraint {
         let range = Self::valid_range();
 
         if !range.contains(&value) {
-            Err(Error::Contains { value, range })
+            Err(Error::Constraint { value, range })
         } else {
             Ok(value)
         }

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -11,7 +11,7 @@ mod arbitrary;
 mod tests;
 
 /// An amount spread between different Zcash pools.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ValueBalance<C> {
     transparent: Amount<C>,
     sprout: Amount<C>,

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -131,6 +131,20 @@ where
         }
     }
 
+    /// Convert this value balance to a different ValueBalance type,
+    /// if it satisfies the new constraint
+    pub fn constrain<C2>(self) -> Result<ValueBalance<C2>, ValueBalanceError>
+    where
+        C2: Constraint,
+    {
+        Ok(ValueBalance::<C2> {
+            transparent: self.transparent.constrain()?,
+            sprout: self.sprout.constrain()?,
+            sapling: self.sapling.constrain()?,
+            orchard: self.orchard.constrain()?,
+        })
+    }
+
     /// To byte array
     pub fn to_bytes(self) -> [u8; 32] {
         let transparent = self.transparent.to_bytes();
@@ -177,7 +191,7 @@ where
     }
 }
 
-#[derive(thiserror::Error, Debug, Clone, PartialEq)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 /// Errors that can be returned when validating a [`ValueBalance`].
 pub enum ValueBalanceError {
     #[error("value balance contains invalid amounts")]

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -1,6 +1,6 @@
 //! A type that can hold the four types of Zcash value pools.
 
-use crate::amount::{Amount, Constraint, Error, NonNegative};
+use crate::amount::{Amount, Constraint, Error, NegativeAllowed, NonNegative};
 
 use std::convert::TryInto;
 
@@ -269,5 +269,21 @@ where
 {
     fn sum<I: Iterator<Item = &'amt ValueBalance<C>>>(iter: I) -> Self {
         iter.copied().sum()
+    }
+}
+
+impl<C> std::ops::Neg for ValueBalance<C>
+where
+    C: Constraint,
+{
+    type Output = ValueBalance<NegativeAllowed>;
+
+    fn neg(self) -> Self::Output {
+        ValueBalance::<NegativeAllowed> {
+            transparent: self.transparent.neg(),
+            sprout: self.sprout.neg(),
+            sapling: self.sapling.neg(),
+            orchard: self.orchard.neg(),
+        }
     }
 }

--- a/zebra-chain/src/value_balance/tests/prop.rs
+++ b/zebra-chain/src/value_balance/tests/prop.rs
@@ -29,7 +29,11 @@ proptest! {
             ),
             _ => prop_assert!(
                 matches!(
-                    value_balance1 + value_balance2, Err(ValueBalanceError::AmountError(_))
+                    value_balance1 + value_balance2,
+                    Err(ValueBalanceError::Transparent(_)
+                        | ValueBalanceError::Sprout(_)
+                        | ValueBalanceError::Sapling(_)
+                        | ValueBalanceError::Orchard(_))
                 )
             ),
         }
@@ -58,7 +62,11 @@ proptest! {
             ),
             _ => prop_assert!(
                 matches!(
-                    value_balance1 - value_balance2, Err(ValueBalanceError::AmountError(_))
+                    value_balance1 - value_balance2,
+                    Err(ValueBalanceError::Transparent(_)
+                        | ValueBalanceError::Sprout(_)
+                        | ValueBalanceError::Sapling(_)
+                        | ValueBalanceError::Orchard(_))
                 )
             ),
         }
@@ -88,7 +96,12 @@ proptest! {
                     orchard,
                 })
             ),
-            _ => prop_assert!(matches!(collection.iter().sum(), Err(ValueBalanceError::AmountError(_))))
+            _ => prop_assert!(matches!(collection.iter().sum(),
+                                       Err(ValueBalanceError::Transparent(_)
+                                           | ValueBalanceError::Sprout(_)
+                                           | ValueBalanceError::Sapling(_)
+                                           | ValueBalanceError::Orchard(_))
+            ))
         }
     }
 


### PR DESCRIPTION
## Motivation

To modify generated amounts, we need some extra operations on `Amount` and `ValueBalance`.
We also need to extend existing operations to both `NonNegative` and `NegativeAllowed` amounts.

This is part of tickets #2381 and #1895, but it doesn't close those tickets.

## Solution

Amount
- extend `Ord` to cover `NonNegative` amounts
  - we could allow comparing `NegativeAllowed` and `NonNegative`, but I haven't needed that yet, and it doesn't match how `i64` to `u64` comparisons work in Rust
- extend `Mul` to cover `NegativeAllowed`
  - `impl TryFrom<i128> for Amount<C>`
    - put `TryFrom` impls in integer size order
- extend `Div` to cover `NonNegative`
- impl `Eq` for all amounts

amount::Error

- rename an amount::Error variant to Constraint, so it's clearer
- add extra detail to some errors
- make some amount arithmetic expectations explicit, rather than using `as` or an unchecked operator
- make amount::Error field order consistent
- derive `Eq` for `amount::Error`

ValueBalance & ValueBalanceError

- implement `ValueBalance::constrain`
- impl `Neg` for `ValueBalance`
- add specific pool variants to `ValueBalanceError`
- derive `Eq` for `ValueBalance` and `ValueBalanceError`

## Review

@oxarbitrage and I are working on implementing value pools.

### Reviewer Checklist

  - [ ] Code makes sense

This code will be tested once the rest of PR #2566 is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2577)
<!-- Reviewable:end -->
