### PR TITLE
Support witnessed transaction IDs in zebra-network requests and responses

### DIFF
--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -6,10 +6,12 @@
 //! * [`WtxId`]: a 64-byte wide transaction ID, which uniquely identifies unmined transactions
 //!   (transactions that are sent by wallets or stored in node mempools).
 //!
-//! Transaction version 5 is uniquely identified by [`WtxId`] when unmined, and [`Hash`] in the blockchain.
+//! Transaction version 5 is uniquely identified by [`WtxId`] when unmined,
+//! and [`Hash`] in the blockchain.
+//!
 //! Transaction versions 1-4 are uniquely identified by narrow transaction IDs,
-//! whether they have been mined or not,
-//! so Zebra and the Zcash network protocol don't use wide transaction IDs for them.
+//! whether they have been mined or not. So Zebra, and the Zcash network protocol,
+//! don't use wide transaction IDs for them.
 //!
 //! Zebra's [`UnminedTxId`] and [`UnminedTx`] enums provide the correct unique ID for
 //! unmined transactions. They can be used to handle transactions regardless of version,

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -1,9 +1,9 @@
 //! Transaction identifiers for Zcash.
 //!
 //! Zcash has two different transaction identifiers, with different widths:
-//! * [`Hash`]: a 32-byte narrow transaction ID, which uniquely identifies mined transactions
+//! * [`Hash`]: a 32-byte transaction ID, which uniquely identifies mined transactions
 //!   (transactions that have been committed to the blockchain in blocks), and
-//! * [`WtxId`]: a 64-byte wide transaction ID, which uniquely identifies unmined transactions
+//! * [`WtxId`]: a 64-byte witnessed transaction ID, which uniquely identifies unmined transactions
 //!   (transactions that are sent by wallets or stored in node mempools).
 //!
 //! Transaction version 5 uses both these unique identifiers:
@@ -13,9 +13,9 @@
 //!   (signatures, proofs, and scripts), so it uniquely identifies the transaction's data
 //!   outside a block. (For example, transactions produced by Zcash wallets, or in node mempools.)
 //!
-//! Transaction versions 1-4 are uniquely identified by narrow transaction IDs,
+//! Transaction versions 1-4 are uniquely identified by legacy [`Hash`] transaction IDs,
 //! whether they have been mined or not. So Zebra, and the Zcash network protocol,
-//! don't use wide transaction IDs for them.
+//! don't use witnessed transaction IDs for them.
 //!
 //! There is no unique identifier that only covers the effects of a v1-4 transaction,
 //! so their legacy IDs are malleable, if submitted with different authorizing data.
@@ -41,7 +41,7 @@ use crate::serialization::{
 
 use super::{txid::TxIdBuilder, AuthDigest, Transaction};
 
-/// A narrow transaction ID, which uniquely identifies mined v5 transactions,
+/// A transaction ID, which uniquely identifies mined v5 transactions,
 /// and all v1-v4 transactions.
 ///
 /// Note: Zebra displays transaction and block hashes in big-endian byte-order,
@@ -137,9 +137,9 @@ impl ZcashDeserialize for Hash {
     }
 }
 
-/// A wide transaction ID, which uniquely identifies unmined v5 transactions.
+/// A witnessed transaction ID, which uniquely identifies unmined v5 transactions.
 ///
-/// Wide transaction IDs are not used for transaction versions 1-4.
+/// Witnessed transaction IDs are not used for transaction versions 1-4.
 ///
 /// "A v5 transaction also has a wtxid (used for example in the peer-to-peer protocol)
 /// as defined in [ZIP-239]."
@@ -158,14 +158,14 @@ pub struct WtxId {
 }
 
 impl WtxId {
-    /// Return this wide transaction ID as a serialized byte array.
+    /// Return this witnessed transaction ID as a serialized byte array.
     pub fn as_bytes(&self) -> [u8; 64] {
         <[u8; 64]>::from(self)
     }
 }
 
 impl From<Transaction> for WtxId {
-    /// Computes the wide transaction ID for a transaction.
+    /// Computes the witnessed transaction ID for a transaction.
     ///
     /// # Panics
     ///
@@ -177,7 +177,7 @@ impl From<Transaction> for WtxId {
 }
 
 impl From<&Transaction> for WtxId {
-    /// Computes the wide transaction ID for a transaction.
+    /// Computes the witnessed transaction ID for a transaction.
     ///
     /// # Panics
     ///

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -6,12 +6,20 @@
 //! * [`WtxId`]: a 64-byte wide transaction ID, which uniquely identifies unmined transactions
 //!   (transactions that are sent by wallets or stored in node mempools).
 //!
-//! Transaction version 5 is uniquely identified by [`WtxId`] when unmined,
-//! and [`Hash`] in the blockchain.
+//! Transaction version 5 uses both these unique identifiers:
+//! * [`Hash`] uniquely identifies the effects of a v5 transaction (spends and outputs),
+//!   so it uniquely identifies the transaction's data after it has been mined into a block;
+//! * [`WtxId`] uniquely identifies the effects and authorizing data of a v5 transaction
+//!   (signatures, proofs, and scripts), so it uniquely identifies the transaction's data
+//!   outside a block. (For example, transactions produced by Zcash wallets, or in node mempools.)
 //!
 //! Transaction versions 1-4 are uniquely identified by narrow transaction IDs,
 //! whether they have been mined or not. So Zebra, and the Zcash network protocol,
 //! don't use wide transaction IDs for them.
+//!
+//! There is no unique identifier that only covers the effects of a v1-4 transaction,
+//! so their legacy IDs are malleable, if submitted with different authorizing data.
+//! So the same spends and outputs can have a completely different [`Hash`].
 //!
 //! Zebra's [`UnminedTxId`] and [`UnminedTx`] enums provide the correct unique ID for
 //! unmined transactions. They can be used to handle transactions regardless of version,

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -1,9 +1,10 @@
 //! Unmined Zcash transaction identifiers and transactions.
 //!
 //! Transaction version 5 is uniquely identified by [`WtxId`] when unmined,
-//! and [`Hash`] in the blockchain.
+//! and [`Hash`] in the blockchain. The effects of a v5 transaction (spends and outputs)
+//! are uniquely identified by the same [`Hash`] in both cases.
 //!
-//! Transaction versions 1-4 are uniquely identified by narrow transaction IDs,
+//! Transaction versions 1-4 are uniquely identified by legacy [`Hash`] transaction IDs,
 //! whether they have been mined or not. So Zebra, and the Zcash network protocol,
 //! don't use wide transaction IDs for them.
 //!
@@ -44,13 +45,15 @@ pub enum UnminedTxId {
     /// A narrow unmined transaction identifier.
     ///
     /// Used to uniquely identify unmined version 1-4 transactions.
-    /// (After v1-4 transactions are mined, they can be uniquely identified using the same [`transaction::Hash`].)
+    /// (After v1-4 transactions are mined, they can be uniquely identified
+    /// using the same [`transaction::Hash`].)
     Narrow(Hash),
 
     /// A wide unmined transaction identifier.
     ///
     /// Used to uniquely identify unmined version 5 transactions.
-    /// (After v5 transactions are mined, they can be uniquely identified using only their `WtxId.id`.)
+    /// (After v5 transactions are mined, they can be uniquely identified
+    /// using only the [`transaction::Hash`] in their `WtxId.id`.)
     ///
     /// For more details, see [`WtxId`].
     Wide(WtxId),
@@ -96,17 +99,17 @@ impl UnminedTxId {
         Narrow(legacy_tx_id)
     }
 
-    /// Return the unique ID for this transaction's effects.
+    /// Return the unique ID that will be used if this transaction gets mined into a block.
     ///
     /// # Correctness
     ///
-    /// This method returns an ID which uniquely identifies
-    /// the effects (spends and outputs) and
-    /// authorizing data (signatures, proofs, and scripts) for v1-v4 transactions.
+    /// For v1-v4 transactions, this method returns an ID which changes
+    /// if this transaction's effects (spends and outputs) change, or
+    /// if its authorizing data changes (signatures, proofs, and scripts).
     ///
-    /// But for v5 transactions, this ID only identifies the transaction's effects.
+    /// But for v5 transactions, this ID uniquely identifies the transaction's effects.
     #[allow(dead_code)]
-    pub fn effect_id(&self) -> Hash {
+    pub fn mined_id(&self) -> Hash {
         match self {
             Narrow(effect_id) => *effect_id,
             Wide(wtx_id) => wtx_id.id,

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -111,7 +111,7 @@ impl UnminedTxId {
     #[allow(dead_code)]
     pub fn mined_id(&self) -> Hash {
         match self {
-            Legacy(effect_id) => *effect_id,
+            Legacy(legacy_id) => *legacy_id,
             Witnessed(wtx_id) => wtx_id.id,
         }
     }

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -1,9 +1,11 @@
 //! Unmined Zcash transaction identifiers and transactions.
 //!
-//! Transaction version 5 is uniquely identified by [`WtxId`] when unmined, and [`Hash`] in the blockchain.
+//! Transaction version 5 is uniquely identified by [`WtxId`] when unmined,
+//! and [`Hash`] in the blockchain.
+//!
 //! Transaction versions 1-4 are uniquely identified by narrow transaction IDs,
-//! whether they have been mined or not,
-//! so Zebra and the Zcash network protocol don't use wide transaction IDs for them.
+//! whether they have been mined or not. So Zebra, and the Zcash network protocol,
+//! don't use wide transaction IDs for them.
 //!
 //! Zebra's [`UnminedTxId`] and [`UnminedTx`] enums provide the correct unique ID for
 //! unmined transactions. They can be used to handle transactions regardless of version,

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -121,7 +121,7 @@ impl UnminedTxId {
     #[allow(dead_code)]
     pub fn auth_digest(&self) -> Option<AuthDigest> {
         match self {
-            Legacy(_effect_id) => None,
+            Legacy(_) => None,
             Witnessed(wtx_id) => Some(wtx_id.auth_digest),
         }
     }

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -982,8 +982,8 @@ where
 /// Map a list of inventory hashes to the corresponding unmined transaction IDs.
 /// Non-transaction inventory hashes are skipped.
 ///
-/// v4 transactions use a narrow transaction ID, and
-/// v5 transactions use a wide transaction ID.
+/// v4 transactions use a legacy transaction ID, and
+/// v5 transactions use a witnessed transaction ID.
 fn transaction_ids(items: &'_ [InventoryHash]) -> impl Iterator<Item = UnminedTxId> + '_ {
     items.iter().filter_map(InventoryHash::unmined_tx_id)
 }

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -288,7 +288,7 @@ impl Handler {
                     .all(|item| matches!(item, InventoryHash::Tx(_))) =>
             {
                 Handler::Finished(Ok(Response::TransactionIds(
-                    transaction_hashes(&items[..]).collect(),
+                    transaction_ids(&items[..]).collect(),
                 )))
             }
             (Handler::FindHeaders, Message::Headers(headers)) => {
@@ -861,7 +861,7 @@ where
                 [InventoryHash::Tx(_), rest @ ..]
                     if rest.iter().all(|item| matches!(item, InventoryHash::Tx(_))) =>
                 {
-                    Request::TransactionsById(transaction_hashes(&items).collect())
+                    Request::TransactionsById(transaction_ids(&items).collect())
                 }
                 _ => {
                     self.fail_with(PeerError::WrongMessage("inv with mixed item types"));
@@ -879,7 +879,7 @@ where
                 [InventoryHash::Tx(_), rest @ ..]
                     if rest.iter().all(|item| matches!(item, InventoryHash::Tx(_))) =>
                 {
-                    Request::TransactionsById(transaction_hashes(&items).collect())
+                    Request::TransactionsById(transaction_ids(&items).collect())
                 }
                 _ => {
                     self.fail_with(PeerError::WrongMessage("getdata with mixed item types"));
@@ -986,7 +986,7 @@ where
     }
 }
 
-fn transaction_hashes(items: &'_ [InventoryHash]) -> impl Iterator<Item = transaction::Hash> + '_ {
+fn transaction_ids(items: &'_ [InventoryHash]) -> impl Iterator<Item = transaction::Hash> + '_ {
     items.iter().filter_map(|item| {
         if let InventoryHash::Tx(hash) = item {
             Some(*hash)

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -803,20 +803,21 @@ where
                             //
                             // TODO: zcashd has a bug where it merges queued inv messages of
                             // the same or different types. So Zebra should split small
-                            // merged inv messages into separate inv messages. (#1799)
+                            // merged inv messages into separate inv messages. (#1768)
                             match hashes.as_slice() {
                                 [hash @ InventoryHash::Block(_)] => {
+                                    debug!(?hash, "registering gossiped block inventory for peer");
                                     let _ = inv_collector.send((*hash, transient_addr));
                                 }
                                 [hashes @ ..] => {
                                     for hash in hashes {
-                                        if matches!(hash, InventoryHash::Tx(_)) {
-                                            debug!(?hash, "registering Tx inventory hash");
+                                        if let Some(unmined_tx_id) = hash.unmined_tx_id() {
+                                            debug!(?unmined_tx_id, "registering unmined transaction inventory for peer");
                                             // The peer set and inv collector use the peer's remote
                                             // address as an identifier
                                             let _ = inv_collector.send((*hash, transient_addr));
                                         } else {
-                                            trace!(?hash, "ignoring non Tx inventory hash")
+                                            trace!(?hash, "ignoring non-transaction inventory hash in multi-hash list")
                                         }
                                     }
                                 }

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -517,11 +517,11 @@ where
                 let hash = InventoryHash::from(*hashes.iter().next().unwrap());
                 self.route_inv(req, hash)
             }
-            Request::TransactionsByHash(ref hashes) if hashes.len() == 1 => {
+            Request::TransactionsById(ref hashes) if hashes.len() == 1 => {
                 let hash = InventoryHash::from(*hashes.iter().next().unwrap());
                 self.route_inv(req, hash)
             }
-            Request::AdvertiseTransactions(_) => self.route_all(req),
+            Request::AdvertiseTransactionIds(_) => self.route_all(req),
             Request::AdvertiseBlock(_) => self.route_all(req),
             _ => self.route_p2c(req),
         };

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -521,8 +521,12 @@ where
                 let hash = InventoryHash::from(*hashes.iter().next().unwrap());
                 self.route_inv(req, hash)
             }
+
+            // Broadcast advertisements to all peers
             Request::AdvertiseTransactionIds(_) => self.route_all(req),
             Request::AdvertiseBlock(_) => self.route_all(req),
+
+            // Choose a random less-loaded peer for all other requests
             _ => self.route_p2c(req),
         };
         self.update_metrics();

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -276,7 +276,7 @@ impl Codec {
             Message::Inv(hashes) => hashes.zcash_serialize(&mut writer)?,
             Message::GetData(hashes) => hashes.zcash_serialize(&mut writer)?,
             Message::NotFound(hashes) => hashes.zcash_serialize(&mut writer)?,
-            Message::Tx(transaction) => transaction.zcash_serialize(&mut writer)?,
+            Message::Tx(transaction) => transaction.transaction.zcash_serialize(&mut writer)?,
             Message::Mempool => { /* Empty payload -- no-op */ }
             Message::FilterLoad {
                 filter,
@@ -910,17 +910,17 @@ mod tests {
 
     #[test]
     fn max_msg_size_round_trip() {
-        use std::sync::Arc;
         use zebra_chain::serialization::ZcashDeserializeInto;
+
         zebra_test::init();
 
         let rt = Runtime::new().unwrap();
 
         // make tests with a Tx message
-        let tx = zebra_test::vectors::DUMMY_TX1
+        let tx: Transaction = zebra_test::vectors::DUMMY_TX1
             .zcash_deserialize_into()
             .unwrap();
-        let msg = Message::Tx(Arc::new(tx));
+        let msg = Message::Tx(tx.into());
 
         use tokio_util::codec::{FramedRead, FramedWrite};
 

--- a/zebra-network/src/protocol/external/inv.rs
+++ b/zebra-network/src/protocol/external/inv.rs
@@ -105,8 +105,8 @@ impl From<&WtxId> for InventoryHash {
 impl From<UnminedTxId> for InventoryHash {
     fn from(tx_id: UnminedTxId) -> InventoryHash {
         match tx_id {
-            Narrow(hash) => InventoryHash::Tx(hash),
-            Wide(wtx_id) => InventoryHash::Wtx(wtx_id),
+            Legacy(hash) => InventoryHash::Tx(hash),
+            Witnessed(wtx_id) => InventoryHash::Wtx(wtx_id),
         }
     }
 }

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -169,6 +169,7 @@ pub enum Message {
     /// `getblocks`.
     ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#inv)
+    /// [ZIP-239](https://zips.z.cash/zip-0239)
     Inv(Vec<InventoryHash>),
 
     /// A `getheaders` message.
@@ -211,6 +212,7 @@ pub enum Message {
     /// Other item or non-item messages can come before or after the batch.
     ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#getdata)
+    /// [ZIP-239](https://zips.z.cash/zip-0239)
     /// [zcashd code](https://github.com/zcash/zcash/blob/e7b425298f6d9a54810cb7183f00be547e4d9415/src/main.cpp#L5523)
     GetData(Vec<InventoryHash>),
 
@@ -220,6 +222,8 @@ pub enum Message {
     Block(Arc<Block>),
 
     /// A `tx` message.
+    ///
+    /// This message is used to advertise unmined transactions for the mempool.
     ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#tx)
     Tx(Arc<Transaction>),
@@ -235,6 +239,7 @@ pub enum Message {
     /// silently skipped, without any `NotFound` messages.
     ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#notfound)
+    /// [ZIP-239](https://zips.z.cash/zip-0239)
     /// [zcashd code](https://github.com/zcash/zcash/blob/e7b425298f6d9a54810cb7183f00be547e4d9415/src/main.cpp#L5632)
     // See note above on `Inventory`.
     NotFound(Vec<InventoryHash>),

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -1,21 +1,21 @@
 //! Definitions of network messages.
 
-use std::error::Error;
-use std::{fmt, net, sync::Arc};
+use std::{error::Error, fmt, net, sync::Arc};
 
 use chrono::{DateTime, Utc};
 
 use zebra_chain::{
     block::{self, Block},
-    transaction::Transaction,
+    transaction::UnminedTx,
 };
 
-use super::inv::InventoryHash;
-use super::types::*;
 use crate::meta_addr::MetaAddr;
+
+use super::{inv::InventoryHash, types::*};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
+
 #[cfg(any(test, feature = "proptest-impl"))]
 use zebra_chain::serialization::arbitrary::datetime_full;
 
@@ -226,7 +226,7 @@ pub enum Message {
     /// This message is used to advertise unmined transactions for the mempool.
     ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#tx)
-    Tx(Arc<Transaction>),
+    Tx(UnminedTx),
 
     /// A `notfound` message.
     ///

--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
 
 use zebra_chain::{
     block,
-    transaction::{self, Transaction},
+    transaction::{UnminedTx, UnminedTxId},
 };
 
 use super::super::types::Nonce;
@@ -83,7 +83,7 @@ pub enum Request {
     /// # Returns
     ///
     /// Returns [`Response::Transactions`](super::Response::Transactions).
-    TransactionsById(HashSet<transaction::Hash>),
+    TransactionsById(HashSet<UnminedTxId>),
 
     /// Request block hashes of subsequent blocks in the chain, given hashes of
     /// known blocks.
@@ -132,7 +132,7 @@ pub enum Request {
     /// # Returns
     ///
     /// Returns [`Response::Nil`](super::Response::Nil).
-    PushTransaction(Arc<Transaction>),
+    PushTransaction(UnminedTx),
 
     /// Advertise a set of unmined transactions to all peers.
     ///
@@ -156,7 +156,7 @@ pub enum Request {
     /// # Returns
     ///
     /// Returns [`Response::Nil`](super::Response::Nil).
-    AdvertiseTransactionIds(HashSet<transaction::Hash>),
+    AdvertiseTransactionIds(HashSet<UnminedTxId>),
 
     /// Advertise a block to all peers.
     ///

--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -80,7 +80,7 @@ pub enum Request {
     /// # Returns
     ///
     /// Returns [`Response::Transactions`](super::Response::Transactions).
-    TransactionsByHash(HashSet<transaction::Hash>),
+    TransactionsById(HashSet<transaction::Hash>),
 
     /// Request block hashes of subsequent blocks in the chain, given hashes of
     /// known blocks.
@@ -150,7 +150,7 @@ pub enum Request {
     /// # Returns
     ///
     /// Returns [`Response::Nil`](super::Response::Nil).
-    AdvertiseTransactions(HashSet<transaction::Hash>),
+    AdvertiseTransactionIds(HashSet<transaction::Hash>),
 
     /// Advertise a block to all peers.
     ///
@@ -172,6 +172,6 @@ pub enum Request {
     ///
     /// # Returns
     ///
-    /// Returns [`Response::TransactionHashes`](super::Response::TransactionHashes).
-    MempoolTransactions,
+    /// Returns [`Response::TransactionIds`](super::Response::TransactionIds).
+    MempoolTransactionIds,
 }

--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -70,8 +70,8 @@ pub enum Request {
 
     /// Request transactions by their unmined transaction ID.
     ///
-    /// v4 transactions use a narrow transaction ID, and
-    /// v5 transactions use a wide transaction ID.
+    /// v4 transactions use a legacy transaction ID, and
+    /// v5 transactions use a witnessed transaction ID.
     ///
     /// This uses a `HashSet` for the same reason as [`Request::BlocksByHash`].
     ///

--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -147,8 +147,8 @@ pub enum Request {
     /// [`Request::TransactionsById`] against the "inbound" service passed to
     /// [`zebra_network::init`].
     ///
-    /// v4 transactions use a narrow transaction ID, and
-    /// v5 transactions use a wide transaction ID.
+    /// v4 transactions use a legacy transaction ID, and
+    /// v5 transactions use a witnessed transaction ID.
     ///
     /// The peer set routes this request specially, sending it to *every*
     /// available peer.

--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -68,7 +68,10 @@ pub enum Request {
     /// Returns [`Response::Blocks`](super::Response::Blocks).
     BlocksByHash(HashSet<block::Hash>),
 
-    /// Request transactions by hash.
+    /// Request transactions by their unmined transaction ID.
+    ///
+    /// v4 transactions use a narrow transaction ID, and
+    /// v5 transactions use a wide transaction ID.
     ///
     /// This uses a `HashSet` for the same reason as [`Request::BlocksByHash`].
     ///
@@ -122,7 +125,7 @@ pub enum Request {
         stop: Option<block::Hash>,
     },
 
-    /// Push a transaction to a remote peer, without advertising it to them first.
+    /// Push an unmined transaction to a remote peer, without advertising it to them first.
     ///
     /// This is implemented by sending an unsolicited `tx` message.
     ///
@@ -131,7 +134,7 @@ pub enum Request {
     /// Returns [`Response::Nil`](super::Response::Nil).
     PushTransaction(Arc<Transaction>),
 
-    /// Advertise a set of transactions to all peers.
+    /// Advertise a set of unmined transactions to all peers.
     ///
     /// This is intended to be used in Zebra with a single transaction at a time
     /// (set of size 1), but multiple transactions are permitted because this is
@@ -139,10 +142,13 @@ pub enum Request {
     /// multiple transactions at once.
     ///
     /// This is implemented by sending an `inv` message containing the
-    /// transaction hash, allowing the remote peer to choose whether to download
+    /// unmined transaction ID, allowing the remote peer to choose whether to download
     /// it. Remote peers who choose to download the transaction will generate a
-    /// [`Request::TransactionsByHash`] against the "inbound" service passed to
+    /// [`Request::TransactionsById`] against the "inbound" service passed to
     /// [`zebra_network::init`].
+    ///
+    /// v4 transactions use a narrow transaction ID, and
+    /// v5 transactions use a wide transaction ID.
     ///
     /// The peer set routes this request specially, sending it to *every*
     /// available peer.

--- a/zebra-network/src/protocol/internal/response.rs
+++ b/zebra-network/src/protocol/internal/response.rs
@@ -1,6 +1,6 @@
 use zebra_chain::{
     block::{self, Block},
-    transaction::{self, Transaction},
+    transaction::{UnminedTx, UnminedTxId},
 };
 
 use crate::meta_addr::MetaAddr;
@@ -38,11 +38,11 @@ pub enum Response {
     BlockHeaders(Vec<block::CountedHeader>),
 
     /// A list of unmined transactions.
-    Transactions(Vec<Arc<Transaction>>),
+    Transactions(Vec<UnminedTx>),
 
     /// A list of unmined transaction IDs.
     ///
     /// v4 transactions use a narrow transaction ID, and
     /// v5 transactions use a wide transaction ID.
-    TransactionIds(Vec<transaction::Hash>),
+    TransactionIds(Vec<UnminedTxId>),
 }

--- a/zebra-network/src/protocol/internal/response.rs
+++ b/zebra-network/src/protocol/internal/response.rs
@@ -18,7 +18,11 @@ pub enum Response {
     ///
     /// Either:
     ///  * the request does not need a response, or
-    ///  * we have no useful data to provide in response to the request.
+    ///  * we have no useful data to provide in response to the request
+    ///
+    /// When Zebra doesn't have any useful data, it always sends no response,
+    /// instead of sending `notfound`. `zcashd` sometimes sends no response,
+    /// and sometimes sends `notfound`.
     Nil,
 
     /// A list of peers, used to respond to `GetPeers`.
@@ -33,9 +37,12 @@ pub enum Response {
     /// A list of block headers.
     BlockHeaders(Vec<block::CountedHeader>),
 
-    /// A list of transactions.
+    /// A list of unmined transactions.
     Transactions(Vec<Arc<Transaction>>),
 
-    /// A list of transaction hashes.
+    /// A list of unmined transaction IDs.
+    ///
+    /// v4 transactions use a narrow transaction ID, and
+    /// v5 transactions use a wide transaction ID.
     TransactionIds(Vec<transaction::Hash>),
 }

--- a/zebra-network/src/protocol/internal/response.rs
+++ b/zebra-network/src/protocol/internal/response.rs
@@ -42,7 +42,7 @@ pub enum Response {
 
     /// A list of unmined transaction IDs.
     ///
-    /// v4 transactions use a narrow transaction ID, and
-    /// v5 transactions use a wide transaction ID.
+    /// v4 transactions use a legacy transaction ID, and
+    /// v5 transactions use a witnessed transaction ID.
     TransactionIds(Vec<UnminedTxId>),
 }

--- a/zebra-network/src/protocol/internal/response.rs
+++ b/zebra-network/src/protocol/internal/response.rs
@@ -37,5 +37,5 @@ pub enum Response {
     Transactions(Vec<Arc<Transaction>>),
 
     /// A list of transaction hashes.
-    TransactionHashes(Vec<transaction::Hash>),
+    TransactionIds(Vec<transaction::Hash>),
 }

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -281,7 +281,7 @@ impl Service<zn::Request> for Inbound {
                     .map_ok(zn::Response::Blocks)
                     .boxed()
             }
-            zn::Request::TransactionsByHash(_transactions) => {
+            zn::Request::TransactionsById(_transactions) => {
                 // `zcashd` returns a list of found transactions, followed by a
                 // `NotFound` message if any transactions are missing. `zcashd`
                 // says that Simplified Payment Verification (SPV) clients rely on
@@ -314,7 +314,7 @@ impl Service<zn::Request> for Inbound {
                 debug!("ignoring unimplemented request");
                 async { Ok(zn::Response::Nil) }.boxed()
             }
-            zn::Request::AdvertiseTransactions(_transactions) => {
+            zn::Request::AdvertiseTransactionIds(_transactions) => {
                 debug!("ignoring unimplemented request");
                 async { Ok(zn::Response::Nil) }.boxed()
             }
@@ -329,7 +329,7 @@ impl Service<zn::Request> for Inbound {
                 }
                 async { Ok(zn::Response::Nil) }.boxed()
             }
-            zn::Request::MempoolTransactions => {
+            zn::Request::MempoolTransactionIds => {
                 debug!("ignoring unimplemented request");
                 async { Ok(zn::Response::Nil) }.boxed()
             }


### PR DESCRIPTION
## Motivation

As part of NU5, Zebra's network service needs to handle unmined v4 and v5 transactions and their IDs.
These transactions have different unique identifiers, which we handle using `UnminedTxId`.

As part of this change, we also use the new `UnminedTx` type in network protocol messages.

### Specifications

[ZIP-239](https://zips.z.cash/zip-0239) describes the consensus rules for a new `MSG_WTX` inventory type, that **MUST** be used when relaying V5 transactions.

> A new inv type MSG_WTX (0x00000005) is added, for use in both inv messages and getdata requests, indicating that the hash being referenced is the wtxid (i.e. the 64-byte value txid || auth_digest).
>
> This inv type MUST be used when announcing v5 transactions. The txid and auth_digest are as defined in 4. 
>
> An inv or getdata message MUST NOT use the MSG_WTX inv type for v4 or earlier transactions

## Solution

- Rename internal network requests for wide transaction IDs
- Add `UnminedTxId` methods and conversions for `InventoryHash`
- Map `WtxId`s to unmined transaction network messages
- Enable `WtxId` mempool inventory tracking for peers 

Closes #2449.

## Review

@dconnolly can review this PR, because it impacts the mempool storage and service types.
Anyone else who is blocked on mempool work is welcome to review it as well.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

Some of these changes are tested by existing integration and network tests.
The NU5-specific changes will be tested by these tests once NU5 activates on testnet.

I launched a manual cached state test here, to check the new network messages work:
https://github.com/ZcashFoundation/zebra/runs/3346890529?check_suite_focus=true

## Follow Up Work

Use these new types as part of the mempool work.
