### PR TITLE
Run some network test cases in parallel to speed them up

### DIFF
--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -31,7 +31,7 @@ use Network::*;
 ///
 /// Note: This test doesn't cover local interface or public IP address discovery.
 #[tokio::test]
-async fn local_listener_unspecified_port_unspecified_addr() {
+async fn local_listener_unspecified_port_unspecified_addr_v4() {
     zebra_test::init();
 
     if zebra_test::net::zebra_skip_network_tests() {
@@ -42,6 +42,19 @@ async fn local_listener_unspecified_port_unspecified_addr() {
     // (localhost should be enough)
     local_listener_port_with("0.0.0.0:0".parse().unwrap(), Mainnet).await;
     local_listener_port_with("0.0.0.0:0".parse().unwrap(), Testnet).await;
+}
+
+/// Test that zebra-network discovers dynamic bind-to-all-interfaces listener ports,
+/// and sends them to the `AddressBook`.
+///
+/// Note: This test doesn't cover local interface or public IP address discovery.
+#[tokio::test]
+async fn local_listener_unspecified_port_unspecified_addr_v6() {
+    zebra_test::init();
+
+    if zebra_test::net::zebra_skip_network_tests() {
+        return;
+    }
 
     if zebra_test::net::zebra_skip_ipv6_tests() {
         return;
@@ -55,7 +68,7 @@ async fn local_listener_unspecified_port_unspecified_addr() {
 /// Test that zebra-network discovers dynamic localhost listener ports,
 /// and sends them to the `AddressBook`.
 #[tokio::test]
-async fn local_listener_unspecified_port_localhost_addr() {
+async fn local_listener_unspecified_port_localhost_addr_v4() {
     zebra_test::init();
 
     if zebra_test::net::zebra_skip_network_tests() {
@@ -65,6 +78,17 @@ async fn local_listener_unspecified_port_localhost_addr() {
     // these tests might fail on machines with unusual IPv4 localhost configs
     local_listener_port_with("127.0.0.1:0".parse().unwrap(), Mainnet).await;
     local_listener_port_with("127.0.0.1:0".parse().unwrap(), Testnet).await;
+}
+
+/// Test that zebra-network discovers dynamic localhost listener ports,
+/// and sends them to the `AddressBook`.
+#[tokio::test]
+async fn local_listener_unspecified_port_localhost_addr_v6() {
+    zebra_test::init();
+
+    if zebra_test::net::zebra_skip_network_tests() {
+        return;
+    }
 
     if zebra_test::net::zebra_skip_ipv6_tests() {
         return;
@@ -77,11 +101,10 @@ async fn local_listener_unspecified_port_localhost_addr() {
 
 /// Test that zebra-network propagates fixed localhost listener ports to the `AddressBook`.
 #[tokio::test]
-async fn local_listener_fixed_port_localhost_addr() {
+async fn local_listener_fixed_port_localhost_addr_v4() {
     zebra_test::init();
 
     let localhost_v4 = "127.0.0.1".parse().unwrap();
-    let localhost_v6 = "::1".parse().unwrap();
 
     if zebra_test::net::zebra_skip_network_tests() {
         return;
@@ -89,6 +112,18 @@ async fn local_listener_fixed_port_localhost_addr() {
 
     local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), Mainnet).await;
     local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), Testnet).await;
+}
+
+/// Test that zebra-network propagates fixed localhost listener ports to the `AddressBook`.
+#[tokio::test]
+async fn local_listener_fixed_port_localhost_addr_v6() {
+    zebra_test::init();
+
+    let localhost_v6 = "::1".parse().unwrap();
+
+    if zebra_test::net::zebra_skip_network_tests() {
+        return;
+    }
 
     if zebra_test::net::zebra_skip_ipv6_tests() {
         return;


### PR DESCRIPTION
## Motivation

Some of our network tests are quite slow, and we're running into test timeouts on Windows.

This is unexpected work in sprint 21.

## Solution

Run some network tests in parallel to speed them up.

## Review

@oxarbitrage can review this PR. It's a low priority.

ZIP-401 and the security tickets should merge before this PR.

### Reviewer Checklist

  - [ ] Existing tests pass
