### PR TITLE
Generate test chains with valid chain value pools

### DIFF
--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -18,13 +18,16 @@ use crate::{
     },
     serialization,
     transaction::arbitrary::MAX_ARBITRARY_ITEMS,
-    transparent::{new_transaction_ordered_outputs, CoinbaseSpendRestriction},
+    transparent::{
+        new_transaction_ordered_outputs, CoinbaseSpendRestriction,
+        MIN_TRANSPARENT_COINBASE_MATURITY,
+    },
     work::{difficulty::CompactDifficulty, equihash},
 };
 
 use super::*;
 
-/// The chain length for zebra-chain proptests.
+/// The chain length for most zebra-chain proptests.
 ///
 /// Most generated chains will contain transparent spends at or before this height.
 ///
@@ -43,6 +46,17 @@ use super::*;
 ///
 /// To increase the proportion of test runs with proptest spends, increase `PREVOUTS_CHAIN_HEIGHT`.
 pub const PREVOUTS_CHAIN_HEIGHT: usize = 4;
+
+/// The chain length for most zebra-state proptests.
+///
+/// Most generated chains will contain transparent spends at or before this height.
+///
+/// This height was chosen as a tradeoff between chains with no transparent spends,
+/// and chains which spend outputs created by previous spends.
+///
+/// See [`block::arbitrary::PREVOUTS_CHAIN_HEIGHT`] for details.
+pub const MAX_PARTIAL_CHAIN_BLOCKS: usize =
+    MIN_TRANSPARENT_COINBASE_MATURITY as usize + PREVOUTS_CHAIN_HEIGHT;
 
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -508,40 +508,6 @@ impl Transaction {
 
         Ok(remaining_transaction_value)
     }
-
-    /// Fixup non-coinbase transparent values and shielded value balances.
-    /// See `fix_remaining_value` for details.
-    ///
-    /// `utxos` must contain all the [`Utxo`]s spent in this block.
-    ///
-    /// # Panics
-    ///
-    /// If any spent [`Utxo`] is missing from `utxos`.
-    #[allow(dead_code)]
-    pub fn fix_remaining_value_from_utxos(
-        &mut self,
-        utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
-    ) -> Result<Amount<NonNegative>, ValueBalanceError> {
-        self.fix_remaining_value(&outputs_from_utxos(utxos.clone()))
-    }
-
-    /// Fixup non-coinbase transparent values and shielded value balances.
-    /// See `fix_remaining_value` for details.
-    ///
-    /// `ordered_utxos` must contain all the [`OrderedUtxo`]s spent in this block.
-    ///
-    /// # Panics
-    ///
-    /// If any spent [`OrderedUtxo`] is missing from `ordered_utxos`.
-    #[allow(dead_code)]
-    pub fn fix_remaining_value_from_ordered_utxos(
-        &mut self,
-        ordered_utxos: &HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
-    ) -> Result<Amount<NonNegative>, ValueBalanceError> {
-        self.fix_remaining_value(&outputs_from_utxos(utxos_from_ordered_utxos(
-            ordered_utxos.clone(),
-        )))
-    }
 }
 
 impl Arbitrary for Memo {

--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -35,6 +35,15 @@ use crate::{
 
 use std::{collections::HashMap, iter};
 
+/// The maturity threshold for transparent coinbase outputs.
+///
+/// "A transaction MUST NOT spend a transparent output of a coinbase transaction
+/// from a block less than 100 blocks prior to the spend. Note that transparent
+/// outputs of coinbase transactions include Founders' Reward outputs and
+/// transparent Funding Stream outputs."
+/// [7.1](https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus)
+pub const MIN_TRANSPARENT_COINBASE_MATURITY: u32 = 100;
+
 /// Arbitrary data inserted by miners into a coinbase transaction.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CoinbaseData(

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -1,13 +1,6 @@
 //! Definitions of constants.
 
-/// The maturity threshold for transparent coinbase outputs.
-///
-/// "A transaction MUST NOT spend a transparent output of a coinbase transaction
-/// from a block less than 100 blocks prior to the spend. Note that transparent
-/// outputs of coinbase transactions include Founders' Reward outputs and
-/// transparent Funding Stream outputs."
-/// [7.1](https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus)
-pub const MIN_TRANSPARENT_COINBASE_MATURITY: u32 = 100;
+pub use zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
 
 /// The maximum chain reorganisation height.
 ///

--- a/zebra-state/src/service/arbitrary.rs
+++ b/zebra-state/src/service/arbitrary.rs
@@ -8,27 +8,15 @@ use proptest::{
 };
 
 use zebra_chain::{
-    block::{self, Block},
-    fmt::SummaryDebug,
-    history_tree::HistoryTree,
-    parameters::NetworkUpgrade,
+    block::Block, fmt::SummaryDebug, history_tree::HistoryTree, parameters::NetworkUpgrade,
     LedgerState,
 };
 
-use crate::{arbitrary::Prepare, constants};
+use crate::arbitrary::Prepare;
 
 use super::*;
 
-/// The chain length for state proptests.
-///
-/// Most generated chains will contain transparent spends at or before this height.
-///
-/// This height was chosen as a tradeoff between chains with no transparent spends,
-/// and chains which spend outputs created by previous spends.
-///
-/// See [`block::arbitrary::PREVOUTS_CHAIN_HEIGHT`] for details.
-pub const MAX_PARTIAL_CHAIN_BLOCKS: usize =
-    constants::MIN_TRANSPARENT_COINBASE_MATURITY as usize + block::arbitrary::PREVOUTS_CHAIN_HEIGHT;
+pub use zebra_chain::block::arbitrary::MAX_PARTIAL_CHAIN_BLOCKS;
 
 #[derive(Debug)]
 pub struct PreparedChainTree {


### PR DESCRIPTION
## Motivation

Zebra needs to generate test chains with valid chain value pools, so it can pass existing tests, and test chain value pool validation.

## Solution

- Add a `fix_chain_value_pools` method in `transaction::arbitrary`
- Use this method to fix and update the chain value pools for generated chains in `block::arbitrary`
- Reduce scaling workaround, so it's based on the actual number of blocks and transactions in the tests
- Split `fix_remaining_value` into smaller methods
- Remove unused methods

This is part of ticket #1895, but doesn't close that ticket.

## Review

@oxarbitrage can review this PR, it blocks testing for PR #2599.

### Reviewer Checklist

  - [x] Code makes sense
  - [x] Documentation makes sense
  - [x] Existing tests pass

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2597)
<!-- Reviewable:end -->
