### PR TITLE
Remove unused mempool errors

### DIFF
--- a/zebrad/src/components/mempool/error.rs
+++ b/zebrad/src/components/mempool/error.rs
@@ -1,4 +1,7 @@
-//! Errors that can occur when manipulating transactions in the mempool.
+//! Errors that can occur when interacting with the mempool.
+//!
+//! Most of the mempool errors are related to manipulating transactions in the
+//! mempool.
 
 use thiserror::Error;
 

--- a/zebrad/src/components/mempool/error.rs
+++ b/zebrad/src/components/mempool/error.rs
@@ -11,7 +11,6 @@ use super::storage::{
 
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
-#[allow(dead_code)]
 pub enum MempoolError {
     #[error("mempool storage has a cached tip rejection for this exact transaction")]
     StorageExactTip(#[from] ExactTipRejectionError),
@@ -28,12 +27,6 @@ pub enum MempoolError {
 
     #[error("transaction already exists in mempool")]
     InMempool,
-
-    #[error("transaction is committed in block {0:?}")]
-    InBlock(zebra_chain::block::Hash),
-
-    #[error("transaction was not found in mempool")]
-    NotInMempool,
 
     /// The transaction hash is already queued, so this request was ignored.
     ///
@@ -52,7 +45,4 @@ pub enum MempoolError {
 
     #[error("mempool is disabled since synchronization is behind the chain tip")]
     Disabled,
-
-    #[error("error calling a service")]
-    ServiceError,
 }


### PR DESCRIPTION
## Motivation

Part of #2859.

## Solution

This PR removes unused error variants and also removes `#[allow(dead_code)]` from `pub enum MempoolError`. The PR also slightly refactors the documentation for the module. I could not think of any other additions to the docs.

## Review

Anyone can review.