### PR TITLE
Clear the mempool by using a sync method

### DIFF
--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -327,8 +327,7 @@ impl ChainTipChange {
     /// See [`wait_for_tip_change`] for details.
     pub fn last_tip_change(&mut self) -> Option<TipAction> {
         // Obtain the tip block.
-        let block_guard = self.receiver.borrow();
-        let block = block_guard.as_ref()?;
+        let block = self.best_tip_block()?;
 
         // Ignore an unchanged tip.
         if Some(block.hash) == self.last_change_hash {

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -329,7 +329,7 @@ impl ChainTipChange {
         // Obtain the tip block.
         let block_guard = self.receiver.borrow();
         let block = block_guard.as_ref()?;
-        
+
         // Ignore an unchanged tip.
         if Some(block.hash) == self.last_change_hash {
             return None;

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -311,7 +311,7 @@ impl ChainTipChange {
     ///
     /// If a lot of blocks are committed at the same time,
     /// the change will skip some blocks, and return a [`Reset`].
-    async fn tip_change(&mut self) -> Result<TipAction, watch::error::RecvError> {
+    pub async fn wait_for_tip_change(&mut self) -> Result<TipAction, watch::error::RecvError> {
         let block = self.tip_block_change().await?;
 
         let action = self.action(block.clone());
@@ -338,8 +338,10 @@ impl ChainTipChange {
     ///
     /// If a lot of blocks are committed at the same time,
     /// the change will skip some blocks, and return a [`Reset`].
-    pub fn get_tip_change(&mut self) -> Option<TipAction> {
-        match self.tip_change().now_or_never().transpose() {
+    ///
+    /// See [`wait_for_tip_change`] for details.
+    pub fn last_tip_change(&mut self) -> Result<Option<TipAction>, watch::error::RecvError> {
+        match tokio::task::unconstrained(self.tip_change()).now_or_never().transpose() {
             Ok(tip_action) => tip_action,
             Err(_) => None,
         }

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -322,8 +322,22 @@ impl ChainTipChange {
     }
 
     /// Returns:
-    /// - `Some(TipAction)` if there has been a change since the last time the method was called.
+    /// - `Some(`[`TipAction`]`)` if there has been a change since the last time the method was called.
     /// - [`None`] if there has been no change.
+    ///
+    /// The returned action describes how the tip has changed
+    /// since the last call to this method.
+    ///
+    /// If there have been no changes since the last time this method was called,
+    /// it waits for the next tip change before returning.
+    ///
+    /// If there have been multiple changes since the last time this method was called,
+    /// they are combined into a single [`TipAction::Reset`].
+    ///
+    /// ## Note
+    ///
+    /// If a lot of blocks are committed at the same time,
+    /// the change will skip some blocks, and return a [`Reset`].
     pub fn get_tip_change(&mut self) -> Option<TipAction> {
         match self.tip_change().now_or_never().transpose() {
             Ok(tip_action) => tip_action,

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -327,22 +327,19 @@ impl ChainTipChange {
     /// See [`wait_for_tip_change`] for details.
     pub fn last_tip_change(&mut self) -> Option<TipAction> {
         // Obtain the tip block.
-        match self.receiver.borrow().as_ref() {
-            Some(block) => {
-                // Ignore an unchanged tip.
-                if Some(block.hash) == self.last_change_hash {
-                    return None;
-                }
-
-                let action = self.action(block.clone());
-
-                self.last_change_hash = Some(block.hash);
-
-                Some(action)
-            }
-
-            None => None,
+        let block_guard = self.receiver.borrow();
+        let block = block_guard.as_ref()?;
+        
+        // Ignore an unchanged tip.
+        if Some(block.hash) == self.last_change_hash {
+            return None;
         }
+
+        let action = self.action(block.clone());
+
+        self.last_change_hash = Some(block.hash);
+
+        Some(action)
     }
 
     /// Return an action based on `block` and the last change we returned.

--- a/zebra-state/src/service/chain_tip/tests/prop.rs
+++ b/zebra-state/src/service/chain_tip/tests/prop.rs
@@ -100,7 +100,7 @@ proptest! {
 
         prop_assert_eq!(
             chain_tip_change
-                .tip_change()
+                .wait_for_tip_change()
                 .now_or_never()
                 .transpose()
                 .expect("watch sender is not dropped"),

--- a/zebra-state/src/service/chain_tip/tests/vectors.rs
+++ b/zebra-state/src/service/chain_tip/tests/vectors.rs
@@ -40,7 +40,7 @@ fn chain_tip_change_is_initially_not_ready() {
         ChainTipSender::new(None, Mainnet);
 
     let first = chain_tip_change
-        .tip_change()
+        .wait_for_tip_change()
         .now_or_never()
         .transpose()
         .expect("watch sender is not dropped");
@@ -49,7 +49,7 @@ fn chain_tip_change_is_initially_not_ready() {
 
     // try again, just to be sure
     let first = chain_tip_change
-        .tip_change()
+        .wait_for_tip_change()
         .now_or_never()
         .transpose()
         .expect("watch sender is not dropped");
@@ -60,7 +60,7 @@ fn chain_tip_change_is_initially_not_ready() {
     #[allow(clippy::redundant_clone)]
     let first_clone = chain_tip_change
         .clone()
-        .tip_change()
+        .wait_for_tip_change()
         .now_or_never()
         .transpose()
         .expect("watch sender is not dropped");

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -300,7 +300,7 @@ proptest! {
         let (mut state_service, latest_chain_tip, mut chain_tip_change) = StateService::new(Config::ephemeral(), network);
 
         prop_assert_eq!(latest_chain_tip.best_tip_height(), None);
-        prop_assert_eq!(chain_tip_change.get_tip_change(), None);
+        prop_assert_eq!(chain_tip_change.last_tip_change(), None);
 
         for block in finalized_blocks {
             let expected_block = block.clone();
@@ -316,7 +316,7 @@ proptest! {
             state_service.queue_and_commit_finalized(block);
 
             prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
-            prop_assert_eq!(chain_tip_change.get_tip_change(), Some(expected_action));
+            prop_assert_eq!(chain_tip_change.last_tip_change(), Some(expected_action));
         }
 
         for block in non_finalized_blocks {
@@ -332,7 +332,7 @@ proptest! {
             state_service.queue_and_commit_non_finalized(block);
 
             prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
-            prop_assert_eq!(chain_tip_change.get_tip_change(), Some(expected_action));
+            prop_assert_eq!(chain_tip_change.last_tip_change(), Some(expected_action));
         }
     }
 

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -1,6 +1,6 @@
 use std::{convert::TryInto, env, sync::Arc};
 
-use futures::{stream::FuturesUnordered, FutureExt};
+use futures::stream::FuturesUnordered;
 use tower::{buffer::Buffer, util::BoxService, Service, ServiceExt};
 
 use zebra_chain::{
@@ -300,14 +300,7 @@ proptest! {
         let (mut state_service, latest_chain_tip, mut chain_tip_change) = StateService::new(Config::ephemeral(), network);
 
         prop_assert_eq!(latest_chain_tip.best_tip_height(), None);
-        prop_assert_eq!(
-            chain_tip_change
-                .tip_change()
-                .now_or_never()
-                .transpose()
-                .expect("watch sender is not dropped"),
-            None
-        );
+        prop_assert_eq!(chain_tip_change.get_tip_change(), None);
 
         for block in finalized_blocks {
             let expected_block = block.clone();
@@ -323,14 +316,7 @@ proptest! {
             state_service.queue_and_commit_finalized(block);
 
             prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
-            prop_assert_eq!(
-                chain_tip_change
-                    .tip_change()
-                    .now_or_never()
-                    .transpose()
-                    .expect("watch sender is not dropped"),
-                Some(expected_action)
-            );
+            prop_assert_eq!(chain_tip_change.get_tip_change(), Some(expected_action));
         }
 
         for block in non_finalized_blocks {
@@ -346,14 +332,7 @@ proptest! {
             state_service.queue_and_commit_non_finalized(block);
 
             prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
-            prop_assert_eq!(
-                chain_tip_change
-                    .tip_change()
-                    .now_or_never()
-                    .transpose()
-                    .expect("watch sender is not dropped"),
-                Some(expected_action)
-            );
+            prop_assert_eq!(chain_tip_change.get_tip_change(), Some(expected_action));
         }
     }
 

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -142,7 +142,7 @@ impl Service<Request> for Mempool {
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         // Clear the mempool if there has been a chain tip reset.
         if let Some(TipAction::Reset { height: _, hash: _ }) =
-            self.chain_tip_change.get_tip_change()
+            self.chain_tip_change.last_tip_change()
         {
             self.storage.clear();
         }

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -141,8 +141,7 @@ impl Service<Request> for Mempool {
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         // Clear the mempool if there has been a chain tip reset.
-        if let Some(TipAction::Reset { height: _, hash: _ }) =
-            self.chain_tip_change.last_tip_change()
+        if let Some(TipAction::Reset { .. }) = self.chain_tip_change.last_tip_change() {
         {
             self.storage.clear();
         }

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -141,8 +141,8 @@ impl Service<Request> for Mempool {
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         // Clear the mempool if there has been a chain tip reset.
-        if let Some(Ok(TipAction::Reset { height: _, hash: _ })) =
-            self.chain_tip_change.tip_change().now_or_never()
+        if let Some(TipAction::Reset { height: _, hash: _ }) =
+            self.chain_tip_change.get_tip_change()
         {
             self.storage.clear();
         }

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -142,7 +142,6 @@ impl Service<Request> for Mempool {
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         // Clear the mempool if there has been a chain tip reset.
         if let Some(TipAction::Reset { .. }) = self.chain_tip_change.last_tip_change() {
-        {
             self.storage.clear();
         }
 


### PR DESCRIPTION
Addresses https://github.com/ZcashFoundation/zebra/pull/2773#discussion_r711861630

I changed https://github.com/ZcashFoundation/zebra/blob/44ac06775bf6bb77dea06d53a6fc5e04a79baf31/zebra-state/src/service/chain_tip.rs#L313 to a private method so that `get_tip_change()` doesn't miss any tip changes.
