### PR TITLE
Avoid spurious unit test failures on busy machines

### DIFF
--- a/zebra-test/src/mock_service.rs
+++ b/zebra-test/src/mock_service.rs
@@ -76,7 +76,7 @@ const DEFAULT_PROXY_CHANNEL_SIZE: usize = 100;
 ///
 /// Note that if a test checks that no requests are received, each check has to wait for this
 /// amount of time, so this may affect the test execution time.
-const DEFAULT_MAX_REQUEST_DELAY: Duration = Duration::from_millis(25);
+const DEFAULT_MAX_REQUEST_DELAY: Duration = Duration::from_millis(500);
 
 /// An internal type representing the item that's sent in the [`broadcast`] channel.
 ///


### PR DESCRIPTION
## Motivation

Currently, some of Zebra's tests assume that they will get a significant amount of processor time at least every 25 milliseconds.

But this isn't guaranteed on heavily loaded machines with only a few cores. (Like our GitHub test VMs.)

`cargo` tends to trigger this issue by running all the tests for a crate in parallel.

This is unexpected work in sprint 20.

### Test Failure Logs

> thread 'components::inbound::tests::mempool_advertise_transaction_ids' panicked at 'Timeout while waiting for a request', /Users/runner/work/zebra/zebra/zebra-test/src/mock_service.rs:428:21

https://github.com/ZcashFoundation/zebra/pull/2894/checks?check_run_id=3910337270#step:10:1104

## Solution

- Expect significant processor time every 500ms (half a second)

Currently, Zebra's tests only call `expect_no_requests` up to 5 times. So the extra 2.4 seconds should not be noticeable, because the tests for each crate are run in parallel.

## Review

@jvff wrote this code.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
