### PR TITLE
Fix join errors in initial seed peer versions dashboard

### DIFF
--- a/grafana/peers.json
+++ b/grafana/peers.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 7,
-  "iteration": 1632962541240,
+  "iteration": 1632966001778,
   "links": [],
   "panels": [
     {
@@ -40,10 +40,14 @@
       "hiddenSeries": false,
       "id": 2,
       "legend": {
+        "alignAsTable": false,
         "avg": false,
         "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": false
@@ -74,7 +78,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) (count_values by (remote_ip) (\"remote_version\", zcash_net_peers_version_connected{job=\"$job\"})))",
+          "expr": "sum by (remote_version, seed) (label_replace(zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"}, \"seed\", \"$1\", \"seed\", \"(.*):1?8233\") * on(remote_ip) group_left(remote_version) (count_values by (remote_ip) (\"remote_version\", zcash_net_peers_version_connected{job=\"$job\"})))",
           "instant": false,
           "interval": "",
           "legendFormat": "{{remote_version}} - {{seed}}",
@@ -88,7 +92,7 @@
       "title": "Compatible Seed Peers - $job",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -145,10 +149,14 @@
       "hiddenSeries": false,
       "id": 12,
       "legend": {
+        "alignAsTable": false,
         "avg": false,
         "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": false
@@ -164,7 +172,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632962541240,
+      "repeatIteration": 1632966001778,
       "repeatPanelId": 2,
       "scopedVars": {
         "job": {
@@ -180,7 +188,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) (count_values by (remote_ip) (\"remote_version\", zcash_net_peers_version_connected{job=\"$job\"})))",
+          "expr": "sum by (remote_version, seed) (label_replace(zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"}, \"seed\", \"$1\", \"seed\", \"(.*):1?8233\") * on(remote_ip) group_left(remote_version) (count_values by (remote_ip) (\"remote_version\", zcash_net_peers_version_connected{job=\"$job\"})))",
           "instant": false,
           "interval": "",
           "legendFormat": "{{remote_version}} - {{seed}}",
@@ -194,7 +202,7 @@
       "title": "Compatible Seed Peers - $job",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -255,6 +263,7 @@
         "current": false,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": false
@@ -285,7 +294,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) (count_values by (remote_ip) (\"remote_version\", zcash_net_peers_version_obsolete{job=\"$job\"})))",
+          "expr": "sum by (remote_version, seed) (label_replace(zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"}, \"seed\", \"$1\", \"seed\", \"(.*):1?8233\") * on(remote_ip) group_left(remote_version) (count_values by (remote_ip) (\"remote_version\", zcash_net_peers_version_obsolete{job=\"$job\"})))",
           "instant": false,
           "interval": "",
           "legendFormat": "{{remote_version}} - {{seed}}",
@@ -299,7 +308,7 @@
       "title": "Obsolete Seed Peers - $job",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -360,6 +369,7 @@
         "current": false,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
         "values": false
@@ -375,7 +385,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632962541240,
+      "repeatIteration": 1632966001778,
       "repeatPanelId": 11,
       "scopedVars": {
         "job": {
@@ -391,7 +401,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) (count_values by (remote_ip) (\"remote_version\", zcash_net_peers_version_obsolete{job=\"$job\"})))",
+          "expr": "sum by (remote_version, seed) (label_replace(zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"}, \"seed\", \"$1\", \"seed\", \"(.*):1?8233\") * on(remote_ip) group_left(remote_version) (count_values by (remote_ip) (\"remote_version\", zcash_net_peers_version_obsolete{job=\"$job\"})))",
           "instant": false,
           "interval": "",
           "legendFormat": "{{remote_version}} - {{seed}}",
@@ -405,7 +415,7 @@
       "title": "Obsolete Seed Peers - $job",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -585,7 +595,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632962541240,
+      "repeatIteration": 1632966001778,
       "repeatPanelId": 4,
       "scopedVars": {
         "job": {
@@ -794,7 +804,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632962541240,
+      "repeatIteration": 1632966001778,
       "repeatPanelId": 7,
       "scopedVars": {
         "job": {
@@ -906,22 +916,10 @@
         "current": {
           "selected": false,
           "text": [
-            "dnsseed.str4d.xyz:8233",
-            "dnsseed.testnet.z.cash:18233",
-            "dnsseed.z.cash:8233",
-            "mainnet.is.yolo.money:8233",
-            "mainnet.seeder.zfnd.org:8233",
-            "testnet.is.yolo.money:18233",
-            "testnet.seeder.zfnd.org:18233"
+            "All"
           ],
           "value": [
-            "dnsseed.str4d.xyz:8233",
-            "dnsseed.testnet.z.cash:18233",
-            "dnsseed.z.cash:8233",
-            "mainnet.is.yolo.money:8233",
-            "mainnet.seeder.zfnd.org:8233",
-            "testnet.is.yolo.money:18233",
-            "testnet.seeder.zfnd.org:18233"
+            "$__all"
           ]
         },
         "datasource": null,
@@ -951,12 +949,12 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "peers",
   "uid": "S29TgUH7k",
-  "version": 26
+  "version": 31
 }

--- a/grafana/peers.json
+++ b/grafana/peers.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 7,
-  "iteration": 1632879075996,
+  "iteration": 1632962541240,
   "links": [],
   "panels": [
     {
@@ -74,7 +74,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_connected{job=\"$job\"})",
+          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) (count_values by (remote_ip) (\"remote_version\", zcash_net_peers_version_connected{job=\"$job\"})))",
           "instant": false,
           "interval": "",
           "legendFormat": "{{remote_version}} - {{seed}}",
@@ -164,7 +164,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632879075996,
+      "repeatIteration": 1632962541240,
       "repeatPanelId": 2,
       "scopedVars": {
         "job": {
@@ -180,7 +180,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_connected{job=\"$job\"})",
+          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) (count_values by (remote_ip) (\"remote_version\", zcash_net_peers_version_connected{job=\"$job\"})))",
           "instant": false,
           "interval": "",
           "legendFormat": "{{remote_version}} - {{seed}}",
@@ -285,7 +285,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_obsolete{job=\"$job\"})",
+          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) (count_values by (remote_ip) (\"remote_version\", zcash_net_peers_version_obsolete{job=\"$job\"})))",
           "instant": false,
           "interval": "",
           "legendFormat": "{{remote_version}} - {{seed}}",
@@ -375,7 +375,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632879075996,
+      "repeatIteration": 1632962541240,
       "repeatPanelId": 11,
       "scopedVars": {
         "job": {
@@ -391,7 +391,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) zcash_net_peers_obsolete{job=\"$job\"})",
+          "expr": "sum by (remote_version, seed) (zcash_net_peers_initial{job=\"$job\",seed=~\"$seed\"} * on(remote_ip) group_left(remote_version) (count_values by (remote_ip) (\"remote_version\", zcash_net_peers_version_obsolete{job=\"$job\"})))",
           "instant": false,
           "interval": "",
           "legendFormat": "{{remote_version}} - {{seed}}",
@@ -585,7 +585,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632879075996,
+      "repeatIteration": 1632962541240,
       "repeatPanelId": 4,
       "scopedVars": {
         "job": {
@@ -794,7 +794,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1632879075996,
+      "repeatIteration": 1632962541240,
       "repeatPanelId": 7,
       "scopedVars": {
         "job": {
@@ -904,8 +904,7 @@
       {
         "allValue": ".+",
         "current": {
-          "selected": true,
-          "tags": [],
+          "selected": false,
           "text": [
             "dnsseed.str4d.xyz:8233",
             "dnsseed.testnet.z.cash:18233",
@@ -959,5 +958,5 @@
   "timezone": "",
   "title": "peers",
   "uid": "S29TgUH7k",
-  "version": 22
+  "version": 26
 }

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -596,12 +596,20 @@ pub async fn negotiate_version(
             "disconnecting from peer with obsolete network protocol version"
         );
 
+        // the value is the number of rejected handshakes, by peer IP and protocol version
         metrics::counter!(
             "zcash.net.peers.obsolete",
             1,
             "remote_ip" => their_addr.to_string(),
             "remote_version" => remote_version.to_string(),
             "min_version" => min_version.to_string(),
+        );
+
+        // the value is the remote version of the most recent rejected handshake from each peer
+        metrics::gauge!(
+            "zcash.net.peers.version.obsolete",
+            remote_version.0.into(),
+            "remote_ip" => their_addr.to_string(),
         );
 
         // Disconnect if peer is using an obsolete version.
@@ -617,6 +625,7 @@ pub async fn negotiate_version(
             "negotiated network protocol version with peer"
         );
 
+        // the value is the number of connected handshakes, by peer IP and protocol version
         metrics::counter!(
             "zcash.net.peers.connected",
             1,
@@ -624,6 +633,13 @@ pub async fn negotiate_version(
             "remote_version" => remote_version.to_string(),
             "negotiated_version" => negotiated_version.to_string(),
             "min_version" => min_version.to_string(),
+        );
+
+        // the value is the remote version of the most recent connected handshake from each peer
+        metrics::gauge!(
+            "zcash.net.peers.version.connected",
+            remote_version.0.into(),
+            "remote_ip" => their_addr.to_string(),
         );
     }
 


### PR DESCRIPTION
## Motivation

When a peer upgrades and connects with a new network protocol version, the initial peers dashboard shows an error.

## Solution

- Add metrics for the latest network protocol version from each peer
- Join those metrics to the seed names in the dashboard
- Make the seeder labels more readable

### Testing

I tested this PR by downgrading one of my local instances from `zcashd` 4.5.1 (170015) to 4.4.1 (170013).
(This instance is in my local `zebrad` configs as a seed peer.)

The version change was shown on the metrics dashboard without errors.

## Review

@upbqdn reviewed PR #2804, this is a bug fix.

### Reviewer Checklist

  - [x] Dashboards work
