### PR TITLE
Allow deliberate instances of the clippy::derivable_impls lint

### DIFF
--- a/zebra-consensus/src/config.rs
+++ b/zebra-consensus/src/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
 }
 
 // we like our default configs to be explicit
+#[allow(unknown_lints)]
 #[allow(clippy::derivable_impls)]
 impl Default for Config {
     fn default() -> Self {

--- a/zebra-consensus/src/config.rs
+++ b/zebra-consensus/src/config.rs
@@ -14,6 +14,8 @@ pub struct Config {
     pub checkpoint_sync: bool,
 }
 
+// we like our default configs to be explicit
+#[allow(clippy::derivable_impls)]
 impl Default for Config {
     fn default() -> Self {
         Self {

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -125,6 +125,7 @@ impl ZebradApp {
 ///
 /// By default no configuration is loaded, and the framework state is
 /// initialized to a default, empty state (no components, threads, etc).
+#[allow(clippy::derivable_impls)]
 impl Default for ZebradApp {
     fn default() -> Self {
         Self {

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -125,6 +125,7 @@ impl ZebradApp {
 ///
 /// By default no configuration is loaded, and the framework state is
 /// initialized to a default, empty state (no components, threads, etc).
+#[allow(unknown_lints)]
 #[allow(clippy::derivable_impls)]
 impl Default for ZebradApp {
     fn default() -> Self {

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -133,6 +133,8 @@ pub struct MetricsSection {
     pub endpoint_addr: Option<SocketAddr>,
 }
 
+// we like our default configs to be explicit
+#[allow(clippy::derivable_impls)]
 impl Default for MetricsSection {
     fn default() -> Self {
         Self {

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -134,6 +134,7 @@ pub struct MetricsSection {
 }
 
 // we like our default configs to be explicit
+#[allow(unknown_lints)]
 #[allow(clippy::derivable_impls)]
 impl Default for MetricsSection {
     fn default() -> Self {


### PR DESCRIPTION
## Motivation

We want to remove spurious warnings on nightly Rust, because some developers use nightly.

But we also want our config defaults to be explicit.
I'm not so sure about the application defaults, but they also contain a config, so I've left them as an explicit impl.

## Review

Anyone can review this cleanup PR.


### Reviewer Checklist

  - [x] Disabling these lints is sensible

