### PR TITLE
Attempt to fix test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
       # Build and run test container
       - name: Run all tests
         run: |
-          gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --ssh-flag="-o ServerAliveInterval=5" --zone "$ZONE" --command \
+          gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --zone "$ZONE" --command \
           "git clone -b $BRANCH_NAME https://github.com/ZcashFoundation/zebra.git &&
           cd zebra/ &&
           docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test . &&

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,12 +64,12 @@ jobs:
       # Build and run test container
       - name: Run all tests
         run: |
-          gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --zone "$ZONE" --command \
+          gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --ssh-flag="-o ServerAliveInterval=5" --zone "$ZONE" --command \
           "git clone -b $BRANCH_NAME https://github.com/ZcashFoundation/zebra.git &&
           cd zebra/ &&
           docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test . &&
-          docker run -i -e "ZEBRA_SKIP_IPV6_TESTS=1" zebrad-test:latest cargo test --workspace --no-fail-fast -- -Zunstable-options --include-ignored &&
-          docker run -i -e "ZEBRA_SKIP_IPV6_TESTS=1" --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-canopy,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_past_mandatory_checkpoint_mainnet --manifest-path zebrad/Cargo.toml sync_past_mandatory_checkpoint_mainnet
+          docker run -t -e ZEBRA_SKIP_IPV6_TESTS=1 zebrad-test:latest cargo test --workspace --no-fail-fast -- -Zunstable-options --include-ignored &&
+          docker run -t -e ZEBRA_SKIP_IPV6_TESTS=1 --mount type=bind,source=/mnt/disks/gce-containers-mounts/gce-persistent-disks/zebrad-cache-$SHORT_SHA-mainnet-canopy,target=/zebrad-cache zebrad-test:latest cargo test --verbose --features test_sync_past_mandatory_checkpoint_mainnet --manifest-path zebrad/Cargo.toml sync_past_mandatory_checkpoint_mainnet
           "
       # Clean up
       - name: Delete test instance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
       # Build and run test container
       - name: Run all tests
         run: |
-          gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --zone "$ZONE" --command \
+          gcloud compute ssh "zebrad-tests-$BRANCH_NAME-$SHORT_SHA" --ssh-flag="-o ServerAliveInterval=5" --zone "$ZONE" --command \
           "git clone -b $BRANCH_NAME https://github.com/ZcashFoundation/zebra.git &&
           cd zebra/ &&
           docker build --build-arg SHORT_SHA=$SHORT_SHA -f docker/Dockerfile.test -t zebrad-test . &&


### PR DESCRIPTION
## Motivation

test.yml sometimes fail, I'm not sure what is the reason, but it seems related to a timeout in the SSH connection.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

This enables the SSH keep alive (to make sure the connection isn't dropped if something gets stuck, getting in the way of finding out what is stuck), and changes the docker `-i` flag to `-t` (to prevent anything from hanging while trying to read from stdin, see [discussion](https://discord.com/channels/676527656170160146/716086297210650634/876597332962078720))

It worked twice with `-t`, and I've just started another run with the keep-alive too: https://github.com/ZcashFoundation/zebra/actions/workflows/test.yml

## Review

@dconnolly has been handling these, but anyone can review

### Reviewer Checklist

  - [x] Check if the last workflow run worked

## Follow Up Work

<!--
Is there anything missing from the solution?
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zcashfoundation/zebra/2635)
<!-- Reviewable:end -->
