### PR TITLE
Limit the number of outbound peer connections

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -11,6 +11,9 @@ use zebra_chain::{parameters::Network, serialization::canonical_socket_addr};
 
 use crate::{constants, BoxError};
 
+#[cfg(test)]
+mod tests;
+
 /// The number of times Zebra will retry each initial peer's DNS resolution,
 /// before checking if any other initial peers have returned addresses.
 const MAX_SINGLE_PEER_RETRIES: usize = 2;
@@ -291,6 +294,7 @@ impl<'de> Deserialize<'de> for Config {
         }
 
         let config = DConfig::deserialize(deserializer)?;
+
         // TODO: perform listener DNS lookups asynchronously with a timeout (#1631)
         let listen_addr = match config.listen_addr.parse::<SocketAddr>() {
             Ok(socket) => Ok(socket),
@@ -313,6 +317,3 @@ impl<'de> Deserialize<'de> for Config {
         })
     }
 }
-
-#[cfg(test)]
-mod tests;

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -74,7 +74,8 @@ pub struct Config {
 }
 
 impl Config {
-    /// The maximum number of outbound connections that Zebra will make.
+    /// The maximum number of outbound connections that Zebra will open at the same time.
+    /// When this limit is reached, Zebra stops opening outbound connections.
     ///
     /// # Security
     ///
@@ -83,15 +84,16 @@ impl Config {
     pub fn peerset_outbound_connection_limit(&self) -> usize {
         let inbound_limit = self.peerset_inbound_connection_limit();
 
-        inbound_limit + inbound_limit / constants::OUTBOUND_PEER_BIAS_FRACTION
+        inbound_limit + inbound_limit / constants::OUTBOUND_PEER_BIAS_DENOMINATOR
     }
 
-    /// The maximum number of inbound connections that Zebra will make.
+    /// The maximum number of inbound connections that Zebra will accept at the same time.
+    /// When this limit is reached, Zebra drops new inbound connections without handshaking on them.
     pub fn peerset_inbound_connection_limit(&self) -> usize {
         self.peerset_initial_target_size
     }
 
-    /// The maximum total number of inbound and outbound connections that Zebra will make.
+    /// The maximum number of inbound and outbound connections that Zebra will have at the same time.
     pub fn peerset_total_connection_limit(&self) -> usize {
         self.peerset_outbound_connection_limit() + self.peerset_inbound_connection_limit()
     }

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -13,6 +13,24 @@ use zebra_chain::{
     serialization::Duration32,
 };
 
+/// The fractional bias towards outbound peers in the peer set,
+/// if connection limits have been reached.
+///
+/// Inbound and outbound connections are limited based on
+/// [`Config.peerset_initial_target_size`].
+///
+/// The outbound limit is larger than the inbound limit by:
+/// `Config.peerset_initial_target_size / OUTBOUND_PEER_BIAS_FRACTION`.
+///
+/// # Security
+///
+/// This bias helps make sure that Zebra is connected to a majority of peers
+/// that it has chosen from its [`AddressBook`].
+///
+/// Inbound peer connections are initiated by the remote peer,
+/// so inbound peer selection is not controlled by the local node.
+pub const OUTBOUND_PEER_BIAS_FRACTION: usize = 2;
+
 /// The buffer size for the peer set.
 ///
 /// This should be greater than 1 to avoid sender contention, but also reasonably

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -20,7 +20,7 @@ use zebra_chain::{
 /// [`Config.peerset_initial_target_size`].
 ///
 /// The outbound limit is larger than the inbound limit by:
-/// `Config.peerset_initial_target_size / OUTBOUND_PEER_BIAS_FRACTION`.
+/// `Config.peerset_initial_target_size / OUTBOUND_PEER_BIAS_DENOMINATOR`.
 ///
 /// # Security
 ///
@@ -29,7 +29,7 @@ use zebra_chain::{
 ///
 /// Inbound peer connections are initiated by the remote peer,
 /// so inbound peer selection is not controlled by the local node.
-pub const OUTBOUND_PEER_BIAS_FRACTION: usize = 2;
+pub const OUTBOUND_PEER_BIAS_DENOMINATOR: usize = 2;
 
 /// The buffer size for the peer set.
 ///

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -12,10 +12,9 @@ mod error;
 mod handshake;
 
 use client::{ClientRequest, ClientRequestReceiver, InProgressClientRequest, MustUseOneshotSender};
-use error::ErrorSlot;
 
 pub use client::Client;
 pub use connection::Connection;
 pub use connector::{Connector, OutboundConnectorRequest};
-pub use error::{HandshakeError, PeerError, SharedPeerError};
+pub use error::{ErrorSlot, HandshakeError, PeerError, SharedPeerError};
 pub use handshake::{ConnectedAddr, Handshake, HandshakeRequest};

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -331,6 +331,8 @@ pub struct Connection<S, Tx> {
     pub(super) client_rx: ClientRequestReceiver,
 
     /// A slot for an error shared between the Connection and the Client that uses it.
+    //
+    /// `None` unless the connection or client have errored.
     pub(super) error_slot: ErrorSlot,
 
     /// A channel for sending requests to the connected peer.

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -72,7 +72,7 @@ pub enum PeerError {
 /// mutex should be held for as short a time as possible. This avoids blocking
 /// the async task thread on acquiring the mutex.
 #[derive(Default, Clone)]
-pub(super) struct ErrorSlot(Arc<std::sync::Mutex<Option<SharedPeerError>>>);
+pub struct ErrorSlot(Arc<std::sync::Mutex<Option<SharedPeerError>>>);
 
 impl std::fmt::Debug for ErrorSlot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -473,6 +473,11 @@ where
             // Zebra can't control how many queued connections are waiting,
             // but most OSes also limit the number of queued inbound connections on a listener port.
             tokio::time::sleep(constants::MIN_PEER_CONNECTION_INTERVAL).await;
+        } else {
+            // Security: Let other tasks run after each errored connection is processed.
+            //
+            // Avoids remote peers starving other Zebra tasks using inbound connection errors.
+            tokio::task::yield_now().await;
         }
     }
 }
@@ -668,6 +673,11 @@ where
                 let _ = demand_tx.try_send(MorePeers);
             }
         }
+
+        // Security: Let other tasks run after each crawler action is processed.
+        //
+        // Avoids remote peers starving other Zebra tasks using outbound connection errors.
+        tokio::task::yield_now().await;
     }
 }
 

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -79,8 +79,14 @@ where
     let (tcp_listener, listen_addr) = open_listener(&config.clone()).await;
 
     let (address_book, timestamp_collector) = TimestampCollector::spawn(listen_addr);
-    // Create a broadcast channel for peer inventory advertisements,
-    // based on the maximum number of inbound and outbound peers.
+
+    // Create a broadcast channel for peer inventory advertisements.
+    // If it reaches capacity, this channel drops older inventory advertisements.
+    //
+    // When Zebra is at the chain tip with an up-to-date mempool,
+    // we expect to have at most 1 new transaction per connected peer,
+    // and 1-2 new blocks across the entire network.
+    // (The block syncer and mempool crawler handle bulk fetches of blocks and transactions.)
     let (inv_sender, inv_receiver) = broadcast::channel(config.peerset_total_connection_limit());
 
     // Construct services that handle inbound handshakes and perform outbound

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -413,7 +413,7 @@ where
         if let Ok((tcp_stream, addr)) = listener.accept().await {
             // The peer already opened a connection, so increment the connection count immediately.
             let connection_tracker = active_inbound_connections.track_connection();
-            info!(
+            debug!(
                 inbound_connections = ?active_inbound_connections.update_count(),
                 "handshaking on an open inbound peer connection"
             );
@@ -579,7 +579,7 @@ where
             DemandHandshake { candidate } => {
                 // Increment the connection count before we spawn the connection.
                 let outbound_connection_tracker = active_outbound_connections.track_connection();
-                info!(
+                debug!(
                     outbound_connections = ?active_outbound_connections.update_count(),
                     "opening an outbound peer connection"
                 );

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -319,6 +319,11 @@ where
         peerset_tx
             .send(handshake_result.map_err(|(_addr, e)| e))
             .await?;
+
+        // Security: Let other tasks run after each connection is processed.
+        //
+        // Avoids remote peers starving other Zebra tasks using initial connection successes or errors.
+        tokio::task::yield_now().await;
     }
 
     let outbound_connections = active_outbound_connections.update_count();
@@ -473,12 +478,12 @@ where
             // Zebra can't control how many queued connections are waiting,
             // but most OSes also limit the number of queued inbound connections on a listener port.
             tokio::time::sleep(constants::MIN_PEER_CONNECTION_INTERVAL).await;
-        } else {
-            // Security: Let other tasks run after each errored connection is processed.
-            //
-            // Avoids remote peers starving other Zebra tasks using inbound connection errors.
-            tokio::task::yield_now().await;
         }
+
+        // Security: Let other tasks run after each connection is processed.
+        //
+        // Avoids remote peers starving other Zebra tasks using inbound connection successes or errors.
+        tokio::task::yield_now().await;
     }
 }
 

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -496,7 +496,15 @@ enum CrawlerAction {
 ///
 /// Uses `active_outbound_connections` to track the number of active outbound connections
 /// in both the initial peers and crawler.
-#[instrument(skip(demand_tx, demand_rx, candidates, outbound_connector, peerset_tx,))]
+#[instrument(skip(
+    config,
+    demand_tx,
+    demand_rx,
+    candidates,
+    outbound_connector,
+    peerset_tx,
+    active_outbound_connections,
+))]
 async fn crawl_and_dial<C, S>(
     config: Config,
     mut demand_tx: mpsc::Sender<MorePeers>,

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -43,10 +43,14 @@ use crate::{
 
 use Network::*;
 
-/// The amount of time we run the crawler before testing it.
+/// The amount of time to run the crawler, before testing what it has done.
+///
+/// Using a very short time can make the crawler not run at all.
 const CRAWLER_TEST_DURATION: Duration = Duration::from_secs(5);
 
 /// The number of fake crawler peers in the testing [`AddressBook`].
+///
+/// Using a large number of peers can make the tests time out.
 const CRAWLER_FAKE_PEER_COUNT: usize = 2;
 
 /// Test that zebra-network discovers dynamic bind-to-all-interfaces listener ports,
@@ -123,9 +127,7 @@ async fn local_listener_fixed_port_localhost_addr() {
 
 /// Test zebra-network with a peer limit of zero peers on mainnet.
 /// (Zebra does not support this mode of operation.)
-///
-/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[should_panic]
 async fn peer_limit_zero_mainnet() {
     zebra_test::init();
@@ -146,9 +148,7 @@ async fn peer_limit_zero_mainnet() {
 
 /// Test zebra-network with a peer limit of zero peers on testnet.
 /// (Zebra does not support this mode of operation.)
-///
-/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 #[should_panic]
 async fn peer_limit_zero_testnet() {
     zebra_test::init();
@@ -168,9 +168,7 @@ async fn peer_limit_zero_testnet() {
 }
 
 /// Test zebra-network with a peer limit of one inbound and one outbound peer on mainnet.
-///
-/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn peer_limit_one_mainnet() {
     zebra_test::init();
 
@@ -189,9 +187,7 @@ async fn peer_limit_one_mainnet() {
 }
 
 /// Test zebra-network with a peer limit of one inbound and one outbound peer on testnet.
-///
-/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn peer_limit_one_testnet() {
     zebra_test::init();
 
@@ -210,9 +206,7 @@ async fn peer_limit_one_testnet() {
 }
 
 /// Test zebra-network with a peer limit of two inbound and three outbound peers on mainnet.
-///
-/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn peer_limit_two_mainnet() {
     zebra_test::init();
 
@@ -231,9 +225,7 @@ async fn peer_limit_two_mainnet() {
 }
 
 /// Test zebra-network with a peer limit of two inbound and three outbound peers on testnet.
-///
-/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn peer_limit_two_testnet() {
     zebra_test::init();
 
@@ -252,9 +244,7 @@ async fn peer_limit_two_testnet() {
 }
 
 /// Test the crawler with an outbound peer limit of zero.
-///
-/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn crawler_peer_limit_zero() {
     zebra_test::init();
 
@@ -291,9 +281,7 @@ async fn crawler_peer_limit_zero() {
 }
 
 /// Test the crawler with an outbound peer limit of one.
-///
-/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn crawler_peer_limit_one() {
     zebra_test::init();
 
@@ -329,9 +317,7 @@ async fn crawler_peer_limit_one() {
 }
 
 /// Test the crawler with an outbound peer limit of three peers.
-///
-/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn crawler_peer_limit_two() {
     zebra_test::init();
 

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -14,7 +14,6 @@
 //! skip all the network tests by setting the `ZEBRA_SKIP_NETWORK_TESTS` environmental variable.
 
 use std::{
-    cmp::min,
     collections::HashSet,
     net::{Ipv4Addr, SocketAddr},
     sync::Arc,
@@ -50,9 +49,6 @@ use Network::*;
 ///
 /// Using a very short time can make the crawler not run at all.
 const CRAWLER_TEST_DURATION: Duration = Duration::from_secs(10);
-
-/// The number of fake crawler peers in the testing [`AddressBook`].
-const CRAWLER_FAKE_PEER_COUNT: usize = 100;
 
 /// Test that zebra-network discovers dynamic bind-to-all-interfaces listener ports,
 /// and sends them to the `AddressBook`.
@@ -244,9 +240,9 @@ async fn peer_limit_two_testnet() {
     // Any number of address book peers is valid here, because some peers might have failed.
 }
 
-/// Test the crawler with an outbound peer limit of zero peers, and a connector that always errors.
+/// Test the crawler with an outbound peer limit of zero peers, and a connector that panics.
 #[tokio::test]
-async fn crawler_peer_limit_zero_connect_error() {
+async fn crawler_peer_limit_zero_connect_panic() {
     zebra_test::init();
 
     // This test does not require network access, because the outbound connector
@@ -264,7 +260,7 @@ async fn crawler_peer_limit_zero_connect_error() {
         // `Err(_)` means that no peers are available, and the sender has not been dropped.
         // `Ok(None)` means that no peers are available, and the sender has been dropped.
         matches!(peer_result, Err(_) | Ok(None)),
-        "unexpected peer when peer limit is zero: {:?}",
+        "unexpected peer when outbound limit is zero: {:?}",
         peer_result,
     );
 }
@@ -293,35 +289,10 @@ async fn crawler_peer_limit_one_connect_error() {
     );
 }
 
-/// Test the crawler with an outbound peer limit of three peers, and a connector that always errors.
-#[tokio::test]
-async fn crawler_peer_limit_three_connect_error() {
-    zebra_test::init();
-
-    // This test does not require network access, because the outbound connector
-    // and peer set are fake.
-
-    let error_outbound_connector =
-        service_fn(|_| async { Err("test outbound connector always returns errors".into()) });
-
-    // The initial target size is multiplied by 1.5 to give the actual limit of 3 peers.
-    let (_config, mut peerset_tx) =
-        spawn_crawler_with_peer_limit(2, error_outbound_connector).await;
-
-    let peer_result = peerset_tx.try_next();
-    assert!(
-        // `Err(_)` means that no peers are available, and the sender has not been dropped.
-        // `Ok(None)` means that no peers are available, and the sender has been dropped.
-        matches!(peer_result, Err(_) | Ok(None)),
-        "unexpected peer when all connections error: {:?}",
-        peer_result,
-    );
-}
-
-/// Test the crawler with an outbound peer limit of three peers,
+/// Test the crawler with an outbound peer limit of one peer,
 /// and a connector that returns success then disconnects the peer.
 #[tokio::test]
-async fn crawler_peer_limit_three_connect_ok_then_drop() {
+async fn crawler_peer_limit_one_connect_ok_then_drop() {
     zebra_test::init();
 
     // This test does not require network access, because the outbound connector
@@ -347,12 +318,14 @@ async fn crawler_peer_limit_three_connect_ok_then_drop() {
             // Fake the connection closing.
             std::mem::drop(connection_tracker);
 
+            // Give the crawler time to get the message.
+            tokio::task::yield_now().await;
+
             Ok(Change::Insert(addr, fake_client))
         });
 
-    // The initial target size is multiplied by 1.5 to give the actual limit of 3 peers.
     let (config, mut peerset_tx) =
-        spawn_crawler_with_peer_limit(2, success_disconnect_outbound_connector).await;
+        spawn_crawler_with_peer_limit(1, success_disconnect_outbound_connector).await;
 
     let mut peer_count: usize = 0;
     loop {
@@ -377,29 +350,24 @@ async fn crawler_peer_limit_three_connect_ok_then_drop() {
         }
     }
 
-    // We can't guarantee that we'll be over the limit, because the crawler runs other tasks
-    // with large timeouts.
-    //
-    // TODO: work around the `CandidateSet.update()` timeouts,
-    //       then check that we get a lot of connections.
     assert!(
-        peer_count >= config.peerset_outbound_connection_limit(),
+        peer_count > config.peerset_outbound_connection_limit(),
         "unexpected number of peer connections {}, should be at least the limit of {}",
         peer_count,
         config.peerset_outbound_connection_limit(),
     );
 }
 
-/// Test the crawler with an outbound peer limit of three peers,
+/// Test the crawler with an outbound peer limit of one peer,
 /// and a connector that returns success then holds the peer open.
 #[tokio::test]
-async fn crawler_peer_limit_three_connect_ok_stay_open() {
+async fn crawler_peer_limit_one_connect_ok_stay_open() {
     zebra_test::init();
 
     // This test does not require network access, because the outbound connector
     // and peer set are fake.
 
-    let success_disconnect_outbound_connector =
+    let success_stay_open_outbound_connector =
         service_fn(|req: OutboundConnectorRequest| async move {
             let OutboundConnectorRequest {
                 addr,
@@ -422,9 +390,8 @@ async fn crawler_peer_limit_three_connect_ok_stay_open() {
             Ok(Change::Insert(addr, fake_client))
         });
 
-    // The initial target size is multiplied by 1.5 to give the actual limit of 3 peers.
     let (config, mut peerset_tx) =
-        spawn_crawler_with_peer_limit(2, success_disconnect_outbound_connector).await;
+        spawn_crawler_with_peer_limit(1, success_stay_open_outbound_connector).await;
 
     let mut peer_count: usize = 0;
     loop {
@@ -457,10 +424,34 @@ async fn crawler_peer_limit_three_connect_ok_stay_open() {
     );
 }
 
-/// Test the crawler with the default outbound peer limit,
-/// and a connector that returns success then holds the peer open.
+/// Test the crawler with the default outbound peer limit, and a connector that always errors.
 #[tokio::test]
-async fn crawler_peer_limit_default_connect_ok_stay_open() {
+async fn crawler_peer_limit_default_connect_error() {
+    zebra_test::init();
+
+    // This test does not require network access, because the outbound connector
+    // and peer set are fake.
+
+    let error_outbound_connector =
+        service_fn(|_| async { Err("test outbound connector always returns errors".into()) });
+
+    let (_config, mut peerset_tx) =
+        spawn_crawler_with_peer_limit(None, error_outbound_connector).await;
+
+    let peer_result = peerset_tx.try_next();
+    assert!(
+        // `Err(_)` means that no peers are available, and the sender has not been dropped.
+        // `Ok(None)` means that no peers are available, and the sender has been dropped.
+        matches!(peer_result, Err(_) | Ok(None)),
+        "unexpected peer when all connections error: {:?}",
+        peer_result,
+    );
+}
+
+/// Test the crawler with the default outbound peer limit,
+/// and a connector that returns success then disconnects the peer.
+#[tokio::test]
+async fn crawler_peer_limit_default_connect_ok_then_drop() {
     zebra_test::init();
 
     // This test does not require network access, because the outbound connector
@@ -483,13 +474,15 @@ async fn crawler_peer_limit_default_connect_ok_stay_open() {
                 error_slot,
             };
 
-            // Fake the connection being open forever.
-            std::mem::forget(connection_tracker);
+            // Fake the connection closing.
+            std::mem::drop(connection_tracker);
+
+            // Give the crawler time to get the message.
+            tokio::task::yield_now().await;
 
             Ok(Change::Insert(addr, fake_client))
         });
 
-    // The initial target size is multiplied by 1.5 to give the actual limit.
     let (config, mut peerset_tx) =
         spawn_crawler_with_peer_limit(None, success_disconnect_outbound_connector).await;
 
@@ -516,15 +509,81 @@ async fn crawler_peer_limit_default_connect_ok_stay_open() {
         }
     }
 
-    let peer_limit = min(
-        config.peerset_outbound_connection_limit(),
-        CRAWLER_FAKE_PEER_COUNT,
-    );
+    // TODO: tweak the crawler timeouts and rate-limits so we get over the actual limit
+    //       (currently, getting over the limit can take 30 seconds or more)
+    let lower_limit = config.peerset_outbound_connection_limit() / 3;
     assert!(
-        peer_count <= peer_limit,
+        peer_count > lower_limit,
+        "unexpected number of peer connections {}, should be over the limit of {}",
+        peer_count,
+        lower_limit,
+    );
+}
+
+/// Test the crawler with the default outbound peer limit,
+/// and a connector that returns success then holds the peer open.
+#[tokio::test]
+async fn crawler_peer_limit_default_connect_ok_stay_open() {
+    zebra_test::init();
+
+    // This test does not require network access, because the outbound connector
+    // and peer set are fake.
+
+    let success_stay_open_outbound_connector =
+        service_fn(|req: OutboundConnectorRequest| async move {
+            let OutboundConnectorRequest {
+                addr,
+                connection_tracker,
+            } = req;
+
+            let (server_tx, _server_rx) = mpsc::channel(0);
+            let (shutdown_tx, _shutdown_rx) = oneshot::channel();
+            let error_slot = ErrorSlot::default();
+
+            let fake_client = peer::Client {
+                shutdown_tx: Some(shutdown_tx),
+                server_tx,
+                error_slot,
+            };
+
+            // Fake the connection being open forever.
+            std::mem::forget(connection_tracker);
+
+            Ok(Change::Insert(addr, fake_client))
+        });
+
+    // The initial target size is multiplied by 1.5 to give the actual limit.
+    let (config, mut peerset_tx) =
+        spawn_crawler_with_peer_limit(None, success_stay_open_outbound_connector).await;
+
+    let mut peer_count: usize = 0;
+    loop {
+        let peer_result = peerset_tx.try_next();
+        match peer_result {
+            // A peer handshake succeeded.
+            Ok(Some(peer_result)) => {
+                assert!(
+                    matches!(peer_result, Ok(Change::Insert(_, _))),
+                    "unexpected connection error: {:?}\n\
+                     {} previous peers succeeded",
+                    peer_result,
+                    peer_count,
+                );
+                peer_count += 1;
+            }
+
+            // The channel is closed and there are no messages left in the channel.
+            Ok(None) => break,
+            // The channel is still open, but there are no messages left in the channel.
+            Err(_) => break,
+        }
+    }
+
+    assert!(
+        peer_count <= config.peerset_outbound_connection_limit(),
         "unexpected number of peer connections {}, over limit of {}",
         peer_count,
-        peer_limit,
+        config.peerset_outbound_connection_limit(),
     );
 }
 
@@ -614,6 +673,7 @@ where
         + 'static,
     C::Future: Send + 'static,
 {
+    // Create a test config.
     let mut config = Config::default();
     if let Some(peerset_initial_target_size) = peerset_initial_target_size.into() {
         config.peerset_initial_target_size = peerset_initial_target_size;
@@ -622,9 +682,10 @@ where
     // Manually initialize an address book without a timestamp tracker.
     let mut address_book = AddressBook::new(config.listen_addr, Span::current());
 
-    // Add fake peers.
+    // Add enough fake peers to go over the limit, even if the limit is zero.
+    let over_limit_peers = config.peerset_outbound_connection_limit() * 2 + 1;
     let mut fake_peer = None;
-    for address_number in 0..CRAWLER_FAKE_PEER_COUNT {
+    for address_number in 0..over_limit_peers {
         let addr = SocketAddr::new(Ipv4Addr::new(127, 1, 1, address_number as _).into(), 1);
         let addr =
             MetaAddr::new_gossiped_meta_addr(addr, PeerServices::NODE_NETWORK, DateTime32::now());
@@ -634,6 +695,7 @@ where
         address_book.update(addr);
     }
 
+    // Create a fake peer set.
     let nil_peer_set = service_fn(move |req| async move {
         let rsp = match req {
             // Return the correct response variant for Peers requests,
@@ -647,11 +709,9 @@ where
 
     let address_book = Arc::new(std::sync::Mutex::new(address_book));
 
-    // Use the standard channel sizes, plus one, so the initializers never panic
-    let (peerset_tx, peerset_rx) =
-        mpsc::channel::<PeerChange>(config.peerset_total_connection_limit() + 1);
-    let (mut demand_tx, demand_rx) =
-        mpsc::channel::<MorePeers>(config.peerset_outbound_connection_limit() + 1);
+    // Make the channels large enough to hold all the peers.
+    let (peerset_tx, peerset_rx) = mpsc::channel::<PeerChange>(over_limit_peers);
+    let (mut demand_tx, demand_rx) = mpsc::channel::<MorePeers>(over_limit_peers);
 
     let candidates = CandidateSet::new(address_book.clone(), nil_peer_set);
 
@@ -659,11 +719,12 @@ where
     // but in this test we start with an empty counter.
     let active_outbound_connections = ActiveConnectionCounter::new_counter();
 
-    // Add initial demand.
-    for _ in 0..config.peerset_initial_target_size {
+    // Add fake demand over the limit.
+    for _ in 0..over_limit_peers {
         let _ = demand_tx.try_send(MorePeers);
     }
 
+    // Start the crawler.
     let crawl_fut = crawl_and_dial(
         config.clone(),
         demand_tx,
@@ -694,9 +755,9 @@ where
     // Check the final address book contents.
     assert_eq!(
         address_book.lock().unwrap().peers().count(),
-        CRAWLER_FAKE_PEER_COUNT,
+        over_limit_peers,
         "expected {} peers in Mainnet address book, but got: {:?}",
-        CRAWLER_FAKE_PEER_COUNT,
+        over_limit_peers,
         address_book.lock().unwrap().address_metrics()
     );
 

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -1,4 +1,4 @@
-//! Specific configs used for zebra-network initialization tests.
+//! zebra-network initialization tests using fixed configs.
 //!
 //! ## Failures due to Port Conflicts
 //!
@@ -13,16 +13,14 @@
 //! If it does not have any IPv4 interfaces, or IPv4 localhost is not on `127.0.0.1`,
 //! skip all the network tests by setting the `ZEBRA_SKIP_NETWORK_TESTS` environmental variable.
 
-use std::{collections::HashSet, net::SocketAddr};
+use std::{collections::HashSet, net::SocketAddr, sync::Arc};
 
-use tower::service_fn;
+use tower::{service_fn, Service};
 
 use zebra_chain::{chain_tip::NoChainTip, parameters::Network};
 use zebra_test::net::random_known_port;
 
-use crate::Config;
-
-use super::super::init;
+use crate::{init, AddressBook, BoxError, Config, Request, Response};
 
 use Network::*;
 
@@ -98,6 +96,114 @@ async fn local_listener_fixed_port_localhost_addr() {
     local_listener_port_with(SocketAddr::new(localhost_v6, random_known_port()), Testnet).await;
 }
 
+/// Test zebra-network with a peer limit of zero peers on mainnet.
+/// (Zebra does not support this mode of operation.)
+#[tokio::test]
+#[should_panic]
+async fn peer_limit_zero_mainnet() {
+    zebra_test::init();
+
+    // This test should not require network access, because the connection limit is zero.
+
+    let unreachable_inbound_service =
+        service_fn(|_| async { unreachable!("inbound service should never be called") });
+
+    let address_book = init_with_peer_limit(0, unreachable_inbound_service, Mainnet).await;
+    assert_eq!(
+        address_book.lock().unwrap().peers().count(),
+        0,
+        "expected no peers in Mainnet address book, but got: {:?}",
+        address_book.lock().unwrap().address_metrics()
+    );
+}
+
+/// Test zebra-network with a peer limit of zero peers on testnet.
+/// (Zebra does not support this mode of operation.)
+#[tokio::test]
+#[should_panic]
+async fn peer_limit_zero_testnet() {
+    zebra_test::init();
+
+    // This test should not require network access, because the connection limit is zero.
+
+    let unreachable_inbound_service =
+        service_fn(|_| async { unreachable!("inbound service should never be called") });
+
+    let address_book = init_with_peer_limit(0, unreachable_inbound_service, Testnet).await;
+    assert_eq!(
+        address_book.lock().unwrap().peers().count(),
+        0,
+        "expected no peers in Testnet address book, but got: {:?}",
+        address_book.lock().unwrap().address_metrics()
+    );
+}
+
+/// Test zebra-network with a peer limit of one inbound and one outbound peer on mainnet.
+#[tokio::test]
+async fn peer_limit_one_mainnet() {
+    zebra_test::init();
+
+    if zebra_test::net::zebra_skip_network_tests() {
+        return;
+    }
+
+    let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
+
+    let _ = init_with_peer_limit(1, nil_inbound_service, Mainnet).await;
+
+    // Any number of address book peers is valid here, because some peers might have failed.
+}
+
+/// Test zebra-network with a peer limit of one inbound and one outbound peer on testnet.
+#[tokio::test]
+async fn peer_limit_one_testnet() {
+    zebra_test::init();
+
+    if zebra_test::net::zebra_skip_network_tests() {
+        return;
+    }
+
+    let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
+
+    let _ = init_with_peer_limit(1, nil_inbound_service, Testnet).await;
+
+    // Any number of address book peers is valid here, because some peers might have failed.
+}
+
+/// Test zebra-network with a peer limit of two inbound and three outbound peers on mainnet.
+#[tokio::test]
+async fn peer_limit_two_mainnet() {
+    zebra_test::init();
+
+    if zebra_test::net::zebra_skip_network_tests() {
+        return;
+    }
+
+    let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
+
+    let _ = init_with_peer_limit(2, nil_inbound_service, Mainnet).await;
+
+    // Any number of address book peers is valid here, because some peers might have failed.
+}
+
+/// Test zebra-network with a peer limit of two inbound and three outbound peers on testnet.
+#[tokio::test]
+async fn peer_limit_two_testnet() {
+    zebra_test::init();
+
+    if zebra_test::net::zebra_skip_network_tests() {
+        return;
+    }
+
+    let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
+
+    let _ = init_with_peer_limit(2, nil_inbound_service, Testnet).await;
+
+    // Any number of address book peers is valid here, because some peers might have failed.
+}
+
+/// Open a local listener on `listen_addr` for `network`.
+/// Asserts that the local listener address works as expected.
 async fn local_listener_port_with(listen_addr: SocketAddr, network: Network) {
     let config = Config {
         listen_addr,
@@ -132,4 +238,33 @@ async fn local_listener_port_with(listen_addr: SocketAddr, network: Network) {
         listen_addr.ip(),
         "IP addresses are correctly propagated"
     );
+}
+
+/// Initialize a peer set with `peerset_initial_target_size` and `inbound_service` on `network`.
+/// Returns the newly created [`AddressBook`] for testing.
+async fn init_with_peer_limit<S>(
+    peerset_initial_target_size: usize,
+    inbound_service: S,
+    network: Network,
+) -> Arc<std::sync::Mutex<AddressBook>>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    // This test might fail on machines with no configured IPv4 addresses
+    // (localhost should be enough).
+    let unused_v4 = "0.0.0.0:0".parse().unwrap();
+
+    let config = Config {
+        peerset_initial_target_size,
+
+        network,
+        listen_addr: unused_v4,
+
+        ..Config::default()
+    };
+
+    let (_peer_service, address_book) = init(config, inbound_service, NoChainTip).await;
+
+    address_book
 }

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -13,16 +13,41 @@
 //! If it does not have any IPv4 interfaces, or IPv4 localhost is not on `127.0.0.1`,
 //! skip all the network tests by setting the `ZEBRA_SKIP_NETWORK_TESTS` environmental variable.
 
-use std::{collections::HashSet, net::SocketAddr, sync::Arc};
+use std::{
+    collections::HashSet,
+    net::{Ipv4Addr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
 
-use tower::{service_fn, Service};
+use futures::{channel::mpsc, FutureExt};
+use tokio::task::JoinHandle;
+use tower::{discover::Change, service_fn, Service};
 
-use zebra_chain::{chain_tip::NoChainTip, parameters::Network};
+use tracing::Span;
+use zebra_chain::{chain_tip::NoChainTip, parameters::Network, serialization::DateTime32};
 use zebra_test::net::random_known_port;
 
-use crate::{init, AddressBook, BoxError, Config, Request, Response};
+use crate::{
+    init,
+    meta_addr::MetaAddr,
+    peer::{self, OutboundConnectorRequest},
+    peer_set::{
+        initialize::{crawl_and_dial, PeerChange},
+        set::MorePeers,
+        ActiveConnectionCounter, CandidateSet,
+    },
+    protocol::types::PeerServices,
+    AddressBook, BoxError, Config, Request, Response,
+};
 
 use Network::*;
+
+/// The amount of time we run the crawler before testing it.
+const CRAWLER_TEST_DURATION: Duration = Duration::from_secs(5);
+
+/// The number of fake crawler peers in the testing [`AddressBook`].
+const CRAWLER_FAKE_PEER_COUNT: usize = 2;
 
 /// Test that zebra-network discovers dynamic bind-to-all-interfaces listener ports,
 /// and sends them to the `AddressBook`.
@@ -98,7 +123,9 @@ async fn local_listener_fixed_port_localhost_addr() {
 
 /// Test zebra-network with a peer limit of zero peers on mainnet.
 /// (Zebra does not support this mode of operation.)
-#[tokio::test]
+///
+/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
+#[tokio::test(flavor = "multi_thread")]
 #[should_panic]
 async fn peer_limit_zero_mainnet() {
     zebra_test::init();
@@ -119,7 +146,9 @@ async fn peer_limit_zero_mainnet() {
 
 /// Test zebra-network with a peer limit of zero peers on testnet.
 /// (Zebra does not support this mode of operation.)
-#[tokio::test]
+///
+/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
+#[tokio::test(flavor = "multi_thread")]
 #[should_panic]
 async fn peer_limit_zero_testnet() {
     zebra_test::init();
@@ -139,7 +168,9 @@ async fn peer_limit_zero_testnet() {
 }
 
 /// Test zebra-network with a peer limit of one inbound and one outbound peer on mainnet.
-#[tokio::test]
+///
+/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
+#[tokio::test(flavor = "multi_thread")]
 async fn peer_limit_one_mainnet() {
     zebra_test::init();
 
@@ -151,11 +182,16 @@ async fn peer_limit_one_mainnet() {
 
     let _ = init_with_peer_limit(1, nil_inbound_service, Mainnet).await;
 
+    // Let the crawler run for a while.
+    tokio::time::sleep(CRAWLER_TEST_DURATION).await;
+
     // Any number of address book peers is valid here, because some peers might have failed.
 }
 
 /// Test zebra-network with a peer limit of one inbound and one outbound peer on testnet.
-#[tokio::test]
+///
+/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
+#[tokio::test(flavor = "multi_thread")]
 async fn peer_limit_one_testnet() {
     zebra_test::init();
 
@@ -167,11 +203,16 @@ async fn peer_limit_one_testnet() {
 
     let _ = init_with_peer_limit(1, nil_inbound_service, Testnet).await;
 
+    // Let the crawler run for a while.
+    tokio::time::sleep(CRAWLER_TEST_DURATION).await;
+
     // Any number of address book peers is valid here, because some peers might have failed.
 }
 
 /// Test zebra-network with a peer limit of two inbound and three outbound peers on mainnet.
-#[tokio::test]
+///
+/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
+#[tokio::test(flavor = "multi_thread")]
 async fn peer_limit_two_mainnet() {
     zebra_test::init();
 
@@ -183,11 +224,16 @@ async fn peer_limit_two_mainnet() {
 
     let _ = init_with_peer_limit(2, nil_inbound_service, Mainnet).await;
 
+    // Let the crawler run for a while.
+    tokio::time::sleep(CRAWLER_TEST_DURATION).await;
+
     // Any number of address book peers is valid here, because some peers might have failed.
 }
 
 /// Test zebra-network with a peer limit of two inbound and three outbound peers on testnet.
-#[tokio::test]
+///
+/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
+#[tokio::test(flavor = "multi_thread")]
 async fn peer_limit_two_testnet() {
     zebra_test::init();
 
@@ -199,7 +245,125 @@ async fn peer_limit_two_testnet() {
 
     let _ = init_with_peer_limit(2, nil_inbound_service, Testnet).await;
 
+    // Let the crawler run for a while.
+    tokio::time::sleep(CRAWLER_TEST_DURATION).await;
+
     // Any number of address book peers is valid here, because some peers might have failed.
+}
+
+/// Test the crawler with an outbound peer limit of zero.
+///
+/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
+#[tokio::test(flavor = "multi_thread")]
+async fn crawler_peer_limit_zero() {
+    zebra_test::init();
+
+    // This test does not require network access, because the outbound connector
+    // and peer set are fake.
+
+    let unreachable_outbound_connector = service_fn(|_| async {
+        unreachable!("outbound connector should never be called with a zero peer limit")
+    });
+
+    let (crawl_task_handle, mut peerset_tx) =
+        spawn_crawler_with_peer_limit(0, unreachable_outbound_connector);
+
+    // Let the crawler run for a while.
+    tokio::time::sleep(CRAWLER_TEST_DURATION).await;
+    crawl_task_handle.abort();
+
+    let peer_result = peerset_tx.try_next();
+    assert!(
+        // `Err(_)` means that no peers are available, and the sender has not been dropped.
+        // `Ok(None)` means that no peers are available, and the sender has been dropped.
+        matches!(peer_result, Err(_) | Ok(None)),
+        "unexpected peer when peer limit is zero: {:?}",
+        peer_result,
+    );
+
+    let crawl_result = crawl_task_handle.now_or_never();
+    assert!(
+        matches!(crawl_result, None)
+            || matches!(crawl_result, Some(Err(ref e)) if e.is_cancelled()),
+        "unexpected error or panic in peer crawler task: {:?}",
+        crawl_result,
+    );
+}
+
+/// Test the crawler with an outbound peer limit of one.
+///
+/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
+#[tokio::test(flavor = "multi_thread")]
+async fn crawler_peer_limit_one() {
+    zebra_test::init();
+
+    // This test does not require network access, because the outbound connector
+    // and peer set are fake.
+
+    let error_outbound_connector =
+        service_fn(|_| async { Err("test outbound connector always returns errors".into()) });
+
+    let (crawl_task_handle, mut peerset_tx) =
+        spawn_crawler_with_peer_limit(1, error_outbound_connector);
+
+    // Let the crawler run for a while.
+    tokio::time::sleep(CRAWLER_TEST_DURATION).await;
+    crawl_task_handle.abort();
+
+    let peer_result = peerset_tx.try_next();
+    assert!(
+        // `Err(_)` means that no peers are available, and the sender has not been dropped.
+        // `Ok(None)` means that no peers are available, and the sender has been dropped.
+        matches!(peer_result, Err(_) | Ok(None)),
+        "unexpected peer when all connections error: {:?}",
+        peer_result,
+    );
+
+    let crawl_result = crawl_task_handle.now_or_never();
+    assert!(
+        matches!(crawl_result, None)
+            || matches!(crawl_result, Some(Err(ref e)) if e.is_cancelled()),
+        "unexpected error or panic in peer crawler task: {:?}",
+        crawl_result,
+    );
+}
+
+/// Test the crawler with an outbound peer limit of three peers.
+///
+/// This test doesn't require the multi-threaded executor, but it's a lot faster with it.
+#[tokio::test(flavor = "multi_thread")]
+async fn crawler_peer_limit_two() {
+    zebra_test::init();
+
+    // This test does not require network access, because the outbound connector
+    // and peer set are fake.
+
+    let error_outbound_connector =
+        service_fn(|_| async { Err("test outbound connector always returns errors".into()) });
+
+    let (crawl_task_handle, mut peerset_tx) =
+        spawn_crawler_with_peer_limit(2, error_outbound_connector);
+
+    // Let the crawler run for a while.
+    tokio::time::sleep(CRAWLER_TEST_DURATION).await;
+    crawl_task_handle.abort();
+
+    let peer_result = peerset_tx.try_next();
+    assert!(
+        // `Err(_)` means that no peers are available, and the sender has not been dropped.
+        // `Ok(None)` means that no peers are available, and the sender has been dropped.
+        matches!(peer_result, Err(_) | Ok(None)),
+        "unexpected peer when all connections error: {:?}",
+        peer_result,
+    );
+
+    let crawl_result = crawl_task_handle.now_or_never();
+    assert!(
+        matches!(crawl_result, None)
+            || matches!(crawl_result, Some(Err(ref e)) if e.is_cancelled()),
+        "unexpected error or panic in peer crawler task: {:?}",
+        crawl_result,
+    );
 }
 
 /// Open a local listener on `listen_addr` for `network`.
@@ -267,4 +431,91 @@ where
     let (_peer_service, address_book) = init(config, inbound_service, NoChainTip).await;
 
     address_book
+}
+
+/// Initialize a peer crawler with `peerset_initial_target_size`.
+///
+/// Returns the crawler task [`JoinHandle`], and the peer set receiver.
+fn spawn_crawler_with_peer_limit<C>(
+    peerset_initial_target_size: usize,
+    outbound_connector: C,
+) -> (JoinHandle<Result<(), BoxError>>, mpsc::Receiver<PeerChange>)
+where
+    C: Service<
+            OutboundConnectorRequest,
+            Response = Change<SocketAddr, peer::Client>,
+            Error = BoxError,
+        > + Clone
+        + Send
+        + 'static,
+    C::Future: Send + 'static,
+{
+    let config = Config {
+        peerset_initial_target_size,
+
+        ..Config::default()
+    };
+
+    // Manually initialize an address book without a timestamp tracker.
+    let mut address_book = AddressBook::new(config.listen_addr, Span::current());
+
+    // Add fake peers.
+    let mut fake_peer = None;
+    for address_number in 0..CRAWLER_FAKE_PEER_COUNT {
+        let addr = SocketAddr::new(Ipv4Addr::new(127, 1, 1, address_number as _).into(), 1);
+        let addr =
+            MetaAddr::new_gossiped_meta_addr(addr, PeerServices::NODE_NETWORK, DateTime32::now());
+        fake_peer = Some(addr);
+        let addr = addr.new_gossiped_change();
+
+        address_book.update(addr);
+    }
+
+    let nil_peer_set = service_fn(move |req| async move {
+        let rsp = match req {
+            // Return the correct response variant for Peers requests,
+            // re-using one of the peers we already provided.
+            Request::Peers => Response::Peers(vec![fake_peer.unwrap()]),
+            _ => unreachable!("unexpected request: {:?}", req),
+        };
+
+        Ok(rsp)
+    });
+
+    let address_book = Arc::new(std::sync::Mutex::new(address_book));
+
+    // Use the standard channel sizes, plus one, so the initializers never panic
+    let (peerset_tx, peerset_rx) =
+        mpsc::channel::<PeerChange>(config.peerset_total_connection_limit() + 1);
+    let (mut demand_tx, demand_rx) =
+        mpsc::channel::<MorePeers>(config.peerset_outbound_connection_limit() + 1);
+
+    let candidates = CandidateSet::new(address_book, nil_peer_set);
+
+    // In zebra_network::initialize() the counter would already have some initial peer connections,
+    // but in this test we start with an empty counter.
+    let active_outbound_connections = ActiveConnectionCounter::new_counter();
+
+    // Add initial demand.
+    for _ in 0..config.peerset_initial_target_size {
+        let _ = demand_tx.try_send(MorePeers);
+    }
+
+    let crawl_fut = crawl_and_dial(
+        config,
+        demand_tx,
+        demand_rx,
+        candidates,
+        outbound_connector,
+        peerset_tx,
+        active_outbound_connections,
+    );
+    let crawl_task_handle = tokio::spawn(crawl_fut);
+
+    // TODO: return and test the address book, once we've turned it into a service (#1976)
+    //
+    // Currently, the address book mutex deadlocks if we try to access it in the tests.
+    // This happens regardless of the executor type.
+
+    (crawl_task_handle, peerset_rx)
 }


### PR DESCRIPTION
## Motivation

We want to limit Zebra's outbound peer connections to avoid whole-of-network denial of service attacks.

## Solution

Implementation:
- Limit the number of outbound connections in the crawler
- Bias Zebra towards outbound connections 
- Make zebra-network channel bounds depend on `config.peerset_initial_target_size`

Bug fixes:
- Avoid cooperative async task starvation in the peer crawler and listener

Unit tests:
- Add zebra_network::initialize tests with limited numbers of peers
- Test the crawler with small connection limits and connection errors
- Test the crawler with small connection limits and connection success then close
- Test the crawler with small connection limits and connection success then stay open
- Test the crawler with the default connection limit and connection success then stay open

Runtime checks:
- #2947

Local tests:
- I've run the node for a few days and it seems stable, the connection limits seem to work
- I've run the unit tests repeatedly, and they seem reliable on my machine

Closes #1850.

## Review

@jvff is a good person to review this PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

