### PR TITLE
Add test-only methods for modifying orchard shielded data and joinsplits

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -638,7 +638,7 @@ impl Transaction {
 
     // orchard
 
-    /// Access the [`orchard::ShieldedData`] in this transaction, if there are any,
+    /// Access the [`orchard::ShieldedData`] in this transaction,
     /// regardless of version.
     pub fn orchard_shielded_data(&self) -> Option<&orchard::ShieldedData> {
         match self {
@@ -653,6 +653,27 @@ impl Transaction {
             | Transaction::V2 { .. }
             | Transaction::V3 { .. }
             | Transaction::V4 { .. } => None,
+        }
+    }
+
+    /// Modify the [`orchard::ShieldedData`] in this transaction,
+    /// regardless of version.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn orchard_shielded_data_mut(&mut self) -> Option<&mut orchard::ShieldedData> {
+        match self {
+            Transaction::V5 {
+                orchard_shielded_data: Some(orchard_shielded_data),
+                ..
+            } => Some(orchard_shielded_data),
+
+            Transaction::V1 { .. }
+            | Transaction::V2 { .. }
+            | Transaction::V3 { .. }
+            | Transaction::V4 { .. }
+            | Transaction::V5 {
+                orchard_shielded_data: None,
+                ..
+            } => None,
         }
     }
 
@@ -690,7 +711,8 @@ impl Transaction {
             .map(|orchard_shielded_data| orchard_shielded_data.flags)
     }
 
-    /// Return if the transaction has any Orchard shielded data.
+    /// Return if the transaction has any Orchard shielded data,
+    /// regardless of version.
     pub fn has_orchard_shielded_data(&self) -> bool {
         self.orchard_shielded_data().is_some()
     }

--- a/zebra-chain/src/transaction/joinsplit.rs
+++ b/zebra-chain/src/transaction/joinsplit.rs
@@ -53,6 +53,13 @@ impl<P: ZkSnarkProof> JoinSplitData<P> {
         std::iter::once(&self.first).chain(self.rest.iter())
     }
 
+    /// Modify the [`JoinSplit`]s in `self`,
+    /// in the order they appear in the transaction.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn joinsplits_mut(&mut self) -> impl Iterator<Item = &mut JoinSplit<P>> {
+        std::iter::once(&mut self.first).chain(self.rest.iter_mut())
+    }
+
     /// Iterate over the [`Nullifier`]s in `self`.
     pub fn nullifiers(&self) -> impl Iterator<Item = &Nullifier> {
         self.joinsplits()


### PR DESCRIPTION
## Motivation

To modify generated transactions, we need to create replacement sprout and orchard data.

This is part of tickets #2381 and #1895, but it doesn't close those tickets.

## Solution

- add a test-only method for modifying sprout joinsplits
- add a test-only method for modifying orchard shielded data

## Review

@oxarbitrage and I are working on the value pools implementation together.

### Reviewer Checklist

  - [ ] Code makes sense

This code will be tested once the rest of PR #2566 is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2580)
<!-- Reviewable:end -->
