### PR TITLE
Use unmined types for transaction verifier mempool requests and responses

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -132,11 +132,22 @@ pub enum Transaction {
 }
 
 impl Transaction {
-    // hashes
+    // identifiers and hashes
 
-    /// Compute the hash (id) of this transaction.
+    /// Compute the hash (mined transaction ID) of this transaction.
+    ///
+    /// The hash uniquely identifies mined v5 transactions,
+    /// and all v1-v4 transactions, whether mined or unmined.
     pub fn hash(&self) -> Hash {
         Hash::from(self)
+    }
+
+    /// Compute the unmined transaction ID of this transaction.
+    ///
+    /// This ID uniquely identifies unmined transactions,
+    /// regardless of version.
+    pub fn unmined_id(&self) -> UnminedTxId {
+        UnminedTxId::from(self)
     }
 
     /// Calculate the sighash for the current transaction

--- a/zebra-chain/src/transaction/auth_digest.rs
+++ b/zebra-chain/src/transaction/auth_digest.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
@@ -42,6 +42,17 @@ impl From<&Transaction> for AuthDigest {
     /// If passed a pre-v5 transaction.
     fn from(transaction: &Transaction) -> Self {
         auth_digest(transaction)
+    }
+}
+
+impl From<Arc<Transaction>> for AuthDigest {
+    /// Computes the authorizing data commitment for a transaction.
+    ///
+    /// # Panics
+    ///
+    /// If passed a pre-v5 transaction.
+    fn from(transaction: Arc<Transaction>) -> Self {
+        transaction.as_ref().into()
     }
 }
 

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -28,6 +28,7 @@
 use std::{
     convert::{TryFrom, TryInto},
     fmt,
+    sync::Arc,
 };
 
 #[cfg(any(test, feature = "proptest-impl"))]
@@ -72,6 +73,12 @@ impl From<&Transaction> for Hash {
         hasher
             .txid()
             .expect("zcash_primitives and Zebra transaction formats must be compatible")
+    }
+}
+
+impl From<Arc<Transaction>> for Hash {
+    fn from(transaction: Arc<Transaction>) -> Self {
+        Hash::from(transaction.as_ref())
     }
 }
 
@@ -187,6 +194,17 @@ impl From<&Transaction> for WtxId {
             id: transaction.into(),
             auth_digest: transaction.into(),
         }
+    }
+}
+
+impl From<Arc<Transaction>> for WtxId {
+    /// Computes the witnessed transaction ID for a transaction.
+    ///
+    /// # Panics
+    ///
+    /// If passed a pre-v5 transaction.
+    fn from(transaction: Arc<Transaction>) -> Self {
+        transaction.as_ref().into()
     }
 }
 

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -75,6 +75,12 @@ impl From<&Transaction> for UnminedTxId {
     }
 }
 
+impl From<Arc<Transaction>> for UnminedTxId {
+    fn from(transaction: Arc<Transaction>) -> Self {
+        transaction.as_ref().into()
+    }
+}
+
 impl From<WtxId> for UnminedTxId {
     fn from(wtx_id: WtxId) -> Self {
         Witnessed(wtx_id)

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -63,7 +63,7 @@ where
 ///
 /// Transaction verification has slightly different consensus rules, depending on
 /// whether the transaction is to be included in a block on in the mempool.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Request {
     /// Verify the supplied transaction as part of a block.
     Block {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -139,6 +139,14 @@ impl Request {
     pub fn upgrade(&self, network: Network) -> NetworkUpgrade {
         NetworkUpgrade::current(network, self.height())
     }
+
+    /// Returns true if the request is a mempool request.
+    pub fn is_mempool(&self) -> bool {
+        match self {
+            Request::Block { .. } => false,
+            Request::Mempool { .. } => true,
+        }
+    }
 }
 
 impl<ZS> Service<Request> for Verifier<ZS>
@@ -157,11 +165,7 @@ where
 
     // TODO: break up each chunk into its own method
     fn call(&mut self, req: Request) -> Self::Future {
-        let is_mempool = match req {
-            Request::Block { .. } => false,
-            Request::Mempool { .. } => true,
-        };
-        if is_mempool {
+        if req.is_mempool() {
             // XXX determine exactly which rules apply to mempool transactions
             unimplemented!("Zebra does not yet have a mempool (#2309)");
         }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -92,7 +92,13 @@ pub enum Request {
 
 /// The response type for the transaction verifier service.
 /// Responses identify the transaction that was verified.
-pub type Response = zebra_chain::transaction::Hash;
+///
+/// [`Block`] requests can be uniquely identified by [`UnminedTxId::mined_id`],
+/// because the block's authorizing data root will be checked during contextual validation.
+///
+/// [`Mempool`] requests are uniquely identified by the [`UnminedTxId`]
+/// variant for their transaction version.
+pub type Response = zebra_chain::transaction::UnminedTxId;
 
 impl Request {
     /// The transaction to verify that's in this request.
@@ -218,7 +224,7 @@ where
 
             async_checks.check().await?;
 
-            Ok(tx.hash())
+            Ok(tx.unmined_id())
         }
         .instrument(span)
         .boxed()

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -254,7 +254,7 @@ async fn v5_transaction_is_accepted_after_nu5_activation() {
             .next()
             .expect("At least one fake V5 transaction in the test vectors");
 
-        let expected_hash = transaction.hash();
+        let expected_hash = transaction.unmined_id();
 
         let result = verifier
             .oneshot(Request::Block {
@@ -298,7 +298,7 @@ async fn v4_transaction_with_transparent_transfer_is_accepted() {
         sapling_shielded_data: None,
     };
 
-    let transaction_hash = transaction.hash();
+    let transaction_hash = transaction.unmined_id();
 
     let state_service =
         service_fn(|_| async { unreachable!("State service should not be called") });
@@ -341,7 +341,7 @@ async fn v4_coinbase_transaction_is_accepted() {
         sapling_shielded_data: None,
     };
 
-    let transaction_hash = transaction.hash();
+    let transaction_hash = transaction.unmined_id();
 
     let state_service =
         service_fn(|_| async { unreachable!("State service should not be called") });
@@ -445,7 +445,7 @@ async fn v5_transaction_with_transparent_transfer_is_accepted() {
         network_upgrade,
     };
 
-    let transaction_hash = transaction.hash();
+    let transaction_hash = transaction.unmined_id();
 
     let state_service =
         service_fn(|_| async { unreachable!("State service should not be called") });
@@ -494,7 +494,7 @@ async fn v5_coinbase_transaction_is_accepted() {
         orchard_shielded_data: None,
     };
 
-    let transaction_hash = transaction.hash();
+    let transaction_hash = transaction.unmined_id();
 
     let state_service =
         service_fn(|_| async { unreachable!("State service should not be called") });
@@ -616,7 +616,7 @@ fn v4_with_signed_sprout_transfer_is_accepted() {
             _ => unreachable!("Mock transaction was created incorrectly"),
         }
 
-        let expected_hash = transaction.hash();
+        let expected_hash = transaction.unmined_id();
 
         // Test the transaction verifier
         let result = verifier
@@ -707,7 +707,7 @@ fn v4_with_sapling_spends() {
             .find(|(_, transaction)| transaction.sapling_spends_per_anchor().next().is_some())
             .expect("No transaction found with Sapling spends");
 
-        let expected_hash = transaction.hash();
+        let expected_hash = transaction.unmined_id();
 
         // Initialize the verifier
         let state_service =
@@ -747,7 +747,7 @@ fn v4_with_sapling_outputs_and_no_spends() {
             })
             .expect("No transaction found with Sapling outputs and no Sapling spends");
 
-        let expected_hash = transaction.hash();
+        let expected_hash = transaction.unmined_id();
 
         // Initialize the verifier
         let state_service =
@@ -785,7 +785,7 @@ fn v5_with_sapling_spends() {
                 .find(|transaction| transaction.sapling_spends_per_anchor().next().is_some())
                 .expect("No transaction found with Sapling spends");
 
-        let expected_hash = transaction.hash();
+        let expected_hash = transaction.unmined_id();
         let height = transaction
             .expiry_height()
             .expect("Transaction is missing expiry height");


### PR DESCRIPTION
## Motivation

Now that `zebra-network` uses unmined types for transactions, we also need to use them in the transaction verifier's `Mempool` request.

## Solution

- Use `UnminedTx` in transaction verifier `Mempool` requests
- Use `UnminedTxId` as the transaction verifier response type

We'll want the full witnessed ID even for `Block` requests, because it will help us diagnose mined transaction verification failures, and auth data root verification failures.

Minor cleanup:

- Refactor `is_mempool` into a transaction verifier request method
- Improve debug and trace logs

## Review

@conradoplg might want this PR before starting work on #2637, so the types match up.

This PR is based on PR #2665, feel free to rebase it on `main` if needed.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [x] Existing tests pass

We'll add more tests for this code as part of the mempool work.
