### PR TITLE
Add mempool::Storage::remove()

### DIFF
--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -103,13 +103,13 @@ impl Storage {
         // `retain()` removes it and returns `Some(UnminedTx)`. If it's not
         // present and nothing changes, returns `None`.
 
-        return match self.verified.clone().iter().find(|tx| &tx.id == txid) {
+        match self.verified.clone().iter().find(|tx| &tx.id == txid) {
             Some(tx) => {
                 self.verified.retain(|tx| &tx.id != txid);
                 Some(tx.clone())
             }
             None => None,
-        };
+        }
     }
 
     /// Returns the set of [`UnminedTxId`]s in the mempool.

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet, VecDeque},
-    hash::Hash,
-};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use zebra_chain::{
     block,
@@ -106,12 +103,12 @@ impl Storage {
         // `retain()` removes it and returns `Some(UnminedTx)`. If it's not
         // present and nothing changes, returns `None`.
 
-        return match self.verified.binary_search_by_key(txid, |&tx| tx.id.hash()) {
-            Ok(tx) => {
-                self.verified.retain(|x| &x.id != txid);
-                Some(tx)
+        return match self.verified.clone().iter().find(|tx| &tx.id == txid) {
+            Some(tx) => {
+                self.verified.retain(|tx| &tx.id != txid);
+                Some(tx.clone())
             }
-            Err(e) => None,
+            None => None,
         };
     }
 

--- a/zebrad/src/components/mempool/storage/tests.rs
+++ b/zebrad/src/components/mempool/storage/tests.rs
@@ -16,16 +16,16 @@ fn mempool_storage_crud_mainnet() {
     let mut storage: Storage = Default::default();
 
     // Get transactions from the first 10 blocks of the Zcash blockchain
-    let (total_transactions, unmined_transactions) = unmined_transactions_in_blocks(10, network);
+    let (_, unmined_transactions) = unmined_transactions_in_blocks(10, network);
 
     // Get one (1) unmined transaction
-    let unmined_tx = unmined_transactions[0];
+    let unmined_tx = &unmined_transactions[0];
 
     // Insert unmined tx into the mempool.
-    storage.insert(unmined_tx);
+    let _ = storage.insert(unmined_tx.clone());
 
     // Check that it is in the mempool, and not rejected.
-    assert!(storage.contains(&unmined_tx.id));
+    assert!(storage.clone().contains(&unmined_tx.id));
 
     // Remove tx
     let _ = storage.remove(&unmined_tx.id);

--- a/zebrad/src/components/mempool/storage/tests.rs
+++ b/zebrad/src/components/mempool/storage/tests.rs
@@ -25,7 +25,7 @@ fn mempool_storage_crud_mainnet() {
     let _ = storage.insert(unmined_tx.clone());
 
     // Check that it is in the mempool, and not rejected.
-    assert!(storage.clone().contains(&unmined_tx.id));
+    assert!(storage.contains(&unmined_tx.id));
 
     // Remove tx
     let _ = storage.remove(&unmined_tx.id);

--- a/zebrad/src/components/mempool/storage/tests.rs
+++ b/zebrad/src/components/mempool/storage/tests.rs
@@ -7,6 +7,34 @@ use zebra_chain::{
 use color_eyre::eyre::Result;
 
 #[test]
+fn mempool_storage_crud_mainnet() {
+    zebra_test::init();
+
+    let network = Network::Mainnet;
+
+    // Create an empty storage instance
+    let mut storage: Storage = Default::default();
+
+    // Get transactions from the first 10 blocks of the Zcash blockchain
+    let (total_transactions, unmined_transactions) = unmined_transactions_in_blocks(10, network);
+
+    // Get one (1) unmined transaction
+    let unmined_tx = unmined_transactions[0];
+
+    // Insert unmined tx into the mempool.
+    storage.insert(unmined_tx);
+
+    // Check that it is in the mempool, and not rejected.
+    assert!(storage.contains(&unmined_tx.id));
+
+    // Remove tx
+    let _ = storage.remove(&unmined_tx.id);
+
+    // Check that it is /not/ in the mempool.
+    assert!(!storage.contains(&unmined_tx.id));
+}
+
+#[test]
 fn mempool_storage_basic() -> Result<()> {
     zebra_test::init();
 


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

Need to support removing transactions from `mempool::Storage`, such as when they have been mined in blocks.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Add a method to `mempool::Storage` that allows removal by `UnminedTxId` and returns the `UnminedTx` in an `Option` if it was in the verified set.

Resolves #2738

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [x] Tests for Expected Behaviour
  - [x] Tests for Errors


