### PR TITLE
Pass sync_status to mempool

### DIFF
--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -82,7 +82,7 @@ pub struct Mempool {
     /// Allows checking if we are near the tip to enable/disable the mempool.
     sync_status: SyncStatus,
 
-    /// Indicates wether the mempool is enabled or not.
+    /// Indicates whether the mempool is enabled or not.
     enabled: bool,
 }
 

--- a/zebrad/src/components/mempool/tests.rs
+++ b/zebrad/src/components/mempool/tests.rs
@@ -16,6 +16,7 @@ async fn mempool_service_basic() -> Result<(), Report> {
     let consensus_config = ConsensusConfig::default();
     let state_config = StateConfig::ephemeral();
     let (peer_set, _) = mock_peer_set();
+    let (sync_status, _recent_syncs) = SyncStatus::new();
 
     let (state, _, _) = zebra_state::init(state_config, network);
     let state_service = ServiceBuilder::new().buffer(1).service(state);
@@ -26,7 +27,13 @@ async fn mempool_service_basic() -> Result<(), Report> {
     // get the genesis block transactions from the Zcash blockchain.
     let genesis_transactions = unmined_transactions_in_blocks(0, network);
     // Start the mempool service
-    let mut service = Mempool::new(network, peer_set, state_service.clone(), tx_verifier);
+    let mut service = Mempool::new(
+        network,
+        peer_set,
+        state_service.clone(),
+        tx_verifier,
+        sync_status,
+    );
     // Insert the genesis block coinbase transaction into the mempool storage.
     service.storage.insert(genesis_transactions.1[0].clone())?;
 


### PR DESCRIPTION
## Motivation

The mempool needs to know the status of the sync (if it's near the tip) to check if it will enable itself or not.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

This passes a `SyncStatus` to it in order to enable that (e.g. #2629). It uses it to set a `enabled` flag, but does not do anything with it yet.

## Review

I think @dconnolly and @upbqdn will be interested in this.

This will be required by #2629.

Note that eventually, for tests, we'll need to make the `sync_status` return it's at the tip. I think the simplest way to do that is to start a task that feeds dummy values to the `recent_syncs` that is created with the `SyncStatus`. But I decided to not do that yet since it will only be needed when we actually disable the mempool (i.e. drop requests) in response to the status.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
