### PR TITLE
Rename mempool storage methods by match type

### DIFF
--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -184,7 +184,7 @@ impl Mempool {
         if storage.contains_transaction_exact(&txid) {
             return Err(MempoolError::InMempool);
         }
-        if let Some(error) = storage.rejection_error(&txid) {
+        if let Some(error) = storage.rejection_error_exact(&txid) {
             return Err(error);
         }
         Ok(())
@@ -266,9 +266,8 @@ impl Service<Request> for Mempool {
                     async move { Ok(Response::Transactions(res)) }.boxed()
                 }
                 Request::RejectedTransactionIds(ids) => {
-                    let rsp = Ok(storage.rejected_transactions(ids))
-                        .map(Response::RejectedTransactionIds);
-                    async move { rsp }.boxed()
+                    let res = storage.rejected_transactions_exact(ids).collect();
+                    async move { Ok(Response::RejectedTransactionIds(res)) }.boxed()
                 }
                 Request::Queue(gossiped_txs) => {
                     let rsp: Vec<Result<(), MempoolError>> = gossiped_txs

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -184,7 +184,7 @@ impl Mempool {
         if storage.contains_transaction_exact(&txid) {
             return Err(MempoolError::InMempool);
         }
-        if let Some(error) = storage.rejection_error_exact(&txid) {
+        if let Some(error) = storage.rejection_error(&txid) {
             return Err(error);
         }
         Ok(())
@@ -266,7 +266,7 @@ impl Service<Request> for Mempool {
                     async move { Ok(Response::Transactions(res)) }.boxed()
                 }
                 Request::RejectedTransactionIds(ids) => {
-                    let res = storage.rejected_transactions_exact(ids).collect();
+                    let res = storage.rejected_transactions(ids).collect();
                     async move { Ok(Response::RejectedTransactionIds(res)) }.boxed()
                 }
                 Request::Queue(gossiped_txs) => {

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -78,7 +78,7 @@ impl Storage {
         let tx_id = tx.id;
 
         // First, check if we have a cached rejection for this transaction.
-        if let Some(error) = self.rejection_error_exact(&tx.id) {
+        if let Some(error) = self.rejection_error(&tx.id) {
             return Err(error);
         }
 
@@ -214,11 +214,11 @@ impl Storage {
         self.rejected_exact.len() + self.rejected_same_effects.len()
     }
 
-    /// Returns `true` if a [`UnminedTx`] exactly matching an [`UnminedTxId`] is in
-    /// the mempool rejected list.
+    /// Returns `true` if a [`UnminedTx`] matching an [`UnminedTxId`] is in
+    /// any mempool rejected list.
     ///
-    /// This matches the exact transaction, with identical blockchain effects, signatures, and proofs.
-    pub fn rejection_error_exact(&self, txid: &UnminedTxId) -> Option<MempoolError> {
+    /// This matches transactions based on each rejection list's matching rule.
+    pub fn rejection_error(&self, txid: &UnminedTxId) -> Option<MempoolError> {
         if let Some(exact_error) = self.rejected_exact.get(txid) {
             return Some(exact_error.clone().into());
         }
@@ -230,23 +230,23 @@ impl Storage {
         None
     }
 
-    /// Returns the set of [`UnminedTxId`]s exactly matching ids in the rejected list.
+    /// Returns the set of [`UnminedTxId`]s matching `tx_ids` in the rejected list.
     ///
-    /// This matches the exact transaction, with identical blockchain effects, signatures, and proofs.
-    pub fn rejected_transactions_exact(
+    /// This matches transactions based on each rejection list's matching rule.
+    pub fn rejected_transactions(
         &self,
         tx_ids: HashSet<UnminedTxId>,
     ) -> impl Iterator<Item = UnminedTxId> + '_ {
         tx_ids
             .into_iter()
-            .filter(move |txid| self.contains_rejected_exact(txid))
+            .filter(move |txid| self.contains_rejected(txid))
     }
 
-    /// Returns `true` if a [`UnminedTx`] exactly matching the supplied [`UnminedTxId`] is in
+    /// Returns `true` if a [`UnminedTx`] matching the supplied [`UnminedTxId`] is in
     /// the mempool rejected list.
     ///
-    /// This matches the exact transaction, with identical blockchain effects, signatures, and proofs.
-    pub fn contains_rejected_exact(&self, txid: &UnminedTxId) -> bool {
+    /// This matches transactions based on each rejection list's matching rule.
+    pub fn contains_rejected(&self, txid: &UnminedTxId) -> bool {
         self.rejected_exact.contains_key(txid)
             || self.rejected_same_effects.contains_key(&txid.mined_id())
     }

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -45,7 +45,7 @@ proptest! {
                 Err(MempoolError::StorageEffects(SameEffectsRejectionError::SpendConflict))
             );
 
-            assert!(storage.contains_rejected_exact(&id_to_reject));
+            assert!(storage.contains_rejected(&id_to_reject));
 
             storage.clear();
         }

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -45,7 +45,7 @@ proptest! {
                 Err(MempoolError::StorageEffects(SameEffectsRejectionError::SpendConflict))
             );
 
-            assert!(storage.contains_rejected(&id_to_reject));
+            assert!(storage.contains_rejected_exact(&id_to_reject));
 
             storage.clear();
         }

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -24,14 +24,14 @@ fn mempool_storage_crud_exact_mainnet() {
     let _ = storage.insert(unmined_tx.clone());
 
     // Check that it is in the mempool, and not rejected.
-    assert!(storage.contains(&unmined_tx.id));
+    assert!(storage.contains_transaction_exact(&unmined_tx.id));
 
     // Remove tx
     let removal_count = storage.remove_exact(&iter::once(unmined_tx.id).collect());
 
     // Check that it is /not/ in the mempool.
     assert_eq!(removal_count, 1);
-    assert!(!storage.contains(&unmined_tx.id));
+    assert!(!storage.contains_transaction_exact(&unmined_tx.id));
 }
 
 #[test]
@@ -52,7 +52,7 @@ fn mempool_storage_crud_same_effects_mainnet() {
     let _ = storage.insert(unmined_tx.clone());
 
     // Check that it is in the mempool, and not rejected.
-    assert!(storage.contains(&unmined_tx.id));
+    assert!(storage.contains_transaction_exact(&unmined_tx.id));
 
     // Remove tx
     let removal_count =
@@ -60,7 +60,7 @@ fn mempool_storage_crud_same_effects_mainnet() {
 
     // Check that it is /not/ in the mempool.
     assert_eq!(removal_count, 1);
-    assert!(!storage.contains(&unmined_tx.id));
+    assert!(!storage.contains_transaction_exact(&unmined_tx.id));
 }
 
 #[test]
@@ -103,12 +103,12 @@ fn mempool_storage_basic_for_network(network: Network) -> Result<()> {
 
     // Make sure the last MEMPOOL_SIZE transactions we sent are in the verified
     for tx in expected_in_mempool {
-        assert!(storage.contains(&tx.id));
+        assert!(storage.contains_transaction_exact(&tx.id));
     }
 
     // Anything greater should not be in the verified
     for tx in expected_to_be_rejected {
-        assert!(!storage.contains(&tx.id));
+        assert!(!storage.contains_transaction_exact(&tx.id));
     }
 
     // Query all the ids we have for rejected, get back `total - MEMPOOL_SIZE`

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -115,19 +115,17 @@ fn mempool_storage_basic_for_network(network: Network) -> Result<()> {
     let all_ids: HashSet<UnminedTxId> = unmined_transactions.iter().map(|tx| tx.id).collect();
 
     // Convert response to a `HashSet`, because the order of the response doesn't matter.
-    let rejected_response: HashSet<UnminedTxId> = storage
-        .rejected_transactions_exact(all_ids)
-        .into_iter()
-        .collect();
+    let rejected_response: HashSet<UnminedTxId> =
+        storage.rejected_transactions(all_ids).into_iter().collect();
 
     let rejected_ids = expected_to_be_rejected.iter().map(|tx| tx.id).collect();
 
     assert_eq!(rejected_response, rejected_ids);
 
     // Make sure the first id stored is now rejected
-    assert!(storage.contains_rejected_exact(&expected_to_be_rejected[0].id));
+    assert!(storage.contains_rejected(&expected_to_be_rejected[0].id));
     // Make sure the last id stored is not rejected
-    assert!(!storage.contains_rejected_exact(&expected_in_mempool[0].id));
+    assert!(!storage.contains_rejected(&expected_in_mempool[0].id));
 
     Ok(())
 }

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -114,18 +114,20 @@ fn mempool_storage_basic_for_network(network: Network) -> Result<()> {
     // Query all the ids we have for rejected, get back `total - MEMPOOL_SIZE`
     let all_ids: HashSet<UnminedTxId> = unmined_transactions.iter().map(|tx| tx.id).collect();
 
-    // Convert response to a `HashSet` as we need a fixed order to compare.
-    let rejected_response: HashSet<UnminedTxId> =
-        storage.rejected_transactions(all_ids).into_iter().collect();
+    // Convert response to a `HashSet`, because the order of the response doesn't matter.
+    let rejected_response: HashSet<UnminedTxId> = storage
+        .rejected_transactions_exact(all_ids)
+        .into_iter()
+        .collect();
 
     let rejected_ids = expected_to_be_rejected.iter().map(|tx| tx.id).collect();
 
     assert_eq!(rejected_response, rejected_ids);
 
-    // Use `contains_rejected` to make sure the first id stored is now rejected
-    assert!(storage.contains_rejected(&expected_to_be_rejected[0].id));
-    // Use `contains_rejected` to make sure the last id stored is not rejected
-    assert!(!storage.contains_rejected(&expected_in_mempool[0].id));
+    // Make sure the first id stored is now rejected
+    assert!(storage.contains_rejected_exact(&expected_to_be_rejected[0].id));
+    // Make sure the last id stored is not rejected
+    assert!(!storage.contains_rejected_exact(&expected_in_mempool[0].id));
 
     Ok(())
 }

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -57,7 +57,7 @@ proptest! {
             // The first call to `poll_ready` shouldn't clear the storage yet.
             mempool.dummy_call().await;
 
-            prop_assert_eq!(mempool.storage().tx_ids().len(), 1);
+            prop_assert_eq!(mempool.storage().transaction_count(), 1);
 
             // Simulate a chain reset.
             chain_tip_sender.set_finalized_tip(chain_tip);
@@ -65,7 +65,7 @@ proptest! {
             // This time a call to `poll_ready` should clear the storage.
             mempool.dummy_call().await;
 
-            prop_assert!(mempool.storage().tx_ids().is_empty());
+            prop_assert_eq!(mempool.storage().transaction_count(), 0);
 
             peer_set.expect_no_requests().await?;
             state_service.expect_no_requests().await?;
@@ -110,7 +110,7 @@ proptest! {
             // The first call to `poll_ready` shouldn't clear the storage yet.
             mempool.dummy_call().await;
 
-            prop_assert_eq!(mempool.storage().tx_ids().len(), 1);
+            prop_assert_eq!(mempool.storage().transaction_count(), 1);
 
             // Simulate the synchronizer catching up to the network chain tip.
             mempool.disable(&mut recent_syncs).await;
@@ -121,7 +121,7 @@ proptest! {
             // Enable the mempool again so the storage can be accessed.
             mempool.enable(&mut recent_syncs).await;
 
-            prop_assert!(mempool.storage().tx_ids().is_empty());
+            prop_assert_eq!(mempool.storage().transaction_count(), 0);
 
             peer_set.expect_no_requests().await?;
             state_service.expect_no_requests().await?;


### PR DESCRIPTION
## Motivation

1. Some mempool method names are ambiguous - we need to be clear which part of the ID we're matching as part of tickets #2819 and #2834
2. Some mempool methods return a cloned vector, when they could just return an iterator

## Solution

- rename mempool methods to specify all items or exact WTXID matching
- return `impl Iterator` where possible

## Review

@conradoplg suggested the `impl Iterator` optimisation.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [x] Tests for Expected Behaviour
  - [ ] Tests for Errors
