### PR TITLE
Stop converting `Message::Inv(TxId+)` into `Request::TransactionsById`

### DIFF
--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -853,7 +853,7 @@ where
                     if tx_ids.iter().all(|item| item.unmined_tx_id().is_some())
                         && !tx_ids.is_empty() =>
                 {
-                    Request::TransactionsById(transaction_ids(&items).collect())
+                    Request::AdvertiseTransactionIds(transaction_ids(&items).collect())
                 }
                 _ => {
                     self.fail_with(PeerError::WrongMessage("inv with mixed item types"));


### PR DESCRIPTION
## Motivation

`Message::Inv(TxId+)` is a transaction advertisement, so it should be converted into `Request::AdvertiseTransactionIds`.

This is a copy-paste mistake from the original zebra-network implementation.

This bug is unexpected work in sprint 17.

### Specifications

> The “inv” message (inventory message) transmits one or more inventories of objects known to the transmitting peer. It can be sent unsolicited to announce new transactions or blocks...

https://developer.bitcoin.org/reference/p2p_networking.html#inv

### Designs

https://github.com/ZcashFoundation/zebra/blob/bc4194fcb93e41b9482acb2a6626933c950d5695/zebra-network/src/protocol/internal/request.rs#L137-L159

## Solution

- use `AdvertiseTransactionIds` for inbound `Inv` requests from peers

## Review

@jvff can review this PR.
@oxarbitrage might also be interested, because this fix is needed for #1077 

### Reviewer Checklist

  - [ ] Code implements Specs and Designs

## Follow Up Work

We'll use and test this message in #1077