### PR TITLE
Rate limit the amount of inbound connections

### DIFF
--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -397,7 +397,9 @@ where
             //
             // If there is a flood of connections,
             // this stops Zebra overloading the network with handshake data.
-            // Most OSes also limit the number of queued inbound connections on a listener port.
+            //
+            // Zebra can't control how many queued connections are waiting,
+            // but most OSes also limit the number of queued inbound connections on a listener port.
             tokio::time::sleep(constants::MIN_PEER_CONNECTION_INTERVAL).await;
         }
     }

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -351,7 +351,11 @@ where
                 .instrument(handshaker_span),
             );
 
-            // Only one sucesful connection per `MIN_PEER_CONNECTION_INTERVAL` is allowed.
+            // Only spawn one inbound connection handshake per `MIN_PEER_CONNECTION_INTERVAL`.
+            // But clear failed connections as fast as possible.
+            //
+            // If there is a flood of connections, this stops Zebra overloading the network with handshake data.
+            // Most OSes also limit the number of queued inbound connections on a listener port.
             tokio::time::sleep(constants::MIN_PEER_CONNECTION_INTERVAL).await;
         }
     }

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -350,6 +350,9 @@ where
                 }
                 .instrument(handshaker_span),
             );
+
+            // Only one sucesful connection per `MIN_PEER_CONNECTION_INTERVAL` is allowed.
+            tokio::time::sleep(constants::MIN_PEER_CONNECTION_INTERVAL).await;
         }
     }
 }


### PR DESCRIPTION
## Motivation

We want to limit the rate of inbound connections. Closes https://github.com/ZcashFoundation/zebra/issues/2901

## Solution

In the connection loop add a `sleep` after any connection is accepted. Sleep for `MIN_PEER_CONNECTION_INTERVAL` (currently this is `0.1` seconds).

## Review

Anyone can review.
