### PR TITLE
Make block metrics more accurate

### DIFF
--- a/grafana/block_verification.json
+++ b/grafana/block_verification.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 1,
-  "iteration": 1633496074821,
+  "iteration": 1633497866311,
   "links": [],
   "panels": [
     {
@@ -25,6 +25,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "decimals": 6,
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -40,13 +41,16 @@
       "hiddenSeries": false,
       "id": 4,
       "legend": {
+        "alignAsTable": false,
         "avg": false,
-        "current": false,
+        "current": true,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
+        "sideWidth": null,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -153,6 +157,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "decimals": 6,
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -168,13 +173,16 @@
       "hiddenSeries": false,
       "id": 6,
       "legend": {
+        "alignAsTable": false,
         "avg": false,
-        "current": false,
+        "current": true,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
+        "sideWidth": null,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -187,7 +195,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1633496074821,
+      "repeatIteration": 1633497866311,
       "repeatPanelId": 4,
       "scopedVars": {
         "job": {
@@ -439,7 +447,7 @@
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1633496074821,
+      "repeatIteration": 1633497866311,
       "repeatPanelId": 5,
       "scopedVars": {
         "job": {
@@ -684,7 +692,7 @@
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1633496074821,
+      "repeatIteration": 1633497866311,
       "repeatPanelId": 2,
       "scopedVars": {
         "job": {
@@ -818,5 +826,5 @@
   "timezone": "",
   "title": "block verification",
   "uid": "rO_Cl5tGz",
-  "version": 5
+  "version": 8
 }

--- a/grafana/block_verification.json
+++ b/grafana/block_verification.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 5,
-  "iteration": 1614572681383,
+  "id": 1,
+  "iteration": 1633496074821,
   "links": [],
   "panels": [
     {
@@ -26,9 +26,7 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -57,7 +55,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -75,17 +73,42 @@
       "steppedLine": false,
       "targets": [
         {
+          "exemplar": true,
           "expr": "zcash_chain_verified_block_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "verified block height",
+          "legendFormat": "committed block height",
           "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_full_verifier_committed_block_height{job=\"$job\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "full block verifier height",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_checkpoint_finalized_block_height{job=\"$job\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "checkpoint verifier height",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_finalized_block_height{job=\"$job\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "finalized block height",
+          "refId": "D"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Block Verifier Block Height - $job",
+      "title": "Verified Block Height - $job",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -101,6 +124,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:84",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -109,6 +133,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:85",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -129,9 +154,7 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -160,11 +183,11 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1614572681383,
+      "repeatIteration": 1633496074821,
       "repeatPanelId": 4,
       "scopedVars": {
         "job": {
@@ -179,17 +202,42 @@
       "steppedLine": false,
       "targets": [
         {
+          "exemplar": true,
           "expr": "zcash_chain_verified_block_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "verified block height",
+          "legendFormat": "committed block height",
           "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_full_verifier_committed_block_height{job=\"$job\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "full block verifier height",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_checkpoint_finalized_block_height{job=\"$job\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "checkpoint verifier height",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_finalized_block_height{job=\"$job\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "finalized block height",
+          "refId": "D"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Block Verifier Block Height - $job",
+      "title": "Verified Block Height - $job",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -205,6 +253,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:84",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -213,6 +262,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:85",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -233,9 +283,7 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -264,7 +312,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -311,7 +359,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Block Verifier Sync Count - $job",
+      "title": "Block Sync Count - $job",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -327,6 +375,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:167",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -335,6 +384,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:168",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -355,9 +405,7 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -386,12 +434,12 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1614572681383,
+      "repeatIteration": 1633496074821,
       "repeatPanelId": 5,
       "scopedVars": {
         "job": {
@@ -434,7 +482,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Block Verifier Sync Count - $job",
+      "title": "Block Sync Count - $job",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -450,6 +498,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:167",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -458,6 +507,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:168",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -478,9 +528,7 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -509,7 +557,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -556,7 +604,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Block Verifier Gossip Count - $job",
+      "title": "Block Gossip Count - $job",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -572,6 +620,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:252",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -580,6 +629,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:253",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -600,9 +650,7 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -631,12 +679,12 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1614572681383,
+      "repeatIteration": 1633496074821,
       "repeatPanelId": 2,
       "scopedVars": {
         "job": {
@@ -679,7 +727,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Block Verifier Gossip Count - $job",
+      "title": "Block Gossip Count - $job",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -695,6 +743,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:252",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -703,6 +752,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:253",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -718,7 +768,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -726,7 +776,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "All"
           ],
@@ -736,13 +786,18 @@
         },
         "datasource": "Prometheus-Zebra",
         "definition": "label_values(zcash_chain_verified_block_height, job)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "job",
         "options": [],
-        "query": "label_values(zcash_chain_verified_block_height, job)",
+        "query": {
+          "query": "label_values(zcash_chain_verified_block_height, job)",
+          "refId": "Prometheus-Zebra-job-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -763,5 +818,5 @@
   "timezone": "",
   "title": "block verification",
   "uid": "rO_Cl5tGz",
-  "version": 19
+  "version": 5
 }

--- a/grafana/block_verification.json
+++ b/grafana/block_verification.json
@@ -138,7 +138,7 @@
         },
         {
           "$$hashKey": "object:85",
-          "format": "short",
+          "format": "none",
           "label": null,
           "logBase": 1,
           "max": null,

--- a/grafana/block_verification.json
+++ b/grafana/block_verification.json
@@ -129,7 +129,7 @@
       "yaxes": [
         {
           "$$hashKey": "object:84",
-          "format": "short",
+          "format": "none",
           "label": null,
           "logBase": 1,
           "max": null,

--- a/grafana/block_verification.json
+++ b/grafana/block_verification.json
@@ -25,7 +25,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "decimals": 6,
+      "decimals": 0,
       "fieldConfig": {
         "defaults": {},
         "overrides": []

--- a/grafana/checkpoint_verification.json
+++ b/grafana/checkpoint_verification.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 2,
-  "iteration": 1633492869106,
+  "iteration": 1633497830198,
   "links": [],
   "panels": [
     {
@@ -25,6 +25,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "decimals": 6,
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -41,12 +42,13 @@
       "id": 2,
       "legend": {
         "avg": false,
-        "current": false,
+        "current": true,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -161,6 +163,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "decimals": 6,
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -177,12 +180,13 @@
       "id": 9,
       "legend": {
         "avg": false,
-        "current": false,
+        "current": true,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -196,7 +200,7 @@
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1633492869106,
+      "repeatIteration": 1633497830198,
       "repeatPanelId": 2,
       "scopedVars": {
         "job": {
@@ -235,13 +239,15 @@
           "refId": "D"
         },
         {
-          "expr": "state_finalized_committed_block_height{job=\"$job\"}",
+          "exemplar": true,
+          "expr": "state_checkpoint_committed_block_height{job=\"$job\"}",
           "interval": "",
           "legendFormat": "state_finalized_committed_block_height",
           "refId": "E"
         },
         {
-          "expr": "state_finalized_queued_max_height{job=\"$job\"}",
+          "exemplar": true,
+          "expr": "state_checkpoint_queued_max_height{job=\"$job\"}",
           "interval": "",
           "legendFormat": "state_finalized_queued_max_height",
           "refId": "F"
@@ -267,6 +273,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:84",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -275,6 +282,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:85",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -452,7 +460,7 @@
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1633492869106,
+      "repeatIteration": 1633497830198,
       "repeatPanelId": 8,
       "scopedVars": {
         "job": {
@@ -473,7 +481,8 @@
           "refId": "A"
         },
         {
-          "expr": "rate(state_finalized_committed_block_count[1s])",
+          "exemplar": true,
+          "expr": "rate(state_checkpoint_committed_block_count[1s])",
           "interval": "",
           "legendFormat": "state commit rate [1s]",
           "refId": "C"
@@ -511,6 +520,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:252",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -519,6 +529,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:253",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -720,7 +731,7 @@
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1633492869106,
+      "repeatIteration": 1633497830198,
       "repeatPanelId": 4,
       "scopedVars": {
         "job": {
@@ -741,7 +752,8 @@
           "refId": "A"
         },
         {
-          "expr": "state_finalized_queued_block_count{job=\"$job\"}",
+          "exemplar": true,
+          "expr": "state_checkpoint_queued_block_count{job=\"$job\"}",
           "interval": "",
           "legendFormat": "state_finalized_queued_block_count",
           "refId": "B"
@@ -803,6 +815,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:337",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -811,6 +824,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:338",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -889,5 +903,5 @@
   "timezone": "",
   "title": "checkpoint verification",
   "uid": "o4LmN_OMk",
-  "version": 2
+  "version": 4
 }

--- a/grafana/checkpoint_verification.json
+++ b/grafana/checkpoint_verification.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 3,
-  "iteration": 1614572686856,
+  "id": 2,
+  "iteration": 1633492869106,
   "links": [],
   "panels": [
     {
@@ -26,9 +26,7 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -57,7 +55,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -100,13 +98,15 @@
           "refId": "D"
         },
         {
-          "expr": "state_finalized_committed_block_height{job=\"$job\"}",
+          "exemplar": true,
+          "expr": "state_checkpoint_committed_block_height{job=\"$job\"}",
           "interval": "",
           "legendFormat": "state_finalized_committed_block_height",
           "refId": "E"
         },
         {
-          "expr": "state_finalized_queued_max_height{job=\"$job\"}",
+          "exemplar": true,
+          "expr": "state_checkpoint_queued_max_height{job=\"$job\"}",
           "interval": "",
           "legendFormat": "state_finalized_queued_max_height",
           "refId": "F"
@@ -132,6 +132,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:84",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -140,6 +141,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:85",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -160,9 +162,7 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -191,12 +191,12 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1614572686856,
+      "repeatIteration": 1633492869106,
       "repeatPanelId": 2,
       "scopedVars": {
         "job": {
@@ -295,9 +295,7 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -326,7 +324,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -351,7 +349,8 @@
           "refId": "A"
         },
         {
-          "expr": "rate(state_finalized_committed_block_count[1s])",
+          "exemplar": true,
+          "expr": "rate(state_checkpoint_committed_block_count[1s])",
           "interval": "",
           "legendFormat": "state commit rate [1s]",
           "refId": "C"
@@ -389,6 +388,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:252",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -397,6 +397,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:253",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -417,9 +418,7 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -448,12 +447,12 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1614572686856,
+      "repeatIteration": 1633492869106,
       "repeatPanelId": 8,
       "scopedVars": {
         "job": {
@@ -540,9 +539,7 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -571,7 +568,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -596,7 +593,8 @@
           "refId": "A"
         },
         {
-          "expr": "state_finalized_queued_block_count{job=\"$job\"}",
+          "exemplar": true,
+          "expr": "state_checkpoint_queued_block_count{job=\"$job\"}",
           "interval": "",
           "legendFormat": "state_finalized_queued_block_count",
           "refId": "B"
@@ -658,6 +656,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:337",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -666,6 +665,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:338",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -686,9 +686,7 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -717,12 +715,12 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1614572686856,
+      "repeatIteration": 1633492869106,
       "repeatPanelId": 4,
       "scopedVars": {
         "job": {
@@ -828,7 +826,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -836,7 +834,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "All"
           ],
@@ -846,13 +844,18 @@
         },
         "datasource": "Prometheus-Zebra",
         "definition": "label_values(sync_prospective_tips_len, job)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "job",
         "options": [],
-        "query": "label_values(sync_prospective_tips_len, job)",
+        "query": {
+          "query": "label_values(sync_prospective_tips_len, job)",
+          "refId": "Prometheus-Zebra-job-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -886,5 +889,5 @@
   "timezone": "",
   "title": "checkpoint verification",
   "uid": "o4LmN_OMk",
-  "version": 42
+  "version": 2
 }

--- a/grafana/checkpoint_verification.json
+++ b/grafana/checkpoint_verification.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 2,
-  "iteration": 1633497830198,
+  "iteration": 1633574016226,
   "links": [],
   "panels": [
     {
@@ -25,7 +25,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "decimals": 6,
+      "decimals": null,
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -135,7 +135,7 @@
       "yaxes": [
         {
           "$$hashKey": "object:84",
-          "format": "short",
+          "format": "none",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -144,7 +144,7 @@
         },
         {
           "$$hashKey": "object:85",
-          "format": "short",
+          "format": "none",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -163,7 +163,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "decimals": 6,
+      "decimals": null,
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -200,7 +200,7 @@
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1633497830198,
+      "repeatIteration": 1633574016226,
       "repeatPanelId": 2,
       "scopedVars": {
         "job": {
@@ -274,7 +274,7 @@
       "yaxes": [
         {
           "$$hashKey": "object:84",
-          "format": "short",
+          "format": "none",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -283,7 +283,7 @@
         },
         {
           "$$hashKey": "object:85",
-          "format": "short",
+          "format": "none",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -460,7 +460,7 @@
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1633497830198,
+      "repeatIteration": 1633574016226,
       "repeatPanelId": 8,
       "scopedVars": {
         "job": {
@@ -731,7 +731,7 @@
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1633497830198,
+      "repeatIteration": 1633574016226,
       "repeatPanelId": 4,
       "scopedVars": {
         "job": {
@@ -903,5 +903,5 @@
   "timezone": "",
   "title": "checkpoint verification",
   "uid": "o4LmN_OMk",
-  "version": 4
+  "version": 6
 }

--- a/grafana/syncer.json
+++ b/grafana/syncer.json
@@ -17,7 +17,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 5,
-  "iteration": 1628659147689,
+  "iteration": 1633496321106,
   "links": [],
   "panels": [
     {
@@ -172,7 +172,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1628659147689,
+      "repeatIteration": 1633496321106,
       "repeatPanelId": 2,
       "scopedVars": {
         "job": {
@@ -363,7 +363,7 @@
         "show": false
       },
       "pluginVersion": "7.5.7",
-      "repeatIteration": 1628659147689,
+      "repeatIteration": 1633496321106,
       "repeatPanelId": 4,
       "reverseYBuckets": false,
       "scopedVars": {
@@ -602,7 +602,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1628659147689,
+      "repeatIteration": 1633496321106,
       "repeatPanelId": 7,
       "scopedVars": {
         "job": {
@@ -757,7 +757,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Syncer",
+  "title": "syncer",
   "uid": "Sl3h19Gnk",
-  "version": 9
+  "version": 11
 }

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -198,11 +198,6 @@ where
                     .map_err(VerifyBlockError::Transaction)?;
             }
 
-            // Update the metrics after all the validation is finished
-            tracing::trace!("verified block");
-            metrics::gauge!("zcash.chain.verified.block.height", height.0 as _);
-            metrics::counter!("zcash.chain.verified.block.total", 1);
-
             let new_outputs = Arc::try_unwrap(known_utxos)
                 .expect("all verification tasks using known_utxos are complete");
 

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -220,6 +220,7 @@ where
                 zs::Response::Committed(committed_hash) => {
                     assert_eq!(committed_hash, hash, "state must commit correct hash");
 
+                    // Update the metrics if semantic and contextual validation passes
                     metrics::counter!("state.full_verifier.committed.block.count", 1);
                     metrics::gauge!("state.full_verifier.committed.block.height", height.0 as _);
 

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -219,11 +219,6 @@ where
             {
                 zs::Response::Committed(committed_hash) => {
                     assert_eq!(committed_hash, hash, "state must commit correct hash");
-
-                    // Update the metrics if semantic and contextual validation passes
-                    metrics::counter!("state.full_verifier.committed.block.count", 1);
-                    metrics::gauge!("state.full_verifier.committed.block.height", height.0 as _);
-
                     Ok(hash)
                 }
                 _ => unreachable!("wrong response for CommitBlock"),

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -219,6 +219,10 @@ where
             {
                 zs::Response::Committed(committed_hash) => {
                     assert_eq!(committed_hash, hash, "state must commit correct hash");
+
+                    metrics::counter!("state.full_verifier.committed.block.count", 1);
+                    metrics::gauge!("state.full_verifier.committed.block.height", height.0 as _);
+
                     Ok(hash)
                 }
                 _ => unreachable!("wrong response for CommitBlock"),

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -131,9 +131,7 @@ where
     }
 
     fn call(&mut self, block: Arc<Block>) -> Self::Future {
-        let height = block.coinbase_height();
-
-        let result = match height {
+        match block.coinbase_height() {
             Some(height) if height <= self.max_checkpoint_height => self
                 .checkpoint
                 .call(block)
@@ -146,18 +144,7 @@ where
                 .call(block)
                 .map_err(VerifyChainError::Block)
                 .boxed(),
-        };
-
-        // Update the metrics if semantic and contextual validation passes
-        result
-            .inspect_ok(move |_| {
-                let height = height.expect("unexpected valid block with no coinbase height");
-
-                tracing::trace!(?height, "verified block");
-                metrics::gauge!("zcash.chain.verified.block.height", height.0 as _);
-                metrics::counter!("zcash.chain.verified.block.total", 1);
-            })
-            .boxed()
+        }
     }
 }
 

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -480,6 +480,12 @@ impl FinalizedState {
                 finalized.height.0 as _
             );
 
+            // This height gauge is updated for both fully verified and checkpoint blocks.
+            // These updates can't conflict, because the state makes sure that blocks
+            // are committed in order.
+            metrics::gauge!("zcash.chain.verified.block.height", finalized.height.0 as _);
+            metrics::counter!("zcash.chain.verified.block.total", 1);
+
             block_result = Ok(finalized);
         } else {
             metrics::counter!("state.checkpoint.error.block.count", 1);

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -180,7 +180,7 @@ impl FinalizedState {
             self.max_queued_height = height.0 as _;
         }
 
-        metrics::gauge!("state.checkoint.queued.max.height", self.max_queued_height);
+        metrics::gauge!("state.checkpoint.queued.max.height", self.max_queued_height);
         metrics::gauge!(
             "state.checkpoint.queued.block.count",
             self.queued_by_prev_hash.len() as f64

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -180,9 +180,9 @@ impl FinalizedState {
             self.max_queued_height = height.0 as _;
         }
 
-        metrics::gauge!("state.finalized.queued.max.height", self.max_queued_height);
+        metrics::gauge!("state.checkoint.queued.max.height", self.max_queued_height);
         metrics::gauge!(
-            "state.finalized.queued.block.count",
+            "state.checkpoint.queued.block.count",
             self.queued_by_prev_hash.len() as f64
         );
 
@@ -474,17 +474,17 @@ impl FinalizedState {
 
         let block_result;
         if result.is_ok() {
-            metrics::counter!("state.finalized.committed.block.count", 1);
+            metrics::counter!("state.checkpoint.finalized.block.count", 1);
             metrics::gauge!(
-                "state.finalized.committed.block.height",
+                "state.checkpoint.finalized.block.height",
                 finalized.height.0 as _
             );
 
             block_result = Ok(finalized);
         } else {
-            metrics::counter!("state.finalized.error.block.count", 1);
+            metrics::counter!("state.checkpoint.error.block.count", 1);
             metrics::gauge!(
-                "state.finalized.error.block.height",
+                "state.checkpoint.error.block.height",
                 finalized.height.0 as _
             );
 
@@ -722,6 +722,10 @@ fn block_precommit_metrics(block: &Block, hash: block::Hash, height: block::Heig
         orchard_nullifier_count,
         "preparing to commit finalized block"
     );
+
+    metrics::counter!("state.finalized.block.count", 1);
+    metrics::gauge!("state.finalized.block.height", height.0 as _);
+
     metrics::counter!(
         "state.finalized.cumulative.transactions",
         transaction_count as u64


### PR DESCRIPTION
## Motivation

Some of our block metrics names were very confusing.
And some block metrics were updated, even if the block failed contextual validation.

Closes #2832.

## Solution

Error handling:
- Check for contextual validation success before updating metrics

Metrics bug fixes:
- Make the generic zcash block metrics apply to all blocks
- Update the metrics in the state, so that they are always based on the most recent block

New and renamed metrics:
- Add metrics for Zebra full block verification
- Add metrics for all finalized blocks
- Rename checkpoint-specific metrics to clarify their meaning
- Update metric names in dashboards

Dashboard improvements:
- Add the new block metrics to the block verification dashboard
- Add exact block heights to Grafana dashboards

## Review

@conradoplg opened the ticket.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

