### PR TITLE
Upgrade Hyper to version 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ panic = "abort"
 [patch.crates-io]
 
 # awaiting stable versions which all depend on tokio 1.0, see #1086 for details
-hyper = { git = "https://github.com/hyperium/hyper", rev = "ed2b22a7f66899d338691552fbcb6c0f2f4e06b9" }
 metrics = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
 metrics-exporter-prometheus = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
 tower = { git = "https://github.com/tower-rs/tower", rev = "d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39" }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1", features = ["serde_derive"] }
 toml = "0.5"
 chrono = "0.4"
 
-hyper = { version = "0.14.0-dev", features = ["full"] }
+hyper = { version = "0.14.13", features = ["full"] }
 futures = "0.3"
 tokio = { version = "0.3.6", features = ["time", "rt-multi-thread", "stream", "macros", "tracing", "signal"] }
 tower = { version = "0.4", features = ["hedge", "limit"] }


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
This is part of the update to use Tokio version 1 (#2200), and must be merged together with the other PRs.

The previous version of `hyper` needs a runtime created by the older Tokio version. With the update to a newer version of Tokio, either an old runtime instance has to be spawned beside the new runtime, or the dependency on Hyper has to be updated to a version that supports the newer version of Tokio.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Update `hyper` to version `0.14`, which supports the newer Tokio version.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
Anyone from the team can review this, but it shouldn't be merged yet.
