### PR TITLE
Update README when tagging a new release

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -92,6 +92,17 @@ Also check for crates that depend on crates that have changed. They should get a
 
 - [ ] After any changes, test that the `cargo install` command in works. Use
       e.g. `cargo install --locked --path zebrad`.
+      
+## README
+
+As we resolve various outstanding known issues and implement new functionality with each release, we should double check the README for any necessary updates.
+
+We should check and update if necessary:
+
+- [ ] The "Beta Release" section
+- [ ] The "Known Issues" section 
+
+to ensure that any items that are resolved in the latest release are no longer listed in the README. 
 
 ## Change Log
 


### PR DESCRIPTION
Include potential changes to the README in the release checklist

## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

The "Beta releases" and "Known Issues" sections of the README list a number of items that may change as we implement new features and fix issues in Zebra and subsequently tag beta releases including these updates. 

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Add an item to the release checklist to remind the release manager and reviewers to check if there are any updates that we can make to the README with each tagged release.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

This is a very low priority change

### Reviewer Checklist

  - [x] Changes make sense
  - [x] Content is in the right place
  - [x] Content is visible and noticeable to anyone tagging a new release

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
Actually update the README if necessary when tagging a new beta release