### PR TITLE
Always zero the mempool metrics when the mempool is disabled

### DIFF
--- a/zebrad/src/components/mempool/storage/verified_set.rs
+++ b/zebrad/src/components/mempool/storage/verified_set.rs
@@ -43,6 +43,13 @@ pub struct VerifiedSet {
     orchard_nullifiers: HashSet<orchard::Nullifier>,
 }
 
+impl Drop for VerifiedSet {
+    fn drop(&mut self) {
+        // zero the metrics on drop
+        self.clear()
+    }
+}
+
 impl VerifiedSet {
     /// Returns an iterator over the transactions in the set.
     pub fn transactions(&self) -> impl Iterator<Item = &UnminedTx> + '_ {


### PR DESCRIPTION
## Motivation

We can drop the mempool's storage without updating its metrics.

This might not be a bug yet - it depends on exactly how we do metrics, and exactly how we disable the mempool.

This is unexpected work in sprint 20.

## Solution

- Add a Drop impl that clears the storage and metrics

## Review

I think this might conflict with @conradoplg's mempool metrics PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Do this for all the metrics
