### PR TITLE
Create initial transaction crawler for the mempool

### DIFF
--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -55,7 +55,7 @@ once_cell = "1.8"
 regex = "1.4.6"
 semver = "1.0.3"
 tempdir = "0.3.7"
-tokio = { version = "0.3.6", features = ["time", "rt-multi-thread", "stream", "macros", "tracing", "signal", "test-util"] }
+tokio = { version = "0.3.6", features = ["full", "test-util"] }
 
 proptest = "0.10"
 proptest-derive = "0.3"

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -55,6 +55,7 @@ once_cell = "1.8"
 regex = "1.4.6"
 semver = "1.0.3"
 tempdir = "0.3.7"
+tokio = { version = "0.3.6", features = ["time", "rt-multi-thread", "stream", "macros", "tracing", "signal", "test-util"] }
 
 proptest = "0.10"
 proptest-derive = "0.3"

--- a/zebrad/src/components.rs
+++ b/zebrad/src/components.rs
@@ -6,6 +6,7 @@
 //! don't fit the async context well.
 
 mod inbound;
+pub mod mempool;
 pub mod metrics;
 mod sync;
 pub mod tokio;

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -1,0 +1,5 @@
+//! Zebra mempool.
+
+mod crawler;
+
+pub use self::crawler::Crawler;

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -92,7 +92,7 @@ where
             transaction_ids.len()
         );
 
-        // TODO: Download transactions and send them to the mempool
+        // TODO: Download transactions and send them to the mempool (#2650)
 
         Ok(())
     }

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -1,0 +1,87 @@
+//! Zebra Mempool crawler.
+//!
+//! The crawler periodically requests transactions from peers in order to populate the mempool.
+
+use std::time::Duration;
+
+use futures::{stream, StreamExt, TryStreamExt};
+use tokio::{sync::Mutex, task::JoinHandle, time::sleep};
+use tower::{BoxError, Service, ServiceExt};
+
+use zebra_network::{Request, Response};
+
+/// The number of peers to request transactions from per crawl event.
+const FANOUT: usize = 4;
+
+/// The delay between crawl events.
+const RATE_LIMIT_DELAY: Duration = Duration::from_secs(75);
+
+/// The mempool transaction crawler.
+pub struct Crawler<S> {
+    peer_set: Mutex<S>,
+}
+
+impl<S> Crawler<S>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send,
+{
+    /// Spawn an asynchronous task to run the mempool crawler.
+    pub fn spawn(peer_set: S) -> JoinHandle<()> {
+        let crawler = Crawler {
+            peer_set: Mutex::new(peer_set),
+        };
+
+        tokio::spawn(crawler.run())
+    }
+
+    /// Periodically crawl peers for transactions to include in the mempool.
+    pub async fn run(self) {
+        loop {
+            self.wait_until_enabled().await;
+            self.crawl_transactions().await;
+            sleep(RATE_LIMIT_DELAY).await;
+        }
+    }
+
+    /// Wait until the mempool is enabled.
+    async fn wait_until_enabled(&self) {
+        // TODO: Check if synchronizing up to chain tip has finished (#).
+    }
+
+    /// Crawl peers for transactions.
+    ///
+    /// Concurrently request [`FANOUT`] peers for transactions to include in the mempool.
+    async fn crawl_transactions(&self) {
+        let requests = stream::repeat(Request::MempoolTransactionIds).take(FANOUT);
+        let peer_set = self.peer_set.lock().await.clone();
+
+        trace!("Crawling for mempool transactions");
+
+        peer_set
+            .call_all(requests)
+            .unordered()
+            .and_then(|response| self.handle_response(response))
+            // TODO: Reduce the log level of the errors (#2655).
+            .inspect_err(|error| info!("Failed to crawl peer for mempool transactions: {}", error))
+            .for_each(|_| async {})
+            .await;
+    }
+
+    /// Handle a peer's response to the crawler's request for transactions.
+    async fn handle_response(&self, response: Response) -> Result<(), BoxError> {
+        let transaction_ids = match response {
+            Response::TransactionIds(ids) => ids,
+            _ => unreachable!("Peer set did not respond with transaction IDs to mempool crawler"),
+        };
+
+        trace!(
+            "Mempool crawler received {} transaction IDs",
+            transaction_ids.len()
+        );
+
+        // TODO: Download transactions and send them to the mempool
+
+        Ok(())
+    }
+}

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use futures::{stream, StreamExt, TryStreamExt};
 use tokio::{sync::Mutex, task::JoinHandle, time::sleep};
-use tower::{BoxError, Service, ServiceExt};
+use tower::{timeout::Timeout, BoxError, Service, ServiceExt};
 
 use zebra_network::{Request, Response};
 
@@ -16,9 +16,18 @@ const FANOUT: usize = 4;
 /// The delay between crawl events.
 const RATE_LIMIT_DELAY: Duration = Duration::from_secs(75);
 
+/// The time to wait for a peer response.
+///
+/// # Correctness
+///
+/// If this timeout is removed or set too high, the crawler may hang waiting for a peer to respond.
+///
+/// If this timeout is set too low, the crawler may fail to populate the mempool.
+const PEER_RESPONSE_TIMEOUT: Duration = Duration::from_secs(6);
+
 /// The mempool transaction crawler.
 pub struct Crawler<S> {
-    peer_set: Mutex<S>,
+    peer_set: Mutex<Timeout<S>>,
 }
 
 impl<S> Crawler<S>
@@ -29,7 +38,7 @@ where
     /// Spawn an asynchronous task to run the mempool crawler.
     pub fn spawn(peer_set: S) -> JoinHandle<()> {
         let crawler = Crawler {
-            peer_set: Mutex::new(peer_set),
+            peer_set: Mutex::new(Timeout::new(peer_set, PEER_RESPONSE_TIMEOUT)),
         };
 
         tokio::spawn(crawler.run())

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -58,7 +58,7 @@ where
 
     /// Wait until the mempool is enabled.
     async fn wait_until_enabled(&self) {
-        // TODO: Check if synchronizing up to chain tip has finished (#).
+        // TODO: Check if synchronizing up to chain tip has finished (#2603).
     }
 
     /// Crawl peers for transactions.

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -10,6 +10,9 @@ use tower::{timeout::Timeout, BoxError, Service, ServiceExt};
 
 use zebra_network::{Request, Response};
 
+#[cfg(test)]
+mod tests;
+
 /// The number of peers to request transactions from per crawl event.
 const FANOUT: usize = 4;
 

--- a/zebrad/src/components/mempool/crawler/tests.rs
+++ b/zebrad/src/components/mempool/crawler/tests.rs
@@ -1,0 +1,76 @@
+use std::time::Duration;
+
+use tokio::{
+    sync::mpsc::{self, UnboundedReceiver},
+    time::{self, timeout},
+};
+use tower::{buffer::Buffer, util::BoxService, BoxError};
+
+use zebra_network::{Request, Response};
+
+use super::{Crawler, FANOUT, RATE_LIMIT_DELAY};
+
+/// The number of iterations to crawl while testing.
+///
+/// Note that this affects the total run time of the [`crawler_requests_for_transaction_ids`] test.
+/// See more information in [`MAX_REQUEST_DELAY`].
+const CRAWL_ITERATIONS: usize = 4;
+
+/// The maximum time to wait for a request to arrive before considering it won't arrive.
+///
+/// Note that this affects the total run time of the [`crawler_requests_for_transaction_ids`] test.
+/// There are [`CRAWL_ITERATIONS`] requests that are expected to not be sent, so the test runs for
+/// at least `MAX_REQUEST_DELAY * CRAWL_ITERATIONS`.
+const MAX_REQUEST_DELAY: Duration = Duration::from_millis(250);
+
+/// The amount of time to advance beyond the expected instant that the crawler wakes up.
+const ERROR_MARGIN: Duration = Duration::from_millis(100);
+
+#[tokio::test]
+async fn crawler_requests_for_transaction_ids() {
+    let (peer_set, mut requests) = mock_peer_set();
+
+    Crawler::spawn(peer_set);
+
+    time::pause();
+
+    for _ in 0..CRAWL_ITERATIONS {
+        for _ in 0..FANOUT {
+            let request = timeout(MAX_REQUEST_DELAY, requests.recv()).await;
+
+            assert!(matches!(request, Ok(Some(Request::MempoolTransactionIds))));
+        }
+
+        let extra_request = timeout(MAX_REQUEST_DELAY, requests.recv()).await;
+
+        assert!(extra_request.is_err());
+
+        time::advance(RATE_LIMIT_DELAY + ERROR_MARGIN).await;
+    }
+}
+
+/// Create a mock service to represent a [`PeerSet`][zebra_network::PeerSet] and intercept the
+/// requests it receives.
+///
+/// The intercepted requests are sent through an unbounded channel to the receiver that's also
+/// returned from this function.
+fn mock_peer_set() -> (
+    Buffer<BoxService<Request, Response, BoxError>, Request>,
+    UnboundedReceiver<Request>,
+) {
+    let (sender, receiver) = mpsc::unbounded_channel();
+
+    let proxy_service = tower::service_fn(move |request| {
+        let sender = sender.clone();
+
+        async move {
+            let _ = sender.send(request);
+
+            Ok(Response::TransactionIds(vec![]))
+        }
+    });
+
+    let service = Buffer::new(BoxService::new(proxy_service), 10);
+
+    (service, receiver)
+}


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
As part of the work to implement a mempool for Zebra, there's a need to crawl peers for transactions to populate the mempool. The mempool crawler is a background task that periodically asks a few peers for transactions.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->
The Bitcoin documentation contains a [small description](https://developer.bitcoin.org/reference/p2p_networking.html#mempool) about the mempool related network messages.

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
A `Crawler` type is created inside the `mempool` component. Calling `Crawler::spawn` will construct the type and spawn a task to run it on the background. The crawler periodically requests a few peers (configured by a fan-out constant) for transaction IDs.

There's a single test to make sure that the requests are sent in a timely manner to the `PeerSet` service.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 has been following the design of this, but anyone else can chime in as well.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
- Implement disabling the mempool until chain synchronization is complete #2592 
- Download and store the transactions for the mempool #2650
- Reduce the log level of crawl errors after the mempool is complete #2655 