### PR TITLE
Handle `Semaphore::acquire()` error

### DIFF
--- a/zebrad/src/components/sync/status/tests.rs
+++ b/zebrad/src/components/sync/status/tests.rs
@@ -100,7 +100,7 @@ proptest! {
 
                 let awoke = match timeout(EVENT_TIMEOUT, wake_events.acquire()).await {
                     Ok(permit) => {
-                        permit.forget();
+                        permit.expect("Sempahore closed prematurely").forget();
                         true
                     }
                     Err(_) => false,
@@ -127,7 +127,7 @@ proptest! {
             wake_events: Arc<Semaphore>,
         ) -> Result<(), TestCaseError> {
             loop {
-                update_events.acquire().await.forget();
+                update_events.acquire().await.expect("Sempahore closed prematurely").forget();
 
                 if status.wait_until_close_to_tip().await.is_err() {
                     return Ok(());


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
This is part of the update to use Tokio version 1 (#2200), and must be merged together with the other PRs.

The newer version of Tokio changed the `Semaphore::acquire()` method to return an error if the semaphore has been closed. Usages of that method need to be updated to handle the error.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
In the two usages of semaphores in Zebra they are never closed, so the solution here was just to `expect` that calls to `acquire` will never fail.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
Anyone from the team can review this, but it shouldn't be merged yet.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
