### PR TITLE
Reject a mempool transaction if it has internal spend conflicts

### DIFF
--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -7,6 +7,8 @@
 
 use thiserror::Error;
 
+use zebra_chain::{orchard, sapling, sprout, transparent};
+
 use crate::BoxError;
 
 #[cfg(any(test, feature = "proptest-impl"))]
@@ -102,6 +104,18 @@ pub enum TransactionError {
 
     #[error("could not calculate the transaction fee")]
     IncorrectFee,
+
+    #[error("transparent double-spend: {_0:?} is spent twice")]
+    DuplicateTransparentSpend(transparent::OutPoint),
+
+    #[error("sprout double-spend: duplicate nullifier: {_0:?}")]
+    DuplicateSproutNullifier(sprout::Nullifier),
+
+    #[error("sapling double-spend: duplicate nullifier: {_0:?}")]
+    DuplicateSaplingNullifier(sapling::Nullifier),
+
+    #[error("orchard double-spend: duplicate nullifier: {_0:?}")]
+    DuplicateOrchardNullifier(orchard::Nullifier),
 }
 
 impl From<BoxError> for TransactionError {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -277,6 +277,8 @@ where
             // https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc
             check::disabled_add_to_sprout_pool(&tx, req.height(), network)?;
 
+            check::spend_conflicts(&tx)?;
+
             // "The consensus rules applied to valueBalance, vShieldedOutput, and bindingSig
             // in non-coinbase transactions MUST also be applied to coinbase transactions."
             //

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -141,7 +141,14 @@ pub fn disabled_add_to_sprout_pool(
 /// An internal spend conflict happens if the transaction spends a UTXO more than once or if it
 /// reveals a nullifier more than once.
 ///
-/// Consensus rule:
+/// Consensus rules:
+///
+/// "each output of a particular transaction
+/// can only be used as an input once in the block chain.
+/// Any subsequent reference is a forbidden double spend-
+/// an attempt to spend the same satoshis twice."
+///
+/// https://developer.bitcoin.org/devguide/block_chain.html#introduction
 ///
 /// A _nullifier_ *MUST NOT* repeat either within a _transaction_, or across _transactions_ in a
 /// _valid blockchain_ . *Sprout* and *Sapling* and *Orchard* _nulliers_ are considered disjoint,

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -2,6 +2,8 @@
 //!
 //! Code in this file can freely assume that no pre-V4 transactions are present.
 
+use std::convert::TryFrom;
+
 use zebra_chain::{
     amount::{Amount, NonNegative},
     block::Height,
@@ -12,8 +14,6 @@ use zebra_chain::{
 };
 
 use crate::error::TransactionError;
-
-use std::convert::TryFrom;
 
 /// Checks that the transaction has inputs and outputs.
 ///

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -958,7 +958,8 @@ fn mock_sprout_join_split_data() -> (JoinSplitData<Groth16Proof>, ed25519::Signi
         .try_into()
         .expect("Invalid JoinSplit transparent input");
     let anchor = sprout::tree::Root::default();
-    let nullifier = sprout::note::Nullifier([0u8; 32]);
+    let first_nullifier = sprout::note::Nullifier([0u8; 32]);
+    let second_nullifier = sprout::note::Nullifier([1u8; 32]);
     let commitment = sprout::commitment::NoteCommitment::from([0u8; 32]);
     let ephemeral_key =
         x25519::PublicKey::from(&x25519::EphemeralSecret::new(rand07::thread_rng()));
@@ -973,7 +974,7 @@ fn mock_sprout_join_split_data() -> (JoinSplitData<Groth16Proof>, ed25519::Signi
         vpub_old: zero_amount,
         vpub_new: zero_amount,
         anchor,
-        nullifiers: [nullifier; 2],
+        nullifiers: [first_nullifier, second_nullifier],
         commitments: [commitment; 2],
         ephemeral_key,
         random_seed,

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -544,6 +544,77 @@ fn v4_transaction_with_conflicting_sprout_nullifier_inside_joinsplit_is_rejected
     });
 }
 
+/// Test if V4 transaction with duplicate nullifiers across joinsplits is rejected.
+#[test]
+fn v4_transaction_with_conflicting_sprout_nullifier_across_joinsplits_is_rejected() {
+    zebra_test::init();
+    zebra_test::RUNTIME.block_on(async {
+        let network = Network::Mainnet;
+        let network_upgrade = NetworkUpgrade::Canopy;
+
+        let canopy_activation_height = NetworkUpgrade::Canopy
+            .activation_height(network)
+            .expect("Canopy activation height is specified");
+
+        let transaction_block_height =
+            (canopy_activation_height + 10).expect("transaction block height is too large");
+
+        // Create a fake Sprout join split
+        let (mut joinsplit_data, signing_key) = mock_sprout_join_split_data();
+
+        // Duplicate a nullifier from the created joinsplit
+        let duplicate_nullifier = joinsplit_data.first.nullifiers[1];
+
+        // Add a new joinsplit with the duplicate nullifier
+        let mut new_joinsplit = joinsplit_data.first.clone();
+        new_joinsplit.nullifiers[0] = duplicate_nullifier;
+        new_joinsplit.nullifiers[1] = sprout::note::Nullifier([2u8; 32]);
+
+        joinsplit_data.rest.push(new_joinsplit);
+
+        // Create a V4 transaction
+        let mut transaction = Transaction::V4 {
+            inputs: vec![],
+            outputs: vec![],
+            lock_time: LockTime::Height(block::Height(0)),
+            expiry_height: (transaction_block_height + 1).expect("expiry height is too large"),
+            joinsplit_data: Some(joinsplit_data),
+            sapling_shielded_data: None,
+        };
+
+        // Sign the transaction
+        let sighash = transaction.sighash(network_upgrade, HashType::ALL, None);
+
+        match &mut transaction {
+            Transaction::V4 {
+                joinsplit_data: Some(joinsplit_data),
+                ..
+            } => joinsplit_data.sig = signing_key.sign(sighash.as_ref()),
+            _ => unreachable!("Mock transaction was created incorrectly"),
+        }
+
+        let state_service =
+            service_fn(|_| async { unreachable!("State service should not be called") });
+        let script_verifier = script::Verifier::new(state_service);
+        let verifier = Verifier::new(network, script_verifier);
+
+        let result = verifier
+            .oneshot(Request::Block {
+                transaction: Arc::new(transaction),
+                known_utxos: Arc::new(HashMap::new()),
+                height: transaction_block_height,
+            })
+            .await;
+
+        assert_eq!(
+            result,
+            Err(TransactionError::DuplicateSproutNullifier(
+                duplicate_nullifier
+            ))
+        );
+    });
+}
+
 /// Test if V5 transaction with transparent funds is accepted.
 #[tokio::test]
 async fn v5_transaction_with_transparent_transfer_is_accepted() {


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
Zebra checks for double spends in `zebra-state`, but that means that transactions with internal double spends (i.e., spend the same UTXO more than once or reveal the same nullifier more than once) aren't rejected by the transaction verifier. The consequence of this is that the mempool could end up with such invalid transactions.

This closes #2787.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->
[Consensus rule](https://zips.z.cash/protocol/protocol.pdf#nullifierset):

A _nullifier_ *MUST NOT* repeat either within a _transaction_, or across _transactions_ in a
_valid blockchain_ . *Sprout* and *Sapling* and *Orchard* _nulliers_ are considered disjoint,
even if they have the same bit pattern.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Check for double spends inside the transaction verifier.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 implemented similar code for rejecting double-spends.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->