### PR TITLE
Increase timeout of cached database creation

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -879,8 +879,8 @@ where
     P: FnOnce(&mut TestChild<PathBuf>) -> Result<()>,
 {
     println!("Creating cached database");
-    // 8 hours
-    let timeout = Duration::from_secs(60 * 60 * 8);
+    // 16 hours
+    let timeout = Duration::from_secs(60 * 60 * 16);
 
     // Use a persistent state, so we can handle large syncs
     let mut config = cached_mandatory_checkpoint_test_config()?;


### PR DESCRIPTION
## Motivation

With the recent changes the test that we use to recreate the cached timeout is reaching its timeout and failing.
It's now taking ~13 hours.

### Specifications

N/A

### Designs

N/A

## Solution

This increases the timeout.

## Review

Anyone can review this. It's not urgent because we can just re-run the test and it will keep syncing, but it's cumbersome.

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2581)
<!-- Reviewable:end -->
