### PR TITLE
Stop panicking when pruning unused queued blocks

### DIFF
--- a/zebra-state/src/service/non_finalized_state/queued_blocks.rs
+++ b/zebra-state/src/service/non_finalized_state/queued_blocks.rs
@@ -111,6 +111,11 @@ impl QueuedBlocks {
                 self.blocks.remove(&hash).expect("block is present");
             let parent_hash = &expired_block.block.header.previous_block_hash;
 
+            // we don't care if the receiver was dropped
+            let _ = expired_sender.send(Err(
+                "pruned block at or below the finalized tip height".into()
+            ));
+
             // TODO: only remove UTXOs if there are no queued blocks with that UTXO
             //       (known_utxos is best-effort, so this is ok for now)
             for outpoint in expired_block.new_outputs.keys() {


### PR DESCRIPTION
## Motivation

1. When Zebra prunes queued blocks, it drops their senders without sending a response. This caused a panic in one Zebra testnet node, shortly after NU5 activation.

2. When Zebra prunes queued blocks, it doesn't remove their known UTXOs.

This is unexpected work in Sprint 20.

### Logs

The panic happens when the `CommitBlock` future checks for a response on its oneshot receiver.

<details>

```
Oct 06 22:10:10.960  INFO {zebrad="339fefb" net="Test"}:crawl_and_dial{crawl_new_peer_interval=60s}: zebra_network::peer_set::candidate_set: timeout waiting for the peer service to become rea
dy                                                                                                                                                                                             
Oct 06 22:10:28.037  INFO {zebrad="339fefb" net="Test"}:sync:obtain_tips: zebra_network::peer_set::set: network request with no ready peers: finding more peers, waiting for 13 peers to answer
 requests address_metrics=AddressMetrics { responded: 13, never_attempted_gossiped: 0, never_attempted_alternate: 0, failed: 546, attempt_pending: 49, recently_live: 13, recently_stopped_resp
onding: 0 }                                                                                                                                                                                    
Oct 06 22:10:41.680  INFO {zebrad="339fefb" net="Test"}:crawl_and_dial{crawl_new_peer_interval=60s}: zebra_network::peer_set::candidate_set: timeout waiting for the peer service to become rea
dy                                                                                                                                                                                             
The application panicked (crashed).                                                                                                                                                            
Message:  sender is not dropped: RecvError(())                                                                                                                                                 
Location: zebra-state/src/service.rs:694                                                                                                                                                       
                                                                                                                                                                                               
Metadata:                                                                                                                                                                                      
version: 1.0.0-alpha.17+39.g339fefb                                                                                                                                                            
Zcash network: Testnet                                                                                                                                                                         
state version: 10                                                                                                                                                                              
branch: main
git commit: 339fefb                            
commit timestamp: 2021-10-06T01:08:41+00:00
target triple: x86_64-unknown-linux-gnu
build profile: release
```

</details>

## Solution

- Send an error on pruned queued blocks
- Remove known UTXOs from pruned queued blocks
  - Add tests for UTXO removal

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [x] Tests for Expected Behaviour
  - [ ] Tests for Errors

