### PR TITLE
Update Tokio to version 1.12.0

### DIFF
--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 futures = "0.3.17"
 futures-core = "0.3.13"
 pin-project = "1.0.7"
-tokio = { version = "0.3.6", features = ["time", "sync", "stream", "tracing", "macros"] }
+tokio = { version = "1.13.0", features = ["time", "sync", "tracing", "macros"] }
 tower = { version = "0.4", features = ["util", "buffer"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
@@ -18,7 +18,7 @@ tracing-futures = "0.2.5"
 color-eyre = "0.5.11"
 ed25519-zebra = "3.0.0"
 rand = "0.8"
-tokio = { version = "0.3.6", features = ["full"]}
+tokio = { version = "1.13.0", features = ["full"]}
 tokio-test = "0.4.2"
 tower-fallback = { path = "../tower-fallback/" }
 tower-test = "0.4.0"

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -13,4 +13,4 @@ tracing = "0.1"
 
 [dev-dependencies]
 zebra-test = { path = "../zebra-test/" }
-tokio = { version = "0.3.6", features = ["full"]}
+tokio = { version = "1.13.0", features = ["full"]}

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -25,7 +25,7 @@ futures = "0.3.17"
 futures-util = "0.3.17"
 metrics = "0.13.0-alpha.8"
 thiserror = "1.0.30"
-tokio = { version = "0.3.6", features = ["time", "sync", "stream", "tracing"] }
+tokio = { version = "1.13.0", features = ["time", "sync", "tracing"] }
 tower = { version = "0.4", features = ["timeout", "util", "buffer"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
@@ -46,7 +46,7 @@ proptest = "0.10"
 proptest-derive = "0.3.0"
 rand07 = { package = "rand", version = "0.7" }
 spandoc = "0.2"
-tokio = { version = "0.3.6", features = ["full"] }
+tokio = { version = "1.13.0", features = ["full"] }
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.25"
 

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -6,9 +6,12 @@ use super::types::Progress::*;
 use super::types::TargetHeight::*;
 
 use color_eyre::eyre::{eyre, Report};
-use futures::{future::TryFutureExt, stream::FuturesUnordered};
+use futures::{
+    future::TryFutureExt,
+    stream::{FuturesUnordered, StreamExt},
+};
 use std::{cmp::min, convert::TryInto, mem::drop, time::Duration};
-use tokio::{stream::StreamExt, time::timeout};
+use tokio::time::timeout;
 use tower::{Service, ServiceExt};
 use tracing_futures::Instrument;
 

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"
 
 futures = "0.3"
-tokio = { version = "0.3.6", features = ["net", "time", "stream", "tracing", "macros", "rt-multi-thread"] }
+tokio = { version = "1.13.0", features = ["net", "time", "tracing", "macros", "rt-multi-thread"] }
 tokio-util = { version = "0.5", features = ["codec"] }
 tower = { version = "0.4", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 
@@ -38,7 +38,7 @@ zebra-chain = { path = "../zebra-chain" }
 [dev-dependencies]
 proptest = "0.10"
 proptest-derive = "0.3"
-tokio = { version = "0.3.6", features = ["test-util"] }
+tokio = { version = "1.13.0", features = ["test-util"] }
 toml = "0.5"
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -23,7 +23,7 @@ metrics = "0.13.0-alpha.8"
 tower = { version = "0.4", features = ["buffer", "util"] }
 tracing = "0.1"
 thiserror = "1.0.30"
-tokio = { version = "0.3.6", features = ["sync"] }
+tokio = { version = "1.13.0", features = ["sync"] }
 displaydoc = "0.2.2"
 rocksdb = "0.16.0"
 tempdir = "0.3.7"
@@ -46,7 +46,7 @@ once_cell = "1.8"
 itertools = "0.10.1"
 spandoc = "0.2"
 tempdir = "0.3.7"
-tokio = { version = "0.3.6", features = ["full"] }
+tokio = { version = "1.13.0", features = ["full"] }
 # TODO: replace w/ crate version when released: https://github.com/ZcashFoundation/zebra/issues/2083
 # Note: if updating this, also update the workspace Cargo.toml to match.
 halo2 = "=0.1.0-beta.1"

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -15,8 +15,8 @@ proptest = "0.10.1"
 rand = "0.8"
 regex = "1.4.6"
 
+tokio = { version = "1.13.0", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }
-tokio = { version = "0.3", features = ["full"] }
 futures = "0.3.17"
 
 color-eyre = "0.5.11"

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -23,7 +23,7 @@ chrono = "0.4"
 
 hyper = { version = "0.14.0-dev", features = ["full"] }
 futures = "0.3"
-tokio = { version = "0.3.6", features = ["time", "rt-multi-thread", "stream", "macros", "tracing", "signal"] }
+tokio = { version = "1.13.0", features = ["time", "rt-multi-thread", "macros", "tracing", "signal"] }
 tower = { version = "0.4", features = ["hedge", "limit"] }
 pin-project = "1.0.7"
 
@@ -57,7 +57,7 @@ once_cell = "1.8"
 regex = "1.4.6"
 semver = "1.0.3"
 tempdir = "0.3.7"
-tokio = { version = "0.3.6", features = ["full", "test-util"] }
+tokio = { version = "1.13.0", features = ["full", "test-util"] }
 
 proptest = "0.10"
 proptest-derive = "0.3"


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
This is part of the update to use Tokio version 1 (#2200), and must be merged together with the other PRs.

Newer versions of Tokio have some interesting features, as well as unblocking Zebra from updating other dependencies.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
The Tokio version was updated to 1.12.0. This unfortunately breaks the Zebra build, so this PR can't be merged until other PRs that fix the issues are approved.

One of the fixes is to not use the `StreamExt` trait that was available in Tokio 0.3.6 but isn't available in Tokio 1.12.0. Some usages of that trait need some work, but one of the usages just needs to change the import so it was included in this PR.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
Anyone from the team can review this, but it shouldn't be merged yet.

### Testing

In the tokio rollup PR, make sure that Zebra's dependency tree only has the upgraded tokio version. Also check for duplicates for other dependencies we upgraded.

If we have multiple versions, we'll be running multiple executors, and might have other subtle bugs.

We can check for duplicates using `cargo deny check bans`:
https://embarkstudios.github.io/cargo-deny/checks/bans/index.html#use-case---duplicate-version-detection

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
