### PR TITLE
Use `broadcast::Receiver::recv` instead of `next`

### DIFF
--- a/tower-batch/src/worker.rs
+++ b/tower-batch/src/worker.rs
@@ -6,7 +6,6 @@ use std::{
 use futures::future::TryFutureExt;
 use pin_project::pin_project;
 use tokio::{
-    stream::StreamExt,
     sync::mpsc,
     time::{sleep, Sleep},
 };
@@ -127,7 +126,7 @@ where
         let mut pending_items = 0usize;
         loop {
             match timer.as_mut() {
-                None => match self.rx.next().await {
+                None => match self.rx.recv().await {
                     // The first message in a new batch.
                     Some(msg) => {
                         let span = msg.span;


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

This is part of the update to use Tokio version 1 (#2200), and must be merged together with the other PRs.

On newer versions of Tokio the `broadcast::Receiver` doesn't implement `Stream`, so the `StreamExt::next` method used in `tower-batch` is no longer available.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Instead of wrapping the `broadcast::Receiver` in a `tokio_stream::wrappers::BroadcastStream` like in #2922, in this case a simpler solution was used, simply replacing the usage of `StreamExt::next()` with `broadcast::Receiver::recv()`.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
Anyone from the team can review this, but it shouldn't be merged yet.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
