### PR TITLE
Panic if Zebra exceeds its connection limit

### DIFF
--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -144,6 +144,7 @@ where
 
     // Connect the rx end to a PeerSet, wrapping new peers in load instruments.
     let peer_set = PeerSet::new(
+        &config,
         PeakEwmaDiscover::new(
             // Discover interprets an error as stream termination,
             // so discard any errored connections...


### PR DESCRIPTION
## Motivation

This is a runtime check for PR #2944 and PR #2961.

It's based on those PRs.

## Solution

Panic if the `PeerSet` has more peers than the total `inbound + outbound` connection limit.

## Review

@jvff is reviewing PRs #2944 and #2961.

### Reviewer Checklist

  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

