### PR TITLE
Return a transaction verifier from `zebra_consensus::init`

### DIFF
--- a/zebra-consensus/src/chain/tests.rs
+++ b/zebra-consensus/src/chain/tests.rs
@@ -64,7 +64,7 @@ async fn verifiers_from_network(
         + 'static,
 ) {
     let state_service = zs::init_test(network);
-    let chain_verifier =
+    let (chain_verifier, _transaction_verifier) =
         crate::chain::init(Config::default(), network, state_service.clone()).await;
 
     (chain_verifier, state_service)
@@ -153,7 +153,8 @@ async fn verify_checkpoint(config: Config) -> Result<(), Report> {
 
     // Test that the chain::init function works. Most of the other tests use
     // init_from_verifiers.
-    let chain_verifier = super::init(config.clone(), network, zs::init_test(network)).await;
+    let (chain_verifier, _transaction_verifier) =
+        super::init(config.clone(), network, zs::init_test(network)).await;
 
     // Add a timeout layer
     let chain_verifier =

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -90,6 +90,10 @@ pub enum Request {
     },
 }
 
+/// The response type for the transaction verifier service.
+/// Responses identify the transaction that was verified.
+pub type Response = zebra_chain::transaction::Hash;
+
 impl Request {
     /// The transaction to verify that's in this request.
     pub fn transaction(&self) -> Arc<Transaction> {
@@ -127,7 +131,7 @@ where
     ZS: Service<zs::Request, Response = zs::Response, Error = BoxError> + Send + Clone + 'static,
     ZS::Future: Send + 'static,
 {
-    type Response = transaction::Hash;
+    type Response = Response;
     type Error = TransactionError;
     type Future =
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -406,7 +406,8 @@ async fn v4_transaction_with_transparent_transfer_is_rejected_by_the_script() {
     assert_eq!(
         result,
         Err(TransactionError::InternalDowncastError(
-            "downcast to redjubjub::Error failed, original error: ScriptInvalid".to_string()
+            "downcast to known transaction error type failed, original error: ScriptInvalid"
+                .to_string()
         ))
     );
 }
@@ -683,7 +684,7 @@ fn v4_with_unsigned_sprout_transfer_is_rejected() {
                 // TODO: Fix error downcast
                 // Err(TransactionError::Ed25519(ed25519::Error::InvalidSignature))
                 TransactionError::InternalDowncastError(
-                    "downcast to redjubjub::Error failed, original error: InvalidSignature"
+                    "downcast to known transaction error type failed, original error: InvalidSignature"
                         .to_string(),
                 )
             )

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -55,8 +55,8 @@ impl StartCmd {
         let state = ServiceBuilder::new().buffer(20).service(state_service);
 
         info!("initializing verifiers");
-        // TODO: use the mempool verifier to verify mempool transactions (#2637, #2606)
-        let (chain_verifier, _mempool_verifier) = zebra_consensus::chain::init(
+        // TODO: use the transaction verifier to verify mempool transactions (#2637, #2606)
+        let (chain_verifier, _tx_verifier) = zebra_consensus::chain::init(
             config.consensus.clone(),
             config.network.network,
             state.clone(),

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -55,7 +55,8 @@ impl StartCmd {
         let state = ServiceBuilder::new().buffer(20).service(state_service);
 
         info!("initializing verifiers");
-        let verifier = zebra_consensus::chain::init(
+        // TODO: use the mempool verifier to verify mempool transactions (#2637, #2606)
+        let (chain_verifier, _mempool_verifier) = zebra_consensus::chain::init(
             config.consensus.clone(),
             config.network.network,
             state.clone(),
@@ -70,7 +71,11 @@ impl StartCmd {
         let inbound = ServiceBuilder::new()
             .load_shed()
             .buffer(20)
-            .service(Inbound::new(setup_rx, state.clone(), verifier.clone()));
+            .service(Inbound::new(
+                setup_rx,
+                state.clone(),
+                chain_verifier.clone(),
+            ));
 
         let (peer_set, address_book) =
             zebra_network::init(config.network.clone(), inbound, Some(best_tip_height)).await;
@@ -81,7 +86,7 @@ impl StartCmd {
         info!("initializing syncer");
         // TODO: use sync_length_receiver to activate the mempool (#2592)
         let (syncer, _sync_length_receiver) =
-            ChainSync::new(&config, peer_set.clone(), state, verifier);
+            ChainSync::new(&config, peer_set.clone(), state, chain_verifier);
 
         select! {
             result = syncer.sync().fuse() => result,


### PR DESCRIPTION
## Motivation

To verify mempool transactions, we need a transaction verifier.

## Solution

- Wrap the existing transaction verifier in a buffer
- Initialize the block verifier with the buffered transaction verifier
- Return the buffered transaction verifier

Also:
- downcast buffered transaction verifier errors, so they can still be cloned and checked for equality

## Review

@conradoplg needs this PR for #2637

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [x] Existing tests pass

