### PR TITLE
Remove dconnolly as default assignee and reviewer on dependabot PRs, and make them low priority

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,6 @@ updates:
     interval: daily
     timezone: America/New_York
   open-pull-requests-limit: 10
-  reviewers:
-  - dconnolly
-  assignees:
-  - dconnolly
   labels:
   - "A-infrastructure"
   - "A-dependencies"
@@ -24,10 +20,6 @@ updates:
     interval: daily
     timezone: America/New_York
   open-pull-requests-limit: 10
-  reviewers:
-  - dconnolly
-  assignees:
-  - dconnolly
   labels:
   - "A-infrastructure"
   - "A-dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,9 @@ updates:
     timezone: America/New_York
   open-pull-requests-limit: 10
   labels:
-  - "A-infrastructure"
   - "A-dependencies"
   - "A-rust"
+  - "P-Low"
   ignore:
   - dependency-name: tokio-util
     versions:
@@ -23,3 +23,4 @@ updates:
   labels:
   - "A-infrastructure"
   - "A-dependencies"
+  - "P-Low"


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

When Dependabot opens PRs that update our dependencies, dconnolly is currently assigned and added as reviewer. We want to spread the load for reviewers.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

- Remove defaults for assignees and reviewers.
- Assign dependabot PRs low priority by default.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->


## Follow Up Work

<!--
Is there anything missing from the solution?
-->

Change labels depending on priority of the update
