### PR TITLE
Stop ignoring the mempool conflicting transaction reject list size limit

### DIFF
--- a/zebra-chain/src/transaction/auth_digest.rs
+++ b/zebra-chain/src/transaction/auth_digest.rs
@@ -20,7 +20,7 @@ use super::Transaction;
 /// [ZIP-244]: https://zips.z.cash/zip-0244
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
-pub struct AuthDigest(pub(crate) [u8; 32]);
+pub struct AuthDigest(pub [u8; 32]);
 
 impl From<Transaction> for AuthDigest {
     /// Computes the authorizing data commitment for a transaction.

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -111,7 +111,6 @@ impl UnminedTxId {
     ///
     /// This method must only be used for v1-v4 transaction IDs.
     /// [`Hash`] does not uniquely identify unmined v5 transactions.
-    #[allow(dead_code)]
     pub fn from_legacy_id(legacy_tx_id: Hash) -> UnminedTxId {
         Legacy(legacy_tx_id)
     }
@@ -125,7 +124,6 @@ impl UnminedTxId {
     /// if its authorizing data changes (signatures, proofs, and scripts).
     ///
     /// But for v5 transactions, this ID uniquely identifies the transaction's effects.
-    #[allow(dead_code)]
     pub fn mined_id(&self) -> Hash {
         match self {
             Legacy(legacy_id) => *legacy_id,
@@ -133,13 +131,34 @@ impl UnminedTxId {
         }
     }
 
+    /// Returns a mutable reference to the unique ID
+    /// that will be used if this transaction gets mined into a block.
+    ///
+    /// See [mined_id] for details.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn mined_id_mut(&mut self) -> &mut Hash {
+        match self {
+            Legacy(legacy_id) => legacy_id,
+            Witnessed(wtx_id) => &mut wtx_id.id,
+        }
+    }
+
     /// Return the digest of this transaction's authorizing data,
     /// (signatures, proofs, and scripts), if it is a v5 transaction.
-    #[allow(dead_code)]
     pub fn auth_digest(&self) -> Option<AuthDigest> {
         match self {
             Legacy(_) => None,
             Witnessed(wtx_id) => Some(wtx_id.auth_digest),
+        }
+    }
+
+    /// Returns a mutable reference to the digest of this transaction's authorizing data,
+    /// (signatures, proofs, and scripts), if it is a v5 transaction.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn auth_digest_mut(&mut self) -> Option<&mut AuthDigest> {
+        match self {
+            Legacy(_) => None,
+            Witnessed(wtx_id) => Some(&mut wtx_id.auth_digest),
         }
     }
 }

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -206,14 +206,14 @@ proptest! {
             let id_to_accept = transaction_to_accept.id;
             let id_to_reject = transaction_to_reject.id;
 
-            assert_eq!(storage.insert(transaction_to_accept), Ok(id_to_accept));
+            prop_assert_eq!(storage.insert(transaction_to_accept), Ok(id_to_accept));
 
-            assert_eq!(
+            prop_assert_eq!(
                 storage.insert(transaction_to_reject),
                 Err(MempoolError::StorageEffectsTip(SameEffectsTipRejectionError::SpendConflict))
             );
 
-            assert!(storage.contains_rejected(&id_to_reject));
+            prop_assert!(storage.contains_rejected(&id_to_reject));
 
             storage.clear();
         }
@@ -252,19 +252,19 @@ proptest! {
             let second_id_to_accept = second_transaction_to_accept.id;
             let id_to_reject = transaction_to_reject.id;
 
-            assert_eq!(
+            prop_assert_eq!(
                 storage.insert(first_transaction_to_accept),
                 Ok(first_id_to_accept)
             );
 
-            assert_eq!(
+            prop_assert_eq!(
                 storage.insert(transaction_to_reject),
                 Err(MempoolError::StorageEffectsTip(SameEffectsTipRejectionError::SpendConflict))
             );
 
-            assert!(storage.contains_rejected(&id_to_reject));
+            prop_assert!(storage.contains_rejected(&id_to_reject));
 
-            assert_eq!(
+            prop_assert_eq!(
                 storage.insert(second_transaction_to_accept),
                 Ok(second_id_to_accept)
             );
@@ -290,7 +290,7 @@ proptest! {
 
         // Check that the inserted transactions are still there.
         for transaction_id in &inserted_transactions {
-            assert!(storage.contains_transaction_exact(transaction_id));
+            prop_assert!(storage.contains_transaction_exact(transaction_id));
         }
 
         // Remove some transactions.
@@ -303,14 +303,14 @@ proptest! {
         let removed_transactions = input.removed_transaction_ids();
 
         for removed_transaction_id in &removed_transactions {
-            assert!(!storage.contains_transaction_exact(removed_transaction_id));
+            prop_assert!(!storage.contains_transaction_exact(removed_transaction_id));
         }
 
         // Check that the remaining transactions are still in the storage.
         let remaining_transactions = inserted_transactions.difference(&removed_transactions);
 
         for remaining_transaction_id in remaining_transactions {
-            assert!(storage.contains_transaction_exact(remaining_transaction_id));
+            prop_assert!(storage.contains_transaction_exact(remaining_transaction_id));
         }
     }
 }


### PR DESCRIPTION
## Motivation

If `MempoolStorage::insert` gets a transaction spend conflict error, it returns that error early.
This early return skips the mempool reject list limits, allowing those lists to have an unlimited size.

This is a memory denial of service security issue.
It is not in any release - the reject list limits were only added in PR #2844.

(The small mempool size does not prevent this issue, because a small mempool can still have conflicts.)

## Solution

- always reject using `MempoolStorage::reject`, which enforces the size limits for every reject list
- add rejection list size tests for the two errors returned by `MempoolStorage::insert`
- add a general rejection list size test for randomly generated rejection errors

## Review

Anyone can review this PR.

It's based on PR #2852 and the latest `main` branch.

@conradoplg might want to review commit 51e59aec7402204fa507ac55fb1fb9993b2f8456,
which resolves a tricky conflict between his PR #2852 and PR #2826.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

