### PR TITLE
Implement best tip block hashes for ChainTip receivers

### DIFF
--- a/zebra-chain/src/chain_tip.rs
+++ b/zebra-chain/src/chain_tip.rs
@@ -10,6 +10,9 @@ use crate::block;
 pub trait ChainTip {
     /// Return the height of the best chain tip.
     fn best_tip_height(&self) -> Option<block::Height>;
+
+    /// Return the block hash of the best chain tip.
+    fn best_tip_hash(&self) -> Option<block::Hash>;
 }
 
 /// A chain tip that is always empty.
@@ -18,6 +21,10 @@ pub struct NoChainTip;
 
 impl ChainTip for NoChainTip {
     fn best_tip_height(&self) -> Option<block::Height> {
+        None
+    }
+
+    fn best_tip_hash(&self) -> Option<block::Hash> {
         None
     }
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -195,18 +195,8 @@ impl StateService {
         );
         self.queued_blocks.prune_by_height(finalized_tip_height);
 
-        let best_non_finalized_tip = self.mem.best_tip_block();
-
-        // skip finalized updates if they would be ignored anyway
-        if best_non_finalized_tip.is_some() {
-            self.chain_tip_sender
-                .set_best_non_finalized_tip(best_non_finalized_tip);
-        } else {
-            // TODO: move into the finalized state,
-            //       so we can clone committed `Arc<Block>`s before they get dropped
-            self.chain_tip_sender
-                .set_finalized_tip(self.disk.tip_block());
-        }
+        self.chain_tip_sender
+            .set_best_non_finalized_tip(self.mem.best_tip_block());
 
         tracing::trace!("finished processing queued block");
         rsp_rx

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -77,6 +77,10 @@ impl ChainTipSender {
     fn update(&mut self, new_tip: impl Into<Option<Arc<Block>>>) {
         let new_tip = new_tip.into();
 
+        if new_tip.is_none() {
+            return;
+        }
+
         if new_tip != self.active_value {
             let _ = self.sender.send(new_tip.clone());
             self.active_value = new_tip;

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -5,62 +5,69 @@ use zebra_chain::{block, chain_tip::ChainTip};
 #[cfg(test)]
 mod tests;
 
+/// The internal watch channel data type for [`ChainTipSender`] and [`ChainTipReceiver`].
+type ChainTipData = Option<block::Height>;
+
 /// A sender for recent changes to the non-finalized and finalized chain tips.
 #[derive(Debug)]
 pub struct ChainTipSender {
-    finalized: Option<block::Height>,
-    non_finalized: Option<block::Height>,
-    sender: watch::Sender<Option<block::Height>>,
+    /// Have we got any chain tips from the non-finalized state?
+    ///
+    /// Once this flag is set, we ignore the finalized state.
+    non_finalized_tip: bool,
+
+    /// The sender channel for chain tip data.
+    sender: watch::Sender<ChainTipData>,
+
+    /// A copy of the data in `sender`.
     // TODO: Replace with calls to `watch::Sender::borrow` once Tokio is updated to 1.0.0 (#2573)
-    active_value: Option<block::Height>,
+    active_value: ChainTipData,
 }
 
 impl ChainTipSender {
     /// Create new linked instances of [`ChainTipSender`] and [`ChainTipReceiver`].
-    pub fn new() -> (Self, ChainTipReceiver) {
+    pub fn new(initial_tip_height: impl Into<Option<block::Height>>) -> (Self, ChainTipReceiver) {
         let (sender, receiver) = watch::channel(None);
+        let mut sender = ChainTipSender {
+            non_finalized_tip: false,
+            sender,
+            active_value: None,
+        };
+        let receiver = ChainTipReceiver::new(receiver);
 
-        (
-            ChainTipSender {
-                finalized: None,
-                non_finalized: None,
-                sender,
-                active_value: None,
-            },
-            ChainTipReceiver::new(receiver),
-        )
+        sender.update(initial_tip_height);
+
+        (sender, receiver)
     }
 
     /// Update the current finalized block height.
     ///
     /// May trigger an update to best tip height.
-    pub fn set_finalized_height(&mut self, new_height: block::Height) {
-        if self.finalized != Some(new_height) {
-            self.finalized = Some(new_height);
-            self.update();
+    pub fn set_finalized_height(&mut self, new_height: impl Into<Option<block::Height>>) {
+        if !self.non_finalized_tip {
+            self.update(new_height);
         }
     }
 
     /// Update the current non-finalized block height.
     ///
     /// May trigger an update to the best tip height.
-    pub fn set_best_non_finalized_height(&mut self, new_height: Option<block::Height>) {
-        if self.non_finalized != new_height {
-            self.non_finalized = new_height;
-            self.update();
-        }
+    pub fn set_best_non_finalized_height(&mut self, new_height: impl Into<Option<block::Height>>) {
+        self.non_finalized_tip = true;
+
+        self.update(new_height)
     }
 
     /// Possibly send an update to listeners.
     ///
     /// An update is only sent if the current best tip height is different from the last best tip
     /// height that was sent.
-    fn update(&mut self) {
-        let new_value = self.non_finalized.max(self.finalized);
+    fn update(&mut self, new_height: impl Into<Option<block::Height>>) {
+        let new_height = new_height.into();
 
-        if new_value != self.active_value {
-            let _ = self.sender.send(new_value);
-            self.active_value = new_value;
+        if new_height != self.active_value {
+            let _ = self.sender.send(new_height);
+            self.active_value = new_height;
         }
     }
 }
@@ -70,12 +77,12 @@ impl ChainTipSender {
 /// The latest changes are available from all cloned instances of this type.
 #[derive(Clone, Debug)]
 pub struct ChainTipReceiver {
-    receiver: watch::Receiver<Option<block::Height>>,
+    receiver: watch::Receiver<ChainTipData>,
 }
 
 impl ChainTipReceiver {
     /// Create a new chain tip receiver from a watch channel receiver.
-    fn new(receiver: watch::Receiver<Option<block::Height>>) -> Self {
+    fn new(receiver: watch::Receiver<ChainTipData>) -> Self {
         Self { receiver }
     }
 }

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -87,6 +87,10 @@ impl ChainTipSender {
 /// A receiver for recent changes to the non-finalized and finalized chain tips.
 ///
 /// The latest changes are available from all cloned instances of this type.
+///
+/// The chain tip data is based on:
+/// * the best non-finalized chain tip, if available, or
+/// * the finalized tip.
 #[derive(Clone, Debug)]
 pub struct ChainTipReceiver {
     receiver: watch::Receiver<ChainTipData>,
@@ -101,14 +105,17 @@ impl ChainTipReceiver {
 
 impl ChainTip for ChainTipReceiver {
     /// Return the height of the best chain tip.
-    ///
-    /// The returned block height comes from:
-    /// * the best non-finalized chain tip, if available, or
-    /// * the finalized tip.
     fn best_tip_height(&self) -> Option<block::Height> {
         self.receiver
             .borrow()
             .as_ref()
             .and_then(|block| block.coinbase_height())
+    }
+
+    /// Return the block hash of the best chain tip.
+    fn best_tip_hash(&self) -> Option<block::Hash> {
+        // TODO: get the hash from the state and store it in the sender,
+        //       so we don't have to recalculate it every time
+        self.receiver.borrow().as_ref().map(|block| block.hash())
     }
 }

--- a/zebra-state/src/service/chain_tip/tests/prop.rs
+++ b/zebra-state/src/service/chain_tip/tests/prop.rs
@@ -33,7 +33,9 @@ proptest! {
             match update {
                 BlockUpdate::Finalized(block) => {
                     chain_tip_sender.set_finalized_tip(block.clone());
-                    latest_finalized_tip = block;
+                    if block.is_some() {
+                        latest_finalized_tip = block;
+                    }
                 }
                 BlockUpdate::NonFinalized(block) => {
                     chain_tip_sender.set_best_non_finalized_tip(block.clone());

--- a/zebra-state/src/service/chain_tip/tests/prop.rs
+++ b/zebra-state/src/service/chain_tip/tests/prop.rs
@@ -1,47 +1,61 @@
+use std::{env, sync::Arc};
+
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
 
-use zebra_chain::{block, chain_tip::ChainTip};
+use zebra_chain::{block::Block, chain_tip::ChainTip};
 
 use super::super::ChainTipSender;
 
+const DEFAULT_BLOCK_VEC_PROPTEST_CASES: u32 = 4;
+
 proptest! {
+    #![proptest_config(
+        proptest::test_runner::Config::with_cases(env::var("PROPTEST_CASES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_BLOCK_VEC_PROPTEST_CASES))
+    )]
+
     #[test]
     fn best_tip_is_highest_of_latest_finalized_and_non_finalized_heights(
-        height_updates in any::<Vec<HeightUpdate>>(),
+        height_updates in any::<Vec<BlockUpdate>>(),
     ) {
         let (mut chain_tip_sender, chain_tip_receiver) = ChainTipSender::new(None);
 
-        let mut latest_finalized_height = None;
-        let mut latest_non_finalized_height = None;
+        let mut latest_finalized_tip = None;
+        let mut latest_non_finalized_tip = None;
         let mut seen_non_finalized_tip = false;
 
         for update in height_updates {
             match update {
-                HeightUpdate::Finalized(height) => {
-                    chain_tip_sender.set_finalized_height(height);
-                    latest_finalized_height = height;
+                BlockUpdate::Finalized(block) => {
+                    chain_tip_sender.set_finalized_tip(block.clone());
+                    latest_finalized_tip = block;
                 }
-                HeightUpdate::NonFinalized(height) => {
-                    chain_tip_sender.set_best_non_finalized_height(height);
-                    latest_non_finalized_height = height;
-                    seen_non_finalized_tip = true;
+                BlockUpdate::NonFinalized(block) => {
+                    chain_tip_sender.set_best_non_finalized_tip(block.clone());
+                    if block.is_some() {
+                        latest_non_finalized_tip = block;
+                        seen_non_finalized_tip = true;
+                    }
                 }
             }
         }
 
-        let expected_height = if seen_non_finalized_tip {
-            latest_non_finalized_height
+        let expected_tip = if seen_non_finalized_tip {
+            latest_non_finalized_tip
         } else {
-            latest_finalized_height
+            latest_finalized_tip
         };
+        let expected_height = expected_tip.and_then(|block| block.coinbase_height());
 
         prop_assert_eq!(chain_tip_receiver.best_tip_height(), expected_height);
     }
 }
 
-#[derive(Arbitrary, Clone, Copy, Debug)]
-enum HeightUpdate {
-    Finalized(Option<block::Height>),
-    NonFinalized(Option<block::Height>),
+#[derive(Arbitrary, Clone, Debug)]
+enum BlockUpdate {
+    Finalized(Option<Arc<Block>>),
+    NonFinalized(Option<Arc<Block>>),
 }

--- a/zebra-state/src/service/chain_tip/tests/vectors.rs
+++ b/zebra-state/src/service/chain_tip/tests/vectors.rs
@@ -1,10 +1,19 @@
-use zebra_chain::chain_tip::ChainTip;
+use zebra_chain::chain_tip::{ChainTip, NoChainTip};
 
 use super::super::ChainTipSender;
 
 #[test]
-fn best_tip_height_is_initially_empty() {
+fn best_tip_is_initially_empty() {
     let (_chain_tip_sender, chain_tip_receiver) = ChainTipSender::new(None);
 
     assert_eq!(chain_tip_receiver.best_tip_height(), None);
+    assert_eq!(chain_tip_receiver.best_tip_hash(), None);
+}
+
+#[test]
+fn empty_chain_tip_is_empty() {
+    let chain_tip_receiver = NoChainTip;
+
+    assert_eq!(chain_tip_receiver.best_tip_height(), None);
+    assert_eq!(chain_tip_receiver.best_tip_hash(), None);
 }

--- a/zebra-state/src/service/chain_tip/tests/vectors.rs
+++ b/zebra-state/src/service/chain_tip/tests/vectors.rs
@@ -4,7 +4,7 @@ use super::super::ChainTipSender;
 
 #[test]
 fn best_tip_height_is_initially_empty() {
-    let (_chain_tip_sender, chain_tip_receiver) = ChainTipSender::new();
+    let (_chain_tip_sender, chain_tip_receiver) = ChainTipSender::new(None);
 
     assert_eq!(chain_tip_receiver.best_tip_height(), None);
 }

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -473,6 +473,12 @@ impl FinalizedState {
             })
     }
 
+    /// Returns the tip block, if there is one.
+    pub fn tip_block(&self) -> Option<Arc<Block>> {
+        let (height, _hash) = self.tip()?;
+        self.block(height.into())
+    }
+
     /// Returns the height of the given block if it exists.
     pub fn height(&self, hash: block::Hash) -> Option<block::Height> {
         let height_by_hash = self.db.cf_handle("height_by_hash").unwrap();

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -318,6 +318,12 @@ impl NonFinalizedState {
         Some((height, hash))
     }
 
+    /// Returns the block at the tip of the best chain.
+    pub fn best_tip_block(&self) -> Option<Arc<Block>> {
+        let (height, _hash) = self.best_tip()?;
+        self.best_block(height.into())
+    }
+
     /// Returns the height of `hash` in the best chain.
     pub fn best_height_by_hash(&self, hash: block::Hash) -> Option<block::Height> {
         let best_chain = self.best_chain()?;


### PR DESCRIPTION
## Motivation

In ticket #2639, we want to get block hashes, transaction information, and rollback information out of the state.

The `ChainTip` struct already gets block heights out of the state.

In this PR, I've added block hashes to the `ChainTip` information.

## Solution

- Always prefer the non-finalized tip in ChainTipSender
- Update ChainTipSender with blocks, not heights
- Provide a best tip hash in ChainTip receivers

Optimisation:
- Skip finalized blocks once the non-finalized state is active 

This PR does not close any tickets.

## Review

@jvff can review this PR.

This PR is based on PR #2676.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Do the rest of ticket #2639: transaction IDs, resets, initialization and missed update handling.
