### PR TITLE
Gossip recently verified block hashes to peers

### DIFF
--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -540,6 +540,15 @@ impl TipAction {
         }
     }
 
+    /// Returns the block height of this tip action,
+    /// regardless of the underlying variant.
+    pub fn best_tip_height(&self) -> block::Height {
+        match self {
+            Grow { block } => block.height,
+            Reset { height, .. } => *height,
+        }
+    }
+
     /// Returns a [`Grow`] based on `block`.
     pub(crate) fn grow_with(block: ChainTipBlock) -> Self {
         Grow { block }

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -106,22 +106,24 @@ impl StartCmd {
             .send((peer_set.clone(), address_book, mempool.clone()))
             .map_err(|_| eyre!("could not send setup data to inbound service"))?;
 
-        let sync_gossip = tokio::spawn(sync::gossip_best_tip_block_hashes(
+        let syncer_error_future = syncer.sync();
+
+        let sync_gossip_task_handle = tokio::spawn(sync::gossip_best_tip_block_hashes(
             sync_status.clone(),
             chain_tip_change,
             peer_set.clone(),
         ));
 
-        let mempool_crawl = mempool::Crawler::spawn(peer_set, mempool, sync_status);
+        let mempool_crawler_task_handle = mempool::Crawler::spawn(peer_set, mempool, sync_status);
 
         select! {
-            sync_result = syncer.sync().fuse() => sync_result,
+            sync_result = syncer_error_future.fuse() => sync_result,
 
-            sync_gossip_result = sync_gossip.fuse() => sync_gossip_result
-                .expect("unexpected panic in the chain tip gossip task")
+            sync_gossip_result = sync_gossip_task_handle.fuse() => sync_gossip_result
+                .expect("unexpected panic in the chain tip block gossip task")
                 .map_err(|e| eyre!(e)),
 
-            mempool_crawl_result = mempool_crawl.fuse() => mempool_crawl_result
+            mempool_crawl_result = mempool_crawler_task_handle.fuse() => mempool_crawl_result
                 .expect("unexpected panic in the mempool crawler")
                 .map_err(|e| eyre!(e)),
         }

--- a/zebrad/src/components.rs
+++ b/zebrad/src/components.rs
@@ -8,7 +8,7 @@
 mod inbound;
 pub mod mempool;
 pub mod metrics;
-mod sync;
+pub mod sync;
 pub mod tokio;
 pub mod tracing;
 

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -442,7 +442,7 @@ async fn setup(
 
     let r = setup_tx.send((buffered_peer_set, address_book, mempool));
     // We can't expect or unwrap because the returned Result does not implement Debug
-    assert!(r.is_ok());
+    assert!(r.is_ok(), "unexpected setup channel send failure");
 
     (
         inbound_service,

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -78,7 +78,6 @@ async fn mempool_requests_for_transactions() {
     };
 
     // check that nothing unexpected happened
-
     peer_set.expect_no_requests().await;
 
     let sync_gossip_result = sync_gossip_task_handle.now_or_never();
@@ -148,7 +147,6 @@ async fn mempool_push_transaction() -> Result<(), crate::BoxError> {
     };
 
     // check that nothing unexpected happened
-
     peer_set.expect_no_requests().await;
 
     let sync_gossip_result = sync_gossip_task_handle.now_or_never();
@@ -236,7 +234,6 @@ async fn mempool_advertise_transaction_ids() -> Result<(), crate::BoxError> {
     };
 
     // check that nothing unexpected happened
-
     peer_set.expect_no_requests().await;
 
     let sync_gossip_result = sync_gossip_task_handle.now_or_never();
@@ -453,7 +450,6 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
     }
 
     // check that nothing unexpected happened
-
     peer_set.expect_no_requests().await;
 
     let sync_gossip_result = sync_gossip_task_handle.now_or_never();

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -69,6 +69,8 @@ where
     /// Runs until the [`SyncStatus`] loses its connection to the chain syncer, which happens when
     /// Zebra is shutting down.
     pub async fn run(mut self) -> Result<(), BoxError> {
+        info!("initializing mempool crawler task");
+
         while self.status.wait_until_close_to_tip().await.is_ok() {
             self.crawl_transactions().await?;
             sleep(RATE_LIMIT_DELAY).await;

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -30,7 +30,7 @@ mod tests;
 
 use downloads::{AlwaysHedge, Downloads};
 
-pub use gossip::gossip_best_tip_block_hashes;
+pub use gossip::{gossip_best_tip_block_hashes, BlockGossipError};
 pub use recent_sync_lengths::RecentSyncLengths;
 pub use status::SyncStatus;
 

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -21,6 +21,7 @@ use zebra_state as zs;
 use crate::{config::ZebradConfig, BoxError};
 
 mod downloads;
+mod gossip;
 mod recent_sync_lengths;
 mod status;
 
@@ -28,6 +29,8 @@ mod status;
 mod tests;
 
 use downloads::{AlwaysHedge, Downloads};
+
+pub use gossip::gossip_best_tip_block_hashes;
 pub use recent_sync_lengths::RecentSyncLengths;
 pub use status::SyncStatus;
 

--- a/zebrad/src/components/sync/gossip.rs
+++ b/zebrad/src/components/sync/gossip.rs
@@ -49,6 +49,9 @@ where
             // unlike the mempool, we don't care if the change is a reset
             let request = zn::Request::AdvertiseBlock(tip_action.best_tip_hash());
 
+            let height = tip_action.best_tip_height();
+            info!(?height, ?request, "sending verified block broadcast");
+
             // broadcast requests don't return errors, and we'd just want to ignore them anyway
             let _ = broadcast_network.ready_and().await?.call(request).await;
         }

--- a/zebrad/src/components/sync/gossip.rs
+++ b/zebrad/src/components/sync/gossip.rs
@@ -55,6 +55,7 @@ where
     loop {
         // wait for at least one tip change, to make sure we have a new block hash to broadcast
         let tip_action = chain_state.wait_for_tip_change().await.map_err(TipChange)?;
+
         // wait until we're close to the tip, because broadcasts are only useful for nodes near the tip
         // (if they're a long way from the tip, they use the syncer and block locators)
         sync_status

--- a/zebrad/src/components/sync/gossip.rs
+++ b/zebrad/src/components/sync/gossip.rs
@@ -1,0 +1,56 @@
+//! A task that gossips newly verified [`block::Hash`]es to peers.
+
+use tower::{timeout::Timeout, Service, ServiceExt};
+
+use zebra_network as zn;
+use zebra_state::ChainTipChange;
+
+use crate::BoxError;
+
+use super::{SyncStatus, TIPS_RESPONSE_TIMEOUT};
+
+/// Run continuously, gossiping newly verified [`block::Hash`]es to peers.
+///
+/// Once the state has reached the chain tip, broadcast the [`block::Hash`]es
+/// of newly verified blocks to all ready peers.
+///
+/// Blocks are only gossiped if they are:
+/// - on the best chain, and
+/// - the most recent block verified since the last gossip.
+///
+/// In particular, if a lot of blocks are committed at the same time,
+/// gossips will be disabled or skipped until the state reaches the latest tip.
+pub async fn gossip_best_tip_block_hashes<ZN>(
+    mut sync_status: SyncStatus,
+    mut chain_state: ChainTipChange,
+    broadcast_network: ZN,
+) -> Result<(), BoxError>
+where
+    ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Clone + 'static,
+    ZN::Future: Send,
+{
+    info!("initializing block gossip task");
+
+    // use the same timeout as tips requests,
+    // so broadcasts don't delay the syncer too long
+    let mut broadcast_network = Timeout::new(broadcast_network, TIPS_RESPONSE_TIMEOUT);
+
+    // TODO:
+    //
+    // Optional Cleanup
+    // - wrap returned errors in a newtype, so we can distinguish sync and tip watch errors
+    // - refactor to avoid checking SyncStatus twice, maybe by passing a closure?
+    loop {
+        sync_status.wait_until_close_to_tip().await?;
+
+        let tip_action = chain_state.wait_for_tip_change().await?;
+        // check sync status again, because it might be a long time between blocks
+        if sync_status.is_close_to_tip() {
+            // unlike the mempool, we don't care if the change is a reset
+            let request = zn::Request::AdvertiseBlock(tip_action.best_tip_hash());
+
+            // broadcast requests don't return errors, and we'd just want to ignore them anyway
+            let _ = broadcast_network.ready_and().await?.call(request).await;
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Zebra needs to broadcast verified block hashes to its peers, so they learn about new blocks.

### Designs

`Grow` and `Reset` chain tip changes should be sent in block gossips.

<details>

Tasks can wait until they are near the tip using `SyncStatus::wait_until_close_to_tip`:
https://github.com/ZcashFoundation/zebra/blob/44ac06775bf6bb77dea06d53a6fc5e04a79baf31/zebrad/src/components/sync/status.rs#L31-L34

Tasks can await tip changes using `ChainTipChange::tip_change` and `TipAction`:
https://github.com/ZcashFoundation/zebra/blob/44ac06775bf6bb77dea06d53a6fc5e04a79baf31/zebra-state/src/service/chain_tip.rs#L313

</details>

## Solution

- wait for state best tip changes
- wait until Zebra is close to the tip
- make sure we have the latest tip change
- broadcast each change to all ready peers
- test that committed blocks are gossiped to peers

Closes #2712.

### Testing

Here are the manual tests I did:
- run on an ephemeral instance: no gossips during initial sync
- run on a synced instance: gossips after the 100 non-finalized blocks are synced
- looked at the outbound `inv` messages using the Grafana dashboard: more `inv` messages than before this change

## Review

@jvff or @oxarbitrage can review this PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors


