### PR TITLE
Sync to, not past, activation for regenerate-stateful-test-disks.yml

### DIFF
--- a/.github/workflows/regenerate-stateful-test-disks.yml
+++ b/.github/workflows/regenerate-stateful-test-disks.yml
@@ -2,6 +2,9 @@ name: Regenerate test state
 
 on:
   workflow_dispatch:
+    inputs:
+      network:
+        default: 'mainnet'
 
 env:
   PROJECT_ID: zealous-zebra
@@ -48,11 +51,9 @@ jobs:
           --boot-disk-size 100GB \
           --boot-disk-type pd-ssd \
           --container-image rust:buster \
-          --container-mount-disk mount-path='/mainnet',name="zebrad-cache-$SHORT_SHA-mainnet-1046400" \
-          --container-mount-disk mount-path='/testnet',name="zebrad-cache-$SHORT_SHA-testnet-1028500" \
+          --container-mount-disk mount-path='/${{ github.event.inputs.network }}',name="zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}" \
           --container-restart-policy never \
-          --create-disk name="zebrad-cache-$SHORT_SHA-mainnet-1046400",size=100GB,type=pd-balanced,auto-delete=no \
-          --create-disk name="zebrad-cache-$SHORT_SHA-testnet-1028500",size=100GB,type=pd-balanced,auto-delete=no \
+          --create-disk name="zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}",size=100GB,type=pd-balanced,auto-delete=no \
           --machine-type n2-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
@@ -65,8 +66,7 @@ jobs:
           "git clone -b $BRANCH_NAME https://github.com/ZcashFoundation/zebra.git &&
           cd zebra/ &&
           docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test . &&
-          docker run -i -e "ZEBRA_SKIP_IPV6_TESTS=1" --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-1046400,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_mandatory_checkpoint_mainnet --manifest-path zebrad/Cargo.toml sync_to_mandatory_checkpoint_mainnet &&
-          docker run -i -e "ZEBRA_SKIP_IPV6_TESTS=1" --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-testnet-1028500,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_mandatory_checkpoint_testnet --manifest-path zebrad/Cargo.toml sync_to_mandatory_checkpoint_testnet;
+          docker run -i -e "ZEBRA_SKIP_IPV6_TESTS=1" --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }},target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_mandatory_checkpoint_${{ github.event.inputs.network }} --manifest-path zebrad/Cargo.toml sync_to_mandatory_checkpoint_${{ github.event.inputs.network }};
           "
       # Clean up
       - name: Delete test instance

--- a/.github/workflows/regenerate-stateful-test-disks.yml
+++ b/.github/workflows/regenerate-stateful-test-disks.yml
@@ -59,8 +59,9 @@ jobs:
           --scopes cloud-platform \
           --tags zebrad \
           --zone "$ZONE"
-      # Build and run test container to sync up to activation and no further, for mainnet and then testnet
+      # Build and run test container to sync up to activation and no further
       - name: Regenerate state for tests
+        id: regenerate-state
         run: |
           gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --zone "$ZONE" --command \
           "git clone -b $BRANCH_NAME https://github.com/ZcashFoundation/zebra.git &&
@@ -68,6 +69,12 @@ jobs:
           docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test . &&
           docker run -i -e "ZEBRA_SKIP_IPV6_TESTS=1" --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }},target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_mandatory_checkpoint_${{ github.event.inputs.network }} --manifest-path zebrad/Cargo.toml sync_to_mandatory_checkpoint_${{ github.event.inputs.network }};
           "
+      # Create image from disk that will be used in test.yml workflow
+      - name: Create image from state disk
+        # Only run if the earlier step succeeds
+        if: steps.regenerate-state.outcome == 'success'
+        run: |
+          gcloud compute images create "zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}" --source-disk="zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}" --source-disk-zone="$ZONE"
       # Clean up
       - name: Delete test instance
         # Always run even if the earlier step fails

--- a/.github/workflows/regenerate-stateful-test-disks.yml
+++ b/.github/workflows/regenerate-stateful-test-disks.yml
@@ -51,30 +51,30 @@ jobs:
           --boot-disk-size 100GB \
           --boot-disk-type pd-ssd \
           --container-image rust:buster \
-          --container-mount-disk mount-path='/${{ github.event.inputs.network }}',name="zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}" \
+          --container-mount-disk mount-path='/${{ github.event.inputs.network }}',name="zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}-canopy" \
           --container-restart-policy never \
-          --create-disk name="zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}",size=100GB,type=pd-balanced,auto-delete=no \
+          --create-disk name="zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}-canopy",size=100GB,type=pd-balanced,auto-delete=no \
           --machine-type n2-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
           --tags zebrad \
           --zone "$ZONE"
       # Build and run test container to sync up to activation and no further
-      - name: Regenerate state for tests
-        id: regenerate-state
-        run: |
-          gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --zone "$ZONE" --command \
-          "git clone -b $BRANCH_NAME https://github.com/ZcashFoundation/zebra.git &&
-          cd zebra/ &&
-          docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test . &&
-          docker run -i -e "ZEBRA_SKIP_IPV6_TESTS=1" --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }},target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_mandatory_checkpoint_${{ github.event.inputs.network }} --manifest-path zebrad/Cargo.toml sync_to_mandatory_checkpoint_${{ github.event.inputs.network }};
-          "
+      #- name: Regenerate state for tests
+      #  id: regenerate-state
+      #  run: |
+      #    gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --zone "$ZONE" --command \
+      #    "git clone -b $BRANCH_NAME https://github.com/ZcashFoundation/zebra.git &&
+      #    cd zebra/ &&
+      #    docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test . &&
+      #    docker run -i -e "ZEBRA_SKIP_IPV6_TESTS=1" --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}-canopy,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_mandatory_checkpoint_${{ github.event.inputs.network }} --manifest-path zebrad/Cargo.toml sync_to_mandatory_checkpoint_${{ github.event.inputs.network }};
+      #    "
       # Create image from disk that will be used in test.yml workflow
       - name: Create image from state disk
         # Only run if the earlier step succeeds
-        if: steps.regenerate-state.outcome == 'success'
+      # if: steps.regenerate-state.outcome == 'success'
         run: |
-          gcloud compute images create "zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}" --source-disk="zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}" --source-disk-zone="$ZONE"
+          gcloud compute images create "zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}-canopy" --source-disk="zebrad-cache-9121ae2-mainnet" --source-disk-zone="$ZONE"
       # Clean up
       - name: Delete test instance
         # Always run even if the earlier step fails

--- a/.github/workflows/regenerate-stateful-test-disks.yml
+++ b/.github/workflows/regenerate-stateful-test-disks.yml
@@ -53,31 +53,31 @@ jobs:
           --container-image rust:buster \
           --container-mount-disk mount-path='/${{ github.event.inputs.network }}',name="zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}-canopy" \
           --container-restart-policy never \
-          --create-disk name="zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}-canopy",size=100GB,type=pd-balanced,auto-delete=no \
+          --create-disk name="zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}-canopy",size=100GB,type=pd-balanced \
           --machine-type n2-standard-4 \
           --service-account cos-vm@zealous-zebra.iam.gserviceaccount.com \
           --scopes cloud-platform \
           --tags zebrad \
           --zone "$ZONE"
       # Build and run test container to sync up to activation and no further
-      #- name: Regenerate state for tests
-      #  id: regenerate-state
-      #  run: |
-      #    gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --zone "$ZONE" --command \
-      #    "git clone -b $BRANCH_NAME https://github.com/ZcashFoundation/zebra.git &&
-      #    cd zebra/ &&
-      #    docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test . &&
-      #    docker run -i -e "ZEBRA_SKIP_IPV6_TESTS=1" --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}-canopy,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_mandatory_checkpoint_${{ github.event.inputs.network }} --manifest-path zebrad/Cargo.toml sync_to_mandatory_checkpoint_${{ github.event.inputs.network }};
-      #    "
+      - name: Regenerate state for tests
+        id: regenerate-state
+        run: |
+          gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --zone "$ZONE" --command \
+          "git clone -b $BRANCH_NAME https://github.com/ZcashFoundation/zebra.git &&
+          cd zebra/ &&
+          docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test . &&
+          docker run -i -e "ZEBRA_SKIP_IPV6_TESTS=1" --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}-canopy,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_mandatory_checkpoint_${{ github.event.inputs.network }} --manifest-path zebrad/Cargo.toml sync_to_mandatory_checkpoint_${{ github.event.inputs.network }};
+          "
       # Create image from disk that will be used in test.yml workflow
       - name: Create image from state disk
         # Only run if the earlier step succeeds
-      # if: steps.regenerate-state.outcome == 'success'
+        if: steps.regenerate-state.outcome == 'success'
         run: |
-          gcloud compute images create "zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}-canopy" --source-disk="zebrad-cache-9121ae2-mainnet" --source-disk-zone="$ZONE"
+          gcloud compute images create "zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}-canopy" --source-disk="zebrad-cache-$SHORT_SHA-${{ github.event.inputs.network }}-canopy" --source-disk-zone="$ZONE"
       # Clean up
       - name: Delete test instance
         # Always run even if the earlier step fails
         if: ${{ always() }}
         run: |
-          gcloud compute instances delete "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --delete-disks boot --zone "$ZONE"
+          gcloud compute instances delete "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --delete-disks all --zone "$ZONE"

--- a/.github/workflows/regenerate-stateful-test-disks.yml
+++ b/.github/workflows/regenerate-stateful-test-disks.yml
@@ -59,14 +59,14 @@ jobs:
           --tags zebrad \
           --zone "$ZONE"
       # Build and run test container to sync up to activation and no further, for mainnet and then testnet
-      - name: Run all tests
+      - name: Regenerate state for tests
         run: |
           gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --zone "$ZONE" --command \
           "git clone -b $BRANCH_NAME https://github.com/ZcashFoundation/zebra.git &&
           cd zebra/ &&
           docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test . &&
-          docker run -i -e "ZEBRA_SKIP_IPV6_TESTS=1" --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-1046400,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_past_mandatory_checkpoint_mainnet --manifest-path zebrad/Cargo.toml sync_past_mandatory_checkpoint_mainnet &&
-          docker run -i -e "ZEBRA_SKIP_IPV6_TESTS=1" --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-testnet-1028500,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_past_mandatory_checkpoint_testnet --manifest-path zebrad/Cargo.toml sync_past_mandatory_checkpoint_testnet;
+          docker run -i -e "ZEBRA_SKIP_IPV6_TESTS=1" --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-1046400,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_mandatory_checkpoint_mainnet --manifest-path zebrad/Cargo.toml sync_to_mandatory_checkpoint_mainnet &&
+          docker run -i -e "ZEBRA_SKIP_IPV6_TESTS=1" --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-testnet-1028500,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_to_mandatory_checkpoint_testnet --manifest-path zebrad/Cargo.toml sync_to_mandatory_checkpoint_testnet;
           "
       # Clean up
       - name: Delete test instance


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

The `regenerate-stateful-test-disks.yml` workflow was syncing past, not to, the latest network upgrade.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

s/`sync_past`/`sync_to`/g

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

## Follow Up Work

<!--
Is there anything missing from the solution?
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2601)
<!-- Reviewable:end -->
