### PR TITLE
Verify inbound PushTransactions

### DIFF
--- a/grafana/transaction_verification.json
+++ b/grafana/transaction_verification.json
@@ -1,4 +1,34 @@
 {
+    "__inputs": [
+        {
+            "name": "DS_PROMETHEUS-ZEBRA",
+            "label": "Prometheus-Zebra",
+            "description": "",
+            "type": "datasource",
+            "pluginId": "prometheus",
+            "pluginName": "Prometheus"
+        }
+    ],
+    "__requires": [
+        {
+            "type": "grafana",
+            "id": "grafana",
+            "name": "Grafana",
+            "version": "8.1.2"
+        },
+        {
+            "type": "panel",
+            "id": "graph",
+            "name": "Graph (old)",
+            "version": ""
+        },
+        {
+            "type": "datasource",
+            "id": "prometheus",
+            "name": "Prometheus",
+            "version": "1.0.0"
+        }
+    ],
     "annotations": {
         "list": [
             {
@@ -21,8 +51,8 @@
     "editable": true,
     "gnetId": null,
     "graphTooltip": 0,
-    "id": 5,
-    "iteration": 1630611911135,
+    "id": null,
+    "iteration": 1630092146360,
     "links": [],
     "panels": [
         {
@@ -87,14 +117,6 @@
                     "interval": "",
                     "legendFormat": "gossip_queued_transaction_count",
                     "refId": "E"
-                },
-                {
-                    "exemplar": true,
-                    "expr": "rate(gossip_pushed_transaction_count{job=\"$job\"}[1m]) * 60",
-                    "hide": false,
-                    "interval": "",
-                    "legendFormat": "gossip_pushed_transaction_count per min",
-                    "refId": "A"
                 }
             ],
             "thresholds": [],
@@ -147,16 +169,8 @@
         "list": [
             {
                 "allValue": null,
-                "current": {
-                    "selected": true,
-                    "text": [
-                        "All"
-                    ],
-                    "value": [
-                        "$__all"
-                    ]
-                },
-                "datasource": "Prometheus-Zebra",
+                "current": {},
+                "datasource": "${DS_PROMETHEUS-ZEBRA}",
                 "definition": "label_values(zcash_chain_verified_block_height, job)",
                 "description": null,
                 "error": null,
@@ -189,5 +203,5 @@
     "timezone": "",
     "title": "transaction verification",
     "uid": "oBEHvS4nz",
-    "version": 4
+    "version": 2
 }

--- a/grafana/transaction_verification.json
+++ b/grafana/transaction_verification.json
@@ -1,34 +1,4 @@
 {
-    "__inputs": [
-        {
-            "name": "DS_PROMETHEUS-ZEBRA",
-            "label": "Prometheus-Zebra",
-            "description": "",
-            "type": "datasource",
-            "pluginId": "prometheus",
-            "pluginName": "Prometheus"
-        }
-    ],
-    "__requires": [
-        {
-            "type": "grafana",
-            "id": "grafana",
-            "name": "Grafana",
-            "version": "8.1.2"
-        },
-        {
-            "type": "panel",
-            "id": "graph",
-            "name": "Graph (old)",
-            "version": ""
-        },
-        {
-            "type": "datasource",
-            "id": "prometheus",
-            "name": "Prometheus",
-            "version": "1.0.0"
-        }
-    ],
     "annotations": {
         "list": [
             {
@@ -51,8 +21,8 @@
     "editable": true,
     "gnetId": null,
     "graphTooltip": 0,
-    "id": null,
-    "iteration": 1630092146360,
+    "id": 5,
+    "iteration": 1630611911135,
     "links": [],
     "panels": [
         {
@@ -117,6 +87,14 @@
                     "interval": "",
                     "legendFormat": "gossip_queued_transaction_count",
                     "refId": "E"
+                },
+                {
+                    "exemplar": true,
+                    "expr": "rate(gossip_pushed_transaction_count{job=\"$job\"}[1m]) * 60",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "gossip_pushed_transaction_count per min",
+                    "refId": "A"
                 }
             ],
             "thresholds": [],
@@ -169,8 +147,16 @@
         "list": [
             {
                 "allValue": null,
-                "current": {},
-                "datasource": "${DS_PROMETHEUS-ZEBRA}",
+                "current": {
+                    "selected": true,
+                    "text": [
+                        "All"
+                    ],
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": "Prometheus-Zebra",
                 "definition": "label_values(zcash_chain_verified_block_height, job)",
                 "description": null,
                 "error": null,
@@ -203,5 +189,5 @@
     "timezone": "",
     "title": "transaction verification",
     "uid": "oBEHvS4nz",
-    "version": 2
+    "version": 4
 }

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -356,7 +356,7 @@ impl Service<zn::Request> for Inbound {
                 if let Setup::Initialized { tx_downloads, .. } = &mut self.network_setup {
                     // TODO: check if we're close to the tip before proceeding?
                     // what do we do if it's not?
-                    tx_downloads.verify(transaction);
+                    tx_downloads.download_if_needed_and_verify(transaction.into());
                 } else {
                     info!(
                         "ignoring `AdvertiseTransactionIds` request from remote peer during network setup"
@@ -369,7 +369,7 @@ impl Service<zn::Request> for Inbound {
                     // TODO: check if we're close to the tip before proceeding?
                     // what do we do if it's not?
                     for txid in transactions {
-                        tx_downloads.download_and_verify(txid);
+                        tx_downloads.download_if_needed_and_verify(txid.into());
                     }
                 } else {
                     info!(

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -354,8 +354,6 @@ impl Service<zn::Request> for Inbound {
             }
             zn::Request::PushTransaction(transaction) => {
                 if let Setup::Initialized { tx_downloads, .. } = &mut self.network_setup {
-                    // TODO: check if we're close to the tip before proceeding?
-                    // what do we do if it's not?
                     tx_downloads.download_if_needed_and_verify(transaction.into());
                 } else {
                     info!(
@@ -366,8 +364,6 @@ impl Service<zn::Request> for Inbound {
             }
             zn::Request::AdvertiseTransactionIds(transactions) => {
                 if let Setup::Initialized { tx_downloads, .. } = &mut self.network_setup {
-                    // TODO: check if we're close to the tip before proceeding?
-                    // what do we do if it's not?
                     for txid in transactions {
                         tx_downloads.download_if_needed_and_verify(txid.into());
                     }


### PR DESCRIPTION
## Motivation

Transactions can be directly pushed to nodes (instead of their IDs being advertised) and we need to verify them before adding to the mempool.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

This adds a new function to the transaction dowloader/verifier to just verify a pushed transaction.

Closes #2692
<!--
Summarize the changes in this PR.
Does it close any issues?
-->

## Review

Must be merged after #2718.

Probably anyone working on the mempool can review this.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
