### PR TITLE
Make `services` field in `MetaAddr` optional

### DIFF
--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -832,6 +832,8 @@ impl Ord for MetaAddr {
         // So this comparison will have no impact until Zebra implements
         // more service features.
         //
+        // None is less than Some(T), so peers with missing services are chosen last.
+        //
         // TODO: order services by usefulness, not bit pattern values (#2324)
         //       Security: split gossiped and direct services
         let larger_services = self.services.cmp(&other.services);

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -879,10 +879,16 @@ impl Eq for MetaAddr {}
 impl ZcashSerialize for MetaAddr {
     fn zcash_serialize<W: Write>(&self, mut writer: W) -> Result<(), std::io::Error> {
         self.last_seen()
-            .expect("unexpected MetaAddr with missing last seen time: MetaAddrs should be sanitized before serialization")
+            .expect(
+                "unexpected MetaAddr with missing last seen time: MetaAddrs should be sanitized \
+                before serialization",
+            )
             .zcash_serialize(&mut writer)?;
+
         writer.write_u64::<LittleEndian>(self.services.bits())?;
+
         writer.write_socket_addr(self.addr)?;
+
         Ok(())
     }
 }

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -529,6 +529,8 @@ impl MetaAddr {
         Some(MetaAddr {
             addr: canonical_socket_addr(self.addr),
             // initial peers are sanitized assuming they are `NODE_NETWORK`
+            // TODO: split untrusted and direct services
+            //       consider sanitizing untrusted services to NODE_NETWORK (#2324)
             services: self.services.or(Some(PeerServices::NODE_NETWORK)),
             // only put the last seen time in the untrusted field,
             // this matches deserialization, and avoids leaking internal state

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -269,15 +269,19 @@ impl MetaAddr {
     }
 
     /// Returns a [`MetaAddrChange::NewGossiped`], based on a gossiped peer
-    /// `MetaAddr`.
-    pub fn new_gossiped_change(self) -> MetaAddrChange {
-        NewGossiped {
+    /// [`MetaAddr`].
+    ///
+    /// Returns [`None`] if the gossiped peer is missing the untrusted services field.
+    pub fn new_gossiped_change(self) -> Option<MetaAddrChange> {
+        let untrusted_services = self.services?;
+
+        Some(NewGossiped {
             addr: canonical_socket_addr(self.addr),
-            untrusted_services: self.services.expect("unexpected missing services"),
+            untrusted_services,
             untrusted_last_seen: self
                 .untrusted_last_seen
                 .expect("unexpected missing last seen"),
-        }
+        })
     }
 
     /// Returns a [`MetaAddrChange::UpdateResponded`] for a peer that has just

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -151,7 +151,7 @@ pub struct MetaAddr {
     /// records, older peer versions, or buggy or malicious peers.
     //
     // TODO: make services private and optional
-    //       split gossiped and handshake services? (#2234)
+    //       split gossiped and handshake services? (#2324)
     pub(crate) services: PeerServices,
 
     /// The unverified "last seen time" gossiped by the remote peer that sent us
@@ -525,7 +525,7 @@ impl MetaAddr {
         Some(MetaAddr {
             addr: canonical_socket_addr(self.addr),
             // TODO: split untrusted and direct services
-            //       sanitize untrusted services to NODE_NETWORK only? (#2234)
+            //       sanitize untrusted services to NODE_NETWORK only? (#2324)
             services: self.services,
             // only put the last seen time in the untrusted field,
             // this matches deserialization, and avoids leaking internal state
@@ -586,10 +586,10 @@ impl MetaAddrChange {
             NewAlternate {
                 untrusted_services, ..
             } => Some(*untrusted_services),
-            // TODO: create a "services implemented by Zebra" constant (#2234)
+            // TODO: create a "services implemented by Zebra" constant (#2324)
             NewLocal { .. } => Some(PeerServices::NODE_NETWORK),
             UpdateAttempt { .. } => None,
-            // TODO: split untrusted and direct services (#2234)
+            // TODO: split untrusted and direct services (#2324)
             UpdateResponded { services, .. } => Some(*services),
             UpdateFailed { services, .. } => *services,
         }
@@ -727,7 +727,7 @@ impl MetaAddrChange {
                     // so malicious peers can't keep changing our peer connection order.
                     Some(MetaAddr {
                         addr: self.addr(),
-                        // TODO: or(self.untrusted_services()) when services become optional (#2234)
+                        // TODO: or(self.untrusted_services()) when services become optional (#2324)
                         services: previous.services,
                         untrusted_last_seen: previous
                             .untrusted_last_seen
@@ -831,7 +831,7 @@ impl Ord for MetaAddr {
         // So this comparison will have no impact until Zebra implements
         // more service features.
         //
-        // TODO: order services by usefulness, not bit pattern values (#2234)
+        // TODO: order services by usefulness, not bit pattern values (#2324)
         //       Security: split gossiped and direct services
         let larger_services = self.services.cmp(&other.services);
 

--- a/zebra-network/src/meta_addr/tests/check.rs
+++ b/zebra-network/src/meta_addr/tests/check.rs
@@ -70,8 +70,9 @@ pub(crate) fn sanitize_avoids_leaks(original: &MetaAddr, sanitized: &MetaAddr) {
     // Sanitize to the the default state, even though it's not serialized
     assert_eq!(sanitized.last_connection_state, Default::default());
     // Sanitize to known flags
-    let sanitized_peer_services = original.services & PeerServices::all();
-    assert_eq!(sanitized.services, sanitized_peer_services);
+    let sanitized_peer_services =
+        original.services.unwrap_or(PeerServices::NODE_NETWORK) & PeerServices::all();
+    assert_eq!(sanitized.services, Some(sanitized_peer_services));
 
     // Remove IPv6 scope ID and flow information
     let sanitized_socket_addr = SocketAddr::new(original.addr.ip(), original.addr.port());

--- a/zebra-network/src/meta_addr/tests/prop.rs
+++ b/zebra-network/src/meta_addr/tests/prop.rs
@@ -52,7 +52,10 @@ proptest! {
             // also check the address, port, and services individually
             prop_assert!(!addr.addr.ip().is_unspecified());
             prop_assert_ne!(addr.addr.port(), 0);
-            prop_assert!(addr.services.contains(PeerServices::NODE_NETWORK));
+
+            if let Some(services) = addr.services {
+                prop_assert!(services.contains(PeerServices::NODE_NETWORK));
+            }
 
             check::sanitize_avoids_leaks(&addr, &sanitized);
         }

--- a/zebra-network/src/meta_addr/tests/prop.rs
+++ b/zebra-network/src/meta_addr/tests/prop.rs
@@ -219,9 +219,11 @@ proptest! {
 
                 // services:
                 // check that we only change if there was a handshake
-                if changed_addr.last_connection_state.is_never_attempted()
-                    || changed_addr.last_connection_state == AttemptPending
-                    || change.untrusted_services().is_none() {
+                if addr.services.is_some()
+                    && (changed_addr.last_connection_state.is_never_attempted()
+                        || changed_addr.last_connection_state == AttemptPending
+                        || change.untrusted_services().is_none())
+                {
                     prop_assert_eq!(changed_addr.services, addr.services);
                 }
 

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -267,7 +267,12 @@ where
 
     /// Add new `addrs` to the address book.
     fn send_addrs(&self, addrs: impl IntoIterator<Item = MetaAddr>) {
-        let addrs = addrs.into_iter().filter_map(MetaAddr::new_gossiped_change);
+        let addrs = addrs
+            .into_iter()
+            .map(MetaAddr::new_gossiped_change)
+            .map(|maybe_addr| {
+                maybe_addr.expect("Received gossiped peers always have services set")
+            });
 
         // # Correctness
         //

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -267,7 +267,7 @@ where
 
     /// Add new `addrs` to the address book.
     fn send_addrs(&self, addrs: impl IntoIterator<Item = MetaAddr>) {
-        let addrs = addrs.into_iter().map(MetaAddr::new_gossiped_change);
+        let addrs = addrs.into_iter().filter_map(MetaAddr::new_gossiped_change);
 
         // # Correctness
         //

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -1260,7 +1260,9 @@ where
         let addr =
             MetaAddr::new_gossiped_meta_addr(addr, PeerServices::NODE_NETWORK, DateTime32::now());
         fake_peer = Some(addr);
-        let addr = addr.new_gossiped_change();
+        let addr = addr
+            .new_gossiped_change()
+            .expect("created MetaAddr contains enough information to represent a gossiped address");
 
         address_book.update(addr);
     }


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
@upbqdn ran into an issue while working on #2974 where it was not trivial how to convert a `MetaAddrChange` representing an initial peer into a `MetaAddr`. One of the issues was that the `services` field had to be set. While we could assume that the field is `NODE_NETWORK`, the surrounding code referenced an issue #2324 with a `TODO` mentioning `services` should become optional in the future. I thought it might be a good idea to implement that part to help out with the issue.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Make the `services` field optional in `MetaAddr`, and assume that the peer is a `NETWORK_NODE` when sanitizing. Update the tests to support this change.

The PR also contains a few additional changes:

- fix a typo referencing the incorrect issue in some `TODO`s,
- split a long string into a multi-line string so that `rustfmt` can properly format the expression,
- use `prop_assert!` instead of `assert!` in property tests,
- run `rustfmt` inside the property tests.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
This is low priority. @upbqdn can review this, but I'd also like @teor2345 to take a look if they have some time, just to confirm that I'm not missing anything or breaking any semantics of the network code.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->