### PR TITLE
Cancel pending download tasks when the mempool is disabled

### DIFF
--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -228,7 +228,10 @@ impl Mempool {
 
         // Update enabled / disabled state
         if is_close_to_tip {
-            info!("activating mempool: Zebra is close to the tip");
+            info!(
+                tip_height = ?self.latest_chain_tip.best_tip_height(),
+                "activating mempool: Zebra is close to the tip"
+            );
 
             let tx_downloads = Box::pin(TxDownloads::new(
                 Timeout::new(self.outbound.clone(), TRANSACTION_DOWNLOAD_TIMEOUT),
@@ -240,7 +243,10 @@ impl Mempool {
                 tx_downloads,
             };
         } else {
-            info!("deactivating mempool: Zebra is syncing lots of blocks");
+            info!(
+                tip_height = ?self.latest_chain_tip.best_tip_height(),
+                "deactivating mempool: Zebra is syncing lots of blocks"
+            );
 
             // This drops the previous ActiveState::Enabled,
             // cancelling its download tasks.
@@ -288,6 +294,11 @@ impl Service<Request> for Mempool {
 
         // Clear the mempool and cancel downloads if there has been a chain tip reset.
         if matches!(tip_action, Some(TipAction::Reset { .. })) {
+            info!(
+                tip_height = ?tip_action.as_ref().unwrap().best_tip_height(),
+                "resetting mempool: switched best chain, skipped blocks, or activated network upgrade"
+            );
+
             // Use the same code for dropping and resetting the mempool,
             // to avoid subtle bugs.
 

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -96,6 +96,27 @@ enum ActiveState {
     },
 }
 
+impl Default for ActiveState {
+    fn default() -> Self {
+        ActiveState::Disabled
+    }
+}
+
+impl Drop for ActiveState {
+    fn drop(&mut self) {
+        if let ActiveState::Enabled { tx_downloads, .. } = self {
+            tx_downloads.cancel_all();
+        }
+    }
+}
+
+impl ActiveState {
+    /// Returns the current state, leaving a [`Disabled`] in its place.
+    fn take(&mut self) -> Self {
+        std::mem::take(self)
+    }
+}
+
 /// Mempool async management and query service.
 ///
 /// The mempool is the set of all verified transactions that this node is aware

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -242,6 +242,8 @@ impl Mempool {
         } else {
             info!("deactivating mempool: Zebra is syncing lots of blocks");
 
+            // This drops the previous ActiveState::Enabled,
+            // cancelling its download tasks.
             self.active_state = ActiveState::Disabled
         }
     }

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -215,6 +215,7 @@ impl Storage {
     }
 
     /// Clears the whole mempool storage.
+    #[allow(dead_code)]
     pub fn clear(&mut self) {
         self.verified.clear();
         self.tip_rejected_exact.clear();


### PR DESCRIPTION
## Motivation

Zebra doesn't cancel the download tasks when it disables the mempool.
This is a potential denial of service risk, if peers can get the mempool to activate and decativate quickly.

Also, we're using different code for disable and reset, which is a future bug risk.

This bug is unexpected work in sprint 20.

## Solution

- Impl `Drop`, `Default` and `take()` for `ActiveState`
- Refactor `Mempool::poll_ready` to check if the mempool is disabled or reset first
- Use the same code for dropping and resetting the mempool
- Log mempool resets at info level
    - Add the height to enable/disable/reset logs

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

