### PR TITLE
Fix synchronization delay issue

### DIFF
--- a/zebrad/src/async_ext.rs
+++ b/zebrad/src/async_ext.rs
@@ -1,0 +1,5 @@
+//! Extensions used in [`Future`]s and async code.
+
+mod now_or_later;
+
+pub use self::now_or_later::NowOrLater;

--- a/zebrad/src/async_ext/now_or_later.rs
+++ b/zebrad/src/async_ext/now_or_later.rs
@@ -1,0 +1,63 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use pin_project::pin_project;
+
+/// A helper [`Future`] wrapper that will always return [`Poll::Ready`].
+///
+/// If the inner [`Future`] `F` is ready and produces an output `value`, then [`NowOrNever`] will
+/// also be ready but with an output `Some(value)`.
+///
+/// If the inner [`Future`] `F` is not ready, then:
+///
+/// - [`NowOrNever`] will be still be ready but with an output `None`,
+/// - and the task associated with the future will be scheduled to awake whenever the inner
+///   [`Future`] `F` becomes ready.
+///
+/// This is different from [`FutureExt::now_or_never`] because `now_or_never` uses a fake task
+/// [`Context`], which means that calling `now_or_never` inside an `async` function doesn't
+/// schedule the generated future to be polled again when the inner future becomes ready.
+///
+/// # Examples
+///
+/// ```
+/// use futures::{FutureExt, future};
+/// # use zebrad::async_ext::NowOrLater;
+///
+/// let inner_future = future::ready(());
+///
+/// # let runtime = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
+/// #
+/// # runtime.block_on(async move {
+/// assert_eq!(NowOrLater(inner_future).await, Some(()));
+/// # });
+/// ```
+///
+/// ```
+/// use futures::{FutureExt, future};
+/// # use zebrad::async_ext::NowOrLater;
+///
+/// let inner_future = future::pending::<()>();
+///
+/// # let runtime = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
+/// #
+/// # runtime.block_on(async move {
+/// assert_eq!(NowOrLater(inner_future).await, None);
+/// # });
+/// ```
+#[pin_project]
+pub struct NowOrLater<F>(#[pin] pub F);
+
+impl<F: Future> Future for NowOrLater<F> {
+    type Output = Option<F::Output>;
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project().0.poll(context) {
+            Poll::Ready(value) => Poll::Ready(Some(value)),
+            Poll::Pending => Poll::Ready(None),
+        }
+    }
+}

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -39,6 +39,7 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 mod components;
 
 pub mod application;
+pub mod async_ext;
 pub mod commands;
 pub mod config;
 pub mod prelude;


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
Zebra would sometimes take a long time to resume downloading blocks. This was likely caused by a usage of `now_or_never` which resulted in the `Downloads` `Stream` being incorrectly polled, because `now_or_never` uses a fake task `Context` instead of the one for the currently active task, which means that the active task isn't scheduled to wake up when the `Downloads` stream produces a new item.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
A new `NowOrLater` type was created. It polls the inner `Future` with the correct task `Context`, but still returns `Poll::Ready<Option<Future::Output>>` every time it is polled, with the `Option` being `Some` if the inner `Future` is ready or `None` otherwise.

The new type was used instead of `now_or_never` inside the synchronizer implementation.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 and/or @conradoplg can review this, since we talked about the issue and possible solutions on Discord.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
