### PR TITLE
Remove some dead code attributes from the mempool

### DIFF
--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -96,13 +96,11 @@ pub struct Mempool {
     active_state: ActiveState,
 
     /// Allows checking if we are near the tip to enable/disable the mempool.
-    #[allow(dead_code)]
     sync_status: SyncStatus,
 
     /// Allow efficient access to the best tip of the blockchain.
     latest_chain_tip: zs::LatestChainTip,
     /// Allows the detection of chain tip resets.
-    #[allow(dead_code)]
     chain_tip_change: ChainTipChange,
 
     /// Handle to the outbound service.
@@ -119,7 +117,6 @@ pub struct Mempool {
 }
 
 impl Mempool {
-    #[allow(dead_code)]
     pub(crate) fn new(
         _network: Network,
         outbound: Outbound,

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -51,7 +51,6 @@ impl Storage {
     ///
     /// If its insertion results in evicting other transactions, they will be tracked
     /// as [`State::Excess`].
-    #[allow(dead_code)]
     pub fn insert(&mut self, tx: UnminedTx) -> Result<UnminedTxId, MempoolError> {
         let tx_id = tx.id;
 
@@ -101,7 +100,6 @@ impl Storage {
 
     /// Returns `true` if a [`UnminedTx`] matching an [`UnminedTxId`] is in
     /// the mempool.
-    #[allow(dead_code)]
     pub fn contains(&self, txid: &UnminedTxId) -> bool {
         self.verified.iter().any(|tx| &tx.id == txid)
     }
@@ -112,7 +110,6 @@ impl Storage {
     /// Removes from the 'verified' set, does not remove from the 'rejected'
     /// tracking set, if present. Maintains the order in which the other unmined
     /// transactions have been inserted into the mempool.
-    #[allow(dead_code)]
     pub fn remove(&mut self, txid: &UnminedTxId) -> Option<UnminedTx> {
         // If the txid exists in the verified set and is then deleted,
         // `retain()` removes it and returns `Some(UnminedTx)`. If it's not

--- a/zebrad/src/components/sync/status.rs
+++ b/zebrad/src/components/sync/status.rs
@@ -1,6 +1,3 @@
-// TODO: Remove this attribute once this type is used (#2603).
-#![allow(dead_code)]
-
 use tokio::sync::watch;
 
 use super::RecentSyncLengths;


### PR DESCRIPTION
## Motivation

Some of the dead code attributes we have around the mempool are not needed anymore.

## Solution

Remove the ones that we can, not all of them can be removed yet.

## Review

This is minor cleanup, anyone can review.
