### PR TITLE
Send crawled transaction IDs to downloader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4566,6 +4566,8 @@ dependencies = [
  "lazy_static",
  "metrics",
  "once_cell",
+ "proptest",
+ "proptest-derive",
  "rand 0.7.3",
  "rand 0.8.4",
  "serde",

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -10,11 +10,15 @@ use std::ops::Bound::*;
 
 use chrono::{DateTime, Duration, Utc};
 
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
 /// A Zcash network upgrade.
 ///
 /// Network upgrades can change the Zcash network protocol or consensus rules in
 /// incompatible ways.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum NetworkUpgrade {
     /// The Zcash protocol for a Genesis block.
     ///

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
+[features]
+default = []
+proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl"]
+
 [dependencies]
 blake2b_simd = "0.5.11"
 bellman = "0.10.0"
@@ -33,8 +37,13 @@ zebra-state = { path = "../zebra-state" }
 zebra-script = { path = "../zebra-script" }
 wagyu-zcash-parameters = "0.2.0"
 
+proptest = { version = "0.10", optional = true }
+proptest-derive = { version = "0.3.0", optional = true }
+
 [dev-dependencies]
 color-eyre = "0.5.11"
+proptest = "0.10"
+proptest-derive = "0.3.0"
 rand07 = { package = "rand", version = "0.7" }
 spandoc = "0.2"
 tokio = { version = "0.3.6", features = ["full"] }

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -9,6 +9,9 @@ use thiserror::Error;
 
 use crate::BoxError;
 
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
 #[derive(Error, Copy, Clone, Debug, PartialEq)]
 pub enum SubsidyError {
     #[error("no coinbase transaction in block")]
@@ -19,6 +22,7 @@ pub enum SubsidyError {
 }
 
 #[derive(Error, Clone, Debug, PartialEq)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum TransactionError {
     #[error("first transaction must be coinbase")]
     CoinbasePosition,
@@ -45,6 +49,7 @@ pub enum TransactionError {
     CoinbaseInMempool,
 
     #[error("coinbase transaction failed subsidy validation")]
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     Subsidy(#[from] SubsidyError),
 
     #[error("transaction version number MUST be >= 4")]
@@ -63,6 +68,7 @@ pub enum TransactionError {
     BadBalance,
 
     #[error("could not verify a transparent script")]
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     Script(#[from] zebra_script::Error),
 
     #[error("spend description cv and rk MUST NOT be of small order")]
@@ -76,12 +82,15 @@ pub enum TransactionError {
     #[error(
         "Sprout joinSplitSig MUST represent a valid signature under joinSplitPubKey of dataToBeSigned"
     )]
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     Ed25519(#[from] zebra_chain::primitives::ed25519::Error),
 
     #[error("Sapling bindingSig MUST represent a valid signature under the transaction binding validating key bvk of SigHash")]
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     RedJubjub(zebra_chain::primitives::redjubjub::Error),
 
     #[error("Orchard bindingSig MUST represent a valid signature under the transaction binding validating key bvk of SigHash")]
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     RedPallas(zebra_chain::primitives::redpallas::Error),
 
     // temporary error type until #1186 is fixed

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -61,6 +61,7 @@ proptest = "0.10"
 proptest-derive = "0.3"
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus/", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test" }
 

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -102,12 +102,12 @@ impl StartCmd {
         let mempool = ServiceBuilder::new().buffer(20).service(mempool_service);
 
         setup_tx
-            .send((peer_set.clone(), address_book, mempool))
+            .send((peer_set.clone(), address_book, mempool.clone()))
             .map_err(|_| eyre!("could not send setup data to inbound service"))?;
 
         select! {
             result = syncer.sync().fuse() => result,
-            _ = mempool::Crawler::spawn(peer_set, sync_status).fuse() => {
+            _ = mempool::Crawler::spawn(peer_set, mempool, sync_status).fuse() => {
                 unreachable!("The mempool crawler only stops if it panics");
             }
         }

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -50,7 +50,7 @@ type TxVerifier = Buffer<
 >;
 type InboundTxDownloads = TxDownloads<Timeout<Outbound>, Timeout<TxVerifier>, State>;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 #[allow(dead_code)]
 pub enum Request {
     TransactionIds,

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -119,11 +119,13 @@ where
             transaction_ids.len()
         );
 
-        self.mempool
-            .ready_and()
-            .await?
-            .call(mempool::Request::Queue(transaction_ids))
-            .await?;
+        if !transaction_ids.is_empty() {
+            self.mempool
+                .ready_and()
+                .await?
+                .call(mempool::Request::Queue(transaction_ids))
+                .await?;
+        }
 
         Ok(())
     }

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -98,7 +98,7 @@ where
         while let Some(result) = requests.next().await {
             // log individual response errors
             match result {
-                Ok(response) => self.handle_response(response).await?,
+                Ok(response) => self.handle_response(response).await,
                 // TODO: Reduce the log level of the errors (#2655).
                 Err(error) => info!("Failed to crawl peer for mempool transactions: {}", error),
             }
@@ -108,7 +108,7 @@ where
     }
 
     /// Handle a peer's response to the crawler's request for transactions.
-    async fn handle_response(&mut self, response: zn::Response) -> Result<(), BoxError> {
+    async fn handle_response(&mut self, response: zn::Response) {
         let transaction_ids: Vec<_> = match response {
             zn::Response::TransactionIds(ids) => ids.into_iter().map(Gossip::Id).collect(),
             _ => unreachable!("Peer set did not respond with transaction IDs to mempool crawler"),
@@ -120,11 +120,33 @@ where
         );
 
         if !transaction_ids.is_empty() {
-            self.mempool
-                .ready_and()
-                .await?
-                .call(mempool::Request::Queue(transaction_ids))
-                .await?;
+            if let Err(error) = self.queue_transactions(transaction_ids).await {
+                error!(
+                    "Failed to forward crawled transactions to mempool transaction downloader: {}",
+                    error
+                );
+            }
+        }
+    }
+
+    /// Forward the crawled transactions IDs to the mempool transaction downloader.
+    async fn queue_transactions(&mut self, transaction_ids: Vec<Gossip>) -> Result<(), BoxError> {
+        let response = self
+            .mempool
+            .ready_and()
+            .await?
+            .call(mempool::Request::Queue(transaction_ids))
+            .await?;
+
+        let queue_errors = match response {
+            mempool::Response::Queued(queue_results) => {
+                queue_results.into_iter().filter_map(Result::err)
+            }
+            _ => unreachable!("Mempool did not respond with queue results to mempool crawler"),
+        };
+
+        for error in queue_errors {
+            warn!("Failed to download a crawled transaction: {}", error);
         }
 
         Ok(())

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -31,18 +31,18 @@ const RATE_LIMIT_DELAY: Duration = Duration::from_secs(75);
 const PEER_RESPONSE_TIMEOUT: Duration = Duration::from_secs(6);
 
 /// The mempool transaction crawler.
-pub struct Crawler<S> {
-    peer_set: Timeout<S>,
+pub struct Crawler<PeerSet> {
+    peer_set: Timeout<PeerSet>,
     status: SyncStatus,
 }
 
-impl<S> Crawler<S>
+impl<PeerSet> Crawler<PeerSet>
 where
-    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
-    S::Future: Send,
+    PeerSet: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    PeerSet::Future: Send,
 {
     /// Spawn an asynchronous task to run the mempool crawler.
-    pub fn spawn(peer_set: S, status: SyncStatus) -> JoinHandle<Result<(), BoxError>> {
+    pub fn spawn(peer_set: PeerSet, status: SyncStatus) -> JoinHandle<Result<(), BoxError>> {
         let crawler = Crawler {
             peer_set: Timeout::new(peer_set, PEER_RESPONSE_TIMEOUT),
             status,

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -146,7 +146,7 @@ where
         };
 
         for error in queue_errors {
-            warn!("Failed to download a crawled transaction: {}", error);
+            debug!("Failed to download a crawled transaction: {}", error);
         }
 
         Ok(())

--- a/zebrad/src/components/mempool/crawler/tests.rs
+++ b/zebrad/src/components/mempool/crawler/tests.rs
@@ -27,6 +27,11 @@ const MAX_CRAWLED_TX: usize = 10;
 const ERROR_MARGIN: Duration = Duration::from_millis(100);
 
 proptest! {
+    /// Test if crawler periodically crawls for transaction IDs.
+    ///
+    /// The crawler should periodically perform a fanned-out series of requests to obtain
+    /// transaction IDs from other peers. These requests should only be sent if the mempool is
+    /// enabled, i.e., if the block synchronizer is likely close to the chain tip.
     #[test]
     fn crawler_requests_for_transaction_ids(mut sync_lengths in any::<Vec<usize>>()) {
         let runtime = tokio::runtime::Builder::new_current_thread()

--- a/zebrad/src/components/mempool/crawler/tests.rs
+++ b/zebrad/src/components/mempool/crawler/tests.rs
@@ -1,12 +1,16 @@
 use std::time::Duration;
 
-use proptest::prelude::*;
+use proptest::{collection::vec, prelude::*};
 use tokio::time;
 
+use zebra_chain::transaction::UnminedTxId;
 use zebra_network as zn;
 use zebra_test::mock_service::MockService;
 
-use super::{Crawler, SyncStatus, FANOUT, RATE_LIMIT_DELAY};
+use super::{
+    super::{super::mempool, downloads::Gossip},
+    Crawler, SyncStatus, FANOUT, RATE_LIMIT_DELAY,
+};
 
 /// The number of iterations to crawl while testing.
 ///
@@ -15,6 +19,9 @@ use super::{Crawler, SyncStatus, FANOUT, RATE_LIMIT_DELAY};
 /// at least `CRAWL_ITERATIONS` times the timeout for receiving a request (see more information in
 /// [`MockServiceBuilder::with_max_request_delay`]).
 const CRAWL_ITERATIONS: usize = 4;
+
+/// The maximum number of transactions crawled from a mocked peer.
+const MAX_CRAWLED_TX: usize = 10;
 
 /// The amount of time to advance beyond the expected instant that the crawler wakes up.
 const ERROR_MARGIN: Duration = Duration::from_millis(100);
@@ -67,6 +74,65 @@ proptest! {
                 // appended to the events so that all of the original values are applied.
                 recent_sync_lengths.push_extend_tips_length(sync_length);
             }
+
+            Ok::<(), TestCaseError>(())
+        })?;
+    }
+
+    /// Test if crawled transactions are forwarded to the [`Mempool`][mempool::Mempool] service.
+    ///
+    /// The transaction IDs sent by other peers to the crawler should be forwarded to the
+    /// [`Mempool`][mempool::Mempool] service so that they can be downloaded, verified and added to
+    /// the mempool.
+    #[test]
+    fn crawled_transactions_are_forwarded_to_downloader(
+        transaction_ids in vec(any::<UnminedTxId>(), 1..MAX_CRAWLED_TX),
+    ) {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create Tokio runtime");
+        let _guard = runtime.enter();
+
+        runtime.block_on(async move {
+            let mut peer_set = MockService::build().for_prop_tests();
+            let mut mempool = MockService::build().for_prop_tests();
+            let (sync_status, mut recent_sync_lengths) = SyncStatus::new();
+
+            time::pause();
+
+            // Mock end of chain sync to enable the mempool crawler.
+            SyncStatus::sync_close_to_tip(&mut recent_sync_lengths);
+
+            Crawler::spawn(peer_set.clone(), mempool.clone(), sync_status);
+
+            peer_set
+                .expect_request_that(|request| {
+                    matches!(request, zn::Request::MempoolTransactionIds)
+                })
+                .await?
+                .respond(zn::Response::TransactionIds(transaction_ids.clone()));
+
+            for _ in 1..FANOUT {
+                peer_set
+                    .expect_request_that(|request| {
+                        matches!(request, zn::Request::MempoolTransactionIds)
+                    })
+                    .await?
+                    .respond(zn::Response::TransactionIds(vec![]));
+            }
+
+            peer_set.expect_no_requests().await?;
+
+            let response_list = vec![Ok(()); transaction_ids.len()];
+            let request_param = transaction_ids.into_iter().map(Gossip::Id).collect();
+
+            mempool
+                .expect_request(mempool::Request::Queue(request_param))
+                .await?
+                .respond(mempool::Response::Queued(response_list));
+
+            mempool.expect_no_requests().await?;
 
             Ok::<(), TestCaseError>(())
         })?;

--- a/zebrad/src/components/mempool/crawler/tests.rs
+++ b/zebrad/src/components/mempool/crawler/tests.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use proptest::prelude::*;
 use tokio::time;
 
-use zebra_network::{Request, Response};
+use zebra_network as zn;
 use zebra_test::mock_service::MockService;
 
 use super::{Crawler, SyncStatus, FANOUT, RATE_LIMIT_DELAY};
@@ -47,10 +47,10 @@ proptest! {
                         if mempool_is_enabled {
                             peer_set
                                 .expect_request_that(|request| {
-                                    matches!(request, Request::MempoolTransactionIds)
+                                    matches!(request, zn::Request::MempoolTransactionIds)
                                 })
                                 .await?
-                                .respond(Response::TransactionIds(vec![]));
+                                .respond(zn::Response::TransactionIds(vec![]));
                         } else {
                             peer_set.expect_no_requests().await?;
                         }

--- a/zebrad/src/components/mempool/crawler/tests.rs
+++ b/zebrad/src/components/mempool/crawler/tests.rs
@@ -64,9 +64,7 @@ proptest! {
                     for _ in 0..FANOUT {
                         if mempool_is_enabled {
                             peer_set
-                                .expect_request_that(|request| {
-                                    matches!(request, zn::Request::MempoolTransactionIds)
-                                })
+                                .expect_request(zn::Request::MempoolTransactionIds)
                                 .await?
                                 .respond(zn::Response::TransactionIds(vec![]));
                         } else {
@@ -114,17 +112,13 @@ proptest! {
             SyncStatus::sync_close_to_tip(&mut recent_sync_lengths);
 
             peer_set
-                .expect_request_that(|request| {
-                    matches!(request, zn::Request::MempoolTransactionIds)
-                })
+                .expect_request(zn::Request::MempoolTransactionIds)
                 .await?
                 .respond(zn::Response::TransactionIds(transaction_ids.clone()));
 
             for _ in 1..FANOUT {
                 peer_set
-                    .expect_request_that(|request| {
-                        matches!(request, zn::Request::MempoolTransactionIds)
-                    })
+                    .expect_request(zn::Request::MempoolTransactionIds)
                     .await?
                     .respond(zn::Response::TransactionIds(vec![]));
             }

--- a/zebrad/src/components/mempool/crawler/tests.rs
+++ b/zebrad/src/components/mempool/crawler/tests.rs
@@ -33,11 +33,12 @@ proptest! {
 
         runtime.block_on(async move {
             let mut peer_set = MockService::build().for_prop_tests();
+            let mempool = MockService::build().for_prop_tests();
             let (sync_status, mut recent_sync_lengths) = SyncStatus::new();
 
             time::pause();
 
-            Crawler::spawn(peer_set.clone(), sync_status.clone());
+            Crawler::spawn(peer_set.clone(), mempool, sync_status.clone());
 
             for sync_length in sync_lengths {
                 let mempool_is_enabled = sync_status.is_close_to_tip();

--- a/zebrad/src/components/mempool/crawler/tests.rs
+++ b/zebrad/src/components/mempool/crawler/tests.rs
@@ -208,3 +208,26 @@ async fn respond_to_queue_request(
 
     Ok(())
 }
+
+/// Intercept request for mempool to download and verify transactions, and answer with an error.
+///
+/// The intercepted request will be verified to check if it has the `expected_transaction_ids`, and
+/// it will be answered with `error`, as if the service had an internal failure that prevented it
+/// from queuing the transactions for downloading.
+async fn respond_to_queue_request_with_error(
+    mempool: &mut MockMempool,
+    expected_transaction_ids: Vec<UnminedTxId>,
+    error: MempoolError,
+) -> Result<(), TestCaseError> {
+    let request_parameter = expected_transaction_ids
+        .into_iter()
+        .map(Gossip::Id)
+        .collect();
+
+    mempool
+        .expect_request(mempool::Request::Queue(request_parameter))
+        .await?
+        .respond(Err(error));
+
+    Ok(())
+}

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -66,7 +66,7 @@ pub(crate) const TRANSACTION_VERIFY_TIMEOUT: Duration = BLOCK_VERIFY_TIMEOUT;
 pub(crate) const MAX_INBOUND_CONCURRENCY: usize = 10;
 
 /// A gossiped transaction, which can be the transaction itself or just its ID.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Gossip {
     Id(UnminedTxId),
     Tx(UnminedTx),

--- a/zebrad/src/components/mempool/error.rs
+++ b/zebrad/src/components/mempool/error.rs
@@ -2,7 +2,11 @@
 
 use thiserror::Error;
 
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
 #[derive(Error, Clone, Debug, PartialEq)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 #[allow(dead_code)]
 pub enum MempoolError {
     #[error("transaction already exists in mempool")]


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
The mempool crawler currently only logs crawled transaction IDs, but doesn't forward them so that the transactions can be downloaded and stored in the mempool.

This closes #2650.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
The `mempool::Crawler` was updated to receive a handle to the mempool service, and after it receives crawled transactions it just forwards them to be queued in the mempool's transaction downloader.

## Review

Anyone working on the mempool can review this PR.
<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
