### PR TITLE
Use `tokio-stream` crate to replace usages of Tokio types that were `Stream`s

### DIFF
--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "1"
 
 futures = "0.3"
 tokio = { version = "0.3.6", features = ["net", "time", "stream", "tracing", "macros", "rt-multi-thread"] }
+tokio-stream = { version = "0.1.7", features = ["time"] }
 tokio-util = { version = "0.5", features = ["codec"] }
 tower = { version = "0.4", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1"
 
 futures = "0.3"
 tokio = { version = "0.3.6", features = ["net", "time", "stream", "tracing", "macros", "rt-multi-thread"] }
-tokio-stream = { version = "0.1.7", features = ["time"] }
+tokio-stream = { version = "0.1.7", features = ["sync", "time"] }
 tokio-util = { version = "0.5", features = ["codec"] }
 tower = { version = "0.4", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -15,6 +15,7 @@ use futures::{
     future, FutureExt, SinkExt, StreamExt,
 };
 use tokio::{net::TcpStream, sync::broadcast, task::JoinError, time::timeout};
+use tokio_stream::wrappers::IntervalStream;
 use tokio_util::codec::Framed;
 use tower::Service;
 use tracing::{span, Level, Span};
@@ -946,7 +947,8 @@ where
                     let mut shutdown_rx = shutdown_rx;
                     let mut server_tx = server_tx;
                     let mut timestamp_collector = heartbeat_ts_collector.clone();
-                    let mut interval_stream = tokio::time::interval(constants::HEARTBEAT_INTERVAL);
+                    let mut interval_stream =
+                        IntervalStream::new(tokio::time::interval(constants::HEARTBEAT_INTERVAL));
 
                     loop {
                         let shutdown_rx_ref = Pin::new(&mut shutdown_rx);

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -18,6 +18,7 @@ use tokio::{
     sync::broadcast,
     time::{sleep, Instant},
 };
+use tokio_stream::wrappers::IntervalStream;
 use tower::{
     buffer::Buffer, discover::Change, layer::Layer, load::peak_ewma::PeakEwmaDiscover,
     util::BoxService, Service, ServiceExt,
@@ -606,7 +607,8 @@ where
     handshakes.push(future::pending().boxed());
 
     let mut crawl_timer =
-        tokio::time::interval(config.crawl_new_peer_interval).map(|tick| TimerCrawl { tick });
+        IntervalStream::new(tokio::time::interval(config.crawl_new_peer_interval))
+            .map(|tick| TimerCrawl { tick });
 
     loop {
         metrics::gauge!(

--- a/zebra-network/src/peer_set/inventory_registry.rs
+++ b/zebra-network/src/peer_set/inventory_registry.rs
@@ -10,11 +10,9 @@ use std::{
     time::Duration,
 };
 
-use futures::{Stream, StreamExt};
-use tokio::{
-    sync::broadcast,
-    time::{self, Interval},
-};
+use futures::{FutureExt, Stream, StreamExt};
+use tokio::{sync::broadcast, time};
+use tokio_stream::wrappers::IntervalStream;
 
 use crate::{protocol::external::InventoryHash, BoxError};
 
@@ -38,7 +36,7 @@ pub struct InventoryRegistry {
         >,
     >,
     /// Interval tracking how frequently we should rotate our maps
-    interval: Interval,
+    interval: IntervalStream,
 }
 
 impl std::fmt::Debug for InventoryRegistry {
@@ -57,7 +55,7 @@ impl InventoryRegistry {
             current: Default::default(),
             prev: Default::default(),
             inv_stream: inv_stream.into_stream().boxed(),
-            interval: time::interval(Duration::from_secs(75)),
+            interval: IntervalStream::new(time::interval(Duration::from_secs(75))),
         }
     }
 


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
This is part of the update to use Tokio version 1 (#2200), and must be merged together with the other PRs.

Newer versions of Tokio have removed some `impl Stream` from some types, so they have to either be used differently or have them wrapped in helper types from a separate `tokio-stream` crate.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Wrappers from the `tokio-stream` crate were used to fix a few usages of Tokio types that were previously `Stream`s.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
Anyone from the team can review this, but it shouldn't be merged yet.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
