### PR TITLE
Enable 'full' feature in tokio for zebra-test

### DIFF
--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -16,7 +16,7 @@ rand = "0.8"
 regex = "1.4.6"
 
 tower = { version = "0.4", features = ["util"] }
-tokio = { version = "0.3", features = ["rt-multi-thread"] }
+tokio = { version = "0.3", features = ["full"] }
 futures = "0.3.17"
 
 color-eyre = "0.5.11"
@@ -30,4 +30,3 @@ tracing-error = "0.1.2"
 
 [dev-dependencies]
 tempdir = "0.3.7"
-tokio = { version = "0.3.6", features = ["full"] }


### PR DESCRIPTION
## Motivation

Currently in `main` you can't compile a test for a single package, i.e. `cargo test -p zebra-chain --lib`. This is because it uses `zebra-test` which requires the `sync` feature from `tokio`, but only enables it in `dev-dependencies`. However, `dev-dependencies` of dependencies are ignored:

> Note that dev-dependencies in dependencies are always ignored, this is only relevant for the top-level package or workspace members.

https://doc.rust-lang.org/cargo/reference/resolver.html



### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

Enable `full` in  `zebra-test`, not only on `dev-dependencies`.
My rationale is that `zebra-test` is not a test in itself, so for it to be used it needs to specify its proper dependencies in `dependencies` and not `dev-`

But I'm not confident this is the best solution. Possible options / improvements:

- Don't use `full` but actually enumerate everything that is required
- Instead add a `dev-dependencies` in each package that uses it

Some package include `zebra-test`in `dependencies` (e.g. `zebra-chain`) instead of just in `dev-dependencies`, so this PR would end up making Zebra always use `full` in `tokio`.

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

## Review

This is not urgent, but this issue prevents running specific tests in some packages (e.g. `zebra-chain`) while developing which is annoying.

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
