### PR TITLE
Make some mempool functions associated with the `mempool::Storage` type

### DIFF
--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use zebra_chain::transaction::{self, UnminedTx, UnminedTxId};
 
 use self::verified_set::VerifiedSet;
-use super::MempoolError;
+use super::{downloads::TransactionDownloadVerifyError, MempoolError};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
@@ -361,5 +361,86 @@ impl Storage {
     /// This matches transactions based on each rejection list's matching rule.
     pub fn contains_rejected(&self, txid: &UnminedTxId) -> bool {
         self.rejection_error(txid).is_some()
+    }
+
+    /// Add a transaction that failed download and verification to the rejected list
+    /// if needed, depending on the reason for the failure.
+    pub fn reject_if_needed(&mut self, txid: UnminedTxId, e: TransactionDownloadVerifyError) {
+        match e {
+            // Rejecting a transaction already in state would speed up further
+            // download attempts without checking the state. However it would
+            // make the reject list grow forever.
+            //
+            // TODO: revisit after reviewing the rejected list cleanup criteria?
+            // TODO: if we decide to reject it, then we need to pass the block hash
+            // to State::Confirmed. This would require the zs::Response::Transaction
+            // to include the hash, which would need to be implemented.
+            TransactionDownloadVerifyError::InState |
+            // An unknown error in the state service, better do nothing
+            TransactionDownloadVerifyError::StateError(_) |
+            // Sync has just started. Mempool shouldn't even be enabled, so will not
+            // happen in practice.
+            TransactionDownloadVerifyError::NoTip |
+            // If download failed, do nothing; the crawler will end up trying to
+            // download it again.
+            TransactionDownloadVerifyError::DownloadFailed(_) |
+            // If it was cancelled then a block was mined, or there was a network
+            // upgrade, etc. No reason to reject it.
+            TransactionDownloadVerifyError::Cancelled => {}
+
+            // Consensus verification failed. Reject transaction to avoid
+            // having to download and verify it again just for it to fail again.
+            TransactionDownloadVerifyError::Invalid(e) => {
+                self.reject(txid, ExactTipRejectionError::FailedVerification(e).into())
+            }
+        }
+    }
+
+    /// Remove transactions from the mempool if they have not been mined after a
+    /// specified height.
+    ///
+    /// https://zips.z.cash/zip-0203#specification
+    pub fn remove_expired_transactions(
+        &mut self,
+        tip_height: zebra_chain::block::Height,
+    ) -> HashSet<UnminedTxId> {
+        let mut txid_set = HashSet::new();
+        // we need a separate set, since reject() takes the original unmined ID,
+        // then extracts the mined ID out of it
+        let mut unmined_id_set = HashSet::new();
+
+        for t in self.transactions() {
+            if let Some(expiry_height) = t.transaction.expiry_height() {
+                if tip_height >= expiry_height {
+                    txid_set.insert(t.id.mined_id());
+                    unmined_id_set.insert(t.id);
+                }
+            }
+        }
+
+        // expiry height is effecting data, so we match by non-malleable TXID
+        self.remove_same_effects(&txid_set);
+
+        // also reject it
+        for id in unmined_id_set.iter() {
+            self.reject(*id, SameEffectsChainRejectionError::Expired.into());
+        }
+
+        unmined_id_set
+    }
+
+    /// Check if transaction should be downloaded and/or verified.
+    ///
+    /// If it is already in the mempool (or in its rejected list)
+    /// then it shouldn't be downloaded/verified.
+    pub fn should_download_or_verify(&mut self, txid: UnminedTxId) -> Result<(), MempoolError> {
+        // Check if the transaction is already in the mempool.
+        if self.contains_transaction_exact(&txid) {
+            return Err(MempoolError::InMempool);
+        }
+        if let Some(error) = self.rejection_error(&txid) {
+            return Err(error);
+        }
+        Ok(())
     }
 }

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -180,7 +180,7 @@ fn mempool_expired_basic_for_network(network: Network) -> Result<()> {
     assert!(everything_in_mempool.contains(&tx_id));
 
     // remove_expired_transactions() will return what was removed
-    let expired = Mempool::remove_expired_transactions(&mut storage, Height(1));
+    let expired = storage.remove_expired_transactions(Height(1));
     assert!(expired.contains(&tx_id));
     let everything_in_mempool: HashSet<UnminedTxId> = storage.tx_ids().collect();
     assert_eq!(everything_in_mempool.len(), 0);

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use crate::components::mempool::{remove_expired_from_peer_list, remove_expired_transactions};
+use crate::components::mempool::Mempool;
 
 use super::{super::*, unmined_transactions_in_blocks};
 
@@ -180,13 +180,13 @@ fn mempool_expired_basic_for_network(network: Network) -> Result<()> {
     assert!(everything_in_mempool.contains(&tx_id));
 
     // remove_expired_transactions() will return what was removed
-    let expired = remove_expired_transactions(&mut storage, Height(1));
+    let expired = Mempool::remove_expired_transactions(&mut storage, Height(1));
     assert!(expired.contains(&tx_id));
     let everything_in_mempool: HashSet<UnminedTxId> = storage.tx_ids().collect();
     assert_eq!(everything_in_mempool.len(), 0);
 
     // No transaction will be sent to peers
-    let send_to_peers = remove_expired_from_peer_list(&everything_in_mempool, &expired);
+    let send_to_peers = Mempool::remove_expired_from_peer_list(&everything_in_mempool, &expired);
     assert_eq!(send_to_peers.len(), 0);
 
     Ok(())


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

Encapsulates some `mempool` functions with the `Mempool` type.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

A bit of a style / tidy nit.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

Not urgent, low priority.

### Reviewer Checklist

  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
