### PR TITLE
Reply to `Request::MempoolTransactionIds` with mempool content

### DIFF
--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -13,7 +13,7 @@ default-run = "zebrad"
 zebra-chain = { path = "../zebra-chain" }
 zebra-consensus = { path = "../zebra-consensus/" }
 zebra-network = { path = "../zebra-network" }
-zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state" }
 
 abscissa_core = "0.5"
 gumdrop = "0.7"

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -13,7 +13,7 @@ default-run = "zebrad"
 zebra-chain = { path = "../zebra-chain" }
 zebra-consensus = { path = "../zebra-consensus/" }
 zebra-network = { path = "../zebra-network" }
-zebra-state = { path = "../zebra-state" }
+zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
 
 abscissa_core = "0.5"
 gumdrop = "0.7"

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -63,6 +63,9 @@ impl StartCmd {
         )
         .await;
 
+        info!("initializing mempool");
+        let mempool = mempool::Mempool::new(config.network.network);
+
         info!("initializing network");
         // The service that our node uses to respond to requests by peers. The
         // load_shed middleware ensures that we reduce the size of the peer set
@@ -75,6 +78,7 @@ impl StartCmd {
                 setup_rx,
                 state.clone(),
                 chain_verifier.clone(),
+                mempool,
             ));
 
         let (peer_set, address_book) =

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -143,7 +143,7 @@ impl Inbound {
         state: State,
         block_verifier: BlockVerifier,
         tx_verifier: TxVerifier,
-        mempool: mempool::Mempool
+        mempool: mempool::Mempool,
     ) -> Self {
         Self {
             network_setup: Setup::AwaitingNetwork {

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -11,7 +11,6 @@ use zebra_chain::{
 };
 use zebra_consensus::Config as ConsensusConfig;
 use zebra_network::{Request, Response};
-
 use zebra_state::Config as StateConfig;
 
 #[tokio::test]

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -1,0 +1,72 @@
+use tower::ServiceExt;
+
+use super::mempool::{unmined_transactions_in_blocks, Mempool};
+
+use tokio::sync::oneshot;
+use tower::builder::ServiceBuilder;
+
+use zebra_chain::{
+    parameters::Network,
+    transaction::{UnminedTx, UnminedTxId},
+};
+use zebra_consensus::Config;
+use zebra_network::{Request, Response};
+
+#[test]
+fn mempool_requests_for_transaction_ids() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create Tokio runtime");
+    let _guard = runtime.enter();
+
+    let network = Network::Mainnet;
+    let config = Config::default();
+
+    let state_service = zebra_state::init_test(network);
+    let mut mempool_service = Mempool::new(network);
+
+    let added_transaction_ids: Vec<UnminedTxId> =
+        add_some_stuff_to_mempool(&mut mempool_service, network)
+            .iter()
+            .map(|t| t.id)
+            .collect();
+
+    runtime.block_on(async move {
+        let (chain_verifier, _transaction_verifier) =
+            zebra_consensus::chain::init(config.clone(), network, zebra_state::init_test(network))
+                .await;
+        let (_setup_tx, setup_rx) = oneshot::channel();
+
+        let inbound_service =
+            ServiceBuilder::new()
+                .load_shed()
+                .buffer(20)
+                .service(super::Inbound::new(
+                    setup_rx,
+                    state_service.clone(),
+                    chain_verifier.clone(),
+                    mempool_service,
+                ));
+
+        let request = inbound_service
+            .oneshot(Request::MempoolTransactionIds)
+            .await;
+        match request {
+            Ok(Response::TransactionIds(response)) => assert_eq!(response, added_transaction_ids),
+            _ => panic!("in this test we are pretty sure there is always a correct response"),
+        };
+    });
+}
+
+fn add_some_stuff_to_mempool(mempool_service: &mut Mempool, network: Network) -> Vec<UnminedTx> {
+    // get the genesis block transactions from the Zcash blockchain.
+    let genesis_transactions = unmined_transactions_in_blocks(0, network);
+    // Insert the genesis block coinbase transaction into the mempool storage.
+    mempool_service
+        .storage
+        .insert(genesis_transactions.1[0].clone())
+        .unwrap();
+
+    genesis_transactions.1
+}

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -47,7 +47,9 @@ async fn mempool_requests_for_transaction_ids() {
         .await;
     match request {
         Ok(Response::TransactionIds(response)) => assert_eq!(response, added_transaction_ids),
-        _ => panic!("in this test we are pretty sure there is always a correct response"),
+        _ => unreachable!(
+            "`MempoolTransactionIds` requests should always respond `Ok(Vec<UnminedTxId>)`"
+        ),
     };
 }
 

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -19,7 +19,7 @@ async fn mempool_requests_for_transaction_ids() {
     let consensus_config = ConsensusConfig::default();
     let state_config = StateConfig::ephemeral();
 
-    let (state, _) = zebra_state::init(state_config, network);
+    let (state, _, _) = zebra_state::init(state_config, network);
     let state_service = ServiceBuilder::new().buffer(1).service(state);
     let mut mempool_service = Mempool::new(network);
 
@@ -29,7 +29,7 @@ async fn mempool_requests_for_transaction_ids() {
             .map(|t| t.id)
             .collect();
 
-    let (chain_verifier, _transaction_verifier) =
+    let (block_verifier, transaction_verifier) =
         zebra_consensus::chain::init(consensus_config.clone(), network, state_service.clone())
             .await;
     let (_setup_tx, setup_rx) = oneshot::channel();
@@ -40,7 +40,8 @@ async fn mempool_requests_for_transaction_ids() {
         .service(super::Inbound::new(
             setup_rx,
             state_service,
-            chain_verifier.clone(),
+            block_verifier.clone(),
+            transaction_verifier.clone(),
             mempool_service,
         ));
 

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -56,7 +56,7 @@ fn add_some_stuff_to_mempool(mempool_service: &mut Mempool, network: Network) ->
     let genesis_transactions = unmined_transactions_in_blocks(0, network);
     // Insert the genesis block coinbase transaction into the mempool storage.
     mempool_service
-        .storage
+        .storage()
         .insert(genesis_transactions.1[0].clone())
         .unwrap();
 

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -53,7 +53,7 @@ pub struct Mempool {
     ///
     /// ##: Correctness: only components internal to the [`Mempool`] struct are allowed to
     /// inject transactions into `storage`, as transactions must be verified beforehand.
-    pub storage: storage::Storage,
+    storage: storage::Storage,
 }
 
 impl Mempool {
@@ -62,6 +62,12 @@ impl Mempool {
         Mempool {
             storage: Default::default(),
         }
+    }
+
+    ///  Get the storage field of the mempool for testing purposes.
+    #[cfg(test)]
+    pub fn storage(&mut self) -> &mut storage::Storage {
+        &mut self.storage
     }
 }
 

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -26,6 +26,8 @@ mod tests;
 
 pub use self::crawler::Crawler;
 pub use self::error::MempoolError;
+#[cfg(test)]
+pub use self::storage::tests::unmined_transactions_in_blocks;
 
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -51,7 +53,7 @@ pub struct Mempool {
     ///
     /// ##: Correctness: only components internal to the [`Mempool`] struct are allowed to
     /// inject transactions into `storage`, as transactions must be verified beforehand.
-    storage: storage::Storage,
+    pub storage: storage::Storage,
 }
 
 impl Mempool {


### PR DESCRIPTION
## Motivation

Now that we have a mempool we can start responding with it contents to some inbound messages.

Close https://github.com/ZcashFoundation/zebra/issues/1083 when merged.

## Solution

This is the easier message that responds with the ids available in the mempool. Most of the work is in the test.

## Review

I used some code from other tests made by @jvff so i think it will be a good candidate to the an initial review. On the other hand as we are all in  mempool pretty much anyone can review so feel free to send feedback.

### Reviewer Checklist

  - [ ] Tests for the new code added
