### PR TITLE
Display mempool documentation in our public docs website

### DIFF
--- a/zebrad/src/components.rs
+++ b/zebrad/src/components.rs
@@ -8,8 +8,11 @@
 mod inbound;
 pub mod mempool;
 pub mod metrics;
+#[allow(missing_docs)]
 pub mod sync;
+#[allow(missing_docs)]
 pub mod tokio;
+#[allow(missing_docs)]
 pub mod tracing;
 
 pub use inbound::Inbound;

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -124,6 +124,7 @@ pub struct Inbound {
 }
 
 impl Inbound {
+    /// Initialize a new `Inbound` service.
     pub fn new(
         network_setup: oneshot::Receiver<NetworkSetupData>,
         state: State,

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -24,11 +24,15 @@ use zebra_state::{ChainTipChange, TipAction};
 
 use crate::components::sync::SyncStatus;
 
-mod config;
+pub mod config;
 mod crawler;
+#[allow(missing_docs)]
 pub mod downloads;
+#[allow(missing_docs)]
 mod error;
+#[allow(missing_docs)]
 pub mod gossip;
+#[allow(missing_docs)]
 mod storage;
 
 #[cfg(test)]
@@ -61,6 +65,7 @@ type InboundTxDownloads = TxDownloads<Timeout<Outbound>, Timeout<TxVerifier>, St
 
 #[derive(Debug, Eq, PartialEq)]
 #[allow(dead_code)]
+#[allow(missing_docs)]
 pub enum Request {
     TransactionIds,
     TransactionsById(HashSet<UnminedTxId>),
@@ -69,6 +74,7 @@ pub enum Request {
 }
 
 #[derive(Debug)]
+#[allow(missing_docs)]
 pub enum Response {
     Transactions(Vec<UnminedTx>),
     TransactionIds(Vec<UnminedTxId>),

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -36,10 +36,9 @@ extern crate tracing;
 /// parameterized by 'a), *not* that the object itself has 'static lifetime.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-mod components;
-
 pub mod application;
 pub mod commands;
+pub mod components;
 pub mod config;
 pub mod prelude;
 pub mod sentry;


### PR DESCRIPTION
## Motivation

We are writing documentation for the mempool pieces of zebra in https://github.com/ZcashFoundation/zebra/issues/2859 but we want this docs to show up in https://doc.zebra.zfnd.org/zebrad/

## Solution

Make the components and mempool config mods public as suggested in https://github.com/ZcashFoundation/zebra/issues/2859#issuecomment-943786821

When doing this a lot of warnings of missing docs appeared. The easy fix was to add some `#[allow(missing_docs)]` that we should eventually remove https://github.com/ZcashFoundation/zebra/issues/2891

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] `cargo doc` can create docs (with a lot of warnings but that is another issue: https://github.com/ZcashFoundation/zebra/issues/2892)
  - [ ] Generated docs contain mempool and mempool config.
  - [ ] No warnings are displayed in normal builds (`cargo build` or `cargo test`)

## Follow Up Work

https://github.com/ZcashFoundation/zebra/issues/2891
https://github.com/ZcashFoundation/zebra/issues/2892

