### PR TITLE
Improve logging for initial peer connections

### DIFF
--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -87,6 +87,15 @@ pub(super) struct MustUseOneshotSender<T: std::fmt::Debug> {
     pub tx: Option<oneshot::Sender<T>>,
 }
 
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // skip the channels, they don't tell us anything useful
+        f.debug_struct("Client")
+            .field("error_slot", &self.error_slot)
+            .finish()
+    }
+}
+
 impl From<ClientRequest> for InProgressClientRequest {
     fn from(client_request: ClientRequest) -> Self {
         let ClientRequest { request, tx, span } = client_request;

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -74,6 +74,16 @@ pub enum PeerError {
 #[derive(Default, Clone)]
 pub(super) struct ErrorSlot(Arc<std::sync::Mutex<Option<SharedPeerError>>>);
 
+impl std::fmt::Debug for ErrorSlot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // don't hang if the mutex is locked
+        // show the panic if the mutex was poisoned
+        f.debug_struct("ErrorSlot")
+            .field("error", &self.0.try_lock())
+            .finish()
+    }
+}
+
 impl ErrorSlot {
     /// Read the current error in the slot.
     ///

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -195,7 +195,16 @@ where
     S: Service<SocketAddr, Response = Change<SocketAddr, peer::Client>, Error = BoxError> + Clone,
     S::Future: Send + 'static,
 {
-    info!(?initial_peers, "connecting to initial peer set");
+    let initial_peer_count = initial_peers.len();
+    let mut handshake_success_total: usize = 0;
+    let mut handshake_error_total: usize = 0;
+
+    info!(
+        ?initial_peer_count,
+        ?initial_peers,
+        "connecting to initial peer set"
+    );
+
     // # Security
     //
     // TODO: rate-limit initial seed peer connections (#2326)
@@ -217,12 +226,37 @@ where
         .collect();
 
     while let Some(handshake_result) = handshakes.next().await {
-        // this is verbose, but it's better than just hanging with no output
-        if let Err((addr, ref e)) = handshake_result {
-            info!(?addr, ?e, "an initial peer connection failed");
+        match handshake_result {
+            Ok(ref change) => {
+                handshake_success_total += 1;
+                debug!(
+                    ?handshake_success_total,
+                    ?handshake_error_total,
+                    ?change,
+                    "an initial peer handshake succeeded"
+                );
+            }
+            Err((addr, ref e)) => {
+                // this is verbose, but it's better than just hanging with no output when there are errors
+                handshake_error_total += 1;
+                info!(
+                    ?handshake_success_total,
+                    ?handshake_error_total,
+                    ?addr,
+                    ?e,
+                    "an initial peer connection failed"
+                );
+            }
         }
+
         tx.send(handshake_result.map_err(|(_addr, e)| e)).await?;
     }
+
+    info!(
+        ?handshake_success_total,
+        ?handshake_error_total,
+        "finished connecting to initial seed peers"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

1. This PR helps diagnose CI failures while connecting to initial peers

2. As part of ticket #2326, we need to make sure that we don't trigger these failures more often. (Or we could fix them entirely as part of that ticket.)

### Detailed Failure Logs

>  Oct 15 18:27:40.621  INFO {zebrad="4648f8f" net="Main"}:add_initial_peers: zebra_network::peer_set::initialize: an initial peer connection failed addr=8.140.105.213:8233 e=Elapsed(())
> Oct 15 18:27:56.622  INFO {zebrad="4648f8f" net="Main"}: zebra_network::peer_set::candidate_set: timeout waiting for the peer service to become ready
> ...
> 0: stdout of command did not contain any matches for the given regex
> ...
> Match Regex:
>   "state is already at the configured height"
> ...
> failures:
>    restart_stop_at_height

https://github.com/ZcashFoundation/zebra/runs/3909044730#step:10:1245
https://github.com/ZcashFoundation/zebra/runs/3909044730#step:10:1262

## Solution

- Log the number of successful handshakes and failed connections when connecting to initial peers
- Log each successful handshake at debug level

## Review

I think I'm going to be working on #2326 with @jvff.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- #2326