### PR TITLE
Stop panicking when using sync and async methods on the same ChainTipChange

### DIFF
--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -519,4 +519,18 @@ impl TipAction {
             hash: block.hash,
         }
     }
+
+    /// Converts this [`TipAction`] into a [`Reset`].
+    ///
+    /// Designed for use in tests.
+    #[cfg(test)]
+    pub(crate) fn into_reset(self) -> Self {
+        match self {
+            Grow { block } => Reset {
+                height: block.height,
+                hash: block.hash,
+            },
+            reset @ Reset { .. } => reset,
+        }
+    }
 }

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -492,7 +492,7 @@ impl ChainTipChange {
                 // So code that uses both sync and async methods can have spurious pending changes.
                 //
                 // TODO: use `receiver.borrow_and_update()` in `best_tip_block()`,
-                //       once we upgrade to tokio 1.0
+                //       once we upgrade to tokio 1.0 (#2200)
                 //       and remove this extra check
                 if Some(block.hash) != self.last_change_hash {
                     return Ok(block);

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -471,6 +471,10 @@ impl ChainTipChange {
                 //
                 // last_tip_change() updates last_change_hash, but it doesn't call receiver.changed().
                 // So code that uses both sync and async methods can have spurious pending changes.
+                //
+                // TODO: use `receiver.borrow_and_update()` in `best_tip_block()`,
+                //       once we upgrade to tokio 1.0
+                //       and remove this extra check
                 if Some(block.hash) != self.last_change_hash {
                     return Ok(block);
                 }

--- a/zebra-state/src/service/chain_tip/tests/prop.rs
+++ b/zebra-state/src/service/chain_tip/tests/prop.rs
@@ -1,4 +1,4 @@
-use std::{env, sync::Arc};
+use std::{collections::HashSet, env, sync::Arc};
 
 use futures::FutureExt;
 use proptest::prelude::*;
@@ -8,10 +8,12 @@ use zebra_chain::{
     block::Block,
     chain_tip::ChainTip,
     fmt::{DisplayToDebug, SummaryDebug},
-    parameters::Network,
+    parameters::{Network, NetworkUpgrade},
 };
 
 use crate::service::chain_tip::{ChainTipBlock, ChainTipSender, TipAction};
+
+use TipChangeCheck::*;
 
 const DEFAULT_BLOCK_VEC_PROPTEST_CASES: u32 = 4;
 
@@ -27,7 +29,7 @@ proptest! {
     /// or otherwise the finalized tip.
     #[test]
     fn best_tip_is_latest_non_finalized_then_latest_finalized(
-        tip_updates in any::<SummaryDebug<Vec<BlockUpdate>>>(),
+        tip_updates in any::<SummaryDebug<Vec<(BlockUpdate, TipChangeCheck)>>>(),
         network in any::<Network>(),
     ) {
         let (mut chain_tip_sender, latest_chain_tip, mut chain_tip_change) = ChainTipSender::new(None, network);
@@ -36,81 +38,181 @@ proptest! {
         let mut latest_non_finalized_tip = None;
         let mut seen_non_finalized_tip = false;
 
-        for update in tip_updates {
+        let mut pending_action = None;
+        let mut chain_hashes = HashSet::new();
+
+        for (update, tip_change_check) in tip_updates {
+            // do the update
             match update {
                 BlockUpdate::Finalized(block) => {
                     let chain_tip = block.clone().map(|block| ChainTipBlock::from(block.0));
+
+                    if let Some(chain_tip) = chain_tip.clone() {
+                        if chain_hashes.contains(&chain_tip.hash) {
+                            // skip duplicate blocks - they are rejected by zebra-state
+                            continue;
+                        }
+                        chain_hashes.insert(chain_tip.hash);
+                    }
+
                     chain_tip_sender.set_finalized_tip(chain_tip.clone());
+
                     if let Some(block) = block {
-                        latest_finalized_tip = Some((chain_tip, block));
+                        latest_finalized_tip = Some((chain_tip.unwrap(), block));
                     }
                 }
                 BlockUpdate::NonFinalized(block) => {
                     let chain_tip = block.clone().map(|block| ChainTipBlock::from(block.0));
+
+                    if let Some(chain_tip) = chain_tip.clone() {
+                        if chain_hashes.contains(&chain_tip.hash) {
+                            // skip duplicate blocks - they are rejected by zebra-state
+                            continue;
+                        }
+                        chain_hashes.insert(chain_tip.hash);
+                    }
+
                     chain_tip_sender.set_best_non_finalized_tip(chain_tip.clone());
+
                     if let Some(block) = block {
-                        latest_non_finalized_tip = Some((chain_tip, block));
+                        latest_non_finalized_tip = Some((chain_tip.unwrap(), block));
                         seen_non_finalized_tip = true;
                     }
                 }
             }
+
+            // check the results
+            let expected_tip = if seen_non_finalized_tip {
+                latest_non_finalized_tip.clone()
+            } else {
+                latest_finalized_tip.clone()
+            };
+
+            let chain_tip_height = expected_tip
+                .as_ref()
+                .map(|(chain_tip, _block)| chain_tip.height);
+            let expected_height = expected_tip.as_ref().and_then(|(_chain_tip, block)| block.coinbase_height());
+            prop_assert_eq!(latest_chain_tip.best_tip_height(), chain_tip_height);
+            prop_assert_eq!(latest_chain_tip.best_tip_height(), expected_height);
+
+            let chain_tip_hash = expected_tip
+                .as_ref()
+                .map(|(chain_tip, _block)| chain_tip.hash);
+            let expected_hash = expected_tip.as_ref().map(|(_chain_tip, block)| block.hash());
+            prop_assert_eq!(latest_chain_tip.best_tip_hash(), chain_tip_hash);
+            prop_assert_eq!(latest_chain_tip.best_tip_hash(), expected_hash);
+
+            let chain_tip_transaction_ids = expected_tip
+                .as_ref()
+                .map(|(chain_tip, _block)| chain_tip.transaction_hashes.clone())
+                .unwrap_or_else(|| Arc::new([]));
+            let expected_transaction_ids = expected_tip
+                .as_ref()
+                .iter()
+                .flat_map(|(_chain_tip, block)| block.transactions.clone())
+                .map(|transaction| transaction.hash())
+                .collect();
+            prop_assert_eq!(
+                latest_chain_tip.best_tip_mined_transaction_ids(),
+                chain_tip_transaction_ids
+            );
+            prop_assert_eq!(
+                latest_chain_tip.best_tip_mined_transaction_ids(),
+                expected_transaction_ids
+            );
+
+            let old_last_change_hash = chain_tip_change.last_change_hash;
+
+            let new_action =
+                expected_tip.and_then(|(chain_tip, block)| {
+                    if Some(chain_tip.hash) == old_last_change_hash {
+                        // some updates don't do anything, so there's no new action
+                        None
+                    } else if Some(chain_tip.previous_block_hash) != old_last_change_hash ||
+                        NetworkUpgrade::is_activation_height(network, chain_tip.height) {
+                            Some(TipAction::reset_with(block.0.into()))
+                    } else {
+                            Some(TipAction::grow_with(block.0.into()))
+                    }
+                });
+
+            let expected_action = match (pending_action.clone(), new_action.clone()) {
+                (Some(_pending_action), Some(new_action)) => Some(new_action.into_reset()),
+                (None, new_action) => new_action,
+                (pending_action, None) => pending_action,
+            };
+
+            match tip_change_check {
+                WaitFor => {
+                    // TODO: use `unconstrained` to avoid spurious cooperative multitasking waits
+                    //       (needs a recent tokio version)
+                    // See:
+                    // https://github.com/ZcashFoundation/zebra/pull/2777#discussion_r712488817
+                    // https://docs.rs/tokio/1.11.0/tokio/task/index.html#cooperative-scheduling
+                    // https://tokio.rs/blog/2020-04-preemption
+                    prop_assert_eq!(
+                        chain_tip_change
+                            .wait_for_tip_change()
+                            .now_or_never()
+                            .transpose()
+                            .expect("watch sender is not dropped"),
+                        expected_action,
+                        "\n\
+                         unexpected wait_for_tip_change TipAction\n\
+                         new_action: {:?}\n\
+                         pending_action: {:?}\n\
+                         old last_change_hash: {:?}\n\
+                         new last_change_hash: {:?}",
+                        new_action,
+                        pending_action,
+                        old_last_change_hash,
+                        chain_tip_change.last_change_hash
+                    );
+                    pending_action = None;
+                }
+
+                Last => {
+                    prop_assert_eq!(
+                        chain_tip_change.last_tip_change(),
+                        expected_action,
+                        "\n\
+                         unexpected last_tip_change TipAction\n\
+                         new_action: {:?}\n\
+                         pending_action: {:?}\n\
+                         old last_change_hash: {:?}\n\
+                         new last_change_hash: {:?}",
+                        new_action,
+                        pending_action,
+                        old_last_change_hash,
+                        chain_tip_change.last_change_hash
+                    );
+                    pending_action = None;
+                }
+
+                Skip => {
+                    pending_action = expected_action;
+                }
+            }
         }
-
-        let expected_tip = if seen_non_finalized_tip {
-            latest_non_finalized_tip
-        } else {
-            latest_finalized_tip
-        };
-
-        let chain_tip_height = expected_tip
-            .as_ref()
-            .and_then(|(chain_tip, _block)| chain_tip.as_ref())
-            .map(|chain_tip| chain_tip.height);
-        let expected_height = expected_tip.as_ref().and_then(|(_chain_tip, block)| block.coinbase_height());
-        prop_assert_eq!(latest_chain_tip.best_tip_height(), chain_tip_height);
-        prop_assert_eq!(latest_chain_tip.best_tip_height(), expected_height);
-
-        let chain_tip_hash = expected_tip
-            .as_ref()
-            .and_then(|(chain_tip, _block)| chain_tip.as_ref())
-            .map(|chain_tip| chain_tip.hash);
-        let expected_hash = expected_tip.as_ref().map(|(_chain_tip, block)| block.hash());
-        prop_assert_eq!(latest_chain_tip.best_tip_hash(), chain_tip_hash);
-        prop_assert_eq!(latest_chain_tip.best_tip_hash(), expected_hash);
-
-        let chain_tip_transaction_ids = expected_tip
-            .as_ref()
-            .and_then(|(chain_tip, _block)| chain_tip.as_ref())
-            .map(|chain_tip| chain_tip.transaction_hashes.clone())
-            .unwrap_or_else(|| Arc::new([]));
-        let expected_transaction_ids = expected_tip
-            .as_ref()
-            .iter()
-            .flat_map(|(_chain_tip, block)| block.transactions.clone())
-            .map(|transaction| transaction.hash())
-            .collect();
-        prop_assert_eq!(
-            latest_chain_tip.best_tip_mined_transaction_ids(),
-            chain_tip_transaction_ids
-        );
-        prop_assert_eq!(
-            latest_chain_tip.best_tip_mined_transaction_ids(),
-            expected_transaction_ids
-        );
-
-        prop_assert_eq!(
-            chain_tip_change
-                .wait_for_tip_change()
-                .now_or_never()
-                .transpose()
-                .expect("watch sender is not dropped"),
-            expected_tip.map(|(_chain_tip, block)| TipAction::reset_with(block.0.into()))
-        );
     }
 }
 
+/// Block update test cases for [`ChainTipSender`]
 #[derive(Arbitrary, Clone, Debug)]
 enum BlockUpdate {
     Finalized(Option<DisplayToDebug<Arc<Block>>>),
     NonFinalized(Option<DisplayToDebug<Arc<Block>>>),
+}
+
+/// Block update checks for [`ChainTipChange`]
+#[derive(Arbitrary, Copy, Clone, Debug)]
+enum TipChangeCheck {
+    /// Check that `wait_for_tip_change` returns the correct result
+    WaitFor,
+
+    /// Check that `last_tip_change` returns the correct result
+    Last,
+
+    /// Don't check this case (causes a `TipAction::Reset` in the next check)
+    Skip,
 }

--- a/zebra-state/src/service/chain_tip/tests/prop.rs
+++ b/zebra-state/src/service/chain_tip/tests/prop.rs
@@ -123,18 +123,18 @@ proptest! {
 
             let old_last_change_hash = chain_tip_change.last_change_hash;
 
-            let new_action =
-                expected_tip.and_then(|(chain_tip, block)| {
-                    if Some(chain_tip.hash) == old_last_change_hash {
-                        // some updates don't do anything, so there's no new action
-                        None
-                    } else if Some(chain_tip.previous_block_hash) != old_last_change_hash ||
-                        NetworkUpgrade::is_activation_height(network, chain_tip.height) {
-                            Some(TipAction::reset_with(block.0.into()))
-                    } else {
-                            Some(TipAction::grow_with(block.0.into()))
-                    }
-                });
+            let new_action = expected_tip.and_then(|(chain_tip, block)| {
+                if Some(chain_tip.hash) == old_last_change_hash {
+                    // some updates don't do anything, so there's no new action
+                    None
+                } else if Some(chain_tip.previous_block_hash) != old_last_change_hash
+                    || NetworkUpgrade::is_activation_height(network, chain_tip.height)
+                {
+                    Some(TipAction::reset_with(block.0.into()))
+                } else {
+                    Some(TipAction::grow_with(block.0.into()))
+                }
+            });
 
             let expected_action = match (pending_action.clone(), new_action.clone()) {
                 (Some(pending_action), Some(new_action)) if pending_action == new_action => Some(new_action),

--- a/zebra-state/src/service/chain_tip/tests/vectors.rs
+++ b/zebra-state/src/service/chain_tip/tests/vectors.rs
@@ -39,7 +39,7 @@ fn chain_tip_change_is_initially_not_ready() {
     let (_chain_tip_sender, _latest_chain_tip, mut chain_tip_change) =
         ChainTipSender::new(None, Mainnet);
 
-    // TODO: use `unconstrained` to avoid spurious waits from tokio's cooperative multitasking
+    // TODO: use `tokio::task::unconstrained` to avoid spurious waits from tokio's cooperative multitasking
     //       (needs a recent tokio version)
     // See:
     // https://github.com/ZcashFoundation/zebra/pull/2777#discussion_r712488817

--- a/zebra-state/src/service/chain_tip/tests/vectors.rs
+++ b/zebra-state/src/service/chain_tip/tests/vectors.rs
@@ -39,6 +39,13 @@ fn chain_tip_change_is_initially_not_ready() {
     let (_chain_tip_sender, _latest_chain_tip, mut chain_tip_change) =
         ChainTipSender::new(None, Mainnet);
 
+    // TODO: use `unconstrained` to avoid spurious waits from tokio's cooperative multitasking
+    //       (needs a recent tokio version)
+    // See:
+    // https://github.com/ZcashFoundation/zebra/pull/2777#discussion_r712488817
+    // https://docs.rs/tokio/1.11.0/tokio/task/index.html#cooperative-scheduling
+    // https://tokio.rs/blog/2020-04-preemption
+
     let first = chain_tip_change
         .wait_for_tip_change()
         .now_or_never()
@@ -46,6 +53,8 @@ fn chain_tip_change_is_initially_not_ready() {
         .expect("watch sender is not dropped");
 
     assert_eq!(first, None);
+
+    assert_eq!(chain_tip_change.last_tip_change(), None);
 
     // try again, just to be sure
     let first = chain_tip_change
@@ -55,6 +64,8 @@ fn chain_tip_change_is_initially_not_ready() {
         .expect("watch sender is not dropped");
 
     assert_eq!(first, None);
+
+    assert_eq!(chain_tip_change.last_tip_change(), None);
 
     // also test our manual `Clone` impl
     #[allow(clippy::redundant_clone)]
@@ -66,4 +77,6 @@ fn chain_tip_change_is_initially_not_ready() {
         .expect("watch sender is not dropped");
 
     assert_eq!(first_clone, None);
+
+    assert_eq!(chain_tip_change.last_tip_change(), None);
 }


### PR DESCRIPTION
## Motivation

In PR #2729, I used `wait_for_tip_change` and `last_tip_change` on the same `ChainTipChange`.
But that causes an assertion failure in some cases.

## Solution

- Ignore changes if the tip hash is the same
- Expand the tests to cover these cases

## Review

@jvff knows all the details here.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

