### PR TITLE
Fix or disable the new clippy::question_mark lint

### DIFF
--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -189,12 +189,10 @@ pub fn merkle_root_validity(
     block: &Block,
     transaction_hashes: &[transaction::Hash],
 ) -> Result<(), BlockError> {
-    if block
+    // TODO: deduplicate zebra-chain and zebra-consensus errors (#2908)
+    block
         .check_transaction_network_upgrade_consistency(network)
-        .is_err()
-    {
-        return Err(BlockError::WrongTransactionConsensusBranchId);
-    }
+        .map_err(|_| BlockError::WrongTransactionConsensusBranchId)?;
 
     let merkle_root = transaction_hashes.iter().cloned().collect();
 

--- a/zebrad/src/components/sync/status/tests.rs
+++ b/zebrad/src/components/sync/status/tests.rs
@@ -129,6 +129,8 @@ proptest! {
             loop {
                 update_events.acquire().await.forget();
 
+                // The refactor suggested by clippy is harder to read and understand.
+                #[allow(clippy::question_mark)]
                 if status.wait_until_close_to_tip().await.is_err() {
                     return Ok(());
                 }


### PR DESCRIPTION
## Motivation

The refactored code can be easier to read.

Resolving warnings helps us focus on the new warnings created by new PRs.
Nightly warnings can cause CI failures when they stabilise.

## Review

Anyone can review this PR.

It is a medium priority, because these warnings might hide other more important warnings.
This doesn't conflict with any open PR or high-priority ticket.

### Reviewer Checklist

    - [ ] Refactor makes sense
    - [ ] Existing tests pass
