### PR TITLE
Reset `ChainTipChange`s on chain fork and network upgrade activation

### DIFF
--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -208,6 +208,14 @@ impl NetworkUpgrade {
             .next()
     }
 
+    /// Returns `true` if `height` is the activation height of any network upgrade
+    /// on `network`.
+    ///
+    /// Use [`activation_height`] to get the specific network upgrade.
+    pub fn is_activation_height(network: Network, height: block::Height) -> bool {
+        NetworkUpgrade::activation_list(network).contains_key(&height)
+    }
+
     /// Returns a BTreeMap of NetworkUpgrades and their ConsensusBranchIds.
     ///
     /// Branch ids are the same for mainnet and testnet.

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -45,7 +45,7 @@ where
 impl From<PreparedBlock> for ChainTipBlock {
     fn from(prepared: PreparedBlock) -> Self {
         let PreparedBlock {
-            block: _,
+            block,
             hash,
             height,
             new_outputs: _,
@@ -55,6 +55,7 @@ impl From<PreparedBlock> for ChainTipBlock {
             hash,
             height,
             transaction_hashes,
+            previous_block_hash: block.header.previous_block_hash,
         }
     }
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -83,7 +83,7 @@ impl StateService {
             .map(FinalizedBlock::from)
             .map(ChainTipBlock::from);
         let (chain_tip_sender, latest_chain_tip, chain_tip_change) =
-            ChainTipSender::new(initial_tip);
+            ChainTipSender::new(initial_tip, network);
 
         let mem = NonFinalizedState::new(network);
         let queued_blocks = QueuedBlocks::default();

--- a/zebra-state/src/service/chain_tip/tests/prop.rs
+++ b/zebra-state/src/service/chain_tip/tests/prop.rs
@@ -8,6 +8,7 @@ use zebra_chain::{
     block::Block,
     chain_tip::ChainTip,
     fmt::{DisplayToDebug, SummaryDebug},
+    parameters::Network,
 };
 
 use crate::service::chain_tip::{ChainTipBlock, ChainTipSender, TipAction};
@@ -27,8 +28,9 @@ proptest! {
     #[test]
     fn best_tip_is_latest_non_finalized_then_latest_finalized(
         tip_updates in any::<SummaryDebug<Vec<BlockUpdate>>>(),
+        network in any::<Network>(),
     ) {
-        let (mut chain_tip_sender, latest_chain_tip, mut chain_tip_change) = ChainTipSender::new(None);
+        let (mut chain_tip_sender, latest_chain_tip, mut chain_tip_change) = ChainTipSender::new(None, network);
 
         let mut latest_finalized_tip = None;
         let mut latest_non_finalized_tip = None;

--- a/zebra-state/src/service/chain_tip/tests/vectors.rs
+++ b/zebra-state/src/service/chain_tip/tests/vectors.rs
@@ -2,13 +2,17 @@ use std::iter;
 
 use futures::FutureExt;
 
-use zebra_chain::chain_tip::{ChainTip, NoChainTip};
+use zebra_chain::{
+    chain_tip::{ChainTip, NoChainTip},
+    parameters::Network::*,
+};
 
 use super::super::ChainTipSender;
 
 #[test]
 fn current_best_tip_is_initially_empty() {
-    let (_chain_tip_sender, latest_chain_tip, _chain_tip_change) = ChainTipSender::new(None);
+    let (_chain_tip_sender, latest_chain_tip, _chain_tip_change) =
+        ChainTipSender::new(None, Mainnet);
 
     assert_eq!(latest_chain_tip.best_tip_height(), None);
     assert_eq!(latest_chain_tip.best_tip_hash(), None);
@@ -32,7 +36,8 @@ fn empty_latest_chain_tip_is_empty() {
 
 #[test]
 fn chain_tip_change_is_initially_not_ready() {
-    let (_chain_tip_sender, _latest_chain_tip, mut chain_tip_change) = ChainTipSender::new(None);
+    let (_chain_tip_sender, _latest_chain_tip, mut chain_tip_change) =
+        ChainTipSender::new(None, Mainnet);
 
     let first = chain_tip_change
         .tip_change()

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -336,13 +336,12 @@ proptest! {
         for block in non_finalized_blocks {
             let expected_block = block.clone();
 
-            let expected_action;
-            if expected_block.height == block::Height(1) {
+            let expected_action = if expected_block.height == block::Height(1) {
                 // 1: reset by the BeforeOverwinter network upgrade
-                expected_action = TipAction::reset_with(expected_block.clone().into());
+                TipAction::reset_with(expected_block.clone().into())
             } else {
-                expected_action = TipAction::grow_with(expected_block.clone().into());
-            }
+                TipAction::grow_with(expected_block.clone().into())
+            };
 
             state_service.queue_and_commit_non_finalized(block);
 

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -312,14 +312,13 @@ proptest! {
         for block in finalized_blocks {
             let expected_block = block.clone();
 
-            let expected_action;
-            if expected_block.height <= block::Height(1) {
+            let expected_action = if expected_block.height <= block::Height(1) {
                 // 0: reset by both initialization and the Genesis network upgrade
                 // 1: reset by the BeforeOverwinter network upgrade
-                expected_action = TipAction::reset_with(expected_block.clone().into());
+                TipAction::reset_with(expected_block.clone().into())
             } else {
-                expected_action = TipAction::grow_with(expected_block.clone().into());
-            }
+                TipAction::grow_with(expected_block.clone().into())
+            };
 
             state_service.queue_and_commit_finalized(block);
 

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -17,10 +17,7 @@ use zebra_test::{prelude::*, transcript::Transcript};
 use crate::{
     arbitrary::Prepare,
     constants, init_test,
-    service::{
-        chain_tip::TipAction::{self, *},
-        StateService,
-    },
+    service::{chain_tip::TipAction, StateService},
     tests::setup::{partial_nu5_chain_strategy, transaction_v4_from_coinbase},
     BoxError, Config, FinalizedBlock, PreparedBlock, Request, Response,
 };
@@ -316,8 +313,9 @@ proptest! {
             let expected_block = block.clone();
 
             let expected_action;
-            if expected_block.height == block::Height(0) {
-                // reset by both initialization and the genesis network upgrade
+            if expected_block.height <= block::Height(1) {
+                // 0: reset by both initialization and the Genesis network upgrade
+                // 1: reset by the BeforeOverwinter network upgrade
                 expected_action = TipAction::reset_with(expected_block.clone().into());
             } else {
                 expected_action = TipAction::grow_with(expected_block.clone().into());
@@ -339,6 +337,14 @@ proptest! {
         for block in non_finalized_blocks {
             let expected_block = block.clone();
 
+            let expected_action;
+            if expected_block.height == block::Height(1) {
+                // 1: reset by the BeforeOverwinter network upgrade
+                expected_action = TipAction::reset_with(expected_block.clone().into());
+            } else {
+                expected_action = TipAction::grow_with(expected_block.clone().into());
+            }
+
             state_service.queue_and_commit_non_finalized(block);
 
             prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
@@ -348,7 +354,7 @@ proptest! {
                     .now_or_never()
                     .transpose()
                     .expect("watch sender is not dropped"),
-                Some(Grow { block: expected_block.into() })
+                Some(expected_action)
             );
         }
     }


### PR DESCRIPTION
## Motivation

We want to reset the mempool for specific chain tip changes.

### Specifications

https://zips.z.cash/zip-0200

### Designs

Resets are rare, so we can just clear the mempool when they happen.

Here are some different reset reasons:

#### Consensus rules

Network upgrades: stop mempool downloads and verifies, and clear storage and rejections:
- #2374
- #2710

Chain rollbacks: stop rejecting transactions which spend rolled back inputs, by clearing our entire reject list:
- #2714

#### Zebra-specific

Initializing or cloning the receiver:
- we know we're not up to date with the latest changes

Skipped updates:
- we're lagging behind
- we just received a large number of blocks
- we might have skipped a network upgrade activation block
- a chain fork change might have rolled back or rolled forward a network upgrade activation

## Solution

Use `TipAction::Reset` for:
- initialization and out-of-order blocks, including rollbacks, fork changes, and skips
- network upgrade activation blocks 

This PR (finally) closes #2639.

### TODO

This PR still needs tests for:
- cloning a `ChainTipChange` resets the cloned instance
- skipped updates reset the cloned instance
- changing forks resets the cloned instance

## Review

@jvff can review this PR.

It's based on PR #2715, so it might need a rebase after that PR merges.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Actually use the chain tip changes.
See the tickets listed in this PR and ticket #2639.