### PR TITLE
Improve `MockService` ergonomics for sending error responses

### DIFF
--- a/zebra-test/src/mock_service.rs
+++ b/zebra-test/src/mock_service.rs
@@ -694,6 +694,42 @@ impl<Request, Response, Error> ResponseSender<Request, Response, Error> {
     /// sent.
     ///
     /// If this method is not called, the caller will panic.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use zebra_test::mock_service::MockService;
+    /// # use tower::{Service, ServiceExt};
+    /// #
+    /// # let reactor = tokio::runtime::Builder::new_current_thread()
+    /// #     .enable_all()
+    /// #     .build()
+    /// #     .expect("Failed to build Tokio runtime");
+    /// #
+    /// # reactor.block_on(async {
+    /// // Mock a service with a `String` as the service `Error` type.
+    /// let mut mock_service: MockService<_, _, _, String> =
+    ///     MockService::build().for_unit_tests();
+    ///
+    /// # let mut service = mock_service.clone();
+    /// # let task = tokio::spawn(async move {
+    /// #     let first_call_result = (&mut service).oneshot(1).await;
+    /// #     let second_call_result = service.oneshot(1).await;
+    /// #
+    /// #     (first_call_result, second_call_result)
+    /// # });
+    /// #
+    /// mock_service
+    ///     .expect_request(1)
+    ///     .await
+    ///     .respond("Received one".to_owned());
+    ///
+    /// mock_service
+    ///     .expect_request(1)
+    ///     .await
+    ///     .respond(Err("Duplicate request"));
+    /// # });
+    /// ```
     pub fn respond(self, response: impl ResponseResult<Response, Error>) {
         let _ = self.response_sender.send(response.into_result());
     }

--- a/zebra-test/src/mock_service.rs
+++ b/zebra-test/src/mock_service.rs
@@ -735,7 +735,7 @@ impl<Response, Error> ResponseResult<Response, Error> for Response {
 
 impl<Response, Error> ResponseResult<Response, Error> for Result<Response, Error>
 where
-    Error: std::error::Error + Send + Sync + 'static,
+    Error: Send + Sync + 'static,
 {
     fn into_result(self) -> Result<Response, Error> {
         self

--- a/zebra-test/src/mock_service.rs
+++ b/zebra-test/src/mock_service.rs
@@ -733,11 +733,12 @@ impl<Response, Error> ResponseResult<Response, Error> for Response {
     }
 }
 
-impl<Response, Error> ResponseResult<Response, Error> for Result<Response, Error>
+impl<Response, SourceError, TargetError> ResponseResult<Response, TargetError>
+    for Result<Response, SourceError>
 where
-    Error: Send + Sync + 'static,
+    SourceError: Into<TargetError>,
 {
-    fn into_result(self) -> Result<Response, Error> {
-        self
+    fn into_result(self) -> Result<Response, TargetError> {
+        self.map_err(|source_error| source_error.into())
     }
 }


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
While working on the tests in #2801, I stumbled onto an issue with the `MockService`. Unfortunately, the `Error` generic type parameter had a constraint where it needed to `std::error::Error`, and that's not actually necessary. This caused some issues when I was trying to respond to requests with errors.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
I removed the constraint, but I also used the opportunity to improve the ergonomics of responding with errors in general. This PR includes changes to:

1. Remove the `Error: std::error::Error` constraint;
2. Automatic conversion of a provided `SourceError` type into a `TargetError` type, so the caller doesn't have to call `.into()`;
3. Add a documentation example for responding with an error, that also serves as a simple test case.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
Anyone can review this, but since this blocks #2801 and @teor2345 is already reviewing that PR, I tagged them directly.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
