### PR TITLE
Implement a WtxId struct, and use it in Zebra's external network protocol

### DIFF
--- a/zebra-chain/src/serialization/error.rs
+++ b/zebra-chain/src/serialization/error.rs
@@ -1,4 +1,4 @@
-use std::{io, num::TryFromIntError, str::Utf8Error};
+use std::{array::TryFromSliceError, io, num::TryFromIntError, str::Utf8Error};
 
 use thiserror::Error;
 
@@ -20,6 +20,10 @@ pub enum SerializationError {
     /// Note: Rust `String` and `str` are always UTF-8.
     #[error("string was not UTF-8: {0}")]
     Utf8Error(#[from] Utf8Error),
+
+    /// A slice was an unexpected length during deserialization.
+    #[error("slice was the wrong length: {0}")]
+    TryFromSliceError(#[from] TryFromSliceError),
 
     /// The length of a vec is too large to convert to a usize (and thus, too large to allocate on this platform)
     #[error("compactsize too large: {0}")]

--- a/zebra-chain/src/serialization/error.rs
+++ b/zebra-chain/src/serialization/error.rs
@@ -1,4 +1,4 @@
-use std::{io, num::TryFromIntError};
+use std::{io, num::TryFromIntError, str::Utf8Error};
 
 use thiserror::Error;
 
@@ -9,13 +9,22 @@ pub enum SerializationError {
     /// An io error that prevented deserialization
     #[error("io error: {0}")]
     Io(#[from] io::Error),
+
     /// The data to be deserialized was malformed.
     // XXX refine errors
     #[error("parse error: {0}")]
     Parse(&'static str),
+
+    /// A string was not UTF-8.
+    ///
+    /// Note: Rust `String` and `str` are always UTF-8.
+    #[error("string was not UTF-8: {0}")]
+    Utf8Error(#[from] Utf8Error),
+
     /// The length of a vec is too large to convert to a usize (and thus, too large to allocate on this platform)
     #[error("compactsize too large: {0}")]
     TryFromIntError(#[from] TryFromIntError),
+
     /// An error caused when validating a zatoshi `Amount`
     #[error("input couldn't be parsed as a zatoshi `Amount`: {source}")]
     Amount {
@@ -23,6 +32,7 @@ pub enum SerializationError {
         #[from]
         source: crate::amount::Error,
     },
+
     /// Invalid transaction with a non-zero balance and no Sapling shielded spends or outputs.
     ///
     /// Transaction does not conform to the Sapling [consensus

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -18,7 +18,7 @@ pub mod arbitrary;
 mod tests;
 
 pub use auth_digest::AuthDigest;
-pub use hash::Hash;
+pub use hash::{Hash, WtxId};
 pub use joinsplit::JoinSplitData;
 pub use lock_time::LockTime;
 pub use memo::Memo;

--- a/zebra-chain/src/transaction/auth_digest.rs
+++ b/zebra-chain/src/transaction/auth_digest.rs
@@ -1,9 +1,14 @@
-use std::fmt;
+use std::{borrow::Borrow, fmt};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
 
-use crate::{primitives::zcash_primitives::auth_digest, serialization::SerializationError};
+use crate::{
+    primitives::zcash_primitives::auth_digest,
+    serialization::{
+        ReadZcashExt, SerializationError, WriteZcashExt, ZcashDeserialize, ZcashSerialize,
+    },
+};
 
 use super::Transaction;
 
@@ -17,14 +22,35 @@ use super::Transaction;
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct AuthDigest(pub(crate) [u8; 32]);
 
-impl<'a> From<&'a Transaction> for AuthDigest {
+impl<Tx> From<Tx> for AuthDigest
+where
+    Tx: Borrow<Transaction>,
+{
     /// Computes the authorizing data commitment for a transaction.
     ///
     /// # Panics
     ///
     /// If passed a pre-v5 transaction.
-    fn from(transaction: &'a Transaction) -> Self {
-        auth_digest(transaction)
+    fn from(transaction: Tx) -> Self {
+        auth_digest(transaction.borrow())
+    }
+}
+
+impl From<[u8; 32]> for AuthDigest {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<AuthDigest> for [u8; 32] {
+    fn from(auth_digest: AuthDigest) -> Self {
+        auth_digest.0
+    }
+}
+
+impl From<&AuthDigest> for [u8; 32] {
+    fn from(auth_digest: &AuthDigest) -> Self {
+        (*auth_digest).into()
     }
 }
 
@@ -57,5 +83,17 @@ impl std::str::FromStr for AuthDigest {
             bytes.reverse();
             Ok(AuthDigest(bytes))
         }
+    }
+}
+
+impl ZcashSerialize for AuthDigest {
+    fn zcash_serialize<W: std::io::Write>(&self, mut writer: W) -> Result<(), std::io::Error> {
+        writer.write_32_bytes(&self.into())
+    }
+}
+
+impl ZcashDeserialize for AuthDigest {
+    fn zcash_deserialize<R: std::io::Read>(mut reader: R) -> Result<Self, SerializationError> {
+        Ok(reader.read_32_bytes()?.into())
     }
 }

--- a/zebra-chain/src/transaction/auth_digest.rs
+++ b/zebra-chain/src/transaction/auth_digest.rs
@@ -1,11 +1,20 @@
-use crate::primitives::zcash_primitives::auth_digest;
+use std::fmt;
+
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
+use crate::{primitives::zcash_primitives::auth_digest, serialization::SerializationError};
 
 use super::Transaction;
 
 /// An authorizing data commitment hash as specified in [ZIP-244].
 ///
-/// [ZIP-244]: https://zips.z.cash/zip-0244..
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+/// Note: Zebra displays transaction and block hashes in big-endian byte-order,
+/// following the u256 convention set by Bitcoin and zcashd.
+///
+/// [ZIP-244]: https://zips.z.cash/zip-0244
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct AuthDigest(pub(crate) [u8; 32]);
 
 impl<'a> From<&'a Transaction> for AuthDigest {
@@ -16,5 +25,37 @@ impl<'a> From<&'a Transaction> for AuthDigest {
     /// If passed a pre-v5 transaction.
     fn from(transaction: &'a Transaction) -> Self {
         auth_digest(transaction)
+    }
+}
+
+impl fmt::Display for AuthDigest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut reversed_bytes = self.0;
+        reversed_bytes.reverse();
+        f.write_str(&hex::encode(&reversed_bytes))
+    }
+}
+
+impl fmt::Debug for AuthDigest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut reversed_bytes = self.0;
+        reversed_bytes.reverse();
+        f.debug_tuple("AuthDigest")
+            .field(&hex::encode(reversed_bytes))
+            .finish()
+    }
+}
+
+impl std::str::FromStr for AuthDigest {
+    type Err = SerializationError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut bytes = [0; 32];
+        if hex::decode_to_slice(s, &mut bytes[..]).is_err() {
+            Err(SerializationError::Parse("hex decoding error"))
+        } else {
+            bytes.reverse();
+            Ok(AuthDigest(bytes))
+        }
     }
 }

--- a/zebra-chain/src/transaction/auth_digest.rs
+++ b/zebra-chain/src/transaction/auth_digest.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Borrow, fmt};
+use std::fmt;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
@@ -22,17 +22,26 @@ use super::Transaction;
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct AuthDigest(pub(crate) [u8; 32]);
 
-impl<Tx> From<Tx> for AuthDigest
-where
-    Tx: Borrow<Transaction>,
-{
+impl From<Transaction> for AuthDigest {
     /// Computes the authorizing data commitment for a transaction.
     ///
     /// # Panics
     ///
     /// If passed a pre-v5 transaction.
-    fn from(transaction: Tx) -> Self {
-        auth_digest(transaction.borrow())
+    fn from(transaction: Transaction) -> Self {
+        // use the ref implementation, to avoid cloning the transaction
+        AuthDigest::from(&transaction)
+    }
+}
+
+impl From<&Transaction> for AuthDigest {
+    /// Computes the authorizing data commitment for a transaction.
+    ///
+    /// # Panics
+    ///
+    /// If passed a pre-v5 transaction.
+    fn from(transaction: &Transaction) -> Self {
+        auth_digest(transaction)
     }
 }
 

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -1,9 +1,9 @@
 //! Transaction identifiers for Zcash.
 //!
 //! Zcash has two different transaction identifiers, with different widths:
-//! * a 32-byte narrow transaction ID, which uniquely identifies mined transactions
+//! * [`Hash`]: a 32-byte narrow transaction ID, which uniquely identifies mined transactions
 //!   (transactions that have been committed to the blockchain in blocks), and
-//! * a 64-byte wide transaction ID, which uniquely identifies unmined transactions
+//! * [`WtxId`]: a 64-byte wide transaction ID, which uniquely identifies unmined transactions
 //!   (transactions that are sent by wallets or stored in node mempools).
 //!
 //! Transaction versions 1-4 are uniquely identified by narrow transaction IDs,
@@ -17,10 +17,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::serialization::SerializationError;
 
-use super::{txid::TxIdBuilder, Transaction};
+use super::{txid::TxIdBuilder, AuthDigest, Transaction};
 
-/// A narrow transaction ID, which uniquely identifies mined transactions
-/// (transactions that have been committed to a block in the blockchain).
+/// A narrow transaction ID, which uniquely identifies mined v5 transactions,
+/// and all v1-v4 transactions.
 ///
 /// Note: Zebra displays transaction and block hashes in big-endian byte-order,
 /// following the u256 convention set by Bitcoin and zcashd.
@@ -65,6 +65,65 @@ impl std::str::FromStr for Hash {
         } else {
             bytes.reverse();
             Ok(Hash(bytes))
+        }
+    }
+}
+
+/// A wide transaction ID, which uniquely identifies unmined v5 transactions.
+///
+/// Wide transaction IDs are not used for transaction versions 1-4.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
+pub struct WtxId {
+    /// The non-malleable transaction ID for this transaction's effects.
+    pub id: Hash,
+
+    /// The authorizing data digest for this transactions signatures, proofs, and scripts.
+    pub auth_digest: AuthDigest,
+}
+
+impl<'a> From<&'a Transaction> for WtxId {
+    /// Computes the wide transaction ID for a transaction.
+    ///
+    /// # Panics
+    ///
+    /// If passed a pre-v5 transaction.
+    fn from(transaction: &'a Transaction) -> Self {
+        Self {
+            id: transaction.into(),
+            auth_digest: transaction.into(),
+        }
+    }
+}
+
+impl fmt::Display for WtxId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.id.to_string())?;
+        f.write_str(&self.auth_digest.to_string())
+    }
+}
+
+impl std::str::FromStr for WtxId {
+    type Err = SerializationError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // we need to split using bytes,
+        // because str::split_at panics if it splits a UTF-8 codepoint
+        let s = s.as_bytes();
+
+        if s.len() == 128 {
+            let (id, auth_digest) = s.split_at(64);
+            let id = std::str::from_utf8(id)?;
+            let auth_digest = std::str::from_utf8(auth_digest)?;
+
+            Ok(Self {
+                id: id.parse()?,
+                auth_digest: auth_digest.parse()?,
+            })
+        } else {
+            Err(SerializationError::Parse(
+                "wrong length for WtxId hex string",
+            ))
         }
     }
 }

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -68,21 +68,3 @@ impl std::str::FromStr for Hash {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn transactionhash_from_str() {
-        zebra_test::init();
-
-        let hash: Hash = "3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf"
-            .parse()
-            .unwrap();
-        assert_eq!(
-            format!("{:?}", hash),
-            r#"transaction::Hash("3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf")"#
-        );
-    }
-}

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -1,4 +1,14 @@
-#![allow(clippy::unit_arg)]
+//! Transaction identifiers for Zcash.
+//!
+//! Zcash has two different transaction identifiers, with different widths:
+//! * a 32-byte narrow transaction ID, which uniquely identifies mined transactions
+//!   (transactions that have been committed to the blockchain in blocks), and
+//! * a 64-byte wide transaction ID, which uniquely identifies unmined transactions
+//!   (transactions that are sent by wallets or stored in node mempools).
+//!
+//! Transaction versions 1-4 are uniquely identified by narrow transaction IDs,
+//! so Zebra and the Zcash network protocol don't use wide transaction IDs for them.
+
 use std::fmt;
 
 #[cfg(any(test, feature = "proptest-impl"))]
@@ -9,7 +19,8 @@ use crate::serialization::SerializationError;
 
 use super::{txid::TxIdBuilder, Transaction};
 
-/// A transaction hash.
+/// A narrow transaction ID, which uniquely identifies mined transactions
+/// (transactions that have been committed to a block in the blockchain).
 ///
 /// Note: Zebra displays transaction and block hashes in big-endian byte-order,
 /// following the u256 convention set by Bitcoin and zcashd.

--- a/zebra-chain/src/transaction/tests/prop.rs
+++ b/zebra-chain/src/transaction/tests/prop.rs
@@ -33,12 +33,60 @@ proptest! {
     }
 
     #[test]
-    fn transaction_hash_display_fromstr_roundtrip(hash in any::<Hash>()) {
+    fn transaction_hash_struct_display_roundtrip(hash in any::<Hash>()) {
         zebra_test::init();
 
         let display = format!("{}", hash);
         let parsed = display.parse::<Hash>().expect("hash should parse");
         prop_assert_eq!(hash, parsed);
+    }
+
+    #[test]
+    fn transaction_hash_string_parse_roundtrip(hash in any::<String>()) {
+        zebra_test::init();
+
+        if let Ok(parsed) = hash.parse::<Hash>() {
+            let display = format!("{}", parsed);
+            prop_assert_eq!(hash, display);
+        }
+    }
+
+    #[test]
+    fn transaction_auth_digest_struct_display_roundtrip(auth_digest in any::<AuthDigest>()) {
+        zebra_test::init();
+
+        let display = format!("{}", auth_digest);
+        let parsed = display.parse::<AuthDigest>().expect("auth digest should parse");
+        prop_assert_eq!(auth_digest, parsed);
+    }
+
+    #[test]
+    fn transaction_auth_digest_string_parse_roundtrip(auth_digest in any::<String>()) {
+        zebra_test::init();
+
+        if let Ok(parsed) = auth_digest.parse::<AuthDigest>() {
+            let display = format!("{}", parsed);
+            prop_assert_eq!(auth_digest, display);
+        }
+    }
+
+    #[test]
+    fn transaction_wtx_id_struct_display_roundtrip(wtx_id in any::<WtxId>()) {
+        zebra_test::init();
+
+        let display = format!("{}", wtx_id);
+        let parsed = display.parse::<WtxId>().expect("wide transaction ID should parse");
+        prop_assert_eq!(wtx_id, parsed);
+    }
+
+    #[test]
+    fn transaction_wtx_id_string_parse_roundtrip(wtx_id in any::<String>()) {
+        zebra_test::init();
+
+        if let Ok(parsed) = wtx_id.parse::<WtxId>() {
+            let display = format!("{}", parsed);
+            prop_assert_eq!(wtx_id, display);
+        }
     }
 
     #[test]

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -31,6 +31,19 @@ lazy_static! {
 }
 
 #[test]
+fn transactionhash_from_str() {
+    zebra_test::init();
+
+    let hash: Hash = "3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf"
+        .parse()
+        .unwrap();
+    assert_eq!(
+        format!("{:?}", hash),
+        r#"transaction::Hash("3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf")"#
+    );
+}
+
+#[test]
 fn librustzcash_tx_deserialize_and_round_trip() {
     zebra_test::init();
 

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -44,6 +44,19 @@ fn transactionhash_from_str() {
 }
 
 #[test]
+fn auth_digest_from_str() {
+    zebra_test::init();
+
+    let digest: AuthDigest = "3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf"
+        .parse()
+        .unwrap();
+    assert_eq!(
+        format!("{:?}", digest),
+        r#"AuthDigest("3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf")"#
+    );
+}
+
+#[test]
 fn librustzcash_tx_deserialize_and_round_trip() {
     zebra_test::init();
 

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -3,20 +3,21 @@ use std::convert::{TryFrom, TryInto};
 use color_eyre::eyre::Result;
 use lazy_static::lazy_static;
 
-use zebra_test::{zip0143, zip0243, zip0244};
-
-use super::super::*;
 use crate::{
+    amount::Amount,
     block::{Block, Height, MAX_BLOCK_BYTES},
     parameters::{Network, NetworkUpgrade},
     serialization::{SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
-    transaction::{sighash::SigHasher, txid::TxIdBuilder},
+    transaction::{hash::WtxId, sighash::SigHasher, txid::TxIdBuilder, Transaction},
+    transparent::Script,
 };
 
-use crate::{amount::Amount, transaction::Transaction};
+use zebra_test::{
+    vectors::{ZIP143_1, ZIP143_2, ZIP243_1, ZIP243_2, ZIP243_3},
+    zip0143, zip0243, zip0244,
+};
 
-use transparent::Script;
-use zebra_test::vectors::{ZIP143_1, ZIP143_2, ZIP243_1, ZIP243_2, ZIP243_3};
+use super::super::*;
 
 lazy_static! {
     pub static ref EMPTY_V5_TX: Transaction = Transaction::V5 {
@@ -31,28 +32,56 @@ lazy_static! {
 }
 
 #[test]
-fn transactionhash_from_str() {
+fn transactionhash_struct_from_str_roundtrip() {
     zebra_test::init();
 
     let hash: Hash = "3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf"
         .parse()
         .unwrap();
+
     assert_eq!(
         format!("{:?}", hash),
         r#"transaction::Hash("3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf")"#
     );
+    assert_eq!(
+        hash.to_string(),
+        "3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf"
+    );
 }
 
 #[test]
-fn auth_digest_from_str() {
+fn auth_digest_struct_from_str_roundtrip() {
     zebra_test::init();
 
     let digest: AuthDigest = "3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf"
         .parse()
         .unwrap();
+
     assert_eq!(
         format!("{:?}", digest),
         r#"AuthDigest("3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf")"#
+    );
+    assert_eq!(
+        digest.to_string(),
+        "3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf"
+    );
+}
+
+#[test]
+fn wtx_id_struct_from_str_roundtrip() {
+    zebra_test::init();
+
+    let wtx_id: WtxId = "3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf0000000000000000000000000000000000000000000000000000000000000001"
+        .parse()
+        .unwrap();
+
+    assert_eq!(
+        format!("{:?}", wtx_id),
+        r#"WtxId { id: transaction::Hash("3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf"), auth_digest: AuthDigest("0000000000000000000000000000000000000000000000000000000000000001") }"#
+    );
+    assert_eq!(
+        wtx_id.to_string(),
+        "3166411bd5343e0b284a108f39a929fbbb62619784f8c6dafe520703b5b446bf0000000000000000000000000000000000000000000000000000000000000001"
     );
 }
 

--- a/zebra-network/src/protocol/external/tests/vectors.rs
+++ b/zebra-network/src/protocol/external/tests/vectors.rs
@@ -22,5 +22,5 @@ fn parses_msg_wtx_inventory_type() {
         .zcash_deserialize_into()
         .expect("Failed to deserialize dummy `InventoryHash::Wtx`");
 
-    assert_eq!(deserialized, InventoryHash::Wtx([0; 64]));
+    assert_eq!(deserialized, InventoryHash::Wtx([0u8; 64].into()));
 }


### PR DESCRIPTION
## Motivation

In order to handle wide transaction IDs from the network, Zebra needs to:
-  split them into `id` and `auth_data` fields
- use them when serializing and deserializing inventory hashes (in `inv`, `getdata`, and `notfound` messages)

### Specifications

https://zips.z.cash/zip-0239#specification

## Solution

Changes
- Add a `WtxId` type for wide transaction IDs
- Add conversions between transaction IDs and bytes
- Use the `WtxId` type in external network protocol messages 

Bug Fixes
- Make the `AuthDigest` display order match transaction IDs

Tests
- Move a `transaction::Hash` test to tests module
- Add display order tests for transaction IDs and auth digests
- Add round-trip byte and struct tests for transaction IDs and auth digests

This is part of ticket #2449, but it does not close that ticket.

## Review

Anyone can review this PR.
It's blocking all of the mempool work that needs wide transaction IDs.

It's based on PR #2547, so it might need rebasing after that PR merges to `main`.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Create an `UnminedTxId` enum, to abstract over unmined v4 and v5 transactions in Zebra's internal network protocol
  - `UnminedTxId` is also blocking all of the mempool work that needs wide transaction IDs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2618)
<!-- Reviewable:end -->
