### PR TITLE
Document why CheckForVerifiedTransactions is required for correctness

### DIFF
--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -98,6 +98,16 @@ pub enum Request {
     /// but we can't rely on peers to send queries regularly,
     /// and crawler queue requests depend on peer responses.
     /// Also, crawler requests aren't frequent enough for transaction propagation.
+    ///
+    /// # Correctness
+    ///
+    /// This request is required to avoid hangs in the mempool.
+    ///
+    /// The queue checker task can't call `poll_ready` directly on the [`Mempool`] service,
+    /// because the mempool service is wrapped in a `Buffer`.
+    /// Calling [`Buffer::poll_ready`] reserves a buffer slot, which can cause hangs when
+    /// too many slots are reserved but unused:
+    /// https://docs.rs/tower/0.4.10/tower/buffer/struct.Buffer.html#a-note-on-choosing-a-bound
     CheckForVerifiedTransactions,
 }
 


### PR DESCRIPTION
## Motivation

This documentation answers a question from the PR #2888 review.

This is unexpected work in sprint 21.

## Review

Anyone can review this low-priority PR.

It doesn't conflict with any open high-priority PRs.

### Reviewer Checklist

  - [ ] Documentation makes sense
