### PR TITLE
Store the transaction fee in the mempool storage

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -25,7 +25,7 @@ pub use lock_time::LockTime;
 pub use memo::Memo;
 pub use sapling::FieldNotPresent;
 pub use sighash::{HashType, SigHash};
-pub use unmined::{UnminedTx, UnminedTxId};
+pub use unmined::{UnminedTx, UnminedTxId, VerifiedUnminedTx};
 
 use crate::{
     amount::{Amount, Error as AmountError, NegativeAllowed, NonNegative},

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -17,12 +17,14 @@ use std::{fmt, sync::Arc};
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
 
-use crate::serialization::ZcashSerialize;
-
-use super::{
-    AuthDigest, Hash,
-    Transaction::{self, *},
-    WtxId,
+use crate::{
+    amount::{Amount, NonNegative},
+    serialization::ZcashSerialize,
+    transaction::{
+        AuthDigest, Hash,
+        Transaction::{self, *},
+        WtxId,
+    },
 };
 
 use UnminedTxId::*;
@@ -164,6 +166,9 @@ impl UnminedTxId {
 }
 
 /// An unmined transaction, and its pre-calculated unique identifying ID.
+///
+/// This transaction has been structurally verified.
+/// (But it might still need semantic or contextual verification.)
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UnminedTx {
     /// A unique identifier for this unmined transaction.
@@ -224,5 +229,24 @@ impl From<&Arc<Transaction>> for UnminedTx {
                 .zcash_serialized_size()
                 .expect("all transactions have a size"),
         }
+    }
+}
+
+/// A verified unmined transaction, and the corresponding transaction fee.
+///
+/// This transaction has been fully verified, in the context of the mempool.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedUnminedTx {
+    /// The unmined transaction.
+    pub tx: UnminedTx,
+
+    /// The transaction fee for this unmined transaction.
+    pub miner_fee: Amount<NonNegative>,
+}
+
+impl VerifiedUnminedTx {
+    /// Create a new verified unmined transaction from a transaction and its fee.
+    pub fn new(tx: UnminedTx, miner_fee: Amount<NonNegative>) -> Self {
+        Self { tx, miner_fee }
     }
 }

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -245,6 +245,7 @@ impl From<&Arc<Transaction>> for UnminedTx {
 ///
 /// This transaction has been fully verified, in the context of the mempool.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct VerifiedUnminedTx {
     /// The unmined transaction.
     pub transaction: UnminedTx,

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -238,7 +238,7 @@ impl From<&Arc<Transaction>> for UnminedTx {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VerifiedUnminedTx {
     /// The unmined transaction.
-    pub tx: UnminedTx,
+    pub transaction: UnminedTx,
 
     /// The transaction fee for this unmined transaction.
     pub miner_fee: Amount<NonNegative>,
@@ -246,7 +246,10 @@ pub struct VerifiedUnminedTx {
 
 impl VerifiedUnminedTx {
     /// Create a new verified unmined transaction from a transaction and its fee.
-    pub fn new(tx: UnminedTx, miner_fee: Amount<NonNegative>) -> Self {
-        Self { tx, miner_fee }
+    pub fn new(transaction: UnminedTx, miner_fee: Amount<NonNegative>) -> Self {
+        Self {
+            transaction,
+            miner_fee,
+        }
     }
 }

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -181,6 +181,15 @@ pub struct UnminedTx {
     pub size: usize,
 }
 
+impl fmt::Display for UnminedTx {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnminedTx")
+            .field("transaction", &self.transaction)
+            .field("serialized_size", &self.size)
+            .finish()
+    }
+}
+
 // Each of these conversions is implemented slightly differently,
 // to avoid cloning the transaction where possible.
 
@@ -242,6 +251,15 @@ pub struct VerifiedUnminedTx {
 
     /// The transaction fee for this unmined transaction.
     pub miner_fee: Amount<NonNegative>,
+}
+
+impl fmt::Display for VerifiedUnminedTx {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VerifiedUnminedTx")
+            .field("transaction", &self.transaction)
+            .field("miner_fee", &self.miner_fee)
+            .finish()
+    }
 }
 
 impl VerifiedUnminedTx {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -134,12 +134,26 @@ pub enum Response {
     },
 }
 
+impl From<VerifiedUnminedTx> for Response {
+    fn from(transaction: VerifiedUnminedTx) -> Self {
+        Response::Mempool { transaction }
+    }
+}
+
 impl Request {
     /// The transaction to verify that's in this request.
     pub fn transaction(&self) -> Arc<Transaction> {
         match self {
             Request::Block { transaction, .. } => transaction.clone(),
             Request::Mempool { transaction, .. } => transaction.transaction.clone(),
+        }
+    }
+
+    /// The unverified mempool transaction, if this is a mempool request.
+    pub fn into_mempool_transaction(self) -> Option<UnminedTx> {
+        match self {
+            Request::Block { .. } => None,
+            Request::Mempool { transaction, .. } => Some(transaction),
         }
     }
 

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -23,7 +23,9 @@ use zebra_chain::{
     parameters::{Network, NetworkUpgrade},
     primitives::Groth16Proof,
     sapling,
-    transaction::{self, HashType, SigHash, Transaction, UnminedTx, UnminedTxId},
+    transaction::{
+        self, HashType, SigHash, Transaction, UnminedTx, UnminedTxId, VerifiedUnminedTx,
+    },
     transparent,
 };
 
@@ -97,13 +99,40 @@ pub enum Request {
 
 /// The response type for the transaction verifier service.
 /// Responses identify the transaction that was verified.
-///
-/// [`Block`] requests can be uniquely identified by [`UnminedTxId::mined_id`],
-/// because the block's authorizing data root will be checked during contextual validation.
-///
-/// [`Mempool`] requests are uniquely identified by the [`UnminedTxId`]
-/// variant for their transaction version.
-pub type Response = (zebra_chain::transaction::UnminedTxId, Amount<NonNegative>);
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Response {
+    /// A response to a block transaction verification request.
+    Block {
+        /// The witnessed transaction ID for this transaction.
+        ///
+        /// [`Block`] responses can be uniquely identified by [`UnminedTxId::mined_id`],
+        /// because the block's authorizing data root will be checked during contextual validation.
+        tx_id: UnminedTxId,
+
+        /// The miner fee for this transaction.
+        /// `None` for coinbase transactions.
+        ///
+        /// Consensus rule:
+        /// > The remaining value in the transparent transaction value pool
+        /// > of a coinbase transaction is destroyed.
+        ///
+        /// https://zips.z.cash/protocol/protocol.pdf#transactions
+        miner_fee: Option<Amount<NonNegative>>,
+    },
+
+    /// A response to a mempool transaction verification request.
+    Mempool {
+        /// The full content of the verified mempool transaction.
+        /// Also contains the transaction fee and other associated fields.
+        ///
+        /// Mempool transactions always have a transaction fee,
+        /// because coinbase transactions are rejected from the mempool.
+        ///
+        /// [`Mempool`] responses are uniquely identified by the [`UnminedTxId`]
+        /// variant for their transaction version.
+        transaction: VerifiedUnminedTx,
+    },
+}
 
 impl Request {
     /// The transaction to verify that's in this request.
@@ -154,6 +183,42 @@ impl Request {
     }
 }
 
+impl Response {
+    /// The verified mempool transaction, if this is a mempool response.
+    pub fn into_mempool_transaction(self) -> Option<VerifiedUnminedTx> {
+        match self {
+            Response::Block { .. } => None,
+            Response::Mempool { transaction, .. } => Some(transaction),
+        }
+    }
+
+    /// The unmined transaction ID for the transaction in this response.
+    pub fn tx_id(&self) -> UnminedTxId {
+        match self {
+            Response::Block { tx_id, .. } => *tx_id,
+            Response::Mempool { transaction, .. } => transaction.transaction.id,
+        }
+    }
+
+    /// The miner fee for the transaction in this response.
+    ///
+    /// Coinbase transactions do not have a miner fee.
+    pub fn miner_fee(&self) -> Option<Amount<NonNegative>> {
+        match self {
+            Response::Block { miner_fee, .. } => *miner_fee,
+            Response::Mempool { transaction, .. } => Some(transaction.miner_fee),
+        }
+    }
+
+    /// Returns true if the request is a mempool request.
+    pub fn is_mempool(&self) -> bool {
+        match self {
+            Response::Block { .. } => false,
+            Response::Mempool { .. } => true,
+        }
+    }
+}
+
 impl<ZS> Service<Request> for Verifier<ZS>
 where
     ZS: Service<zs::Request, Response = zs::Response, Error = BoxError> + Send + Clone + 'static,
@@ -174,8 +239,8 @@ where
         let network = self.network;
 
         let tx = req.transaction();
-        let id = req.tx_id();
-        let span = tracing::debug_span!("tx", ?id);
+        let tx_id = req.tx_id();
+        let span = tracing::debug_span!("tx", ?tx_id);
 
         async move {
             tracing::trace!(?req);
@@ -221,7 +286,7 @@ where
                     sapling_shielded_data,
                     ..
                 } => Self::verify_v4_transaction(
-                    req,
+                    &req,
                     network,
                     script_verifier,
                     inputs,
@@ -235,7 +300,7 @@ where
                     orchard_shielded_data,
                     ..
                 } => Self::verify_v5_transaction(
-                    req,
+                    &req,
                     network,
                     script_verifier,
                     inputs,
@@ -255,21 +320,32 @@ where
             // Get the `value_balance` to calculate the transaction fee.
             let value_balance = tx.value_balance(&spent_utxos);
 
-            // Initialize the transaction fee to zero.
-            let mut tx_fee = Amount::<NonNegative>::zero();
-
             // Calculate the fee only for non-coinbase transactions.
+            let mut miner_fee = None;
             if !tx.has_valid_coinbase_transaction_inputs() {
-                tx_fee = match value_balance {
+                // TODO: deduplicate this code with remaining_transaction_value (#TODO: open ticket)
+                miner_fee = match value_balance {
                     Ok(vb) => match vb.remaining_transaction_value() {
-                        Ok(tx_rtv) => tx_rtv,
+                        Ok(tx_rtv) => Some(tx_rtv),
                         Err(_) => return Err(TransactionError::IncorrectFee),
                     },
                     Err(_) => return Err(TransactionError::IncorrectFee),
                 };
             }
 
-            Ok((id, tx_fee))
+            let rsp = match req {
+                Request::Block { .. } => Response::Block { tx_id, miner_fee },
+                Request::Mempool { transaction, .. } => Response::Mempool {
+                    transaction: VerifiedUnminedTx::new(
+                        transaction,
+                        miner_fee.expect(
+                            "unexpected mempool coinbase transaction: should have already rejected",
+                        ),
+                    ),
+                },
+            };
+
+            Ok(rsp)
         }
         .instrument(span)
         .boxed()
@@ -300,7 +376,7 @@ where
     /// - the Sprout `joinsplit_data` shielded data in the transaction
     /// - the `sapling_shielded_data` in the transaction
     fn verify_v4_transaction(
-        request: Request,
+        request: &Request,
         network: Network,
         script_verifier: script::Verifier<ZS>,
         inputs: &[transparent::Input],
@@ -316,7 +392,7 @@ where
         let shielded_sighash = tx.sighash(upgrade, HashType::ALL, None);
 
         Ok(Self::verify_transparent_inputs_and_outputs(
-            &request,
+            request,
             network,
             script_verifier,
             inputs,
@@ -382,7 +458,7 @@ where
     /// - the sapling shielded data of the transaction, if any
     /// - the orchard shielded data of the transaction, if any
     fn verify_v5_transaction(
-        request: Request,
+        request: &Request,
         network: Network,
         script_verifier: script::Verifier<ZS>,
         inputs: &[transparent::Input],
@@ -398,7 +474,7 @@ where
         let shielded_sighash = transaction.sighash(upgrade, HashType::ALL, None);
 
         Ok(Self::verify_transparent_inputs_and_outputs(
-            &request,
+            request,
             network,
             script_verifier,
             inputs,

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -275,7 +275,7 @@ async fn v5_transaction_is_accepted_after_nu5_activation_for_network(network: Ne
         .await;
 
     assert_eq!(
-        result.expect("expected a tx_id and tx_fee").0,
+        result.expect("unexpected error response").tx_id(),
         expected_hash
     );
 }
@@ -324,7 +324,7 @@ async fn v4_transaction_with_transparent_transfer_is_accepted() {
         .await;
 
     assert_eq!(
-        result.expect("expected a tx_id and tx_fee").0,
+        result.expect("unexpected error response").tx_id(),
         transaction_hash
     );
 }
@@ -370,7 +370,7 @@ async fn v4_coinbase_transaction_is_accepted() {
         .await;
 
     assert_eq!(
-        result.expect("expected a tx_id and tx_fee").0,
+        result.expect("unexpected error response").tx_id(),
         transaction_hash
     );
 }
@@ -474,7 +474,7 @@ async fn v5_transaction_with_transparent_transfer_is_accepted() {
         .await;
 
     assert_eq!(
-        result.expect("expected a tx_id and tx_fee").0,
+        result.expect("unexpected error response").tx_id(),
         transaction_hash
     );
 }
@@ -523,7 +523,7 @@ async fn v5_coinbase_transaction_is_accepted() {
         .await;
 
     assert_eq!(
-        result.expect("expected a tx_id and tx_fee").0,
+        result.expect("unexpected error response").tx_id(),
         transaction_hash
     );
 }
@@ -643,7 +643,7 @@ fn v4_with_signed_sprout_transfer_is_accepted() {
             .await;
 
         assert_eq!(
-            result.expect("expected a tx_id and tx_fee").0,
+            result.expect("unexpected error response").tx_id(),
             expected_hash
         );
     });
@@ -744,7 +744,7 @@ fn v4_with_sapling_spends() {
             .await;
 
         assert_eq!(
-            result.expect("expected a tx_id and tx_fee").0,
+            result.expect("unexpected error response").tx_id(),
             expected_hash
         );
     });
@@ -788,7 +788,7 @@ fn v4_with_sapling_outputs_and_no_spends() {
             .await;
 
         assert_eq!(
-            result.expect("expected a tx_id and tx_fee").0,
+            result.expect("unexpected error response").tx_id(),
             expected_hash
         );
     });
@@ -835,7 +835,7 @@ fn v5_with_sapling_spends() {
             .await;
 
         assert_eq!(
-            result.expect("expected a tx_id and tx_fee").0,
+            result.expect("unexpected error response").tx_id(),
             expected_hash
         );
     });

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -12,7 +12,7 @@ use zebra_chain::{
     block::Block,
     parameters::Network,
     serialization::ZcashDeserializeInto,
-    transaction::{UnminedTx, UnminedTxId},
+    transaction::{UnminedTx, UnminedTxId, VerifiedUnminedTx},
 };
 use zebra_consensus::{error::TransactionError, transaction, Config as ConsensusConfig};
 use zebra_network::{AddressBook, Request, Response};
@@ -41,6 +41,10 @@ async fn mempool_requests_for_transactions() {
         tx_gossip_task_handle,
     ) = setup(true).await;
 
+    let added_transactions: Vec<UnminedTx> = added_transactions
+        .iter()
+        .map(|t| t.transaction.clone())
+        .collect();
     let added_transaction_ids: Vec<UnminedTxId> = added_transactions.iter().map(|t| t.id).collect();
 
     // Test `Request::MempoolTransactionIds`
@@ -117,11 +121,17 @@ async fn mempool_push_transaction() -> Result<(), crate::BoxError> {
         .oneshot(Request::PushTransaction(tx.clone().into()));
     // Simulate a successful transaction verification
     let verification = tx_verifier.expect_request_that(|_| true).map(|responder| {
-        let txid = responder.request().tx_id();
+        let transaction = responder
+            .request()
+            .clone()
+            .into_mempool_transaction()
+            .expect("unexpected non-mempool request");
 
         // Set a dummy fee.
-        let tx_fee = Amount::zero();
-        responder.respond((txid, tx_fee));
+        responder.respond(transaction::Response::from(VerifiedUnminedTx::new(
+            transaction,
+            Amount::zero(),
+        )));
     });
     let (response, _) = futures::join!(request, verification);
     match response {
@@ -208,11 +218,17 @@ async fn mempool_advertise_transaction_ids() -> Result<(), crate::BoxError> {
             });
     // Simulate a successful transaction verification
     let verification = tx_verifier.expect_request_that(|_| true).map(|responder| {
-        let txid = responder.request().tx_id();
+        let transaction = responder
+            .request()
+            .clone()
+            .into_mempool_transaction()
+            .expect("unexpected non-mempool request");
 
         // Set a dummy fee.
-        let tx_fee = Amount::zero();
-        responder.respond((txid, tx_fee));
+        responder.respond(transaction::Response::from(VerifiedUnminedTx::new(
+            transaction,
+            Amount::zero(),
+        )));
     });
     let (response, _, _) = futures::join!(request, peer_set_responder, verification);
 
@@ -299,10 +315,17 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
     // Simulate a successful transaction verification
     let verification = tx_verifier.expect_request_that(|_| true).map(|responder| {
         tx1_id = responder.request().tx_id();
+        let transaction = responder
+            .request()
+            .clone()
+            .into_mempool_transaction()
+            .expect("unexpected non-mempool request");
 
         // Set a dummy fee.
-        let tx_fee = Amount::zero();
-        responder.respond((tx1_id, tx_fee));
+        responder.respond(transaction::Response::from(VerifiedUnminedTx::new(
+            transaction,
+            Amount::zero(),
+        )));
     });
     let (response, _) = futures::join!(request, verification);
     match response {
@@ -391,10 +414,17 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
     // Simulate a successful transaction verification
     let verification = tx_verifier.expect_request_that(|_| true).map(|responder| {
         tx2_id = responder.request().tx_id();
+        let transaction = responder
+            .request()
+            .clone()
+            .into_mempool_transaction()
+            .expect("unexpected non-mempool request");
 
         // Set a dummy fee.
-        let tx_fee = Amount::zero();
-        responder.respond((tx2_id, tx_fee));
+        responder.respond(transaction::Response::from(VerifiedUnminedTx::new(
+            transaction,
+            Amount::zero(),
+        )));
     });
     let (response, _) = futures::join!(request, verification);
     match response {
@@ -529,7 +559,7 @@ async fn setup(
     >,
     Buffer<BoxService<mempool::Request, mempool::Response, BoxError>, mempool::Request>,
     Vec<Arc<Block>>,
-    Vec<UnminedTx>,
+    Vec<VerifiedUnminedTx>,
     MockService<transaction::Request, transaction::Response, PanicAssertion, TransactionError>,
     MockService<Request, Response, PanicAssertion>,
     Buffer<BoxService<zebra_state::Request, zebra_state::Response, BoxError>, zebra_state::Request>,
@@ -667,7 +697,10 @@ async fn setup(
 /// Manually add a transaction to the mempool storage.
 ///
 /// Skips some mempool functionality, like transaction verification and peer broadcasts.
-fn add_some_stuff_to_mempool(mempool_service: &mut Mempool, network: Network) -> Vec<UnminedTx> {
+fn add_some_stuff_to_mempool(
+    mempool_service: &mut Mempool,
+    network: Network,
+) -> Vec<VerifiedUnminedTx> {
     // get the genesis block coinbase transaction from the Zcash blockchain.
     let genesis_transactions: Vec<_> = unmined_transactions_in_blocks(..=0, network)
         .take(1)

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -16,7 +16,7 @@ use tokio::{sync::oneshot, task::JoinHandle};
 use tower::{Service, ServiceExt};
 use tracing_futures::Instrument;
 
-use zebra_chain::transaction::{self, UnminedTx, UnminedTxId};
+use zebra_chain::transaction::{self, UnminedTx, UnminedTxId, VerifiedUnminedTx};
 use zebra_consensus::transaction as tx;
 use zebra_network as zn;
 use zebra_state as zs;
@@ -144,7 +144,7 @@ where
     /// A list of pending transaction download and verify tasks.
     #[pin]
     pending: FuturesUnordered<
-        JoinHandle<Result<UnminedTx, (TransactionDownloadVerifyError, UnminedTxId)>>,
+        JoinHandle<Result<VerifiedUnminedTx, (TransactionDownloadVerifyError, UnminedTxId)>>,
     >,
 
     /// A list of channels that can be used to cancel pending transaction download and
@@ -161,7 +161,7 @@ where
     ZS: Service<zs::Request, Response = zs::Response, Error = BoxError> + Send + Clone + 'static,
     ZS::Future: Send,
 {
-    type Item = Result<UnminedTx, (UnminedTxId, TransactionDownloadVerifyError)>;
+    type Item = Result<VerifiedUnminedTx, (UnminedTxId, TransactionDownloadVerifyError)>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         let this = self.project();
@@ -177,7 +177,7 @@ where
         if let Some(join_result) = ready!(this.pending.poll_next(cx)) {
             match join_result.expect("transaction download and verify tasks must not panic") {
                 Ok(tx) => {
-                    this.cancel_handles.remove(&tx.id);
+                    this.cancel_handles.remove(&tx.transaction.id);
                     Poll::Ready(Some(Ok(tx)))
                 }
                 Err((e, hash)) => {
@@ -300,7 +300,10 @@ where
                     transaction: tx.clone(),
                     height,
                 })
-                .map_ok(|(_tx_id, _tx_fee)| tx)
+                .map_ok(|rsp| {
+                    rsp.into_mempool_transaction()
+                        .expect("unexpected non-mempool response to mempool request")
+                })
                 .await;
 
             tracing::debug!(?txid, ?result, "verified transaction for the mempool");

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use thiserror::Error;
 
-use zebra_chain::transaction::{self, UnminedTx, UnminedTxId};
+use zebra_chain::transaction::{self, UnminedTx, UnminedTxId, VerifiedUnminedTx};
 
 use self::verified_set::VerifiedSet;
 use super::{downloads::TransactionDownloadVerifyError, MempoolError};
@@ -117,7 +117,7 @@ pub struct Storage {
 }
 
 impl Storage {
-    /// Insert a [`UnminedTx`] into the mempool, caching any rejections.
+    /// Insert a [`VerifiedUnminedTx`] into the mempool, caching any rejections.
     ///
     /// Returns an error if the mempool's verified transactions or rejection caches
     /// prevent this transaction from being inserted.
@@ -125,14 +125,14 @@ impl Storage {
     ///
     /// If inserting this transaction evicts other transactions, they will be tracked
     /// as [`StorageRejectionError::RandomlyEvicted`].
-    pub fn insert(&mut self, tx: UnminedTx) -> Result<UnminedTxId, MempoolError> {
+    pub fn insert(&mut self, tx: VerifiedUnminedTx) -> Result<UnminedTxId, MempoolError> {
         // # Security
         //
         // This method must call `reject`, rather than modifying the rejection lists directly.
-        let tx_id = tx.id;
+        let tx_id = tx.transaction.id;
 
         // First, check if we have a cached rejection for this transaction.
-        if let Some(error) = self.rejection_error(&tx.id) {
+        if let Some(error) = self.rejection_error(&tx_id) {
             return Err(error);
         }
 
@@ -140,7 +140,7 @@ impl Storage {
         //
         // Security: transactions must not get refreshed by new queries,
         // because that allows malicious peers to keep transactions live forever.
-        if self.verified.contains(&tx.id) {
+        if self.verified.contains(&tx_id) {
             return Err(MempoolError::InMempool);
         }
 
@@ -160,13 +160,13 @@ impl Storage {
                 .expect("mempool is empty, but was expected to be full");
 
             self.reject(
-                evicted_tx.id,
+                evicted_tx.transaction.id,
                 SameEffectsChainRejectionError::RandomlyEvicted.into(),
             );
 
             // If this transaction gets evicted, set its result to the same error
             // (we could return here, but we still want to check the mempool size)
-            if evicted_tx.id == tx_id {
+            if evicted_tx.transaction.id == tx_id {
                 result = Err(SameEffectsChainRejectionError::RandomlyEvicted.into());
             }
         }
@@ -176,7 +176,7 @@ impl Storage {
         result
     }
 
-    /// Remove [`UnminedTx`]es from the mempool via exact [`UnminedTxId`].
+    /// Remove transactions from the mempool via exact [`UnminedTxId`].
     ///
     /// For v5 transactions, transactions are matched by WTXID, using both the:
     /// - non-malleable transaction ID, and
@@ -193,10 +193,10 @@ impl Storage {
     #[allow(dead_code)]
     pub fn remove_exact(&mut self, exact_wtxids: &HashSet<UnminedTxId>) -> usize {
         self.verified
-            .remove_all_that(|tx| exact_wtxids.contains(&tx.id))
+            .remove_all_that(|tx| exact_wtxids.contains(&tx.transaction.id))
     }
 
-    /// Remove [`UnminedTx`]es from the mempool via non-malleable [`transaction::Hash`].
+    /// Remove transactions from the mempool via non-malleable [`transaction::Hash`].
     ///
     /// For v5 transactions, transactions are matched by TXID,
     /// using only the non-malleable transaction ID.
@@ -211,7 +211,7 @@ impl Storage {
     /// Does not add or remove from the 'rejected' tracking set.
     pub fn remove_same_effects(&mut self, mined_ids: &HashSet<transaction::Hash>) -> usize {
         self.verified
-            .remove_all_that(|tx| mined_ids.contains(&tx.id.mined_id()))
+            .remove_all_that(|tx| mined_ids.contains(&tx.transaction.id.mined_id()))
     }
 
     /// Clears the whole mempool storage.
@@ -254,7 +254,7 @@ impl Storage {
         self.verified.transactions().map(|tx| tx.id)
     }
 
-    /// Returns the set of [`Transaction`][transaction::Transaction]s in the mempool.
+    /// Returns the set of [`UnminedTx`]es in the mempool.
     pub fn transactions(&self) -> impl Iterator<Item = &UnminedTx> {
         self.verified.transactions()
     }
@@ -265,7 +265,7 @@ impl Storage {
         self.verified.transaction_count()
     }
 
-    /// Returns the set of [`Transaction`][transaction::Transaction]s with exactly matching
+    /// Returns the set of [`UnminedTx`]es with exactly matching
     /// `tx_ids` in the mempool.
     ///
     /// This matches the exact transaction, with identical blockchain effects, signatures, and proofs.
@@ -278,7 +278,7 @@ impl Storage {
             .filter(move |tx| tx_ids.contains(&tx.id))
     }
 
-    /// Returns `true` if a [`UnminedTx`] exactly matching an [`UnminedTxId`] is in
+    /// Returns `true` if a transaction exactly matching an [`UnminedTxId`] is in
     /// the mempool.
     ///
     /// This matches the exact transaction, with identical blockchain effects, signatures, and proofs.
@@ -319,7 +319,7 @@ impl Storage {
         self.limit_rejection_list_memory();
     }
 
-    /// Returns the rejection error if a [`UnminedTx`] matching an [`UnminedTxId`]
+    /// Returns the rejection error if a transaction matching an [`UnminedTxId`]
     /// is in any mempool rejected list.
     ///
     /// This matches transactions based on each rejection list's matching rule.
@@ -355,7 +355,7 @@ impl Storage {
             .filter(move |txid| self.contains_rejected(txid))
     }
 
-    /// Returns `true` if a [`UnminedTx`] matching the supplied [`UnminedTxId`] is in
+    /// Returns `true` if a transaction matching the supplied [`UnminedTxId`] is in
     /// the mempool rejected list.
     ///
     /// This matches transactions based on each rejection list's matching rule.

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -4,7 +4,7 @@ use proptest::prelude::*;
 use tokio::time;
 use tower::{buffer::Buffer, util::BoxService};
 
-use zebra_chain::{parameters::Network, transaction::UnminedTx};
+use zebra_chain::{parameters::Network, transaction::VerifiedUnminedTx};
 use zebra_consensus::{error::TransactionError, transaction as tx};
 use zebra_network as zn;
 use zebra_state::{self as zs, ChainTipBlock, ChainTipSender};
@@ -29,7 +29,7 @@ proptest! {
     #[test]
     fn storage_is_cleared_on_chain_reset(
         network in any::<Network>(),
-        transaction in any::<UnminedTx>(),
+        transaction in any::<VerifiedUnminedTx>(),
         chain_tip in any::<ChainTipBlock>(),
     ) {
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -83,7 +83,7 @@ proptest! {
     #[test]
     fn storage_is_cleared_if_syncer_falls_behind(
         network in any::<Network>(),
-        transaction in any::<UnminedTx>(),
+        transaction in any::<VerifiedUnminedTx>(),
     ) {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -81,7 +81,7 @@ async fn mempool_service_basic() -> Result<(), Report> {
 
     // Make sure the transaction from the blockchain test vector is the same as the
     // response of `Request::TransactionsById`
-    assert_eq!(genesis_transaction, transactions[0]);
+    assert_eq!(genesis_transaction.transaction, transactions[0]);
 
     // Insert more transactions into the mempool storage.
     // This will cause the genesis transaction to be moved into rejected.
@@ -113,7 +113,7 @@ async fn mempool_service_basic() -> Result<(), Report> {
         .ready_and()
         .await
         .unwrap()
-        .call(Request::Queue(vec![last_transaction.id.into()]))
+        .call(Request::Queue(vec![last_transaction.transaction.id.into()]))
         .await
         .unwrap();
     let queued_responses = match response {
@@ -167,7 +167,7 @@ async fn mempool_queue() -> Result<(), Report> {
         .ready_and()
         .await
         .unwrap()
-        .call(Request::Queue(vec![new_tx.id.into()]))
+        .call(Request::Queue(vec![new_tx.transaction.id.into()]))
         .await
         .unwrap();
     let queued_responses = match response {
@@ -182,7 +182,7 @@ async fn mempool_queue() -> Result<(), Report> {
         .ready_and()
         .await
         .unwrap()
-        .call(Request::Queue(vec![stored_tx.id.into()]))
+        .call(Request::Queue(vec![stored_tx.transaction.id.into()]))
         .await
         .unwrap();
     let queued_responses = match response {
@@ -197,7 +197,7 @@ async fn mempool_queue() -> Result<(), Report> {
         .ready_and()
         .await
         .unwrap()
-        .call(Request::Queue(vec![rejected_tx.id.into()]))
+        .call(Request::Queue(vec![rejected_tx.transaction.id.into()]))
         .await
         .unwrap();
     let queued_responses = match response {
@@ -256,7 +256,7 @@ async fn mempool_service_disabled() -> Result<(), Report> {
 
     // Queue a transaction for download
     // Use the ID of the last transaction in the list
-    let txid = more_transactions.last().unwrap().id;
+    let txid = more_transactions.last().unwrap().transaction.id;
     let response = service
         .ready_and()
         .await
@@ -522,7 +522,7 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
         .ready_and()
         .await
         .unwrap()
-        .call(Request::Queue(vec![rejected_tx.clone().into()]));
+        .call(Request::Queue(vec![rejected_tx.transaction.clone().into()]));
     // Make the mock verifier return that the transaction is invalid.
     let verification = tx_verifier.expect_request_that(|_| true).map(|responder| {
         responder.respond(Err(TransactionError::BadBalance));
@@ -549,7 +549,7 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
         .ready_and()
         .await
         .unwrap()
-        .call(Request::Queue(vec![rejected_tx.id.into()]))
+        .call(Request::Queue(vec![rejected_tx.transaction.id.into()]))
         .await
         .unwrap();
     let queued_responses = match response {
@@ -604,7 +604,10 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
         .ready_and()
         .await
         .unwrap()
-        .call(Request::Queue(vec![rejected_valid_tx.id.into()]));
+        .call(Request::Queue(vec![rejected_valid_tx
+            .transaction
+            .id
+            .into()]));
     // Make the mock peer set return that the download failed.
     let verification = peer_set
         .expect_request_that(|r| matches!(r, zn::Request::TransactionsById(_)))
@@ -633,7 +636,10 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
         .ready_and()
         .await
         .unwrap()
-        .call(Request::Queue(vec![rejected_valid_tx.id.into()]))
+        .call(Request::Queue(vec![rejected_valid_tx
+            .transaction
+            .id
+            .into()]))
         .await
         .unwrap();
     let queued_responses = match response {


### PR DESCRIPTION
## Motivation

In PR #2876, we calculate the transaction fee in the transaction verifier, and return it in the verifier response.

But we need to use the fee in the mempool storage.
So we need to get the fee from the downloader response to the mempool storage.

This is unexpected work in sprint 20, we didn't really think of getting the fee into storage when we split the tickets.

## Solution

- Create a new `VerifiedUnminedTx` struct containing the miner fee
- Use `VerifiedUnminedTx` in mempool verification `Response`s
- Use `VerifiedUnminedTx` in mempool download and verifier
- Use `VerifiedUnminedTx` in mempool storage and verified set
- Use `VerifiedUnminedTx` in existing tests

## Review

@dconnolly probably needs this PR for ticket #2780.

@upbqdn might want to check how the new `VerifiedUnminedTx` and transaction verifier `Response`s work.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Actually use the fee to evict transactions #2780