### PR TITLE
Fix a clippy::collapsible_match lint

### DIFF
--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -44,21 +44,15 @@ fn v5_fake_transactions() -> Result<(), Report> {
             check::coinbase_tx_no_prevout_joinsplit_spend(&transaction)?;
 
             // validate the sapling shielded data
-            match transaction {
-                Transaction::V5 {
-                    sapling_shielded_data,
-                    ..
-                } => {
-                    if let Some(s) = sapling_shielded_data {
-                        for spend in s.spends_per_anchor() {
-                            check::spend_cv_rk_not_small_order(&spend)?
-                        }
-                        for output in s.outputs() {
-                            check::output_cv_epk_not_small_order(output)?;
-                        }
-                    }
+            if transaction.version() == 5 {
+                for spend in transaction.sapling_spends_per_anchor() {
+                    check::spend_cv_rk_not_small_order(&spend)?;
                 }
-                _ => panic!("we should have no tx other than 5"),
+                for output in transaction.sapling_outputs() {
+                    check::output_cv_epk_not_small_order(output)?;
+                }
+            } else {
+                panic!("we should have no tx other than 5");
             }
         }
     }


### PR DESCRIPTION
## Motivation

Clippy is suggesting that we collapse a nested `match ... { if let ... { ... } }`.

However, the suggestion is actually wrong:
https://github.com/rust-lang/rust-clippy/issues/7575

This lint only seems to be on nightly right now, but eventually it will cause our CI to fail.

## Solution

- remove the nested match, preserving behaviour

## Review

Anyone can review this tiny fix.

### Reviewer Checklist

  - [ ] Existing tests pass

