### PR TITLE
Refactor handshake rate limiting to not store a `Sleep` type

### DIFF
--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -1,7 +1,7 @@
-use std::{cmp::min, mem, sync::Arc, time::Duration};
+use std::{cmp::min, sync::Arc};
 
 use futures::stream::{FuturesUnordered, StreamExt};
-use tokio::time::{sleep, timeout, Instant, Sleep};
+use tokio::time::{sleep_until, timeout, Instant};
 use tower::{Service, ServiceExt};
 
 use zebra_chain::serialization::DateTime32;
@@ -114,7 +114,7 @@ mod tests;
 pub(crate) struct CandidateSet<S> {
     pub(super) address_book: Arc<std::sync::Mutex<AddressBook>>,
     pub(super) peer_service: S,
-    wait_next_handshake: Sleep,
+    min_next_handshake: Instant,
     min_next_crawl: Instant,
 }
 
@@ -131,7 +131,7 @@ where
         CandidateSet {
             address_book,
             peer_service,
-            wait_next_handshake: sleep(Duration::from_secs(0)),
+            min_next_handshake: Instant::now(),
             min_next_crawl: Instant::now(),
         }
     }
@@ -321,9 +321,8 @@ where
         };
 
         // SECURITY: rate-limit new outbound peer connections
-        (&mut self.wait_next_handshake).await;
-        let mut sleep = sleep(constants::MIN_PEER_CONNECTION_INTERVAL);
-        mem::swap(&mut self.wait_next_handshake, &mut sleep);
+        sleep_until(self.min_next_handshake).await;
+        self.min_next_handshake = Instant::now() + constants::MIN_PEER_CONNECTION_INTERVAL;
 
         Some(reconnect)
     }


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
This is part of the update to use Tokio  version 1 (#2200), but can be merged separately.

In newer Tokio versions the `Sleep` type doesn't implement `Unpin`, so it's a little more complicated to use it.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
In this case it was easier to refactor the code to not store the `Sleep` type instead of wrapping it in a `Pin` type.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
Since this might be a security issue if not implemented correctly, I'd like @teor2345 to take a look at it.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
