### PR TITLE
Refactor Zebra metrics docs

### DIFF
--- a/book/src/user/metrics.md
+++ b/book/src/user/metrics.md
@@ -10,7 +10,7 @@ This requires supporting infrastructure to collect and visualize metrics, for ex
    endpoint_addr = "127.0.0.1:9999"
    ```
 
-2. Run Zebra:
+2. Run Zebra, and specify the path to the `zebrad.toml` file, for example:
    ```
    zebrad -c zebrad.toml start
    ```

--- a/book/src/user/metrics.md
+++ b/book/src/user/metrics.md
@@ -4,38 +4,42 @@ Zebra has support for Prometheus, configured using the [`MetricsSection`][metric
 
 This requires supporting infrastructure to collect and visualize metrics, for example:
 
-1. Install Prometheus and Grafana via Docker
+1. Create the `zebrad.toml` file with the following contents:
+   ```
+   [metrics]
+   endpoint_addr = "127.0.0.1:9999"
+   ```
 
-```
-# create a storage volume for grafana (once)
-sudo docker volume create grafana-storage
-# create a storage volume for prometheus (once)
-sudo docker volume create prometheus-storage
+2. Run Zebra:
+   ```
+   zebrad -c zebrad.toml start
+   ```
 
-# run prometheus with the included config
-sudo docker run --detach --network host --volume prometheus-storage:/prometheus --volume /path/to/zebra/prometheus.yaml:/etc/prometheus/prometheus.yml  prom/prometheus
+3. Install and run Prometheus and Grafana via Docker:
 
-# run grafana
-sudo docker run --detach --network host --env GF_SERVER_HTTP_PORT=3030 --env GF_SERVER_HTTP_ADDR=localhost --volume grafana-storage:/var/lib/grafana grafana/grafana
-```
+   ```
+   # create a storage volume for grafana (once)
+   sudo docker volume create grafana-storage
+   # create a storage volume for prometheus (once)
+   sudo docker volume create prometheus-storage
 
-Now the grafana dashboard is available at [http://localhost:3030](http://localhost:3030) ; the default username and password is `admin`/`admin`.
-Prometheus scrapes Zebra on `localhost:9999`, and provides the results on `localhost:9090`.
+   # run prometheus with the included config
+   sudo docker run --detach --network host --volume prometheus-storage:/prometheus --volume /path/to/zebra/prometheus.yaml:/etc/prometheus/prometheus.yml  prom/prometheus
 
-2. Configure Grafana with a Prometheus HTTP Data Source, using Zebra's `metrics.endpoint_addr`.
+   # run grafana
+   sudo docker run --detach --network host --env GF_SERVER_HTTP_PORT=3030 --env GF_SERVER_HTTP_ADDR=localhost --volume grafana-storage:/var/lib/grafana grafana/grafana
+   ```
 
-In zebrad.toml:
-```
-[metrics]
-endpoint_addr = "127.0.0.1:9999"
-```
+   Now the grafana dashboard is available at [http://localhost:3030](http://localhost:3030) ; the default username and password is `admin`/`admin`.
+   Prometheus scrapes Zebra on `localhost:9999`, and provides the results on `localhost:9090`.
 
-In the grafana dashboard:
-1. Create a new Prometheus Data Source `Prometheus-Zebra`
-2. Enter the HTTP URL: `127.0.0.1:9090`
-3. Save the configuration
+4. Configure Grafana with a Prometheus HTTP Data Source, using Zebra's `metrics.endpoint_addr`.
 
-Now you can add the grafana dashboards from `zebra/grafana` (Create > Import >
-Upload JSON File), or create your own.
+   In the grafana dashboard:
+   1. Create a new Prometheus Data Source `Prometheus-Zebra`
+   2. Enter the HTTP URL: `127.0.0.1:9090`
+   3. Save the configuration
+
+5. Now you can add the grafana dashboards from `zebra/grafana` (Create > Import > Upload JSON File), or create your own.
 
 [metrics_section]: https://doc.zebra.zfnd.org/zebrad/config/struct.MetricsSection.html


### PR DESCRIPTION
## Motivation
It was not possible to get the Zebra stats by following the metrics docs page step-by-step. 

## Solution
The docs now explicitly lead the reader to the intended goal.

### Reviewer Checklist
  - [x] It is straightforward enough to follow the steps in order to display the Zebra stats.
