### PR TITLE
Add metrics for initial peer network protocol versions

### DIFF
--- a/grafana/peers.json
+++ b/grafana/peers.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 7,
-  "iteration": 1632878057247,
+  "iteration": 1632879075996,
   "links": [],
   "panels": [
     {
@@ -74,7 +74,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_connected{job=\"$job\"})",
+          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_connected{job=\"$job\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "{{remote_version}} - {{seed}}",
@@ -85,7 +85,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Compatible Initial Peers - $job",
+      "title": "Compatible Seed Peers - $job",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -164,7 +164,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632878057247,
+      "repeatIteration": 1632879075996,
       "repeatPanelId": 2,
       "scopedVars": {
         "job": {
@@ -180,7 +180,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_connected{job=\"$job\"})",
+          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_connected{job=\"$job\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "{{remote_version}} - {{seed}}",
@@ -191,7 +191,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Compatible Initial Peers - $job",
+      "title": "Compatible Seed Peers - $job",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -285,7 +285,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_obsolete{job=\"$job\"})",
+          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_obsolete{job=\"$job\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "{{remote_version}} - {{seed}}",
@@ -296,7 +296,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Obsolete Initial Peers - $job",
+      "title": "Obsolete Seed Peers - $job",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -375,7 +375,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632878057247,
+      "repeatIteration": 1632879075996,
       "repeatPanelId": 11,
       "scopedVars": {
         "job": {
@@ -391,7 +391,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_obsolete{job=\"$job\"})",
+          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_obsolete{job=\"$job\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "{{remote_version}} - {{seed}}",
@@ -402,7 +402,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Obsolete Initial Peers - $job",
+      "title": "Obsolete Seed Peers - $job",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -585,7 +585,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632878057247,
+      "repeatIteration": 1632879075996,
       "repeatPanelId": 4,
       "scopedVars": {
         "job": {
@@ -794,7 +794,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632878057247,
+      "repeatIteration": 1632879075996,
       "repeatPanelId": 7,
       "scopedVars": {
         "job": {
@@ -900,6 +900,54 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": [
+            "dnsseed.str4d.xyz:8233",
+            "dnsseed.testnet.z.cash:18233",
+            "dnsseed.z.cash:8233",
+            "mainnet.is.yolo.money:8233",
+            "mainnet.seeder.zfnd.org:8233",
+            "testnet.is.yolo.money:18233",
+            "testnet.seeder.zfnd.org:18233"
+          ],
+          "value": [
+            "dnsseed.str4d.xyz:8233",
+            "dnsseed.testnet.z.cash:18233",
+            "dnsseed.z.cash:8233",
+            "mainnet.is.yolo.money:8233",
+            "mainnet.seeder.zfnd.org:8233",
+            "testnet.is.yolo.money:18233",
+            "testnet.seeder.zfnd.org:18233"
+          ]
+        },
+        "datasource": null,
+        "definition": "label_values(zcash_net_peers_initial, seed)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "seed",
+        "options": [],
+        "query": {
+          "query": "label_values(zcash_net_peers_initial, seed)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
@@ -911,5 +959,5 @@
   "timezone": "",
   "title": "peers",
   "uid": "S29TgUH7k",
-  "version": 17
+  "version": 22
 }

--- a/grafana/peers.json
+++ b/grafana/peers.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 7,
-  "iteration": 1632801377123,
+  "iteration": 1632874374410,
   "links": [],
   "panels": [
     {
@@ -32,7 +32,7 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 9,
+        "h": 7,
         "w": 12,
         "x": 0,
         "y": 0
@@ -136,13 +136,13 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 9,
+        "h": 7,
         "w": 12,
         "x": 12,
         "y": 0
       },
       "hiddenSeries": false,
-      "id": 3,
+      "id": 8,
       "legend": {
         "avg": false,
         "current": false,
@@ -163,7 +163,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632801377123,
+      "repeatIteration": 1632874374410,
       "repeatPanelId": 2,
       "scopedVars": {
         "job": {
@@ -227,8 +227,427 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "job",
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-mainnet",
+          "value": "zebrad-mainnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (remote_version) (zcash_net_peers_connected{job=\"$job\"})",
+          "interval": "",
+          "legendFormat": "{{remote_version}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Peer Connections - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 9,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1632874374410,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet",
+          "value": "zebrad-testnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (remote_version) (zcash_net_peers_connected{job=\"$job\"})",
+          "interval": "",
+          "legendFormat": "{{remote_version}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Peer Connections - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "job",
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-mainnet",
+          "value": "zebrad-mainnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (remote_version) (zcash_net_peers_obsolete{job=\"$job\"})",
+          "interval": "",
+          "legendFormat": "{{remote_version}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Obsolete Peers - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1632874374410,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet",
+          "value": "zebrad-testnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (remote_version) (zcash_net_peers_obsolete{job=\"$job\"})",
+          "interval": "",
+          "legendFormat": "{{remote_version}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Obsolete Peers - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
+  "refresh": "5s",
   "schemaVersion": 27,
   "style": "dark",
   "tags": [],
@@ -237,8 +656,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
-          "tags": [],
+          "selected": false,
           "text": [
             "All"
           ],
@@ -280,5 +698,5 @@
   "timezone": "",
   "title": "peers",
   "uid": "S29TgUH7k",
-  "version": 5
+  "version": 10
 }

--- a/grafana/peers.json
+++ b/grafana/peers.json
@@ -1,0 +1,284 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 7,
+  "iteration": 1632801377123,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "job",
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-mainnet",
+          "value": "zebrad-mainnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (seed) (zcash_net_peers_initial{job=\"$job\"})",
+          "interval": "",
+          "legendFormat": "{{seed}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Initial Peers - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1632801377123,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet",
+          "value": "zebrad-testnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (seed) (zcash_net_peers_initial{job=\"$job\"})",
+          "interval": "",
+          "legendFormat": "{{seed}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Initial Peers - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": null,
+        "definition": "label_values(zcash_net_in_bytes_total, job)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(zcash_net_in_bytes_total, job)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "peers",
+  "uid": "S29TgUH7k",
+  "version": 5
+}

--- a/grafana/peers.json
+++ b/grafana/peers.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 7,
-  "iteration": 1632874374410,
+  "iteration": 1632878057247,
   "links": [],
   "panels": [
     {
@@ -32,7 +32,7 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 12,
         "x": 0,
         "y": 0
@@ -74,9 +74,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (seed) (zcash_net_peers_initial{job=\"$job\"})",
+          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_connected{job=\"$job\"})",
+          "instant": false,
           "interval": "",
-          "legendFormat": "{{seed}}",
+          "legendFormat": "{{remote_version}} - {{seed}}",
           "refId": "A"
         }
       ],
@@ -84,7 +85,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Initial Peers - $job",
+      "title": "Compatible Initial Peers - $job",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -136,13 +137,13 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 12,
         "x": 12,
         "y": 0
       },
       "hiddenSeries": false,
-      "id": 8,
+      "id": 12,
       "legend": {
         "avg": false,
         "current": false,
@@ -163,7 +164,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632874374410,
+      "repeatIteration": 1632878057247,
       "repeatPanelId": 2,
       "scopedVars": {
         "job": {
@@ -179,9 +180,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (seed) (zcash_net_peers_initial{job=\"$job\"})",
+          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_connected{job=\"$job\"})",
+          "instant": false,
           "interval": "",
-          "legendFormat": "{{seed}}",
+          "legendFormat": "{{remote_version}} - {{seed}}",
           "refId": "A"
         }
       ],
@@ -189,7 +191,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Initial Peers - $job",
+      "title": "Compatible Initial Peers - $job",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -241,10 +243,221 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 0,
-        "y": 7
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "job",
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-mainnet",
+          "value": "zebrad-mainnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_obsolete{job=\"$job\"})",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{remote_version}} - {{seed}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Obsolete Initial Peers - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1632878057247,
+      "repeatPanelId": 11,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet",
+          "value": "zebrad-testnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_obsolete{job=\"$job\"})",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{remote_version}} - {{seed}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Obsolete Initial Peers - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
       },
       "hiddenSeries": false,
       "id": 4,
@@ -293,7 +506,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Peer Connections - $job",
+      "title": "Compatible Peers - $job",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -345,13 +558,13 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 7
+        "y": 17
       },
       "hiddenSeries": false,
-      "id": 9,
+      "id": 14,
       "legend": {
         "avg": false,
         "current": false,
@@ -372,7 +585,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632874374410,
+      "repeatIteration": 1632878057247,
       "repeatPanelId": 4,
       "scopedVars": {
         "job": {
@@ -398,7 +611,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Peer Connections - $job",
+      "title": "Compatible Peers - $job",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -450,10 +663,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 0,
-        "y": 14
+        "y": 25
       },
       "hiddenSeries": false,
       "id": 7,
@@ -554,13 +767,13 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 14
+        "y": 25
       },
       "hiddenSeries": false,
-      "id": 10,
+      "id": 15,
       "legend": {
         "avg": false,
         "current": false,
@@ -581,7 +794,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632874374410,
+      "repeatIteration": 1632878057247,
       "repeatPanelId": 7,
       "scopedVars": {
         "job": {
@@ -698,5 +911,5 @@
   "timezone": "",
   "title": "peers",
   "uid": "S29TgUH7k",
-  "version": 10
+  "version": 17
 }

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -149,13 +149,15 @@ impl Config {
 
                 // if we're logging at debug level,
                 // the full list of IP addresses will be shown in the log message
-                let debug_span = debug_span!("", ?ip_addrs);
+                let debug_span = debug_span!("", resolved = ?ip_addrs);
                 let _span_guard = debug_span.enter();
-                info!(?host, ip_count = ?ip_addrs.len(), "resolved seed peer IP addresses");
+                info!(seed = ?host, resolved_ip_count = ?ip_addrs.len(), "resolved seed peer IP addresses");
 
                 for ip in &ip_addrs {
                     // Count each initial peer, recording the seed config and resolved IP address.
-                    // If an IP is returned by multiple seeds, records the number of duplicates.
+                    //
+                    // If an IP is returned by multiple seeds,
+                    // each duplicate adds 1 to the initial peer count.
                     // (But we only make one initial connection attempt to each IP.)
                     metrics::counter!(
                         "zcash.net.peers.initial",

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -149,9 +149,9 @@ impl Config {
 
                 // if we're logging at debug level,
                 // the full list of IP addresses will be shown in the log message
-                let debug_span = debug_span!("", resolved = ?ip_addrs);
+                let debug_span = debug_span!("", remote_ip_addrs = ?ip_addrs);
                 let _span_guard = debug_span.enter();
-                info!(seed = ?host, resolved_ip_count = ?ip_addrs.len(), "resolved seed peer IP addresses");
+                info!(seed = ?host, remote_ip_count = ?ip_addrs.len(), "resolved seed peer IP addresses");
 
                 for ip in &ip_addrs {
                     // Count each initial peer, recording the seed config and resolved IP address.
@@ -163,7 +163,7 @@ impl Config {
                         "zcash.net.peers.initial",
                         1,
                         "seed" => host.to_string(),
-                        "resolved" => ip.to_string()
+                        "remote_ip" => ip.to_string()
                     );
                 }
 

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::min,
     collections::HashSet,
     fmt,
     future::Future,
@@ -588,8 +589,42 @@ pub async fn negotiate_version(
     let height = latest_chain_tip.best_tip_height();
     let min_version = Version::min_remote_for_height(config.network, height);
     if remote_version < min_version {
+        debug!(
+            remote_ip = ?their_addr,
+            ?remote_version,
+            ?min_version,
+            "disconnecting from peer with obsolete network protocol version"
+        );
+
+        metrics::counter!(
+            "zcash.net.peers.obsolete",
+            1,
+            "remote_ip" => their_addr.to_string(),
+            "remote_version" => remote_version.to_string(),
+            "min_version" => min_version.to_string(),
+        );
+
         // Disconnect if peer is using an obsolete version.
         Err(HandshakeError::ObsoleteVersion(remote_version))?;
+    } else {
+        let negotiated_version = min(constants::CURRENT_NETWORK_PROTOCOL_VERSION, remote_version);
+
+        debug!(
+            remote_ip = ?their_addr,
+            ?remote_version,
+            ?negotiated_version,
+            ?min_version,
+            "negotiated network protocol version with peer"
+        );
+
+        metrics::counter!(
+            "zcash.net.peers.connected",
+            1,
+            "remote_ip" => their_addr.to_string(),
+            "remote_version" => remote_version.to_string(),
+            "negotiated_version" => negotiated_version.to_string(),
+            "min_version" => min_version.to_string(),
+        );
     }
 
     peer_conn.send(Message::Verack).await?;

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -41,6 +41,12 @@ impl From<Network> for Magic {
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct Version(pub u32);
 
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0.to_string())
+    }
+}
+
 impl Version {
     /// Returns the minimum remote node network protocol version for `network` and
     /// `height`. Zebra disconnects from peers with lower versions.


### PR DESCRIPTION
## Motivation

As part of ticket #2797, we want to check the network protocol versions of the peers supplied by the Zcash DNS seeders.

### Designs

Zebra already has this information, we just need to add it to the logs and metrics.

## Solution

Seed Peer DNS Resolution:
- log the initial peers resolved from each seed
- add metrics for initial peer resolution, including the seed and remote peer IP
- add a grafana dashboard for seed peer resolution
- add a per-seed filter to the peer dashboard

Network Protocol Versions
- add tracing and metrics for peer network protocol versions
- add network protocol versions to  peers dashboard
- show peer network protocol versions for each seeder in the peer dashboard

## Review

Anyone can review this PR, but I think @conradoplg or @upbqdn have set up a Grafana instance already?

Merging this PR isn't urgent.

### Reviewer Checklist

  - [ ] Code records metrics and logs correctly
  - [x] Dashboards work

## Follow Up Work

- #2137
- #2797
- #2812
