### PR TITLE
Un-reject mempool transactions if the rejection depends on the current tip

### DIFF
--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -220,6 +220,7 @@ impl Service<Request> for Mempool {
                             let mined_ids = block.transaction_hashes.iter().cloned().collect();
                             tx_downloads.cancel(&mined_ids);
                             storage.remove_same_effects(&mined_ids);
+                            storage.clear_tip_rejections();
                         }
                     }
                 }

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -33,7 +33,9 @@ mod tests;
 
 pub use self::crawler::Crawler;
 pub use self::error::MempoolError;
-pub use self::storage::{ExactRejectionError, SameEffectsRejectionError};
+pub use self::storage::{
+    ExactTipRejectionError, SameEffectsChainRejectionError, SameEffectsTipRejectionError,
+};
 
 #[cfg(test)]
 pub use self::storage::tests::unmined_transactions_in_blocks;

--- a/zebrad/src/components/mempool/error.rs
+++ b/zebrad/src/components/mempool/error.rs
@@ -5,17 +5,26 @@ use thiserror::Error;
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
 
-use super::storage::{ExactRejectionError, SameEffectsRejectionError};
+use super::storage::{
+    ExactTipRejectionError, SameEffectsChainRejectionError, SameEffectsTipRejectionError,
+};
 
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 #[allow(dead_code)]
 pub enum MempoolError {
-    #[error("mempool storage has a cached rejection for this exact transaction")]
-    StorageExact(#[from] ExactRejectionError),
+    #[error("mempool storage has a cached tip rejection for this exact transaction")]
+    StorageExactTip(#[from] ExactTipRejectionError),
 
-    #[error("mempool storage has a cached rejection for any transaction with the same effects")]
-    StorageEffects(#[from] SameEffectsRejectionError),
+    #[error(
+        "mempool storage has a cached tip rejection for any transaction with the same effects"
+    )]
+    StorageEffectsTip(#[from] SameEffectsTipRejectionError),
+
+    #[error(
+        "mempool storage has a cached chain rejection for any transaction with the same effects"
+    )]
+    StorageEffectsChain(#[from] SameEffectsChainRejectionError),
 
     #[error("transaction already exists in mempool")]
     InMempool,

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -196,6 +196,12 @@ impl Storage {
         self.chain_rejected_same_effects.clear();
     }
 
+    /// Clears rejections that only apply to the current tip.
+    pub fn clear_tip_rejections(&mut self) {
+        self.tip_rejected_exact.clear();
+        self.tip_rejected_same_effects.clear();
+    }
+
     /// Returns the set of [`UnminedTxId`]s in the mempool.
     pub fn tx_ids(&self) -> impl Iterator<Item = UnminedTxId> + '_ {
         self.verified.iter().map(|tx| tx.id)

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -11,7 +11,7 @@ use zebra_chain::{
     transparent, LedgerState,
 };
 
-use crate::components::mempool::storage::SameEffectsRejectionError;
+use crate::components::mempool::storage::SameEffectsTipRejectionError;
 
 use super::super::{MempoolError, Storage};
 
@@ -42,7 +42,7 @@ proptest! {
 
             assert_eq!(
                 storage.insert(transaction_to_reject),
-                Err(MempoolError::StorageEffects(SameEffectsRejectionError::SpendConflict))
+                Err(MempoolError::StorageEffectsTip(SameEffectsTipRejectionError::SpendConflict))
             );
 
             assert!(storage.contains_rejected(&id_to_reject));

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -231,8 +231,8 @@ async fn mempool_queue() -> Result<(), Report> {
     assert_eq!(queued_responses.len(), 1);
     assert_eq!(
         queued_responses[0],
-        Err(MempoolError::StorageEffects(
-            SameEffectsRejectionError::RandomlyEvicted
+        Err(MempoolError::StorageEffectsChain(
+            SameEffectsChainRejectionError::RandomlyEvicted
         ))
     );
 


### PR DESCRIPTION
## Motivation

Some mempool rejections only apply to the current tip, so we want to un-reject them whenever the tip changes.

We also want to make sure the rejection lists don't get too big.

Closes #2694.
Implements part of #2759 (some size limits).

### Specifications

The mempool rejection rules aren't really specified anywhere.

We're re-using the size limit from ZIP-401 for all our reject lists:

> The size of RecentlyEvicted SHOULD never exceed `eviction_memory_entries` entries,
> which is the constant 40000.

https://zips.z.cash/zip-0401#specification

## Solution

- Split mempool storage errors into tip-based and chain-based
- Expire tip rejections every time we get a new block
- Enforce MAX_EVICTION_MEMORY_ENTRIES for mempool reject lists

We might want to wait to add more tests until after PR #2821 or ZIP-401, because the APIs are still changing a lot.

## Review

Anyone can review this PR, but I think @conradoplg wants it so he can complete PR #2821.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
