### PR TITLE
Limit the size and age of the ZIP-401 rejected transaction ID list

### DIFF
--- a/zebrad/proptest-regressions/components/mempool/storage/tests/prop.txt
+++ b/zebrad/proptest-regressions/components/mempool/storage/tests/prop.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc b258d507c0b2aef6c2793bdb3fc29e6367e62fba9df378ea6797e9bc97fd2780 # shrinks to input = RemoveSameEffects { transactions: alloc::vec::Vec<zebra_chain::transaction::unmined::UnminedTx><zebra_chain::transaction::unmined::UnminedTx>, len=2, mined_ids_to_remove: std::collections::hash::set::HashSet<zebra_chain::transaction::hash::Hash><zebra_chain::transaction::hash::Hash>, len=2 }
+cc 4616d813ba54e7b7475a1adb880905dfb05a63b59a18dc079893bf963ae92097 # shrinks to rejection_error = SameEffectsChain(Expired), mut rejection_template = Witnessed(WtxId { id: transaction::Hash("0000000000000000000000000000000000000000000000000000000000000000"), auth_digest: AuthDigest("353b92c552d72e06b512c81f909991b291ca0fec5251d6696755091100000000") })

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -126,6 +126,13 @@ pub struct Storage {
     /// These rejections apply until a rollback or network upgrade.
     ///
     /// Any transaction with the same `transaction::Hash` is invalid.
+    ///
+    /// An [`EvictionList`] is used for both randomly evicted and expired transactions,
+    /// even if it is only needed for the evicted ones. This was done just to simplify
+    /// the existing code; there is no harm in having a timeout for expired transactions
+    /// too since re-checking expired transactions is cheap. If this code is ever refactored
+    /// and the lists are split in different fields, then we can use an `EvictionList` just for
+    /// the evicted list.
     chain_rejected_same_effects: HashMap<SameEffectsChainRejectionError, EvictionList>,
 
     /// The mempool transaction eviction age limit.

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -284,11 +284,7 @@ impl Storage {
         if self.tip_rejected_same_effects.len() > MAX_EVICTION_MEMORY_ENTRIES {
             self.tip_rejected_same_effects.clear();
         }
-        for (_, map) in self.chain_rejected_same_effects.iter_mut() {
-            if map.len() > MAX_EVICTION_MEMORY_ENTRIES {
-                map.clear();
-            }
-        }
+        // `chain_rejected_same_effects` limits its size by itself
         self.update_rejected_metrics();
     }
 
@@ -333,12 +329,12 @@ impl Storage {
     ///
     /// Transactions on multiple rejected lists are counted multiple times.
     #[allow(dead_code)]
-    pub fn rejected_transaction_count(&self) -> usize {
+    pub fn rejected_transaction_count(&mut self) -> usize {
         self.tip_rejected_exact.len()
             + self.tip_rejected_same_effects.len()
             + self
                 .chain_rejected_same_effects
-                .iter()
+                .iter_mut()
                 .map(|(_, map)| map.len())
                 .sum::<usize>()
     }
@@ -493,7 +489,7 @@ impl Storage {
     /// Update metrics related to the rejected lists.
     ///
     /// Must be called every time the rejected lists change.
-    fn update_rejected_metrics(&self) {
+    fn update_rejected_metrics(&mut self) {
         metrics::gauge!(
             "mempool.rejected.transaction.ids",
             self.rejected_transaction_count() as _

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -130,9 +130,9 @@ pub struct Storage {
     /// An [`EvictionList`] is used for both randomly evicted and expired transactions,
     /// even if it is only needed for the evicted ones. This was done just to simplify
     /// the existing code; there is no harm in having a timeout for expired transactions
-    /// too since re-checking expired transactions is cheap. If this code is ever refactored
-    /// and the lists are split in different fields, then we can use an `EvictionList` just for
-    /// the evicted list.
+    /// too since re-checking expired transactions is cheap.
+    // If this code is ever refactored and the lists are split in different fields,
+    // then we can use an `EvictionList` just for the evicted list.
     chain_rejected_same_effects: HashMap<SameEffectsChainRejectionError, EvictionList>,
 
     /// The mempool transaction eviction age limit.

--- a/zebrad/src/components/mempool/storage/eviction_list.rs
+++ b/zebrad/src/components/mempool/storage/eviction_list.rs
@@ -12,11 +12,8 @@ use zebra_chain::transaction;
 pub struct EvictionList {
     // Maps each TXID in the list to the most recent instant they were added.
     unique_entries: HashMap<transaction::Hash, Instant>,
-    // The entries in the order they were inserted.
-    // This can be larger than `unique_entries` if a same txid is added
-    // multiple times. Its instant will be overwritten in
-    // `unique_entries` but all entries will kept in `ordered_entries`.
-    ordered_entries: VecDeque<(transaction::Hash, Instant)>,
+    // The same as `unique_entries` but in the order they were inserted.
+    ordered_entries: VecDeque<transaction::Hash>,
     // The maximum size of `unique_entries`.
     max_size: usize,
     /// The mempool transaction eviction age limit.
@@ -38,9 +35,12 @@ impl EvictionList {
 
     /// Inserts a TXID in the list, keeping track of the time it was inserted.
     ///
-    /// If the TXID is already in the list, its insertion time will be updated.
-    ///
     /// All entries older than [`EvictionList::eviction_memory_time`] will be removed.
+    ///
+    /// # Panics
+    ///
+    /// If the TXID is already in the list.
+    ///
     pub fn insert(&mut self, key: transaction::Hash) {
         // From https://zips.z.cash/zip-0401#specification:
         // > Nodes SHOULD remove transactions from RecentlyEvicted that were evicted more than
@@ -49,24 +49,20 @@ impl EvictionList {
         self.prune_old();
         // > Add the txid and the current time to RecentlyEvicted, dropping the oldest entry
         // > in RecentlyEvicted if necessary to keep it to at most eviction_memory_entries entries.
-        // Use a `while` because it is possible that more than one item is removed
-        // (if an entry is refreshed, it leaves the old value in the list).
-        while self.len() >= self.max_size {
+        if self.len() >= self.max_size {
             self.pop_front();
         }
         let value = Instant::now();
         let old_value = self.unique_entries.insert(key, value);
-        if old_value != Some(value) {
-            // Also limit the size of `ordered_entries`
-            if self.ordered_entries.len() >= self.max_size {
-                if let Some((removed_key, removed_value)) = self.ordered_entries.pop_front() {
-                    if self.unique_entries.get(&removed_key) == Some(&removed_value) {
-                        self.unique_entries.remove(&removed_key);
-                    }
-                }
-            }
-            self.ordered_entries.push_back((key, value))
-        }
+        // It should be impossible for an already-evicted transaction to be evicted
+        // again since transactions are not added to the mempool if they are evicted,
+        // and the mempool doesn't allow inserting two transactions with the same
+        // hash (they would conflict).
+        assert!(
+            old_value.is_none(),
+            "an already-evicted transaction should not be evicted again"
+        );
+        self.ordered_entries.push_back(key)
     }
 
     /// Checks if the given TXID is in the list.
@@ -82,6 +78,9 @@ impl EvictionList {
     }
 
     /// Get the size of the list.
+    //
+    // Note: if this method being mutable becomes an issue, it's possible
+    // to compute the number of expired transactions and subtract.
     pub fn len(&mut self) -> usize {
         self.prune_old();
         self.unique_entries.len()
@@ -99,7 +98,11 @@ impl EvictionList {
     // This method is public because ZIP-401 states about pruning:
     // > This MAY be done periodically,
     pub fn prune_old(&mut self) {
-        while let Some((_txid, evicted_at)) = self.front() {
+        while let Some(txid) = self.front() {
+            let evicted_at = self
+                .unique_entries
+                .get(txid)
+                .expect("all entries should exist in both ordered_entries and unique_entries");
             if self.has_expired(evicted_at) {
                 self.pop_front();
             } else {
@@ -109,27 +112,23 @@ impl EvictionList {
     }
 
     /// Get the oldest TXID in the list.
-    ///
-    /// If the TXID was refreshed, then the entry can correspond to the older
-    /// value.
-    fn front(&self) -> Option<&(transaction::Hash, Instant)> {
+    fn front(&self) -> Option<&transaction::Hash> {
         self.ordered_entries.front()
     }
 
     /// Removes the first element and returns it, or `None` if the `EvictionList`
     /// is empty.
-    ///
-    /// If the TXID was refreshed, then the entry can correspond to the older
-    /// value. In that case, the most recent TXID won't be removed from the list
-    /// yet.
-    fn pop_front(&mut self) -> Option<(transaction::Hash, Instant)> {
-        let entry = self.ordered_entries.pop_front();
-        if let Some((key, value)) = &entry {
-            if self.unique_entries.get(key) == Some(value) {
-                self.unique_entries.remove(key);
-            }
+    fn pop_front(&mut self) -> Option<transaction::Hash> {
+        if let Some(key) = self.ordered_entries.pop_front() {
+            let removed = self.unique_entries.remove(&key);
+            assert!(
+                removed.is_some(),
+                "all entries should exist in both ordered_entries and unique_entries"
+            );
+            Some(key)
+        } else {
+            None
         }
-        entry
     }
 
     /// Returns if `evicted_at` is considered expired considering the current
@@ -137,17 +136,5 @@ impl EvictionList {
     fn has_expired(&self, evicted_at: &Instant) -> bool {
         let now = Instant::now();
         (now - *evicted_at) > self.eviction_memory_time
-    }
-
-    /// Test-only getter
-    #[cfg(test)]
-    pub(crate) fn unique_entries(&self) -> &HashMap<transaction::Hash, Instant> {
-        &self.unique_entries
-    }
-
-    /// Test-only getter
-    #[cfg(test)]
-    pub(crate) fn ordered_entries(&self) -> &VecDeque<(transaction::Hash, Instant)> {
-        &self.ordered_entries
     }
 }

--- a/zebrad/src/components/mempool/storage/eviction_list.rs
+++ b/zebrad/src/components/mempool/storage/eviction_list.rs
@@ -74,21 +74,13 @@ impl EvictionList {
     }
 
     /// Get the size of the list.
-    pub fn len(&self) -> usize {
-        // Since the list is pruned only in mutable functions, make sure
-        // we take expired items into account.
-        let expired = self
-            .ordered_entries
-            .iter()
-            // Take all expired entries
-            .take_while(|(_txid, evicted_at)| self.has_expired(evicted_at))
-            // Count only those that correspond to entries in `unique_entries`
-            .filter(|(txid, evicted_at)| self.unique_entries.get(txid) == Some(evicted_at))
-            .count();
-        self.unique_entries.len() - expired
+    pub fn len(&mut self) -> usize {
+        self.prune_old();
+        self.unique_entries.len()
     }
 
     /// Clear the list.
+    #[allow(dead_code)]
     pub fn clear(&mut self) {
         self.unique_entries.clear();
         self.ordered_entries.clear();

--- a/zebrad/src/components/mempool/storage/eviction_list.rs
+++ b/zebrad/src/components/mempool/storage/eviction_list.rs
@@ -7,7 +7,7 @@ use std::{
 
 use zebra_chain::transaction;
 
-/// An eviction list that allows to efficiently add entries, get entries,
+/// An eviction list that allows Zebra to efficiently add entries, get entries,
 /// and remove older entries in the order they were inserted.
 pub struct EvictionList {
     // Maps each TXID in the list to the most recent instant they were added.
@@ -15,7 +15,7 @@ pub struct EvictionList {
     // The entries in the order they were inserted.
     // This can be larger than `unique_entries` if a same txid is added
     // multiple times. Its instant will be overwritten in
-    // `unique_entries` but all entries will kept in `unique_entries`.
+    // `unique_entries` but all entries will kept in `ordered_entries`.
     ordered_entries: VecDeque<(transaction::Hash, Instant)>,
     // The maximum size of `unique_entries`.
     max_size: usize,
@@ -40,7 +40,7 @@ impl EvictionList {
     ///
     /// If the TXID is already in the list, its insertion time will be updated.
     ///
-    /// All entries older than [`EvictionList::eviction_time`] will be removed.
+    /// All entries older than [`EvictionList::eviction_memory_time`] will be removed.
     pub fn insert(&mut self, key: transaction::Hash) {
         // From https://zips.z.cash/zip-0401#specification:
         // > Nodes SHOULD remove transactions from RecentlyEvicted that were evicted more than

--- a/zebrad/src/components/mempool/storage/eviction_list.rs
+++ b/zebrad/src/components/mempool/storage/eviction_list.rs
@@ -78,9 +78,12 @@ impl EvictionList {
         // Since the list is pruned only in mutable functions, make sure
         // we take expired items into account.
         let expired = self
-            .unique_entries
+            .ordered_entries
             .iter()
-            .take_while(|(_txid, evicted_at)| self.has_expired(*evicted_at))
+            // Take all expired entries
+            .take_while(|(_txid, evicted_at)| self.has_expired(evicted_at))
+            // Count only those that correspond to entries in `unique_entries`
+            .filter(|(txid, evicted_at)| self.unique_entries.get(txid) == Some(evicted_at))
             .count();
         self.unique_entries.len() - expired
     }

--- a/zebrad/src/components/mempool/storage/eviction_list.rs
+++ b/zebrad/src/components/mempool/storage/eviction_list.rs
@@ -10,7 +10,7 @@ use zebra_chain::transaction;
 /// An eviction list that allows to efficiently add entries, get entries,
 /// and remove older entries in the order they were inserted.
 pub struct EvictionList {
-    // Maps each TXID In the list to the instant they were added.
+    // Maps each TXID in the list to the most recent instant they were added.
     unique_entries: HashMap<transaction::Hash, Instant>,
     // The entries in the order they were inserted.
     // This can be larger than `unique_entries` if a same txid is added
@@ -18,7 +18,7 @@ pub struct EvictionList {
     // `unique_entries` but all entries will kept in `unique_entries`.
     ordered_entries: VecDeque<(transaction::Hash, Instant)>,
     // The maximum size of `unique_entries`.
-    size: usize,
+    max_size: usize,
     /// The mempool transaction eviction age limit.
     /// Same as [`Config::eviction_memory_time`].
     eviction_time: Duration,
@@ -27,7 +27,7 @@ pub struct EvictionList {
 impl EvictionList {
     /// Create a new [`EvictionList`] with the given maximum size and
     /// eviction time.
-    pub fn new(size: usize, eviction_time: Duration) -> Self {
+    pub fn new(max_size: usize, eviction_time: Duration) -> Self {
         Self {
             unique_entries: Default::default(),
             ordered_entries: Default::default(),

--- a/zebrad/src/components/mempool/storage/eviction_list.rs
+++ b/zebrad/src/components/mempool/storage/eviction_list.rs
@@ -1,0 +1,107 @@
+//! [`EvictionList`] represents the transaction eviction list with
+//! efficient operations.
+use std::{
+    collections::{HashMap, VecDeque},
+    time::{Duration, Instant},
+};
+
+use zebra_chain::transaction;
+
+/// An eviction list that allows to efficiently add entries, get entries,
+/// and remove older entries in the order they were inserted.
+pub struct EvictionList {
+    // Maps each TXID In the list to the instant they were added.
+    unique_entries: HashMap<transaction::Hash, Instant>,
+    // The entries in the order they were inserted.
+    // This can be larger than `unique_entries` if a same txid is added
+    // multiple times. Its instant will be overwritten in
+    // `unique_entries` but all entries will kept in `unique_entries`.
+    ordered_entries: VecDeque<(transaction::Hash, Instant)>,
+    // The maximum size of `unique_entries`.
+    size: usize,
+    /// The mempool transaction eviction age limit.
+    /// Same as [`Config::eviction_memory_time`].
+    eviction_time: Duration,
+}
+
+impl EvictionList {
+    /// Create a new [`EvictionList`] with the given maximum size and
+    /// eviction time.
+    pub fn new(size: usize, eviction_time: Duration) -> Self {
+        Self {
+            unique_entries: Default::default(),
+            ordered_entries: Default::default(),
+            size,
+            eviction_time,
+        }
+    }
+
+    /// Inserts a TXID in the list, keeping track of the time it was inserted.
+    ///
+    /// If the TXID is already in the list, its insertion time will be updated.
+    ///
+    /// All entries older than [`EvictionList::eviction_time`] will be removed.
+    pub fn insert(&mut self, key: transaction::Hash) {
+        self.prune_old();
+        while self.len() >= self.size {
+            self.pop_front();
+        }
+        let value = Instant::now();
+        let old_value = self.unique_entries.insert(key, value);
+        if old_value != Some(value) {
+            self.ordered_entries.push_back((key, value))
+        }
+    }
+
+    /// Checks if the given TXID is in the list.
+    pub fn contains_key(&self, txid: &transaction::Hash) -> bool {
+        self.unique_entries.contains_key(txid)
+    }
+
+    /// Get the size of the list.
+    pub fn len(&self) -> usize {
+        self.unique_entries.len()
+    }
+
+    /// Clear the list.
+    pub fn clear(&mut self) {
+        self.unique_entries.clear();
+        self.ordered_entries.clear();
+    }
+
+    /// Prune TXIDs that are older than `eviction_time` ago.
+    pub fn prune_old(&mut self) {
+        let now = Instant::now();
+        while let Some((_txid, evicted_at)) = self.front() {
+            if (now - *evicted_at) > self.eviction_time {
+                self.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Get the oldest TXID in the list.
+    ///
+    /// If the TXID was refreshed, then the entry can correspond to the older
+    /// value.
+    fn front(&self) -> Option<&(transaction::Hash, Instant)> {
+        self.ordered_entries.front()
+    }
+
+    /// Removes the first element and returns it, or `None` if the `EvictionList`
+    /// is empty.
+    ///
+    /// If the TXID was refreshed, then the entry can correspond to the older
+    /// value. In that case, the most recent TXID won't be removed from the list
+    /// yet.
+    fn pop_front(&mut self) -> Option<(transaction::Hash, Instant)> {
+        let entry = self.ordered_entries.pop_front();
+        if let Some((key, value)) = &entry {
+            if self.unique_entries.get(key) == Some(value) {
+                self.unique_entries.remove(key);
+            }
+        }
+        entry
+    }
+}

--- a/zebrad/src/components/mempool/storage/eviction_list.rs
+++ b/zebrad/src/components/mempool/storage/eviction_list.rs
@@ -59,8 +59,7 @@ impl EvictionList {
         // and the mempool doesn't allow inserting two transactions with the same
         // hash (they would conflict).
         assert_eq!(
-            old_value,
-            None,
+            old_value, None,
             "an already-evicted transaction should not be evicted again"
         );
         self.ordered_entries.push_back(key)
@@ -106,7 +105,7 @@ impl EvictionList {
             let evicted_at = self
                 .unique_entries
                 .get(txid)
-                .unwrap_or_else(|_| panic!("all entries should exist in both ordered_entries and unique_entries, missing {:?} in unique_entries", txid));
+                .unwrap_or_else(|| panic!("all entries should exist in both ordered_entries and unique_entries, missing {:?} in unique_entries", txid));
             if self.has_expired(evicted_at) {
                 self.pop_front();
             } else {
@@ -125,10 +124,10 @@ impl EvictionList {
     fn pop_front(&mut self) -> Option<transaction::Hash> {
         if let Some(key) = self.ordered_entries.pop_front() {
             let removed = self.unique_entries.remove(&key);
-            assert_eq!(
-                removed,
-                Some(key),
-                "all entries should exist in both ordered_entries and unique_entries"
+            assert!(
+                removed.is_some(),
+                "all entries should exist in both ordered_entries and unique_entries, missing {:?} in unique_entries",
+                key
             );
             Some(key)
         } else {

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -981,11 +981,11 @@ proptest! {
         for txid in txids.iter() {
             e.insert(txid.mined_id());
         }
-        prop_assert_eq!(e.len(), 2);
         prop_assert!(!e.contains_key(&txids[0].mined_id()));
         prop_assert!(!e.contains_key(&txids[1].mined_id()));
         prop_assert!(e.contains_key(&txids[2].mined_id()));
         prop_assert!(e.contains_key(&txids[3].mined_id()));
+        prop_assert_eq!(e.len(), 2);
     }
 
     /// Check if EvictionList removes old entries.
@@ -1010,13 +1010,13 @@ proptest! {
 
         // First txid has expired, but list wasn't pruned yet.
         // Make sure len() and contains_key() take that into account.
-        prop_assert_eq!(e.len(), 0);
         prop_assert!(!e.contains_key(&txids[0].mined_id()));
+        prop_assert_eq!(e.len(), 0);
 
         e.insert(txids[1].mined_id());
-        prop_assert_eq!(e.len(), 1);
         prop_assert!(!e.contains_key(&txids[0].mined_id()));
         prop_assert!(e.contains_key(&txids[1].mined_id()));
+        prop_assert_eq!(e.len(), 1);
     }
 
     /// Check if EvictionList removes old entries and computes length correctly
@@ -1060,23 +1060,23 @@ proptest! {
         // At this point, the first 10 entries should be expired
         // and the next 10 should not, and the list hasn't been pruned yet.
         // Make sure len() and contains_key() take that into account.
-        // Note: if this fails, you may need to adjust EVICTION_TIME and/or
+        // Note: if one of these fails, you may need to adjust EVICTION_TIME and/or
         // BEFORE_EVICTION_TIME, see above.
-        prop_assert_eq!(e.len(), 10);
         for txid in txids.iter().take(10) {
             prop_assert!(!e.contains_key(&txid.mined_id()));
         }
         for txid in txids.iter().skip(10) {
             prop_assert!(e.contains_key(&txid.mined_id()));
         }
+        prop_assert_eq!(e.len(), 10);
 
         // Make sure all of them are expired
         thread::sleep(Duration::from_millis(EVICTION_TIME + 1));
 
-        prop_assert_eq!(e.len(), 0);
         for txid in txids.iter() {
             prop_assert!(!e.contains_key(&txid.mined_id()));
         }
+        prop_assert_eq!(e.len(), 0);
     }
 
     /// Check if EvictionList refreshes entries added multiple times.
@@ -1092,7 +1092,7 @@ proptest! {
         // The list is pruned in the insertion, but call prune_old() anyway
         // to make sure we're testing the post-pruned state.
         e.prune_old();
-        prop_assert_eq!(e.len(), 1);
         prop_assert!(e.contains_key(&txid.mined_id()));
+        prop_assert_eq!(e.len(), 1);
     }
 }

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -1079,54 +1079,14 @@ proptest! {
         prop_assert_eq!(e.len(), 0);
     }
 
-    /// Check if EvictionList refreshes entries added multiple times.
+    /// Check if EvictionList panics if entries are added multiple times.
     #[test]
+    #[should_panic]
     fn eviction_list_refresh(
         txid in any::<UnminedTxId>()
     ) {
-        let mut e = EvictionList::new(2, Duration::from_millis(10));
+        let mut e = EvictionList::new(2, EVICTION_MEMORY_TIME);
         e.insert(txid.mined_id());
-        thread::sleep(Duration::from_millis(11));
-        // Refresh entry.
         e.insert(txid.mined_id());
-        // The list is pruned in the insertion, but call prune_old() anyway
-        // to make sure we're testing the post-pruned state.
-        e.prune_old();
-        prop_assert!(e.contains_key(&txid.mined_id()));
-        prop_assert_eq!(e.len(), 1);
-    }
-
-    /// Check if EvictionList keeps both internal lists from growing.
-    #[test]
-    fn eviction_list_limit(
-        txid in any::<UnminedTxId>(),
-        txid2 in any::<UnminedTxId>()
-    ) {
-        let mut e = EvictionList::new(2, Duration::from_millis(10));
-
-        // Add tx and refresh twice
-        e.insert(txid.mined_id());
-        thread::sleep(Duration::from_millis(1));
-        e.insert(txid.mined_id());
-        thread::sleep(Duration::from_millis(1));
-        e.insert(txid.mined_id());
-        thread::sleep(Duration::from_millis(1));
-        // There should be only one effective ID in the list
-        prop_assert_eq!(e.unique_entries().len(), 1);
-        // One entry should have been removed to keep the limit.
-        prop_assert_eq!(e.ordered_entries().len(), 2);
-
-        e.clear();
-
-        // Add txid, add txid2, refresh txid2
-        e.insert(txid.mined_id());
-        e.insert(txid2.mined_id());
-        thread::sleep(Duration::from_millis(1));
-        e.insert(txid2.mined_id());
-        // That should trigger txid to be removed from the ordered_list,
-        // which also removes it from the unique_list (since it's a non-
-        // refreshed entry).
-        prop_assert_eq!(e.unique_entries().len(), 1);
-        prop_assert_eq!(e.ordered_entries().len(), 2);
     }
 }

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -997,6 +997,12 @@ proptest! {
         let mut e = EvictionList::new(2, Duration::from_millis(10));
         e.insert(txids[0].mined_id());
         thread::sleep(Duration::from_millis(11));
+
+        // First txid has expired, but list wasn't pruned yet.
+        // Make sure len() and contains_key() take that into account.
+        prop_assert_eq!(e.len(), 0);
+        prop_assert!(!e.contains_key(&txids[0].mined_id()));
+
         e.insert(txids[1].mined_id());
         prop_assert_eq!(e.len(), 1);
         prop_assert!(!e.contains_key(&txids[0].mined_id()));
@@ -1013,6 +1019,8 @@ proptest! {
         thread::sleep(Duration::from_millis(11));
         // Refresh entry.
         e.insert(txid.mined_id());
+        // The list is pruned in the insertion, but call prune_old() anyway
+        // to make sure we're testing the post-pruned state.
         e.prune_old();
         prop_assert_eq!(e.len(), 1);
         prop_assert!(e.contains_key(&txid.mined_id()));

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -1027,12 +1027,12 @@ proptest! {
     ) {
         // Eviction time (in ms) used in this test. If the value is too low it may cause
         // this test to fail in slower systems.
-        const EVICTION_TIME: u64 = 100;
+        const EVICTION_TIME: u64 = 500;
         // Time to wait (in ms) before adding transactions that should not expire
         // after EVICTION_TIME.
         // If should be a bit smaller than EVICTION_TIME, but with enough time to
         // add 10 transactions to the list and still have time to spare before EVICTION_TIME.
-        const BEFORE_EVICTION_TIME: u64 = 50;
+        const BEFORE_EVICTION_TIME: u64 = 250;
 
         // Make unique IDs by converting the index to bytes, and writing it to each ID
         let txids: Vec<UnminedTxId> = (0..20_u32).map(move |index| {

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -14,6 +14,10 @@ use crate::components::mempool::{
     storage::tests::unmined_transactions_in_blocks, storage::*, Mempool,
 };
 
+/// Eviction memory time used for tests. Most tests won't care about this
+/// so we use a large enough value that will never be reached in the tests.
+const EVICTION_MEMORY_TIME: Duration = Duration::from_secs(60 * 60);
+
 #[test]
 fn mempool_storage_crud_exact_mainnet() {
     zebra_test::init();
@@ -21,7 +25,7 @@ fn mempool_storage_crud_exact_mainnet() {
     let network = Network::Mainnet;
 
     // Create an empty storage instance
-    let mut storage: Storage = Default::default();
+    let mut storage: Storage = Storage::new(EVICTION_MEMORY_TIME);
 
     // Get one (1) unmined transaction
     let unmined_tx = unmined_transactions_in_blocks(.., network)
@@ -49,7 +53,7 @@ fn mempool_storage_crud_same_effects_mainnet() {
     let network = Network::Mainnet;
 
     // Create an empty storage instance
-    let mut storage: Storage = Default::default();
+    let mut storage: Storage = Storage::new(EVICTION_MEMORY_TIME);
 
     // Get one (1) unmined transaction
     let unmined_tx = unmined_transactions_in_blocks(.., network)
@@ -83,7 +87,7 @@ fn mempool_storage_basic() -> Result<()> {
 
 fn mempool_storage_basic_for_network(network: Network) -> Result<()> {
     // Create an empty storage
-    let mut storage: Storage = Default::default();
+    let mut storage: Storage = Storage::new(EVICTION_MEMORY_TIME);
 
     // Get transactions from the first 10 blocks of the Zcash blockchain
     let unmined_transactions: Vec<_> = unmined_transactions_in_blocks(..=10, network).collect();
@@ -156,7 +160,7 @@ fn mempool_expired_basic() -> Result<()> {
 
 fn mempool_expired_basic_for_network(network: Network) -> Result<()> {
     // Create an empty storage
-    let mut storage: Storage = Default::default();
+    let mut storage: Storage = Storage::new(EVICTION_MEMORY_TIME);
 
     let block: Block = match network {
         Network::Mainnet => {


### PR DESCRIPTION
## Motivation

ZIP-401 specifies that the list of TXIDs must have a maximum size and entries older than a specified threshold must be removed.

### Specifications

https://zips.z.cash/zip-0401#specification

### Designs

Some of the design was discussed in https://github.com/ZcashFoundation/zebra/issues/2759

## Solution

- Create a `EvictedList` that encapsulates both behaviours
- Use the `EvictedList` for both rejected and expired transactions
  - I'm using in both because that was easier with the current `Storage` design, and seems harmless (expired transactions will also have a timeout)
  
I tried creating a generic `OrderedMap` data structure, that `EvictedList` would use, in order to organize the code. However I noticed it would be more work since it's tricky to handle/document the behavior that removing a item from the list might not _really_ remove a item from the list (when a value was refreshed and an stale entry is left behind). So I left the entire logic inside `EvictedList` (where the removal methods are not exposed).

Closes https://github.com/ZcashFoundation/zebra/issues/2759
Closes #2958

## Review

Anyone can review. @teor2345 discussed the design.

This may require adjustments after https://github.com/ZcashFoundation/zebra/pull/2889/ so it may be better to wait for that to be merged first.

### Reviewer Checklist

  - [ ] Does it make sense to use `EvictList` for the expired transaction, or should change `Storage` so that only rejected list uses it?
  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
