### PR TITLE
Add value pool/balances to non-finalized state

### DIFF
--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -316,21 +316,17 @@ impl Transaction {
 
         let sapling_input = self.sapling_value_balance().constrain::<NonNegative>();
         if let Ok(sapling_input) = sapling_input {
-            if sapling_input != ValueBalance::zero() {
-                match input_chain_value_pools.update_with_chain_value_pool_change(-sapling_input) {
-                    Ok(new_chain_pools) => input_chain_value_pools = new_chain_pools,
-                    Err(_) => *self.sapling_value_balance_mut().unwrap() = Amount::zero(),
-                }
+            match input_chain_value_pools.update_with_chain_value_pool_change(-sapling_input) {
+                Ok(new_chain_pools) => input_chain_value_pools = new_chain_pools,
+                Err(_) => *self.sapling_value_balance_mut().unwrap() = Amount::zero(),
             }
         }
 
         let orchard_input = self.orchard_value_balance().constrain::<NonNegative>();
         if let Ok(orchard_input) = orchard_input {
-            if orchard_input != ValueBalance::zero() {
-                match input_chain_value_pools.update_with_chain_value_pool_change(-orchard_input) {
-                    Ok(new_chain_pools) => input_chain_value_pools = new_chain_pools,
-                    Err(_) => *self.orchard_value_balance_mut().unwrap() = Amount::zero(),
-                }
+            match input_chain_value_pools.update_with_chain_value_pool_change(-orchard_input) {
+                Ok(new_chain_pools) => input_chain_value_pools = new_chain_pools,
+                Err(_) => *self.orchard_value_balance_mut().unwrap() = Amount::zero(),
             }
         }
 

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -293,7 +293,7 @@ impl Transaction {
 
         for input in self.inputs() {
             input_chain_value_pools = input_chain_value_pools
-                .update_with_transparent_input(input, outputs)
+                .add_transparent_input(input, outputs)
                 .expect("find_valid_utxo_for_spend only spends unspent transparent outputs");
         }
 
@@ -304,7 +304,7 @@ impl Transaction {
         //       so at least one of the values in each JoinSplit is zero
         for input in self.input_values_from_sprout_mut() {
             match input_chain_value_pools
-                .update_with_chain_value_pool_change(ValueBalance::from_sprout_amount(input.neg()))
+                .add_chain_value_pool_change(ValueBalance::from_sprout_amount(input.neg()))
             {
                 Ok(new_chain_pools) => input_chain_value_pools = new_chain_pools,
                 // set the invalid input value to zero
@@ -316,7 +316,7 @@ impl Transaction {
 
         let sapling_input = self.sapling_value_balance().constrain::<NonNegative>();
         if let Ok(sapling_input) = sapling_input {
-            match input_chain_value_pools.update_with_chain_value_pool_change(-sapling_input) {
+            match input_chain_value_pools.add_chain_value_pool_change(-sapling_input) {
                 Ok(new_chain_pools) => input_chain_value_pools = new_chain_pools,
                 Err(_) => *self.sapling_value_balance_mut().unwrap() = Amount::zero(),
             }
@@ -324,7 +324,7 @@ impl Transaction {
 
         let orchard_input = self.orchard_value_balance().constrain::<NonNegative>();
         if let Ok(orchard_input) = orchard_input {
-            match input_chain_value_pools.update_with_chain_value_pool_change(-orchard_input) {
+            match input_chain_value_pools.add_chain_value_pool_change(-orchard_input) {
                 Ok(new_chain_pools) => input_chain_value_pools = new_chain_pools,
                 Err(_) => *self.orchard_value_balance_mut().unwrap() = Amount::zero(),
             }
@@ -340,7 +340,7 @@ impl Transaction {
             .neg();
 
         let chain_value_pools = chain_value_pools
-            .update_with_transaction(self, outputs)
+            .add_transaction(self, outputs)
             .unwrap_or_else(|err| {
                 panic!(
                     "unexpected chain value pool error: {:?}, \n\

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -1,7 +1,7 @@
 //! A type that can hold the four types of Zcash value pools.
 
 use crate::{
-    amount::{self, Amount, Constraint, NegativeAllowed, NonNegative},
+    amount::{self, Amount, Constraint, NegativeAllowed, NonNegative, MAX_MONEY},
     block::Block,
     transparent,
 };
@@ -347,6 +347,32 @@ impl ValueBalance<NonNegative> {
             sapling,
             orchard,
         })
+    }
+
+    /// Create a fake value pool for testing purposes.
+    ///
+    /// The resulting [`ValueBalance`] will have half of the MAX_MONEY amount on each pool.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn fake_populated_pool() -> ValueBalance<NonNegative> {
+        use std::convert::TryFrom;
+
+        let mut fake_value_pool = ValueBalance::zero();
+
+        let fake_transparent_value_balance =
+            ValueBalance::from_transparent_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
+        let fake_sprout_value_balance =
+            ValueBalance::from_sprout_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
+        let fake_sapling_value_balance =
+            ValueBalance::from_sapling_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
+        let fake_orchard_value_balance =
+            ValueBalance::from_orchard_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
+
+        fake_value_pool.set_transparent_value_balance(fake_transparent_value_balance);
+        fake_value_pool.set_sprout_value_balance(fake_sprout_value_balance);
+        fake_value_pool.set_sapling_value_balance(fake_sapling_value_balance);
+        fake_value_pool.set_orchard_value_balance(fake_orchard_value_balance);
+
+        fake_value_pool
     }
 }
 

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -1,7 +1,7 @@
 //! A type that can hold the four types of Zcash value pools.
 
 use crate::{
-    amount::{self, Amount, Constraint, NegativeAllowed, NonNegative, MAX_MONEY},
+    amount::{self, Amount, Constraint, NegativeAllowed, NonNegative},
     block::Block,
     transparent,
 };
@@ -347,32 +347,6 @@ impl ValueBalance<NonNegative> {
             sapling,
             orchard,
         })
-    }
-
-    /// Create a fake value pool for testing purposes.
-    ///
-    /// The resulting [`ValueBalance`] will have half of the MAX_MONEY amount on each pool.
-    #[cfg(any(test, feature = "proptest-impl"))]
-    pub fn fake_populated_pool() -> ValueBalance<NonNegative> {
-        use std::convert::TryFrom;
-
-        let mut fake_value_pool = ValueBalance::zero();
-
-        let fake_transparent_value_balance =
-            ValueBalance::from_transparent_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
-        let fake_sprout_value_balance =
-            ValueBalance::from_sprout_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
-        let fake_sapling_value_balance =
-            ValueBalance::from_sapling_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
-        let fake_orchard_value_balance =
-            ValueBalance::from_orchard_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
-
-        fake_value_pool.set_transparent_value_balance(fake_transparent_value_balance);
-        fake_value_pool.set_sprout_value_balance(fake_sprout_value_balance);
-        fake_value_pool.set_sapling_value_balance(fake_sapling_value_balance);
-        fake_value_pool.set_orchard_value_balance(fake_orchard_value_balance);
-
-        fake_value_pool
     }
 }
 

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -206,8 +206,6 @@ where
             let new_outputs = Arc::try_unwrap(known_utxos)
                 .expect("all verification tasks using known_utxos are complete");
 
-            let block_utxos = transparent::utxos_from_ordered_utxos(new_outputs.clone());
-
             // Finally, submit the block for contextual verification.
             let prepared_block = zs::PreparedBlock {
                 block,
@@ -215,7 +213,6 @@ where
                 height,
                 new_outputs,
                 transaction_hashes,
-                block_utxos,
             };
             match state_service
                 .ready_and()

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -206,6 +206,8 @@ where
             let new_outputs = Arc::try_unwrap(known_utxos)
                 .expect("all verification tasks using known_utxos are complete");
 
+            let block_utxos = transparent::utxos_from_ordered_utxos(new_outputs.clone());
+
             // Finally, submit the block for contextual verification.
             let prepared_block = zs::PreparedBlock {
                 block,
@@ -213,6 +215,7 @@ where
                 height,
                 new_outputs,
                 transaction_hashes,
+                block_utxos,
             };
             match state_service
                 .ready_and()

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -1,8 +1,14 @@
 use std::sync::Arc;
 
-use zebra_chain::{block::Block, transparent};
+use zebra_chain::{
+    amount::{Amount, NegativeAllowed},
+    block::{self, Block},
+    transaction::Transaction,
+    transparent,
+    value_balance::ValueBalance,
+};
 
-use crate::PreparedBlock;
+use crate::{request::ContextuallyValidBlock, PreparedBlock};
 
 /// Mocks computation done during semantic validation
 pub trait Prepare {
@@ -16,7 +22,6 @@ impl Prepare for Arc<Block> {
         let height = block.coinbase_height().unwrap();
         let transaction_hashes: Vec<_> = block.transactions.iter().map(|tx| tx.hash()).collect();
         let new_outputs = transparent::new_ordered_outputs(&block, transaction_hashes.as_slice());
-        let block_utxos = transparent::utxos_from_ordered_utxos(new_outputs.clone());
 
         PreparedBlock {
             block,
@@ -24,7 +29,107 @@ impl Prepare for Arc<Block> {
             height,
             new_outputs,
             transaction_hashes,
-            block_utxos,
         }
+    }
+}
+
+impl PreparedBlock {
+    /// Returns a [`ContextuallyValidBlock`] created from this block,
+    /// with fake zero-valued spent UTXOs.
+    ///
+    /// Only for use in tests.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn test_with_zero_spent_utxos(&self) -> ContextuallyValidBlock {
+        ContextuallyValidBlock::test_with_zero_spent_utxos(self)
+    }
+
+    /// Returns a [`ContextuallyValidBlock`] created from this block,
+    /// using a fake chain value pool change.
+    ///
+    /// Only for use in tests.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn test_with_chain_pool_change(
+        &self,
+        fake_chain_value_pool_change: ValueBalance<NegativeAllowed>,
+    ) -> ContextuallyValidBlock {
+        ContextuallyValidBlock::test_with_chain_pool_change(self, fake_chain_value_pool_change)
+    }
+
+    /// Returns a [`ContextuallyValidBlock`] created from this block,
+    /// with no chain value pool change.
+    ///
+    /// Only for use in tests.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn test_with_zero_chain_pool_change(&self) -> ContextuallyValidBlock {
+        ContextuallyValidBlock::test_with_zero_chain_pool_change(self)
+    }
+}
+
+impl ContextuallyValidBlock {
+    /// Create a block that's ready for non-finalized [`Chain`] contextual validation,
+    /// using a [`PreparedBlock`] and fake zero-valued spent UTXOs.
+    ///
+    /// Only for use in tests.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn test_with_zero_spent_utxos(block: impl Into<PreparedBlock>) -> Self {
+        let block = block.into();
+
+        let zero_utxo = transparent::Utxo {
+            output: transparent::Output {
+                value: Amount::zero(),
+                lock_script: transparent::Script::new(&[]),
+            },
+            height: block::Height(1),
+            from_coinbase: false,
+        };
+
+        let zero_spent_utxos = block
+            .block
+            .transactions
+            .iter()
+            .map(AsRef::as_ref)
+            .flat_map(Transaction::inputs)
+            .flat_map(transparent::Input::outpoint)
+            .map(|outpoint| (outpoint, zero_utxo.clone()))
+            .collect();
+
+        ContextuallyValidBlock::with_block_and_spent_utxos(block, zero_spent_utxos)
+            .expect("all UTXOs are provided with zero values")
+    }
+
+    /// Create a [`ContextuallyValidBlock`] from a [`Block`] or [`PreparedBlock`],
+    /// using a fake chain value pool change.
+    ///
+    /// Only for use in tests.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn test_with_chain_pool_change(
+        block: impl Into<PreparedBlock>,
+        fake_chain_value_pool_change: ValueBalance<NegativeAllowed>,
+    ) -> Self {
+        let PreparedBlock {
+            block,
+            hash,
+            height,
+            new_outputs,
+            transaction_hashes,
+        } = block.into();
+
+        Self {
+            block,
+            hash,
+            height,
+            new_outputs: transparent::utxos_from_ordered_utxos(new_outputs),
+            transaction_hashes,
+            chain_value_pool_change: fake_chain_value_pool_change,
+        }
+    }
+
+    /// Create a [`ContextuallyValidBlock`] from a [`Block`] or [`PreparedBlock`],
+    /// with no chain value pool change.
+    ///
+    /// Only for use in tests.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn test_with_zero_chain_pool_change(block: impl Into<PreparedBlock>) -> Self {
+        Self::test_with_chain_pool_change(block, ValueBalance::zero())
     }
 }

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -38,7 +38,6 @@ impl PreparedBlock {
     /// with fake zero-valued spent UTXOs.
     ///
     /// Only for use in tests.
-    #[cfg(any(test, feature = "proptest-impl"))]
     pub fn test_with_zero_spent_utxos(&self) -> ContextuallyValidBlock {
         ContextuallyValidBlock::test_with_zero_spent_utxos(self)
     }
@@ -47,7 +46,6 @@ impl PreparedBlock {
     /// using a fake chain value pool change.
     ///
     /// Only for use in tests.
-    #[cfg(any(test, feature = "proptest-impl"))]
     pub fn test_with_chain_pool_change(
         &self,
         fake_chain_value_pool_change: ValueBalance<NegativeAllowed>,
@@ -59,7 +57,6 @@ impl PreparedBlock {
     /// with no chain value pool change.
     ///
     /// Only for use in tests.
-    #[cfg(any(test, feature = "proptest-impl"))]
     pub fn test_with_zero_chain_pool_change(&self) -> ContextuallyValidBlock {
         ContextuallyValidBlock::test_with_zero_chain_pool_change(self)
     }
@@ -70,7 +67,6 @@ impl ContextuallyValidBlock {
     /// using a [`PreparedBlock`] and fake zero-valued spent UTXOs.
     ///
     /// Only for use in tests.
-    #[cfg(any(test, feature = "proptest-impl"))]
     pub fn test_with_zero_spent_utxos(block: impl Into<PreparedBlock>) -> Self {
         let block = block.into();
 
@@ -101,7 +97,6 @@ impl ContextuallyValidBlock {
     /// using a fake chain value pool change.
     ///
     /// Only for use in tests.
-    #[cfg(any(test, feature = "proptest-impl"))]
     pub fn test_with_chain_pool_change(
         block: impl Into<PreparedBlock>,
         fake_chain_value_pool_change: ValueBalance<NegativeAllowed>,
@@ -128,7 +123,6 @@ impl ContextuallyValidBlock {
     /// with no chain value pool change.
     ///
     /// Only for use in tests.
-    #[cfg(any(test, feature = "proptest-impl"))]
     pub fn test_with_zero_chain_pool_change(block: impl Into<PreparedBlock>) -> Self {
         Self::test_with_chain_pool_change(block, ValueBalance::zero())
     }

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -16,6 +16,7 @@ impl Prepare for Arc<Block> {
         let height = block.coinbase_height().unwrap();
         let transaction_hashes: Vec<_> = block.transactions.iter().map(|tx| tx.hash()).collect();
         let new_outputs = transparent::new_ordered_outputs(&block, transaction_hashes.as_slice());
+        let block_utxos = transparent::utxos_from_ordered_utxos(new_outputs.clone());
 
         PreparedBlock {
             block,
@@ -23,6 +24,7 @@ impl Prepare for Arc<Block> {
             height,
             new_outputs,
             transaction_hashes,
+            block_utxos,
         }
     }
 }

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -181,6 +181,13 @@ pub enum ValidateContextError {
     },
 
     #[error(
+        "error calculating the block chain value pool change: \
+         {0:?}"
+    )]
+    #[non_exhaustive]
+    CalculateBlockChainValueChange(ValueBalanceError),
+
+    #[error(
         "error adding value balances to the chain value pool: \
          {value_balance_error:?}"
     )]

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -180,6 +180,15 @@ pub enum ValidateContextError {
         transaction_hash: zebra_chain::transaction::Hash,
     },
 
+    #[error(
+        "error adding value balances to the chain value pool: \
+         {value_balance_error:?}"
+    )]
+    #[non_exhaustive]
+    AddValuePool {
+        value_balance_error: ValueBalanceError,
+    },
+
     #[error("error in Sapling note commitment tree")]
     SaplingNoteCommitmentTreeError(#[from] zebra_chain::sapling::tree::NoteCommitmentTreeError),
 

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -4,8 +4,12 @@ use chrono::{DateTime, Utc};
 use thiserror::Error;
 
 use zebra_chain::{
-    amount, block, history_tree::HistoryTreeError, orchard, sapling, sprout, transparent,
-    value_balance::ValueBalanceError, work::difficulty::CompactDifficulty,
+    amount::{self, NegativeAllowed, NonNegative},
+    block,
+    history_tree::HistoryTreeError,
+    orchard, sapling, sprout, transaction, transparent,
+    value_balance::{ValueBalance, ValueBalanceError},
+    work::difficulty::CompactDifficulty,
 };
 
 use crate::constants::MIN_TRANSPARENT_COINBASE_MATURITY;
@@ -142,58 +146,72 @@ pub enum ValidateContextError {
     },
 
     #[error(
-        "the remaining value in the transparent transaction value pool MUST be nonnegative: \
-         {amount_error:?}, {height:?}, index in block: {tx_index_in_block:?}, \
-         {transaction_hash:?}"
+        "the remaining value in the transparent transaction value pool MUST be nonnegative:\n\
+         {amount_error:?},\n\
+         {height:?}, index in block: {tx_index_in_block:?}, {transaction_hash:?}"
     )]
     #[non_exhaustive]
     NegativeRemainingTransactionValue {
         amount_error: amount::Error,
         height: block::Height,
         tx_index_in_block: usize,
-        transaction_hash: zebra_chain::transaction::Hash,
+        transaction_hash: transaction::Hash,
     },
 
     #[error(
-        "error calculating the remaining value in the transaction value pool: \
-         {amount_error:?}, {height:?}, index in block: {tx_index_in_block:?}, \
-         {transaction_hash:?}"
+        "error calculating the remaining value in the transaction value pool:\n\
+         {amount_error:?},\n\
+         {height:?}, index in block: {tx_index_in_block:?}, {transaction_hash:?}"
     )]
     #[non_exhaustive]
     CalculateRemainingTransactionValue {
         amount_error: amount::Error,
         height: block::Height,
         tx_index_in_block: usize,
-        transaction_hash: zebra_chain::transaction::Hash,
+        transaction_hash: transaction::Hash,
     },
 
     #[error(
-        "error calculating value balances for the remaining value in the transaction value pool: \
-         {value_balance_error:?}, {height:?}, index in block: {tx_index_in_block:?}, \
-         {transaction_hash:?}"
+        "error calculating value balances for the remaining value in the transaction value pool:\n\
+         {value_balance_error:?},\n\
+         {height:?}, index in block: {tx_index_in_block:?}, {transaction_hash:?}"
     )]
     #[non_exhaustive]
     CalculateTransactionValueBalances {
         value_balance_error: ValueBalanceError,
         height: block::Height,
         tx_index_in_block: usize,
-        transaction_hash: zebra_chain::transaction::Hash,
+        transaction_hash: transaction::Hash,
     },
 
     #[error(
-        "error calculating the block chain value pool change: \
-         {0:?}"
+        "error calculating the block chain value pool change:\n\
+         {value_balance_error:?},\n\
+         {height:?}, {block_hash:?},\n\
+         transactions: {transaction_count:?}, spent UTXOs: {spent_utxo_count:?}"
     )]
     #[non_exhaustive]
-    CalculateBlockChainValueChange(ValueBalanceError),
+    CalculateBlockChainValueChange {
+        value_balance_error: ValueBalanceError,
+        height: block::Height,
+        block_hash: block::Hash,
+        transaction_count: usize,
+        spent_utxo_count: usize,
+    },
 
     #[error(
-        "error adding value balances to the chain value pool: \
-         {value_balance_error:?}"
+        "error adding value balances to the chain value pool:\n\
+         {value_balance_error:?},\n\
+         {chain_value_pools:?},\n\
+         {block_value_pool_change:?},\n\
+         {height:?}"
     )]
     #[non_exhaustive]
     AddValuePool {
         value_balance_error: ValueBalanceError,
+        chain_value_pools: ValueBalance<NonNegative>,
+        block_value_pool_change: ValueBalance<NegativeAllowed>,
+        height: Option<block::Height>,
     },
 
     #[error("error in Sapling note commitment tree")]

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -81,6 +81,8 @@ pub struct PreparedBlock {
     // TODO: add these parameters when we can compute anchors.
     // sprout_anchor: sprout::tree::Root,
     // sapling_anchor: sapling::tree::Root,
+    /// Storage for all the utxos related to this block.
+    pub block_utxos: HashMap<transparent::OutPoint, transparent::Utxo>,
 }
 
 /// A contextually validated block, ready to be committed directly to the finalized state with
@@ -94,6 +96,7 @@ pub(crate) struct ContextuallyValidBlock {
     pub(crate) height: block::Height,
     pub(crate) new_outputs: HashMap<transparent::OutPoint, transparent::Utxo>,
     pub(crate) transaction_hashes: Vec<transaction::Hash>,
+    pub(crate) block_utxos: HashMap<transparent::OutPoint, transparent::Utxo>,
 }
 
 /// A finalized block, ready to be committed directly to the finalized state with
@@ -145,6 +148,7 @@ impl From<PreparedBlock> for ContextuallyValidBlock {
             height,
             new_outputs,
             transaction_hashes,
+            block_utxos,
         } = prepared;
         Self {
             block,
@@ -152,6 +156,7 @@ impl From<PreparedBlock> for ContextuallyValidBlock {
             height,
             new_outputs: transparent::utxos_from_ordered_utxos(new_outputs),
             transaction_hashes,
+            block_utxos,
         }
     }
 }
@@ -164,6 +169,7 @@ impl From<ContextuallyValidBlock> for FinalizedBlock {
             height,
             new_outputs,
             transaction_hashes,
+            block_utxos: _,
         } = contextually_valid;
         Self {
             block,

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -601,8 +601,7 @@ impl FinalizedState {
     }
 
     /// Allow to set up a fake value pool in the database for testing purposes.
-    //#[cfg(any(test, feature = "proptest-impl"))]
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn set_current_value_pool(&self, fake_value_pool: ValueBalance<NonNegative>) {
         let mut batch = rocksdb::WriteBatch::default();
         let value_pool_cf = self.db.cf_handle("tip_chain_value_pool").unwrap();

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -599,6 +599,16 @@ impl FinalizedState {
             .zs_get(value_pool_cf, &())
             .unwrap_or_else(ValueBalance::zero)
     }
+
+    /// Allow to set up a fake value pool in the database for testing purposes.
+    //#[cfg(any(test, feature = "proptest-impl"))]
+    #[allow(dead_code)]
+    pub fn set_current_value_pool(&self, fake_value_pool: ValueBalance<NonNegative>) {
+        let mut batch = rocksdb::WriteBatch::default();
+        let value_pool_cf = self.db.cf_handle("tip_chain_value_pool").unwrap();
+        batch.zs_insert(value_pool_cf, (), fake_value_pool);
+        self.db.write(batch).unwrap();
+    }
 }
 
 // Drop isn't guaranteed to run, such as when we panic, or if someone stored

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -420,8 +420,7 @@ impl FinalizedState {
             all_utxos_spent_by_block.extend(new_outputs);
 
             let current_pool = self.current_value_pool();
-            let new_pool =
-                current_pool.update_with_block(block.borrow(), &all_utxos_spent_by_block)?;
+            let new_pool = current_pool.add_block(block.borrow(), &all_utxos_spent_by_block)?;
             batch.zs_insert(tip_chain_value_pool, (), new_pool);
 
             Ok(batch)

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -601,7 +601,8 @@ impl FinalizedState {
     }
 
     /// Allow to set up a fake value pool in the database for testing purposes.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "proptest-impl"))]
+    #[allow(dead_code)]
     pub fn set_current_value_pool(&self, fake_value_pool: ValueBalance<NonNegative>) {
         let mut batch = rocksdb::WriteBatch::default();
         let value_pool_cf = self.db.cf_handle("tip_chain_value_pool").unwrap();

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -201,8 +201,19 @@ impl NonFinalizedState {
             &parent_chain.history_tree,
         )?;
 
-        let contextual = ContextuallyValidBlock::with_block_and_spent_utxos(prepared, spent_utxos)
-            .map_err(ValidateContextError::CalculateBlockChainValueChange)?;
+        let contextual = ContextuallyValidBlock::with_block_and_spent_utxos(
+            prepared.clone(),
+            spent_utxos.clone(),
+        )
+        .map_err(|value_balance_error| {
+            ValidateContextError::CalculateBlockChainValueChange {
+                value_balance_error,
+                height: prepared.height,
+                block_hash: prepared.hash,
+                transaction_count: prepared.block.transactions.len(),
+                spent_utxo_count: spent_utxos.len(),
+            }
+        })?;
 
         parent_chain.push(contextual)
     }

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -167,6 +167,7 @@ impl NonFinalizedState {
             finalized_state.sapling_note_commitment_tree(),
             finalized_state.orchard_note_commitment_tree(),
             finalized_state.history_tree(),
+            finalized_state.current_value_pool(),
         );
         let (height, hash) = (prepared.height, prepared.hash);
 
@@ -182,10 +183,10 @@ impl NonFinalizedState {
     fn validate_and_commit(
         &self,
         parent_chain: Chain,
-        prepared: PreparedBlock,
+        mut prepared: PreparedBlock,
         finalized_state: &FinalizedState,
     ) -> Result<Chain, ValidateContextError> {
-        check::utxo::transparent_spend(
+        let utxos = check::utxo::transparent_spend(
             &prepared,
             &parent_chain.unspent_utxos(),
             &parent_chain.spent_utxos,
@@ -197,6 +198,7 @@ impl NonFinalizedState {
             &parent_chain.history_tree,
         )?;
 
+        prepared.block_utxos.extend(utxos);
         parent_chain.push(prepared)
     }
 

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -370,7 +370,7 @@ impl NonFinalizedState {
     }
 
     /// Return the non-finalized portion of the current best chain
-    fn best_chain(&self) -> Option<&Chain> {
+    pub(crate) fn best_chain(&self) -> Option<&Chain> {
         self.chain_set
             .iter()
             .next_back()

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -43,20 +43,23 @@ pub struct Chain {
     /// including those created by earlier transactions or blocks in the chain.
     pub(crate) spent_utxos: HashSet<transparent::OutPoint>,
 
-    /// The Sapling note commitment tree of the tip of this Chain.
+    /// The Sapling note commitment tree of the tip of this `Chain`,
+    /// including all finalized notes, and the non-finalized notes in this chain.
     pub(super) sapling_note_commitment_tree: sapling::tree::NoteCommitmentTree,
-    /// The Orchard note commitment tree of the tip of this Chain.
+    /// The Orchard note commitment tree of the tip of this `Chain`,
+    /// including all finalized notes, and the non-finalized notes in this chain.
     pub(super) orchard_note_commitment_tree: orchard::tree::NoteCommitmentTree,
-    /// The ZIP-221 history tree of the tip of this Chain.
+    /// The ZIP-221 history tree of the tip of this `Chain`,
+    /// including all finalized blocks, and the non-finalized `blocks` in this chain.
     pub(crate) history_tree: HistoryTree,
 
     /// The Sapling anchors created by `blocks`.
     pub(super) sapling_anchors: HashMultiSet<sapling::tree::Root>,
-    /// The Sapling anchors created by each block in the chain.
+    /// The Sapling anchors created by each block in `blocks`.
     pub(super) sapling_anchors_by_height: BTreeMap<block::Height, sapling::tree::Root>,
     /// The Orchard anchors created by `blocks`.
     pub(super) orchard_anchors: HashMultiSet<orchard::tree::Root>,
-    /// The Orchard anchors created by each block in the chain.
+    /// The Orchard anchors created by each block in `blocks`.
     pub(super) orchard_anchors_by_height: BTreeMap<block::Height, orchard::tree::Root>,
 
     /// The Sprout nullifiers revealed by `blocks`.
@@ -66,7 +69,11 @@ pub struct Chain {
     /// The Orchard nullifiers revealed by `blocks`.
     pub(super) orchard_nullifiers: HashSet<orchard::Nullifier>,
 
-    /// The cumulative work represented by this partial non-finalized chain.
+    /// The cumulative work represented by `blocks`.
+    ///
+    /// Since the best chain is determined by the largest cumulative work,
+    /// the work represented by finalized blocks can be ignored,
+    /// because they are common to all non-finalized chains.
     pub(super) partial_cumulative_work: PartialCumulativeWork,
 
     /// The value balance in of this Chain.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -82,7 +82,7 @@ pub struct Chain {
     ///
     /// When a new chain is created from the finalized tip,
     /// it is initialized with the finalized tip chain value pool balances.
-    pub(super) chain_value_pools: ValueBalance<NonNegative>,
+    pub(crate) chain_value_pools: ValueBalance<NonNegative>,
 }
 
 impl Chain {

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -799,15 +799,17 @@ impl UpdateWith<ValueBalance<NegativeAllowed>> for Chain {
             .chain_value_pools
             .update_with_chain_value_pool_change(*block_value_pool_change)
         {
-            Ok(_) => Ok(()),
+            Ok(chain_value_pools) => self.chain_value_pools = chain_value_pools,
             Err(value_balance_error) => Err(ValidateContextError::AddValuePool {
                 value_balance_error,
                 chain_value_pools: self.chain_value_pools,
                 block_value_pool_change: *block_value_pool_change,
                 // assume that the current block is added to `blocks` after `update_chain_tip_with`
                 height: self.max_block_height().and_then(|height| height + 1),
-            }),
-        }
+            })?,
+        };
+
+        Ok(())
     }
 
     /// Revert the chain state using a block chain value pool change.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -797,7 +797,7 @@ impl UpdateWith<ValueBalance<NegativeAllowed>> for Chain {
     ) -> Result<(), ValidateContextError> {
         match self
             .chain_value_pools
-            .update_with_chain_value_pool_change(*block_value_pool_change)
+            .add_chain_value_pool_change(*block_value_pool_change)
         {
             Ok(chain_value_pools) => self.chain_value_pools = chain_value_pools,
             Err(value_balance_error) => Err(ValidateContextError::AddValuePool {
@@ -835,7 +835,7 @@ impl UpdateWith<ValueBalance<NegativeAllowed>> for Chain {
         if position == RevertPosition::Tip {
             self.chain_value_pools = self
                 .chain_value_pools
-                .update_with_chain_value_pool_change(block_value_pool_change.neg())
+                .add_chain_value_pool_change(block_value_pool_change.neg())
                 .expect("reverting the tip will leave the pools in a previously valid state");
         }
     }

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -8,6 +8,7 @@ use zebra_chain::{
     history_tree::{HistoryTree, NonEmptyHistoryTree},
     parameters::NetworkUpgrade::*,
     parameters::{Network, *},
+    value_balance::ValueBalance,
     LedgerState,
 };
 
@@ -42,8 +43,8 @@ fn forked_equals_pushed() -> Result<()> {
             // use `fork_at_count` as the fork tip
             let fork_tip_hash = chain[fork_at_count - 1].hash;
 
-            let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone());
-            let mut partial_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone());
+            let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone(), ValueBalance::zero());
+            let mut partial_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone(), ValueBalance::zero());
 
             for block in chain.iter().take(fork_at_count) {
                 partial_chain = partial_chain.push(block.clone())?;
@@ -113,7 +114,7 @@ fn finalized_equals_pushed() -> Result<()> {
         let chain = &chain[1..];
         // use `end_count` as the number of non-finalized blocks at the end of the chain
         let finalized_count = chain.len() - end_count;
-        let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree);
+        let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree, ValueBalance::zero());
 
         for block in chain.iter().take(finalized_count) {
             full_chain = full_chain.push(block.clone())?;
@@ -123,6 +124,7 @@ fn finalized_equals_pushed() -> Result<()> {
             full_chain.sapling_note_commitment_tree.clone(),
             full_chain.orchard_note_commitment_tree.clone(),
             full_chain.history_tree.clone(),
+            full_chain.value_balance,
         );
         for block in chain.iter().skip(finalized_count) {
             partial_chain = partial_chain.push(block.clone())?;
@@ -261,8 +263,8 @@ fn different_blocks_different_chains() -> Result<()> {
         } else {
             Default::default()
         };
-        let chain1 = Chain::new(Network::Mainnet, Default::default(), Default::default(), finalized_tree1);
-        let chain2 = Chain::new(Network::Mainnet, Default::default(), Default::default(), finalized_tree2);
+        let chain1 = Chain::new(Network::Mainnet, Default::default(), Default::default(), finalized_tree1, ValueBalance::zero());
+        let chain2 = Chain::new(Network::Mainnet, Default::default(), Default::default(), finalized_tree2, ValueBalance::zero());
 
         let block1 = vec1[1].clone().prepare();
         let block2 = vec2[1].clone().prepare();

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -44,8 +44,9 @@ fn forked_equals_pushed() -> Result<()> {
             // use `fork_at_count` as the fork tip
             let fork_tip_hash = chain[fork_at_count - 1].hash;
 
-            let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone(), ValueBalance::zero());
-            let mut partial_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone(), ValueBalance::zero());
+            let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+            let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone(), fake_value_pool);
+            let mut partial_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone(), fake_value_pool);
 
             for block in chain.iter().take(fork_at_count) {
                 partial_chain = partial_chain.push(block.clone())?;
@@ -115,7 +116,9 @@ fn finalized_equals_pushed() -> Result<()> {
         let chain = &chain[1..];
         // use `end_count` as the number of non-finalized blocks at the end of the chain
         let finalized_count = chain.len() - end_count;
-        let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree, ValueBalance::zero());
+
+        let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+        let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree, fake_value_pool);
 
         for block in chain.iter().take(finalized_count) {
             full_chain = full_chain.push(block.clone())?;

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -146,7 +146,7 @@ fn finalized_equals_pushed() -> Result<()> {
             full_chain.sapling_note_commitment_tree.clone(),
             full_chain.orchard_note_commitment_tree.clone(),
             full_chain.history_tree.clone(),
-            full_chain.value_balance,
+            full_chain.chain_value_pools,
         );
         for block in chain
             .iter()
@@ -352,7 +352,7 @@ fn different_blocks_different_chains() -> Result<()> {
                 chain1.partial_cumulative_work = chain2.partial_cumulative_work;
 
                 // chain value pool
-                chain1.value_balance = chain2.value_balance;
+                chain1.chain_value_pools = chain2.chain_value_pools;
 
                 // If this check fails, the `Chain` fields are out
                 // of sync with `eq_internal_state` or this test.

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -3,6 +3,7 @@ use std::{env, sync::Arc};
 use zebra_test::prelude::*;
 
 use zebra_chain::{
+    amount::NonNegative,
     block::{self, arbitrary::allow_all_transparent_coinbase_spends, Block},
     fmt::DisplayToDebug,
     history_tree::{HistoryTree, NonEmptyHistoryTree},
@@ -175,6 +176,9 @@ fn rejection_restores_internal_state() -> Result<()> {
                 ))| {
                   let mut state = NonFinalizedState::new(network);
                   let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+
+                  let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+                  finalized_state.set_current_value_pool(fake_value_pool);
 
                   // use `valid_count` as the number of valid blocks before an invalid block
                   let valid_tip_height = chain[valid_count - 1].height;

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -45,9 +45,9 @@ fn construct_single() -> Result<()> {
         Default::default(),
         Default::default(),
         Default::default(),
-        ValueBalance::zero(),
+        ValueBalance::fake_populated_pool(),
     );
-    chain = chain.push(block.prepare())?;
+    chain = chain.push(block.prepare().test_with_zero_spent_utxos())?;
 
     assert_eq!(1, chain.blocks.len());
 
@@ -73,11 +73,11 @@ fn construct_many() -> Result<()> {
         Default::default(),
         Default::default(),
         Default::default(),
-        ValueBalance::zero(),
+        ValueBalance::fake_populated_pool(),
     );
 
     for block in blocks {
-        chain = chain.push(block.prepare())?;
+        chain = chain.push(block.prepare().test_with_zero_spent_utxos())?;
     }
 
     assert_eq!(100, chain.blocks.len());
@@ -100,7 +100,7 @@ fn ord_matches_work() -> Result<()> {
         Default::default(),
         ValueBalance::zero(),
     );
-    lesser_chain = lesser_chain.push(less_block.prepare())?;
+    lesser_chain = lesser_chain.push(less_block.prepare().test_with_zero_chain_pool_change())?;
 
     let mut bigger_chain = Chain::new(
         Network::Mainnet,
@@ -109,7 +109,7 @@ fn ord_matches_work() -> Result<()> {
         Default::default(),
         ValueBalance::zero(),
     );
-    bigger_chain = bigger_chain.push(more_block.prepare())?;
+    bigger_chain = bigger_chain.push(more_block.prepare().test_with_zero_chain_pool_change())?;
 
     assert!(bigger_chain > lesser_chain);
 

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -98,9 +98,9 @@ fn ord_matches_work() -> Result<()> {
         Default::default(),
         Default::default(),
         Default::default(),
-        ValueBalance::zero(),
+        ValueBalance::fake_populated_pool(),
     );
-    lesser_chain = lesser_chain.push(less_block.prepare().test_with_zero_chain_pool_change())?;
+    lesser_chain = lesser_chain.push(less_block.prepare().test_with_zero_spent_utxos())?;
 
     let mut bigger_chain = Chain::new(
         Network::Mainnet,
@@ -109,7 +109,7 @@ fn ord_matches_work() -> Result<()> {
         Default::default(),
         ValueBalance::zero(),
     );
-    bigger_chain = bigger_chain.push(more_block.prepare().test_with_zero_chain_pool_change())?;
+    bigger_chain = bigger_chain.push(more_block.prepare().test_with_zero_spent_utxos())?;
 
     assert!(bigger_chain > lesser_chain);
 

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -185,6 +185,9 @@ fn finalize_pops_from_best_chain_for_network(network: Network) -> Result<()> {
     let mut state = NonFinalizedState::new(network);
     let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
 
+    let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+    finalized_state.set_current_value_pool(fake_value_pool);
+
     state.commit_new_chain(block1.clone().prepare(), &finalized_state)?;
     state.commit_block(block2.clone().prepare(), &finalized_state)?;
     state.commit_block(child.prepare(), &finalized_state)?;
@@ -232,6 +235,9 @@ fn commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(
 
     let mut state = NonFinalizedState::new(network);
     let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+
+    let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+    finalized_state.set_current_value_pool(fake_value_pool);
 
     assert_eq!(0, state.chain_set.len());
     state.commit_new_chain(block1.prepare(), &finalized_state)?;
@@ -324,6 +330,9 @@ fn longer_chain_with_more_work_wins_for_network(network: Network) -> Result<()> 
     let mut state = NonFinalizedState::new(network);
     let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
 
+    let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+    finalized_state.set_current_value_pool(fake_value_pool);
+
     state.commit_new_chain(block1.prepare(), &finalized_state)?;
     state.commit_block(long_chain_block1.prepare(), &finalized_state)?;
     state.commit_block(long_chain_block2.prepare(), &finalized_state)?;
@@ -365,6 +374,9 @@ fn equal_length_goes_to_more_work_for_network(network: Network) -> Result<()> {
 
     let mut state = NonFinalizedState::new(network);
     let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+
+    let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+    finalized_state.set_current_value_pool(fake_value_pool);
 
     state.commit_new_chain(block1.prepare(), &finalized_state)?;
     state.commit_block(less_work_child.prepare(), &finalized_state)?;

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use zebra_chain::{
+    amount::NonNegative,
     block::Block,
     history_tree::NonEmptyHistoryTree,
     parameters::{Network, NetworkUpgrade},
@@ -275,6 +276,9 @@ fn shorter_chain_can_be_best_chain_for_network(network: Network) -> Result<()> {
 
     let mut state = NonFinalizedState::new(network);
     let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+
+    let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+    finalized_state.set_current_value_pool(fake_value_pool);
 
     state.commit_new_chain(block1.prepare(), &finalized_state)?;
     state.commit_block(long_chain_block1.prepare(), &finalized_state)?;

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -5,6 +5,7 @@ use zebra_chain::{
     history_tree::NonEmptyHistoryTree,
     parameters::{Network, NetworkUpgrade},
     serialization::ZcashDeserializeInto,
+    value_balance::ValueBalance,
 };
 use zebra_test::prelude::*;
 
@@ -28,6 +29,7 @@ fn construct_empty() {
         Default::default(),
         Default::default(),
         Default::default(),
+        ValueBalance::zero(),
     );
 }
 
@@ -42,6 +44,7 @@ fn construct_single() -> Result<()> {
         Default::default(),
         Default::default(),
         Default::default(),
+        ValueBalance::zero(),
     );
     chain = chain.push(block.prepare())?;
 
@@ -69,6 +72,7 @@ fn construct_many() -> Result<()> {
         Default::default(),
         Default::default(),
         Default::default(),
+        ValueBalance::zero(),
     );
 
     for block in blocks {
@@ -93,6 +97,7 @@ fn ord_matches_work() -> Result<()> {
         Default::default(),
         Default::default(),
         Default::default(),
+        ValueBalance::zero(),
     );
     lesser_chain = lesser_chain.push(less_block.prepare())?;
 
@@ -101,6 +106,7 @@ fn ord_matches_work() -> Result<()> {
         Default::default(),
         Default::default(),
         Default::default(),
+        ValueBalance::zero(),
     );
     bigger_chain = bigger_chain.push(more_block.prepare())?;
 

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -5,6 +5,7 @@ use tower::{buffer::Buffer, util::BoxService, Service, ServiceExt};
 
 use zebra_chain::{
     block::{self, Block},
+    fmt::SummaryDebug,
     parameters::{Network, NetworkUpgrade},
     serialization::{ZcashDeserialize, ZcashDeserializeInto},
     transaction, transparent,
@@ -377,8 +378,13 @@ proptest! {
 /// Selects either the mainnet or testnet chain test vector and randomly splits the chain in two
 /// lists of blocks. The first containing the blocks to be finalized (which always includes at
 /// least the genesis block) and the blocks to be stored in the non-finalized state.
-fn continuous_empty_blocks_from_test_vectors(
-) -> impl Strategy<Value = (Network, Vec<FinalizedBlock>, Vec<PreparedBlock>)> {
+fn continuous_empty_blocks_from_test_vectors() -> impl Strategy<
+    Value = (
+        Network,
+        SummaryDebug<Vec<FinalizedBlock>>,
+        SummaryDebug<Vec<PreparedBlock>>,
+    ),
+> {
     any::<Network>()
         .prop_flat_map(|network| {
             // Select the test vector based on the network
@@ -414,6 +420,10 @@ fn continuous_empty_blocks_from_test_vectors(
                 .map(|prepared_block| FinalizedBlock::from(prepared_block.block))
                 .collect();
 
-            (network, finalized_blocks, non_finalized_blocks)
+            (
+                network,
+                finalized_blocks.into(),
+                non_finalized_blocks.into(),
+            )
         })
 }


### PR DESCRIPTION
## Motivation

PR #2652 has some bugs in the new value pool calculations that I added.

## Solution

1. Only revert the chain value pool balances when the tip is popped. Don't modify them when the root is finalized, because the balances are for the entire finalized and non-finalized chain.

2. Only update or revert the chain value pool balances once per block. (Previously, the block changes were multiplied by the number of *transactions*.)

3. Actually update the chain value balances in the non-finalized state. (Previously, the changes were ignored using `Ok(_)`.)

4. Make existing tests pass

5. Add new tests to increase value balance coverage, particularly for non-finalized chain forks, and non-finalized chain root finalization

6. Add tests that check for specific value pool balances in the finalized and non-finalized state

These changes along with PR #2652:
Closes #1895 
Closes #2640

## Review

@oxarbitrage can review this PR.

I can split it into separate PRs, if that would help with the review.

This PR is based on PR #2652 merged with a recent `main` branch.
It will need a manual rebase and squash before merging.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
