### PR TITLE
Update `metrics` to version 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,6 @@ panic = "abort"
 
 # awaiting stable versions which all depend on tokio 1.0, see #1086 for details
 hyper = { git = "https://github.com/hyperium/hyper", rev = "ed2b22a7f66899d338691552fbcb6c0f2f4e06b9" }
-metrics = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
-metrics-exporter-prometheus = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
 tower = { git = "https://github.com/tower-rs/tower", rev = "d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39" }
 
 # TODO: remove these after a new librustzcash release.

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["serde_derive"] }
 
 futures = "0.3.17"
 futures-util = "0.3.17"
-metrics = "0.13.0-alpha.8"
+metrics = "0.17"
 thiserror = "1.0.30"
 tokio = { version = "0.3.6", features = ["time", "sync", "stream", "tracing"] }
 tower = { version = "0.4", features = ["timeout", "util", "buffer"] }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["serde_derive"] }
 
 futures = "0.3.17"
 futures-util = "0.3.17"
-metrics = "0.17"
+metrics = "0.17.0"
 thiserror = "1.0.30"
 tokio = { version = "0.3.6", features = ["time", "sync", "stream", "tracing"] }
 tower = { version = "0.4", features = ["timeout", "util", "buffer"] }

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { version = "0.3.6", features = ["net", "time", "stream", "tracing", "ma
 tokio-util = { version = "0.5", features = ["codec"] }
 tower = { version = "0.4", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 
-metrics = "0.13.0-alpha.8"
+metrics = "0.17"
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-error = { version = "0.1.2", features = ["traced-error"] }

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { version = "0.3.6", features = ["net", "time", "stream", "tracing", "ma
 tokio-util = { version = "0.5", features = ["codec"] }
 tower = { version = "0.4", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 
-metrics = "0.17"
+metrics = "0.17.0"
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-error = { version = "0.1.2", features = ["traced-error"] }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", features = ["serde_derive"] }
 bincode = "1"
 
 futures = "0.3.17"
-metrics = "0.13.0-alpha.8"
+metrics = "0.17"
 tower = { version = "0.4", features = ["buffer", "util"] }
 tracing = "0.1"
 thiserror = "1.0.30"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", features = ["serde_derive"] }
 bincode = "1"
 
 futures = "0.3.17"
-metrics = "0.17"
+metrics = "0.17.0"
 tower = { version = "0.4", features = ["buffer", "util"] }
 tracing = "0.1"
 thiserror = "1.0.30"

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -36,8 +36,8 @@ tracing-flame = "0.1.0"
 tracing-journald = "0.1.0"
 tracing-subscriber = { version = "0.2.25", features = ["tracing-log"] }
 tracing-error = "0.1.2"
-metrics = "0.13.0-alpha.8"
-metrics-exporter-prometheus = "0.1.0-alpha.7"
+metrics = "0.17.0"
+metrics-exporter-prometheus = "0.6.1"
 
 dirs = "4.0.0"
 inferno = { version = "0.10.7", default-features = false }

--- a/zebrad/src/components/mempool/storage/verified_set.rs
+++ b/zebrad/src/components/mempool/storage/verified_set.rs
@@ -267,6 +267,6 @@ impl VerifiedSet {
             "zcash.mempool.size.bytes",
             self.transactions_serialized_size as _
         );
-        metrics::gauge!("zcash.mempool.cost.bytes", u64::from(self.total_cost) as _);
+        metrics::gauge!("zcash.mempool.cost.bytes", self.total_cost as _);
     }
 }

--- a/zebrad/src/components/metrics.rs
+++ b/zebrad/src/components/metrics.rs
@@ -23,24 +23,10 @@ impl MetricsEndpoint {
                     // Expose binary metadata to metrics, using a single time series with
                     // value 1:
                     //     https://www.robustperception.io/exposing-the-software-version-to-prometheus
-                    //
-                    // We manually expand the metrics::increment!() macro because it only
-                    // supports string literals for metrics names, preventing us from
-                    // using concat!() to build the name.
-                    static METRIC_NAME: [metrics::SharedString; 2] = [
-                        metrics::SharedString::const_str(env!("CARGO_PKG_NAME")),
-                        metrics::SharedString::const_str("build.info"),
-                    ];
-                    static METRIC_LABELS: [metrics::Label; 1] =
-                        [metrics::Label::from_static_parts(
-                            "version",
-                            env!("CARGO_PKG_VERSION"),
-                        )];
-                    static METRIC_KEY: metrics::KeyData =
-                        metrics::KeyData::from_static_parts(&METRIC_NAME, &METRIC_LABELS);
-                    if let Some(recorder) = metrics::try_recorder() {
-                        recorder.increment_counter(metrics::Key::Borrowed(&METRIC_KEY), 1);
-                    }
+                    metrics::increment_counter!(
+                        format!("{}.build.info", env!("CARGO_PKG_NAME")),
+                        "version" => env!("CARGO_PKG_VERSION")
+                    );
                 }
                 Err(e) => panic!(
                     "Opening metrics endpoint listener {:?} failed: {:?}. \

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -485,7 +485,7 @@ where
                     let new_download_len = download_set.len();
                     let new_hashes = new_download_len - prev_download_len;
                     tracing::debug!(new_hashes, "added hashes to download set");
-                    metrics::histogram!("sync.obtain.response.hash.count", new_hashes as u64);
+                    metrics::histogram!("sync.obtain.response.hash.count", new_hashes as f64);
                 }
                 Ok(_) => unreachable!("network returned wrong response"),
                 // We ignore this error because we made multiple fanout requests.
@@ -621,7 +621,7 @@ where
                         let new_download_len = download_set.len();
                         let new_hashes = new_download_len - prev_download_len;
                         tracing::debug!(new_hashes, "added hashes to download set");
-                        metrics::histogram!("sync.extend.response.hash.count", new_hashes as u64);
+                        metrics::histogram!("sync.extend.response.hash.count", new_hashes as f64);
                     }
                     Ok(_) => unreachable!("network returned wrong response"),
                     // We ignore this error because we made multiple fanout requests.

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1127,7 +1127,7 @@ async fn metrics_endpoint() -> Result<()> {
     let output = output.assert_failure()?;
 
     output.any_output_line_contains(
-        "metrics snapshot",
+        "# TYPE zebrad_build_info counter",
         &body,
         "metrics exporter response",
         "the metrics response header",


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
This is part of the update to use Tokio version 1 (#2200), and must be merged together with the other PRs.

The version of the `metrics` crate used by Zebra doesn't support the new version of Tokio. More specifically, `metrics` depends on Hyper 0.14, which has the same issue. Just like in #2936, either a new version of the runtime must run beside the old version of the runtime, or the dependency has to be updated.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Update `metrics` to `0.17.0`. This also requires the `metrics-exporter-prometheus` to be updated to `0.6.1`.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
Anyone from the team can review this, but it shouldn't be merged yet.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
