### PR TITLE
Limit the number of initial peers

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -5,7 +5,6 @@ use std::{
     time::Duration,
 };
 
-use rand::seq::SliceRandom;
 use serde::{de, Deserialize, Deserializer};
 
 use zebra_chain::{parameters::Network, serialization::canonical_socket_addr};
@@ -117,31 +116,11 @@ impl Config {
     }
 
     /// Get the initial seed peers based on the configured network.
-    /// Limits the number of initial peer addresses to the configured
-    /// `peerset_initial_target_size`.
-    ///
-    /// The result is randomly chosen entries from the provided set of addresses.
     pub async fn initial_peers(&self) -> HashSet<SocketAddr> {
-        let initial_peers = match self.network {
+        match self.network {
             Network::Mainnet => Config::resolve_peers(&self.initial_mainnet_peers).await,
             Network::Testnet => Config::resolve_peers(&self.initial_testnet_peers).await,
-        };
-        let initial_peer_count = initial_peers.len();
-
-        // Limit the number of initial peers to `peerset_initial_target_size`
-        if initial_peer_count > self.peerset_initial_target_size {
-            info!(
-                "Limiting the initial peers list from {} to {}",
-                initial_peer_count, self.peerset_initial_target_size
-            );
         }
-
-        let initial_peers_vect: Vec<SocketAddr> = initial_peers.iter().copied().collect();
-
-        initial_peers_vect
-            .choose_multiple(&mut rand::thread_rng(), self.peerset_initial_target_size)
-            .copied()
-            .collect()
     }
 
     /// Resolves `host` into zero or more IP addresses, retrying up to

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -3,7 +3,8 @@
 // Portions of this submodule were adapted from tower-balance,
 // which is (c) 2019 Tower Contributors (MIT licensed).
 
-use std::{net::SocketAddr, sync::Arc};
+use rand::seq::SliceRandom;
+use std::{collections::HashSet, net::SocketAddr, sync::Arc};
 
 use futures::{
     channel::mpsc,
@@ -204,7 +205,7 @@ where
         > + Clone,
     S::Future: Send + 'static,
 {
-    let initial_peers = config.initial_peers().await;
+    let initial_peers = limit_initial_peers(config).await;
 
     let mut handshake_success_total: usize = 0;
     let mut handshake_error_total: usize = 0;
@@ -281,6 +282,30 @@ where
     );
 
     Ok(active_outbound_connections)
+}
+
+/// Limit the number of `initial_peers` addresses entries to the configured
+/// `peerset_initial_target_size`.
+///
+/// The result is randomly chosen entries from the provided set of addresses.
+async fn limit_initial_peers(config: &Config) -> HashSet<SocketAddr> {
+    let initial_peers = config.initial_peers().await;
+    let initial_peer_count = initial_peers.len();
+
+    // Limit the number of initial peers to `config.peerset_initial_target_size`
+    if initial_peer_count > config.peerset_initial_target_size {
+        info!(
+            "Limiting the initial peers list from {} to {}",
+            initial_peer_count, config.peerset_initial_target_size
+        );
+    }
+
+    let initial_peers_vect: Vec<SocketAddr> = initial_peers.iter().copied().collect();
+
+    initial_peers_vect
+        .choose_multiple(&mut rand::thread_rng(), config.peerset_initial_target_size)
+        .copied()
+        .collect()
 }
 
 /// Open a peer connection listener on `config.listen_addr`,

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -3,8 +3,7 @@
 // Portions of this submodule were adapted from tower-balance,
 // which is (c) 2019 Tower Contributors (MIT licensed).
 
-use rand::seq::SliceRandom;
-use std::{collections::HashSet, net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc};
 
 use futures::{
     channel::mpsc,
@@ -205,7 +204,7 @@ where
         > + Clone,
     S::Future: Send + 'static,
 {
-    let initial_peers = limit_initial_peers(config).await;
+    let initial_peers = config.initial_peers().await;
 
     let mut handshake_success_total: usize = 0;
     let mut handshake_error_total: usize = 0;
@@ -282,30 +281,6 @@ where
     );
 
     Ok(active_outbound_connections)
-}
-
-/// Limit the number of `initial_peers` addresses entries to the configured
-/// `peerset_initial_target_size`.
-///
-/// The result is randomly chosen entries from the provided set of addresses.
-async fn limit_initial_peers(config: &Config) -> HashSet<SocketAddr> {
-    let initial_peers = config.initial_peers().await;
-    let initial_peer_count = initial_peers.len();
-
-    // Limit the number of initial peers to `config.peerset_initial_target_size`
-    if initial_peer_count > config.peerset_initial_target_size {
-        info!(
-            "Limiting the initial peers list from {} to {}",
-            initial_peer_count, config.peerset_initial_target_size
-        );
-    }
-
-    let initial_peers_vect: Vec<SocketAddr> = initial_peers.iter().copied().collect();
-
-    initial_peers_vect
-        .choose_multiple(&mut rand::thread_rng(), config.peerset_initial_target_size)
-        .copied()
-        .collect()
 }
 
 /// Open a peer connection listener on `config.listen_addr`,

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -3,7 +3,6 @@
 // Portions of this submodule were adapted from tower-balance,
 // which is (c) 2019 Tower Contributors (MIT licensed).
 
-use rand::seq::SliceRandom;
 use std::{collections::HashSet, net::SocketAddr, sync::Arc};
 
 use futures::{
@@ -13,6 +12,7 @@ use futures::{
     stream::{FuturesUnordered, StreamExt},
     TryFutureExt,
 };
+use rand::seq::SliceRandom;
 use tokio::{net::TcpListener, sync::broadcast, time::Instant};
 use tower::{
     buffer::Buffer, discover::Change, layer::Layer, load::peak_ewma::PeakEwmaDiscover,
@@ -302,6 +302,8 @@ async fn limit_initial_peers(config: &Config) -> HashSet<SocketAddr> {
 
     let initial_peers_vect: Vec<SocketAddr> = initial_peers.iter().copied().collect();
 
+    // TODO: add unused peers to the AddressBook (#2931)
+    //       https://docs.rs/rand/0.8.4/rand/seq/trait.SliceRandom.html#tymethod.partial_shuffle
     initial_peers_vect
         .choose_multiple(&mut rand::thread_rng(), config.peerset_initial_target_size)
         .copied()


### PR DESCRIPTION
## Motivation

We want to limit the number of initial peer attempts by config. Close https://github.com/ZcashFoundation/zebra/issues/2900

## Solution

Given the hashset of peers and a config parameter acting as the limit:
- convert the hashset to a vec.
- get a rand chunk from it using the standard library.
- convert back to hashset and use this from now on.

## Review

Anyone can review. This is one of the security issues from created by @teor2345 for the beta.

