### PR TITLE
Handle zero transaction expirations

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -299,6 +299,9 @@ impl Transaction {
             Transaction::V3 { expiry_height, .. }
             | Transaction::V4 { expiry_height, .. }
             | Transaction::V5 { expiry_height, .. } => match expiry_height {
+                // Consensus rule:
+                // > No limit: To set no limit on transactions (so that they do not expire), nExpiryHeight should be set to 0.
+                // https://zips.z.cash/zip-0203#specification
                 block::Height(0) => None,
                 block::Height(expiry_height) => Some(block::Height(*expiry_height)),
             },

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -296,9 +296,12 @@ impl Transaction {
         match self {
             Transaction::V1 { .. } => None,
             Transaction::V2 { .. } => None,
-            Transaction::V3 { expiry_height, .. } => Some(*expiry_height),
-            Transaction::V4 { expiry_height, .. } => Some(*expiry_height),
-            Transaction::V5 { expiry_height, .. } => Some(*expiry_height),
+            Transaction::V3 { expiry_height, .. }
+            | Transaction::V4 { expiry_height, .. }
+            | Transaction::V5 { expiry_height, .. } => match expiry_height {
+                block::Height(0) => None,
+                block::Height(expiry_height) => Some(block::Height(*expiry_height)),
+            },
         }
     }
 

--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -391,7 +391,7 @@ fn founders_reward_validation_failure() -> Result<(), Report> {
             inputs: transaction.inputs().to_vec(),
             outputs: vec![transaction.outputs()[0].clone()],
             lock_time: transaction.lock_time(),
-            expiry_height: transaction.expiry_height().unwrap(),
+            expiry_height: Height(0),
             joinsplit_data: None,
         })
         .unwrap();


### PR DESCRIPTION
## Motivation

We want to return `None` from transaction method `expiry_height()` when the height is zero.

This is part of https://github.com/ZcashFoundation/zebra/issues/2387 but i am unsure if it totally close it. 

This is required for https://github.com/ZcashFoundation/zebra/pull/2774 

### Specifications

https://zips.z.cash/zip-0203#specification

## Solution

Just add some code to handle the `0` in the method.

## Review

Anyone can review, this is a pretty simple code change.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work
