### PR TITLE
Return transaction fee

### DIFF
--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -99,6 +99,9 @@ pub enum TransactionError {
 
     #[error("adding to the sprout pool is disabled after Canopy")]
     DisabledAddToSproutPool,
+
+    #[error("could not calculate the transaction fee")]
+    IncorrectFee,
 }
 
 impl From<BoxError> for TransactionError {

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -274,7 +274,10 @@ async fn v5_transaction_is_accepted_after_nu5_activation_for_network(network: Ne
         })
         .await;
 
-    assert_eq!(result, Ok(expected_hash));
+    assert_eq!(
+        result.expect("expected a tx_id and tx_fee").0,
+        expected_hash
+    );
 }
 
 /// Test if V4 transaction with transparent funds is accepted.
@@ -320,7 +323,10 @@ async fn v4_transaction_with_transparent_transfer_is_accepted() {
         })
         .await;
 
-    assert_eq!(result, Ok(transaction_hash));
+    assert_eq!(
+        result.expect("expected a tx_id and tx_fee").0,
+        transaction_hash
+    );
 }
 
 /// Test if V4 coinbase transaction is accepted.
@@ -363,7 +369,10 @@ async fn v4_coinbase_transaction_is_accepted() {
         })
         .await;
 
-    assert_eq!(result, Ok(transaction_hash));
+    assert_eq!(
+        result.expect("expected a tx_id and tx_fee").0,
+        transaction_hash
+    );
 }
 
 /// Test if V4 transaction with transparent funds is rejected if the source script prevents it.
@@ -464,7 +473,10 @@ async fn v5_transaction_with_transparent_transfer_is_accepted() {
         })
         .await;
 
-    assert_eq!(result, Ok(transaction_hash));
+    assert_eq!(
+        result.expect("expected a tx_id and tx_fee").0,
+        transaction_hash
+    );
 }
 
 /// Test if V5 coinbase transaction is accepted.
@@ -510,7 +522,10 @@ async fn v5_coinbase_transaction_is_accepted() {
         })
         .await;
 
-    assert_eq!(result, Ok(transaction_hash));
+    assert_eq!(
+        result.expect("expected a tx_id and tx_fee").0,
+        transaction_hash
+    );
 }
 
 /// Test if V5 transaction with transparent funds is rejected if the source script prevents it.
@@ -627,7 +642,10 @@ fn v4_with_signed_sprout_transfer_is_accepted() {
             })
             .await;
 
-        assert_eq!(result, Ok(expected_hash));
+        assert_eq!(
+            result.expect("expected a tx_id and tx_fee").0,
+            expected_hash
+        );
     });
 }
 
@@ -725,7 +743,10 @@ fn v4_with_sapling_spends() {
             })
             .await;
 
-        assert_eq!(result, Ok(expected_hash));
+        assert_eq!(
+            result.expect("expected a tx_id and tx_fee").0,
+            expected_hash
+        );
     });
 }
 
@@ -766,7 +787,10 @@ fn v4_with_sapling_outputs_and_no_spends() {
             })
             .await;
 
-        assert_eq!(result, Ok(expected_hash));
+        assert_eq!(
+            result.expect("expected a tx_id and tx_fee").0,
+            expected_hash
+        );
     });
 }
 
@@ -810,7 +834,10 @@ fn v5_with_sapling_spends() {
             })
             .await;
 
-        assert_eq!(result, Ok(expected_hash));
+        assert_eq!(
+            result.expect("expected a tx_id and tx_fee").0,
+            expected_hash
+        );
     });
 }
 

--- a/zebra-test/src/mock_service.rs
+++ b/zebra-test/src/mock_service.rs
@@ -356,7 +356,7 @@ impl<Request, Response, Error> MockService<Request, Response, PanicAssertion, Er
     /// #     let mut service = mock_service.clone();
     /// #
     /// let call = tokio::spawn(mock_service.clone().oneshot(1));
-    ///  
+    ///
     /// mock_service.expect_request_that(|request| *request > 0).await.respond("response");
     ///
     /// assert!(matches!(call.await, Ok(Ok("response"))));

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -8,6 +8,7 @@ use tower::{buffer::Buffer, builder::ServiceBuilder, util::BoxService, Service, 
 use tracing::Span;
 
 use zebra_chain::{
+    amount::Amount,
     block::Block,
     parameters::Network,
     serialization::ZcashDeserializeInto,
@@ -117,7 +118,10 @@ async fn mempool_push_transaction() -> Result<(), crate::BoxError> {
     // Simulate a successful transaction verification
     let verification = tx_verifier.expect_request_that(|_| true).map(|responder| {
         let txid = responder.request().tx_id();
-        responder.respond(txid);
+
+        // Set a dummy fee.
+        let tx_fee = Amount::zero();
+        responder.respond((txid, tx_fee));
     });
     let (response, _) = futures::join!(request, verification);
     match response {
@@ -205,7 +209,10 @@ async fn mempool_advertise_transaction_ids() -> Result<(), crate::BoxError> {
     // Simulate a successful transaction verification
     let verification = tx_verifier.expect_request_that(|_| true).map(|responder| {
         let txid = responder.request().tx_id();
-        responder.respond(txid);
+
+        // Set a dummy fee.
+        let tx_fee = Amount::zero();
+        responder.respond((txid, tx_fee));
     });
     let (response, _, _) = futures::join!(request, peer_set_responder, verification);
 
@@ -292,7 +299,10 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
     // Simulate a successful transaction verification
     let verification = tx_verifier.expect_request_that(|_| true).map(|responder| {
         tx1_id = responder.request().tx_id();
-        responder.respond(tx1_id);
+
+        // Set a dummy fee.
+        let tx_fee = Amount::zero();
+        responder.respond((tx1_id, tx_fee));
     });
     let (response, _) = futures::join!(request, verification);
     match response {
@@ -381,7 +391,10 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
     // Simulate a successful transaction verification
     let verification = tx_verifier.expect_request_that(|_| true).map(|responder| {
         tx2_id = responder.request().tx_id();
-        responder.respond(tx2_id);
+
+        // Set a dummy fee.
+        let tx_fee = Amount::zero();
+        responder.respond((tx2_id, tx_fee));
     });
     let (response, _) = futures::join!(request, verification);
     match response {

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -300,7 +300,7 @@ where
                     transaction: tx.clone(),
                     height,
                 })
-                .map_ok(|_hash| tx)
+                .map_ok(|(_tx_id, _tx_fee)| tx)
                 .await;
 
             tracing::debug!(?txid, ?result, "verified transaction for the mempool");


### PR DESCRIPTION
## Motivation

ZIP-401 requires the mempool to have transaction fees at its disposal.

## Solution

The transaction verifier service now returns the transaction fee. In the case of a coinbase transaction, the verifier does not attempt to obtain the fee and returns a zero fee instead. 

Closes #2779.

### Note
Please note that the verifier service now returns `Ok((id, tx_fee))` instead of `Ok(id)`. I'm not sure if this was the intended solution in #2779.

## Review

@teor2345 and @dconnolly can review this PR.
