### PR TITLE
Pass the mempool config to the mempool

### DIFF
--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -97,6 +97,7 @@ impl StartCmd {
             tokio::sync::watch::channel(HashSet::new());
 
         let mempool_service = BoxService::new(Mempool::new(
+            &config.mempool,
             peer_set.clone(),
             state,
             tx_verifier,

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -26,10 +26,8 @@
 use abscissa_core::{config, Command, FrameworkError, Options, Runnable};
 use color_eyre::eyre::{eyre, Report};
 use futures::{select, FutureExt};
-use std::collections::HashSet;
 use tokio::sync::oneshot;
-use tower::builder::ServiceBuilder;
-use tower::util::BoxService;
+use tower::{builder::ServiceBuilder, util::BoxService};
 
 use crate::{
     components::{
@@ -92,11 +90,7 @@ impl StartCmd {
             ChainSync::new(&config, peer_set.clone(), state.clone(), chain_verifier);
 
         info!("initializing mempool");
-
-        let (mempool_transaction_sender, mempool_transaction_receiver) =
-            tokio::sync::watch::channel(HashSet::new());
-
-        let mempool_service = BoxService::new(Mempool::new(
+        let (mempool, mempool_transaction_receiver) = Mempool::new(
             &config.mempool,
             peer_set.clone(),
             state,
@@ -104,9 +98,9 @@ impl StartCmd {
             sync_status.clone(),
             latest_chain_tip,
             chain_tip_change.clone(),
-            mempool_transaction_sender,
-        ));
-        let mempool = ServiceBuilder::new().buffer(20).service(mempool_service);
+        );
+        let mempool = BoxService::new(mempool);
+        let mempool = ServiceBuilder::new().buffer(20).service(mempool);
 
         setup_tx
             .send((peer_set.clone(), address_book, mempool.clone()))

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -1,3 +1,5 @@
+//! Inbound service tests.
+
 use std::{collections::HashSet, iter::FromIterator, net::SocketAddr, str::FromStr, sync::Arc};
 
 use futures::FutureExt;
@@ -576,9 +578,7 @@ async fn setup(
         .unwrap();
     committed_blocks.push(block_one);
 
-    let (transaction_sender, transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
-
-    let mut mempool_service = Mempool::new(
+    let (mut mempool_service, transaction_receiver) = Mempool::new(
         &mempool::Config::default(),
         buffered_peer_set.clone(),
         state_service.clone(),
@@ -586,7 +586,6 @@ async fn setup(
         sync_status.clone(),
         latest_chain_tip,
         chain_tip_change.clone(),
-        transaction_sender,
     );
 
     // Enable the mempool

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -579,6 +579,7 @@ async fn setup(
     let (transaction_sender, transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
 
     let mut mempool_service = Mempool::new(
+        &mempool::Config::default(),
         buffered_peer_set.clone(),
         state_service.clone(),
         buffered_tx_verifier.clone(),

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -1,14 +1,11 @@
 //! Zebra mempool.
 
-use serde::{Deserialize, Serialize};
-
 use std::{
     collections::HashSet,
     future::Future,
     iter,
     pin::Pin,
     task::{Context, Poll},
-    time::Duration,
 };
 
 use futures::{future::FutureExt, stream::Stream};
@@ -24,8 +21,9 @@ use zebra_network as zn;
 use zebra_state as zs;
 use zebra_state::{ChainTipChange, TipAction};
 
-pub use crate::BoxError;
+use crate::components::sync::SyncStatus;
 
+mod config;
 mod crawler;
 pub mod downloads;
 mod error;
@@ -35,22 +33,23 @@ mod storage;
 #[cfg(test)]
 mod tests;
 
-pub use self::crawler::Crawler;
-pub use self::error::MempoolError;
-pub use self::storage::{
+pub use crate::BoxError;
+
+pub use config::Config;
+pub use crawler::Crawler;
+pub use error::MempoolError;
+pub use gossip::gossip_mempool_transaction_id;
+pub use storage::{
     ExactTipRejectionError, SameEffectsChainRejectionError, SameEffectsTipRejectionError,
 };
 
 #[cfg(test)]
-pub use self::storage::tests::unmined_transactions_in_blocks;
-pub use gossip::gossip_mempool_transaction_id;
+pub use storage::tests::unmined_transactions_in_blocks;
 
-use self::downloads::{
+use downloads::{
     Downloads as TxDownloads, Gossip, TransactionDownloadVerifyError, TRANSACTION_DOWNLOAD_TIMEOUT,
     TRANSACTION_VERIFY_TIMEOUT,
 };
-
-use super::sync::SyncStatus;
 
 type Outbound = Buffer<BoxService<zn::Request, zn::Response, zn::BoxError>, zn::Request>;
 type State = Buffer<BoxService<zs::Request, zs::Response, zs::BoxError>, zs::Request>;
@@ -95,30 +94,6 @@ enum ActiveState {
         /// The transaction download and verify stream.
         tx_downloads: Pin<Box<InboundTxDownloads>>,
     },
-}
-
-/// Mempool configuration section.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Config {
-    /// The transaction cost limit
-    pub tx_cost_limit: u32,
-    /// Max amount of minutes for transactions to be in recently evicted
-    pub eviction_memory_time: Duration,
-}
-
-/// Consensus rules:
-///
-/// - There MUST be a configuration option mempooltxcostlimit, which SHOULD default to 80000000.
-/// - There MUST be a configuration option mempoolevictionmemoryminutes, which SHOULD default to 60.
-///
-/// https://zips.z.cash/zip-0401#specification
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            tx_cost_limit: 80_000_000,
-            eviction_memory_time: Duration::from_secs(60 * 60),
-        }
-    }
 }
 
 /// Mempool async management and query service.

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -155,7 +155,7 @@ impl Mempool {
         };
 
         // Make sure `is_enabled` is accurate.
-        // It is only updated in `poll_ready`, right before each service call.
+        // Otherwise, it is only updated in `poll_ready`, right before each service call.
         service.update_state();
 
         (service, transaction_receiver)

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -132,6 +132,7 @@ pub struct Mempool {
 
 impl Mempool {
     pub(crate) fn new(
+        _config: &Config,
         outbound: Outbound,
         state: State,
         tx_verifier: TxVerifier,

--- a/zebrad/src/components/mempool/config.rs
+++ b/zebrad/src/components/mempool/config.rs
@@ -1,0 +1,46 @@
+//! User-configurable mempool parameters.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// Mempool configuration section.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Config {
+    /// The mempool transaction cost limit.
+    ///
+    /// This limits the total serialized byte size of all transactions in the mempool.
+    ///
+    /// This corresponds to `mempooltxcostlimit` from [ZIP-401](https://zips.z.cash/zip-0401#specification).
+    pub tx_cost_limit: u32,
+
+    /// The mempool transaction eviction age limit.
+    ///
+    /// This limits the maximum amount of time evicted transaction IDs stay in the mempool rejection list.
+    /// Transactions are randomly evicted from the mempool when the mempool reaches [`tx_cost_limit`].
+    ///
+    /// (Transactions can also be rejected by the mempool for other reasons.
+    /// Different rejection reasons can have different age limits.)
+    ///
+    /// This corresponds to `mempoolevictionmemoryminutes` from
+    /// [ZIP-401](https://zips.z.cash/zip-0401#specification).
+    pub eviction_memory_time: Duration,
+}
+
+/// Consensus rules:
+///
+/// > There MUST be a configuration option mempooltxcostlimit,
+/// > which SHOULD default to 80000000.
+/// >
+/// > There MUST be a configuration option mempoolevictionmemoryminutes,
+/// > which SHOULD default to 60 [minutes].
+///
+/// https://zips.z.cash/zip-0401#specification
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            tx_cost_limit: 80_000_000,
+            eviction_memory_time: Duration::from_secs(60 * 60),
+        }
+    }
+}

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -1,5 +1,6 @@
-use proptest::prelude::*;
 use std::collections::HashSet;
+
+use proptest::prelude::*;
 use tokio::time;
 use tower::{buffer::Buffer, util::BoxService};
 
@@ -9,8 +10,10 @@ use zebra_network as zn;
 use zebra_state::{self as zs, ChainTipBlock, ChainTipSender};
 use zebra_test::mock_service::{MockService, PropTestAssertion};
 
-use super::super::Mempool;
-use crate::components::sync::{RecentSyncLengths, SyncStatus};
+use crate::components::{
+    mempool::{self, Mempool},
+    sync::{RecentSyncLengths, SyncStatus},
+};
 
 /// A [`MockService`] representing the network service.
 type MockPeerSet = MockService<zn::Request, zn::Response, PropTestAssertion>;
@@ -154,6 +157,7 @@ fn setup(
     let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
 
     let mempool = Mempool::new(
+        &mempool::Config::default(),
         Buffer::new(BoxService::new(peer_set.clone()), 1),
         Buffer::new(BoxService::new(state_service.clone()), 1),
         Buffer::new(BoxService::new(tx_verifier.clone()), 1),

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+//! Randomised property tests for the mempool.
 
 use proptest::prelude::*;
 use tokio::time;
@@ -154,9 +154,7 @@ fn setup(
     let (sync_status, recent_syncs) = SyncStatus::new();
     let (chain_tip_sender, latest_chain_tip, chain_tip_change) = ChainTipSender::new(None, network);
 
-    let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
-
-    let mempool = Mempool::new(
+    let (mempool, _transaction_receiver) = Mempool::new(
         &mempool::Config::default(),
         Buffer::new(BoxService::new(peer_set.clone()), 1),
         Buffer::new(BoxService::new(state_service.clone()), 1),
@@ -164,7 +162,6 @@ fn setup(
         sync_status,
         latest_chain_tip,
         chain_tip_change,
-        transaction_sender,
     );
 
     (

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -1,3 +1,5 @@
+//! Fixed test vectors for the mempool.
+
 use std::{collections::HashSet, sync::Arc};
 
 use color_eyre::Report;
@@ -5,27 +7,31 @@ use tokio::time;
 use tower::{ServiceBuilder, ServiceExt};
 
 use zebra_chain::{block::Block, parameters::Network, serialization::ZcashDeserializeInto};
-use zebra_consensus::Config as ConsensusConfig;
+use zebra_consensus::transaction as tx;
 use zebra_state::Config as StateConfig;
-use zebra_test::mock_service::MockService;
+use zebra_test::mock_service::{MockService, PanicAssertion};
 
-use crate::components::mempool::{self, storage::tests::unmined_transactions_in_blocks, *};
+use crate::components::{
+    mempool::{self, storage::tests::unmined_transactions_in_blocks, *},
+    sync::RecentSyncLengths,
+};
+
+/// A [`MockService`] representing the network service.
+type MockPeerSet = MockService<zn::Request, zn::Response, PanicAssertion>;
+
+/// The unmocked Zebra state service's type.
+type StateService = Buffer<BoxService<zs::Request, zs::Response, zs::BoxError>, zs::Request>;
+
+/// A [`MockService`] representing the Zebra transaction verifier service.
+type MockTxVerifier = MockService<tx::Request, tx::Response, PanicAssertion, TransactionError>;
 
 #[tokio::test]
 async fn mempool_service_basic() -> Result<(), Report> {
     // Using the mainnet for now
     let network = Network::Mainnet;
-    let consensus_config = ConsensusConfig::default();
-    let state_config = StateConfig::ephemeral();
-    let peer_set = MockService::build().for_unit_tests();
-    let (sync_status, mut recent_syncs) = SyncStatus::new();
-    let (state, latest_chain_tip, chain_tip_change) =
-        zebra_state::init(state_config.clone(), network);
 
-    let state_service = ServiceBuilder::new().buffer(1).service(state);
-    let (_chain_verifier, tx_verifier) =
-        zebra_consensus::chain::init(consensus_config.clone(), network, state_service.clone())
-            .await;
+    let (mut service, _peer_set, _state_service, _tx_verifier, mut recent_syncs) =
+        setup(network).await;
 
     // get the genesis block transactions from the Zcash blockchain.
     let mut unmined_transactions = unmined_transactions_in_blocks(..=10, network);
@@ -34,20 +40,6 @@ async fn mempool_service_basic() -> Result<(), Report> {
         .expect("Missing genesis transaction");
     let last_transaction = unmined_transactions.next_back().unwrap();
     let more_transactions = unmined_transactions;
-
-    // Start the mempool service
-    let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
-
-    let mut service = Mempool::new(
-        &mempool::Config::default(),
-        Buffer::new(BoxService::new(peer_set), 1),
-        state_service.clone(),
-        tx_verifier,
-        sync_status,
-        latest_chain_tip,
-        chain_tip_change,
-        transaction_sender,
-    );
 
     // Enable the mempool
     let _ = service.enable(&mut recent_syncs).await;
@@ -139,17 +131,9 @@ async fn mempool_service_basic() -> Result<(), Report> {
 async fn mempool_queue() -> Result<(), Report> {
     // Using the mainnet for now
     let network = Network::Mainnet;
-    let consensus_config = ConsensusConfig::default();
-    let state_config = StateConfig::ephemeral();
-    let peer_set = MockService::build().for_unit_tests();
-    let (sync_status, mut recent_syncs) = SyncStatus::new();
-    let (state, latest_chain_tip, chain_tip_change) =
-        zebra_state::init(state_config.clone(), network);
 
-    let state_service = ServiceBuilder::new().buffer(1).service(state);
-    let (_chain_verifier, tx_verifier) =
-        zebra_consensus::chain::init(consensus_config.clone(), network, state_service.clone())
-            .await;
+    let (mut service, _peer_set, _state_service, _tx_verifier, mut recent_syncs) =
+        setup(network).await;
 
     // Get transactions to use in the test
     let unmined_transactions = unmined_transactions_in_blocks(..=10, network);
@@ -164,20 +148,6 @@ async fn mempool_queue() -> Result<(), Report> {
     let new_tx = transactions.next_back().unwrap();
     // The last transaction that will be added in the mempool (and thus not rejected)
     let stored_tx = transactions.next_back().unwrap().clone();
-
-    // Start the mempool service
-    let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
-
-    let mut service = Mempool::new(
-        &mempool::Config::default(),
-        Buffer::new(BoxService::new(peer_set), 1),
-        state_service.clone(),
-        tx_verifier,
-        sync_status,
-        latest_chain_tip,
-        chain_tip_change,
-        transaction_sender,
-    );
 
     // Enable the mempool
     let _ = service.enable(&mut recent_syncs).await;
@@ -249,16 +219,9 @@ async fn mempool_queue() -> Result<(), Report> {
 async fn mempool_service_disabled() -> Result<(), Report> {
     // Using the mainnet for now
     let network = Network::Mainnet;
-    let consensus_config = ConsensusConfig::default();
-    let state_config = StateConfig::ephemeral();
-    let peer_set = MockService::build().for_unit_tests();
-    let (sync_status, mut recent_syncs) = SyncStatus::new();
 
-    let (state, latest_chain_tip, chain_tip_change) = zebra_state::init(state_config, network);
-    let state_service = ServiceBuilder::new().buffer(1).service(state);
-    let (_chain_verifier, tx_verifier) =
-        zebra_consensus::chain::init(consensus_config.clone(), network, state_service.clone())
-            .await;
+    let (mut service, _peer_set, _state_service, _tx_verifier, mut recent_syncs) =
+        setup(network).await;
 
     // get the genesis block transactions from the Zcash blockchain.
     let mut unmined_transactions = unmined_transactions_in_blocks(..=10, network);
@@ -266,20 +229,6 @@ async fn mempool_service_disabled() -> Result<(), Report> {
         .next()
         .expect("Missing genesis transaction");
     let more_transactions = unmined_transactions;
-
-    // Start the mempool service
-    let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
-
-    let mut service = Mempool::new(
-        &mempool::Config::default(),
-        Buffer::new(BoxService::new(peer_set), 1),
-        state_service.clone(),
-        tx_verifier,
-        sync_status,
-        latest_chain_tip,
-        chain_tip_change,
-        transaction_sender,
-    );
 
     // Test if mempool is disabled (it should start disabled)
     assert!(!service.is_enabled());
@@ -377,33 +326,11 @@ async fn mempool_cancel_mined() -> Result<(), Report> {
 
     // Using the mainnet for now
     let network = Network::Mainnet;
-    let consensus_config = ConsensusConfig::default();
-    let state_config = StateConfig::ephemeral();
-    let peer_set = MockService::build().for_unit_tests();
-    let (sync_status, mut recent_syncs) = SyncStatus::new();
-    let (state, latest_chain_tip, chain_tip_change) =
-        zebra_state::init(state_config.clone(), network);
 
-    let mut state_service = ServiceBuilder::new().buffer(1).service(state);
-    let (_chain_verifier, tx_verifier) =
-        zebra_consensus::chain::init(consensus_config.clone(), network, state_service.clone())
-            .await;
+    let (mut mempool, _peer_set, mut state_service, _tx_verifier, mut recent_syncs) =
+        setup(network).await;
 
     time::pause();
-
-    // Start the mempool service
-    let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
-
-    let mut mempool = Mempool::new(
-        &mempool::Config::default(),
-        Buffer::new(BoxService::new(peer_set), 1),
-        state_service.clone(),
-        tx_verifier,
-        sync_status,
-        latest_chain_tip,
-        chain_tip_change,
-        transaction_sender,
-    );
 
     // Enable the mempool
     let _ = mempool.enable(&mut recent_syncs).await;
@@ -494,31 +421,9 @@ async fn mempool_cancel_downloads_after_network_upgrade() -> Result<(), Report> 
 
     // Using the mainnet for now
     let network = Network::Mainnet;
-    let consensus_config = ConsensusConfig::default();
-    let state_config = StateConfig::ephemeral();
-    let peer_set = MockService::build().for_unit_tests();
-    let (sync_status, mut recent_syncs) = SyncStatus::new();
-    let (state, latest_chain_tip, chain_tip_change) =
-        zebra_state::init(state_config.clone(), network);
 
-    let mut state_service = ServiceBuilder::new().buffer(1).service(state);
-    let (_chain_verifier, tx_verifier) =
-        zebra_consensus::chain::init(consensus_config.clone(), network, state_service.clone())
-            .await;
-
-    // Start the mempool service
-    let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
-
-    let mut mempool = Mempool::new(
-        &mempool::Config::default(),
-        Buffer::new(BoxService::new(peer_set), 1),
-        state_service.clone(),
-        tx_verifier,
-        sync_status,
-        latest_chain_tip,
-        chain_tip_change,
-        transaction_sender,
-    );
+    let (mut mempool, _peer_set, mut state_service, _tx_verifier, mut recent_syncs) =
+        setup(network).await;
 
     // Enable the mempool
     let _ = mempool.enable(&mut recent_syncs).await;
@@ -584,38 +489,15 @@ async fn mempool_cancel_downloads_after_network_upgrade() -> Result<(), Report> 
 async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
     // Using the mainnet for now
     let network = Network::Mainnet;
-    let consensus_config = ConsensusConfig::default();
-    let state_config = StateConfig::ephemeral();
-    let peer_set = MockService::build().for_unit_tests();
-    let (sync_status, mut recent_syncs) = SyncStatus::new();
-    let (state, latest_chain_tip, chain_tip_change) =
-        zebra_state::init(state_config.clone(), network);
 
-    let mut state_service = ServiceBuilder::new().buffer(1).service(state);
-    let (_chain_verifier, _tx_verifier) =
-        zebra_consensus::chain::init(consensus_config.clone(), network, state_service.clone())
-            .await;
-    let mut tx_verifier = MockService::build().for_unit_tests();
+    let (mut mempool, _peer_set, mut state_service, mut tx_verifier, mut recent_syncs) =
+        setup(network).await;
 
     // Get transactions to use in the test
     let mut unmined_transactions = unmined_transactions_in_blocks(1..=2, network);
     let rejected_tx = unmined_transactions.next().unwrap().clone();
 
     time::pause();
-
-    // Start the mempool service
-    let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
-
-    let mut mempool = Mempool::new(
-        &mempool::Config::default(),
-        Buffer::new(BoxService::new(peer_set.clone()), 1),
-        state_service.clone(),
-        Buffer::new(BoxService::new(tx_verifier.clone()), 1),
-        sync_status,
-        latest_chain_tip,
-        chain_tip_change,
-        transaction_sender,
-    );
 
     // Enable the mempool
     let _ = mempool.enable(&mut recent_syncs).await;
@@ -690,37 +572,15 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
 async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
     // Using the mainnet for now
     let network = Network::Mainnet;
-    let consensus_config = ConsensusConfig::default();
-    let state_config = StateConfig::ephemeral();
-    let mut peer_set = MockService::build().for_unit_tests();
-    let (sync_status, mut recent_syncs) = SyncStatus::new();
-    let (state, latest_chain_tip, chain_tip_change) =
-        zebra_state::init(state_config.clone(), network);
 
-    let mut state_service = ServiceBuilder::new().buffer(1).service(state);
-    let (_chain_verifier, tx_verifier) =
-        zebra_consensus::chain::init(consensus_config.clone(), network, state_service.clone())
-            .await;
+    let (mut mempool, mut peer_set, mut state_service, _tx_verifier, mut recent_syncs) =
+        setup(network).await;
 
     // Get transactions to use in the test
     let mut unmined_transactions = unmined_transactions_in_blocks(1..=2, network);
     let rejected_valid_tx = unmined_transactions.next().unwrap().clone();
 
     time::pause();
-
-    // Start the mempool service
-    let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
-
-    let mut mempool = Mempool::new(
-        &mempool::Config::default(),
-        Buffer::new(BoxService::new(peer_set.clone()), 1),
-        state_service.clone(),
-        tx_verifier,
-        sync_status,
-        latest_chain_tip,
-        chain_tip_change,
-        transaction_sender,
-    );
 
     // Enable the mempool
     let _ = mempool.enable(&mut recent_syncs).await;
@@ -784,4 +644,37 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
     assert!(queued_responses[0].is_ok());
 
     Ok(())
+}
+
+/// Create a new [`Mempool`] instance using mocked services.
+async fn setup(
+    network: Network,
+) -> (
+    Mempool,
+    MockPeerSet,
+    StateService,
+    MockTxVerifier,
+    RecentSyncLengths,
+) {
+    let peer_set = MockService::build().for_unit_tests();
+
+    let state_config = StateConfig::ephemeral();
+    let (state, latest_chain_tip, chain_tip_change) = zebra_state::init(state_config, network);
+    let state_service = ServiceBuilder::new().buffer(1).service(state);
+
+    let tx_verifier = MockService::build().for_unit_tests();
+
+    let (sync_status, recent_syncs) = SyncStatus::new();
+
+    let (mempool, _mempool_transaction_receiver) = Mempool::new(
+        &mempool::Config::default(),
+        Buffer::new(BoxService::new(peer_set.clone()), 1),
+        state_service.clone(),
+        Buffer::new(BoxService::new(tx_verifier.clone()), 1),
+        sync_status,
+        latest_chain_tip,
+        chain_tip_change,
+    );
+
+    (mempool, peer_set, state_service, tx_verifier, recent_syncs)
 }

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -9,7 +9,7 @@ use zebra_consensus::Config as ConsensusConfig;
 use zebra_state::Config as StateConfig;
 use zebra_test::mock_service::MockService;
 
-use super::super::{storage::tests::unmined_transactions_in_blocks, *};
+use crate::components::mempool::{self, storage::tests::unmined_transactions_in_blocks, *};
 
 #[tokio::test]
 async fn mempool_service_basic() -> Result<(), Report> {
@@ -39,6 +39,7 @@ async fn mempool_service_basic() -> Result<(), Report> {
     let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
 
     let mut service = Mempool::new(
+        &mempool::Config::default(),
         Buffer::new(BoxService::new(peer_set), 1),
         state_service.clone(),
         tx_verifier,
@@ -168,6 +169,7 @@ async fn mempool_queue() -> Result<(), Report> {
     let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
 
     let mut service = Mempool::new(
+        &mempool::Config::default(),
         Buffer::new(BoxService::new(peer_set), 1),
         state_service.clone(),
         tx_verifier,
@@ -269,6 +271,7 @@ async fn mempool_service_disabled() -> Result<(), Report> {
     let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
 
     let mut service = Mempool::new(
+        &mempool::Config::default(),
         Buffer::new(BoxService::new(peer_set), 1),
         state_service.clone(),
         tx_verifier,
@@ -392,6 +395,7 @@ async fn mempool_cancel_mined() -> Result<(), Report> {
     let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
 
     let mut mempool = Mempool::new(
+        &mempool::Config::default(),
         Buffer::new(BoxService::new(peer_set), 1),
         state_service.clone(),
         tx_verifier,
@@ -506,6 +510,7 @@ async fn mempool_cancel_downloads_after_network_upgrade() -> Result<(), Report> 
     let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
 
     let mut mempool = Mempool::new(
+        &mempool::Config::default(),
         Buffer::new(BoxService::new(peer_set), 1),
         state_service.clone(),
         tx_verifier,
@@ -602,6 +607,7 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
     let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
 
     let mut mempool = Mempool::new(
+        &mempool::Config::default(),
         Buffer::new(BoxService::new(peer_set.clone()), 1),
         state_service.clone(),
         Buffer::new(BoxService::new(tx_verifier.clone()), 1),
@@ -706,6 +712,7 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
     let (transaction_sender, _transaction_receiver) = tokio::sync::watch::channel(HashSet::new());
 
     let mut mempool = Mempool::new(
+        &mempool::Config::default(),
         Buffer::new(BoxService::new(peer_set.clone()), 1),
         state_service.clone(),
         tx_verifier,


### PR DESCRIPTION
## Motivation

To implement ZIP-401, we need to pass the mempool config to the mempool.

This is a high priority, because ZIP-401 is on the critical path.
This PR is unexpected work - it wasn't done as part of creating the mempool config.

## Solution

Functionality:
- Pass the mempool config to the mempool

Refactors:
- Split mempool config into its own module
- Create the transaction sender channel inside the mempool
  - Refactor a setup function out of the mempool unit tests

## Review

@dconnolly might want to review this PR, because the config is needed for ticket #2780.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- #2690 
- #2780