### PR TITLE
Improve some test errors

### DIFF
--- a/zebra-chain/src/history_tree.rs
+++ b/zebra-chain/src/history_tree.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 
 use crate::{
     block::{Block, ChainHistoryMmrRootHash, Height},
+    fmt::SummaryDebug,
     orchard,
     parameters::{Network, NetworkUpgrade},
     primitives::zcash_history::{Entry, Tree, V1 as PreOrchard, V2 as OrchardOnward},
@@ -66,7 +67,7 @@ pub struct NonEmptyHistoryTree {
     size: u32,
     /// The peaks of the tree, indexed by their position in the array representation
     /// of the tree. This can be persisted to save the tree.
-    peaks: BTreeMap<u32, Entry>,
+    peaks: SummaryDebug<BTreeMap<u32, Entry>>,
     /// The height of the most recent block added to the tree.
     current_height: Height,
 }
@@ -117,7 +118,7 @@ impl NonEmptyHistoryTree {
             network_upgrade,
             inner,
             size,
-            peaks,
+            peaks: peaks.into(),
             current_height,
         })
     }
@@ -171,7 +172,7 @@ impl NonEmptyHistoryTree {
             network_upgrade,
             inner: tree,
             size: 1,
-            peaks,
+            peaks: peaks.into(),
             current_height: height,
         })
     }

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -182,12 +182,23 @@ fn rejection_restores_internal_state() -> Result<()> {
                   prop_assert!(state.eq_internal_state(&state));
 
                   if let Some(first_block) = chain.next() {
-                      state.commit_new_chain(first_block, &finalized_state)?;
+                      let result = state.commit_new_chain(first_block, &finalized_state);
+                      prop_assert_eq!(
+                          result,
+                          Ok(()),
+                          "PreparedChain should generate a valid first block"
+                      );
                       prop_assert!(state.eq_internal_state(&state));
                   }
 
                   for block in chain {
-                      state.commit_block(block, &finalized_state)?;
+                      let result = state.commit_block(block.clone(), &finalized_state);
+                      prop_assert_eq!(
+                          result,
+                          Ok(()),
+                          "PreparedChain should generate a valid block at {:?}",
+                          block.height,
+                      );
                       prop_assert!(state.eq_internal_state(&state));
                   }
 


### PR DESCRIPTION
## Motivation

1. Sometimes it's hard to read proptest output, because the debug format contains a lot of information
2. The `rejection_restores_internal_state` test doesn't provide enough information about errors

## Solution

1. Wrap the history tree peaks in `SummaryDebug`
2. Print the height and error when `rejection_restores_internal_state` fails

## Review

1. @conradoplg might want to review the history tree changes
2. @oxarbitrage might want both sets of changes, to make it easier to fix tests in https://github.com/oxarbitrage/zebra/pull/130

### Reviewer Checklist

  - [ ] Existing tests pass

