### PR TITLE
make `INITIAL_MIN_NETWORK_PROTOCOL_VERSION` suport testnet and mainnet

### DIFF
--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -80,7 +80,12 @@ impl Version {
     /// - after Zebra restarts, and
     /// - after Zebra's local network is slow or shut down.
     fn initial_min_for_network(network: Network) -> Version {
-        Version::min_specified_for_upgrade(network, constants::INITIAL_MIN_NETWORK_PROTOCOL_VERSION)
+        Version::min_specified_for_upgrade(
+            network,
+            *constants::INITIAL_MIN_NETWORK_PROTOCOL_VERSION
+                .get(&network)
+                .expect("We always have a value for testnet or mainnet"),
+        )
     }
 
     /// Returns the minimum specified network protocol version for `network` and


### PR DESCRIPTION
## Motivation

We want to avoid connecting to peers that are not in the `Nu5` network upgrade in the testnet while keeping `Canopy` for the mainnet.

Resolves https://github.com/ZcashFoundation/zebra/issues/2532

## Solution

Change `INITIAL_MIN_NETWORK_PROTOCOL_VERSION` to a hashmap so it can support `Network::Testnet` and `Network::Mainnet` values. 

## Review

Anyone can review.