### PR TITLE
Update Sentry to version 0.23.0

### DIFF
--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -44,7 +44,7 @@ inferno = { version = "0.10.7", default-features = false }
 atty = "0.2.14"
 
 sentry = { version = "0.23.0", default-features = false, features = ["backtrace", "contexts", "reqwest", "rustls"] }
-sentry-tracing = "0.23"
+sentry-tracing = "0.23.0"
 
 [build-dependencies]
 vergen = { version = "5.1.12", default-features = false, features = ["cargo", "git"] }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -43,8 +43,8 @@ dirs = "4.0.0"
 inferno = { version = "0.10.7", default-features = false }
 atty = "0.2.14"
 
-sentry = { version = "0.21.0", default-features = false, features = ["backtrace", "contexts", "reqwest", "rustls"] }
-sentry-tracing = { git = "https://github.com/kellpossible/sentry-tracing.git", rev = "f1a4a4a16b5ff1022ae60be779eb3fb928ce9b0f" }
+sentry = { version = "0.23.0", default-features = false, features = ["backtrace", "contexts", "reqwest", "rustls"] }
+sentry-tracing = "0.23"
 
 [build-dependencies]
 vergen = { version = "5.1.12", default-features = false, features = ["cargo", "git"] }

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -306,14 +306,11 @@ impl Application for ZebradApp {
         // The Sentry default config pulls in the DSN from the `SENTRY_DSN`
         // environment variable.
         #[cfg(feature = "enable-sentry")]
-        let guard = sentry::init(
-            sentry::ClientOptions {
-                debug: true,
-                release: Some(app_version().to_string().into()),
-                ..Default::default()
-            }
-            .add_integration(sentry_tracing::TracingIntegration::default()),
-        );
+        let guard = sentry::init(sentry::ClientOptions {
+            debug: true,
+            release: Some(app_version().to_string().into()),
+            ..Default::default()
+        });
 
         std::panic::set_hook(Box::new(move |panic_info| {
             let panic_report = panic_hook.panic_report(panic_info);

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -46,7 +46,10 @@ impl Tracing {
             None
         };
 
-        let subscriber = builder.finish().with(ErrorLayer::default());
+        let subscriber = builder
+            .finish()
+            .with(ErrorLayer::default())
+            .with(sentry_tracing::layer());
         match (flamelayer, journaldlayer) {
             (None, None) => subscriber.init(),
             (Some(layer1), None) => subscriber.with(layer1).init(),


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
This is part of the update to use Tokio version 1 (#2200), and must be merged together with the other PRs.

The version of the `sentry` crate used by Zebra uses an older version of Tokio. In order to prune the dependency tree and avoid having multiple versions of the Tokio runtime running simultaneously, we should update the `sentry` dependency to a newer version that uses the same version of Tokio as Zebra.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Update to `sentry` version 0.23.0. This requires some changes because the `TracingIntegration` type seems to no longer exist.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@dconnolly has worked with `sentry` before and can review this, but it shouldn't be merged yet.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
