### PR TITLE
Proposal to help automate categorisation of release notes in github

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+# release.yml
+
+changelog:
+  exclude:
+    authors:
+      - dependabot
+  categories:
+    - title: Added
+      labels:
+        - "C-enhancement"
+    - title: Changed
+      labels: 
+        - "C-cleanup"
+    - title: Deprecated
+      labels:
+        - ""
+    - title: Removed
+      labels:
+        - ""
+    - title: Fixed
+      labels:
+        - "C-bug"
+        - "C-enhancement"
+    - title: Security
+      labels:
+        - "C-security"


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

The process to produce release notes for zebra releases can be quite time consuming and it can sometimes be hard to figure out which category a PR falls under.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

We can leverage the new github automated release notes feature together with a `release.yml` file to try to pre-categorise some PRs according to their label or author. 

Looking at PRs included in previous releases I could detect a pattern in the labels used for a  PR and the final category used in the release notes.

This change is related to and may be compatible with #2839 

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

This is not high priority at all and just intended to start a discussion. We can also merge this without any adverse impact as this will only be used if and when we choose to use the automated release notes feature in github when tagging a new release


<img width="777" alt="Screenshot 2021-10-22 at 15 22 37" src="https://user-images.githubusercontent.com/1311133/138460866-dd1f72c7-b102-465a-a14a-070398ecb71c.png">

## Follow Up Work

<!--
Is there anything missing from the solution?
-->

PR authors should try to appropriately tag their PRs with the relevant tags according to the PR category for the release notes. 

We may also want to create specific labels in github to be used for the release notes. 