### PR TITLE
ZIP-221 and ZIP-244 commitment validation in non-finalized state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4639,6 +4639,7 @@ name = "zebra-state"
 version = "1.0.0-alpha.14"
 dependencies = [
  "bincode",
+ "blake2b_simd",
  "chrono",
  "color-eyre",
  "dirs",

--- a/zebra-chain/src/block/commitment.rs
+++ b/zebra-chain/src/block/commitment.rs
@@ -169,6 +169,18 @@ impl From<ChainHistoryMmrRootHash> for [u8; 32] {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ChainHistoryBlockTxAuthCommitmentHash([u8; 32]);
 
+impl From<[u8; 32]> for ChainHistoryBlockTxAuthCommitmentHash {
+    fn from(hash: [u8; 32]) -> Self {
+        ChainHistoryBlockTxAuthCommitmentHash(hash)
+    }
+}
+
+impl From<ChainHistoryBlockTxAuthCommitmentHash> for [u8; 32] {
+    fn from(hash: ChainHistoryBlockTxAuthCommitmentHash) -> Self {
+        hash.0
+    }
+}
+
 /// Errors that can occur when checking RootHash consensus rules.
 ///
 /// Each error variant corresponds to a consensus rule, so enumerating

--- a/zebra-chain/src/block/merkle.rs
+++ b/zebra-chain/src/block/merkle.rs
@@ -155,6 +155,18 @@ impl fmt::Debug for AuthDataRoot {
     }
 }
 
+impl From<[u8; 32]> for AuthDataRoot {
+    fn from(hash: [u8; 32]) -> Self {
+        AuthDataRoot(hash)
+    }
+}
+
+impl From<AuthDataRoot> for [u8; 32] {
+    fn from(hash: AuthDataRoot) -> Self {
+        hash.0
+    }
+}
+
 impl<T> std::iter::FromIterator<T> for AuthDataRoot
 where
     T: std::convert::AsRef<Transaction>,

--- a/zebra-chain/src/history_tree.rs
+++ b/zebra-chain/src/history_tree.rs
@@ -481,6 +481,11 @@ impl HistoryTree {
         };
         Ok(())
     }
+
+    /// Return the hash of the tree root if the tree is not empty.
+    pub fn hash(&self) -> Option<ChainHistoryMmrRootHash> {
+        Some(self.0.as_ref()?.hash())
+    }
 }
 
 impl From<NonEmptyHistoryTree> for HistoryTree {

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -32,6 +32,7 @@ rlimit = "0.5.4"
 # TODO: this crate is not maintained anymore. Replace it?
 # https://github.com/ZcashFoundation/zebra/issues/2523
 multiset = "0.0.5"
+blake2b_simd = "0.5.11"
 
 proptest = { version = "0.10.1", optional = true }
 zebra-test = { path = "../zebra-test/", optional = true }

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -188,6 +188,9 @@ pub enum ValidateContextError {
 
     #[error("error building the history tree")]
     HistoryTreeError(#[from] HistoryTreeError),
+
+    #[error("block contains an invalid commitment")]
+    InvalidBlockCommitment(#[from] block::CommitmentError),
 }
 
 /// Trait for creating the corresponding duplicate nullifier error from a nullifier.

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -276,7 +276,7 @@ impl StateService {
         let relevant_chain = self.any_ancestor_blocks(prepared.block.header.previous_block_hash);
 
         // Security: check proof of work before any other checks
-        check::block_is_contextually_valid(
+        check::block_is_valid_for_recent_chain(
             prepared,
             self.network,
             self.disk.finalized_tip_height(),

--- a/zebra-state/src/service/arbitrary.rs
+++ b/zebra-state/src/service/arbitrary.rs
@@ -62,7 +62,9 @@ pub struct PreparedChain {
 
 impl PreparedChain {
     /// Create a PreparedChain strategy with Heartwood-onward blocks.
-    #[cfg(test)]
+    // dead_code is allowed because the function is called only by tests,
+    // but the code is also compiled when proptest-impl is activated.
+    #[allow(dead_code)]
     pub(crate) fn new_heartwood() -> Self {
         // The history tree only works with Heartwood onward.
         // Since the network will be chosen later, we pick the larger

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -102,7 +102,7 @@ where
 
 /// Check that the `prepared` block is contextually valid for `network`, using
 /// the `history_tree` up to and including the previous block.
-#[tracing::instrument(skip(prepared))]
+#[tracing::instrument(skip(prepared, history_tree))]
 pub(crate) fn block_commitment_is_valid_for_chain_history(
     prepared: &PreparedBlock,
     network: Network,

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -1,11 +1,12 @@
 //! Consensus critical contextual checks
 
-use std::borrow::Borrow;
+use std::{borrow::Borrow, convert::TryInto};
 
 use chrono::Duration;
 
 use zebra_chain::{
-    block::{self, Block},
+    block::{self, Block, CommitmentError},
+    history_tree::HistoryTree,
     parameters::POW_AVERAGING_WINDOW,
     parameters::{Network, NetworkUpgrade},
     work::difficulty::CompactDifficulty,
@@ -24,8 +25,11 @@ pub(crate) mod utxo;
 #[cfg(test)]
 mod tests;
 
-/// Check that `block` is contextually valid for `network`, based on the
-/// `finalized_tip_height` and `relevant_chain`.
+/// Check that the `prepared` block is contextually valid for `network`, based
+/// on the `finalized_tip_height` and `relevant_chain`.
+///
+/// This function performs checks that require a small number of recent blocks,
+/// including previous hash, previous height, and block difficulty.
 ///
 /// The relevant chain is an iterator over the ancestors of `block`, starting
 /// with its parent block.
@@ -34,12 +38,8 @@ mod tests;
 ///
 /// If the state contains less than 28
 /// (`POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN`) blocks.
-#[tracing::instrument(
-    name = "contextual_validation",
-    fields(?network),
-    skip(prepared, network, finalized_tip_height, relevant_chain)
-)]
-pub(crate) fn block_is_contextually_valid<C>(
+#[tracing::instrument(skip(prepared, finalized_tip_height, relevant_chain))]
+pub(crate) fn block_is_valid_for_recent_chain<C>(
     prepared: &PreparedBlock,
     network: Network,
     finalized_tip_height: Option<block::Height>,
@@ -98,6 +98,75 @@ where
     )?;
 
     Ok(())
+}
+
+/// Check that the `prepared` block is contextually valid for `network`, using
+/// the `history_tree` up to and including the previous block.
+#[tracing::instrument(skip(prepared))]
+pub(crate) fn block_commitment_is_valid_for_chain_history(
+    prepared: &PreparedBlock,
+    network: Network,
+    history_tree: &HistoryTree,
+) -> Result<(), ValidateContextError> {
+    match prepared.block.commitment(network)? {
+        block::Commitment::PreSaplingReserved(_)
+        | block::Commitment::FinalSaplingRoot(_)
+        | block::Commitment::ChainHistoryActivationReserved => {
+            // No contextual checks needed for those.
+            Ok(())
+        }
+        block::Commitment::ChainHistoryRoot(actual_history_tree_root) => {
+            let history_tree_root = history_tree
+                .hash()
+                .expect("the history tree of the previous block must exist since the current block has a ChainHistoryRoot");
+            if actual_history_tree_root == history_tree_root {
+                Ok(())
+            } else {
+                Err(ValidateContextError::InvalidBlockCommitment(
+                    CommitmentError::InvalidChainHistoryRoot {
+                        actual: actual_history_tree_root.into(),
+                        expected: history_tree_root.into(),
+                    },
+                ))
+            }
+        }
+        block::Commitment::ChainHistoryBlockTxAuthCommitment(actual_hash_block_commitments) => {
+            let actual_block_commitments: [u8; 32] = actual_hash_block_commitments.into();
+            let history_tree_root = history_tree
+                .hash()
+                .expect("the history tree of the previous block must exist since the current block has a ChainHistoryBlockTxAuthCommitment");
+            let auth_data_root = prepared.block.auth_data_root();
+
+            // > The value of this hash [hashBlockCommitments] is the BLAKE2b-256 hash personalized
+            // > by the string "ZcashBlockCommit" of the following elements:
+            // >   hashLightClientRoot (as described in ZIP 221)
+            // >   hashAuthDataRoot    (as described below)
+            // >   terminator          [0u8;32]
+            // https://zips.z.cash/zip-0244#block-header-changes
+            let hash_block_commitments: [u8; 32] = blake2b_simd::Params::new()
+                .hash_length(32)
+                .personal(b"ZcashBlockCommit")
+                .to_state()
+                .update(&<[u8; 32]>::from(history_tree_root)[..])
+                .update(&<[u8; 32]>::from(auth_data_root))
+                .update(&[0u8; 32])
+                .finalize()
+                .as_bytes()
+                .try_into()
+                .expect("32 byte array");
+
+            if actual_block_commitments == hash_block_commitments {
+                Ok(())
+            } else {
+                Err(ValidateContextError::InvalidBlockCommitment(
+                    CommitmentError::InvalidChainHistoryBlockTxAuthCommitment {
+                        actual: actual_block_commitments,
+                        expected: hash_block_commitments,
+                    },
+                ))
+            }
+        }
+    }
 }
 
 /// Returns `ValidateContextError::OrphanedBlock` if the height of the given

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -191,6 +191,11 @@ impl NonFinalizedState {
             &parent_chain.spent_utxos,
             finalized_state,
         )?;
+        check::block_commitment_is_valid_for_chain_history(
+            &prepared,
+            self.network,
+            &parent_chain.history_tree,
+        )?;
 
         parent_chain.push(prepared)
     }

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -17,6 +17,8 @@ pub trait FakeChainHelper {
     fn make_fake_child(&self) -> Arc<Block>;
 
     fn set_work(self, work: u128) -> Arc<Block>;
+
+    fn set_block_commitment(self, commitment: [u8; 32]) -> Arc<Block>;
 }
 
 impl FakeChainHelper for Arc<Block> {
@@ -51,6 +53,12 @@ impl FakeChainHelper for Arc<Block> {
 
         let block = Arc::make_mut(&mut self);
         block.header.difficulty_threshold = expanded.into();
+        self
+    }
+
+    fn set_block_commitment(mut self, block_commitment: [u8; 32]) -> Arc<Block> {
+        let block = Arc::make_mut(&mut self);
+        block.header.commitment_bytes = block_commitment;
         self
     }
 }


### PR DESCRIPTION
## Motivation

ZIP-221 specifies a history tree to which each block must commit to. ZIP-244 expands this commitment to also include the authentication data commitment.

This adds both checks.

### Specifications

https://zips.z.cash/zip-0221#block-header-semantics-and-consensus-rules

![image](https://user-images.githubusercontent.com/35766/129088751-f36e7465-ada0-45d0-9d12-ee3f456d46a3.png)

https://zips.z.cash/zip-0244#block-header-changes

![image](https://user-images.githubusercontent.com/35766/129088905-965b9fb5-24af-4820-874c-add675893673.png)


### Designs

N/A

## Solution

Compute the correct commitment and compare with the commitment in the block header.

The ZIP-244 path is not tested because there aren't post-Nu5 blocks yet and I couldn't come up with a way to test it. Suggestions are welcome.

## Review

https://github.com/ZcashFoundation/zebra/pull/2547 must be reviewed & merged first.

This (hopefully) finishes what we need for minimal validation post-Nu5, so must be reviewed before that.

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [x] Tests for Expected Behaviour
  - [x] Tests for Errors

## Follow Up Work

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2609)
<!-- Reviewable:end -->
