### PR TITLE
Remove unused mempool errors

### DIFF
--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -12,7 +12,7 @@ use crate::BoxError;
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
 
-#[derive(Error, Copy, Clone, Debug, PartialEq)]
+#[derive(Error, Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SubsidyError {
     #[error("no coinbase transaction in block")]
     NoCoinbase,
@@ -21,7 +21,7 @@ pub enum SubsidyError {
     FoundersRewardNotFound,
 }
 
-#[derive(Error, Clone, Debug, PartialEq)]
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum TransactionError {
     #[error("first transaction must be coinbase")]
@@ -128,7 +128,7 @@ impl From<SubsidyError> for BlockError {
     }
 }
 
-#[derive(Error, Clone, Debug, PartialEq)]
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum BlockError {
     #[error("block contains invalid transactions")]
     Transaction(#[from] TransactionError),

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -24,7 +24,7 @@ use zebra_chain::{
     transparent,
 };
 
-#[derive(Copy, Clone, Debug, Display, Error, PartialEq)]
+#[derive(Copy, Clone, Debug, Display, Error, PartialEq, Eq)]
 #[non_exhaustive]
 /// An Error type representing the error codes returned from zcash_script.
 pub enum Error {

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -33,6 +33,8 @@ mod tests;
 
 pub use self::crawler::Crawler;
 pub use self::error::MempoolError;
+pub use self::storage::StorageRejectionError;
+
 #[cfg(test)]
 pub use self::storage::tests::unmined_transactions_in_blocks;
 
@@ -182,8 +184,8 @@ impl Mempool {
         if storage.contains(&txid) {
             return Err(MempoolError::InMempool);
         }
-        if storage.contains_rejected(&txid) {
-            return Err(MempoolError::Rejected);
+        if let Some(error) = storage.rejection_error(&txid) {
+            return Err(error.into());
         }
         Ok(())
     }

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -3,10 +3,7 @@ use std::{
     hash::Hash,
 };
 
-use zebra_chain::{
-    block,
-    transaction::{self, Transaction, UnminedTx, UnminedTxId},
-};
+use zebra_chain::transaction::{self, Transaction, UnminedTx, UnminedTxId};
 use zebra_consensus::error::TransactionError;
 
 use super::MempoolError;
@@ -21,17 +18,10 @@ const MEMPOOL_SIZE: usize = 2;
 pub enum State {
     /// Rejected because verification failed.
     Invalid(TransactionError),
-    /// An otherwise valid mempool transaction was mined into a block, therefore
-    /// no longer belongs in the mempool.
-    Confirmed(block::Hash),
     /// Rejected because it has a spend conflict with another transaction already in the mempool.
     SpendConflict,
     /// Stayed in mempool for too long without being mined.
-    // TODO(2021-09-09): Implement ZIP-203: Validate Transaction Expiry Height.
-    // TODO(2021-09-09): https://github.com/ZcashFoundation/zebra/issues/2387
     Expired,
-    /// Transaction fee is too low for the current mempool state.
-    LowFee,
     /// Otherwise valid transaction removed from mempool, say because of FIFO
     /// (first in, first out) policy.
     Excess,
@@ -59,9 +49,7 @@ impl Storage {
             return Err(match self.rejected.get(&tx.id).unwrap() {
                 State::Invalid(e) => MempoolError::Invalid(e.clone()),
                 State::Expired => MempoolError::Expired,
-                State::Confirmed(block_hash) => MempoolError::InBlock(*block_hash),
                 State::Excess => MempoolError::Excess,
-                State::LowFee => MempoolError::LowFee,
                 State::SpendConflict => MempoolError::SpendConflict,
             });
         }

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -11,6 +11,8 @@ use zebra_chain::{
     transparent, LedgerState,
 };
 
+use crate::components::mempool::storage::StorageRejectionError;
+
 use super::super::{MempoolError, Storage};
 
 proptest! {
@@ -40,7 +42,7 @@ proptest! {
 
             assert_eq!(
                 storage.insert(transaction_to_reject),
-                Err(MempoolError::Rejected)
+                Err(MempoolError::Storage(StorageRejectionError::SpendConflict))
             );
 
             assert!(storage.contains_rejected(&id_to_reject));

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -229,7 +229,7 @@ async fn mempool_queue() -> Result<(), Report> {
         _ => unreachable!("will never happen in this test"),
     };
     assert_eq!(queued_responses.len(), 1);
-    assert_eq!(queued_responses[0], Err(MempoolError::Rejected));
+    assert_eq!(queued_responses[0], Err(MempoolError::Storage(StorageRejectionError::RandomlyEvicted)));
 
     Ok(())
 }

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -229,7 +229,12 @@ async fn mempool_queue() -> Result<(), Report> {
         _ => unreachable!("will never happen in this test"),
     };
     assert_eq!(queued_responses.len(), 1);
-    assert_eq!(queued_responses[0], Err(MempoolError::Storage(StorageRejectionError::RandomlyEvicted)));
+    assert_eq!(
+        queued_responses[0],
+        Err(MempoolError::Storage(
+            StorageRejectionError::RandomlyEvicted
+        ))
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

Removing these errors means that we don't have to decide which type of transaction ID match we want for them.

Preparation for ticket #2819.

## Solution

- Remove unused mempool storage errors
- Remove unused mempool errors
- Deduplicate mempool and mempool storage errors

(I kept some that we'll be using soon in other tickets.)

We can restore the removed errors in future PRs if we need them.

## Review

@upbqdn might want to review this PR.

This PR is based on PR #2827, it might need a rebase after that PR merges.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Actually implement #2819