### PR TITLE
Disable an unreliable network test on macOS

### DIFF
--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -949,6 +949,10 @@ async fn listener_peer_limit_default_handshake_error() {
 
 /// Test the listener with the default inbound peer limit,
 /// and a handshaker that returns success then disconnects the peer.
+///
+/// TODO: tweak the crawler timeouts and rate-limits so we get over the actual limit on macOS
+///       (currently, getting over the limit can take 30 seconds or more)
+#[cfg(not(target_os = "macos"))]
 #[tokio::test]
 async fn listener_peer_limit_default_handshake_ok_then_drop() {
     zebra_test::init();


### PR DESCRIPTION
## Motivation

One of our new network tests is unreliable on macOS.

This is unexpected beta work in sprint 22.
I needed to fix this bug to reproduce some high-priority macOS crashes (#2990).

## Solution

Disable the test, but only on macOS.
I tried using a lower peer limit, but that didn't work.

Closes #2979.

## Review

Anyone can review this low-priority fix.

@rex4539 can you confirm that this fix solves the `listener_peer_limit_default_handshake_ok_then_drop` test failure?

### Reviewer Checklist

  - [ ] Test changes make sense
  - [ ] Test passes in CI

