### PR TITLE
Depend on a multiset git commit that includes a bug fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,8 +2109,7 @@ dependencies = [
 [[package]]
 name = "multiset"
 version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8738c9ddd350996cb8b8b718192851df960803764bcdaa3afb44a63b1ddb5c"
+source = "git+https://github.com/jmitchell/multiset?rev=91ef8550b518f75ae87ae0d8771150f259fd34d5#91ef8550b518f75ae87ae0d8771150f259fd34d5"
 
 [[package]]
 name = "nibble_vec"

--- a/deny.toml
+++ b/deny.toml
@@ -93,6 +93,9 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     # ticket #2982: librustzcash and orchard git versions
     "https://github.com/str4d/redjubjub",
+
+    # ticket #2523: replace unmaintained multiset
+    "https://github.com/jmitchell/multiset",
 ]
 
 [sources.allow-org]

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -31,7 +31,10 @@ chrono = "0.4.19"
 rlimit = "0.5.4"
 # TODO: this crate is not maintained anymore. Replace it?
 # https://github.com/ZcashFoundation/zebra/issues/2523
-multiset = "0.0.5"
+#
+# Pinned to a commit which includes bug fix https://github.com/jmitchell/multiset/pull/21
+# The fix should be included in multiset 0.0.6.
+multiset = { git = "https://github.com/jmitchell/multiset", rev = "91ef8550b518f75ae87ae0d8771150f259fd34d5" }
 
 proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.3", optional = true }


### PR DESCRIPTION
## Motivation

`MultiSet` has a bug that's fixed on `master`, but not in any released version:
https://github.com/jmitchell/multiset/pull/21

Zebra doesn't use the buggy method yet, but we're just about to change the code that uses `MultiSet`.

This is unexpected work in sprint 22.

## Solution

Depend on a git commit that contains the bug fix.

## Review

I think @upbqdn might be working on anchors next sprint, and this is a bug fix on that code.

### Reviewer Checklist

  - [x] Dependency update makes sense
  - [x] Existing tests still pass

## Follow Up Work

- #2523