### PR TITLE
Speed up alternative state and zebrad tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,8 @@ jobs:
           TEST_FAKE_ACTIVATION_HEIGHTS:
         with:
           command: test
-          args: --verbose --all -- with_fake_activation_heights
+          # Note: this only runs the zebra-state crate tests, because re-running all the test binaries is slow on Windows
+          args: --verbose --package zebra-state --lib -- with_fake_activation_heights
 
       # Explicitly run any tests that are usually #[ignored]
 
@@ -86,7 +87,8 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --verbose --manifest-path zebrad/Cargo.toml sync_large_checkpoints_ -- --ignored
+          # Note: this only runs the zebrad acceptance tests, because re-running all the test binaries is slow on Windows
+          args: --verbose --package zebrad --test acceptance sync_large_checkpoints_ -- --ignored
 
   build-chain-no-features:
     name: Build (+${{ matrix.rust }}) zebra-chain w/o features on ubuntu-latest


### PR DESCRIPTION
## Motivation

Re-running the compiler and test binaries for unused crates is slow in CI.

This is unexpected work in sprint 21.

## Solution

- Only run the zebra-state crate tests in the `with_fake_activation_heights` CI
- Only run the zebrad acceptance tests in the `sync_large_checkpoints_` CI

## Review

Anyone can review this PR.

It's a lower priority CI speedup, but it has caused some CI failures such as:
https://github.com/ZcashFoundation/zebra/runs/3965592317

### Reviewer Checklist

  - [x] `with_fake_activation_heights` tests still run on all platforms
  - [x] `sync_large_checkpoints_` tests still run on macOS

