### PR TITLE
Downgrade startup logs to debug to speed up CI

### DIFF
--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -257,14 +257,34 @@ where
             }
             Err((addr, ref e)) => {
                 handshake_error_total += 1;
+
                 // this is verbose, but it's better than just hanging with no output when there are errors
-                info!(
-                    ?handshake_success_total,
-                    ?handshake_error_total,
-                    ?addr,
-                    ?e,
-                    "an initial peer connection failed"
-                );
+                let mut expected_error = false;
+                if let Some(io_error) = e.downcast_ref::<tokio::io::Error>() {
+                    // Some systems only have IPv4, or only have IPv6,
+                    // so these errors are not particularly interesting.
+                    if io_error.kind() == tokio::io::ErrorKind::AddrNotAvailable {
+                        expected_error = true;
+                    }
+                }
+
+                if expected_error {
+                    debug!(
+                        successes = ?handshake_success_total,
+                        errors = ?handshake_error_total,
+                        ?addr,
+                        ?e,
+                        "an initial peer connection failed"
+                    );
+                } else {
+                    info!(
+                        successes = ?handshake_success_total,
+                        errors = ?handshake_error_total,
+                        ?addr,
+                        %e,
+                        "an initial peer connection failed"
+                    );
+                }
             }
         }
 

--- a/zebra-network/src/peer_set/limit.rs
+++ b/zebra-network/src/peer_set/limit.rs
@@ -105,7 +105,7 @@ impl ConnectionTracker {
     fn new(counter: &mut ActiveConnectionCounter) -> Self {
         counter.count += 1;
 
-        info!(open_connections = ?counter.count, "opening a new peer connection");
+        debug!(open_connections = ?counter.count, "opening a new peer connection");
 
         Self {
             close_notification_tx: counter.close_notification_tx.clone(),

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -445,7 +445,7 @@ impl StateService {
         let chain_tip_height = if let Some((height, _)) = self.best_tip() {
             height
         } else {
-            tracing::info!(
+            tracing::debug!(
                 response_len = ?0,
                 "responding to peer GetBlocks or GetHeaders with empty state",
             );

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -372,7 +372,8 @@ impl Service<zn::Request> for Inbound {
                         .map_ok(|_resp| zn::Response::Nil)
                         .boxed()
                 } else {
-                    info!(
+                    // Peers send a lot of these when we first connect to them.
+                    debug!(
                         "ignoring `AdvertiseTransactionIds` request from remote peer during network setup"
                     );
                     async { Ok(zn::Response::Nil) }.boxed()
@@ -385,7 +386,8 @@ impl Service<zn::Request> for Inbound {
                 {
                     block_downloads.download_and_verify(hash);
                 } else {
-                    info!(
+                    // Peers send a lot of these when we first connect to them.
+                    debug!(
                         ?hash,
                         "ignoring `AdvertiseBlock` request from remote peer during network setup"
                     );


### PR DESCRIPTION
## Motivation

There are a lot of these messages when Zebra starts up.
They might be slowing down CI and causing timeouts.

This CI might have timed out and failed due to thousands of log lines:
https://github.com/ZcashFoundation/zebra/runs/3969394222?check_suite_focus=true#step:6:6020

## Solution

- Downgrade seed peer connection failures due to missing IPv4 or IPv6 to debug
- Downgrade generic peer "opening connection" logs to debug
    - this is a logging bug in PR #2912 from this sprint
- Downgrade "empty state" logs to debug
    - this is a logging bug in a fix from last sprint
- Downgrade some frequently repeated "ignoring inbound" logs to debug
    - some of these logs are triggered by mempool PRs from last sprint

## Review

Anyone can review this PR.
It's medium priority, because it might be causing CI failures.

@oxarbitrage came up with the idea for it, but he is busy.

### Reviewer Checklist

  - [ ] Code makes sense

## Follow Up Work

We might downgrade more logs if we get time.