### PR TITLE
Replace read_compactsize and write_compactsize with CompactSizeMessage 

### DIFF
--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Duration, Utc};
 use thiserror::Error;
 
 use crate::{
-    serialization::{TrustedPreallocate, MAX_PROTOCOL_MESSAGE_LEN},
+    serialization::{CompactSizeMessage, TrustedPreallocate, MAX_PROTOCOL_MESSAGE_LEN},
     work::{difficulty::CompactDifficulty, equihash::Solution},
 };
 
@@ -129,10 +129,11 @@ impl Header {
 pub struct CountedHeader {
     /// The header for a block
     pub header: Header,
+
     /// The number of transactions that come after the header
     ///
     /// TODO: should this always be zero? (#1924)
-    pub transaction_count: usize,
+    pub transaction_count: CompactSizeMessage,
 }
 
 /// The serialized size of a Zcash block header.

--- a/zebra-chain/src/block/serialize.rs
+++ b/zebra-chain/src/block/serialize.rs
@@ -5,8 +5,7 @@ use chrono::{TimeZone, Utc};
 
 use crate::{
     serialization::{
-        ReadZcashExt, SerializationError, WriteZcashExt, ZcashDeserialize, ZcashDeserializeInto,
-        ZcashSerialize,
+        ReadZcashExt, SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
     },
     work::{difficulty::CompactDifficulty, equihash},
 };
@@ -89,7 +88,7 @@ impl ZcashDeserialize for Header {
 impl ZcashSerialize for CountedHeader {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         self.header.zcash_serialize(&mut writer)?;
-        writer.write_compactsize(self.transaction_count as u64)?;
+        self.transaction_count.zcash_serialize(&mut writer)?;
         Ok(())
     }
 }
@@ -98,7 +97,7 @@ impl ZcashDeserialize for CountedHeader {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
         Ok(CountedHeader {
             header: (&mut reader).zcash_deserialize_into()?,
-            transaction_count: reader.read_compactsize()?.try_into().unwrap(),
+            transaction_count: (&mut reader).zcash_deserialize_into()?,
         })
     }
 }

--- a/zebra-chain/src/serialization/read_zcash.rs
+++ b/zebra-chain/src/serialization/read_zcash.rs
@@ -1,97 +1,14 @@
 use std::{
-    convert::TryInto,
     io,
     net::{IpAddr, Ipv6Addr, SocketAddr},
 };
 
-use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
-
-use super::{SerializationError, MAX_PROTOCOL_MESSAGE_LEN};
+use byteorder::{BigEndian, ReadBytesExt};
 
 /// Extends [`Read`] with methods for writing Zcash/Bitcoin types.
 ///
 /// [`Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
 pub trait ReadZcashExt: io::Read {
-    /// Reads a `u64` using the Bitcoin `CompactSize` encoding.
-    ///
-    /// # Security
-    ///
-    /// Deserialized sizes must be validated before being used.
-    ///
-    /// Preallocating vectors using untrusted `CompactSize`s allows memory
-    /// denial of service attacks. Valid sizes must be less than
-    /// `MAX_PROTOCOL_MESSAGE_LEN / min_serialized_item_bytes` (or a lower limit
-    /// specified by the Zcash consensus rules or Bitcoin network protocol).
-    ///
-    /// As a defence-in-depth for memory preallocation attacks,
-    /// Zebra rejects sizes greater than the protocol message length limit.
-    /// (These sizes should be impossible, because each array items takes at
-    /// least one byte.)
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use zebra_chain::serialization::ReadZcashExt;
-    ///
-    /// use std::io::Cursor;
-    /// assert_eq!(
-    ///     0x12,
-    ///     Cursor::new(b"\x12")
-    ///         .read_compactsize().unwrap()
-    /// );
-    /// assert_eq!(
-    ///     0xfd,
-    ///     Cursor::new(b"\xfd\xfd\x00")
-    ///         .read_compactsize().unwrap()
-    /// );
-    /// assert_eq!(
-    ///     0xaafd,
-    ///     Cursor::new(b"\xfd\xfd\xaa")
-    ///         .read_compactsize().unwrap()
-    /// );
-    /// ```
-    ///
-    /// Sizes greater than the maximum network message length are invalid,
-    /// they return a `Parse` error:
-    /// ```
-    /// # use zebra_chain::serialization::ReadZcashExt;
-    /// # use std::io::Cursor;
-    /// Cursor::new(b"\xfe\xfd\xaa\xbb\x00").read_compactsize().unwrap_err();
-    /// Cursor::new(b"\xff\xfd\xaa\xbb\xcc\x22\x00\x00\x00").read_compactsize().unwrap_err();
-    /// ```
-    #[inline]
-    fn read_compactsize(&mut self) -> Result<u64, SerializationError> {
-        use SerializationError::Parse;
-        let flag_byte = self.read_u8()?;
-        let size = match flag_byte {
-            n @ 0x00..=0xfc => Ok(n as u64),
-            0xfd => match self.read_u16::<LittleEndian>()? {
-                n @ 0x0000_00fd..=0x0000_ffff => Ok(n as u64),
-                _ => Err(Parse("non-canonical CompactSize")),
-            },
-            0xfe => match self.read_u32::<LittleEndian>()? {
-                n @ 0x0001_0000..=0xffff_ffff => Ok(n as u64),
-                _ => Err(Parse("non-canonical CompactSize")),
-            },
-            0xff => match self.read_u64::<LittleEndian>()? {
-                n @ 0x1_0000_0000..=0xffff_ffff_ffff_ffff => Ok(n),
-                _ => Err(Parse("non-canonical CompactSize")),
-            },
-        }?;
-
-        // # Security
-        // Defence-in-depth for memory DoS via preallocation.
-        if size
-            > MAX_PROTOCOL_MESSAGE_LEN
-                .try_into()
-                .expect("usize fits in u64")
-        {
-            Err(Parse("CompactSize larger than protocol message limit"))?;
-        }
-
-        Ok(size)
-    }
-
     /// Read an IP address in Bitcoin format.
     #[inline]
     fn read_ip_addr(&mut self) -> io::Result<IpAddr> {

--- a/zebra-chain/src/serialization/tests/prop.rs
+++ b/zebra-chain/src/serialization/tests/prop.rs
@@ -5,13 +5,15 @@ use std::io::Cursor;
 use proptest::prelude::*;
 
 use crate::{
-    serialization::{CompactSizeMessage, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
+    serialization::{
+        CompactSize64, CompactSizeMessage, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
+    },
     transaction::UnminedTx,
 };
 
 proptest! {
     #[test]
-    fn compactsize_write_then_read_round_trip(s in any::<CompactSizeMessage>()) {
+    fn compact_size_message_write_then_read_round_trip(s in any::<CompactSizeMessage>()) {
         zebra_test::init();
 
         let buf = s.zcash_serialize_to_vec().unwrap();
@@ -23,11 +25,42 @@ proptest! {
     }
 
     #[test]
-    fn compactsize_read_then_write_round_trip(bytes in prop::array::uniform9(0u8..)) {
+    fn compact_size_message_read_then_write_round_trip(bytes in prop::array::uniform9(0u8..)) {
         zebra_test::init();
 
         // Only do the test if the bytes were valid.
         if let Ok(s) = CompactSizeMessage::zcash_deserialize(Cursor::new(&bytes[..])) {
+            // The CompactSize encoding is variable-length, so we may not even
+            // read all of the input bytes, and therefore we can't expect that
+            // the encoding will reproduce bytes that were never read. Instead,
+            // copy the input bytes, and overwrite them with the encoding of s,
+            // so that if the encoding is different, we'll catch it on the part
+            // that's written.
+            let mut expect_bytes = bytes;
+            s.zcash_serialize(Cursor::new(&mut expect_bytes[..])).unwrap();
+
+            prop_assert_eq!(bytes, expect_bytes);
+        }
+    }
+
+    #[test]
+    fn compact_size_64_write_then_read_round_trip(s in any::<CompactSize64>()) {
+        zebra_test::init();
+
+        let buf = s.zcash_serialize_to_vec().unwrap();
+        // Maximum encoding size of a CompactSize is 9 bytes.
+        prop_assert!(buf.len() <= 9);
+
+        let expect_s: CompactSize64 = buf.zcash_deserialize_into().unwrap();
+        prop_assert_eq!(s, expect_s);
+    }
+
+    #[test]
+    fn compact_size_64_read_then_write_round_trip(bytes in prop::array::uniform9(0u8..)) {
+        zebra_test::init();
+
+        // Only do the test if the bytes were valid.
+        if let Ok(s) = CompactSize64::zcash_deserialize(Cursor::new(&bytes[..])) {
             // The CompactSize encoding is variable-length, so we may not even
             // read all of the input bytes, and therefore we can't expect that
             // the encoding will reproduce bytes that were never read. Instead,

--- a/zebra-chain/src/serialization/write_zcash.rs
+++ b/zebra-chain/src/serialization/write_zcash.rs
@@ -1,81 +1,14 @@
 use std::{
-    convert::TryInto,
     io,
     net::{IpAddr, SocketAddr},
 };
 
-use byteorder::{BigEndian, LittleEndian, WriteBytesExt};
-
-use super::MAX_PROTOCOL_MESSAGE_LEN;
+use byteorder::{BigEndian, WriteBytesExt};
 
 /// Extends [`Write`] with methods for writing Zcash/Bitcoin types.
 ///
 /// [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 pub trait WriteZcashExt: io::Write {
-    /// Writes a `u64` using the Bitcoin `CompactSize` encoding.
-    ///
-    /// # Panics
-    ///
-    /// Zebra panics on sizes greater than the protocol message length limit.
-    /// This is a defence-in-depth for memory preallocation attacks.
-    /// (These sizes should be impossible, because each array item takes at
-    /// least one byte.)
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use zebra_chain::serialization::WriteZcashExt;
-    ///
-    /// let mut buf = Vec::new();
-    /// buf.write_compactsize(0x12).unwrap();
-    /// assert_eq!(buf, b"\x12");
-    ///
-    /// let mut buf = Vec::new();
-    /// buf.write_compactsize(0xfd).unwrap();
-    /// assert_eq!(buf, b"\xfd\xfd\x00");
-    ///
-    /// let mut buf = Vec::new();
-    /// buf.write_compactsize(0xaafd).unwrap();
-    /// assert_eq!(buf, b"\xfd\xfd\xaa");
-    /// ```
-    ///
-    /// Sizes greater than the maximum network message length are invalid
-    /// and cause a panic:
-    /// ```should_panic
-    /// # use zebra_chain::serialization::WriteZcashExt;
-    /// let mut buf = Vec::new();
-    /// buf.write_compactsize(0xbbaafd).unwrap_err();
-    /// buf.write_compactsize(0x22ccbbaafd).unwrap_err();
-    /// ```
-    #[inline]
-    fn write_compactsize(&mut self, n: u64) -> io::Result<()> {
-        // # Security
-        // Defence-in-depth for memory DoS via preallocation.
-        //
-        assert!(
-            n <= MAX_PROTOCOL_MESSAGE_LEN
-                .try_into()
-                .expect("usize fits in u64"),
-            "CompactSize larger than protocol message limit"
-        );
-
-        match n {
-            0x0000_0000..=0x0000_00fc => self.write_u8(n as u8),
-            0x0000_00fd..=0x0000_ffff => {
-                self.write_u8(0xfd)?;
-                self.write_u16::<LittleEndian>(n as u16)
-            }
-            0x0001_0000..=0xffff_ffff => {
-                self.write_u8(0xfe)?;
-                self.write_u32::<LittleEndian>(n as u32)
-            }
-            _ => {
-                self.write_u8(0xff)?;
-                self.write_u64::<LittleEndian>(n)
-            }
-        }
-    }
-
     /// Write an `IpAddr` in Bitcoin format.
     #[inline]
     fn write_ip_addr(&mut self, addr: IpAddr) -> io::Result<()> {

--- a/zebra-chain/src/transparent/script.rs
+++ b/zebra-chain/src/transparent/script.rs
@@ -1,10 +1,10 @@
 //! Bitcoin script for Zebra
 
-#![allow(clippy::unit_arg)]
-
-use crate::serialization::{SerializationError, WriteZcashExt, ZcashDeserialize, ZcashSerialize};
-
 use std::{fmt, io};
+
+use crate::serialization::{
+    zcash_serialize_bytes, SerializationError, ZcashDeserialize, ZcashSerialize,
+};
 
 /// An encoding of a Bitcoin script.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
@@ -42,16 +42,14 @@ impl fmt::Debug for Script {
 }
 
 impl ZcashSerialize for Script {
-    fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
-        writer.write_compactsize(self.0.len() as u64)?;
-        writer.write_all(&self.0[..])?;
-        Ok(())
+    fn zcash_serialize<W: io::Write>(&self, writer: W) -> Result<(), io::Error> {
+        zcash_serialize_bytes(&self.0, writer)
     }
 }
 
 impl ZcashDeserialize for Script {
     fn zcash_deserialize<R: io::Read>(reader: R) -> Result<Self, SerializationError> {
-        Ok(Script(Vec::zcash_deserialize(reader)?))
+        Vec::zcash_deserialize(reader).map(Script)
     }
 }
 

--- a/zebra-chain/src/work/tests/vectors.rs
+++ b/zebra-chain/src/work/tests/vectors.rs
@@ -1,9 +1,12 @@
-use super::super::*;
+use std::convert::TryInto;
 
 use crate::{
-    block::Block,
-    serialization::{ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
+    block::{Block, MAX_BLOCK_BYTES},
+    serialization::{CompactSizeMessage, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
+    work::equihash::{Solution, SOLUTION_SIZE},
 };
+
+use super::super::*;
 
 /// Includes the 32-byte nonce.
 const EQUIHASH_SOLUTION_BLOCK_OFFSET: usize = equihash::Solution::INPUT_LENGTH + 32;
@@ -44,4 +47,37 @@ fn equihash_solution_test_vectors_are_valid() -> color_eyre::eyre::Result<()> {
     }
 
     Ok(())
+}
+
+static EQUIHASH_SIZE_TESTS: &[usize] = &[
+    0,
+    1,
+    SOLUTION_SIZE - 1,
+    SOLUTION_SIZE,
+    SOLUTION_SIZE + 1,
+    (MAX_BLOCK_BYTES - 1) as usize,
+    MAX_BLOCK_BYTES as usize,
+];
+
+#[test]
+fn equihash_solution_size_field() {
+    zebra_test::init();
+
+    for size in EQUIHASH_SIZE_TESTS.iter().copied() {
+        let mut data = Vec::new();
+
+        let size: CompactSizeMessage = size
+            .try_into()
+            .expect("test size fits in MAX_PROTOCOL_MESSAGE_LEN");
+        size.zcash_serialize(&mut data)
+            .expect("CompactSize should serialize");
+        data.resize(data.len() + SOLUTION_SIZE, 0);
+
+        let result = Solution::zcash_deserialize(data.as_slice());
+        if size == SOLUTION_SIZE.try_into().unwrap() {
+            result.expect("Correct size field in EquihashSolution should deserialize");
+        } else {
+            result.expect_err("Wrong size field in EquihashSolution should fail on deserialize");
+        }
+    }
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -790,7 +790,11 @@ impl Service<Request> for StateService {
                             .best_block(hash.into())
                             .expect("block for found hash is in the best chain");
                         block::CountedHeader {
-                            transaction_count: block.transactions.len(),
+                            transaction_count: block
+                                .transactions
+                                .len()
+                                .try_into()
+                                .expect("transaction count has already been validated"),
                             header: block.header,
                         }
                     })

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -62,7 +62,11 @@ async fn test_populated_state_responds_correctly(
         .iter()
         .map(|block| CountedHeader {
             header: block.header,
-            transaction_count: block.transactions.len(),
+            transaction_count: block
+                .transactions
+                .len()
+                .try_into()
+                .expect("test block transaction counts are valid"),
         })
         .collect();
 


### PR DESCRIPTION
## Motivation

To implement addrv2 in #2681, we need a `CompactSize` type that can be larger than `MAX_PROTOCOL_MESSAGE_LEN`.

This is the second part of that change, which does not block the first part of ticket #2681.
(But it blocks completing that ticket.)

## Solution

- Replace read_compactsize and write_compactsize with CompactSizeMessage
- Add tests for CompactSize64
- Add compact size range and conversion tests 

Closes #2173.

## Review

@oxarbitrage can review this PR.

This is a medium-priority refactor, because parts of #2681 conflict with this change.

### Reviewer Checklist

  - [x] Refactor makes sense
  - [x] Existing tests pass

## Follow Up Work

- #2681
