### PR TITLE
Remove a finalized state test dependency on ContextuallyValidBlock

### DIFF
--- a/zebra-state/src/service/finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/tests/prop.rs
@@ -9,7 +9,6 @@ use crate::{
         arbitrary::PreparedChain,
         finalized_state::{FinalizedBlock, FinalizedState},
     },
-    ContextuallyValidBlock,
 };
 
 const DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES: u32 = 1;
@@ -27,7 +26,7 @@ fn blocks_with_v5_transactions() -> Result<()> {
             // use `count` to minimize test failures, so they are easier to diagnose
             for block in chain.iter().take(count) {
                 let hash = state.commit_finalized_direct(
-                    FinalizedBlock::from(ContextuallyValidBlock::from(block.clone())),
+                    FinalizedBlock::from(block.block.clone()),
                     "blocks_with_v5_transactions test"
                 );
                 prop_assert_eq!(Some(height), state.finalized_tip_height());


### PR DESCRIPTION
## Motivation

This PR simplifies a finalized state test, so we don't have to fix it as part of PR #2647.

## Review

Anyone can review this PR, but @oxarbitrage might want to because it blocks PR #2647.

### Reviewer Checklist

  - [ ] Existing Tests Pass
  - [ ] Code Changes make sense
