### PR TITLE
Cancel mempool download tasks when a network upgrade activates

### DIFF
--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -248,9 +248,10 @@ impl Service<Request> for Mempool {
             } => {
                 if let Some(tip_action) = self.chain_tip_change.last_tip_change() {
                     match tip_action {
-                        // Clear the mempool if there has been a chain tip reset.
+                        // Clear the mempool and cancel downloads if there has been a chain tip reset.
                         TipAction::Reset { .. } => {
                             storage.clear();
+                            tx_downloads.cancel_all();
                         }
                         // Cancel downloads/verifications of transactions with the same
                         // IDs as recently mined transactions.

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -334,6 +334,21 @@ where
         }
     }
 
+    /// Cancel all running tasks and reset the downloader state.
+    // Note: copied from zebrad/src/components/sync/downloads.rs
+    pub fn cancel_all(&mut self) {
+        // Replace the pending task list with an empty one and drop it.
+        let _ = std::mem::take(&mut self.pending);
+        // Signal cancellation to all running tasks.
+        // Since we already dropped the JoinHandles above, they should
+        // fail silently.
+        for (_hash, cancel) in self.cancel_handles.drain() {
+            let _ = cancel.send(());
+        }
+        assert!(self.pending.is_empty());
+        assert!(self.cancel_handles.is_empty());
+    }
+
     /// Get the number of currently in-flight download tasks.
     // Note: copied from zebrad/src/components/sync/downloads.rs
     #[allow(dead_code)]


### PR DESCRIPTION
## Motivation

When a network upgrade happens, any outstanding transactions in the tx downloader&verifier must now be validated with the new consensus rules.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

Cancel all downloads/verifications when there is a tip reset.

This is more than needed, since that also happens when multiple blocks are comitted in sequence. But I think that should happen rarely in normal node operation (in the initial sync the mempool is disabled anyway), and it's not a big deal to download/verify transactions again if needed.

Closes https://github.com/ZcashFoundation/zebra/issues/2710

## Review

Anyone can review this.

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [x] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
