### PR TITLE
Move transaction download and verify stream into the mempool service

### DIFF
--- a/zebrad/src/components.rs
+++ b/zebrad/src/components.rs
@@ -12,5 +12,8 @@ mod sync;
 pub mod tokio;
 pub mod tracing;
 
+#[cfg(test)]
+pub(crate) mod tests;
+
 pub use inbound::Inbound;
 pub use sync::ChainSync;

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -329,9 +329,7 @@ impl Service<zn::Request> for Inbound {
                 if let Setup::Initialized { mempool, .. } = &mut self.network_setup {
                     mempool
                         .clone()
-                        .oneshot(mempool::Request::DownloadAndVerify(
-                            vec![transaction.into()],
-                        ))
+                        .oneshot(mempool::Request::Queue(vec![transaction.into()]))
                         // The response just indicates if processing was queued or not; ignore it
                         .map_ok(|_resp| zn::Response::Nil)
                         .boxed()
@@ -348,7 +346,7 @@ impl Service<zn::Request> for Inbound {
                     let transactions = transactions.into_iter().map(Into::into).collect();
                     mempool
                         .clone()
-                        .oneshot(mempool::Request::DownloadAndVerify(transactions))
+                        .oneshot(mempool::Request::Queue(transactions))
                         // The response just indicates if processing was queued or not; ignore it
                         .map_ok(|_resp| zn::Response::Nil)
                         .boxed()

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -1,16 +1,18 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, net::SocketAddr, str::FromStr, sync::Arc};
 
 use super::mempool::{unmined_transactions_in_blocks, Mempool};
+use crate::components::tests::mock_peer_set;
 
 use tokio::sync::oneshot;
 use tower::{builder::ServiceBuilder, util::BoxService, ServiceExt};
 
+use tracing::Span;
 use zebra_chain::{
     parameters::Network,
     transaction::{UnminedTx, UnminedTxId},
 };
 use zebra_consensus::Config as ConsensusConfig;
-use zebra_network::{Request, Response};
+use zebra_network::{AddressBook, Request, Response};
 use zebra_state::Config as StateConfig;
 
 #[tokio::test]
@@ -18,10 +20,23 @@ async fn mempool_requests_for_transactions() {
     let network = Network::Mainnet;
     let consensus_config = ConsensusConfig::default();
     let state_config = StateConfig::ephemeral();
+    let (peer_set, _) = mock_peer_set();
+    let address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Span::none());
+    let address_book = Arc::new(std::sync::Mutex::new(address_book));
 
     let (state, _, _) = zebra_state::init(state_config, network);
     let state_service = ServiceBuilder::new().buffer(1).service(state);
-    let mut mempool_service = Mempool::new(network);
+
+    let (block_verifier, transaction_verifier) =
+        zebra_consensus::chain::init(consensus_config.clone(), network, state_service.clone())
+            .await;
+
+    let mut mempool_service = Mempool::new(
+        network,
+        peer_set.clone(),
+        state_service.clone(),
+        transaction_verifier,
+    );
 
     let added_transactions = add_some_stuff_to_mempool(&mut mempool_service, network);
     let added_transaction_ids: Vec<UnminedTxId> = added_transactions.iter().map(|t| t.id).collect();
@@ -29,10 +44,7 @@ async fn mempool_requests_for_transactions() {
     let mempool_service = BoxService::new(mempool_service);
     let mempool = ServiceBuilder::new().buffer(1).service(mempool_service);
 
-    let (block_verifier, transaction_verifier) =
-        zebra_consensus::chain::init(consensus_config.clone(), network, state_service.clone())
-            .await;
-    let (_setup_tx, setup_rx) = oneshot::channel();
+    let (setup_tx, setup_rx) = oneshot::channel();
 
     let inbound_service = ServiceBuilder::new()
         .load_shed()
@@ -41,9 +53,11 @@ async fn mempool_requests_for_transactions() {
             setup_rx,
             state_service,
             block_verifier.clone(),
-            transaction_verifier.clone(),
-            mempool,
         ));
+
+    let r = setup_tx.send((peer_set.clone(), address_book, mempool));
+    // We can't expect or unwrap because the returned Result does not implement Debug
+    assert!(r.is_ok());
 
     // Test `Request::MempoolTransactionIds`
     let request = inbound_service

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -34,7 +34,7 @@ pub use self::error::MempoolError;
 pub use self::storage::tests::unmined_transactions_in_blocks;
 
 use self::downloads::{
-    Downloads as TxDownloads, GossipedTx, TRANSACTION_DOWNLOAD_TIMEOUT, TRANSACTION_VERIFY_TIMEOUT,
+    Downloads as TxDownloads, Gossip, TRANSACTION_DOWNLOAD_TIMEOUT, TRANSACTION_VERIFY_TIMEOUT,
 };
 
 type Outbound = Buffer<BoxService<zn::Request, zn::Response, zn::BoxError>, zn::Request>;
@@ -60,7 +60,7 @@ pub enum Request {
     TransactionIds,
     TransactionsById(HashSet<UnminedTxId>),
     RejectedTransactionIds(HashSet<UnminedTxId>),
-    Queue(Vec<GossipedTx>),
+    Queue(Vec<Gossip>),
 }
 
 #[derive(Debug)]

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -7,13 +7,16 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::future::FutureExt;
-use tower::Service;
+use futures::{future::FutureExt, stream::Stream};
+use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, Service};
 
 use zebra_chain::{
     parameters::Network,
     transaction::{UnminedTx, UnminedTxId},
 };
+use zebra_consensus::{error::TransactionError, transaction};
+use zebra_network as zn;
+use zebra_state as zs;
 
 pub use crate::BoxError;
 
@@ -30,12 +33,34 @@ pub use self::error::MempoolError;
 #[cfg(test)]
 pub use self::storage::tests::unmined_transactions_in_blocks;
 
+use self::downloads::{
+    Downloads as TxDownloads, GossipedTx, TRANSACTION_DOWNLOAD_TIMEOUT, TRANSACTION_VERIFY_TIMEOUT,
+};
+
+type Outbound = Buffer<BoxService<zn::Request, zn::Response, zn::BoxError>, zn::Request>;
+type State = Buffer<BoxService<zs::Request, zs::Response, zs::BoxError>, zs::Request>;
+type TxVerifier = Buffer<
+    BoxService<transaction::Request, transaction::Response, TransactionError>,
+    transaction::Request,
+>;
+type InboundTxDownloads = TxDownloads<Timeout<Outbound>, Timeout<TxVerifier>, State>;
+
+/// The result of attempting to queue a transaction for downloading/
+/// verifying.
+#[derive(Debug)]
+pub enum DownloadAction {
+    DownloadAction(self::downloads::DownloadAction),
+    InMempool,
+    Rejected,
+}
+
 #[derive(Debug)]
 #[allow(dead_code)]
 pub enum Request {
     TransactionIds,
     TransactionsById(HashSet<UnminedTxId>),
     RejectedTransactionIds(HashSet<UnminedTxId>),
+    DownloadAndVerify(Vec<GossipedTx>),
 }
 
 #[derive(Debug)]
@@ -43,6 +68,7 @@ pub enum Response {
     Transactions(Vec<UnminedTx>),
     TransactionIds(Vec<UnminedTxId>),
     RejectedTransactionIds(Vec<UnminedTxId>),
+    DownloadActions(Vec<DownloadAction>),
 }
 
 /// Mempool async management and query service.
@@ -50,20 +76,33 @@ pub enum Response {
 /// The mempool is the set of all verified transactions that this node is aware
 /// of that have yet to be confirmed by the Zcash network. A transaction is
 /// confirmed when it has been included in a block ('mined').
-#[derive(Clone)]
 pub struct Mempool {
     /// The Mempool storage itself.
     ///
     /// ##: Correctness: only components internal to the [`Mempool`] struct are allowed to
     /// inject transactions into `storage`, as transactions must be verified beforehand.
     storage: storage::Storage,
+
+    /// The transaction dowload and verify stream.
+    tx_downloads: Pin<Box<InboundTxDownloads>>,
 }
 
 impl Mempool {
     #[allow(dead_code)]
-    pub(crate) fn new(_network: Network) -> Self {
+    pub(crate) fn new(
+        _network: Network,
+        outbound: Outbound,
+        state: State,
+        tx_verifier: TxVerifier,
+    ) -> Self {
+        let tx_downloads = Box::pin(TxDownloads::new(
+            Timeout::new(outbound, TRANSACTION_DOWNLOAD_TIMEOUT),
+            Timeout::new(tx_verifier, TRANSACTION_VERIFY_TIMEOUT),
+            state,
+        ));
         Mempool {
             storage: Default::default(),
+            tx_downloads,
         }
     }
 
@@ -80,7 +119,14 @@ impl Service<Request> for Mempool {
     type Future =
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
-    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Clean up completed download tasks and add to mempool if successful
+        while let Poll::Ready(Some(r)) = self.tx_downloads.as_mut().poll_next(cx) {
+            if let Ok(tx) = r {
+                // TODO: should we do something with the result?
+                let _ = self.storage.insert(tx);
+            }
+        }
         Poll::Ready(Ok(()))
     }
 
@@ -100,6 +146,38 @@ impl Service<Request> for Mempool {
                     .map(Response::RejectedTransactionIds);
                 async move { rsp }.boxed()
             }
+            Request::DownloadAndVerify(gossiped_txs) => {
+                let rsp = gossiped_txs
+                    .into_iter()
+                    .map(|gossiped_tx| {
+                        let r = self.should_download_or_verify(gossiped_tx.id());
+                        if let Err(action) = r {
+                            return action;
+                        }
+                        DownloadAction::DownloadAction(
+                            self.tx_downloads.download_if_needed_and_verify(gossiped_tx),
+                        )
+                    })
+                    .collect();
+                async move { Ok(Response::DownloadActions(rsp)) }.boxed()
+            }
         }
+    }
+}
+
+impl Mempool {
+    /// Check if transaction should be downloaded and/or verified.
+    ///
+    /// If it is already in the mempool (or in its rejected list)
+    /// then it shouldn't be downloaded/verified.
+    fn should_download_or_verify(&mut self, txid: UnminedTxId) -> Result<(), DownloadAction> {
+        // Check if the transaction is already in the mempool.
+        if self.storage.clone().contains(&txid) {
+            return Err(DownloadAction::InMempool);
+        }
+        if self.storage.clone().contains_rejected(&txid) {
+            return Err(DownloadAction::Rejected);
+        }
+        Ok(())
     }
 }

--- a/zebrad/src/components/mempool/error.rs
+++ b/zebrad/src/components/mempool/error.rs
@@ -25,4 +25,22 @@ pub enum MempoolError {
 
     #[error("transaction evicted from the mempool due to size restrictions")]
     Excess,
+
+    #[error("transaction is in the mempool rejected list")]
+    Rejected,
+
+    /// The transaction hash is already queued, so this request was ignored.
+    ///
+    /// Another peer has already gossiped the same hash to us, or the mempool crawler has fetched it.
+    #[error("transaction dropped because it is already queued for download")]
+    AlreadyQueued,
+
+    /// The queue is at capacity, so this request was ignored.
+    ///
+    /// The mempool crawler should discover this transaction later.
+    /// If it is mined into a block, it will be downloaded by the syncer, or the inbound block downloader.
+    ///
+    /// The queue's capacity is [`super::downloads::MAX_INBOUND_CONCURRENCY`].
+    #[error("transaction dropped because the queue is full")]
+    FullQueue,
 }

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -104,6 +104,12 @@ impl Storage {
             .collect()
     }
 
+    /// Returns `true` if a [`UnminedTx`] matching an [`UnminedTxId`] is in
+    /// the mempool rejected list.
+    pub fn contains_rejected(self, txid: &UnminedTxId) -> bool {
+        self.rejected.contains_key(txid)
+    }
+
     /// Returns the set of [`UnminedTxId`]s matching ids in the rejected list.
     pub fn rejected_transactions(self, tx_ids: HashSet<UnminedTxId>) -> Vec<UnminedTxId> {
         tx_ids

--- a/zebrad/src/components/mempool/storage/tests.rs
+++ b/zebrad/src/components/mempool/storage/tests.rs
@@ -55,10 +55,20 @@ fn mempool_storage_basic_for_network(network: Network) -> Result<()> {
         .map(|tx| tx.id)
         .collect();
     // Convert response to a `HashSet` as we need a fixed order to compare.
-    let rejected_response: HashSet<UnminedTxId> =
-        storage.rejected_transactions(all_ids).into_iter().collect();
+    let rejected_response: HashSet<UnminedTxId> = storage
+        .clone()
+        .rejected_transactions(all_ids)
+        .into_iter()
+        .collect();
 
     assert_eq!(rejected_response, rejected_ids);
+
+    // Use `contains_rejected` to make sure the first id stored is now rejected
+    assert!(storage
+        .clone()
+        .contains_rejected(&unmined_transactions[0].id));
+    // Use `contains_rejected` to make sure the last id stored is not rejected
+    assert!(!storage.contains_rejected(&unmined_transactions[unmined_transactions.len() - 1].id));
 
     Ok(())
 }

--- a/zebrad/src/components/tests.rs
+++ b/zebrad/src/components/tests.rs
@@ -1,0 +1,29 @@
+use tokio::sync::mpsc::{self, UnboundedReceiver};
+use tower::{buffer::Buffer, util::BoxService};
+use zebra_network::{BoxError, Request, Response};
+
+/// Create a mock service to represent a [`PeerSet`][zebra_network::PeerSet] and intercept the
+/// requests it receives.
+///
+/// The intercepted requests are sent through an unbounded channel to the receiver that's also
+/// returned from this function.
+pub(crate) fn mock_peer_set() -> (
+    Buffer<BoxService<Request, Response, BoxError>, Request>,
+    UnboundedReceiver<Request>,
+) {
+    let (sender, receiver) = mpsc::unbounded_channel();
+
+    let proxy_service = tower::service_fn(move |request| {
+        let sender = sender.clone();
+
+        async move {
+            let _ = sender.send(request);
+
+            Ok(Response::TransactionIds(vec![]))
+        }
+    });
+
+    let service = Buffer::new(BoxService::new(proxy_service), 10);
+
+    (service, receiver)
+}


### PR DESCRIPTION
## Motivation

We need to add transactions to the download and verify stream from two different places: the inbound service and the mempool crawler. The stream only existed in the inbound service, and it would be awkward to reuse it.

Therefore, move the stream into the mempool service and make other components interact with it using a new mempool service Request.

Closes #2728

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

- Move the stream into the mempool service
- Add a new `Request::DownloadAndVerify` and `Response::DownloadActions`
- Refactor callers to accomodate that. In particular, it was required to change the `Mempool::new` to receive the peer set and state services.
- Move the check to see if tx needs to be downloaded. Now it's split into two places, which was easier to implement: checking if already in the state was kept inside the stream, since it already has a handle to the state service and it's already async. Checking if already in the mempool was moved to the mempool service itself, synchronously, before calling the stream.
- Actually add the verified transactions in the mempool. This was particularly easy with the new design. (I had to change the stream to actually return the transaction instead of just its ID). Note that this is different from the block downloader, which sends verified blocks to the state by itself.

## Review

@oxarbitrage and/or @dconnolly will probably want to review it

I tested it by running zebra and checking if transactions are being verified (through grafana, but you can also grep the log)

This refactors a chunk of the mempool and its tests, so it's better to review it soon so that remaining mempool work can start from it.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

This does not wait for the state to be near the tip before accepting transactions, which we must do. But it's probably better to leave to a separate PR.