### PR TITLE
Update some `zebra-network` dependencies

### DIFF
--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 bitflags = "1.2"
 byteorder = "1.4"
-bytes = "1.1"
+bytes = "1.1.0"
 chrono = "0.4"
 hex = "0.4"
 # indexmap has rayon support for parallel iteration,
@@ -25,7 +25,7 @@ thiserror = "1"
 
 futures = "0.3"
 tokio = { version = "0.3.6", features = ["net", "time", "stream", "tracing", "macros", "rt-multi-thread"] }
-tokio-util = { version = "0.6", features = ["codec"] }
+tokio-util = { version = "0.6.9", features = ["codec"] }
 tower = { version = "0.4", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 
 metrics = "0.13.0-alpha.8"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 bitflags = "1.2"
 byteorder = "1.4"
-bytes = "0.6"
+bytes = "1.1"
 chrono = "0.4"
 hex = "0.4"
 # indexmap has rayon support for parallel iteration,
@@ -25,7 +25,7 @@ thiserror = "1"
 
 futures = "0.3"
 tokio = { version = "0.3.6", features = ["net", "time", "stream", "tracing", "macros", "rt-multi-thread"] }
-tokio-util = { version = "0.5", features = ["codec"] }
+tokio-util = { version = "0.6", features = ["codec"] }
 tower = { version = "0.4", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 
 metrics = "0.13.0-alpha.8"


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
This is part of the update to use Tokio version 1 (#2200), and must be merged together with the other PRs.

The newer version of Tokio uses some updated dependencies, and Zebra has to update those dependencies to be compatible.

More specifically, the `bytes` and the `tokio-util` crates have to be updated.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
The `bytes` crate was updated to `1.1` and the `tokio-util` crate was updated to `0.6`.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
Anyone from the team can review this, but it shouldn't be merged yet.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
