### PR TITLE
Add transaction IDs to the chain tip channel

### DIFF
--- a/zebra-chain/src/chain_tip.rs
+++ b/zebra-chain/src/chain_tip.rs
@@ -1,6 +1,6 @@
 //! Chain tip interfaces.
 
-use crate::block;
+use crate::{block, transaction};
 
 /// An interface for querying the chain tip.
 ///
@@ -13,6 +13,12 @@ pub trait ChainTip {
 
     /// Return the block hash of the best chain tip.
     fn best_tip_hash(&self) -> Option<block::Hash>;
+
+    /// Return the mined transaction IDs of the transactions in the best chain tip block.
+    ///
+    /// All transactions with these mined IDs should be rejected from the mempool,
+    /// even if their authorizing data is different.
+    fn best_tip_mined_transaction_ids(&self) -> Vec<transaction::Hash>;
 }
 
 /// A chain tip that is always empty.
@@ -26,5 +32,9 @@ impl ChainTip for NoChainTip {
 
     fn best_tip_hash(&self) -> Option<block::Hash> {
         None
+    }
+
+    fn best_tip_mined_transaction_ids(&self) -> Vec<transaction::Hash> {
+        Vec::new()
     }
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -127,11 +127,9 @@ impl StateService {
     ) -> oneshot::Receiver<Result<block::Hash, BoxError>> {
         let (rsp_tx, rsp_rx) = oneshot::channel();
 
-        self.disk.queue_and_commit_finalized((finalized, rsp_tx));
-        // TODO: move into the finalized state,
-        //       so we can clone committed `Arc<Block>`s before they get dropped
+        let tip_block = self.disk.queue_and_commit_finalized((finalized, rsp_tx));
         self.chain_tip_sender
-            .set_finalized_tip(self.disk.tip_block());
+            .set_finalized_tip(tip_block.map(|finalized| finalized.block));
 
         rsp_rx
     }

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -7,11 +7,58 @@ use zebra_chain::{
     chain_tip::ChainTip,
 };
 
+use crate::{request::ContextuallyValidBlock, FinalizedBlock};
+
 #[cfg(test)]
 mod tests;
 
 /// The internal watch channel data type for [`ChainTipSender`] and [`ChainTipReceiver`].
-type ChainTipData = Option<Arc<Block>>;
+type ChainTipData = Option<ChainTipBlock>;
+
+/// A chain tip block, with precalculated block data.
+///
+/// Used to efficiently update the [`ChainTipSender`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChainTipBlock {
+    pub(crate) block: Arc<Block>,
+    pub(crate) hash: block::Hash,
+    pub(crate) height: block::Height,
+}
+
+impl From<ContextuallyValidBlock> for ChainTipBlock {
+    fn from(contextually_valid: ContextuallyValidBlock) -> Self {
+        let ContextuallyValidBlock {
+            block,
+            hash,
+            height,
+            new_outputs: _,
+            transaction_hashes: _,
+            chain_value_pool_change: _,
+        } = contextually_valid;
+        Self {
+            block,
+            hash,
+            height,
+        }
+    }
+}
+
+impl From<FinalizedBlock> for ChainTipBlock {
+    fn from(finalized: FinalizedBlock) -> Self {
+        let FinalizedBlock {
+            block,
+            hash,
+            height,
+            new_outputs: _,
+            transaction_hashes: _,
+        } = finalized;
+        Self {
+            block,
+            hash,
+            height,
+        }
+    }
+}
 
 /// A sender for recent changes to the non-finalized and finalized chain tips.
 #[derive(Debug)]
@@ -33,7 +80,7 @@ pub struct ChainTipSender {
 impl ChainTipSender {
     /// Create new linked instances of [`ChainTipSender`] and [`ChainTipReceiver`],
     /// using `initial_tip` as the tip.
-    pub fn new(initial_tip: impl Into<Option<Arc<Block>>>) -> (Self, ChainTipReceiver) {
+    pub fn new(initial_tip: impl Into<Option<ChainTipBlock>>) -> (Self, ChainTipReceiver) {
         let (sender, receiver) = watch::channel(None);
         let mut sender = ChainTipSender {
             non_finalized_tip: false,
@@ -50,7 +97,7 @@ impl ChainTipSender {
     /// Update the current finalized tip.
     ///
     /// May trigger an update to the best tip.
-    pub fn set_finalized_tip(&mut self, new_tip: impl Into<Option<Arc<Block>>>) {
+    pub fn set_finalized_tip(&mut self, new_tip: impl Into<Option<ChainTipBlock>>) {
         if !self.non_finalized_tip {
             self.update(new_tip);
         }
@@ -59,7 +106,7 @@ impl ChainTipSender {
     /// Update the current non-finalized tip.
     ///
     /// May trigger an update to the best tip.
-    pub fn set_best_non_finalized_tip(&mut self, new_tip: impl Into<Option<Arc<Block>>>) {
+    pub fn set_best_non_finalized_tip(&mut self, new_tip: impl Into<Option<ChainTipBlock>>) {
         let new_tip = new_tip.into();
 
         // once the non-finalized state becomes active, it is always populated
@@ -74,15 +121,13 @@ impl ChainTipSender {
     ///
     /// An update is only sent if the current best tip is different from the last best tip
     /// that was sent.
-    fn update(&mut self, new_tip: impl Into<Option<Arc<Block>>>) {
+    fn update(&mut self, new_tip: impl Into<Option<ChainTipBlock>>) {
         let new_tip = new_tip.into();
 
         let needs_update = match (new_tip.as_ref(), self.active_value.as_ref()) {
-            // Check if the `Arc<Block>` allocations are different.
-            // Zebra re-uses `Arc`s, and ensures block uniqueness,
-            // so there should not be any `Arc`s with duplicate block data.
-            // If there are, they will just result in a redundant update for the same block.
-            (Some(new_tip), Some(active_value)) => !Arc::ptr_eq(new_tip, active_value),
+            // since the blocks have been contextually validated,
+            // we know their hashes cover all the block data
+            (Some(new_tip), Some(active_value)) => new_tip.hash != active_value.hash,
             (Some(_new_tip), None) => true,
             (None, _active_value) => false,
         };
@@ -116,16 +161,11 @@ impl ChainTipReceiver {
 impl ChainTip for ChainTipReceiver {
     /// Return the height of the best chain tip.
     fn best_tip_height(&self) -> Option<block::Height> {
-        self.receiver
-            .borrow()
-            .as_ref()
-            .and_then(|block| block.coinbase_height())
+        self.receiver.borrow().as_ref().map(|block| block.height)
     }
 
     /// Return the block hash of the best chain tip.
     fn best_tip_hash(&self) -> Option<block::Hash> {
-        // TODO: get the hash from the state and store it in the sender,
-        //       so we don't have to recalculate it every time
-        self.receiver.borrow().as_ref().map(|block| block.hash())
+        self.receiver.borrow().as_ref().map(|block| block.hash)
     }
 }

--- a/zebra-state/src/service/chain_tip/tests/prop.rs
+++ b/zebra-state/src/service/chain_tip/tests/prop.rs
@@ -62,6 +62,17 @@ proptest! {
 
         let expected_hash = expected_tip.as_ref().map(|block| block.block.hash());
         prop_assert_eq!(chain_tip_receiver.best_tip_hash(), expected_hash);
+
+        let expected_transaction_ids: Vec<_> = expected_tip
+            .as_ref()
+            .iter()
+            .flat_map(|block| block.block.transactions.clone())
+            .map(|transaction| transaction.hash())
+            .collect();
+        prop_assert_eq!(
+            chain_tip_receiver.best_tip_mined_transaction_ids(),
+            expected_transaction_ids
+        );
     }
 }
 

--- a/zebra-state/src/service/chain_tip/tests/vectors.rs
+++ b/zebra-state/src/service/chain_tip/tests/vectors.rs
@@ -8,6 +8,10 @@ fn best_tip_is_initially_empty() {
 
     assert_eq!(chain_tip_receiver.best_tip_height(), None);
     assert_eq!(chain_tip_receiver.best_tip_hash(), None);
+    assert_eq!(
+        chain_tip_receiver.best_tip_mined_transaction_ids(),
+        Vec::new()
+    );
 }
 
 #[test]
@@ -16,4 +20,8 @@ fn empty_chain_tip_is_empty() {
 
     assert_eq!(chain_tip_receiver.best_tip_height(), None);
     assert_eq!(chain_tip_receiver.best_tip_hash(), None);
+    assert_eq!(
+        chain_tip_receiver.best_tip_mined_transaction_ids(),
+        Vec::new()
+    );
 }

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -289,16 +289,13 @@ impl NonFinalizedState {
         None
     }
 
-    /// Returns the `block` at a given height or hash in the best chain.
-    pub fn best_block(&self, hash_or_height: HashOrHeight) -> Option<Arc<Block>> {
+    /// Returns the [`Block`] at a given height or hash in the best chain.
+    pub fn best_block(&self, hash_or_height: HashOrHeight) -> Option<ContextuallyValidBlock> {
         let best_chain = self.best_chain()?;
         let height =
             hash_or_height.height_or_else(|hash| best_chain.height_by_hash.get(&hash).cloned())?;
 
-        best_chain
-            .blocks
-            .get(&height)
-            .map(|prepared| prepared.block.clone())
+        best_chain.blocks.get(&height).map(Clone::clone)
     }
 
     /// Returns the hash for a given `block::Height` if it is present in the best chain.
@@ -319,7 +316,7 @@ impl NonFinalizedState {
     }
 
     /// Returns the block at the tip of the best chain.
-    pub fn best_tip_block(&self) -> Option<Arc<Block>> {
+    pub fn best_tip_block(&self) -> Option<ContextuallyValidBlock> {
         let (height, _hash) = self.best_tip()?;
         self.best_block(height.into())
     }

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -289,7 +289,7 @@ impl NonFinalizedState {
         None
     }
 
-    /// Returns the [`Block`] at a given height or hash in the best chain.
+    /// Returns the [`ContextuallyValidBlock`] at a given height or hash in the best chain.
     pub fn best_block(&self, hash_or_height: HashOrHeight) -> Option<ContextuallyValidBlock> {
         let best_chain = self.best_chain()?;
         let height =


### PR DESCRIPTION
## Motivation

1. We want to provide the mined transaction IDs for the chain tip as part of #2639

2. We want to optimise chain tip updates, by re-using precalculated finalized and non-finalized block hashes, heights, and transaction IDs

## Solution

1. Add chain tip mined transaction IDs

2. Optimisation:
    - Re-use finalized blocks for chain tip updates
    - Optimise tip sender equality checks
    - Re-use precalculated block hashes and heights for chain tip updates

This is part of #2639, but doesn't close that ticket.

## Review

@jvff has been reviewing this series of chain tip updates PRs

This PR is based on PR #2683, it might need a manual rebase before it merges.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

I modified the existing tests to cover the optimisations and the transaction hashes.

## Follow Up Work

Handle chain tip resets (#2639)
