### PR TITLE
Remove duplicate IDs in mempool requests and responses

### DIFF
--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -396,7 +396,7 @@ impl Service<zn::Request> for Inbound {
                 if let Setup::Initialized { mempool, .. } = &mut self.network_setup {
                     mempool.clone().oneshot(mempool::Request::TransactionIds).map_ok(|resp| match resp {
                         mempool::Response::TransactionIds(transaction_ids) if transaction_ids.is_empty() => zn::Response::Nil,
-                        mempool::Response::TransactionIds(transaction_ids) => zn::Response::TransactionIds(transaction_ids),
+                        mempool::Response::TransactionIds(transaction_ids) => zn::Response::TransactionIds(transaction_ids.into_iter().collect()),
                         _ => unreachable!("Mempool component should always respond to a `TransactionIds` request with a `TransactionIds` response"),
                     })
                     .boxed()

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -72,8 +72,8 @@ pub enum Request {
 #[derive(Debug)]
 pub enum Response {
     Transactions(Vec<UnminedTx>),
-    TransactionIds(Vec<UnminedTxId>),
-    RejectedTransactionIds(Vec<UnminedTxId>),
+    TransactionIds(HashSet<UnminedTxId>),
+    RejectedTransactionIds(HashSet<UnminedTxId>),
     Queued(Vec<Result<(), MempoolError>>),
 }
 


### PR DESCRIPTION
## Motivation

Currently, Zebra allows duplicate transaction IDs in some mempool service and crawler requests.
But we know those IDs should be unique.

Allowing duplicates is a minor denial of service risk.

## Solution

- Guarantee unique IDs in mempool service responses
- Guarantee unique IDs in crawler task mempool Queue requests 

## Review

I think @upbqdn designed some of these requests?

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

