### PR TITLE
Add a debug config that enables the mempool

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -17,6 +17,7 @@ const MAX_SINGLE_PEER_RETRIES: usize = 2;
 
 /// Configuration for networking code.
 #[derive(Clone, Debug, Serialize)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     /// The address on which this node should listen for connections.
     ///

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -65,6 +65,9 @@ pub struct Config {
     /// - regularly, every time `crawl_new_peer_interval` elapses, and
     /// - if the peer set is busy, and there aren't any peer addresses for the
     ///   next connection attempt.
+    //
+    // Note: Durations become a TOML table, so they must be the final item in the config
+    //       We'll replace them with a more user-friendly format in #2847
     pub crawl_new_peer_interval: Duration,
 }
 

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -110,12 +110,17 @@ impl StartCmd {
 
         let sync_gossip_task_handle = tokio::spawn(sync::gossip_best_tip_block_hashes(
             sync_status.clone(),
-            chain_tip_change,
+            chain_tip_change.clone(),
             peer_set.clone(),
         ));
 
-        let mempool_crawler_task_handle =
-            mempool::Crawler::spawn(peer_set.clone(), mempool, sync_status);
+        let mempool_crawler_task_handle = mempool::Crawler::spawn(
+            &config.mempool,
+            peer_set.clone(),
+            mempool,
+            sync_status,
+            chain_tip_change,
+        );
 
         let tx_gossip_task_handle = tokio::spawn(mempool::gossip_mempool_transaction_id(
             mempool_transaction_receiver,

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -13,6 +13,7 @@ use tokio::sync::watch;
 use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, Service};
 
 use zebra_chain::{
+    block::Height,
     chain_tip::ChainTip,
     transaction::{UnminedTx, UnminedTxId},
 };
@@ -108,6 +109,9 @@ pub struct Mempool {
     /// Allows checking if we are near the tip to enable/disable the mempool.
     sync_status: SyncStatus,
 
+    /// If the state's best chain tip has reached this height, always enable the mempool.
+    debug_enable_at_height: Option<Height>,
+
     /// Allow efficient access to the best tip of the blockchain.
     latest_chain_tip: zs::LatestChainTip,
 
@@ -134,7 +138,7 @@ pub struct Mempool {
 
 impl Mempool {
     pub(crate) fn new(
-        _config: &Config,
+        config: &Config,
         outbound: Outbound,
         state: State,
         tx_verifier: TxVerifier,
@@ -148,6 +152,7 @@ impl Mempool {
         let mut service = Mempool {
             active_state: ActiveState::Disabled,
             sync_status,
+            debug_enable_at_height: config.debug_enable_at_height.map(Height),
             latest_chain_tip,
             chain_tip_change,
             outbound,
@@ -163,10 +168,29 @@ impl Mempool {
         (service, transaction_receiver)
     }
 
+    /// Is the mempool enabled by a debug config option?
+    fn is_enabled_by_debug(&self) -> bool {
+        // optimise non-debug performance
+        if self.debug_enable_at_height.is_none() {
+            return false;
+        }
+
+        let enable_at_height = self
+            .debug_enable_at_height
+            .expect("unexpected debug_enable_at_height: just checked for None");
+
+        if let Some(best_tip_height) = self.latest_chain_tip.best_tip_height() {
+            best_tip_height >= enable_at_height
+        } else {
+            false
+        }
+    }
+
     /// Update the mempool state (enabled / disabled) depending on how close to
     /// the tip is the synchronization, including side effects to state changes.
     fn update_state(&mut self) {
-        let is_close_to_tip = self.sync_status.is_close_to_tip();
+        let is_close_to_tip = self.sync_status.is_close_to_tip() || self.is_enabled_by_debug();
+
         if self.is_enabled() == is_close_to_tip {
             // the active state is up to date
             return;

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -110,7 +110,9 @@ pub struct Mempool {
 
     /// Allow efficient access to the best tip of the blockchain.
     latest_chain_tip: zs::LatestChainTip,
-    /// Allows the detection of chain tip resets.
+
+    /// Allows the detection of newly added chain tip blocks,
+    /// and chain tip resets.
     chain_tip_change: ChainTipChange,
 
     /// Handle to the outbound service.
@@ -415,6 +417,7 @@ fn reject_if_needed(
         // If it was cancelled then a block was mined, or there was a network
         // upgrade, etc. No reason to reject it.
         TransactionDownloadVerifyError::Cancelled => {}
+
         // Consensus verification failed. Reject transaction to avoid
         // having to download and verify it again just for it to fail again.
         TransactionDownloadVerifyError::Invalid(e) => {

--- a/zebrad/src/components/mempool/config.rs
+++ b/zebrad/src/components/mempool/config.rs
@@ -25,22 +25,33 @@ pub struct Config {
     /// This corresponds to `mempoolevictionmemoryminutes` from
     /// [ZIP-401](https://zips.z.cash/zip-0401#specification).
     pub eviction_memory_time: Duration,
+
+    /// If the state's best chain tip has reached this height, always enable the mempool,
+    /// regardless of Zebra's sync status.
+    ///
+    /// Set to `None` by default: Zebra always checks the sync status before enabling the mempool.
+    //
+    // TODO: allow the mempool to be enabled before the genesis block is committed?
+    //       we could replace `Option` with an enum that has an `AlwaysEnable` variant
+    pub debug_enable_at_height: Option<u32>,
 }
 
-/// Consensus rules:
-///
-/// > There MUST be a configuration option mempooltxcostlimit,
-/// > which SHOULD default to 80000000.
-/// >
-/// > There MUST be a configuration option mempoolevictionmemoryminutes,
-/// > which SHOULD default to 60 [minutes].
-///
-/// https://zips.z.cash/zip-0401#specification
 impl Default for Config {
     fn default() -> Self {
         Self {
+            /// Consensus rules:
+            ///
+            /// > There MUST be a configuration option mempooltxcostlimit,
+            /// > which SHOULD default to 80000000.
+            /// >
+            /// > There MUST be a configuration option mempoolevictionmemoryminutes,
+            /// > which SHOULD default to 60 [minutes].
+            ///
+            /// https://zips.z.cash/zip-0401#specification
             tx_cost_limit: 80_000_000,
             eviction_memory_time: Duration::from_secs(60 * 60),
+
+            debug_enable_at_height: None,
         }
     }
 }

--- a/zebrad/src/components/mempool/config.rs
+++ b/zebrad/src/components/mempool/config.rs
@@ -8,6 +8,17 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
+    /// If the state's best chain tip has reached this height, always enable the mempool,
+    /// regardless of Zebra's sync status.
+    ///
+    /// Set to `None` by default: Zebra always checks the sync status before enabling the mempool.
+    //
+    // TODO:
+    // - allow the mempool to be enabled before the genesis block is committed?
+    //   we could replace `Option` with an enum that has an `AlwaysEnable` variant
+    // - move debug configs last (needs #2847)
+    pub debug_enable_at_height: Option<u32>,
+
     /// The mempool transaction cost limit.
     ///
     /// This limits the total serialized byte size of all transactions in the mempool.
@@ -25,16 +36,10 @@ pub struct Config {
     ///
     /// This corresponds to `mempoolevictionmemoryminutes` from
     /// [ZIP-401](https://zips.z.cash/zip-0401#specification).
-    pub eviction_memory_time: Duration,
-
-    /// If the state's best chain tip has reached this height, always enable the mempool,
-    /// regardless of Zebra's sync status.
-    ///
-    /// Set to `None` by default: Zebra always checks the sync status before enabling the mempool.
     //
-    // TODO: allow the mempool to be enabled before the genesis block is committed?
-    //       we could replace `Option` with an enum that has an `AlwaysEnable` variant
-    pub debug_enable_at_height: Option<u32>,
+    // Note: Durations become a TOML table, so they must be the final item in the config
+    //       We'll replace them with a more user-friendly format in #2847
+    pub eviction_memory_time: Duration,
 }
 
 impl Default for Config {

--- a/zebrad/src/components/mempool/config.rs
+++ b/zebrad/src/components/mempool/config.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 /// Mempool configuration section.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     /// The mempool transaction cost limit.
     ///

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -37,7 +37,7 @@ const PEER_RESPONSE_TIMEOUT: Duration = Duration::from_secs(6);
 pub struct Crawler<PeerSet, Mempool> {
     peer_set: Timeout<PeerSet>,
     mempool: Mempool,
-    status: SyncStatus,
+    sync_status: SyncStatus,
 }
 
 impl<PeerSet, Mempool> Crawler<PeerSet, Mempool>
@@ -53,12 +53,12 @@ where
     pub fn spawn(
         peer_set: PeerSet,
         mempool: Mempool,
-        status: SyncStatus,
+        sync_status: SyncStatus,
     ) -> JoinHandle<Result<(), BoxError>> {
         let crawler = Crawler {
             peer_set: Timeout::new(peer_set, PEER_RESPONSE_TIMEOUT),
             mempool,
-            status,
+            sync_status,
         };
 
         tokio::spawn(crawler.run())
@@ -71,7 +71,7 @@ where
     pub async fn run(mut self) -> Result<(), BoxError> {
         info!("initializing mempool crawler task");
 
-        while self.status.wait_until_close_to_tip().await.is_ok() {
+        while self.sync_status.wait_until_close_to_tip().await.is_ok() {
             self.crawl_transactions().await?;
             sleep(RATE_LIMIT_DELAY).await;
         }

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -71,12 +71,12 @@ where
     pub async fn run(mut self) -> Result<(), BoxError> {
         info!("initializing mempool crawler task");
 
-        while self.sync_status.wait_until_close_to_tip().await.is_ok() {
+        loop {
+            self.sync_status.wait_until_close_to_tip().await?;
+
             self.crawl_transactions().await?;
             sleep(RATE_LIMIT_DELAY).await;
         }
-
-        Ok(())
     }
 
     /// Crawl peers for transactions.

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -4,15 +4,17 @@
 
 use std::time::Duration;
 
-use futures::{stream::FuturesUnordered, StreamExt};
-use tokio::{task::JoinHandle, time::sleep};
+use futures::{future, pin_mut, stream::FuturesUnordered, StreamExt};
+use tokio::{sync::watch, task::JoinHandle, time::sleep};
 use tower::{timeout::Timeout, BoxError, Service, ServiceExt};
 
+use zebra_chain::block::Height;
 use zebra_network as zn;
+use zebra_state::ChainTipChange;
 
-use super::{
-    super::{mempool, sync::SyncStatus},
-    downloads::Gossip,
+use crate::components::{
+    mempool::{self, downloads::Gossip, Config},
+    sync::SyncStatus,
 };
 
 #[cfg(test)]
@@ -35,9 +37,20 @@ const PEER_RESPONSE_TIMEOUT: Duration = Duration::from_secs(6);
 
 /// The mempool transaction crawler.
 pub struct Crawler<PeerSet, Mempool> {
+    /// The network peer set to crawl.
     peer_set: Timeout<PeerSet>,
+
+    /// The mempool service that receives crawled transaction IDs.
     mempool: Mempool,
+
+    /// Allows checking if we are near the tip to enable/disable the mempool crawler.
     sync_status: SyncStatus,
+
+    /// Notifies the crawler when the best chain tip height changes.
+    chain_tip_change: ChainTipChange,
+
+    /// If the state's best chain tip has reached this height, always enable the mempool crawler.
+    debug_enable_at_height: Option<Height>,
 }
 
 impl<PeerSet, Mempool> Crawler<PeerSet, Mempool>
@@ -51,17 +64,65 @@ where
 {
     /// Spawn an asynchronous task to run the mempool crawler.
     pub fn spawn(
+        config: &Config,
         peer_set: PeerSet,
         mempool: Mempool,
         sync_status: SyncStatus,
+        chain_tip_change: ChainTipChange,
     ) -> JoinHandle<Result<(), BoxError>> {
         let crawler = Crawler {
             peer_set: Timeout::new(peer_set, PEER_RESPONSE_TIMEOUT),
             mempool,
             sync_status,
+            chain_tip_change,
+            debug_enable_at_height: config.debug_enable_at_height.map(Height),
         };
 
         tokio::spawn(crawler.run())
+    }
+
+    /// Waits until the mempool crawler is enabled by a debug config option.
+    ///
+    /// Returns an error if communication with the state is lost.
+    async fn wait_until_enabled_by_debug(&mut self) -> Result<(), watch::error::RecvError> {
+        // optimise non-debug performance
+        if self.debug_enable_at_height.is_none() {
+            return future::pending().await;
+        }
+
+        let enable_at_height = self
+            .debug_enable_at_height
+            .expect("unexpected debug_enable_at_height: just checked for None");
+
+        loop {
+            let best_tip_height = self
+                .chain_tip_change
+                .wait_for_tip_change()
+                .await?
+                .best_tip_height();
+
+            if best_tip_height >= enable_at_height {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Waits until the mempool crawler is enabled.
+    ///
+    /// Returns an error if communication with the syncer or state is lost.
+    async fn wait_until_enabled(&mut self) -> Result<(), watch::error::RecvError> {
+        let mut sync_status = self.sync_status.clone();
+        let tip_future = sync_status.wait_until_close_to_tip();
+        let debug_future = self.wait_until_enabled_by_debug();
+
+        pin_mut!(tip_future);
+        pin_mut!(debug_future);
+
+        let (result, _unready_future) = future::select(tip_future, debug_future)
+            .await
+            .factor_first();
+
+        result
     }
 
     /// Periodically crawl peers for transactions to include in the mempool.
@@ -72,8 +133,7 @@ where
         info!("initializing mempool crawler task");
 
         loop {
-            self.sync_status.wait_until_close_to_tip().await?;
-
+            self.wait_until_enabled().await?;
             self.crawl_transactions().await?;
             sleep(RATE_LIMIT_DELAY).await;
         }


### PR DESCRIPTION
## Motivation

We want to run acceptance tests on the mempool.

To do that, we need to be able to configure the mempool to start quickly.
(Rather than at the chain tip, which takes hours to sync.)

Closes #2690.

## Solution

- Add a mempool `debug_enable_at_height` config
- Use `debug_enable_at_height` in the mempool service
- Use `debug_enable_at_height` in the mempool crawler

Tests:
- Add a basic mempool activation acceptance tests, using `debug_enable_at_height`

Bug fixes:
- Propagate syncer channel errors through the crawler
- Deny unknown fields and apply defaults for all configs

I'd like to leave the crawler refactor for my next PR, so we can bisect if it causes issues.

## Review

@conradoplg can finish off the review for this PR.

~~This PR is based on PR #2861.~~

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- #2691

Refactor the `debug_enable_at_height` checks - choose one of:
    - move the `debug_enable_at_height` code into `SyncStatus`, so we don't have to copy it everywhere we use `SyncStatus`
    - launch the mempool crawler task when the `Mempool` is enabled, and kill it when it is disabled

