### PR TITLE
Fix an incorrect assertion when the block locator is at the tip

### DIFF
--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -124,7 +124,7 @@ impl Header {
 /// A header with a count of the number of transactions in its block.
 ///
 /// This structure is used in the Bitcoin network protocol.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct CountedHeader {
     /// The header for a block

--- a/zebra-chain/src/block/tests/preallocate.rs
+++ b/zebra-chain/src/block/tests/preallocate.rs
@@ -76,7 +76,7 @@ proptest! {
         let max_allocation: usize = CountedHeader::max_allocation().try_into().unwrap();
         let mut smallest_disallowed_vec = Vec::with_capacity(max_allocation + 1);
         for _ in 0..(CountedHeader::max_allocation()+1) {
-            smallest_disallowed_vec.push(header.clone());
+            smallest_disallowed_vec.push(header);
         }
         let smallest_disallowed_serialized = smallest_disallowed_vec.zcash_serialize_to_vec().expect("Serialization to vec must succeed");
         // Check that our smallest_disallowed_vec is only one item larger than the limit

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -413,7 +413,7 @@ impl StateService {
     ///   * adding `max_len` hashes to the list.
     ///
     /// Returns an empty list if the state is empty,
-    /// or the `intersection` is the best chain tip.
+    /// or if the `intersection` is the best chain tip.
     pub fn collect_best_chain_hashes(
         &self,
         intersection: Option<block::Hash>,

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -183,6 +183,24 @@ async fn test_populated_state_responds_correctly(
                     next_headers.get(0).iter().cloned().cloned().collect(),
                 )),
             ));
+
+            // stop at a block that isn't actually in the chain
+            // tests bug #2789
+            transcript.push((
+                Request::FindBlockHashes {
+                    known_blocks: known_hashes.iter().rev().cloned().collect(),
+                    stop: Some(block::Hash([0xff; 32])),
+                },
+                Ok(Response::BlockHashes(next_hashes.to_vec())),
+            ));
+
+            transcript.push((
+                Request::FindBlockHeaders {
+                    known_blocks: known_hashes.iter().rev().cloned().collect(),
+                    stop: Some(block::Hash([0xff; 32])),
+                },
+                Ok(Response::BlockHeaders(next_headers.to_vec())),
+            ));
         };
 
         // split before the current block, and locate the current block

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -4,7 +4,7 @@ use futures::stream::FuturesUnordered;
 use tower::{buffer::Buffer, util::BoxService, Service, ServiceExt};
 
 use zebra_chain::{
-    block::{self, Block},
+    block::{self, Block, CountedHeader},
     chain_tip::ChainTip,
     fmt::SummaryDebug,
     parameters::{Network, NetworkUpgrade},
@@ -52,14 +52,60 @@ async fn populated_state(
 async fn test_populated_state_responds_correctly(
     mut state: Buffer<BoxService<Request, Response, BoxError>, Request>,
 ) -> Result<()> {
-    let blocks = zebra_test::vectors::MAINNET_BLOCKS
+    let blocks: Vec<Arc<Block>> = zebra_test::vectors::MAINNET_BLOCKS
         .range(0..=LAST_BLOCK_HEIGHT)
-        .map(|(_, block_bytes)| block_bytes.zcash_deserialize_into::<Arc<Block>>().unwrap());
+        .map(|(_, block_bytes)| block_bytes.zcash_deserialize_into().unwrap())
+        .collect();
+
+    let block_hashes: Vec<block::Hash> = blocks.iter().map(|block| block.hash()).collect();
+    let block_headers: Vec<CountedHeader> = blocks
+        .iter()
+        .map(|block| CountedHeader {
+            header: block.header,
+            transaction_count: block.transactions.len(),
+        })
+        .collect();
 
     for (ind, block) in blocks.into_iter().enumerate() {
         let mut transcript = vec![];
         let height = block.coinbase_height().unwrap();
         let hash = block.hash();
+
+        transcript.push((
+            Request::Depth(block.hash()),
+            Ok(Response::Depth(Some(LAST_BLOCK_HEIGHT - height.0))),
+        ));
+
+        // these requests don't have any arguments, so we just do them once
+        if ind == LAST_BLOCK_HEIGHT as usize {
+            transcript.push((Request::Tip, Ok(Response::Tip(Some((height, hash))))));
+
+            let locator_hashes = vec![
+                block_hashes[LAST_BLOCK_HEIGHT as usize],
+                block_hashes[(LAST_BLOCK_HEIGHT - 1) as usize],
+                block_hashes[(LAST_BLOCK_HEIGHT - 2) as usize],
+                block_hashes[(LAST_BLOCK_HEIGHT - 4) as usize],
+                block_hashes[(LAST_BLOCK_HEIGHT - 8) as usize],
+                block_hashes[0],
+            ];
+
+            transcript.push((
+                Request::BlockLocator,
+                Ok(Response::BlockLocator(locator_hashes)),
+            ));
+        }
+
+        // Spec: transactions in the genesis block are ignored.
+        if height.0 != 0 {
+            for transaction in &block.transactions {
+                let transaction_hash = transaction.hash();
+
+                transcript.push((
+                    Request::Transaction(transaction_hash),
+                    Ok(Response::Transaction(Some(transaction.clone()))),
+                ));
+            }
+        }
 
         transcript.push((
             Request::Block(hash.into()),
@@ -71,25 +117,10 @@ async fn test_populated_state_responds_correctly(
             Ok(Response::Block(Some(block.clone()))),
         ));
 
-        transcript.push((
-            Request::Depth(block.hash()),
-            Ok(Response::Depth(Some(LAST_BLOCK_HEIGHT - height.0))),
-        ));
-
-        if ind == LAST_BLOCK_HEIGHT as usize {
-            transcript.push((Request::Tip, Ok(Response::Tip(Some((height, hash))))));
-        }
-
-        // Consensus-critical bug in zcashd: transactions in the genesis block
-        // are ignored.
+        // Spec: transactions in the genesis block are ignored.
         if height.0 != 0 {
             for transaction in &block.transactions {
                 let transaction_hash = transaction.hash();
-
-                transcript.push((
-                    Request::Transaction(transaction_hash),
-                    Ok(Response::Transaction(Some(transaction.clone()))),
-                ));
 
                 let from_coinbase = transaction.has_valid_coinbase_transaction_inputs();
                 for (index, output) in transaction.outputs().iter().cloned().enumerate() {
@@ -107,6 +138,46 @@ async fn test_populated_state_responds_correctly(
                 }
             }
         }
+
+        let block_hashes = block_hashes.clone();
+        let (known_hashes, next_hashes) = block_hashes.split_at(ind);
+
+        let block_headers = block_headers.clone();
+        let (_, next_headers) = block_headers.split_at(ind);
+
+        // no stop
+        transcript.push((
+            Request::FindBlockHashes {
+                known_blocks: known_hashes.iter().rev().cloned().collect(),
+                stop: None,
+            },
+            Ok(Response::BlockHashes(next_hashes.to_vec())),
+        ));
+
+        transcript.push((
+            Request::FindBlockHeaders {
+                known_blocks: known_hashes.iter().rev().cloned().collect(),
+                stop: None,
+            },
+            Ok(Response::BlockHeaders(next_headers.to_vec())),
+        ));
+
+        // stop at next block
+        transcript.push((
+            Request::FindBlockHashes {
+                known_blocks: known_hashes.iter().rev().cloned().collect(),
+                stop: Some(next_hashes[0]),
+            },
+            Ok(Response::BlockHashes(vec![next_hashes[0]])),
+        ));
+
+        transcript.push((
+            Request::FindBlockHeaders {
+                known_blocks: known_hashes.iter().rev().cloned().collect(),
+                stop: Some(next_hashes[0]),
+            },
+            Ok(Response::BlockHeaders(vec![next_headers[0]])),
+        ));
 
         let transcript = Transcript::from(transcript);
         transcript.check(&mut state).await?;
@@ -157,6 +228,20 @@ async fn empty_state_still_responds_to_requests() -> Result<()> {
             Ok(Response::Block(None)),
         ),
         // No check for AwaitUTXO because it will wait if the UTXO isn't present
+        (
+            Request::FindBlockHashes {
+                known_blocks: vec![block.hash()],
+                stop: None,
+            },
+            Ok(Response::BlockHashes(Vec::new())),
+        ),
+        (
+            Request::FindBlockHeaders {
+                known_blocks: vec![block.hash()],
+                stop: None,
+            },
+            Ok(Response::BlockHeaders(Vec::new())),
+        ),
     ]
     .into_iter();
     let transcript = Transcript::from(iter);


### PR DESCRIPTION
## Motivation

Zebra panics when it's at the tip, and it's asked for a block locator for that tip.
(This might depend on whether there's a stop height, and whether integer checks are optimised out.)

This might have been triggered by receiving block hash gossips from the new Zebra code in PR #2729.

## Solution

- Skip the assertion when the response is empty
- Add tests for `BlockLocator`, `FindBlockHashes`, and `FindBlockHeaders`
- Add a specific test for this bug

## Review

Anyone can review this panic fix, but I think @oxarbitrage might have looked at this code recently?

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [x] Tests for Expected Behaviour
  - [x] Tests for Errors
