### PR TITLE
Update README troubleshooting and beta scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,10 @@ These are some of advantages or benefits of Zebra:
 
 Every few weeks, we release a new Zebra beta [release](https://github.com/ZcashFoundation/zebra/releases).
 
-The goals of the beta release series are for Zebra to act as a fully validating Canopy and NU5 node, except for:
+Zebra's network stack is interoperable with `zcashd`,
+and Zebra implements all the features required to reach Zcash network consensus.
 
-- Mempool transactions
-- Block subsidies
-- Transaction fees
-- Some undocumented rules derived from Bitcoin
-- Some consensus rules removed before Canopy activation (Zebra checkpoints on Canopy activation)
-
-Zebra's network stack is interoperable with zcashd.
-Zebra implements all the features required to reach Zcash network consensus.
-
+The goals of the beta release series are for Zebra to act as a fully validating Canopy and NU5 node.
 Currently, Zebra does not validate the following Zcash consensus rules:
 
 #### NU5
@@ -115,8 +108,9 @@ Currently, Zebra does not validate the following Zcash consensus rules:
 - Validation of transaction lock times
 - Validation of sprout note commitment trees
 
-It may be unreliable on Testnet, and under less-than-perfect network conditions.
-See our [roadmap](#future-work) for details.
+#### Other
+- Undocumented rules derived from Bitcoin
+- Undocumented network protocol requirements
 
 ## Getting Started
 
@@ -201,6 +195,9 @@ For more detailed information, refer to the [documentation](https://zebra.zfnd.o
 Some of Zebra's tests download Zcash blocks, so they might be unreliable depending on your network connection.
 You can set `ZEBRA_SKIP_NETWORK_TESTS=1` to skip the network tests.
 
+Zebra may be unreliable on Testnet, and under less-than-perfect network conditions.
+See our [roadmap](#future-work) for details.
+
 ## Known Issues
 
 There are a few bugs in Zebra that we're still working on fixing:
@@ -236,6 +233,11 @@ Performance and Reliability:
 - Reliable syncing under poor network conditions
 - Batch verification
 - Performance tuning
+
+Currently, the following features are out of scope:
+- Mining support
+- Optional Zcash network protocol messages
+- Consensus rules removed before Canopy activation (Zebra checkpoints on Canopy activation)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 - [About](#about)
 - [Beta Releases](#beta-releases)
 - [Getting Started](#getting-started)
-- [Current Features](#current-features)
 - [Known Issues](#known-issues)
 - [Future Work](#future-work)
 - [Documentation](#documentation)
@@ -116,10 +115,8 @@ Currently, Zebra does not validate the following Zcash consensus rules:
 - Validation of transaction lock times
 - Validation of sprout note commitment trees
 
-It may be
-unreliable on Testnet, and under less-than-perfect network conditions. See
-our [current features](#current-features) and [roadmap](#future-work) for
-details.
+It may ben unreliable on Testnet, and under less-than-perfect network conditions.
+See our [roadmap](#future-work) for details.
 
 ## Getting Started
 
@@ -158,10 +155,23 @@ We continuously test that our builds and tests pass on:
 - Ubuntu 18.04 / the latest LTS
 - Debian Buster
 
+Zebra's tests can take over an hour, depending on your machine.
+We're working on making them faster.
+
 `zebrad` might build and run fine on smaller and slower systems - we haven't
 tested its exact limits yet.
 
 For more detailed requirements, refer to the [documentation](https://zebra.zfnd.org/user/requirements.html).
+
+#### Memory Troubleshooting
+
+If Zebra's build runs out of RAM, try setting:
+`export CARGO_BUILD_JOBS=2`
+
+If Zebra's tests timeout or run out of RAM, try running:
+`cargo test -- --test-threads=2`
+
+(cargo uses all the processor cores on your machine by default.)
 
 ### Network Ports and Data Usage
 
@@ -175,35 +185,10 @@ By default, Zebra uses the following inbound TCP listener ports:
 
 For more detailed information, refer to the [documentation](https://zebra.zfnd.org/user/run.html).
 
-## Current Features
+#### Network Troubleshooting
 
-Network:
-- Synchronize the chain from peers
-- Maintain a transaction mempool
-- Download gossiped blocks and transactions from peers
-- Answer inbound peer requests for hashes, headers, blocks and transactions
-
-State:
-- Persist block, transaction, UTXO, and nullifier indexes
-- Handle chain reorganizations
-
-Proof of Work:
-- Validate equihash, block difficulty threshold, and difficulty adjustment
-- Validate transaction merkle roots
-
-Validating proof of work increases the cost of creating a consensus split
-between `zebrad` and `zcashd`.
-
-This release also implements some other Zcash consensus rules, to check that
-Zebra's [validation architecture](https://zebra.zfnd.org/dev/overview.html#architecture)
-supports future work on a
-full validating node:
-- Block and transaction structure
-- Checkpoint-based verification up to and including Canopy activation
-- Transaction validation (incomplete)
-- Transaction cryptography (incomplete)
-- Transaction scripts (incomplete)
-- Batch verification (incomplete)
+Some of Zebra's tests download Zcash blocks, so they might be unreliable depending on your network connection.
+You can set `ZEBRA_SKIP_NETWORK_TESTS=1` to skip the network tests.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,17 @@ If Zebra's tests timeout or run out of RAM, try running:
 
 (cargo uses all the processor cores on your machine by default.)
 
+#### macOS Test Troubleshooting
+
+Some of Zebra's tests deliberately cause errors that make Zebra panic.
+macOS records these panics as crash reports.
+
+If you are seeing "Crash Reporter" dialogs during Zebra tests,
+you can disable them using this Terminal.app command:
+```sh
+defaults write com.apple.CrashReporter DialogType none
+```
+
 ### Network Ports and Data Usage
 
 By default, Zebra uses the following inbound TCP listener ports:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Currently, Zebra does not validate the following Zcash consensus rules:
 - Validation of transaction lock times
 - Validation of sprout note commitment trees
 
-It may ben unreliable on Testnet, and under less-than-perfect network conditions.
+It may be unreliable on Testnet, and under less-than-perfect network conditions.
 See our [roadmap](#future-work) for details.
 
 ## Getting Started


### PR DESCRIPTION
## Motivation

1. We shared some troubleshooting tips with external users, so we want to add them to the README
2. macOS can report crashes in the Zebra tests, which is confusing for users
3. The "current features" section is outdated and overlaps with the "beta" section
4. The summary of missing features in the beta section is confusing and incomplete

This is unscheduled but expected beta-related work in sprint 22.

Closes #2990.

## Solution

1. Add troubleshooting tips to the README
2. Document that macOS can report crashes in the Zebra tests, but they are intentional
3. Delete the "current features" section
4. Update the summary in the beta section from the detailed list

## Review

Anyone can review this low-priority PR.

### Reviewer Checklist

  - [x] Documentation makes sense
  - [ ] Do we want to keep anything from the "current features" section?

