### PR TITLE
Reject conflicting mempool transactions

### DIFF
--- a/zebra-chain/src/sapling/shielded_data.rs
+++ b/zebra-chain/src/sapling/shielded_data.rs
@@ -4,6 +4,8 @@
 //! The `value_balance` change is handled using the default zero value.
 //! The anchor change is handled using the `AnchorVariant` type trait.
 
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
@@ -35,6 +37,7 @@ pub struct SharedAnchor {}
 
 /// This field is not present in this transaction version.
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct FieldNotPresent;
 
 impl AnchorVariant for PerSpendAnchor {

--- a/zebra-chain/src/serialization/constraint.rs
+++ b/zebra-chain/src/serialization/constraint.rs
@@ -192,6 +192,11 @@ impl<T> AtLeastOne<T> {
         &mut self.inner[0]
     }
 
+    /// Appends an element to the back of the collection.
+    pub fn push(&mut self, element: T) {
+        self.inner.push(element);
+    }
+
     /// Returns the first and all the rest of the elements of the vector.
     ///
     /// Unlike `Vec` or slice, `AtLeastOne` always has a first element.

--- a/zebra-chain/src/serialization/constraint.rs
+++ b/zebra-chain/src/serialization/constraint.rs
@@ -185,6 +185,13 @@ impl<T> AtLeastOne<T> {
         &self.inner[0]
     }
 
+    /// Returns a mutable reference to the first element.
+    ///
+    /// Unlike `Vec` or slice, `AtLeastOne` always has a first element.
+    pub fn first_mut(&mut self) -> &mut T {
+        &mut self.inner[0]
+    }
+
     /// Returns the first and all the rest of the elements of the vector.
     ///
     /// Unlike `Vec` or slice, `AtLeastOne` always has a first element.

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -349,6 +349,13 @@ impl Transaction {
         }
     }
 
+    /// Access the [`transparent::OutPoint`]s spent by this transaction.
+    pub fn spent_outpoints(&self) -> impl Iterator<Item = transparent::OutPoint> + '_ {
+        self.inputs()
+            .iter()
+            .filter_map(transparent::Input::outpoint)
+    }
+
     /// Access the transparent outputs of this transaction, regardless of version.
     pub fn outputs(&self) -> &[transparent::Output] {
         match self {

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -349,7 +349,7 @@ impl Transaction {
         }
     }
 
-    /// Access the [`transparent::OutPoint`]s spent by this transaction.
+    /// Access the [`transparent::OutPoint`]s spent by this transaction's [`transparent::Input`]s.
     pub fn spent_outpoints(&self) -> impl Iterator<Item = transparent::OutPoint> + '_ {
         self.inputs()
             .iter()

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -60,6 +60,7 @@ tokio = { version = "0.3.6", features = ["full", "test-util"] }
 proptest = "0.10"
 proptest-derive = "0.3"
 
+zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test" }
 
 [features]

--- a/zebrad/src/components/mempool/error.rs
+++ b/zebrad/src/components/mempool/error.rs
@@ -43,4 +43,8 @@ pub enum MempoolError {
     /// The queue's capacity is [`super::downloads::MAX_INBOUND_CONCURRENCY`].
     #[error("transaction dropped because the queue is full")]
     FullQueue,
+
+    /// The transaction conflicts with another transaction already in the mempool.
+    #[error("transaction rejected because it conflicts with another transaction in the mempool")]
+    Conflict,
 }

--- a/zebrad/src/components/mempool/error.rs
+++ b/zebrad/src/components/mempool/error.rs
@@ -44,7 +44,10 @@ pub enum MempoolError {
     #[error("transaction dropped because the queue is full")]
     FullQueue,
 
-    /// The transaction conflicts with another transaction already in the mempool.
-    #[error("transaction rejected because it conflicts with another transaction in the mempool")]
-    Conflict,
+    /// The transaction has a spend conflict with another transaction already in the mempool.
+    #[error(
+        "transaction rejected because another transaction in the mempool has already spent some of \
+        its inputs"
+    )]
+    SpendConflict,
 }

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -174,7 +174,7 @@ impl Storage {
     }
 
     /// Checks if the `tx` transaction has any conflicts with the transactions in the mempool for
-    /// the provided output type obtrained through the `extractor`.
+    /// the provided output type obtained through the `extractor`.
     fn has_conflicts<'slf, 'tx, Extractor, Outputs>(
         &'slf self,
         tx: &'tx UnminedTx,

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -1,8 +1,11 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    hash::Hash,
+};
 
 use zebra_chain::{
     block,
-    transaction::{UnminedTx, UnminedTxId},
+    transaction::{Transaction, UnminedTx, UnminedTxId},
 };
 use zebra_consensus::error::TransactionError;
 
@@ -21,6 +24,8 @@ pub enum State {
     /// An otherwise valid mempool transaction was mined into a block, therefore
     /// no longer belongs in the mempool.
     Confirmed(block::Hash),
+    /// Rejected because it conflicted with another transaction already in the mempool.
+    Conflict,
     /// Stayed in mempool for too long without being mined.
     // TODO(2021-09-09): Implement ZIP-203: Validate Transaction Expiry Height.
     // TODO(2021-09-09): https://github.com/ZcashFoundation/zebra/issues/2387
@@ -58,6 +63,7 @@ impl Storage {
                 State::Confirmed(block_hash) => MempoolError::InBlock(*block_hash),
                 State::Excess => MempoolError::Excess,
                 State::LowFee => MempoolError::LowFee,
+                State::Conflict => MempoolError::Conflict,
             });
         }
 
@@ -67,6 +73,16 @@ impl Storage {
         // because that allows malicious peers to keep transactions live forever.
         if self.verified.contains(&tx) {
             return Err(MempoolError::InMempool);
+        }
+
+        // If `tx` spends an UTXO already spent by another transaction in the mempool or reveals a
+        // nullifier already revealed by another transaction in the mempool, reject that
+        // transaction.
+        //
+        // TODO: Consider replacing the transaction in the mempool if the fee is higher (#2781).
+        if self.check_spend_conflicts(&tx) {
+            self.rejected.insert(tx.id, State::Conflict);
+            return Err(MempoolError::Rejected);
         }
 
         // Then, we insert into the pool.
@@ -145,5 +161,38 @@ impl Storage {
     pub fn clear(&mut self) {
         self.verified.clear();
         self.rejected.clear();
+    }
+
+    /// Checks if the `tx` transaction conflicts with another transaction in the mempool.
+    ///
+    /// Two transactions conflict if they spent the same UTXO or if they reveal the same nullifier.
+    fn check_spend_conflicts(&self, tx: &UnminedTx) -> bool {
+        self.has_conflicts(tx, Transaction::spent_outpoints)
+            || self.has_conflicts(tx, Transaction::sprout_nullifiers)
+            || self.has_conflicts(tx, Transaction::sapling_nullifiers)
+            || self.has_conflicts(tx, Transaction::orchard_nullifiers)
+    }
+
+    /// Checks if the `tx` transaction has any conflicts with the transactions in the mempool for
+    /// the provided output type obtrained through the `extractor`.
+    fn has_conflicts<'slf, 'tx, Extractor, Outputs>(
+        &'slf self,
+        tx: &'tx UnminedTx,
+        extractor: Extractor,
+    ) -> bool
+    where
+        'slf: 'tx,
+        Extractor: Fn(&'tx Transaction) -> Outputs,
+        Outputs: IntoIterator,
+        Outputs::Item: Eq + Hash + 'tx,
+    {
+        // TODO: This algorithm should be improved to avoid a performance impact when the mempool
+        // size is increased (#2784).
+        let new_outputs: HashSet<_> = extractor(&tx.transaction).into_iter().collect();
+
+        self.verified
+            .iter()
+            .flat_map(|tx| extractor(&tx.transaction))
+            .any(|output| new_outputs.contains(&output))
     }
 }

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -78,8 +78,6 @@ impl Storage {
         // If `tx` spends an UTXO already spent by another transaction in the mempool or reveals a
         // nullifier already revealed by another transaction in the mempool, reject that
         // transaction.
-        //
-        // TODO: Consider replacing the transaction in the mempool if the fee is higher (#2781).
         if self.check_spend_conflicts(&tx) {
             self.rejected.insert(tx.id, State::SpendConflict);
             return Err(MempoolError::Rejected);

--- a/zebrad/src/components/mempool/storage/tests.rs
+++ b/zebrad/src/components/mempool/storage/tests.rs
@@ -1,103 +1,10 @@
 use std::ops::RangeBounds;
 
-use super::*;
-
 use zebra_chain::{
     block::Block, parameters::Network, serialization::ZcashDeserializeInto, transaction::UnminedTx,
 };
 
-use color_eyre::eyre::Result;
-
-#[test]
-fn mempool_storage_crud_mainnet() {
-    zebra_test::init();
-
-    let network = Network::Mainnet;
-
-    // Create an empty storage instance
-    let mut storage: Storage = Default::default();
-
-    // Get one (1) unmined transaction
-    let unmined_tx = unmined_transactions_in_blocks(.., network)
-        .next()
-        .expect("at least one unmined transaction");
-
-    // Insert unmined tx into the mempool.
-    let _ = storage.insert(unmined_tx.clone());
-
-    // Check that it is in the mempool, and not rejected.
-    assert!(storage.contains(&unmined_tx.id));
-
-    // Remove tx
-    let _ = storage.remove(&unmined_tx.id);
-
-    // Check that it is /not/ in the mempool.
-    assert!(!storage.contains(&unmined_tx.id));
-}
-
-#[test]
-fn mempool_storage_basic() -> Result<()> {
-    zebra_test::init();
-
-    mempool_storage_basic_for_network(Network::Mainnet)?;
-    mempool_storage_basic_for_network(Network::Testnet)?;
-
-    Ok(())
-}
-
-fn mempool_storage_basic_for_network(network: Network) -> Result<()> {
-    // Create an empty storage
-    let mut storage: Storage = Default::default();
-
-    // Get transactions from the first 10 blocks of the Zcash blockchain
-    let unmined_transactions: Vec<_> = unmined_transactions_in_blocks(..=10, network).collect();
-    let total_transactions = unmined_transactions.len();
-
-    // Insert them all to the storage
-    for unmined_transaction in unmined_transactions.clone() {
-        storage.insert(unmined_transaction)?;
-    }
-
-    // Separate transactions into the ones expected to be in the mempool and those expected to be
-    // rejected.
-    let rejected_transaction_count = total_transactions - MEMPOOL_SIZE;
-    let expected_to_be_rejected = &unmined_transactions[..rejected_transaction_count];
-    let expected_in_mempool = &unmined_transactions[rejected_transaction_count..];
-
-    // Only MEMPOOL_SIZE should land in verified
-    assert_eq!(storage.verified.len(), MEMPOOL_SIZE);
-
-    // The rest of the transactions will be in rejected
-    assert_eq!(storage.rejected.len(), rejected_transaction_count);
-
-    // Make sure the last MEMPOOL_SIZE transactions we sent are in the verified
-    for tx in expected_in_mempool {
-        assert!(storage.contains(&tx.id));
-    }
-
-    // Anything greater should not be in the verified
-    for tx in expected_to_be_rejected {
-        assert!(!storage.contains(&tx.id));
-    }
-
-    // Query all the ids we have for rejected, get back `total - MEMPOOL_SIZE`
-    let all_ids: HashSet<UnminedTxId> = unmined_transactions.iter().map(|tx| tx.id).collect();
-
-    // Convert response to a `HashSet` as we need a fixed order to compare.
-    let rejected_response: HashSet<UnminedTxId> =
-        storage.rejected_transactions(all_ids).into_iter().collect();
-
-    let rejected_ids = expected_to_be_rejected.iter().map(|tx| tx.id).collect();
-
-    assert_eq!(rejected_response, rejected_ids);
-
-    // Use `contains_rejected` to make sure the first id stored is now rejected
-    assert!(storage.contains_rejected(&expected_to_be_rejected[0].id));
-    // Use `contains_rejected` to make sure the last id stored is not rejected
-    assert!(!storage.contains_rejected(&expected_in_mempool[0].id));
-
-    Ok(())
-}
+mod vectors;
 
 pub fn unmined_transactions_in_blocks(
     block_height_range: impl RangeBounds<u32>,

--- a/zebrad/src/components/mempool/storage/tests.rs
+++ b/zebrad/src/components/mempool/storage/tests.rs
@@ -4,6 +4,7 @@ use zebra_chain::{
     block::Block, parameters::Network, serialization::ZcashDeserializeInto, transaction::UnminedTx,
 };
 
+mod prop;
 mod vectors;
 
 pub fn unmined_transactions_in_blocks(

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -1,0 +1,305 @@
+use std::fmt::Debug;
+
+use proptest::prelude::*;
+use proptest_derive::Arbitrary;
+
+use zebra_chain::{
+    at_least_one, orchard,
+    primitives::Groth16Proof,
+    sapling,
+    transaction::{self, Transaction, UnminedTx},
+    transparent, LedgerState,
+};
+
+use super::super::{MempoolError, Storage};
+
+proptest! {
+    /// Test if a transaction that has a spend conflict with a transaction already in the mempool
+    /// is rejected.
+    ///
+    /// A spend conflict in this case is when two transactions spend the same UTXO or reveal the
+    /// same nullifier.
+    #[test]
+    fn conflicting_transactions_are_rejected(input in any::<SpendConflictTestInput>()) {
+        let mut storage = Storage::default();
+
+        let (first_transaction, second_transaction) = input.conflicting_transactions();
+        let input_permutations = vec![
+            (first_transaction.clone(), second_transaction.clone()),
+            (second_transaction, first_transaction),
+        ];
+
+        for (transaction_to_accept, transaction_to_reject) in input_permutations {
+            let id_to_accept = transaction_to_accept.id;
+            let id_to_reject = transaction_to_reject.id;
+
+            assert_eq!(
+                storage.insert(transaction_to_accept),
+                Ok(id_to_accept)
+            );
+
+            assert_eq!(
+                storage.insert(transaction_to_reject),
+                Err(MempoolError::Rejected)
+            );
+
+            assert!(storage.contains_rejected(&id_to_reject));
+
+            storage.clear();
+        }
+    }
+}
+
+/// Test input consisting of two transactions and a conflict to be applied to them.
+///
+/// When the conflict is applied, both transactions will have a shared spend (either a UTXO used as
+/// an input, or a nullifier revealed by both transactions).
+#[derive(Arbitrary, Debug)]
+enum SpendConflictTestInput {
+    /// Test V4 transactions to include Sprout nullifier conflicts.
+    V4 {
+        #[proptest(strategy = "Transaction::v4_strategy(LedgerState::default())")]
+        first: Transaction,
+
+        #[proptest(strategy = "Transaction::v4_strategy(LedgerState::default())")]
+        second: Transaction,
+
+        conflict: SpendConflictForTransactionV4,
+    },
+
+    /// Test V5 transactions to include Orchard nullifier conflicts.
+    V5 {
+        #[proptest(strategy = "Transaction::v5_strategy(LedgerState::default())")]
+        first: Transaction,
+
+        #[proptest(strategy = "Transaction::v5_strategy(LedgerState::default())")]
+        second: Transaction,
+
+        conflict: SpendConflictForTransactionV5,
+    },
+}
+
+impl SpendConflictTestInput {
+    /// Return two transactions that have a spend conflict.
+    pub fn conflicting_transactions(self) -> (UnminedTx, UnminedTx) {
+        let (first, second) = match self {
+            SpendConflictTestInput::V4 {
+                mut first,
+                mut second,
+                conflict,
+            } => {
+                conflict.clone().apply_to(&mut first);
+                conflict.apply_to(&mut second);
+
+                (first, second)
+            }
+            SpendConflictTestInput::V5 {
+                mut first,
+                mut second,
+                conflict,
+            } => {
+                conflict.clone().apply_to(&mut first);
+                conflict.apply_to(&mut second);
+
+                (first, second)
+            }
+        };
+
+        (first.into(), second.into())
+    }
+}
+
+/// A spend conflict valid for V4 transactions.
+#[derive(Arbitrary, Clone, Debug)]
+enum SpendConflictForTransactionV4 {
+    Transparent(Box<TransparentSpendConflict>),
+    Sprout(Box<SproutSpendConflict>),
+    Sapling(Box<SaplingSpendConflict<sapling::PerSpendAnchor>>),
+}
+
+/// A spend conflict valid for V5 transactions.
+#[derive(Arbitrary, Clone, Debug)]
+enum SpendConflictForTransactionV5 {
+    Transparent(Box<TransparentSpendConflict>),
+    Sapling(Box<SaplingSpendConflict<sapling::SharedAnchor>>),
+    Orchard(Box<OrchardSpendConflict>),
+}
+
+/// A conflict caused by spending the same UTXO.
+#[derive(Arbitrary, Clone, Debug)]
+struct TransparentSpendConflict {
+    new_input: transparent::Input,
+}
+
+/// A conflict caused by revealing the same Sprout nullifier.
+#[derive(Arbitrary, Clone, Debug)]
+struct SproutSpendConflict {
+    new_joinsplit_data: transaction::JoinSplitData<Groth16Proof>,
+}
+
+/// A conflict caused by revealing the same Sapling nullifier.
+#[derive(Clone, Debug)]
+struct SaplingSpendConflict<A: sapling::AnchorVariant + Clone> {
+    new_spend: sapling::Spend<A>,
+    new_shared_anchor: A::Shared,
+    fallback_shielded_data: sapling::ShieldedData<A>,
+}
+
+/// A conflict caused by revealing the same Orchard nullifier.
+#[derive(Arbitrary, Clone, Debug)]
+struct OrchardSpendConflict {
+    new_shielded_data: orchard::ShieldedData,
+}
+
+impl SpendConflictForTransactionV4 {
+    /// Apply a spend conflict to a V4 transaction.
+    ///
+    /// Changes the `transaction_v4` to include the spend that will result in a conflict.
+    pub fn apply_to(self, transaction_v4: &mut Transaction) {
+        let (inputs, joinsplit_data, sapling_shielded_data) = match transaction_v4 {
+            Transaction::V4 {
+                inputs,
+                joinsplit_data,
+                sapling_shielded_data,
+                ..
+            } => (inputs, joinsplit_data, sapling_shielded_data),
+            _ => unreachable!("incorrect transaction version generated for test"),
+        };
+
+        use SpendConflictForTransactionV4::*;
+        match self {
+            Transparent(transparent_conflict) => transparent_conflict.apply_to(inputs),
+            Sprout(sprout_conflict) => sprout_conflict.apply_to(joinsplit_data),
+            Sapling(sapling_conflict) => sapling_conflict.apply_to(sapling_shielded_data),
+        }
+    }
+}
+
+impl SpendConflictForTransactionV5 {
+    /// Apply a spend conflict to a V5 transaction.
+    ///
+    /// Changes the `transaction_v5` to include the spend that will result in a conflict.
+    pub fn apply_to(self, transaction_v5: &mut Transaction) {
+        let (inputs, sapling_shielded_data, orchard_shielded_data) = match transaction_v5 {
+            Transaction::V5 {
+                inputs,
+                sapling_shielded_data,
+                orchard_shielded_data,
+                ..
+            } => (inputs, sapling_shielded_data, orchard_shielded_data),
+            _ => unreachable!("incorrect transaction version generated for test"),
+        };
+
+        use SpendConflictForTransactionV5::*;
+        match self {
+            Transparent(transparent_conflict) => transparent_conflict.apply_to(inputs),
+            Sapling(sapling_conflict) => sapling_conflict.apply_to(sapling_shielded_data),
+            Orchard(orchard_conflict) => orchard_conflict.apply_to(orchard_shielded_data),
+        }
+    }
+}
+
+impl TransparentSpendConflict {
+    /// Apply a transparent spend conflict.
+    ///
+    /// Adds a new input to a transaction's list of transparent `inputs`. The transaction will then
+    /// conflict with any other transaction that also has that same new input.
+    pub fn apply_to(self, inputs: &mut Vec<transparent::Input>) {
+        inputs.push(self.new_input);
+    }
+}
+
+impl SproutSpendConflict {
+    /// Apply a Sprout spend conflict.
+    ///
+    /// Ensures that a transaction's `joinsplit_data` has a nullifier used to represent a conflict.
+    /// If the transaction already has Sprout joinsplits, the first nullifier is replaced with the
+    /// new nullifier. Otherwise, a joinsplit is inserted with that new nullifier in the
+    /// transaction.
+    ///
+    /// The transaction will then conflict with any other transaction with the same new nullifier.
+    pub fn apply_to(self, joinsplit_data: &mut Option<transaction::JoinSplitData<Groth16Proof>>) {
+        if let Some(existing_joinsplit_data) = joinsplit_data.as_mut() {
+            existing_joinsplit_data.first.nullifiers[0] =
+                self.new_joinsplit_data.first.nullifiers[0];
+        } else {
+            *joinsplit_data = Some(self.new_joinsplit_data);
+        }
+    }
+}
+
+/// Generate arbitrary [`SaplingSpendConflict`]s.
+///
+/// This had to be implemented manually because of the constraints required as a consequence of the
+/// generic type parameter.
+impl<A> Arbitrary for SaplingSpendConflict<A>
+where
+    A: sapling::AnchorVariant + Clone + Debug + 'static,
+    A::Shared: Arbitrary,
+    sapling::Spend<A>: Arbitrary,
+    sapling::TransferData<A>: Arbitrary,
+{
+    type Parameters = ();
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        any::<(sapling::Spend<A>, A::Shared, sapling::ShieldedData<A>)>()
+            .prop_map(|(new_spend, new_shared_anchor, fallback_shielded_data)| {
+                SaplingSpendConflict {
+                    new_spend,
+                    new_shared_anchor,
+                    fallback_shielded_data,
+                }
+            })
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl<A: sapling::AnchorVariant + Clone> SaplingSpendConflict<A> {
+    /// Apply a Sapling spend conflict.
+    ///
+    /// Ensures that a transaction's `sapling_shielded_data` has a nullifier used to represent a
+    /// conflict. If the transaction already has Sapling shielded data, a new spend is added with
+    /// the new nullifier. Otherwise, a fallback instance of Sapling shielded data is inserted in
+    /// the transaction, and then the spend is added.
+    ///
+    /// The transaction will then conflict with any other transaction with the same new nullifier.
+    pub fn apply_to(self, sapling_shielded_data: &mut Option<sapling::ShieldedData<A>>) {
+        use sapling::TransferData::*;
+
+        let shielded_data = sapling_shielded_data.get_or_insert(self.fallback_shielded_data);
+
+        match &mut shielded_data.transfers {
+            SpendsAndMaybeOutputs { ref mut spends, .. } => spends.push(self.new_spend),
+            JustOutputs { ref mut outputs } => {
+                let new_outputs = outputs.clone();
+
+                shielded_data.transfers = SpendsAndMaybeOutputs {
+                    shared_anchor: self.new_shared_anchor,
+                    spends: at_least_one![self.new_spend],
+                    maybe_outputs: new_outputs.into_vec(),
+                };
+            }
+        }
+    }
+}
+
+impl OrchardSpendConflict {
+    /// Apply a Orchard spend conflict.
+    ///
+    /// Ensures that a transaction's `orchard_shielded_data` has a nullifier used to represent a
+    /// conflict. If the transaction already has Orchard shielded data, a new action is added with
+    /// the new nullifier. Otherwise, a fallback instance of Orchard shielded data that contains
+    /// the new action is inserted in the transaction.
+    ///
+    /// The transaction will then conflict with any other transaction with the same new nullifier.
+    pub fn apply_to(self, orchard_shielded_data: &mut Option<orchard::ShieldedData>) {
+        if let Some(shielded_data) = orchard_shielded_data.as_mut() {
+            shielded_data.actions.first_mut().action.nullifier =
+                self.new_shielded_data.actions.first().action.nullifier;
+        } else {
+            *orchard_shielded_data = Some(self.new_shielded_data);
+        }
+    }
+}

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -1,0 +1,96 @@
+use super::{super::*, unmined_transactions_in_blocks};
+
+use zebra_chain::parameters::Network;
+
+use color_eyre::eyre::Result;
+
+#[test]
+fn mempool_storage_crud_mainnet() {
+    zebra_test::init();
+
+    let network = Network::Mainnet;
+
+    // Create an empty storage instance
+    let mut storage: Storage = Default::default();
+
+    // Get one (1) unmined transaction
+    let unmined_tx = unmined_transactions_in_blocks(.., network)
+        .next()
+        .expect("at least one unmined transaction");
+
+    // Insert unmined tx into the mempool.
+    let _ = storage.insert(unmined_tx.clone());
+
+    // Check that it is in the mempool, and not rejected.
+    assert!(storage.contains(&unmined_tx.id));
+
+    // Remove tx
+    let _ = storage.remove(&unmined_tx.id);
+
+    // Check that it is /not/ in the mempool.
+    assert!(!storage.contains(&unmined_tx.id));
+}
+
+#[test]
+fn mempool_storage_basic() -> Result<()> {
+    zebra_test::init();
+
+    mempool_storage_basic_for_network(Network::Mainnet)?;
+    mempool_storage_basic_for_network(Network::Testnet)?;
+
+    Ok(())
+}
+
+fn mempool_storage_basic_for_network(network: Network) -> Result<()> {
+    // Create an empty storage
+    let mut storage: Storage = Default::default();
+
+    // Get transactions from the first 10 blocks of the Zcash blockchain
+    let unmined_transactions: Vec<_> = unmined_transactions_in_blocks(..=10, network).collect();
+    let total_transactions = unmined_transactions.len();
+
+    // Insert them all to the storage
+    for unmined_transaction in unmined_transactions.clone() {
+        storage.insert(unmined_transaction)?;
+    }
+
+    // Separate transactions into the ones expected to be in the mempool and those expected to be
+    // rejected.
+    let rejected_transaction_count = total_transactions - MEMPOOL_SIZE;
+    let expected_to_be_rejected = &unmined_transactions[..rejected_transaction_count];
+    let expected_in_mempool = &unmined_transactions[rejected_transaction_count..];
+
+    // Only MEMPOOL_SIZE should land in verified
+    assert_eq!(storage.verified.len(), MEMPOOL_SIZE);
+
+    // The rest of the transactions will be in rejected
+    assert_eq!(storage.rejected.len(), rejected_transaction_count);
+
+    // Make sure the last MEMPOOL_SIZE transactions we sent are in the verified
+    for tx in expected_in_mempool {
+        assert!(storage.contains(&tx.id));
+    }
+
+    // Anything greater should not be in the verified
+    for tx in expected_to_be_rejected {
+        assert!(!storage.contains(&tx.id));
+    }
+
+    // Query all the ids we have for rejected, get back `total - MEMPOOL_SIZE`
+    let all_ids: HashSet<UnminedTxId> = unmined_transactions.iter().map(|tx| tx.id).collect();
+
+    // Convert response to a `HashSet` as we need a fixed order to compare.
+    let rejected_response: HashSet<UnminedTxId> =
+        storage.rejected_transactions(all_ids).into_iter().collect();
+
+    let rejected_ids = expected_to_be_rejected.iter().map(|tx| tx.id).collect();
+
+    assert_eq!(rejected_response, rejected_ids);
+
+    // Use `contains_rejected` to make sure the first id stored is now rejected
+    assert!(storage.contains_rejected(&expected_to_be_rejected[0].id));
+    // Use `contains_rejected` to make sure the last id stored is not rejected
+    assert!(!storage.contains_rejected(&expected_in_mempool[0].id));
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
The mempool should ideally provide a set of transactions that can be included in a block to be mined. This means that it should not contain any conflicting transactions, i.e., transactions that spend the same UTXOs or reveal the same nullifiers.

This closes #2682.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Change the `mempool::Storage` to check if transactions to be included don't conflict with any existing transactions. Reject transactions that conflict with any existing transactions in the mempool.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
- Consider replacing existing transactions in the mempool with a transaction that has conflicts but has a higher fee?