### PR TITLE
Send `Response::Nil` instead of sending empty `Message`s

### DIFF
--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -361,7 +361,6 @@ impl Service<zn::Request> for Inbound {
             zn::Request::AdvertiseTransactionIds(transactions) => {
                 if let Setup::Initialized { mempool, .. } = &mut self.network_setup {
                     let transactions = transactions.into_iter().map(Into::into).collect();
-
                     mempool
                         .clone()
                         .oneshot(mempool::Request::Queue(transactions))


### PR DESCRIPTION
## Motivation

We should try to match `zcashd`'s behaviour and the Bitcoin spec when sending network messages.

In most cases, the network layer filters out empty responses already.
But this change makes the the inbound service code clearer.

### Specifications

Most Bitcoin messages must contain at least one item.

For example:
https://en.bitcoin.it/wiki/Protocol_documentation#addr

### Other Implementations

`zcashd` doesn't send empty messages.

For example:
https://github.com/zcash/zcash/blob/498d42219c2cae93ae808c314a8986ed3b484d6b/src/main.cpp#L7424-L7425

## Solution

- Stop sending empty responses from the inbound service
- Make it clearer that existing empty responses are actually no response - `Response::Nil`
- Make logging consistent

## Review

I think @conradoplg and @oxarbitrage wrote some of this code.
Either can review.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Maybe we should handle empty requests and responses at the network layer? #1724
