### PR TITLE
Restore coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,13 +30,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
-      - name: Install rustfilt symbol demangler
-        run: |
-          cargo install rustfilt
-
       - name: Install cargo-llvm-cov cargo command
-        run: |
-          cargo install cargo-llvm-cov --version ^0.1.0-alpha.4
+        run: cargo install cargo-llvm-cov
 
       - name: Generate code coverage
         env:
@@ -45,4 +40,4 @@ jobs:
         run: cargo llvm-cov --lcov > lcov.info
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v1.5.2
+        uses: codecov/codecov-action@v2.0.3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
   coverage:
     name: Coverage (+nightly)
     # The large timeout is to accommodate nightly builds
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
@@ -27,8 +27,6 @@ jobs:
           override: true
           profile: minimal
           components: llvm-tools-preview
-
-      - uses: Swatinem/rust-cache@v1
 
       - name: Install cargo-llvm-cov cargo command
         run: cargo install cargo-llvm-cov


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

We disabled our coverage jobs because the build was failing consistently, things look to be stable again.

Since we are adding so much new code for mempool it would be good to have coverage metrics back.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Resolves #2454 

Uppgrades the codecov action to 2.0.3, which is nice because they have moved away from the previously-vulnerable bash script in the 2.* releases.

Removes the unneeded rustfilt symbol filter.

Removes the cache layer which looks like it was actually adding almost 10 minutes to the job if there was no cache being restored.

Always use latest published cargo-llvm-cov.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

Anyone can review.

