### PR TITLE
Use single thread Tokio runtime for tests

### DIFF
--- a/zebra-network/src/meta_addr/tests/prop.rs
+++ b/zebra-network/src/meta_addr/tests/prop.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use proptest::{collection::vec, prelude::*};
-use tokio::{runtime::Runtime, time::Instant};
+use tokio::{runtime, time::Instant};
 use tower::service_fn;
 use tracing::Span;
 
@@ -332,7 +332,10 @@ proptest! {
             "there are enough changes for good test coverage",
         );
 
-        let runtime = Runtime::new().expect("Failed to create Tokio runtime");
+        let runtime = runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create Tokio runtime");
         let _guard = runtime.enter();
 
         // Only put valid addresses in the address book.
@@ -424,7 +427,10 @@ proptest! {
             "there are enough changes for good test coverage",
         );
 
-        let runtime = Runtime::new().expect("Failed to create Tokio runtime");
+        let runtime = runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create Tokio runtime");
         let _guard = runtime.enter();
 
         let attempt_counts = runtime.block_on(async move {

--- a/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
@@ -8,7 +8,7 @@ use std::{
 
 use chrono::{DateTime, Duration, Utc};
 use tokio::{
-    runtime::Runtime,
+    runtime,
     time::{self, Instant},
 };
 use tracing::Span;
@@ -138,7 +138,10 @@ fn candidate_set_updates_are_rate_limited() {
 
     zebra_test::init();
 
-    let runtime = Runtime::new().expect("Failed to create Tokio runtime");
+    let runtime = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create Tokio runtime");
     let _guard = runtime.enter();
 
     let address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Span::none());
@@ -179,7 +182,10 @@ fn candidate_set_updates_are_rate_limited() {
 /// rate limited.
 #[test]
 fn candidate_set_update_after_update_initial_is_rate_limited() {
-    let runtime = Runtime::new().expect("Failed to create Tokio runtime");
+    let runtime = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create Tokio runtime");
     let _guard = runtime.enter();
 
     let address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Span::none());


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
This is part of the update to use Tokio version 1 (#2200), but can be merged separately.

Newer versions of Tokio panic if `tokio::time::pause()` is called from a multi-thread executor, so tests should be updated so that doesn't happen.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Since `#[tokio::test]` defaults to a single thread runtime, it makes sense to always use a single thread runtime in all tests unless there's a need for a multi-thread executor.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
Anyone from the team can review this.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
