### PR TITLE
Reduce outgoing peers demand

### DIFF
--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -199,8 +199,16 @@ where
     );
     let _ = candidates.update_initial(active_initial_peer_count).await;
 
-    // TODO: reduce demand by `active_outbound_connections.update_count()` (#2902)
-    for _ in 0..config.peerset_initial_target_size {
+    // Reduce demand by the last `active_outbound_connections.update_count()` output.
+    let demand_count = match config
+        .peerset_initial_target_size
+        .checked_sub(active_outbound_connections.update_count())
+    {
+        Some(count) => count,
+        None => active_initial_peer_count,
+    };
+
+    for _ in 0..demand_count {
         let _ = demand_tx.try_send(MorePeers);
     }
 

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -199,14 +199,10 @@ where
     );
     let _ = candidates.update_initial(active_initial_peer_count).await;
 
-    // Reduce demand by the last `active_outbound_connections.update_count()` output.
-    let demand_count = match config
+    // Compute remaining connections to open.
+    let demand_count = config
         .peerset_initial_target_size
-        .checked_sub(active_outbound_connections.update_count())
-    {
-        Some(count) => count,
-        None => active_initial_peer_count,
-    };
+        .saturating_sub(active_outbound_connections.update_count());
 
     for _ in 0..demand_count {
         let _ = demand_tx.try_send(MorePeers);


### PR DESCRIPTION
## Motivation

When initializing zebra we want to reduce the number of connections we make to peers by load, based in the initial seed connections we just made one step before. Closes https://github.com/ZcashFoundation/zebra/issues/2902

## Solution

Subtract the number of `active_outbound_connections`  from `config.peerset_initial_target_size`. Request `MorePeers` based on that number instead of the full `config.peerset_initial_target_size`.

## Review

Anyone can review.
