### PR TITLE
Update Tower dependency to 0.4.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,7 +1454,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.7",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -2649,9 +2649,9 @@ checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -3122,7 +3122,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "percent-encoding",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.7",
  "rustls",
  "serde",
  "serde_json",
@@ -3853,7 +3853,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.7",
  "signal-hook-registry",
  "slab",
  "tokio-macros",
@@ -3868,7 +3868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
 dependencies = [
  "autocfg",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.7",
 ]
 
 [[package]]
@@ -3901,7 +3901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c535f53c0cfa1acace62995a8994fc9cc1f12d202420da96ff306ee24d576469"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.7",
  "tokio 1.3.0",
 ]
 
@@ -3956,8 +3956,22 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.7",
  "tokio 0.3.6",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.2.7",
+ "tokio 1.3.0",
 ]
 
 [[package]]
@@ -3971,15 +3985,18 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.0"
-source = "git+https://github.com/tower-rs/tower?rev=d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39#d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00e500fff5fa1131c866b246041a6bf96da9c965f8fe4128cb1421f23e93c00"
 dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram 6.3.4",
  "pin-project 1.0.7",
- "tokio 0.3.6",
- "tower-layer 0.3.0",
+ "pin-project-lite 0.2.7",
+ "tokio 1.3.0",
+ "tokio-util 0.6.8",
+ "tower-layer",
  "tower-service",
  "tracing",
 ]
@@ -4018,11 +4035,6 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower?rev=d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39#d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39"
-
-[[package]]
-name = "tower-layer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
@@ -4043,7 +4055,7 @@ dependencies = [
  "pin-project 1.0.7",
  "tokio 1.3.0",
  "tokio-test",
- "tower-layer 0.3.1",
+ "tower-layer",
  "tower-service",
 ]
 
@@ -4055,7 +4067,7 @@ checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.7",
  "tracing-attributes",
  "tracing-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ panic = "abort"
 hyper = { git = "https://github.com/hyperium/hyper", rev = "ed2b22a7f66899d338691552fbcb6c0f2f4e06b9" }
 metrics = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
 metrics-exporter-prometheus = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
-tower = { git = "https://github.com/tower-rs/tower", rev = "d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39" }
 
 # TODO: remove these after a new librustzcash release.
 # These are librustzcash requirements specified in its workspace Cargo.toml that we must replicate here

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -10,7 +10,7 @@ futures = "0.3.17"
 futures-core = "0.3.13"
 pin-project = "1.0.7"
 tokio = { version = "0.3.6", features = ["time", "sync", "stream", "tracing", "macros"] }
-tower = { version = "0.4", features = ["util", "buffer"] }
+tower = { version = "0.4.9", features = ["util", "buffer"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
 

--- a/tower-batch/src/worker.rs
+++ b/tower-batch/src/worker.rs
@@ -83,7 +83,7 @@ where
             tracing::trace!("notifying caller about worker failure");
             let _ = tx.send(Err(failed.clone()));
         } else {
-            match self.service.ready_and().await {
+            match self.service.ready().await {
                 Ok(svc) => {
                     let rsp = svc.call(req.into());
                     let _ = tx.send(Ok(rsp));
@@ -109,7 +109,7 @@ where
     async fn flush_service(&mut self) {
         if let Err(e) = self
             .service
-            .ready_and()
+            .ready()
             .and_then(|svc| svc.call(BatchControl::Flush))
             .await
         {

--- a/tower-batch/tests/ed25519.rs
+++ b/tower-batch/tests/ed25519.rs
@@ -112,7 +112,7 @@ where
             sk.sign(&msg[..])
         };
 
-        verifier.ready_and().await?;
+        verifier.ready().await?;
         results.push(span.in_scope(|| verifier.call((vk_bytes, sig, msg).into())))
     }
 

--- a/tower-batch/tests/worker.rs
+++ b/tower-batch/tests/worker.rs
@@ -21,18 +21,18 @@ async fn wakes_pending_waiters_on_close() {
 
     // // keep the request in the worker
     handle.allow(0);
-    let service1 = service.ready_and().await.unwrap();
+    let service1 = service.ready().await.unwrap();
     let poll = worker.poll();
     assert_pending!(poll);
     let mut response = task::spawn(service1.call(()));
 
     let mut service1 = service.clone();
-    let mut ready1 = task::spawn(service1.ready_and());
+    let mut ready1 = task::spawn(service1.ready());
     assert_pending!(worker.poll());
     assert_pending!(ready1.poll(), "no capacity");
 
     let mut service1 = service.clone();
-    let mut ready2 = task::spawn(service1.ready_and());
+    let mut ready2 = task::spawn(service1.ready());
     assert_pending!(worker.poll());
     assert_pending!(ready2.poll(), "no capacity");
 
@@ -80,17 +80,17 @@ async fn wakes_pending_waiters_on_failure() {
 
     // keep the request in the worker
     handle.allow(0);
-    let service1 = service.ready_and().await.unwrap();
+    let service1 = service.ready().await.unwrap();
     assert_pending!(worker.poll());
     let mut response = task::spawn(service1.call("hello"));
 
     let mut service1 = service.clone();
-    let mut ready1 = task::spawn(service1.ready_and());
+    let mut ready1 = task::spawn(service1.ready());
     assert_pending!(worker.poll());
     assert_pending!(ready1.poll(), "no capacity");
 
     let mut service1 = service.clone();
-    let mut ready2 = task::spawn(service1.ready_and());
+    let mut ready2 = task::spawn(service1.ready());
     assert_pending!(worker.poll());
     assert_pending!(ready2.poll(), "no capacity");
 

--- a/tower-fallback/tests/fallback.rs
+++ b/tower-fallback/tests/fallback.rs
@@ -30,7 +30,7 @@ async fn fallback() {
 
     let mut svc = Fallback::new(svc1, svc2);
 
-    assert_eq!(svc.ready_and().await.unwrap().call(1).await.unwrap(), 1);
-    assert_eq!(svc.ready_and().await.unwrap().call(11).await.unwrap(), 111);
-    assert!(svc.ready_and().await.unwrap().call(21).await.is_err());
+    assert_eq!(svc.ready().await.unwrap().call(1).await.unwrap(), 1);
+    assert_eq!(svc.ready().await.unwrap().call(11).await.unwrap(), 111);
+    assert!(svc.ready().await.unwrap().call(21).await.is_err());
 }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -26,7 +26,7 @@ futures-util = "0.3.17"
 metrics = "0.13.0-alpha.8"
 thiserror = "1.0.30"
 tokio = { version = "0.3.6", features = ["time", "sync", "stream", "tracing"] }
-tower = { version = "0.4", features = ["timeout", "util", "buffer"] }
+tower = { version = "0.4.9", features = ["timeout", "util", "buffer"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
 

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -125,7 +125,7 @@ where
             // Check that this block is actually a new block.
             tracing::trace!("checking that block is not already in state");
             match state_service
-                .ready_and()
+                .ready()
                 .await
                 .map_err(|source| VerifyBlockError::Depth { source, hash })?
                 .call(zs::Request::Depth(hash))
@@ -179,7 +179,7 @@ where
             ));
             for transaction in &block.transactions {
                 let rsp = transaction_verifier
-                    .ready_and()
+                    .ready()
                     .await
                     .expect("transaction verifier is always ready")
                     .call(tx::Request::Block {
@@ -211,7 +211,7 @@ where
                 transaction_hashes,
             };
             match state_service
-                .ready_and()
+                .ready()
                 .await
                 .map_err(VerifyBlockError::Commit)?
                 .call(zs::Request::CommitBlock(prepared_block))

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -203,7 +203,7 @@ where
     };
 
     let tip = match state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zs::Request::Tip)

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -64,10 +64,7 @@ async fn single_item_checkpoint_list() -> Result<(), Report> {
     );
 
     /// SPANDOC: Make sure the verifier service is ready
-    let ready_verifier_service = checkpoint_verifier
-        .ready_and()
-        .map_err(|e| eyre!(e))
-        .await?;
+    let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
     /// SPANDOC: Set up the future for block 0
     let verify_future = timeout(
         Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
@@ -148,10 +145,7 @@ async fn multi_item_checkpoint_list() -> Result<(), Report> {
     // Now verify each block
     for (block, height, hash) in checkpoint_data {
         /// SPANDOC: Make sure the verifier service is ready
-        let ready_verifier_service = checkpoint_verifier
-            .ready_and()
-            .map_err(|e| eyre!(e))
-            .await?;
+        let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
 
         /// SPANDOC: Set up the future for block {?height}
         let verify_future = timeout(
@@ -325,8 +319,7 @@ async fn continuous_blockchain(
                 if height <= restart_height {
                     let mut state_service = state_service.clone();
                     /// SPANDOC: Make sure the state service is ready for block {?height}
-                    let ready_state_service =
-                        state_service.ready_and().map_err(|e| eyre!(e)).await?;
+                    let ready_state_service = state_service.ready().map_err(|e| eyre!(e)).await?;
 
                     /// SPANDOC: Add block directly to the state {?height}
                     ready_state_service
@@ -342,10 +335,7 @@ async fn continuous_blockchain(
             }
 
             /// SPANDOC: Make sure the verifier service is ready for block {?height}
-            let ready_verifier_service = checkpoint_verifier
-                .ready_and()
-                .map_err(|e| eyre!(e))
-                .await?;
+            let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
 
             /// SPANDOC: Set up the future for block {?height}
             let verify_future = timeout(
@@ -470,10 +460,7 @@ async fn block_higher_than_max_checkpoint_fail() -> Result<(), Report> {
     );
 
     /// SPANDOC: Make sure the verifier service is ready
-    let ready_verifier_service = checkpoint_verifier
-        .ready_and()
-        .map_err(|e| eyre!(e))
-        .await?;
+    let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
     /// SPANDOC: Set up the future for block 415000
     let verify_future = timeout(
         Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
@@ -547,10 +534,7 @@ async fn wrong_checkpoint_hash_fail() -> Result<(), Report> {
     );
 
     /// SPANDOC: Make sure the verifier service is ready (1/3)
-    let ready_verifier_service = checkpoint_verifier
-        .ready_and()
-        .map_err(|e| eyre!(e))
-        .await?;
+    let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
     /// SPANDOC: Set up the future for bad block 0 (1/3)
     // TODO(teor || jlusby): check error kind
     let bad_verify_future_1 = timeout(
@@ -574,10 +558,7 @@ async fn wrong_checkpoint_hash_fail() -> Result<(), Report> {
     );
 
     /// SPANDOC: Make sure the verifier service is ready (2/3)
-    let ready_verifier_service = checkpoint_verifier
-        .ready_and()
-        .map_err(|e| eyre!(e))
-        .await?;
+    let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
     /// SPANDOC: Set up the future for bad block 0 again (2/3)
     // TODO(teor || jlusby): check error kind
     let bad_verify_future_2 = timeout(
@@ -601,10 +582,7 @@ async fn wrong_checkpoint_hash_fail() -> Result<(), Report> {
     );
 
     /// SPANDOC: Make sure the verifier service is ready (3/3)
-    let ready_verifier_service = checkpoint_verifier
-        .ready_and()
-        .map_err(|e| eyre!(e))
-        .await?;
+    let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
     /// SPANDOC: Set up the future for good block 0 (3/3)
     let good_verify_future = timeout(
         Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
@@ -732,10 +710,7 @@ async fn checkpoint_drop_cancel() -> Result<(), Report> {
     // Now collect verify futures for each block
     for (block, height, hash) in checkpoint_data {
         /// SPANDOC: Make sure the verifier service is ready
-        let ready_verifier_service = checkpoint_verifier
-            .ready_and()
-            .map_err(|e| eyre!(e))
-            .await?;
+        let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
 
         /// SPANDOC: Set up the future for block {?height}
         let verify_future = timeout(
@@ -811,10 +786,7 @@ async fn hard_coded_mainnet() -> Result<(), Report> {
     assert!(checkpoint_verifier.checkpoint_list.max_height() > block::Height(0));
 
     /// SPANDOC: Make sure the verifier service is ready
-    let ready_verifier_service = checkpoint_verifier
-        .ready_and()
-        .map_err(|e| eyre!(e))
-        .await?;
+    let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
     /// SPANDOC: Set up the future for block 0
     let verify_future = timeout(
         Duration::from_secs(VERIFY_TIMEOUT_SECONDS),

--- a/zebra-consensus/src/primitives/ed25519/tests.rs
+++ b/zebra-consensus/src/primitives/ed25519/tests.rs
@@ -22,7 +22,7 @@ where
         let sk = SigningKey::new(&mut rng);
         let vk = VerificationKey::from(&sk);
         let sig = sk.sign(&msg[..]);
-        verifier.ready_and().await?;
+        verifier.ready().await?;
         results.push(span.in_scope(|| verifier.call((vk.into(), sig, msg).into())))
     }
 

--- a/zebra-consensus/src/primitives/groth16/tests.rs
+++ b/zebra-consensus/src/primitives/groth16/tests.rs
@@ -32,7 +32,7 @@ where
             tracing::trace!(?spend);
 
             let spend_rsp = spend_verifier
-                .ready_and()
+                .ready()
                 .await?
                 .call(groth16::ItemWrapper::from(&spend).into());
 
@@ -43,7 +43,7 @@ where
             tracing::trace!(?output);
 
             let output_rsp = output_verifier
-                .ready_and()
+                .ready()
                 .await?
                 .call(groth16::ItemWrapper::from(output).into());
 
@@ -131,7 +131,7 @@ where
             tracing::trace!(?modified_output);
 
             let output_rsp = output_verifier
-                .ready_and()
+                .ready()
                 .await?
                 .call(groth16::ItemWrapper::from(&modified_output).into());
 

--- a/zebra-consensus/src/primitives/redjubjub/tests.rs
+++ b/zebra-consensus/src/primitives/redjubjub/tests.rs
@@ -24,14 +24,14 @@ where
                 let sk = SigningKey::<SpendAuth>::new(&mut rng);
                 let vk = VerificationKey::from(&sk);
                 let sig = sk.sign(&mut rng, &msg[..]);
-                verifier.ready_and().await?;
+                verifier.ready().await?;
                 results.push(span.in_scope(|| verifier.call((vk.into(), sig, msg).into())))
             }
             1 => {
                 let sk = SigningKey::<Binding>::new(&mut rng);
                 let vk = VerificationKey::from(&sk);
                 let sig = sk.sign(&mut rng, &msg[..]);
-                verifier.ready_and().await?;
+                verifier.ready().await?;
                 results.push(span.in_scope(|| verifier.call((vk.into(), sig, msg).into())))
             }
             _ => panic!(),

--- a/zebra-consensus/src/primitives/redpallas/tests.rs
+++ b/zebra-consensus/src/primitives/redpallas/tests.rs
@@ -24,14 +24,14 @@ where
                 let sk = SigningKey::<SpendAuth>::new(&mut rng);
                 let vk = VerificationKey::from(&sk);
                 let sig = sk.sign(&mut rng, &msg[..]);
-                verifier.ready_and().await?;
+                verifier.ready().await?;
                 results.push(span.in_scope(|| verifier.call((vk.into(), sig, msg).into())))
             }
             1 => {
                 let sk = SigningKey::<Binding>::new(&mut rng);
                 let vk = VerificationKey::from(&sk);
                 let sig = sk.sign(&mut rng, &msg[..]);
-                verifier.ready_and().await?;
+                verifier.ready().await?;
                 results.push(span.in_scope(|| verifier.call((vk.into(), sig, msg).into())))
             }
             _ => panic!(),

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1"
 futures = "0.3"
 tokio = { version = "0.3.6", features = ["net", "time", "stream", "tracing", "macros", "rt-multi-thread"] }
 tokio-util = { version = "0.5", features = ["codec"] }
-tower = { version = "0.4", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
+tower = { version = "0.4.9", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 
 metrics = "0.13.0-alpha.8"
 tracing = "0.1"

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -924,7 +924,7 @@ where
         trace!(?req);
         use tower::{load_shed::error::Overloaded, ServiceExt};
 
-        if self.svc.ready_and().await.is_err() {
+        if self.svc.ready().await.is_err() {
             // Treat all service readiness errors as Overloaded
             // TODO: treat `TryRecvError::Closed` in `Inbound::poll_ready` as a fatal error (#1655)
             self.fail_with(PeerError::Overloaded);

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -78,7 +78,7 @@ where
 
         async move {
             let stream = TcpStream::connect(addr).await?;
-            hs.ready_and().await?;
+            hs.ready().await?;
             let client = hs
                 .call(HandshakeRequest {
                     tcp_stream: stream,

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -239,7 +239,7 @@ where
         debug!(?fanout_limit, "sending GetPeers requests");
         // TODO: launch each fanout in its own task (might require tokio 1.6)
         for _ in 0..fanout_limit {
-            let peer_service = self.peer_service.ready_and().await?;
+            let peer_service = self.peer_service.ready().await?;
             responses.push(peer_service.call(Request::Peers));
         }
         while let Some(rsp) = responses.next().await {

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -477,7 +477,7 @@ where
             let _guard = accept_span.enter();
 
             debug!("got incoming connection");
-            handshaker.ready_and().await?;
+            handshaker.ready().await?;
             // TODO: distinguish between proxied listeners and direct listeners
             let handshaker_span = info_span!("listen_handshaker", peer = ?connected_addr);
 
@@ -750,7 +750,7 @@ where
 
     // the connector is always ready, so this can't hang
     let outbound_connector = outbound_connector
-        .ready_and()
+        .ready()
         .await
         .expect("outbound connector never errors");
 

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -20,7 +20,7 @@ bincode = "1"
 
 futures = "0.3.17"
 metrics = "0.13.0-alpha.8"
-tower = { version = "0.4", features = ["buffer", "util"] }
+tower = { version = "0.4.9", features = ["buffer", "util"] }
 tracing = "0.1"
 thiserror = "1.0.30"
 tokio = { version = "0.3.6", features = ["sync"] }

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -37,7 +37,7 @@ async fn populated_state(
     let mut responses = FuturesUnordered::new();
 
     for request in requests {
-        let rsp = state.ready_and().await.unwrap().call(request);
+        let rsp = state.ready().await.unwrap().call(request);
         responses.push(rsp);
     }
 

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -15,7 +15,7 @@ proptest = "0.10.1"
 rand = "0.8"
 regex = "1.4.6"
 
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.4.9", features = ["util"] }
 tokio = { version = "0.3", features = ["full"] }
 futures = "0.3.17"
 

--- a/zebra-test/src/transcript.rs
+++ b/zebra-test/src/transcript.rs
@@ -98,7 +98,7 @@ where
             // These unwraps could propagate errors with the correct
             // bound on C::Error
             let fut = to_check
-                .ready_and()
+                .ready()
                 .await
                 .map_err(Into::into)
                 .map_err(|e| eyre!(e))

--- a/zebra-test/tests/transcript.rs
+++ b/zebra-test/tests/transcript.rs
@@ -23,11 +23,11 @@ async fn transcript_returns_responses_and_ends() {
 
     for (req, rsp) in TRANSCRIPT_DATA.iter() {
         assert_eq!(
-            svc.ready_and().await.unwrap().call(req).await.unwrap(),
+            svc.ready().await.unwrap().call(req).await.unwrap(),
             *rsp.as_ref().unwrap()
         );
     }
-    assert!(svc.ready_and().await.unwrap().call("end").await.is_err());
+    assert!(svc.ready().await.unwrap().call("end").await.is_err());
 }
 
 #[tokio::test]
@@ -37,10 +37,10 @@ async fn transcript_errors_wrong_request() {
     let mut svc = Transcript::from(TRANSCRIPT_DATA.iter().cloned());
 
     assert_eq!(
-        svc.ready_and().await.unwrap().call("req1").await.unwrap(),
+        svc.ready().await.unwrap().call("req1").await.unwrap(),
         "rsp1",
     );
-    assert!(svc.ready_and().await.unwrap().call("bad").await.is_err());
+    assert!(svc.ready().await.unwrap().call("bad").await.is_err());
 }
 
 #[tokio::test]

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4"
 hyper = { version = "0.14.0-dev", features = ["full"] }
 futures = "0.3"
 tokio = { version = "0.3.6", features = ["time", "rt-multi-thread", "stream", "macros", "tracing", "signal"] }
-tower = { version = "0.4", features = ["hedge", "limit"] }
+tower = { version = "0.4.9", features = ["hedge", "limit"] }
 pin-project = "1.0.7"
 
 color-eyre = { version = "0.5.11", features = ["issue-url"] }

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -609,7 +609,7 @@ async fn setup(
         .zcash_deserialize_into()
         .unwrap();
     state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zebra_state::Request::CommitFinalizedBlock(

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -197,7 +197,7 @@ where
         for _ in 0..FANOUT {
             let mut peer_set = peer_set.clone();
             // end the task on permanent peer set errors
-            let peer_set = peer_set.ready_and().await?;
+            let peer_set = peer_set.ready().await?;
 
             requests.push(peer_set.call(zn::Request::MempoolTransactionIds));
         }
@@ -242,7 +242,7 @@ where
 
         let call_result = self
             .mempool
-            .ready_and()
+            .ready()
             .await?
             .call(mempool::Request::Queue(transaction_ids))
             .await;

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -443,7 +443,7 @@ where
     ) -> Result<(), TransactionDownloadVerifyError> {
         // Check if the transaction is already in the state.
         match state
-            .ready_and()
+            .ready()
             .await
             .map_err(|e| TransactionDownloadVerifyError::StateError(e))?
             .call(zs::Request::Transaction(txid.mined_id()))

--- a/zebrad/src/components/mempool/gossip.rs
+++ b/zebrad/src/components/mempool/gossip.rs
@@ -44,7 +44,7 @@ where
         info!(?request, "sending mempool transaction broadcast");
 
         // broadcast requests don't return errors, and we'd just want to ignore them anyway
-        let _ = broadcast_network.ready_and().await?.call(request).await;
+        let _ = broadcast_network.ready().await?.call(request).await;
 
         metrics::counter!("mempool.gossiped.transactions.total", txs_len as _);
     }

--- a/zebrad/src/components/mempool/queue_checker.rs
+++ b/zebrad/src/components/mempool/queue_checker.rs
@@ -69,7 +69,7 @@ where
         // So we propagate any unexpected errors to the task that spawned us.
         let response = self
             .mempool
-            .ready_and()
+            .ready()
             .await?
             .call(mempool::Request::CheckForVerifiedTransactions)
             .await?;

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -63,7 +63,7 @@ async fn mempool_service_basic_single() -> Result<(), Report> {
 
     // Test `Request::TransactionIds`
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::TransactionIds)
@@ -80,7 +80,7 @@ async fn mempool_service_basic_single() -> Result<(), Report> {
         .copied()
         .collect::<HashSet<_>>();
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::TransactionsById(
@@ -109,7 +109,7 @@ async fn mempool_service_basic_single() -> Result<(), Report> {
 
     // Test `Request::RejectedTransactionIds`
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::RejectedTransactionIds(
@@ -127,7 +127,7 @@ async fn mempool_service_basic_single() -> Result<(), Report> {
     // Test `Request::Queue`
     // Use the ID of the last transaction in the list
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![last_transaction.transaction.id.into()]))
@@ -190,7 +190,7 @@ async fn mempool_queue_single() -> Result<(), Report> {
 
     // Test `Request::Queue` for a new transaction
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![new_tx.transaction.id.into()]))
@@ -207,7 +207,7 @@ async fn mempool_queue_single() -> Result<(), Report> {
     // They should all be rejected; either because they are already in the mempool,
     // or because they are in the recently evicted list.
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(
@@ -273,7 +273,7 @@ async fn mempool_service_disabled() -> Result<(), Report> {
 
     // Test if the mempool answers correctly (i.e. is enabled)
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::TransactionIds)
@@ -288,7 +288,7 @@ async fn mempool_service_disabled() -> Result<(), Report> {
     // Use the ID of the last transaction in the list
     let txid = more_transactions.last().unwrap().transaction.id;
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![txid.into()]))
@@ -310,7 +310,7 @@ async fn mempool_service_disabled() -> Result<(), Report> {
 
     // Test if the mempool returns no transactions when disabled
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::TransactionIds)
@@ -329,7 +329,7 @@ async fn mempool_service_disabled() -> Result<(), Report> {
 
     // Test if the mempool returns to Queue requests correctly when disabled
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![txid.into()]))
@@ -371,7 +371,7 @@ async fn mempool_cancel_mined() -> Result<(), Report> {
         .zcash_deserialize_into()
         .unwrap();
     state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zebra_state::Request::CommitFinalizedBlock(
@@ -385,7 +385,7 @@ async fn mempool_cancel_mined() -> Result<(), Report> {
 
     // Push block 1 to the state
     state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zebra_state::Request::CommitFinalizedBlock(
@@ -402,7 +402,7 @@ async fn mempool_cancel_mined() -> Result<(), Report> {
     // which cancels all downloads.
     let txid = block2.transactions[0].unmined_id();
     let response = mempool
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![txid.into()]))
@@ -464,7 +464,7 @@ async fn mempool_cancel_downloads_after_network_upgrade() -> Result<(), Report> 
         .zcash_deserialize_into()
         .unwrap();
     state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zebra_state::Request::CommitFinalizedBlock(
@@ -476,7 +476,7 @@ async fn mempool_cancel_downloads_after_network_upgrade() -> Result<(), Report> 
     // Queue transaction from block 2 for download
     let txid = block2.transactions[0].unmined_id();
     let response = mempool
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![txid.into()]))
@@ -496,7 +496,7 @@ async fn mempool_cancel_downloads_after_network_upgrade() -> Result<(), Report> 
     // Push block 1 to the state. This is considered a network upgrade,
     // and thus must cancel all pending transaction downloads.
     state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zebra_state::Request::CommitFinalizedBlock(
@@ -537,7 +537,7 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
         .zcash_deserialize_into()
         .unwrap();
     state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zebra_state::Request::CommitFinalizedBlock(
@@ -549,7 +549,7 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
     // Queue first transaction for verification
     // (queue the transaction itself to avoid a download).
     let request = mempool
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![rejected_tx.transaction.clone().into()]));
@@ -576,7 +576,7 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
     // Try to queue the same transaction by its ID and check if it's correctly
     // rejected.
     let response = mempool
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![rejected_tx.transaction.id.into()]))
@@ -620,7 +620,7 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
         .zcash_deserialize_into()
         .unwrap();
     state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zebra_state::Request::CommitFinalizedBlock(
@@ -631,7 +631,7 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
 
     // Queue second transaction for download and verification.
     let request = mempool
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![rejected_valid_tx
@@ -663,7 +663,7 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
     // Try to queue the same transaction by its ID and check if it's not being
     // rejected.
     let response = mempool
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![rejected_valid_tx

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -385,7 +385,7 @@ where
     async fn obtain_tips(&mut self) -> Result<(), Report> {
         let block_locator = self
             .state
-            .ready_and()
+            .ready()
             .await
             .map_err(|e| eyre!(e))?
             .call(zebra_state::Request::BlockLocator)
@@ -403,16 +403,12 @@ where
 
         let mut requests = FuturesUnordered::new();
         for _ in 0..FANOUT {
-            requests.push(
-                self.tip_network
-                    .ready_and()
-                    .await
-                    .map_err(|e| eyre!(e))?
-                    .call(zn::Request::FindBlocks {
-                        known_blocks: block_locator.clone(),
-                        stop: None,
-                    }),
-            );
+            requests.push(self.tip_network.ready().await.map_err(|e| eyre!(e))?.call(
+                zn::Request::FindBlocks {
+                    known_blocks: block_locator.clone(),
+                    stop: None,
+                },
+            ));
         }
 
         let mut download_set = HashSet::new();
@@ -526,16 +522,12 @@ where
             tracing::debug!(?tip, "asking peers to extend chain tip");
             let mut responses = FuturesUnordered::new();
             for _ in 0..FANOUT {
-                responses.push(
-                    self.tip_network
-                        .ready_and()
-                        .await
-                        .map_err(|e| eyre!(e))?
-                        .call(zn::Request::FindBlocks {
-                            known_blocks: vec![tip.tip],
-                            stop: None,
-                        }),
-                );
+                responses.push(self.tip_network.ready().await.map_err(|e| eyre!(e))?.call(
+                    zn::Request::FindBlocks {
+                        known_blocks: vec![tip.tip],
+                        stop: None,
+                    },
+                ));
             }
             while let Some(res) = responses.next().await {
                 match res.map_err::<Report, _>(|e| eyre!(e)) {
@@ -689,7 +681,7 @@ where
     async fn state_contains(&mut self, hash: block::Hash) -> Result<bool, Report> {
         match self
             .state
-            .ready_and()
+            .ready()
             .await
             .map_err(|e| eyre!(e))?
             .call(zebra_state::Request::Depth(hash))

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -167,7 +167,7 @@ where
         tracing::debug!("waiting to request block");
         let block_req = self
             .network
-            .ready_and()
+            .ready()
             .await
             .map_err(|e| eyre!(e))?
             .call(zn::Request::BlocksByHash(std::iter::once(hash).collect()));
@@ -201,7 +201,7 @@ where
                 metrics::counter!("sync.downloaded.block.count", 1);
 
                 let rsp = verifier
-                    .ready_and()
+                    .ready()
                     .await
                     .map_err(BlockDownloadVerifyError::VerifierError)?
                     .call(block);

--- a/zebrad/src/components/sync/gossip.rs
+++ b/zebrad/src/components/sync/gossip.rs
@@ -76,7 +76,7 @@ where
 
         // broadcast requests don't return errors, and we'd just want to ignore them anyway
         let _ = broadcast_network
-            .ready_and()
+            .ready()
             .await
             .map_err(PeerSetReadiness)?
             .call(request)


### PR DESCRIPTION
## Motivation

This is part of the update to use Tokio version 1 (#2200), and must be merged together with the other PRs.

The Tower crate has to be updated to a version that is compatible with the newer version of Tokio. No changes are actually necessary for the update. However, the `ServiceExt::ready_and` function became deprecated and that makes the build produce a lot of warnings.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
The Tower dependency was updated to 0.4.9, which allows removal of the patched dependency. In order to remove all of the warnings, all usages of `ServiceExt::ready_and` were replaced with usages of `ServiceExt::ready`.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
Anyone from the team can review this PR, but it shouldn't be merged yet.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
