### PR TITLE
Make some grafana labels shorter for graph readability

### DIFF
--- a/grafana/block_verification.json
+++ b/grafana/block_verification.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 1,
-  "iteration": 1633497866311,
+  "iteration": 1633652785661,
   "links": [],
   "panels": [
     {
@@ -34,7 +34,7 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 6,
         "x": 0,
         "y": 0
       },
@@ -80,7 +80,7 @@
           "exemplar": true,
           "expr": "zcash_chain_verified_block_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "committed block height",
+          "legendFormat": "committed",
           "refId": "A"
         },
         {
@@ -88,7 +88,7 @@
           "expr": "state_full_verifier_committed_block_height{job=\"$job\"}",
           "hide": false,
           "interval": "",
-          "legendFormat": "full block verifier height",
+          "legendFormat": "full verified",
           "refId": "B"
         },
         {
@@ -96,7 +96,7 @@
           "expr": "state_checkpoint_finalized_block_height{job=\"$job\"}",
           "hide": false,
           "interval": "",
-          "legendFormat": "checkpoint verifier height",
+          "legendFormat": "checkpoint",
           "refId": "C"
         },
         {
@@ -104,7 +104,7 @@
           "expr": "state_finalized_block_height{job=\"$job\"}",
           "hide": false,
           "interval": "",
-          "legendFormat": "finalized block height",
+          "legendFormat": "finalized",
           "refId": "D"
         }
       ],
@@ -157,7 +157,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "decimals": 6,
+      "decimals": 0,
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -166,8 +166,8 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 12,
+        "w": 6,
+        "x": 6,
         "y": 0
       },
       "hiddenSeries": false,
@@ -195,13 +195,13 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1633497866311,
+      "repeatIteration": 1633652785661,
       "repeatPanelId": 4,
       "scopedVars": {
         "job": {
           "selected": false,
-          "text": "zebrad-testnet",
-          "value": "zebrad-testnet"
+          "text": "zebrad-mainnet-tmp",
+          "value": "zebrad-mainnet-tmp"
         }
       },
       "seriesOverrides": [],
@@ -213,7 +213,7 @@
           "exemplar": true,
           "expr": "zcash_chain_verified_block_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "committed block height",
+          "legendFormat": "committed",
           "refId": "A"
         },
         {
@@ -221,7 +221,7 @@
           "expr": "state_full_verifier_committed_block_height{job=\"$job\"}",
           "hide": false,
           "interval": "",
-          "legendFormat": "full block verifier height",
+          "legendFormat": "full verified",
           "refId": "B"
         },
         {
@@ -229,7 +229,7 @@
           "expr": "state_checkpoint_finalized_block_height{job=\"$job\"}",
           "hide": false,
           "interval": "",
-          "legendFormat": "checkpoint verifier height",
+          "legendFormat": "checkpoint",
           "refId": "C"
         },
         {
@@ -237,7 +237,7 @@
           "expr": "state_finalized_block_height{job=\"$job\"}",
           "hide": false,
           "interval": "",
-          "legendFormat": "finalized block height",
+          "legendFormat": "finalized",
           "refId": "D"
         }
       ],
@@ -262,7 +262,7 @@
       "yaxes": [
         {
           "$$hashKey": "object:84",
-          "format": "short",
+          "format": "none",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -271,7 +271,273 @@
         },
         {
           "$$hashKey": "object:85",
-          "format": "short",
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 7,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1633652785661,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet",
+          "value": "zebrad-testnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "zcash_chain_verified_block_height{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "committed",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_full_verifier_committed_block_height{job=\"$job\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "full verified",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_checkpoint_finalized_block_height{job=\"$job\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "checkpoint",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_finalized_block_height{job=\"$job\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "finalized",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Verified Block Height - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:84",
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:85",
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1633652785661,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet-tmp",
+          "value": "zebrad-testnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "zcash_chain_verified_block_height{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "committed",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_full_verifier_committed_block_height{job=\"$job\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "full verified",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_checkpoint_finalized_block_height{job=\"$job\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "checkpoint",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_finalized_block_height{job=\"$job\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "finalized",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Verified Block Height - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:84",
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:85",
+          "format": "none",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -298,7 +564,7 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 6,
         "x": 0,
         "y": 7
       },
@@ -420,12 +686,12 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 12,
+        "w": 6,
+        "x": 6,
         "y": 7
       },
       "hiddenSeries": false,
-      "id": 7,
+      "id": 9,
       "legend": {
         "avg": false,
         "current": false,
@@ -447,7 +713,130 @@
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1633497866311,
+      "repeatIteration": 1633652785661,
+      "repeatPanelId": 5,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-mainnet-tmp",
+          "value": "zebrad-mainnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(zcash_chain_verified_block_total{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "zcash_chain_verified_block_total[1s]",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(sync_downloaded_block_count{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "sync_downloaded_block_count",
+          "refId": "H"
+        },
+        {
+          "expr": "sync_downloads_in_flight{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "sync_downloads_in_flight",
+          "refId": "I"
+        },
+        {
+          "expr": "rate(sync_verified_block_count{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "sync_verified_block_count",
+          "refId": "J"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Block Sync Count - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:167",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:168",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1633652785661,
       "repeatPanelId": 5,
       "scopedVars": {
         "job": {
@@ -543,7 +932,130 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 6,
+        "x": 18,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1633652785661,
+      "repeatPanelId": 5,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet-tmp",
+          "value": "zebrad-testnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(zcash_chain_verified_block_total{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "zcash_chain_verified_block_total[1s]",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(sync_downloaded_block_count{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "sync_downloaded_block_count",
+          "refId": "H"
+        },
+        {
+          "expr": "sync_downloads_in_flight{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "sync_downloads_in_flight",
+          "refId": "I"
+        },
+        {
+          "expr": "rate(sync_verified_block_count{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "sync_verified_block_count",
+          "refId": "J"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Block Sync Count - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:167",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:168",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
         "x": 0,
         "y": 14
       },
@@ -665,12 +1177,12 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 12,
+        "w": 6,
+        "x": 6,
         "y": 14
       },
       "hiddenSeries": false,
-      "id": 8,
+      "id": 12,
       "legend": {
         "avg": false,
         "current": false,
@@ -692,13 +1204,259 @@
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1633497866311,
+      "repeatIteration": 1633652785661,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-mainnet-tmp",
+          "value": "zebrad-mainnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(zcash_chain_verified_block_total{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "zcash_chain_verified_block_total[1s]",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(gossip_downloaded_block_count{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "gossip_downloaded_block_count[1s]",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(gossip_verified_block_count{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "gossip_verified_block_count[1s]",
+          "refId": "D"
+        },
+        {
+          "expr": "gossip_queued_block_count{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "gossip_queued_block_count",
+          "refId": "E"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Block Gossip Count - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:252",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:253",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1633652785661,
       "repeatPanelId": 2,
       "scopedVars": {
         "job": {
           "selected": false,
           "text": "zebrad-testnet",
           "value": "zebrad-testnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(zcash_chain_verified_block_total{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "zcash_chain_verified_block_total[1s]",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(gossip_downloaded_block_count{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "gossip_downloaded_block_count[1s]",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(gossip_verified_block_count{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "gossip_verified_block_count[1s]",
+          "refId": "D"
+        },
+        {
+          "expr": "gossip_queued_block_count{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "gossip_queued_block_count",
+          "refId": "E"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Block Gossip Count - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:252",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:253",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 14,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1633652785661,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet-tmp",
+          "value": "zebrad-testnet-tmp"
         }
       },
       "seriesOverrides": [],
@@ -826,5 +1584,5 @@
   "timezone": "",
   "title": "block verification",
   "uid": "rO_Cl5tGz",
-  "version": 8
+  "version": 14
 }

--- a/grafana/checkpoint_verification.json
+++ b/grafana/checkpoint_verification.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 2,
-  "iteration": 1633574016226,
+  "iteration": 1633652714499,
   "links": [],
   "panels": [
     {
@@ -34,7 +34,7 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 6,
         "x": 0,
         "y": 0
       },
@@ -43,10 +43,13 @@
       "legend": {
         "avg": false,
         "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
         "max": false,
         "min": false,
         "rightSide": true,
         "show": true,
+        "sideWidth": null,
         "total": false,
         "values": true
       },
@@ -76,41 +79,45 @@
       "steppedLine": false,
       "targets": [
         {
+          "exemplar": true,
           "expr": "checkpoint_processing_next_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "checkpoint_processing_next_height",
+          "legendFormat": "next_check",
           "refId": "A"
         },
         {
+          "exemplar": true,
           "expr": "checkpoint_queued_continuous_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "checkpoint_queued_continuous_height",
+          "legendFormat": "queue_cont",
           "refId": "B"
         },
         {
+          "exemplar": true,
           "expr": "checkpoint_verified_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "checkpoint_verified_height",
+          "legendFormat": "verified",
           "refId": "C"
         },
         {
+          "exemplar": true,
           "expr": "checkpoint_queued_max_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "checkpoint_queued_max_height",
+          "legendFormat": "queue_max",
           "refId": "D"
         },
         {
           "exemplar": true,
           "expr": "state_checkpoint_committed_block_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "state_finalized_committed_block_height",
+          "legendFormat": "state_commit",
           "refId": "E"
         },
         {
           "exemplar": true,
           "expr": "state_checkpoint_queued_max_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "state_finalized_queued_max_height",
+          "legendFormat": "state_q_max",
           "refId": "F"
         }
       ],
@@ -172,8 +179,8 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 12,
+        "w": 6,
+        "x": 6,
         "y": 0
       },
       "hiddenSeries": false,
@@ -181,10 +188,13 @@
       "legend": {
         "avg": false,
         "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
         "max": false,
         "min": false,
         "rightSide": true,
         "show": true,
+        "sideWidth": null,
         "total": false,
         "values": true
       },
@@ -200,7 +210,153 @@
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1633574016226,
+      "repeatIteration": 1633652714499,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-mainnet-tmp",
+          "value": "zebrad-mainnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "checkpoint_processing_next_height{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "next_check",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "checkpoint_queued_continuous_height{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "queue_cont",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "checkpoint_verified_height{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "verified",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "checkpoint_queued_max_height{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "queue_max",
+          "refId": "D"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_checkpoint_committed_block_height{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "state_commit",
+          "refId": "E"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_checkpoint_queued_max_height{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "state_q_max",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Checkpoint Height - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:84",
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:85",
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1633652714499,
       "repeatPanelId": 2,
       "scopedVars": {
         "job": {
@@ -215,41 +371,191 @@
       "steppedLine": false,
       "targets": [
         {
+          "exemplar": true,
           "expr": "checkpoint_processing_next_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "checkpoint_processing_next_height",
+          "legendFormat": "next_check",
           "refId": "A"
         },
         {
+          "exemplar": true,
           "expr": "checkpoint_queued_continuous_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "checkpoint_queued_continuous_height",
+          "legendFormat": "queue_cont",
           "refId": "B"
         },
         {
+          "exemplar": true,
           "expr": "checkpoint_verified_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "checkpoint_verified_height",
+          "legendFormat": "verified",
           "refId": "C"
         },
         {
+          "exemplar": true,
           "expr": "checkpoint_queued_max_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "checkpoint_queued_max_height",
+          "legendFormat": "queue_max",
           "refId": "D"
         },
         {
           "exemplar": true,
           "expr": "state_checkpoint_committed_block_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "state_finalized_committed_block_height",
+          "legendFormat": "state_commit",
           "refId": "E"
         },
         {
           "exemplar": true,
           "expr": "state_checkpoint_queued_max_height{job=\"$job\"}",
           "interval": "",
-          "legendFormat": "state_finalized_queued_max_height",
+          "legendFormat": "state_q_max",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Checkpoint Height - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:84",
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:85",
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1633652714499,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet-tmp",
+          "value": "zebrad-testnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "checkpoint_processing_next_height{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "next_check",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "checkpoint_queued_continuous_height{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "queue_cont",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "checkpoint_verified_height{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "verified",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "checkpoint_queued_max_height{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "queue_max",
+          "refId": "D"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_checkpoint_committed_block_height{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "state_commit",
+          "refId": "E"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_checkpoint_queued_max_height{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "state_q_max",
           "refId": "F"
         }
       ],
@@ -310,7 +616,7 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 6,
         "x": 0,
         "y": 7
       },
@@ -433,12 +739,12 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 12,
+        "w": 6,
+        "x": 6,
         "y": 7
       },
       "hiddenSeries": false,
-      "id": 10,
+      "id": 12,
       "legend": {
         "avg": false,
         "current": false,
@@ -460,7 +766,131 @@
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1633574016226,
+      "repeatIteration": 1633652714499,
+      "repeatPanelId": 8,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-mainnet-tmp",
+          "value": "zebrad-mainnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(checkpoint_verified_block_count[1s])",
+          "interval": "",
+          "legendFormat": "checkpoint verify rate [1s]",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(state_checkpoint_committed_block_count[1s])",
+          "interval": "",
+          "legendFormat": "state commit rate [1s]",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(sync_downloaded_block_count[1s])",
+          "interval": "",
+          "legendFormat": "sync download rate [1s]",
+          "refId": "E"
+        },
+        {
+          "expr": "rate(gossip_downloaded_block_count[1s])",
+          "interval": "",
+          "legendFormat": "gossip download rate [1s]",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Checkpoint Pipeline Throughput - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:252",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:253",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1633652714499,
       "repeatPanelId": 8,
       "scopedVars": {
         "job": {
@@ -557,7 +987,131 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 6,
+        "x": 18,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 14,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1633652714499,
+      "repeatPanelId": 8,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet-tmp",
+          "value": "zebrad-testnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(checkpoint_verified_block_count[1s])",
+          "interval": "",
+          "legendFormat": "checkpoint verify rate [1s]",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(state_checkpoint_committed_block_count[1s])",
+          "interval": "",
+          "legendFormat": "state commit rate [1s]",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(sync_downloaded_block_count[1s])",
+          "interval": "",
+          "legendFormat": "sync download rate [1s]",
+          "refId": "E"
+        },
+        {
+          "expr": "rate(gossip_downloaded_block_count[1s])",
+          "interval": "",
+          "legendFormat": "gossip download rate [1s]",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Checkpoint Pipeline Throughput - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:252",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:253",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
         "x": 0,
         "y": 14
       },
@@ -704,12 +1258,12 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 12,
+        "w": 6,
+        "x": 6,
         "y": 14
       },
       "hiddenSeries": false,
-      "id": 11,
+      "id": 15,
       "legend": {
         "avg": false,
         "current": false,
@@ -731,13 +1285,309 @@
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1633574016226,
+      "repeatIteration": 1633652714499,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-mainnet-tmp",
+          "value": "zebrad-mainnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "checkpoint_queued_slots{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "checkpoint_queued_slots",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_checkpoint_queued_block_count{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "state_finalized_queued_block_count",
+          "refId": "B"
+        },
+        {
+          "expr": "sync_prospective_tips_len{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "sync_prospective_tips_len",
+          "refId": "C"
+        },
+        {
+          "expr": "sync_downloads_in_flight{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "sync_downloads_in_flight",
+          "refId": "D"
+        },
+        {
+          "expr": "sync_pending_blocks_len{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "sync_pending_blocks_len",
+          "refId": "E"
+        },
+        {
+          "expr": "rate(sync_cancelled_download_count{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "sync_cancelled_download_count[1s]",
+          "refId": "F"
+        },
+        {
+          "expr": "rate(sync_cancelled_verify_count{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "sync_cancelled_verify_count[1s]",
+          "refId": "G"
+        },
+        {
+          "expr": "rate(gossip_queued_block_count{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "gossip_queued_block_count[1s]",
+          "refId": "H"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Checkpoint Queues - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:337",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:338",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1633652714499,
       "repeatPanelId": 4,
       "scopedVars": {
         "job": {
           "selected": false,
           "text": "zebrad-testnet",
           "value": "zebrad-testnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "checkpoint_queued_slots{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "checkpoint_queued_slots",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "state_checkpoint_queued_block_count{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "state_finalized_queued_block_count",
+          "refId": "B"
+        },
+        {
+          "expr": "sync_prospective_tips_len{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "sync_prospective_tips_len",
+          "refId": "C"
+        },
+        {
+          "expr": "sync_downloads_in_flight{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "sync_downloads_in_flight",
+          "refId": "D"
+        },
+        {
+          "expr": "sync_pending_blocks_len{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "sync_pending_blocks_len",
+          "refId": "E"
+        },
+        {
+          "expr": "rate(sync_cancelled_download_count{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "sync_cancelled_download_count[1s]",
+          "refId": "F"
+        },
+        {
+          "expr": "rate(sync_cancelled_verify_count{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "sync_cancelled_verify_count[1s]",
+          "refId": "G"
+        },
+        {
+          "expr": "rate(gossip_queued_block_count{job=\"$job\"}[1s])",
+          "interval": "",
+          "legendFormat": "gossip_queued_block_count[1s]",
+          "refId": "H"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Checkpoint Queues - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:337",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:338",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 17,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1633652714499,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet-tmp",
+          "value": "zebrad-testnet-tmp"
         }
       },
       "seriesOverrides": [],
@@ -903,5 +1753,5 @@
   "timezone": "",
   "title": "checkpoint verification",
   "uid": "o4LmN_OMk",
-  "version": 6
+  "version": 12
 }


### PR DESCRIPTION
## Motivation

Some graphs are hard to read if:
* the labels are long, and
* the legend is on the right of the graph.

This is particularly important if prometheus is scraping multiple instances.

## Solution

Make the labels shorter.

## Review

Anyone can review this low-priority graph update.

### Reviewer Checklist

  - [ ] Graphs display ok
  - [ ] New labels make sense
