### PR TITLE
Increase the reload timeout in acceptance tests

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -703,7 +703,8 @@ const STOP_AT_HEIGHT_REGEX: &str = "stopping at configured height";
 /// The maximum amount of time Zebra should take to reload after shutting down.
 ///
 /// This should only take a second, but sometimes CI VMs or RocksDB can be slow.
-const STOP_ON_LOAD_TIMEOUT: Duration = Duration::from_secs(10);
+/// In particular, macOS can take more than 5 seconds to read the tip height (#2988).
+const STOP_ON_LOAD_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// The maximum amount of time Zebra should take to sync a few hundred blocks.
 ///


### PR DESCRIPTION
## Motivation

macOS can take a long time to open the database in CI, which causes CI failures like:
https://github.com/ZcashFoundation/zebra/runs/4053025010?check_suite_focus=true#step:10:1344

This is unexpected work in sprint 21.
It does not close any tickets.

## Solution

We've got a log of logging here already, so it seems like our only option is to increase the test timeout.

## Review

Anyone can review this occasional CI failure fix.

### Reviewer Checklist

  - [ ] Test changes make sense

## Follow Up Work

- work out what the underlying issue is in #2988