### PR TITLE
Split ValueBalance methods into NegativeAllowed and NonNegative

### DIFF
--- a/zebra-chain/src/value_balance/tests/prop.rs
+++ b/zebra-chain/src/value_balance/tests/prop.rs
@@ -106,7 +106,7 @@ proptest! {
     }
 
     #[test]
-    fn value_balance_serialization(value_balance in any::<ValueBalance<NegativeAllowed>>()) {
+    fn value_balance_serialization(value_balance in any::<ValueBalance<NonNegative>>()) {
         zebra_test::init();
 
         let bytes = value_balance.to_bytes();
@@ -119,7 +119,7 @@ proptest! {
     fn value_balance_deserialization(bytes in any::<[u8; 32]>()) {
         zebra_test::init();
 
-        if let Ok(deserialized) = ValueBalance::<NegativeAllowed>::from_bytes(bytes) {
+        if let Ok(deserialized) = ValueBalance::<NonNegative>::from_bytes(bytes) {
             let bytes2 = deserialized.to_bytes();
             prop_assert_eq!(bytes, bytes2);
         }


### PR DESCRIPTION
## Motivation

Some `ValueBalance` methods only make sense for `NegativeAllowed` or `NonNegative`.

If we make them generic, it's harder to use them correctly.
And type inference can fail on the generic, which makes code harder to write.

## Solution

- split out some methods into `ValueBalance<NonNegative>` and `ValueBalance<NegativeAllowed>`
- fix serialization tests to use `ValueBalance<NonNegative>`, like the finalized state
- fix an unused import clippy lint

## Review

@oxarbitrage can review this PR, it also includes some of the test methods from PR #2647 and https://github.com/oxarbitrage/zebra/pull/130

### Reviewer Checklist

  - [ ] Code implements consensus rules
  - [ ] Existing tests work

