### PR TITLE
Make zebra-state compile successfully by itself

### DIFF
--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -75,7 +75,7 @@ async fn check_transcripts(network: Network) -> Result<(), Report> {
         Network::Mainnet => mainnet_transcript,
         Network::Testnet => testnet_transcript,
     } {
-        let service = zebra_state::init_test(network);
+        let (service, _) = zebra_state::init(Config::ephemeral(), network);
         let transcript = Transcript::from(transcript_data.iter().cloned());
         /// SPANDOC: check the on disk service against the transcript
         transcript.check(service).await?;


### PR DESCRIPTION
## Motivation

The zebra-state integration test compiles successfully during workspace builds.

But it couldn't find the `init_test` function when the crate was built by itself.
This happens because the function is only active for `test` and `proptest-impl` builds.

## Solution

- remove the dependency on the `init_test` function

This is a workaround for bug #1364, but it doesn't close that ticket.

## Review

Anyone can review this PR.
It's not urgent, because we don't do this check in CI.

### Reviewer Checklist

  - [ ] `zebra-state` compiles by itself
  - [ ] Existing tests pass

## Follow Up Work

Add a CI job which compiles each Zebra crate individually #1364

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2611)
<!-- Reviewable:end -->
