### PR TITLE
Fix doctest failure

### DIFF
--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -13,7 +13,7 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```compile_fail
 //! use zebrad::components::mempool;
 //! #
 //! # use zebra_chain::parameters::Network;


### PR DESCRIPTION
## Motivation

We have a failing doc test. https://github.com/ZcashFoundation/zebra/runs/4046884615?check_suite_focus=true#step:6:1915

## Solution

Try a fix by using `compile_fail` instead of `ignore`

## Review

Anyone can review. This is high priority.

### Reviewer Checklist

- [ ] After this is merged into main, tests should pass.
