### PR TITLE
WIP: fix tests after adding value pools to non-finalized state

### DIFF
--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -206,8 +206,6 @@ where
             let new_outputs = Arc::try_unwrap(known_utxos)
                 .expect("all verification tasks using known_utxos are complete");
 
-            let block_utxos = transparent::utxos_from_ordered_utxos(new_outputs.clone());
-
             // Finally, submit the block for contextual verification.
             let prepared_block = zs::PreparedBlock {
                 block,
@@ -215,7 +213,6 @@ where
                 height,
                 new_outputs,
                 transaction_hashes,
-                block_utxos,
             };
             match state_service
                 .ready_and()

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -1,8 +1,14 @@
 use std::sync::Arc;
 
-use zebra_chain::{block::Block, transparent};
+use zebra_chain::{
+    amount::{Amount, NegativeAllowed},
+    block::{self, Block},
+    transaction::Transaction,
+    transparent,
+    value_balance::ValueBalance,
+};
 
-use crate::PreparedBlock;
+use crate::{request::ContextuallyValidBlock, PreparedBlock};
 
 /// Mocks computation done during semantic validation
 pub trait Prepare {
@@ -16,7 +22,6 @@ impl Prepare for Arc<Block> {
         let height = block.coinbase_height().unwrap();
         let transaction_hashes: Vec<_> = block.transactions.iter().map(|tx| tx.hash()).collect();
         let new_outputs = transparent::new_ordered_outputs(&block, transaction_hashes.as_slice());
-        let block_utxos = transparent::utxos_from_ordered_utxos(new_outputs.clone());
 
         PreparedBlock {
             block,
@@ -24,7 +29,107 @@ impl Prepare for Arc<Block> {
             height,
             new_outputs,
             transaction_hashes,
-            block_utxos,
         }
+    }
+}
+
+impl PreparedBlock {
+    /// Returns a [`ContextuallyValidBlock`] created from this block,
+    /// with fake zero-valued spent UTXOs.
+    ///
+    /// Only for use in tests.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn test_with_zero_spent_utxos(&self) -> ContextuallyValidBlock {
+        ContextuallyValidBlock::test_with_zero_spent_utxos(self)
+    }
+
+    /// Returns a [`ContextuallyValidBlock`] created from this block,
+    /// using a fake chain value pool change.
+    ///
+    /// Only for use in tests.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn test_with_chain_pool_change(
+        &self,
+        fake_chain_value_pool_change: ValueBalance<NegativeAllowed>,
+    ) -> ContextuallyValidBlock {
+        ContextuallyValidBlock::test_with_chain_pool_change(self, fake_chain_value_pool_change)
+    }
+
+    /// Returns a [`ContextuallyValidBlock`] created from this block,
+    /// with no chain value pool change.
+    ///
+    /// Only for use in tests.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn test_with_zero_chain_pool_change(&self) -> ContextuallyValidBlock {
+        ContextuallyValidBlock::test_with_zero_chain_pool_change(self)
+    }
+}
+
+impl ContextuallyValidBlock {
+    /// Create a block that's ready for non-finalized [`Chain`] contextual validation,
+    /// using a [`PreparedBlock`] and fake zero-valued spent UTXOs.
+    ///
+    /// Only for use in tests.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn test_with_zero_spent_utxos(block: impl Into<PreparedBlock>) -> Self {
+        let block = block.into();
+
+        let zero_utxo = transparent::Utxo {
+            output: transparent::Output {
+                value: Amount::zero(),
+                lock_script: transparent::Script::new(&[]),
+            },
+            height: block::Height(1),
+            from_coinbase: false,
+        };
+
+        let zero_spent_utxos = block
+            .block
+            .transactions
+            .iter()
+            .map(AsRef::as_ref)
+            .flat_map(Transaction::inputs)
+            .flat_map(transparent::Input::outpoint)
+            .map(|outpoint| (outpoint, zero_utxo.clone()))
+            .collect();
+
+        ContextuallyValidBlock::with_block_and_spent_utxos(block, zero_spent_utxos)
+            .expect("all UTXOs are provided with zero values")
+    }
+
+    /// Create a [`ContextuallyValidBlock`] from a [`Block`] or [`PreparedBlock`],
+    /// using a fake chain value pool change.
+    ///
+    /// Only for use in tests.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn test_with_chain_pool_change(
+        block: impl Into<PreparedBlock>,
+        fake_chain_value_pool_change: ValueBalance<NegativeAllowed>,
+    ) -> Self {
+        let PreparedBlock {
+            block,
+            hash,
+            height,
+            new_outputs,
+            transaction_hashes,
+        } = block.into();
+
+        Self {
+            block,
+            hash,
+            height,
+            new_outputs: transparent::utxos_from_ordered_utxos(new_outputs),
+            transaction_hashes,
+            chain_value_pool_change: fake_chain_value_pool_change,
+        }
+    }
+
+    /// Create a [`ContextuallyValidBlock`] from a [`Block`] or [`PreparedBlock`],
+    /// with no chain value pool change.
+    ///
+    /// Only for use in tests.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn test_with_zero_chain_pool_change(block: impl Into<PreparedBlock>) -> Self {
+        Self::test_with_chain_pool_change(block, ValueBalance::zero())
     }
 }

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -181,6 +181,13 @@ pub enum ValidateContextError {
     },
 
     #[error(
+        "error calculating the block chain value pool change: \
+         {0:?}"
+    )]
+    #[non_exhaustive]
+    CalculateBlockChainValueChange(ValueBalanceError),
+
+    #[error(
         "error adding value balances to the chain value pool: \
          {value_balance_error:?}"
     )]

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -148,7 +148,10 @@ impl Chain {
             self.orchard_nullifiers == other.orchard_nullifiers &&
 
             // proof of work
-            self.partial_cumulative_work == other.partial_cumulative_work
+            self.partial_cumulative_work == other.partial_cumulative_work &&
+
+            // chain value pool balance
+            self.value_balance == other.value_balance
     }
 
     /// Push a contextually valid non-finalized block into this chain as the new tip.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -21,7 +21,7 @@ use zebra_chain::{
     work::difficulty::PartialCumulativeWork,
 };
 
-use crate::{service::check, ContextuallyValidBlock, PreparedBlock, ValidateContextError};
+use crate::{service::check, ContextuallyValidBlock, ValidateContextError};
 
 #[derive(Debug, Clone)]
 pub struct Chain {
@@ -157,15 +157,16 @@ impl Chain {
     /// Push a contextually valid non-finalized block into this chain as the new tip.
     ///
     /// If the block is invalid, drop this chain and return an error.
+    ///
+    /// Note: a [`ContextuallyValidBlock`] isn't actually contextually valid until
+    /// [`update_chain_state_with`] returns success.
     #[instrument(level = "debug", skip(self, block), fields(block = %block.block))]
-    pub fn push(mut self, block: PreparedBlock) -> Result<Chain, ValidateContextError> {
-        // the block isn't contextually valid until `update_chain_state_with` returns success
-        let block = ContextuallyValidBlock::from(block);
-
+    pub fn push(mut self, block: ContextuallyValidBlock) -> Result<Chain, ValidateContextError> {
         // update cumulative data members
         self.update_chain_state_with(&block)?;
         tracing::debug!(block = %block.block, "adding block to chain");
         self.blocks.insert(block.height, block);
+
         Ok(self)
     }
 
@@ -367,13 +368,13 @@ impl UpdateWith<ContextuallyValidBlock> for Chain {
         &mut self,
         contextually_valid: &ContextuallyValidBlock,
     ) -> Result<(), ValidateContextError> {
-        let (block, hash, height, new_outputs, transaction_hashes, block_utxos) = (
+        let (block, hash, height, new_outputs, transaction_hashes, chain_value_pool_change) = (
             contextually_valid.block.as_ref(),
             contextually_valid.hash,
             contextually_valid.height,
             &contextually_valid.new_outputs,
             &contextually_valid.transaction_hashes,
-            &contextually_valid.block_utxos,
+            &contextually_valid.chain_value_pool_change,
         );
 
         // add hash to height_by_hash
@@ -449,8 +450,7 @@ impl UpdateWith<ContextuallyValidBlock> for Chain {
             self.update_chain_state_with(orchard_shielded_data)?;
 
             // add the value balance
-            let value_balance = block.chain_value_pool_change(block_utxos).unwrap();
-            self.update_chain_state_with(&value_balance)?;
+            self.update_chain_state_with(chain_value_pool_change)?;
         }
 
         // Having updated all the note commitment trees and nullifier sets in
@@ -475,13 +475,13 @@ impl UpdateWith<ContextuallyValidBlock> for Chain {
 
     #[instrument(skip(self, contextually_valid), fields(block = %contextually_valid.block))]
     fn revert_chain_state_with(&mut self, contextually_valid: &ContextuallyValidBlock) {
-        let (block, hash, height, new_outputs, transaction_hashes, block_utxos) = (
+        let (block, hash, height, new_outputs, transaction_hashes, chain_value_pool_change) = (
             contextually_valid.block.as_ref(),
             contextually_valid.hash,
             contextually_valid.height,
             &contextually_valid.new_outputs,
             &contextually_valid.transaction_hashes,
-            &contextually_valid.block_utxos,
+            &contextually_valid.chain_value_pool_change,
         );
 
         // remove the blocks hash from `height_by_hash`
@@ -555,9 +555,8 @@ impl UpdateWith<ContextuallyValidBlock> for Chain {
             self.revert_chain_state_with(orchard_shielded_data);
 
             // remove the value balance
-            let value_balance = block.chain_value_pool_change(block_utxos).unwrap();
             use std::ops::Neg;
-            self.revert_chain_state_with(&value_balance.neg());
+            self.revert_chain_state_with(&chain_value_pool_change.neg());
         }
         let anchor = self
             .sapling_anchors_by_height

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -15,6 +15,7 @@ use zebra_chain::{
 
 use crate::{
     arbitrary::Prepare,
+    request::ContextuallyValidBlock,
     service::{
         arbitrary::PreparedChain,
         finalized_state::FinalizedState,
@@ -52,30 +53,36 @@ fn forked_equals_pushed() -> Result<()> {
             let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone(), fake_value_pool);
             let mut partial_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone(), fake_value_pool);
 
-            for block in chain.iter().take(fork_at_count) {
-                partial_chain = partial_chain.push(block.clone())?;
-            }
-            for block in chain.iter() {
-                full_chain = full_chain.push(block.clone())?;
-
-                // check some other properties of generated chains
-                if block.height == block::Height(0) {
-                    prop_assert_eq!(
-                        block
-                            .block
-                            .transactions
-                            .iter()
-                            .flat_map(|t| t.inputs())
-                            .filter_map(|i| i.outpoint())
-                            .count(),
-                        0,
-                        "unexpected transparent prevout input at height {:?}: \
-                         genesis transparent outputs must be ignored, \
-                         so there can not be any spends in the genesis block",
-                        block.height,
-                    );
+            for block in chain
+                .iter()
+                .take(fork_at_count)
+                .map(ContextuallyValidBlock::test_with_zero_chain_pool_change) {
+                    partial_chain = partial_chain.push(block)?;
                 }
-            }
+
+            for block in chain
+                .iter()
+                .map(ContextuallyValidBlock::test_with_zero_chain_pool_change) {
+                    full_chain = full_chain.push(block.clone())?;
+
+                    // check some other properties of generated chains
+                    if block.height == block::Height(0) {
+                        prop_assert_eq!(
+                            block
+                                .block
+                                .transactions
+                                .iter()
+                                .flat_map(|t| t.inputs())
+                                .filter_map(|i| i.outpoint())
+                                .count(),
+                            0,
+                            "unexpected transparent prevout input at height {:?}: \
+                             genesis transparent outputs must be ignored, \
+                             so there can not be any spends in the genesis block",
+                            block.height,
+                        );
+                    }
+                }
 
             let mut forked = full_chain
                 .fork(
@@ -93,8 +100,11 @@ fn forked_equals_pushed() -> Result<()> {
 
             // Re-add blocks to the fork and check if we arrive at the
             // same original full chain
-            for block in chain.iter().skip(fork_at_count) {
-                forked = forked.push(block.clone())?;
+            for block in chain
+                .iter()
+                .skip(fork_at_count)
+                .map(ContextuallyValidBlock::test_with_zero_chain_pool_change) {
+                    forked = forked.push(block)?;
             }
 
             prop_assert_eq!(forked.blocks.len(), full_chain.blocks.len());
@@ -122,11 +132,15 @@ fn finalized_equals_pushed() -> Result<()> {
         let finalized_count = chain.len() - end_count;
 
         let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
-        let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree, fake_value_pool);
 
-        for block in chain.iter().take(finalized_count) {
-            full_chain = full_chain.push(block.clone())?;
-        }
+        let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree, fake_value_pool);
+        for block in chain
+            .iter()
+            .take(finalized_count)
+            .map(ContextuallyValidBlock::test_with_zero_chain_pool_change) {
+                full_chain = full_chain.push(block)?;
+            }
+
         let mut partial_chain = Chain::new(
             network,
             full_chain.sapling_note_commitment_tree.clone(),
@@ -134,12 +148,19 @@ fn finalized_equals_pushed() -> Result<()> {
             full_chain.history_tree.clone(),
             full_chain.value_balance,
         );
-        for block in chain.iter().skip(finalized_count) {
-            partial_chain = partial_chain.push(block.clone())?;
-        }
-        for block in chain.iter().skip(finalized_count) {
-            full_chain = full_chain.push(block.clone())?;
-        }
+        for block in chain
+            .iter()
+            .skip(finalized_count)
+            .map(ContextuallyValidBlock::test_with_zero_chain_pool_change) {
+                partial_chain = partial_chain.push(block.clone())?;
+            }
+
+        for block in chain
+            .iter()
+            .skip(finalized_count)
+            .map(ContextuallyValidBlock::test_with_zero_chain_pool_change) {
+                full_chain = full_chain.push(block.clone())?;
+            }
 
         for _ in 0..finalized_count {
             let _finalized = full_chain.pop_root();
@@ -274,11 +295,11 @@ fn different_blocks_different_chains() -> Result<()> {
         } else {
             Default::default()
         };
-        let chain1 = Chain::new(Network::Mainnet, Default::default(), Default::default(), finalized_tree1, ValueBalance::zero());
-        let chain2 = Chain::new(Network::Mainnet, Default::default(), Default::default(), finalized_tree2, ValueBalance::zero());
+        let chain1 = Chain::new(Network::Mainnet, Default::default(), Default::default(), finalized_tree1, ValueBalance::fake_populated_pool());
+        let chain2 = Chain::new(Network::Mainnet, Default::default(), Default::default(), finalized_tree2, ValueBalance::fake_populated_pool());
 
-        let block1 = vec1[1].clone().prepare();
-        let block2 = vec2[1].clone().prepare();
+        let block1 = vec1[1].clone().prepare().test_with_zero_spent_utxos();
+        let block2 = vec2[1].clone().prepare().test_with_zero_spent_utxos();
 
         let result1 = chain1.push(block1.clone());
         let result2 = chain2.push(block2.clone());

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -23,7 +23,11 @@ use crate::{
     Config,
 };
 
+/// The default number of proptest cases for long partial chain tests.
 const DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES: u32 = 1;
+
+/// The default number of proptest cases for short partial chain tests.
+const DEFAULT_SHORT_CHAIN_PROPTEST_CASES: u32 = 16;
 
 /// Check that a forked chain is the same as a chain that had the same blocks appended.
 ///
@@ -244,7 +248,7 @@ fn different_blocks_different_chains() -> Result<()> {
     proptest!(ProptestConfig::with_cases(env::var("PROPTEST_CASES")
                                .ok()
                                .and_then(|v| v.parse().ok())
-                               .unwrap_or(DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES)),
+                               .unwrap_or(DEFAULT_SHORT_CHAIN_PROPTEST_CASES)),
     |((vec1, vec2) in (any::<bool>(), any::<bool>())
       .prop_flat_map(|(is_nu5, is_v5)| {
           // generate a Canopy or NU5 block with v4 or v5 transactions
@@ -325,6 +329,9 @@ fn different_blocks_different_chains() -> Result<()> {
 
                 // proof of work
                 chain1.partial_cumulative_work = chain2.partial_cumulative_work;
+
+                // chain value pool
+                chain1.value_balance = chain2.value_balance;
 
                 // If this check fails, the `Chain` fields are out
                 // of sync with `eq_internal_state` or this test.

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -45,9 +45,9 @@ fn construct_single() -> Result<()> {
         Default::default(),
         Default::default(),
         Default::default(),
-        ValueBalance::zero(),
+        ValueBalance::fake_populated_pool(),
     );
-    chain = chain.push(block.prepare())?;
+    chain = chain.push(block.prepare().test_with_zero_spent_utxos())?;
 
     assert_eq!(1, chain.blocks.len());
 
@@ -73,11 +73,11 @@ fn construct_many() -> Result<()> {
         Default::default(),
         Default::default(),
         Default::default(),
-        ValueBalance::zero(),
+        ValueBalance::fake_populated_pool(),
     );
 
     for block in blocks {
-        chain = chain.push(block.prepare())?;
+        chain = chain.push(block.prepare().test_with_zero_spent_utxos())?;
     }
 
     assert_eq!(100, chain.blocks.len());
@@ -100,7 +100,7 @@ fn ord_matches_work() -> Result<()> {
         Default::default(),
         ValueBalance::zero(),
     );
-    lesser_chain = lesser_chain.push(less_block.prepare())?;
+    lesser_chain = lesser_chain.push(less_block.prepare().test_with_zero_chain_pool_change())?;
 
     let mut bigger_chain = Chain::new(
         Network::Mainnet,
@@ -109,7 +109,7 @@ fn ord_matches_work() -> Result<()> {
         Default::default(),
         ValueBalance::zero(),
     );
-    bigger_chain = bigger_chain.push(more_block.prepare())?;
+    bigger_chain = bigger_chain.push(more_block.prepare().test_with_zero_chain_pool_change())?;
 
     assert!(bigger_chain > lesser_chain);
 


### PR DESCRIPTION
## Motivation

These changes:
- change how `Chain` stores value pools, so it's easier to test, and
- fix bugs in existing tests.

## Solution

Code
- store the block value pool change in `ContextuallyValidBlock`
  - replace `block_utxos` with `new_outputs` in `PreparedBlock`
  - replace `block_utxos` with `chain_value_pool_change` in `ContextuallyValidBlock`
- convert `PreparedBlock` to `ContextuallyValidBlock` using `with_block_and_spent_utxos` (rather than `from` or `into`)

Tests
- create test methods for `PreparedBlock` and `ContextuallyValidBlock`
- use `test_with_zero_chain_pool_change` or `test_with_zero_spent_utxos` to make tests pass

Fixes
- Update `Chain::eq_internal_state` with `Chain.value_balance`

## Review

@oxarbitrage and I are working on this one together.

This PR depends on:
- #2648 
- #2649
- https://github.com/oxarbitrage/zebra/pull/130
- the current `main` branch

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Eventually add more tests #2640