### PR TITLE
Create types for unmined transactions and their IDs

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -11,6 +11,7 @@ mod memo;
 mod serialize;
 mod sighash;
 mod txid;
+mod unmined;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod arbitrary;
@@ -23,8 +24,8 @@ pub use joinsplit::JoinSplitData;
 pub use lock_time::LockTime;
 pub use memo::Memo;
 pub use sapling::FieldNotPresent;
-pub use sighash::HashType;
-pub use sighash::SigHash;
+pub use sighash::{HashType, SigHash};
+pub use unmined::{UnminedTx, UnminedTxId};
 
 use crate::{
     amount::{Amount, Error as AmountError, NegativeAllowed, NonNegative},

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -10,7 +10,7 @@
 //! whether they have been mined or not,
 //! so Zebra and the Zcash network protocol don't use wide transaction IDs for them.
 //!
-//! Zebra's [`UnminedTxId`] and [`UnminedTx`] enums provide the correct unique ID for 
+//! Zebra's [`UnminedTxId`] and [`UnminedTx`] enums provide the correct unique ID for
 //! unmined transactions. They can be used to handle transactions regardless of version,
 //! and get the [`WtxId`] or [`Hash`] when required.
 

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -6,6 +6,7 @@
 //! * [`WtxId`]: a 64-byte wide transaction ID, which uniquely identifies unmined transactions
 //!   (transactions that are sent by wallets or stored in node mempools).
 //!
+//! Transaction version 5 is uniquely identified by [`WtxId`] when unmined, and [`Hash`] in the blockchain.
 //! Transaction versions 1-4 are uniquely identified by narrow transaction IDs,
 //! whether they have been mined or not,
 //! so Zebra and the Zcash network protocol don't use wide transaction IDs for them.

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -34,6 +34,15 @@ use super::{txid::TxIdBuilder, AuthDigest, Transaction};
 ///
 /// Note: Zebra displays transaction and block hashes in big-endian byte-order,
 /// following the u256 convention set by Bitcoin and zcashd.
+///
+/// "The transaction ID of a version 4 or earlier transaction is the SHA-256d hash
+/// of the transaction encoding in the pre-v5 format described above.
+///
+/// The transaction ID of a version 5 transaction is as defined in [ZIP-244]."
+/// [Spec: Transaction Identifiers]
+///
+/// [ZIP-244]: https://zips.z.cash/zip-0244
+/// [Spec: Transaction Identifiers]: https://zips.z.cash/protocol/protocol.pdf#txnidentifiers
 #[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct Hash(pub [u8; 32]);
@@ -119,6 +128,13 @@ impl ZcashDeserialize for Hash {
 /// A wide transaction ID, which uniquely identifies unmined v5 transactions.
 ///
 /// Wide transaction IDs are not used for transaction versions 1-4.
+///
+/// "A v5 transaction also has a wtxid (used for example in the peer-to-peer protocol)
+/// as defined in [ZIP-239]."
+/// [Spec: Transaction Identifiers]
+///
+/// [ZIP-239]: https://zips.z.cash/zip-0239
+/// [Spec: Transaction Identifiers]: https://zips.z.cash/protocol/protocol.pdf#txnidentifiers
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct WtxId {

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -7,10 +7,11 @@
 //!   (transactions that are sent by wallets or stored in node mempools).
 //!
 //! Transaction versions 1-4 are uniquely identified by narrow transaction IDs,
+//! whether they have been mined or not,
 //! so Zebra and the Zcash network protocol don't use wide transaction IDs for them.
 //!
-//! Zebra's [`UnminedTxId`] and [`UnminedTx`] enums provide the correct ID for the
-//! transaction version. They can be used to handle transactions regardless of version,
+//! Zebra's [`UnminedTxId`] and [`UnminedTx`] enums provide the correct unique ID for 
+//! unmined transactions. They can be used to handle transactions regardless of version,
 //! and get the [`WtxId`] or [`Hash`] when required.
 
 use std::{

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -8,6 +8,10 @@
 //!
 //! Transaction versions 1-4 are uniquely identified by narrow transaction IDs,
 //! so Zebra and the Zcash network protocol don't use wide transaction IDs for them.
+//!
+//! Zebra's [`UnminedTxId`] and [`UnminedTx`] enums provide the correct ID for the
+//! transaction version. They can be used to handle transactions regardless of version,
+//! and get the [`WtxId`] or [`Hash`] when required.
 
 use std::{
     convert::{TryFrom, TryInto},
@@ -16,6 +20,7 @@ use std::{
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
+
 use serde::{Deserialize, Serialize};
 
 use crate::serialization::{

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -1,5 +1,6 @@
 //! Unmined Zcash transaction identifiers and transactions.
 //!
+//! Transaction version 5 is uniquely identified by [`WtxId`] when unmined, and [`Hash`] in the blockchain.
 //! Transaction versions 1-4 are uniquely identified by narrow transaction IDs,
 //! whether they have been mined or not,
 //! so Zebra and the Zcash network protocol don't use wide transaction IDs for them.
@@ -98,7 +99,8 @@ impl UnminedTxId {
     /// # Correctness
     ///
     /// This method returns an ID which uniquely identifies
-    /// the effects and authorizing data for v1-v4 transactions.
+    /// the effects (spends and outputs) and
+    /// authorizing data (signatures, proofs, and scripts) for v1-v4 transactions.
     ///
     /// But for v5 transactions, this ID only identifies the transaction's effects.
     #[allow(dead_code)]
@@ -110,7 +112,7 @@ impl UnminedTxId {
     }
 
     /// Return the digest of this transaction's authorizing data,
-    /// if it is a v5 transaction.
+    /// (signatures, proofs, and scripts), if it is a v5 transaction.
     #[allow(dead_code)]
     pub fn auth_digest(&self) -> Option<AuthDigest> {
         match self {

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -4,7 +4,7 @@
 //! whether they have been mined or not,
 //! so Zebra and the Zcash network protocol don't use wide transaction IDs for them.
 //!
-//! Zebra's [`UnminedTxId`] and [`UnminedTx`] enums provide the correct unique ID for 
+//! Zebra's [`UnminedTxId`] and [`UnminedTx`] enums provide the correct unique ID for
 //! unmined transactions. They can be used to handle transactions regardless of version,
 //! and get the [`WtxId`] or [`Hash`] when required.
 

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -83,7 +83,7 @@ impl From<&WtxId> for UnminedTxId {
 }
 
 impl UnminedTxId {
-    /// Return a new `UnminedTxId` using a v1-v4 legacy transaction ID.
+    /// Create a new `UnminedTxId` using a v1-v4 legacy transaction ID.
     ///
     /// # Correctness
     ///

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -1,11 +1,12 @@
 //! Unmined Zcash transaction identifiers and transactions.
 //!
-//! Zebra's [`UnminedTxId`] and [`UnminedTx`] enums provide the correct ID for the
-//! transaction version. They can be used to handle transactions regardless of version,
-//! and get the [`WtxId`] or [`Hash`] when required.
-//!
 //! Transaction versions 1-4 are uniquely identified by narrow transaction IDs,
+//! whether they have been mined or not,
 //! so Zebra and the Zcash network protocol don't use wide transaction IDs for them.
+//!
+//! Zebra's [`UnminedTxId`] and [`UnminedTx`] enums provide the correct unique ID for 
+//! unmined transactions. They can be used to handle transactions regardless of version,
+//! and get the [`WtxId`] or [`Hash`] when required.
 
 use std::sync::Arc;
 
@@ -39,12 +40,16 @@ use UnminedTxId::*;
 pub enum UnminedTxId {
     /// A narrow unmined transaction identifier.
     ///
-    /// Used to uniquely identify transaction versions 1-4.
+    /// Used to uniquely identify unmined version 1-4 transactions.
+    /// (After v1-4 transactions are mined, they can be uniquely identified using the same [`transaction::Hash`].)
     Narrow(Hash),
 
     /// A wide unmined transaction identifier.
     ///
-    /// Used to uniquely identify transaction version 5.
+    /// Used to uniquely identify unmined version 5 transactions.
+    /// (After v5 transactions are mined, they can be uniquely identified using only their `WtxId.id`.)
+    ///
+    /// For more details, see [`WtxId`].
     Wide(WtxId),
 }
 

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -1,0 +1,127 @@
+//! Unmined Zcash transaction identifiers and transactions.
+//!
+//! Zebra's [`UnminedTxId`] and [`UnminedTx`] enums provide the correct ID for the
+//! transaction version. They can be used to handle transactions regardless of version,
+//! and get the [`WtxId`] or [`Hash`] when required.
+//!
+//! Transaction versions 1-4 are uniquely identified by narrow transaction IDs,
+//! so Zebra and the Zcash network protocol don't use wide transaction IDs for them.
+
+use std::sync::Arc;
+
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
+use super::{
+    Hash,
+    Transaction::{self, *},
+    WtxId,
+};
+
+use UnminedTxId::*;
+
+/// A unique identifier for an unmined transaction, regardless of version.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
+pub enum UnminedTxId {
+    /// A narrow unmined transaction identifier.
+    ///
+    /// Used to uniquely identify transaction versions 1-4.
+    Narrow(Hash),
+
+    /// A wide unmined transaction identifier.
+    ///
+    /// Used to uniquely identify transaction version 5.
+    Wide(WtxId),
+}
+
+impl From<Transaction> for UnminedTxId {
+    fn from(transaction: Transaction) -> Self {
+        // use the ref implementation, to avoid cloning the transaction
+        UnminedTxId::from(&transaction)
+    }
+}
+
+impl From<&Transaction> for UnminedTxId {
+    fn from(transaction: &Transaction) -> Self {
+        match transaction {
+            V1 { .. } | V2 { .. } | V3 { .. } | V4 { .. } => Narrow(transaction.into()),
+            V5 { .. } => Wide(transaction.into()),
+        }
+    }
+}
+
+impl From<WtxId> for UnminedTxId {
+    fn from(wtx_id: WtxId) -> Self {
+        Wide(wtx_id)
+    }
+}
+
+impl From<&WtxId> for UnminedTxId {
+    fn from(wtx_id: &WtxId) -> Self {
+        (*wtx_id).into()
+    }
+}
+
+impl UnminedTxId {
+    /// Return a new `UnminedTxId` using a v1-v4 legacy transaction ID.
+    ///
+    /// # Correctness
+    ///
+    /// This method must only be used for v1-v4 transaction IDs.
+    /// [`Hash`] does not uniquely identify unmined v5 transactions.
+    #[allow(dead_code)]
+    pub fn from_legacy_id(legacy_tx_id: Hash) -> UnminedTxId {
+        Narrow(legacy_tx_id)
+    }
+}
+
+/// An unmined transaction, and its pre-calculated unique identifying ID.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
+pub struct UnminedTx {
+    /// A unique identifier for this unmined transaction.
+    pub id: UnminedTxId,
+
+    /// The unmined transaction itself.
+    pub transaction: Arc<Transaction>,
+}
+
+// Each of these conversions is implemented slightly differently,
+// to avoid cloning the transaction where possible.
+
+impl From<Transaction> for UnminedTx {
+    fn from(transaction: Transaction) -> Self {
+        Self {
+            id: (&transaction).into(),
+            transaction: Arc::new(transaction),
+        }
+    }
+}
+
+impl From<&Transaction> for UnminedTx {
+    fn from(transaction: &Transaction) -> Self {
+        Self {
+            id: transaction.into(),
+            transaction: Arc::new(transaction.clone()),
+        }
+    }
+}
+
+impl From<Arc<Transaction>> for UnminedTx {
+    fn from(transaction: Arc<Transaction>) -> Self {
+        Self {
+            id: transaction.as_ref().into(),
+            transaction,
+        }
+    }
+}
+
+impl From<&Arc<Transaction>> for UnminedTx {
+    fn from(transaction: &Arc<Transaction>) -> Self {
+        Self {
+            id: transaction.as_ref().into(),
+            transaction: transaction.clone(),
+        }
+    }
+}

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -21,6 +21,19 @@ use super::{
 use UnminedTxId::*;
 
 /// A unique identifier for an unmined transaction, regardless of version.
+///
+/// "The transaction ID of a version 4 or earlier transaction is the SHA-256d hash
+/// of the transaction encoding in the pre-v5 format described above.
+///
+/// The transaction ID of a version 5 transaction is as defined in [ZIP-244].
+///
+/// A v5 transaction also has a wtxid (used for example in the peer-to-peer protocol)
+/// as defined in [ZIP-239]."
+/// [Spec: Transaction Identifiers]
+///
+/// [ZIP-239]: https://zips.z.cash/zip-0239
+/// [ZIP-244]: https://zips.z.cash/zip-0244
+/// [Spec: Transaction Identifiers]: https://zips.z.cash/protocol/protocol.pdf#txnidentifiers
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum UnminedTxId {

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use proptest_derive::Arbitrary;
 
 use super::{
-    Hash,
+    AuthDigest, Hash,
     Transaction::{self, *},
     WtxId,
 };
@@ -86,6 +86,32 @@ impl UnminedTxId {
     #[allow(dead_code)]
     pub fn from_legacy_id(legacy_tx_id: Hash) -> UnminedTxId {
         Narrow(legacy_tx_id)
+    }
+
+    /// Return the unique ID for this transaction's effects.
+    ///
+    /// # Correctness
+    ///
+    /// This method returns an ID which uniquely identifies
+    /// the effects and authorizing data for v1-v4 transactions.
+    ///
+    /// But for v5 transactions, this ID only identifies the transaction's effects.
+    #[allow(dead_code)]
+    pub fn effect_id(&self) -> Hash {
+        match self {
+            Narrow(effect_id) => *effect_id,
+            Wide(wtx_id) => wtx_id.id,
+        }
+    }
+
+    /// Return the digest of this transaction's authorizing data,
+    /// if it is a v5 transaction.
+    #[allow(dead_code)]
+    pub fn auth_digest(&self) -> Option<AuthDigest> {
+        match self {
+            Narrow(_effect_id) => None,
+            Wide(wtx_id) => Some(wtx_id.auth_digest),
+        }
     }
 }
 


### PR DESCRIPTION
## Motivation

Zebra's mempool needs to handle unmined v4 and v5 transactions.

These transactions have different unique identifiers.

### Specifications

> The transaction ID of a version 4 or earlier transaction is the SHA-256d hash of the transaction encoding in the
pre-v5 format described above.
> 
> The transaction ID of a version 5 transaction is as defined in [ZIP-244].
> 
> A v5 transaction also has a wtxid (used for example in the peer-to-peer protocol) as defined in [ZIP-239].

https://zips.z.cash/protocol/protocol.pdf#txnidentifiers
https://zips.z.cash/zip-0239
https://zips.z.cash/zip-0244

## Solution

- Create an `UnminedTxId` enum, which holds a narrow or wide transaction ID, depending on version
  - Add accessor methods for the parts of an `UnminedTxId`
- Create an `UnminedTx` struct, which holds a transaction and its unmined ID

## Review

This PR blocks merging other mempool PRs that handle transaction IDs.

It's based on PR #2618, so it might need a rebase on `main` when that PR merges.

### Reviewer Checklist

  - [ ] Code implements Specs
  - [ ] Code makes sense

We'll test this code when we use these types in `zebra-network` and in `zebrad`'s mempool.

## Follow Up Work

Use these types in internal protocol messages in `zebra-network`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2634)
<!-- Reviewable:end -->
