### PR TITLE
Update to Tokio 1.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,15 @@ jobs:
             echo "CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}"
             echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
 
+      - name: Change target output directory on Windows
+        # Windows doesn't have enough space on the D: drive, so we redirect the build output to the
+        # larger C: drive.
+        # TODO: Remove this workaround once the build is more efficient (#3005).
+        if: matrix.os == 'windows-latest'
+        run: |
+          mkdir C:\zebra-target
+          echo "CARGO_TARGET_DIR=C:\zebra-target" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Run tests
         uses: actions-rs/cargo@v1.0.3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,15 +113,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-dependencies = [
- "const-random",
-]
-
-[[package]]
-name = "ahash"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
@@ -146,7 +137,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -155,7 +146,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -163,12 +154,6 @@ name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
-
-[[package]]
-name = "arc-swap"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688b520bcc7498f6ca8fa006e8031d353e3fd4f51bd4a50fb03cc4230b28bd2"
 
 [[package]]
 name = "arrayref"
@@ -235,7 +220,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -269,12 +254,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -290,12 +269,6 @@ name = "bech32"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
-
-[[package]]
-name = "beef"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474a626a67200bd107d44179bb3d4fc61891172d11696609264589be6a0e6a43"
 
 [[package]]
 name = "bellman"
@@ -412,15 +385,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "bitvec"
@@ -564,15 +528,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "0.6.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
-
-[[package]]
-name = "bytes"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "canonical-path"
@@ -586,7 +544,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc38c385bfd7e444464011bb24820f40dd1c76bcdfa1b78611cb7c2e5cafab75"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -655,7 +613,7 @@ dependencies = [
  "num-traits",
  "serde",
  "time",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -749,42 +707,6 @@ dependencies = [
  "tracing-core",
  "tracing-error",
 ]
-
-[[package]]
-name = "console_error_panic_hook"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
-dependencies = [
- "cfg-if 0.1.10",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "const-random"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dc82c12dc2ee6e1ded861cf7d582b46f66f796d1b6c93fa28b911ead95da02"
-dependencies = [
- "const-random-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc757bbb9544aa296c2ae00c679e81f886b37e28e59097defe0cf524306f6685"
-dependencies = [
- "getrandom 0.2.0",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "const_fn"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
 
 [[package]]
 name = "constant_time_eq"
@@ -886,7 +808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -907,8 +829,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-epoch 0.9.5",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -922,21 +844,20 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
- "memoffset",
+ "memoffset 0.5.6",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.0"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
- "const_fn",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.5",
  "lazy_static",
- "memoffset",
+ "memoffset 0.6.4",
  "scopeguard",
 ]
 
@@ -974,13 +895,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
  "cfg-if 1.0.0",
- "const_fn",
  "lazy_static",
 ]
 
@@ -1089,12 +1008,11 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "3.11.10"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
- "ahash 0.3.8",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "num_cpus",
 ]
 
@@ -1140,7 +1058,7 @@ checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1183,6 +1101,12 @@ checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-iterator"
@@ -1330,22 +1254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "funty"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,7 +1362,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1479,8 +1387,8 @@ dependencies = [
  "cc",
  "libc",
  "log",
- "rustc_version",
- "winapi 0.3.9",
+ "rustc_version 0.2.3",
+ "winapi",
 ]
 
 [[package]]
@@ -1598,11 +1506,11 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.7"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.1.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1610,29 +1518,9 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.23",
- "tokio-util 0.3.1",
+ "tokio",
+ "tokio-util",
  "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.0"
-source = "git+https://github.com/hyperium/h2#cbbdd305b1afc1eaf19f2e3b26f9419048041e7d"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio 0.3.6",
- "tokio-util 0.4.0",
- "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -1660,6 +1548,9 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -1672,20 +1563,6 @@ dependencies = [
  "crossbeam-channel 0.3.9",
  "flate2",
  "nom 4.2.3",
- "num-traits",
-]
-
-[[package]]
-name = "hdrhistogram"
-version = "7.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c22708574c44e924720c5b3a116326c688e6d532f438c77c007ec8768644f9"
-dependencies = [
- "base64 0.12.3",
- "byteorder",
- "crossbeam-channel 0.4.4",
- "flate2",
- "nom 5.1.2",
  "num-traits",
 ]
 
@@ -1731,7 +1608,7 @@ checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
  "libc",
  "match_cfg",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1747,25 +1624,26 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.1.0",
  "http",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.4"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "humantime"
@@ -1775,46 +1653,23 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.14.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.1.0",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.2.7",
+ "h2",
  "http",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.7",
- "socket2",
- "tokio 0.2.23",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
-version = "0.14.0-dev"
-source = "git+https://github.com/hyperium/hyper?rev=ed2b22a7f66899d338691552fbcb6c0f2f4e06b9#ed2b22a7f66899d338691552fbcb6c0f2f4e06b9"
-dependencies = [
- "bytes 0.5.6",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.0",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project 1.0.7",
- "socket2",
- "tokio 0.3.6",
+ "pin-project-lite",
+ "socket2 0.4.2",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -1822,16 +1677,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
- "bytes 0.5.6",
  "futures-util",
- "hyper 0.13.9",
+ "hyper",
  "log",
  "rustls",
- "tokio 0.2.23",
+ "tokio",
  "tokio-rustls",
  "webpki",
 ]
@@ -1851,20 +1705,6 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "im"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
-dependencies = [
- "bitmaps",
- "rand_core 0.5.1",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check 0.9.2",
 ]
 
 [[package]]
@@ -1897,7 +1737,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa5bd9a10b38bf5f3c670f9d75c194adbecd2b1573f737668ab8599f41edc87"
 dependencies = [
- "ahash 0.7.4",
+ "ahash",
  "atty",
  "itoa",
  "lazy_static",
@@ -1915,15 +1755,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -2003,16 +1834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,19 +1844,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "lexical-core"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
-dependencies = [
- "arrayvec 0.5.2",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "libc"
@@ -2062,7 +1870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 dependencies = [
  "cfg-if 1.0.0",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2127,6 +1935,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,6 +1986,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "memuse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,33 +2005,36 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.13.0-alpha.8"
-source = "git+https://github.com/ZcashFoundation/metrics?rev=971133128e5aebe3ad177acffc6154449736cfa2#971133128e5aebe3ad177acffc6154449736cfa2"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00f42f354a2ed4894db863b3a4db47aef2d2e4435b937221749bd37a8a7aaa8"
 dependencies = [
- "beef",
+ "ahash",
  "metrics-macros",
  "proc-macro-hack",
- "sharded-slab",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.1.0-alpha.7"
-source = "git+https://github.com/ZcashFoundation/metrics?rev=971133128e5aebe3ad177acffc6154449736cfa2#971133128e5aebe3ad177acffc6154449736cfa2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343a5ceb38235928e7a5687412590f07e6d281522dcd9ff51246f8856eef5fe5"
 dependencies = [
- "hdrhistogram 7.1.0",
- "hyper 0.14.0-dev",
+ "hyper",
+ "ipnet",
  "metrics",
  "metrics-util",
  "parking_lot",
+ "quanta",
  "thiserror",
- "tokio 0.3.6",
+ "tokio",
 ]
 
 [[package]]
 name = "metrics-macros"
-version = "0.1.0-alpha.5"
-source = "git+https://github.com/ZcashFoundation/metrics?rev=971133128e5aebe3ad177acffc6154449736cfa2#971133128e5aebe3ad177acffc6154449736cfa2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa72e4a3d157986dd2565c82ecbddcc23941513669a3766b938f6b72eb87f3f"
 dependencies = [
  "lazy_static",
  "proc-macro-hack",
@@ -2217,16 +2046,25 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.4.0-alpha.6"
-source = "git+https://github.com/ZcashFoundation/metrics?rev=971133128e5aebe3ad177acffc6154449736cfa2#971133128e5aebe3ad177acffc6154449736cfa2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c9b6aee519e1461b678952d3671652bb341d0664b1188f895a436a4e2e6ffa"
 dependencies = [
- "arc-swap",
+ "ahash",
+ "aho-corasick",
  "atomic-shim",
- "crossbeam-epoch 0.9.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-epoch 0.9.5",
+ "crossbeam-utils 0.8.5",
  "dashmap",
+ "hashbrown",
  "indexmap",
  "metrics",
+ "num_cpus",
+ "ordered-float",
+ "parking_lot",
+ "quanta",
+ "radix_trie",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -2234,16 +2072,6 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -2257,46 +2085,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow 0.2.2",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f33bc887064ef1fd66020c9adfc45bb9f33d75a42096c81e7c56c65b75dd1a8b"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.6",
+ "miow",
  "ntapi",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2305,8 +2102,8 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2",
- "winapi 0.3.9",
+ "socket2 0.3.16",
+ "winapi",
 ]
 
 [[package]]
@@ -2316,14 +2113,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce8738c9ddd350996cb8b8b718192851df960803764bcdaa3afb44a63b1ddb5c"
 
 [[package]]
-name = "net2"
-version = "0.2.36"
+name = "nibble_vec"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cf75f38f16cb05ea017784dc6dbfd354f76c223dba37701734c4f5a9337d02"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
+ "smallvec 1.5.0",
 ]
 
 [[package]]
@@ -2348,7 +2143,6 @@ version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
- "lexical-core",
  "memchr",
  "version_check 0.9.2",
 ]
@@ -2365,7 +2159,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2480,12 +2274,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c9d06878b3a851e8026ef94bf7fef9ba93062cd412601da4d9cf369b1cc62d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2550,7 +2353,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.1.57",
  "smallvec 1.5.0",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2643,15 +2446,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -2808,6 +2605,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
+dependencies = [
+ "crossbeam-utils 0.8.5",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,6 +2660,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2856,7 +2679,7 @@ dependencies = [
  "libc",
  "rand_core 0.3.1",
  "rdrand",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2965,12 +2788,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.4.0"
+name = "raw-cpuid"
+version = "10.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
+checksum = "929f54e29691d4e6a9cc558479de70db7aa3d98cd6fe7ab86d7507aa2886b9d2"
 dependencies = [
- "rand_core 0.5.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2993,7 +2816,7 @@ checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel 0.5.1",
  "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.5",
  "lazy_static",
  "num_cpus",
 ]
@@ -3097,42 +2920,40 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.10.9"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb15d6255c792356a0f578d8a645c677904dc02e862bebe2ecc18e0c01b9a0ce"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
 dependencies = [
  "base64 0.13.0",
- "bytes 0.5.6",
+ "bytes 1.1.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "http",
  "http-body",
- "hyper 0.13.9",
+ "hyper",
  "hyper-rustls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
- "mime_guess",
  "percent-encoding",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.23",
+ "tokio",
  "tokio-rustls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-bindgen-test",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -3159,7 +2980,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3214,12 +3035,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.18.1"
+name = "rustc_version"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "base64 0.12.3",
+ "semver 1.0.3",
+]
+
+[[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64 0.13.0",
  "log",
  "ring",
  "sct",
@@ -3334,22 +3164,23 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933beb0343c84eefd69a368318e9291b179e09e51982d49c65d7b362b0e9466f"
+checksum = "546b9b6f76c26c60ffbcf0b7136e15169fe13d43949b4aadb7c1edc1c3f3a26f"
 dependencies = [
  "httpdate",
  "reqwest",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
+ "tokio",
 ]
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e528fb457baf53fcd6c90beb420705f35c12c3d8caed8817dcf7be00eff7c7"
+checksum = "9cd0cba2aff36ac98708f7a6e7abbdde82dbaf180d5870c41084dc1b473648b9"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -3359,28 +3190,28 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3a560a34cffac347f0b588fc29b31db969e27bf57208f946d6a2d588668b0b"
+checksum = "9bacf1c62427c6c97b896640d0c4dd204bbd3b79dd192d7cb40891aa5ee11d58"
 dependencies = [
  "hostname",
  "lazy_static",
  "libc",
  "regex",
- "rustc_version",
+ "rustc_version 0.4.0",
  "sentry-core",
  "uname",
 ]
 
 [[package]]
 name = "sentry-core"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b8c235063c1007fd8e2fc7e35ce7eac09dd678d198ecc996daee33d46b3dcc"
+checksum = "f9a957270c9a430218f8031c866493061a27e35a70250e9527f093563a33ce6b"
 dependencies = [
- "im",
+ "chrono",
  "lazy_static",
- "rand 0.7.3",
+ "rand 0.8.4",
  "sentry-types",
  "serde",
  "serde_json",
@@ -3388,24 +3219,20 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.1.0"
-source = "git+https://github.com/kellpossible/sentry-tracing.git?rev=f1a4a4a16b5ff1022ae60be779eb3fb928ce9b0f#f1a4a4a16b5ff1022ae60be779eb3fb928ce9b0f"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d291df287241b0ef97f5bf9e9a595691ef8dfb49bc6acfd55b9dc2ade681f1c9"
 dependencies = [
- "eyre",
- "sentry-backtrace",
  "sentry-core",
- "serde",
- "serde_json",
- "strip-ansi-escapes",
- "tracing",
+ "tracing-core",
  "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
 name = "sentry-types"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbbea6debac0a24880a38239d4c2fc3dbb0b1b398f621bea03ed761796b7dfb"
+checksum = "f4dd2266fee014a86e250e98e389191ecd23be546b5c42b6a2fb9af2972fadac"
 dependencies = [
  "chrono",
  "debugid",
@@ -3534,14 +3361,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sized-chunks"
-version = "0.6.2"
+name = "sketches-ddsketch"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
-dependencies = [
- "bitmaps",
- "typenum",
-]
+checksum = "76a77a8fd93886010f05e7ea0720e569d6d16c65329dbe3ec033bbbccccb017b"
 
 [[package]]
 name = "slab"
@@ -3573,7 +3396,17 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "redox_syscall 0.1.57",
- "winapi 0.3.9",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3621,15 +3454,6 @@ name = "str_stack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
-
-[[package]]
-name = "strip-ansi-escapes"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d63676e2abafa709460982ddc02a3bb586b6d15a49b75c212e06edd3933acee"
-dependencies = [
- "vte",
-]
 
 [[package]]
 name = "strsim"
@@ -3734,7 +3558,7 @@ dependencies = [
  "rand 0.7.3",
  "redox_syscall 0.1.57",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3792,7 +3616,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3822,60 +3646,30 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.23"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
- "memchr",
- "mio 0.6.23",
- "num_cpus",
- "pin-project-lite 0.1.11",
- "slab",
-]
-
-[[package]]
-name = "tokio"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "720ba21c25078711bf456d607987d95bce90f7c3bea5abe1db587862e7a1e87c"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg",
- "bytes 0.6.0",
- "futures-core",
+ "bytes 1.1.0",
  "libc",
  "memchr",
- "mio 0.7.6",
+ "mio",
  "num_cpus",
  "once_cell",
  "parking_lot",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "tokio-macros",
  "tracing",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
-dependencies = [
- "autocfg",
- "pin-project-lite 0.2.4",
+ "winapi",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.3.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46dfffa59fc3c8aad216ed61bdc2c263d2b9d87a9c8ac9de0c11a813e51b6db7"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -3884,25 +3678,25 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.14.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "futures-core",
  "rustls",
- "tokio 0.2.23",
+ "tokio",
  "webpki",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c535f53c0cfa1acace62995a8994fc9cc1f12d202420da96ff306ee24d576469"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.4",
- "tokio 1.3.0",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3912,52 +3706,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53474327ae5e166530d17f2d956afcb4f8a004de581b3cae10f12006bc8163e3"
 dependencies = [
  "async-stream",
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "futures-core",
- "tokio 1.3.0",
+ "tokio",
  "tokio-stream",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.3.1"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.1.0",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.1.11",
- "tokio 0.2.23",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24793699f4665ba0416ed287dc794fe6b11a4aa5e4e95b58624f45f6c46b97d4"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite 0.1.11",
- "tokio 0.3.6",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3137de2b078e95274b696cc522e87f22c9a753fe3ef3344116ffb94f104f10a3"
-dependencies = [
- "bytes 0.6.0",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite 0.2.4",
- "tokio 0.3.6",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -3971,15 +3737,18 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.0"
-source = "git+https://github.com/tower-rs/tower?rev=d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39#d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00e500fff5fa1131c866b246041a6bf96da9c965f8fe4128cb1421f23e93c00"
 dependencies = [
  "futures-core",
  "futures-util",
- "hdrhistogram 6.3.4",
+ "hdrhistogram",
  "pin-project 1.0.7",
- "tokio 0.3.6",
- "tower-layer 0.3.0",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
  "tower-service",
  "tracing",
 ]
@@ -3994,7 +3763,7 @@ dependencies = [
  "futures-core",
  "pin-project 1.0.7",
  "rand 0.8.4",
- "tokio 0.3.6",
+ "tokio",
  "tokio-test",
  "tower",
  "tower-fallback",
@@ -4010,16 +3779,11 @@ version = "0.2.13"
 dependencies = [
  "futures-core",
  "pin-project 0.4.28",
- "tokio 0.3.6",
+ "tokio",
  "tower",
  "tracing",
  "zebra-test",
 ]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower?rev=d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39#d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39"
 
 [[package]]
 name = "tower-layer"
@@ -4041,9 +3805,9 @@ checksum = "a4546773ffeab9e4ea02b8872faa49bb616a80a7da66afc2f32688943f97efa7"
 dependencies = [
  "futures-util",
  "pin-project 1.0.7",
- "tokio 1.3.0",
+ "tokio",
  "tokio-test",
- "tower-layer 0.3.1",
+ "tower-layer",
  "tower-service",
 ]
 
@@ -4055,7 +3819,7 @@ checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -4215,15 +3979,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check 0.9.2",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4295,12 +4050,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf8parse"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
-
-[[package]]
 name = "uuid"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4349,15 +4098,6 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-
-[[package]]
-name = "vte"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f42f536e22f7fcbb407639765c8fd78707a33109301f834a594758bedd6e8cf"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "wagyu-zcash-parameters"
@@ -4425,7 +4165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
+ "winapi",
  "winapi-util",
 ]
 
@@ -4458,8 +4198,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -4520,30 +4258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
-name = "wasm-bindgen-test"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0355fa0c1f9b792a09b6dcb6a8be24d51e71e6d74972f9eb4a44c4c004d24a25"
-dependencies = [
- "console_error_panic_hook",
- "js-sys",
- "scoped-tls",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-test-macro"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e07b46b98024c2ba2f9e83a10c2ef0515f057f2da299c1762a2017de80438b"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4565,9 +4279,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki",
 ]
@@ -4583,12 +4297,6 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -4596,12 +4304,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -4615,7 +4317,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -4630,17 +4332,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "winapi",
 ]
 
 [[package]]
@@ -4829,7 +4521,7 @@ dependencies = [
  "serde",
  "spandoc",
  "thiserror",
- "tokio 0.3.6",
+ "tokio",
  "tower",
  "tower-batch",
  "tower-fallback",
@@ -4850,7 +4542,7 @@ version = "1.0.0-beta.0"
 dependencies = [
  "bitflags",
  "byteorder",
- "bytes 0.6.0",
+ "bytes 1.1.0",
  "chrono",
  "futures 0.3.17",
  "hex",
@@ -4864,8 +4556,9 @@ dependencies = [
  "regex",
  "serde",
  "thiserror",
- "tokio 0.3.6",
- "tokio-util 0.5.1",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
  "toml",
  "tower",
  "tracing",
@@ -4919,7 +4612,7 @@ dependencies = [
  "spandoc",
  "tempdir",
  "thiserror",
- "tokio 0.3.6",
+ "tokio",
  "tower",
  "tracing",
  "zebra-chain",
@@ -4943,7 +4636,7 @@ dependencies = [
  "spandoc",
  "tempdir",
  "thiserror",
- "tokio 0.3.6",
+ "tokio",
  "tower",
  "tracing",
  "tracing-error",
@@ -4976,7 +4669,7 @@ dependencies = [
  "dirs",
  "futures 0.3.17",
  "gumdrop",
- "hyper 0.14.0-dev",
+ "hyper",
  "inferno",
  "metrics",
  "metrics-exporter-prometheus",
@@ -4992,7 +4685,7 @@ dependencies = [
  "serde",
  "tempdir",
  "thiserror",
- "tokio 0.3.6",
+ "tokio",
  "toml",
  "tower",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ panic = "abort"
 [patch.crates-io]
 
 # awaiting stable versions which all depend on tokio 1.0, see #1086 for details
-hyper = { git = "https://github.com/hyperium/hyper", rev = "ed2b22a7f66899d338691552fbcb6c0f2f4e06b9" }
 metrics = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
 metrics-exporter-prometheus = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,6 @@ panic = "abort"
 
 [patch.crates-io]
 
-# awaiting stable versions which all depend on tokio 1.0, see #1086 for details
-metrics = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
-metrics-exporter-prometheus = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
-
 # TODO: remove these after a new librustzcash release.
 # These are librustzcash requirements specified in its workspace Cargo.toml that we must replicate here
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "b7bd6246122a6e9ace8edb51553fbf5228906cbb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ panic = "abort"
 hyper = { git = "https://github.com/hyperium/hyper", rev = "ed2b22a7f66899d338691552fbcb6c0f2f4e06b9" }
 metrics = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
 metrics-exporter-prometheus = { git = "https://github.com/ZcashFoundation/metrics", rev = "971133128e5aebe3ad177acffc6154449736cfa2" }
-tower = { git = "https://github.com/tower-rs/tower", rev = "d4d1c67c6a0e4213a52abcc2b9df6cc58276ee39" }
 
 # TODO: remove these after a new librustzcash release.
 # These are librustzcash requirements specified in its workspace Cargo.toml that we must replicate here

--- a/deny.toml
+++ b/deny.toml
@@ -31,12 +31,6 @@ skip = [
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [
-    # ticket #2200: tokio dependencies
-    { name = "metrics-exporter-prometheus", version = "=0.1.0-alpha.7" },
-    { name = "tower", version = "=0.4.0" },
-    { name = "tokio", version = "=0.2.23" },
-    { name = "tokio-util", version = "=0.3.1" },
-
     # ticket #2953: tracing dependencies
     { name = "tracing-subscriber", version = "=0.1.6" },
 
@@ -95,8 +89,4 @@ allow-git = [
 github = [
     "ZcashFoundation",
     "zcash",
-
-    # ticket #2200: tokio dependencies
-    "hyperium",
-    "tower-rs",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -46,6 +46,9 @@ skip-tree = [
     # ticket #2983: criterion dependencies
     { name = "criterion", version = "=0.3.4" },
 
+    # ticket #3000: tower-fallback dependencies
+    { name = "pin-project", version = "=0.4.28" },
+
     # ticket #2981: bindgen dependencies
     { name = "rocksdb", version = "=0.16.0" },
 
@@ -58,9 +61,22 @@ skip-tree = [
     # ticket #2980: inferno dependencies
     { name = "inferno", version = "=0.10.7" },
 
+    # ticket #2998: base64 dependencies
+    { name = "base64", version = "=0.10.1" },
+
+    # ticket #2999: http dependencies
+    { name = "bytes", version = "=0.5.6" },
+
     # upgrade orchard from deprecated `bigint` to `uint`: https://github.com/zcash/orchard/issues/219
     # alternative: downgrade Zebra to `bigint`
     { name = "bigint", version = "=4.4.3" },
+
+    # recent major version bumps
+
+    # wait for lots of crates in the tokio ecosystem to upgrade
+    # we should re-check these dependencies in February 2022
+    { name = "redox_syscall", version = "=0.1.57" },
+    { name = "socket2", version = "=0.3.16" },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/deny.toml
+++ b/deny.toml
@@ -78,9 +78,6 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    # ticket #2200: tokio dependencies
-    "https://github.com/kellpossible/sentry-tracing",
-
     # ticket #2982: librustzcash and orchard git versions
     "https://github.com/str4d/redjubjub",
 ]

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 futures = "0.3.17"
 futures-core = "0.3.13"
 pin-project = "1.0.7"
-tokio = { version = "0.3.6", features = ["time", "sync", "stream", "tracing", "macros"] }
+tokio = { version = "1.13.0", features = ["time", "sync", "tracing", "macros"] }
 tower = { version = "0.4.9", features = ["util", "buffer"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
@@ -18,7 +18,7 @@ tracing-futures = "0.2.5"
 color-eyre = "0.5.11"
 ed25519-zebra = "3.0.0"
 rand = "0.8"
-tokio = { version = "0.3.6", features = ["full"]}
+tokio = { version = "1.13.0", features = ["full"]}
 tokio-test = "0.4.2"
 tower-fallback = { path = "../tower-fallback/" }
 tower-test = "0.4.0"

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -10,7 +10,7 @@ futures = "0.3.17"
 futures-core = "0.3.13"
 pin-project = "1.0.7"
 tokio = { version = "0.3.6", features = ["time", "sync", "stream", "tracing", "macros"] }
-tower = { version = "0.4", features = ["util", "buffer"] }
+tower = { version = "0.4.9", features = ["util", "buffer"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
 

--- a/tower-batch/src/worker.rs
+++ b/tower-batch/src/worker.rs
@@ -83,7 +83,7 @@ where
             tracing::trace!("notifying caller about worker failure");
             let _ = tx.send(Err(failed.clone()));
         } else {
-            match self.service.ready_and().await {
+            match self.service.ready().await {
                 Ok(svc) => {
                     let rsp = svc.call(req.into());
                     let _ = tx.send(Ok(rsp));
@@ -109,7 +109,7 @@ where
     async fn flush_service(&mut self) {
         if let Err(e) = self
             .service
-            .ready_and()
+            .ready()
             .and_then(|svc| svc.call(BatchControl::Flush))
             .await
         {

--- a/tower-batch/tests/ed25519.rs
+++ b/tower-batch/tests/ed25519.rs
@@ -112,7 +112,7 @@ where
             sk.sign(&msg[..])
         };
 
-        verifier.ready_and().await?;
+        verifier.ready().await?;
         results.push(span.in_scope(|| verifier.call((vk_bytes, sig, msg).into())))
     }
 

--- a/tower-batch/tests/worker.rs
+++ b/tower-batch/tests/worker.rs
@@ -21,18 +21,18 @@ async fn wakes_pending_waiters_on_close() {
 
     // // keep the request in the worker
     handle.allow(0);
-    let service1 = service.ready_and().await.unwrap();
+    let service1 = service.ready().await.unwrap();
     let poll = worker.poll();
     assert_pending!(poll);
     let mut response = task::spawn(service1.call(()));
 
     let mut service1 = service.clone();
-    let mut ready1 = task::spawn(service1.ready_and());
+    let mut ready1 = task::spawn(service1.ready());
     assert_pending!(worker.poll());
     assert_pending!(ready1.poll(), "no capacity");
 
     let mut service1 = service.clone();
-    let mut ready2 = task::spawn(service1.ready_and());
+    let mut ready2 = task::spawn(service1.ready());
     assert_pending!(worker.poll());
     assert_pending!(ready2.poll(), "no capacity");
 
@@ -80,17 +80,17 @@ async fn wakes_pending_waiters_on_failure() {
 
     // keep the request in the worker
     handle.allow(0);
-    let service1 = service.ready_and().await.unwrap();
+    let service1 = service.ready().await.unwrap();
     assert_pending!(worker.poll());
     let mut response = task::spawn(service1.call("hello"));
 
     let mut service1 = service.clone();
-    let mut ready1 = task::spawn(service1.ready_and());
+    let mut ready1 = task::spawn(service1.ready());
     assert_pending!(worker.poll());
     assert_pending!(ready1.poll(), "no capacity");
 
     let mut service1 = service.clone();
-    let mut ready2 = task::spawn(service1.ready_and());
+    let mut ready2 = task::spawn(service1.ready());
     assert_pending!(worker.poll());
     assert_pending!(ready2.poll(), "no capacity");
 

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -13,4 +13,4 @@ tracing = "0.1"
 
 [dev-dependencies]
 zebra-test = { path = "../zebra-test/" }
-tokio = { version = "0.3.6", features = ["full"]}
+tokio = { version = "1.13.0", features = ["full"]}

--- a/tower-fallback/tests/fallback.rs
+++ b/tower-fallback/tests/fallback.rs
@@ -30,7 +30,7 @@ async fn fallback() {
 
     let mut svc = Fallback::new(svc1, svc2);
 
-    assert_eq!(svc.ready_and().await.unwrap().call(1).await.unwrap(), 1);
-    assert_eq!(svc.ready_and().await.unwrap().call(11).await.unwrap(), 111);
-    assert!(svc.ready_and().await.unwrap().call(21).await.is_err());
+    assert_eq!(svc.ready().await.unwrap().call(1).await.unwrap(), 1);
+    assert_eq!(svc.ready().await.unwrap().call(11).await.unwrap(), 111);
+    assert!(svc.ready().await.unwrap().call(21).await.is_err());
 }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["serde_derive"] }
 
 futures = "0.3.17"
 futures-util = "0.3.17"
-metrics = "0.13.0-alpha.8"
+metrics = "0.17.0"
 thiserror = "1.0.30"
 tokio = { version = "1.13.0", features = ["time", "sync", "tracing"] }
 tower = { version = "0.4.9", features = ["timeout", "util", "buffer"] }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -26,7 +26,7 @@ futures-util = "0.3.17"
 metrics = "0.13.0-alpha.8"
 thiserror = "1.0.30"
 tokio = { version = "0.3.6", features = ["time", "sync", "stream", "tracing"] }
-tower = { version = "0.4", features = ["timeout", "util", "buffer"] }
+tower = { version = "0.4.9", features = ["timeout", "util", "buffer"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
 

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -25,7 +25,7 @@ futures = "0.3.17"
 futures-util = "0.3.17"
 metrics = "0.13.0-alpha.8"
 thiserror = "1.0.30"
-tokio = { version = "0.3.6", features = ["time", "sync", "stream", "tracing"] }
+tokio = { version = "1.13.0", features = ["time", "sync", "tracing"] }
 tower = { version = "0.4.9", features = ["timeout", "util", "buffer"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
@@ -46,7 +46,7 @@ proptest = "0.10"
 proptest-derive = "0.3.0"
 rand07 = { package = "rand", version = "0.7" }
 spandoc = "0.2"
-tokio = { version = "0.3.6", features = ["full"] }
+tokio = { version = "1.13.0", features = ["full"] }
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.25"
 

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -125,7 +125,7 @@ where
             // Check that this block is actually a new block.
             tracing::trace!("checking that block is not already in state");
             match state_service
-                .ready_and()
+                .ready()
                 .await
                 .map_err(|source| VerifyBlockError::Depth { source, hash })?
                 .call(zs::Request::Depth(hash))
@@ -179,7 +179,7 @@ where
             ));
             for transaction in &block.transactions {
                 let rsp = transaction_verifier
-                    .ready_and()
+                    .ready()
                     .await
                     .expect("transaction verifier is always ready")
                     .call(tx::Request::Block {
@@ -211,7 +211,7 @@ where
                 transaction_hashes,
             };
             match state_service
-                .ready_and()
+                .ready()
                 .await
                 .map_err(VerifyBlockError::Commit)?
                 .call(zs::Request::CommitBlock(prepared_block))

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -203,7 +203,7 @@ where
     };
 
     let tip = match state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zs::Request::Tip)

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -6,9 +6,12 @@ use super::types::Progress::*;
 use super::types::TargetHeight::*;
 
 use color_eyre::eyre::{eyre, Report};
-use futures::{future::TryFutureExt, stream::FuturesUnordered};
+use futures::{
+    future::TryFutureExt,
+    stream::{FuturesUnordered, StreamExt},
+};
 use std::{cmp::min, convert::TryInto, mem::drop, time::Duration};
-use tokio::{stream::StreamExt, time::timeout};
+use tokio::time::timeout;
 use tower::{Service, ServiceExt};
 use tracing_futures::Instrument;
 

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -64,10 +64,7 @@ async fn single_item_checkpoint_list() -> Result<(), Report> {
     );
 
     /// SPANDOC: Make sure the verifier service is ready
-    let ready_verifier_service = checkpoint_verifier
-        .ready_and()
-        .map_err(|e| eyre!(e))
-        .await?;
+    let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
     /// SPANDOC: Set up the future for block 0
     let verify_future = timeout(
         Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
@@ -148,10 +145,7 @@ async fn multi_item_checkpoint_list() -> Result<(), Report> {
     // Now verify each block
     for (block, height, hash) in checkpoint_data {
         /// SPANDOC: Make sure the verifier service is ready
-        let ready_verifier_service = checkpoint_verifier
-            .ready_and()
-            .map_err(|e| eyre!(e))
-            .await?;
+        let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
 
         /// SPANDOC: Set up the future for block {?height}
         let verify_future = timeout(
@@ -325,8 +319,7 @@ async fn continuous_blockchain(
                 if height <= restart_height {
                     let mut state_service = state_service.clone();
                     /// SPANDOC: Make sure the state service is ready for block {?height}
-                    let ready_state_service =
-                        state_service.ready_and().map_err(|e| eyre!(e)).await?;
+                    let ready_state_service = state_service.ready().map_err(|e| eyre!(e)).await?;
 
                     /// SPANDOC: Add block directly to the state {?height}
                     ready_state_service
@@ -342,10 +335,7 @@ async fn continuous_blockchain(
             }
 
             /// SPANDOC: Make sure the verifier service is ready for block {?height}
-            let ready_verifier_service = checkpoint_verifier
-                .ready_and()
-                .map_err(|e| eyre!(e))
-                .await?;
+            let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
 
             /// SPANDOC: Set up the future for block {?height}
             let verify_future = timeout(
@@ -470,10 +460,7 @@ async fn block_higher_than_max_checkpoint_fail() -> Result<(), Report> {
     );
 
     /// SPANDOC: Make sure the verifier service is ready
-    let ready_verifier_service = checkpoint_verifier
-        .ready_and()
-        .map_err(|e| eyre!(e))
-        .await?;
+    let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
     /// SPANDOC: Set up the future for block 415000
     let verify_future = timeout(
         Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
@@ -547,10 +534,7 @@ async fn wrong_checkpoint_hash_fail() -> Result<(), Report> {
     );
 
     /// SPANDOC: Make sure the verifier service is ready (1/3)
-    let ready_verifier_service = checkpoint_verifier
-        .ready_and()
-        .map_err(|e| eyre!(e))
-        .await?;
+    let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
     /// SPANDOC: Set up the future for bad block 0 (1/3)
     // TODO(teor || jlusby): check error kind
     let bad_verify_future_1 = timeout(
@@ -574,10 +558,7 @@ async fn wrong_checkpoint_hash_fail() -> Result<(), Report> {
     );
 
     /// SPANDOC: Make sure the verifier service is ready (2/3)
-    let ready_verifier_service = checkpoint_verifier
-        .ready_and()
-        .map_err(|e| eyre!(e))
-        .await?;
+    let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
     /// SPANDOC: Set up the future for bad block 0 again (2/3)
     // TODO(teor || jlusby): check error kind
     let bad_verify_future_2 = timeout(
@@ -601,10 +582,7 @@ async fn wrong_checkpoint_hash_fail() -> Result<(), Report> {
     );
 
     /// SPANDOC: Make sure the verifier service is ready (3/3)
-    let ready_verifier_service = checkpoint_verifier
-        .ready_and()
-        .map_err(|e| eyre!(e))
-        .await?;
+    let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
     /// SPANDOC: Set up the future for good block 0 (3/3)
     let good_verify_future = timeout(
         Duration::from_secs(VERIFY_TIMEOUT_SECONDS),
@@ -732,10 +710,7 @@ async fn checkpoint_drop_cancel() -> Result<(), Report> {
     // Now collect verify futures for each block
     for (block, height, hash) in checkpoint_data {
         /// SPANDOC: Make sure the verifier service is ready
-        let ready_verifier_service = checkpoint_verifier
-            .ready_and()
-            .map_err(|e| eyre!(e))
-            .await?;
+        let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
 
         /// SPANDOC: Set up the future for block {?height}
         let verify_future = timeout(
@@ -811,10 +786,7 @@ async fn hard_coded_mainnet() -> Result<(), Report> {
     assert!(checkpoint_verifier.checkpoint_list.max_height() > block::Height(0));
 
     /// SPANDOC: Make sure the verifier service is ready
-    let ready_verifier_service = checkpoint_verifier
-        .ready_and()
-        .map_err(|e| eyre!(e))
-        .await?;
+    let ready_verifier_service = checkpoint_verifier.ready().map_err(|e| eyre!(e)).await?;
     /// SPANDOC: Set up the future for block 0
     let verify_future = timeout(
         Duration::from_secs(VERIFY_TIMEOUT_SECONDS),

--- a/zebra-consensus/src/primitives/ed25519/tests.rs
+++ b/zebra-consensus/src/primitives/ed25519/tests.rs
@@ -22,7 +22,7 @@ where
         let sk = SigningKey::new(&mut rng);
         let vk = VerificationKey::from(&sk);
         let sig = sk.sign(&msg[..]);
-        verifier.ready_and().await?;
+        verifier.ready().await?;
         results.push(span.in_scope(|| verifier.call((vk.into(), sig, msg).into())))
     }
 

--- a/zebra-consensus/src/primitives/groth16/tests.rs
+++ b/zebra-consensus/src/primitives/groth16/tests.rs
@@ -32,7 +32,7 @@ where
             tracing::trace!(?spend);
 
             let spend_rsp = spend_verifier
-                .ready_and()
+                .ready()
                 .await?
                 .call(groth16::ItemWrapper::from(&spend).into());
 
@@ -43,7 +43,7 @@ where
             tracing::trace!(?output);
 
             let output_rsp = output_verifier
-                .ready_and()
+                .ready()
                 .await?
                 .call(groth16::ItemWrapper::from(output).into());
 
@@ -131,7 +131,7 @@ where
             tracing::trace!(?modified_output);
 
             let output_rsp = output_verifier
-                .ready_and()
+                .ready()
                 .await?
                 .call(groth16::ItemWrapper::from(&modified_output).into());
 

--- a/zebra-consensus/src/primitives/redjubjub/tests.rs
+++ b/zebra-consensus/src/primitives/redjubjub/tests.rs
@@ -24,14 +24,14 @@ where
                 let sk = SigningKey::<SpendAuth>::new(&mut rng);
                 let vk = VerificationKey::from(&sk);
                 let sig = sk.sign(&mut rng, &msg[..]);
-                verifier.ready_and().await?;
+                verifier.ready().await?;
                 results.push(span.in_scope(|| verifier.call((vk.into(), sig, msg).into())))
             }
             1 => {
                 let sk = SigningKey::<Binding>::new(&mut rng);
                 let vk = VerificationKey::from(&sk);
                 let sig = sk.sign(&mut rng, &msg[..]);
-                verifier.ready_and().await?;
+                verifier.ready().await?;
                 results.push(span.in_scope(|| verifier.call((vk.into(), sig, msg).into())))
             }
             _ => panic!(),

--- a/zebra-consensus/src/primitives/redpallas/tests.rs
+++ b/zebra-consensus/src/primitives/redpallas/tests.rs
@@ -24,14 +24,14 @@ where
                 let sk = SigningKey::<SpendAuth>::new(&mut rng);
                 let vk = VerificationKey::from(&sk);
                 let sig = sk.sign(&mut rng, &msg[..]);
-                verifier.ready_and().await?;
+                verifier.ready().await?;
                 results.push(span.in_scope(|| verifier.call((vk.into(), sig, msg).into())))
             }
             1 => {
                 let sk = SigningKey::<Binding>::new(&mut rng);
                 let vk = VerificationKey::from(&sk);
                 let sig = sk.sign(&mut rng, &msg[..]);
-                verifier.ready_and().await?;
+                verifier.ready().await?;
                 results.push(span.in_scope(|| verifier.call((vk.into(), sig, msg).into())))
             }
             _ => panic!(),

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1"
 futures = "0.3"
 tokio = { version = "0.3.6", features = ["net", "time", "stream", "tracing", "macros", "rt-multi-thread"] }
 tokio-util = { version = "0.5", features = ["codec"] }
-tower = { version = "0.4", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
+tower = { version = "0.4.9", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 
 metrics = "0.13.0-alpha.8"
 tracing = "0.1"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"
 
 futures = "0.3"
-tokio = { version = "0.3.6", features = ["net", "time", "stream", "tracing", "macros", "rt-multi-thread"] }
+tokio = { version = "1.13.0", features = ["net", "time", "tracing", "macros", "rt-multi-thread"] }
 tokio-util = { version = "0.5", features = ["codec"] }
 tower = { version = "0.4.9", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 
@@ -38,7 +38,7 @@ zebra-chain = { path = "../zebra-chain" }
 [dev-dependencies]
 proptest = "0.10"
 proptest-derive = "0.3"
-tokio = { version = "0.3.6", features = ["test-util"] }
+tokio = { version = "1.13.0", features = ["test-util"] }
 toml = "0.5"
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 bitflags = "1.2"
 byteorder = "1.4"
-bytes = "0.6"
+bytes = "1.1.0"
 chrono = "0.4"
 hex = "0.4"
 # indexmap has rayon support for parallel iteration,
@@ -26,7 +26,7 @@ thiserror = "1"
 futures = "0.3"
 tokio = { version = "1.13.0", features = ["net", "time", "tracing", "macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.7", features = ["sync", "time"] }
-tokio-util = { version = "0.5", features = ["codec"] }
+tokio-util = { version = "0.6.9", features = ["codec"] }
 tower = { version = "0.4.9", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 
 metrics = "0.13.0-alpha.8"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "1"
 
 futures = "0.3"
 tokio = { version = "1.13.0", features = ["net", "time", "tracing", "macros", "rt-multi-thread"] }
+tokio-stream = { version = "0.1.7", features = ["time"] }
 tokio-util = { version = "0.5", features = ["codec"] }
 tower = { version = "0.4.9", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -29,7 +29,7 @@ tokio-stream = { version = "0.1.7", features = ["sync", "time"] }
 tokio-util = { version = "0.6.9", features = ["codec"] }
 tower = { version = "0.4.9", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 
-metrics = "0.13.0-alpha.8"
+metrics = "0.17.0"
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-error = { version = "0.1.2", features = ["traced-error"] }

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1"
 
 futures = "0.3"
 tokio = { version = "1.13.0", features = ["net", "time", "tracing", "macros", "rt-multi-thread"] }
-tokio-stream = { version = "0.1.7", features = ["time"] }
+tokio-stream = { version = "0.1.7", features = ["sync", "time"] }
 tokio-util = { version = "0.5", features = ["codec"] }
 tower = { version = "0.4.9", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -924,7 +924,7 @@ where
         trace!(?req);
         use tower::{load_shed::error::Overloaded, ServiceExt};
 
-        if self.svc.ready_and().await.is_err() {
+        if self.svc.ready().await.is_err() {
             // Treat all service readiness errors as Overloaded
             // TODO: treat `TryRecvError::Closed` in `Inbound::poll_ready` as a fatal error (#1655)
             self.fail_with(PeerError::Overloaded);

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -78,7 +78,7 @@ where
 
         async move {
             let stream = TcpStream::connect(addr).await?;
-            hs.ready_and().await?;
+            hs.ready().await?;
             let client = hs
                 .call(HandshakeRequest {
                     tcp_stream: stream,

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -15,6 +15,7 @@ use futures::{
     future, FutureExt, SinkExt, StreamExt,
 };
 use tokio::{net::TcpStream, sync::broadcast, task::JoinError, time::timeout};
+use tokio_stream::wrappers::IntervalStream;
 use tokio_util::codec::Framed;
 use tower::Service;
 use tracing::{span, Level, Span};
@@ -946,7 +947,8 @@ where
                     let mut shutdown_rx = shutdown_rx;
                     let mut server_tx = server_tx;
                     let mut timestamp_collector = heartbeat_ts_collector.clone();
-                    let mut interval_stream = tokio::time::interval(constants::HEARTBEAT_INTERVAL);
+                    let mut interval_stream =
+                        IntervalStream::new(tokio::time::interval(constants::HEARTBEAT_INTERVAL));
 
                     loop {
                         let shutdown_rx_ref = Pin::new(&mut shutdown_rx);

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -239,7 +239,7 @@ where
         debug!(?fanout_limit, "sending GetPeers requests");
         // TODO: launch each fanout in its own task (might require tokio 1.6)
         for _ in 0..fanout_limit {
-            let peer_service = self.peer_service.ready_and().await?;
+            let peer_service = self.peer_service.ready().await?;
             responses.push(peer_service.call(Request::Peers));
         }
         while let Some(rsp) = responses.next().await {

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -18,6 +18,7 @@ use tokio::{
     sync::broadcast,
     time::{sleep, Instant},
 };
+use tokio_stream::wrappers::IntervalStream;
 use tower::{
     buffer::Buffer, discover::Change, layer::Layer, load::peak_ewma::PeakEwmaDiscover,
     util::BoxService, Service, ServiceExt,
@@ -606,7 +607,8 @@ where
     handshakes.push(future::pending().boxed());
 
     let mut crawl_timer =
-        tokio::time::interval(config.crawl_new_peer_interval).map(|tick| TimerCrawl { tick });
+        IntervalStream::new(tokio::time::interval(config.crawl_new_peer_interval))
+            .map(|tick| TimerCrawl { tick });
 
     loop {
         metrics::gauge!(

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -477,7 +477,7 @@ where
             let _guard = accept_span.enter();
 
             debug!("got incoming connection");
-            handshaker.ready_and().await?;
+            handshaker.ready().await?;
             // TODO: distinguish between proxied listeners and direct listeners
             let handshaker_span = info_span!("listen_handshaker", peer = ?connected_addr);
 
@@ -750,7 +750,7 @@ where
 
     // the connector is always ready, so this can't hang
     let outbound_connector = outbound_connector
-        .ready_and()
+        .ready()
         .await
         .expect("outbound connector never errors");
 

--- a/zebra-network/src/peer_set/inventory_registry.rs
+++ b/zebra-network/src/peer_set/inventory_registry.rs
@@ -10,11 +10,9 @@ use std::{
     time::Duration,
 };
 
-use futures::{Stream, StreamExt};
-use tokio::{
-    sync::broadcast,
-    time::{self, Interval},
-};
+use futures::{FutureExt, Stream, StreamExt};
+use tokio::{sync::broadcast, time};
+use tokio_stream::wrappers::IntervalStream;
 
 use crate::{protocol::external::InventoryHash, BoxError};
 
@@ -38,7 +36,7 @@ pub struct InventoryRegistry {
         >,
     >,
     /// Interval tracking how frequently we should rotate our maps
-    interval: Interval,
+    interval: IntervalStream,
 }
 
 impl std::fmt::Debug for InventoryRegistry {
@@ -57,7 +55,7 @@ impl InventoryRegistry {
             current: Default::default(),
             prev: Default::default(),
             inv_stream: inv_stream.into_stream().boxed(),
-            interval: time::interval(Duration::from_secs(75)),
+            interval: IntervalStream::new(time::interval(Duration::from_secs(75))),
         }
     }
 

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -23,7 +23,7 @@ metrics = "0.13.0-alpha.8"
 tower = { version = "0.4.9", features = ["buffer", "util"] }
 tracing = "0.1"
 thiserror = "1.0.30"
-tokio = { version = "0.3.6", features = ["sync"] }
+tokio = { version = "1.13.0", features = ["sync"] }
 displaydoc = "0.2.2"
 rocksdb = "0.16.0"
 tempdir = "0.3.7"
@@ -46,7 +46,7 @@ once_cell = "1.8"
 itertools = "0.10.1"
 spandoc = "0.2"
 tempdir = "0.3.7"
-tokio = { version = "0.3.6", features = ["full"] }
+tokio = { version = "1.13.0", features = ["full"] }
 # TODO: replace w/ crate version when released: https://github.com/ZcashFoundation/zebra/issues/2083
 # Note: if updating this, also update the workspace Cargo.toml to match.
 halo2 = "=0.1.0-beta.1"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", features = ["serde_derive"] }
 bincode = "1"
 
 futures = "0.3.17"
-metrics = "0.13.0-alpha.8"
+metrics = "0.17.0"
 tower = { version = "0.4.9", features = ["buffer", "util"] }
 tracing = "0.1"
 thiserror = "1.0.30"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -20,7 +20,7 @@ bincode = "1"
 
 futures = "0.3.17"
 metrics = "0.13.0-alpha.8"
-tower = { version = "0.4", features = ["buffer", "util"] }
+tower = { version = "0.4.9", features = ["buffer", "util"] }
 tracing = "0.1"
 thiserror = "1.0.30"
 tokio = { version = "0.3.6", features = ["sync"] }

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -37,7 +37,7 @@ async fn populated_state(
     let mut responses = FuturesUnordered::new();
 
     for request in requests {
-        let rsp = state.ready_and().await.unwrap().call(request);
+        let rsp = state.ready().await.unwrap().call(request);
         responses.push(rsp);
     }
 

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -15,7 +15,7 @@ proptest = "0.10.1"
 rand = "0.8"
 regex = "1.4.6"
 
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.4.9", features = ["util"] }
 tokio = { version = "0.3", features = ["full"] }
 futures = "0.3.17"
 

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -15,8 +15,8 @@ proptest = "0.10.1"
 rand = "0.8"
 regex = "1.4.6"
 
+tokio = { version = "1.13.0", features = ["full"] }
 tower = { version = "0.4.9", features = ["util"] }
-tokio = { version = "0.3", features = ["full"] }
 futures = "0.3.17"
 
 color-eyre = "0.5.11"

--- a/zebra-test/src/transcript.rs
+++ b/zebra-test/src/transcript.rs
@@ -98,7 +98,7 @@ where
             // These unwraps could propagate errors with the correct
             // bound on C::Error
             let fut = to_check
-                .ready_and()
+                .ready()
                 .await
                 .map_err(Into::into)
                 .map_err(|e| eyre!(e))

--- a/zebra-test/tests/transcript.rs
+++ b/zebra-test/tests/transcript.rs
@@ -23,11 +23,11 @@ async fn transcript_returns_responses_and_ends() {
 
     for (req, rsp) in TRANSCRIPT_DATA.iter() {
         assert_eq!(
-            svc.ready_and().await.unwrap().call(req).await.unwrap(),
+            svc.ready().await.unwrap().call(req).await.unwrap(),
             *rsp.as_ref().unwrap()
         );
     }
-    assert!(svc.ready_and().await.unwrap().call("end").await.is_err());
+    assert!(svc.ready().await.unwrap().call("end").await.is_err());
 }
 
 #[tokio::test]
@@ -37,10 +37,10 @@ async fn transcript_errors_wrong_request() {
     let mut svc = Transcript::from(TRANSCRIPT_DATA.iter().cloned());
 
     assert_eq!(
-        svc.ready_and().await.unwrap().call("req1").await.unwrap(),
+        svc.ready().await.unwrap().call("req1").await.unwrap(),
         "rsp1",
     );
-    assert!(svc.ready_and().await.unwrap().call("bad").await.is_err());
+    assert!(svc.ready().await.unwrap().call("bad").await.is_err());
 }
 
 #[tokio::test]

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1", features = ["serde_derive"] }
 toml = "0.5"
 chrono = "0.4"
 
-hyper = { version = "0.14.0-dev", features = ["full"] }
+hyper = { version = "0.14.13", features = ["full"] }
 futures = "0.3"
 tokio = { version = "1.13.0", features = ["time", "rt-multi-thread", "macros", "tracing", "signal"] }
 tower = { version = "0.4.9", features = ["hedge", "limit"] }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -36,8 +36,8 @@ tracing-flame = "0.1.0"
 tracing-journald = "0.1.0"
 tracing-subscriber = { version = "0.2.25", features = ["tracing-log"] }
 tracing-error = "0.1.2"
-metrics = "0.13.0-alpha.8"
-metrics-exporter-prometheus = "0.1.0-alpha.7"
+metrics = "0.17.0"
+metrics-exporter-prometheus = "0.6.1"
 
 dirs = "4.0.0"
 inferno = { version = "0.10.7", default-features = false }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -23,7 +23,7 @@ chrono = "0.4"
 
 hyper = { version = "0.14.0-dev", features = ["full"] }
 futures = "0.3"
-tokio = { version = "0.3.6", features = ["time", "rt-multi-thread", "stream", "macros", "tracing", "signal"] }
+tokio = { version = "1.13.0", features = ["time", "rt-multi-thread", "macros", "tracing", "signal"] }
 tower = { version = "0.4.9", features = ["hedge", "limit"] }
 pin-project = "1.0.7"
 
@@ -57,7 +57,7 @@ once_cell = "1.8"
 regex = "1.4.6"
 semver = "1.0.3"
 tempdir = "0.3.7"
-tokio = { version = "0.3.6", features = ["full", "test-util"] }
+tokio = { version = "1.13.0", features = ["full", "test-util"] }
 
 proptest = "0.10"
 proptest-derive = "0.3"

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -43,8 +43,8 @@ dirs = "4.0.0"
 inferno = { version = "0.10.7", default-features = false }
 atty = "0.2.14"
 
-sentry = { version = "0.21.0", default-features = false, features = ["backtrace", "contexts", "reqwest", "rustls"] }
-sentry-tracing = { git = "https://github.com/kellpossible/sentry-tracing.git", rev = "f1a4a4a16b5ff1022ae60be779eb3fb928ce9b0f" }
+sentry = { version = "0.23.0", default-features = false, features = ["backtrace", "contexts", "reqwest", "rustls"] }
+sentry-tracing = "0.23.0"
 
 rand = "0.8.4"
 

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4"
 hyper = { version = "0.14.0-dev", features = ["full"] }
 futures = "0.3"
 tokio = { version = "0.3.6", features = ["time", "rt-multi-thread", "stream", "macros", "tracing", "signal"] }
-tower = { version = "0.4", features = ["hedge", "limit"] }
+tower = { version = "0.4.9", features = ["hedge", "limit"] }
 pin-project = "1.0.7"
 
 color-eyre = { version = "0.5.11", features = ["issue-url"] }

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -306,14 +306,11 @@ impl Application for ZebradApp {
         // The Sentry default config pulls in the DSN from the `SENTRY_DSN`
         // environment variable.
         #[cfg(feature = "enable-sentry")]
-        let guard = sentry::init(
-            sentry::ClientOptions {
-                debug: true,
-                release: Some(app_version().to_string().into()),
-                ..Default::default()
-            }
-            .add_integration(sentry_tracing::TracingIntegration::default()),
-        );
+        let guard = sentry::init(sentry::ClientOptions {
+            debug: true,
+            release: Some(app_version().to_string().into()),
+            ..Default::default()
+        });
 
         std::panic::set_hook(Box::new(move |panic_info| {
             let panic_report = panic_hook.panic_report(panic_info);

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -609,7 +609,7 @@ async fn setup(
         .zcash_deserialize_into()
         .unwrap();
     state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zebra_state::Request::CommitFinalizedBlock(

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -197,7 +197,7 @@ where
         for _ in 0..FANOUT {
             let mut peer_set = peer_set.clone();
             // end the task on permanent peer set errors
-            let peer_set = peer_set.ready_and().await?;
+            let peer_set = peer_set.ready().await?;
 
             requests.push(peer_set.call(zn::Request::MempoolTransactionIds));
         }
@@ -242,7 +242,7 @@ where
 
         let call_result = self
             .mempool
-            .ready_and()
+            .ready()
             .await?
             .call(mempool::Request::Queue(transaction_ids))
             .await;

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -443,7 +443,7 @@ where
     ) -> Result<(), TransactionDownloadVerifyError> {
         // Check if the transaction is already in the state.
         match state
-            .ready_and()
+            .ready()
             .await
             .map_err(|e| TransactionDownloadVerifyError::StateError(e))?
             .call(zs::Request::Transaction(txid.mined_id()))

--- a/zebrad/src/components/mempool/gossip.rs
+++ b/zebrad/src/components/mempool/gossip.rs
@@ -44,7 +44,7 @@ where
         info!(?request, "sending mempool transaction broadcast");
 
         // broadcast requests don't return errors, and we'd just want to ignore them anyway
-        let _ = broadcast_network.ready_and().await?.call(request).await;
+        let _ = broadcast_network.ready().await?.call(request).await;
 
         metrics::counter!("mempool.gossiped.transactions.total", txs_len as _);
     }

--- a/zebrad/src/components/mempool/queue_checker.rs
+++ b/zebrad/src/components/mempool/queue_checker.rs
@@ -69,7 +69,7 @@ where
         // So we propagate any unexpected errors to the task that spawned us.
         let response = self
             .mempool
-            .ready_and()
+            .ready()
             .await?
             .call(mempool::Request::CheckForVerifiedTransactions)
             .await?;

--- a/zebrad/src/components/mempool/storage/verified_set.rs
+++ b/zebrad/src/components/mempool/storage/verified_set.rs
@@ -267,6 +267,6 @@ impl VerifiedSet {
             "zcash.mempool.size.bytes",
             self.transactions_serialized_size as _
         );
-        metrics::gauge!("zcash.mempool.cost.bytes", u64::from(self.total_cost) as _);
+        metrics::gauge!("zcash.mempool.cost.bytes", self.total_cost as _);
     }
 }

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -63,7 +63,7 @@ async fn mempool_service_basic_single() -> Result<(), Report> {
 
     // Test `Request::TransactionIds`
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::TransactionIds)
@@ -80,7 +80,7 @@ async fn mempool_service_basic_single() -> Result<(), Report> {
         .copied()
         .collect::<HashSet<_>>();
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::TransactionsById(
@@ -109,7 +109,7 @@ async fn mempool_service_basic_single() -> Result<(), Report> {
 
     // Test `Request::RejectedTransactionIds`
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::RejectedTransactionIds(
@@ -127,7 +127,7 @@ async fn mempool_service_basic_single() -> Result<(), Report> {
     // Test `Request::Queue`
     // Use the ID of the last transaction in the list
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![last_transaction.transaction.id.into()]))
@@ -190,7 +190,7 @@ async fn mempool_queue_single() -> Result<(), Report> {
 
     // Test `Request::Queue` for a new transaction
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![new_tx.transaction.id.into()]))
@@ -207,7 +207,7 @@ async fn mempool_queue_single() -> Result<(), Report> {
     // They should all be rejected; either because they are already in the mempool,
     // or because they are in the recently evicted list.
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(
@@ -273,7 +273,7 @@ async fn mempool_service_disabled() -> Result<(), Report> {
 
     // Test if the mempool answers correctly (i.e. is enabled)
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::TransactionIds)
@@ -288,7 +288,7 @@ async fn mempool_service_disabled() -> Result<(), Report> {
     // Use the ID of the last transaction in the list
     let txid = more_transactions.last().unwrap().transaction.id;
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![txid.into()]))
@@ -310,7 +310,7 @@ async fn mempool_service_disabled() -> Result<(), Report> {
 
     // Test if the mempool returns no transactions when disabled
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::TransactionIds)
@@ -329,7 +329,7 @@ async fn mempool_service_disabled() -> Result<(), Report> {
 
     // Test if the mempool returns to Queue requests correctly when disabled
     let response = service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![txid.into()]))
@@ -371,7 +371,7 @@ async fn mempool_cancel_mined() -> Result<(), Report> {
         .zcash_deserialize_into()
         .unwrap();
     state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zebra_state::Request::CommitFinalizedBlock(
@@ -385,7 +385,7 @@ async fn mempool_cancel_mined() -> Result<(), Report> {
 
     // Push block 1 to the state
     state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zebra_state::Request::CommitFinalizedBlock(
@@ -402,7 +402,7 @@ async fn mempool_cancel_mined() -> Result<(), Report> {
     // which cancels all downloads.
     let txid = block2.transactions[0].unmined_id();
     let response = mempool
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![txid.into()]))
@@ -464,7 +464,7 @@ async fn mempool_cancel_downloads_after_network_upgrade() -> Result<(), Report> 
         .zcash_deserialize_into()
         .unwrap();
     state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zebra_state::Request::CommitFinalizedBlock(
@@ -476,7 +476,7 @@ async fn mempool_cancel_downloads_after_network_upgrade() -> Result<(), Report> 
     // Queue transaction from block 2 for download
     let txid = block2.transactions[0].unmined_id();
     let response = mempool
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![txid.into()]))
@@ -496,7 +496,7 @@ async fn mempool_cancel_downloads_after_network_upgrade() -> Result<(), Report> 
     // Push block 1 to the state. This is considered a network upgrade,
     // and thus must cancel all pending transaction downloads.
     state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zebra_state::Request::CommitFinalizedBlock(
@@ -537,7 +537,7 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
         .zcash_deserialize_into()
         .unwrap();
     state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zebra_state::Request::CommitFinalizedBlock(
@@ -549,7 +549,7 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
     // Queue first transaction for verification
     // (queue the transaction itself to avoid a download).
     let request = mempool
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![rejected_tx.transaction.clone().into()]));
@@ -576,7 +576,7 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
     // Try to queue the same transaction by its ID and check if it's correctly
     // rejected.
     let response = mempool
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![rejected_tx.transaction.id.into()]))
@@ -620,7 +620,7 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
         .zcash_deserialize_into()
         .unwrap();
     state_service
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(zebra_state::Request::CommitFinalizedBlock(
@@ -631,7 +631,7 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
 
     // Queue second transaction for download and verification.
     let request = mempool
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![rejected_valid_tx
@@ -663,7 +663,7 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
     // Try to queue the same transaction by its ID and check if it's not being
     // rejected.
     let response = mempool
-        .ready_and()
+        .ready()
         .await
         .unwrap()
         .call(Request::Queue(vec![rejected_valid_tx

--- a/zebrad/src/components/metrics.rs
+++ b/zebrad/src/components/metrics.rs
@@ -27,19 +27,16 @@ impl MetricsEndpoint {
                     // We manually expand the metrics::increment!() macro because it only
                     // supports string literals for metrics names, preventing us from
                     // using concat!() to build the name.
-                    static METRIC_NAME: [metrics::SharedString; 2] = [
-                        metrics::SharedString::const_str(env!("CARGO_PKG_NAME")),
-                        metrics::SharedString::const_str("build.info"),
-                    ];
+                    static METRIC_NAME: &str = concat!(env!("CARGO_PKG_NAME"), ".build.info");
                     static METRIC_LABELS: [metrics::Label; 1] =
                         [metrics::Label::from_static_parts(
                             "version",
                             env!("CARGO_PKG_VERSION"),
                         )];
-                    static METRIC_KEY: metrics::KeyData =
-                        metrics::KeyData::from_static_parts(&METRIC_NAME, &METRIC_LABELS);
+                    static METRIC_KEY: metrics::Key =
+                        metrics::Key::from_static_parts(METRIC_NAME, &METRIC_LABELS);
                     if let Some(recorder) = metrics::try_recorder() {
-                        recorder.increment_counter(metrics::Key::Borrowed(&METRIC_KEY), 1);
+                        recorder.increment_counter(&METRIC_KEY, 1);
                     }
                 }
                 Err(e) => panic!(

--- a/zebrad/src/components/metrics.rs
+++ b/zebrad/src/components/metrics.rs
@@ -23,21 +23,10 @@ impl MetricsEndpoint {
                     // Expose binary metadata to metrics, using a single time series with
                     // value 1:
                     //     https://www.robustperception.io/exposing-the-software-version-to-prometheus
-                    //
-                    // We manually expand the metrics::increment!() macro because it only
-                    // supports string literals for metrics names, preventing us from
-                    // using concat!() to build the name.
-                    static METRIC_NAME: &str = concat!(env!("CARGO_PKG_NAME"), ".build.info");
-                    static METRIC_LABELS: [metrics::Label; 1] =
-                        [metrics::Label::from_static_parts(
-                            "version",
-                            env!("CARGO_PKG_VERSION"),
-                        )];
-                    static METRIC_KEY: metrics::Key =
-                        metrics::Key::from_static_parts(METRIC_NAME, &METRIC_LABELS);
-                    if let Some(recorder) = metrics::try_recorder() {
-                        recorder.increment_counter(&METRIC_KEY, 1);
-                    }
+                    metrics::increment_counter!(
+                        format!("{}.build.info", env!("CARGO_PKG_NAME")),
+                        "version" => env!("CARGO_PKG_VERSION")
+                    );
                 }
                 Err(e) => panic!(
                     "Opening metrics endpoint listener {:?} failed: {:?}. \

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -481,7 +481,7 @@ where
                     let new_download_len = download_set.len();
                     let new_hashes = new_download_len - prev_download_len;
                     tracing::debug!(new_hashes, "added hashes to download set");
-                    metrics::histogram!("sync.obtain.response.hash.count", new_hashes as u64);
+                    metrics::histogram!("sync.obtain.response.hash.count", new_hashes as f64);
                 }
                 Ok(_) => unreachable!("network returned wrong response"),
                 // We ignore this error because we made multiple fanout requests.
@@ -613,7 +613,7 @@ where
                         let new_download_len = download_set.len();
                         let new_hashes = new_download_len - prev_download_len;
                         tracing::debug!(new_hashes, "added hashes to download set");
-                        metrics::histogram!("sync.extend.response.hash.count", new_hashes as u64);
+                        metrics::histogram!("sync.extend.response.hash.count", new_hashes as f64);
                     }
                     Ok(_) => unreachable!("network returned wrong response"),
                     // We ignore this error because we made multiple fanout requests.

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -385,7 +385,7 @@ where
     async fn obtain_tips(&mut self) -> Result<(), Report> {
         let block_locator = self
             .state
-            .ready_and()
+            .ready()
             .await
             .map_err(|e| eyre!(e))?
             .call(zebra_state::Request::BlockLocator)
@@ -403,16 +403,12 @@ where
 
         let mut requests = FuturesUnordered::new();
         for _ in 0..FANOUT {
-            requests.push(
-                self.tip_network
-                    .ready_and()
-                    .await
-                    .map_err(|e| eyre!(e))?
-                    .call(zn::Request::FindBlocks {
-                        known_blocks: block_locator.clone(),
-                        stop: None,
-                    }),
-            );
+            requests.push(self.tip_network.ready().await.map_err(|e| eyre!(e))?.call(
+                zn::Request::FindBlocks {
+                    known_blocks: block_locator.clone(),
+                    stop: None,
+                },
+            ));
         }
 
         let mut download_set = HashSet::new();
@@ -526,16 +522,12 @@ where
             tracing::debug!(?tip, "asking peers to extend chain tip");
             let mut responses = FuturesUnordered::new();
             for _ in 0..FANOUT {
-                responses.push(
-                    self.tip_network
-                        .ready_and()
-                        .await
-                        .map_err(|e| eyre!(e))?
-                        .call(zn::Request::FindBlocks {
-                            known_blocks: vec![tip.tip],
-                            stop: None,
-                        }),
-                );
+                responses.push(self.tip_network.ready().await.map_err(|e| eyre!(e))?.call(
+                    zn::Request::FindBlocks {
+                        known_blocks: vec![tip.tip],
+                        stop: None,
+                    },
+                ));
             }
             while let Some(res) = responses.next().await {
                 match res.map_err::<Report, _>(|e| eyre!(e)) {
@@ -689,7 +681,7 @@ where
     async fn state_contains(&mut self, hash: block::Hash) -> Result<bool, Report> {
         match self
             .state
-            .ready_and()
+            .ready()
             .await
             .map_err(|e| eyre!(e))?
             .call(zebra_state::Request::Depth(hash))

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -167,7 +167,7 @@ where
         tracing::debug!("waiting to request block");
         let block_req = self
             .network
-            .ready_and()
+            .ready()
             .await
             .map_err(|e| eyre!(e))?
             .call(zn::Request::BlocksByHash(std::iter::once(hash).collect()));
@@ -201,7 +201,7 @@ where
                 metrics::counter!("sync.downloaded.block.count", 1);
 
                 let rsp = verifier
-                    .ready_and()
+                    .ready()
                     .await
                     .map_err(BlockDownloadVerifyError::VerifierError)?
                     .call(block);

--- a/zebrad/src/components/sync/gossip.rs
+++ b/zebrad/src/components/sync/gossip.rs
@@ -76,7 +76,7 @@ where
 
         // broadcast requests don't return errors, and we'd just want to ignore them anyway
         let _ = broadcast_network
-            .ready_and()
+            .ready()
             .await
             .map_err(PeerSetReadiness)?
             .call(request)

--- a/zebrad/src/components/sync/status/tests.rs
+++ b/zebrad/src/components/sync/status/tests.rs
@@ -100,7 +100,7 @@ proptest! {
 
                 let awoke = match timeout(EVENT_TIMEOUT, wake_events.acquire()).await {
                     Ok(permit) => {
-                        permit.forget();
+                        permit.expect("Sempahore closed prematurely").forget();
                         true
                     }
                     Err(_) => false,
@@ -127,7 +127,7 @@ proptest! {
             wake_events: Arc<Semaphore>,
         ) -> Result<(), TestCaseError> {
             loop {
-                update_events.acquire().await.forget();
+                update_events.acquire().await.expect("Sempahore closed prematurely").forget();
 
                 // The refactor suggested by clippy is harder to read and understand.
                 #[allow(clippy::question_mark)]

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -46,7 +46,10 @@ impl Tracing {
             None
         };
 
-        let subscriber = builder.finish().with(ErrorLayer::default());
+        let subscriber = builder
+            .finish()
+            .with(ErrorLayer::default())
+            .with(sentry_tracing::layer());
         match (flamelayer, journaldlayer) {
             (None, None) => subscriber.init(),
             (Some(layer1), None) => subscriber.with(layer1).init(),

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1127,7 +1127,7 @@ async fn metrics_endpoint() -> Result<()> {
     let output = output.assert_failure()?;
 
     output.any_output_line_contains(
-        "metrics snapshot",
+        "# TYPE zebrad_build_info counter",
         &body,
         "metrics exporter response",
         "the metrics response header",


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
This is the PR with all the rolled-up changes that are part of the update to use Tokio version 1 (#2200). When it is merged, the other draft PRs must be closed:

- #2918
- #2920 
- #2922
- #2934
- #2935 
- #2936 
- #2937 
- #2954 

Newer versions of Tokio have some interesting features, as well as unblocking Zebra from updating other dependencies.

Closes #2200.
Closes #2735.
Closes #1086.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Updates Tokio to version `1.13.0`, and makes Zebra compatible with it.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
Tokio recently released a new version: [1.13.0](https://github.com/tokio-rs/tokio/releases/tag/tokio-1.13.0). Should this PR update to it or should it be done in a separate PR?