### PR TITLE
Add transaction downloader and verifier

### DIFF
--- a/grafana/transaction_verification.json
+++ b/grafana/transaction_verification.json
@@ -1,0 +1,207 @@
+{
+    "__inputs": [
+        {
+            "name": "DS_PROMETHEUS-ZEBRA",
+            "label": "Prometheus-Zebra",
+            "description": "",
+            "type": "datasource",
+            "pluginId": "prometheus",
+            "pluginName": "Prometheus"
+        }
+    ],
+    "__requires": [
+        {
+            "type": "grafana",
+            "id": "grafana",
+            "name": "Grafana",
+            "version": "8.1.2"
+        },
+        {
+            "type": "panel",
+            "id": "graph",
+            "name": "Graph (old)",
+            "version": ""
+        },
+        {
+            "type": "datasource",
+            "id": "prometheus",
+            "name": "Prometheus",
+            "version": "1.0.0"
+        }
+    ],
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
+            }
+        ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": null,
+    "iteration": 1630092146360,
+    "links": [],
+    "panels": [
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "8.1.2",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "repeatDirection": "h",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "rate(gossip_downloaded_transaction_count{job=\"$job\"}[1m]) * 60",
+                    "interval": "",
+                    "legendFormat": "gossip_downloaded_transaction_count per min",
+                    "refId": "C"
+                },
+                {
+                    "exemplar": true,
+                    "expr": "rate(gossip_verified_transaction_count{job=\"$job\"}[1m]) * 60",
+                    "interval": "",
+                    "legendFormat": "gossip_verified_transaction_count per min",
+                    "refId": "D"
+                },
+                {
+                    "exemplar": true,
+                    "expr": "gossip_queued_transaction_count{job=\"$job\"}",
+                    "interval": "",
+                    "legendFormat": "gossip_queued_transaction_count",
+                    "refId": "E"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Transaction Verifier Gossip Count - $job",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 30,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "current": {},
+                "datasource": "${DS_PROMETHEUS-ZEBRA}",
+                "definition": "label_values(zcash_chain_verified_block_height, job)",
+                "description": null,
+                "error": null,
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": true,
+                "name": "job",
+                "options": [],
+                "query": {
+                    "query": "label_values(zcash_chain_verified_block_height, job)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "transaction verification",
+    "uid": "oBEHvS4nz",
+    "version": 2
+}

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -376,9 +376,9 @@ impl Transaction {
         }
     }
 
-    /// Returns `true` if this transaction is a coinbase transaction,
-    /// that is, has a single input and it is a coinbase input.
-    pub fn is_coinbase(&self) -> bool {
+    /// Returns `true` if this transaction has valid inputs for a coinbase
+    /// transaction, that is, has a single input and it is a coinbase input.
+    pub fn has_valid_coinbase_transaction_inputs(&self) -> bool {
         self.inputs().len() == 1
             && matches!(
                 self.inputs().get(0),
@@ -387,7 +387,7 @@ impl Transaction {
     }
 
     /// Returns `true` if transaction contains any coinbase inputs.
-    pub fn contains_coinbase_input(&self) -> bool {
+    pub fn has_any_coinbase_inputs(&self) -> bool {
         self.inputs()
             .iter()
             .any(|input| matches!(input, transparent::Input::Coinbase { .. }))

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -376,7 +376,8 @@ impl Transaction {
         }
     }
 
-    /// Returns `true` if this transaction is a coinbase transaction.
+    /// Returns `true` if this transaction is a coinbase transaction,
+    /// that is, has a single input and it is a coinbase input.
     pub fn is_coinbase(&self) -> bool {
         self.inputs().len() == 1
             && matches!(

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -428,7 +428,7 @@ impl Transaction {
         &mut self,
         outputs: &HashMap<transparent::OutPoint, transparent::Output>,
     ) -> Result<Amount<NonNegative>, ValueBalanceError> {
-        if self.is_coinbase() {
+        if self.has_valid_coinbase_transaction_inputs() {
             // TODO: if needed, fixup coinbase:
             // - miner subsidy
             // - founders reward or funding streams (hopefully not?)

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -12,7 +12,7 @@
 //! unmined transactions. They can be used to handle transactions regardless of version,
 //! and get the [`WtxId`] or [`Hash`] when required.
 
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
@@ -90,6 +90,15 @@ impl From<WtxId> for UnminedTxId {
 impl From<&WtxId> for UnminedTxId {
     fn from(wtx_id: &WtxId) -> Self {
         (*wtx_id).into()
+    }
+}
+
+impl fmt::Display for UnminedTxId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Legacy(hash) => hash.fmt(f),
+            Witnessed(id) => id.fmt(f),
+        }
     }
 }
 

--- a/zebra-chain/src/transparent/utxo.rs
+++ b/zebra-chain/src/transparent/utxo.rs
@@ -157,7 +157,7 @@ pub(crate) fn new_transaction_ordered_outputs(
 ) -> HashMap<transparent::OutPoint, OrderedUtxo> {
     let mut new_ordered_outputs = HashMap::new();
 
-    let from_coinbase = transaction.is_coinbase();
+    let from_coinbase = transaction.has_valid_coinbase_transaction_inputs();
     for (output_index_in_transaction, output) in transaction.outputs().iter().cloned().enumerate() {
         let output_index_in_transaction = output_index_in_transaction
             .try_into()

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -27,10 +27,10 @@ pub fn coinbase_is_first(block: &Block) -> Result<(), BlockError> {
         .get(0)
         .ok_or(BlockError::NoTransactions)?;
     let mut rest = block.transactions.iter().skip(1);
-    if !first.is_coinbase() {
+    if !first.has_valid_coinbase_transaction_inputs() {
         return Err(TransactionError::CoinbasePosition)?;
     }
-    if rest.any(|tx| tx.contains_coinbase_input()) {
+    if rest.any(|tx| tx.has_any_coinbase_inputs()) {
         return Err(TransactionError::CoinbaseAfterFirst)?;
     }
 

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -41,6 +41,9 @@ pub enum TransactionError {
     #[error("coinbase transaction MUST NOT have the EnableSpendsOrchard flag set")]
     CoinbaseHasEnableSpendsOrchard,
 
+    #[error("coinbase transaction MUST NOT exist in mempool")]
+    CoinbaseInMempool,
+
     #[error("coinbase transaction failed subsidy validation")]
     Subsidy(#[from] SubsidyError),
 

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -41,7 +41,7 @@ pub enum TransactionError {
     #[error("coinbase transaction MUST NOT have the EnableSpendsOrchard flag set")]
     CoinbaseHasEnableSpendsOrchard,
 
-    #[error("coinbase transaction MUST NOT exist in mempool")]
+    #[error("coinbase inputs MUST NOT exist in mempool")]
     CoinbaseInMempool,
 
     #[error("coinbase transaction failed subsidy validation")]

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -47,7 +47,7 @@ mod config;
 mod parameters;
 mod primitives;
 mod script;
-mod transaction;
+pub mod transaction;
 
 pub mod chain;
 #[allow(missing_docs)]

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -1,3 +1,5 @@
+//! Asynchronous verification of transactions.
+//!
 use std::{
     collections::HashMap,
     future::Future,
@@ -50,6 +52,7 @@ where
     ZS: Service<zs::Request, Response = zs::Response, Error = BoxError> + Send + Clone + 'static,
     ZS::Future: Send + 'static,
 {
+    /// Create a new transaction verifier.
     pub fn new(network: Network, script_verifier: script::Verifier<ZS>) -> Self {
         Self {
             network,

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -182,11 +182,10 @@ where
             check::has_inputs_and_outputs(&tx)?;
 
             if tx.is_coinbase() {
-                if req.is_mempool() {
-                    return Err(TransactionError::CoinbaseInMempool);
-                } else {
-                    check::coinbase_tx_no_prevout_joinsplit_spend(&tx)?;
-                }
+                check::coinbase_tx_no_prevout_joinsplit_spend(&tx)?;
+            }
+            if req.is_mempool() && tx.contains_coinbase_input() {
+                return Err(TransactionError::CoinbaseInMempool);
             }
 
             // [Canopy onward]: `vpub_old` MUST be zero.

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -398,6 +398,11 @@ where
     ) -> Result<(), TransactionError> {
         match network_upgrade {
             // Supports V5 transactions
+            //
+            // Consensus rules:
+            // > [NU5 onward] The transaction version number MUST be 4 or 5.
+            //
+            // https://zips.z.cash/protocol/protocol.pdf#txnconsensus
             NetworkUpgrade::Nu5 => Ok(()),
 
             // Does not support V5 transactions

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -181,11 +181,11 @@ where
             // Do basic checks first
             check::has_inputs_and_outputs(&tx)?;
 
-            if tx.is_coinbase() {
-                check::coinbase_tx_no_prevout_joinsplit_spend(&tx)?;
-            }
-            if req.is_mempool() && tx.contains_coinbase_input() {
+            if req.is_mempool() && tx.has_any_coinbase_inputs() {
                 return Err(TransactionError::CoinbaseInMempool);
+            }
+            if tx.has_valid_coinbase_transaction_inputs() {
+                check::coinbase_tx_no_prevout_joinsplit_spend(&tx)?;
             }
 
             // [Canopy onward]: `vpub_old` MUST be zero.
@@ -390,7 +390,7 @@ where
     ) -> Result<AsyncChecks, TransactionError> {
         let transaction = request.transaction();
 
-        if transaction.is_coinbase() {
+        if transaction.has_valid_coinbase_transaction_inputs() {
             // The script verifier only verifies PrevOut inputs and their corresponding UTXOs.
             // Coinbase transactions don't have any PrevOut inputs.
             Ok(AsyncChecks::new())

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -309,6 +309,13 @@ where
     ) -> Result<(), TransactionError> {
         match network_upgrade {
             // Supports V4 transactions
+            //
+            // Consensus rules:
+            // > [Sapling to Canopy inclusive, pre-NU5] The transaction version number MUST be 4, ...
+            // >
+            // > [NU5 onward] The transaction version number MUST be 4 or 5.
+            //
+            // https://zips.z.cash/protocol/protocol.pdf#txnconsensus
             NetworkUpgrade::Sapling
             | NetworkUpgrade::Blossom
             | NetworkUpgrade::Heartwood

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -51,7 +51,7 @@ pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> 
 ///
 /// https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
 pub fn coinbase_tx_no_prevout_joinsplit_spend(tx: &Transaction) -> Result<(), TransactionError> {
-    if tx.is_coinbase() {
+    if tx.has_valid_coinbase_transaction_inputs() {
         if tx.contains_prevout_input() {
             return Err(TransactionError::CoinbaseHasPrevOutInput);
         } else if tx.joinsplit_count() > 0 {

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -165,7 +165,7 @@ fn v5_coinbase_transaction_without_enable_spends_flag_passes_validation() {
         zebra_test::vectors::MAINNET_BLOCKS.iter(),
     )
     .rev()
-    .find(|transaction| transaction.is_coinbase())
+    .find(|transaction| transaction.has_valid_coinbase_transaction_inputs())
     .expect("At least one fake V5 coinbase transaction in the test vectors");
 
     insert_fake_orchard_shielded_data(&mut transaction);
@@ -180,7 +180,7 @@ fn v5_coinbase_transaction_with_enable_spends_flag_fails_validation() {
         zebra_test::vectors::MAINNET_BLOCKS.iter(),
     )
     .rev()
-    .find(|transaction| transaction.is_coinbase())
+    .find(|transaction| transaction.has_valid_coinbase_transaction_inputs())
     .expect("At least one fake V5 coinbase transaction in the test vectors");
 
     let shielded_data = insert_fake_orchard_shielded_data(&mut transaction);
@@ -702,7 +702,8 @@ fn v4_with_sapling_spends() {
         let (height, transaction) = test_transactions(network)
             .rev()
             .filter(|(_, transaction)| {
-                !transaction.is_coinbase() && transaction.inputs().is_empty()
+                !transaction.has_valid_coinbase_transaction_inputs()
+                    && transaction.inputs().is_empty()
             })
             .find(|(_, transaction)| transaction.sapling_spends_per_anchor().next().is_some())
             .expect("No transaction found with Sapling spends");
@@ -739,7 +740,8 @@ fn v4_with_sapling_outputs_and_no_spends() {
         let (height, transaction) = test_transactions(network)
             .rev()
             .filter(|(_, transaction)| {
-                !transaction.is_coinbase() && transaction.inputs().is_empty()
+                !transaction.has_valid_coinbase_transaction_inputs()
+                    && transaction.inputs().is_empty()
             })
             .find(|(_, transaction)| {
                 transaction.sapling_spends_per_anchor().next().is_none()
@@ -781,7 +783,10 @@ fn v5_with_sapling_spends() {
         let transaction =
             fake_v5_transactions_for_network(network, zebra_test::vectors::MAINNET_BLOCKS.iter())
                 .rev()
-                .filter(|transaction| !transaction.is_coinbase() && transaction.inputs().is_empty())
+                .filter(|transaction| {
+                    !transaction.has_valid_coinbase_transaction_inputs()
+                        && transaction.inputs().is_empty()
+                })
                 .find(|transaction| transaction.sapling_spends_per_anchor().next().is_some())
                 .expect("No transaction found with Sapling spends");
 

--- a/zebra-state/src/service/check/utxo.rs
+++ b/zebra-state/src/service/check/utxo.rs
@@ -227,7 +227,7 @@ pub fn remaining_transaction_value(
 ) -> Result<(), ValidateContextError> {
     for (tx_index_in_block, transaction) in prepared.block.transactions.iter().enumerate() {
         // TODO: check coinbase transaction remaining value (#338, #1162)
-        if transaction.is_coinbase() {
+        if transaction.has_valid_coinbase_transaction_inputs() {
             continue;
         }
 

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -91,7 +91,7 @@ async fn test_populated_state_responds_correctly(
                     Ok(Response::Transaction(Some(transaction.clone()))),
                 ));
 
-                let from_coinbase = transaction.is_coinbase();
+                let from_coinbase = transaction.has_valid_coinbase_transaction_inputs();
                 for (index, output) in transaction.outputs().iter().cloned().enumerate() {
                     let outpoint = transparent::OutPoint {
                         hash: transaction_hash,

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -56,7 +56,7 @@ impl StartCmd {
 
         info!("initializing verifiers");
         // TODO: use the transaction verifier to verify mempool transactions (#2637, #2606)
-        let (chain_verifier, _tx_verifier) = zebra_consensus::chain::init(
+        let (chain_verifier, tx_verifier) = zebra_consensus::chain::init(
             config.consensus.clone(),
             config.network.network,
             state.clone(),
@@ -75,6 +75,7 @@ impl StartCmd {
                 setup_rx,
                 state.clone(),
                 chain_verifier.clone(),
+                tx_verifier.clone(),
             ));
 
         let (peer_set, address_book) =

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -21,10 +21,10 @@ use zebra_consensus::transaction;
 use zebra_consensus::{chain::VerifyChainError, error::TransactionError};
 use zebra_network::AddressBook;
 
-use crate::components::sync::{TRANSACTION_DOWNLOAD_TIMEOUT, TRANSACTION_VERIFY_TIMEOUT};
-
+use super::mempool::downloads::{
+    Downloads as TxDownloads, TRANSACTION_DOWNLOAD_TIMEOUT, TRANSACTION_VERIFY_TIMEOUT,
+};
 // Re-use the syncer timeouts for consistency.
-use super::mempool::downloads::Downloads as TxDownloads;
 use super::sync::{BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT};
 
 mod downloads;

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -32,10 +32,8 @@ type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// attacks.
 ///
 /// The maximum block size is 2 million bytes. A deserialized malicious
-/// block with ~225_000 transparent outputs can take up 9MB of RAM. As of
-/// February 2021, a growing `Vec` can allocate up to 2x its current length,
-/// leading to an overall memory usage of 18MB per malicious block. (See
-/// #1880 for more details.)
+/// block with ~225_000 transparent outputs can take up 9MB of RAM.
+/// (See #1880 for more details.)
 ///
 /// Malicious blocks will eventually timeout or fail contextual validation.
 /// Once validation fails, the block is dropped, and its memory is deallocated.
@@ -116,8 +114,7 @@ where
         // If no download and verify tasks have exited since the last poll, this
         // task is scheduled for wakeup when the next task becomes ready.
         //
-        // TODO:
-        // This would be cleaner with poll_map #63514, but that's nightly only.
+        // TODO: this would be cleaner with poll_map (#2693)
         if let Some(join_result) = ready!(this.pending.poll_next(cx)) {
             match join_result.expect("block download and verify tasks must not panic") {
                 Ok(hash) => {
@@ -245,7 +242,6 @@ where
         });
 
         self.pending.push(task);
-        // XXX replace with expect_none when stable
         assert!(
             self.cancel_handles.insert(hash, cancel_tx).is_none(),
             "blocks are only queued once"

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -20,6 +20,7 @@ use crate::BoxError;
 mod crawler;
 mod error;
 mod storage;
+pub mod downloads;
 
 #[cfg(test)]
 mod tests;

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -18,9 +18,9 @@ use zebra_chain::{
 use crate::BoxError;
 
 mod crawler;
+pub mod downloads;
 mod error;
 mod storage;
-pub mod downloads;
 
 #[cfg(test)]
 mod tests;

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -117,8 +117,7 @@ where
         // If no download and verify tasks have exited since the last poll, this
         // task is scheduled for wakeup when the next task becomes ready.
         //
-        // TODO:
-        // This would be cleaner with poll_map #63514, but that's nightly only.
+        // TODO: this would be cleaner with poll_map (#2693)
         if let Some(join_result) = ready!(this.pending.poll_next(cx)) {
             match join_result.expect("transaction download and verify tasks must not panic") {
                 Ok(hash) => {

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -1,0 +1,233 @@
+use std::{
+    collections::HashMap,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use color_eyre::eyre::{eyre, Report};
+use futures::{
+    future::TryFutureExt,
+    ready,
+    stream::{FuturesUnordered, Stream},
+};
+use pin_project::pin_project;
+use tokio::{sync::oneshot, task::JoinHandle};
+use tower::{hedge, Service, ServiceExt};
+use tracing_futures::Instrument;
+
+use zebra_chain::{block::Height, transaction::UnminedTxId};
+use zebra_consensus::transaction as tx;
+use zebra_network as zn;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct AlwaysHedge;
+
+impl<Request: Clone> hedge::Policy<Request> for AlwaysHedge {
+    fn can_retry(&self, _req: &Request) -> bool {
+        true
+    }
+    fn clone_request(&self, req: &Request) -> Option<Request> {
+        Some(req.clone())
+    }
+}
+
+/// Represents a [`Stream`] of download and verification tasks.
+#[pin_project]
+#[derive(Debug)]
+pub struct Downloads<ZN, ZV>
+where
+    ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + 'static,
+    ZN::Future: Send,
+    ZV: Service<tx::Request, Response = tx::Response, Error = BoxError> + Send + Clone + 'static,
+    ZV::Future: Send,
+{
+    // Services
+    /// A service that forwards requests to connected peers, and returns their
+    /// responses.
+    network: ZN,
+
+    /// A service that verifies downloaded transactions.
+    verifier: ZV,
+
+    // Internal downloads state
+    /// A list of pending transaction download and verify tasks.
+    #[pin]
+    pending: FuturesUnordered<JoinHandle<Result<UnminedTxId, (BoxError, UnminedTxId)>>>,
+
+    /// A list of channels that can be used to cancel pending transaction download and
+    /// verify tasks.
+    cancel_handles: HashMap<UnminedTxId, oneshot::Sender<()>>,
+}
+
+impl<ZN, ZV> Stream for Downloads<ZN, ZV>
+where
+    ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Clone + 'static,
+    ZN::Future: Send,
+    ZV: Service<tx::Request, Response = tx::Response, Error = BoxError> + Send + Clone + 'static,
+    ZV::Future: Send,
+{
+    type Item = Result<UnminedTxId, BoxError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        // CORRECTNESS
+        //
+        // The current task must be scheduled for wakeup every time we return
+        // `Poll::Pending`.
+        //
+        // If no download and verify tasks have exited since the last poll, this
+        // task is scheduled for wakeup when the next task becomes ready.
+        //
+        // TODO:
+        // This would be cleaner with poll_map #63514, but that's nightly only.
+        if let Some(join_result) = ready!(this.pending.poll_next(cx)) {
+            match join_result.expect("transaction download and verify tasks must not panic") {
+                Ok(hash) => {
+                    this.cancel_handles.remove(&hash);
+                    Poll::Ready(Some(Ok(hash)))
+                }
+                Err((e, hash)) => {
+                    this.cancel_handles.remove(&hash);
+                    Poll::Ready(Some(Err(e)))
+                }
+            }
+        } else {
+            Poll::Ready(None)
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.pending.size_hint()
+    }
+}
+
+impl<ZN, ZV> Downloads<ZN, ZV>
+where
+    ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Clone + 'static,
+    ZN::Future: Send,
+    ZV: Service<tx::Request, Response = tx::Response, Error = BoxError> + Send + Clone + 'static,
+    ZV::Future: Send,
+{
+    /// Initialize a new download stream with the provided `network` and
+    /// `verifier` services.
+    ///
+    /// The [`Downloads`] stream is agnostic to the network policy, so retry and
+    /// timeout limits should be applied to the `network` service passed into
+    /// this constructor.
+    pub fn new(network: ZN, verifier: ZV) -> Self {
+        Self {
+            network,
+            verifier,
+            pending: FuturesUnordered::new(),
+            cancel_handles: HashMap::new(),
+        }
+    }
+
+    /// Queue a transaction for download and verification.
+    ///
+    /// This method waits for the network to become ready, and returns an error
+    /// only if the network service fails. It returns immediately after queuing
+    /// the request.
+    #[instrument(skip(self, txid), fields(txid = %txid))]
+    pub async fn download_and_verify(&mut self, txid: UnminedTxId) -> Result<(), Report> {
+        if self.cancel_handles.contains_key(&txid) {
+            return Err(eyre!("duplicate txid queued for download: {:?}", txid));
+        }
+
+        // We construct the transaction requests sequentially, waiting for the peer
+        // set to be ready to process each request. This ensures that we start
+        // transaction downloads in the order we want them (though they may resolve
+        // out of order), and it means that we respect backpressure. Otherwise,
+        // if we waited for readiness and did the service call in the spawned
+        // tasks, all of the spawned tasks would race each other waiting for the
+        // network to become ready.
+        tracing::debug!("waiting to request transaction");
+        let tx_req = self.network.ready_and().await.map_err(|e| eyre!(e))?.call(
+            zn::Request::TransactionsById(std::iter::once(txid).collect()),
+        );
+        tracing::debug!("requested transaction");
+
+        // This oneshot is used to signal cancellation to the download task.
+        let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
+
+        let mut verifier = self.verifier.clone();
+        let task = tokio::spawn(
+            async move {
+                // TODO: if the verifier and cancel are both ready, which should
+                //       we prefer? (Currently, select! chooses one at random.)
+                let rsp = tokio::select! {
+                    _ = &mut cancel_rx => {
+                        tracing::trace!("task cancelled prior to download completion");
+                        metrics::counter!("mempool.cancelled.transaction.count", 1);
+                        return Err("canceled trasaction download".into())
+                    }
+                    rsp = tx_req => rsp?,
+                };
+
+                let tx = if let zn::Response::Transactions(txs) = rsp {
+                    txs.into_iter()
+                        .next()
+                        .expect("successful response has the transaction in it")
+                } else {
+                    unreachable!("wrong response to transaction request");
+                };
+                metrics::counter!("mempoool.downloaded.transaction.count", 1);
+
+                let rsp = verifier.ready_and().await?.call(tx::Request::Mempool {
+                    transaction: tx,
+                    // TODO: which height to use?
+                    height: Height(0),
+                });
+                // TODO: if the verifier and cancel are both ready, which should
+                //       we prefer? (Currently, select! chooses one at random.)
+                let verification = tokio::select! {
+                    _ = &mut cancel_rx => {
+                        tracing::trace!("task cancelled prior to verification");
+                        metrics::counter!("mempool.cancelled.verify.count", 1);
+                        return Err("canceled transaction verification".into())
+                    }
+                    verification = rsp => verification,
+                };
+                if verification.is_ok() {
+                    metrics::counter!("mempool.verified.transaction.count", 1);
+                }
+
+                verification
+            }
+            .in_current_span()
+            // Tack the hash onto the error so we can remove the cancel handle
+            // on failure as well as on success.
+            .map_err(move |e| (e, txid)),
+        );
+
+        self.pending.push(task);
+        // XXX replace with expect_none when stable
+        assert!(
+            self.cancel_handles.insert(txid, cancel_tx).is_none(),
+            "transactions are only queued once"
+        );
+
+        Ok(())
+    }
+
+    /// Cancel all running tasks and reset the downloader state.
+    pub fn cancel_all(&mut self) {
+        // Replace the pending task list with an empty one and drop it.
+        let _ = std::mem::take(&mut self.pending);
+        // Signal cancellation to all running tasks.
+        // Since we already dropped the JoinHandles above, they should
+        // fail silently.
+        for (_hash, cancel) in self.cancel_handles.drain() {
+            let _ = cancel.send(());
+        }
+        assert!(self.pending.is_empty());
+        assert!(self.cancel_handles.is_empty());
+    }
+
+    /// Get the number of currently in-flight download tasks.
+    pub fn in_flight(&self) -> usize {
+        self.pending.len()
+    }
+}

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashMap,
     pin::Pin,
     task::{Context, Poll},
+    time::Duration,
 };
 
 use color_eyre::eyre::eyre;
@@ -20,7 +21,25 @@ use zebra_consensus::transaction as tx;
 use zebra_network as zn;
 use zebra_state as zs;
 
+use crate::components::sync::{BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT};
+
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Controls how long we wait for a transaction download request to complete.
+///
+/// This is currently equal to [`crate::components::sync::BLOCK_DOWNLOAD_TIMEOUT`] for
+/// consistency, even though parts of the rationale used for defining the value
+/// don't apply here (e.g. we can drop transactions hashes when the queue is full).
+pub(crate) const TRANSACTION_DOWNLOAD_TIMEOUT: Duration = BLOCK_DOWNLOAD_TIMEOUT;
+
+/// Controls how long we wait for a transaction verify request to complete.
+///
+/// This is currently equal to [`crate::components::sync::BLOCK_VERIFY_TIMEOUT`] for
+/// consistency.
+///
+/// This timeout may lead to denial of service, which will be handled in
+/// https://github.com/ZcashFoundation/zebra/issues/2694
+pub(crate) const TRANSACTION_VERIFY_TIMEOUT: Duration = BLOCK_VERIFY_TIMEOUT;
 
 /// The maximum number of concurrent inbound download and verify tasks.
 ///

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -116,14 +116,6 @@ pub(super) const BLOCK_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
 /// failure loop.
 pub(super) const BLOCK_VERIFY_TIMEOUT: Duration = Duration::from_secs(180);
 
-/// Controls how long we wait for a transaction download request to complete.
-/// TODO: review value and rationale
-pub(super) const TRANSACTION_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
-
-/// Controls how long we wait for a transaction verify request to complete.
-/// TODO: review value and rationale
-pub(super) const TRANSACTION_VERIFY_TIMEOUT: Duration = Duration::from_secs(180);
-
 /// Controls how long we wait to restart syncing after finishing a sync run.
 ///
 /// This delay should be long enough to:

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -116,6 +116,14 @@ pub(super) const BLOCK_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
 /// failure loop.
 pub(super) const BLOCK_VERIFY_TIMEOUT: Duration = Duration::from_secs(180);
 
+/// Controls how long we wait for a transaction download request to complete.
+/// TODO: review value and rationale
+pub(super) const TRANSACTION_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Controls how long we wait for a transaction verify request to complete.
+/// TODO: review value and rationale
+pub(super) const TRANSACTION_VERIFY_TIMEOUT: Duration = Duration::from_secs(180);
+
 /// Controls how long we wait to restart syncing after finishing a sync run.
 ///
 /// This delay should be long enough to:

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -80,8 +80,7 @@ where
         // If no download and verify tasks have exited since the last poll, this
         // task is scheduled for wakeup when the next task becomes ready.
         //
-        // TODO:
-        // This would be cleaner with poll_map #63514, but that's nightly only.
+        // TODO: this would be cleaner with poll_map (#2693)
         if let Some(join_result) = ready!(this.pending.poll_next(cx)) {
             match join_result.expect("block download and verify tasks must not panic") {
                 Ok(hash) => {
@@ -203,7 +202,6 @@ where
         );
 
         self.pending.push(task);
-        // XXX replace with expect_none when stable
         assert!(
             self.cancel_handles.insert(hash, cancel_tx).is_none(),
             "blocks are only queued once"


### PR DESCRIPTION
## Motivation

We need to download transactions and verify them in order to implement the mempool.

Closes https://github.com/ZcashFoundation/zebra/issues/2637

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

This basically copies `zebrad/src/components/inbound/downloads.rs` and adapts it to work with transactions.

Currently any `AdvertiseTransactionIds` (`inv`) are downloaded and verified, and the result is just logged.

## Review

@teor2345 already reviewed the draft so they may want to finish it, otherwise @dconnolly can review it


### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

What's missing and will be done in separate PRs / issues:

- Checking if the tx is already in the mempool/state before downloading&verifying #2708
- Checking if we synced to the tip before accepting transactions #2628 & #2629
- The `Elapsed` error issue I described in https://github.com/ZcashFoundation/zebra/pull/2679#issuecomment-907943652 
    - part of #1186
- Tests (can be done in #2690 and #2691 )
- Handling pushed txs (will be done in https://github.com/ZcashFoundation/zebra/issues/2692)
- Ensuring we validate any mempool-specific rules (will be done in https://github.com/ZcashFoundation/zebra/issues/2707. In this PR I've just added the check for coinbase inputs)