### PR TITLE
Re-enable duplicate dependency checking for `inferno`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -58,9 +58,6 @@ skip-tree = [
     # tickets #2985 and #2391: tempdir & rand dependencies
     { name = "tempdir", version = "=0.3.7" },
 
-    # ticket #2980: inferno dependencies
-    { name = "inferno", version = "=0.10.7" },
-
     # ticket #2998: base64 dependencies
     { name = "base64", version = "=0.10.1" },
 


### PR DESCRIPTION
## Motivation

The dependabot update in PR #3011 fixed the duplicate dependencies from `inferno`.

So we need to clean up the dependency checker config file.

Closes #2980.