### PR TITLE
validate orchard flags in v5

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -266,6 +266,21 @@ impl Transaction {
                     .contains(orchard::Flags::ENABLE_OUTPUTS))
     }
 
+    /// Does this transaction has at least one flag when we have at least one orchard action?
+    ///
+    /// [NU5 onward] If effectiveVersion >= 5 and nActionsOrchard > 0, then at least one
+    /// of enableSpendsOrchard and enableOutputsOrchard MUST be 1.
+    ///
+    /// https://zips.z.cash/protocol/protocol.pdf#txnconsensus
+    pub fn has_enough_orchard_flags(&self) -> bool {
+        if self.version() < 5 || self.orchard_actions().count() == 0 {
+            return true;
+        }
+        self.orchard_flags()
+            .unwrap_or_else(orchard::Flags::empty)
+            .intersects(orchard::Flags::ENABLE_SPENDS | orchard::Flags::ENABLE_OUTPUTS)
+    }
+
     /// Returns the [`CoinbaseSpendRestriction`] for this transaction,
     /// assuming it is mined at `spend_height`.
     pub fn coinbase_spend_restriction(

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -116,6 +116,9 @@ pub enum TransactionError {
 
     #[error("orchard double-spend: duplicate nullifier: {_0:?}")]
     DuplicateOrchardNullifier(orchard::Nullifier),
+
+    #[error("must have at least one active orchard flag")]
+    NotEnoughFlags,
 }
 
 impl From<BoxError> for TransactionError {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -265,6 +265,7 @@ where
 
             // Do basic checks first
             check::has_inputs_and_outputs(&tx)?;
+            check::has_enough_orchard_flags(&tx)?;
 
             if req.is_mempool() && tx.has_any_coinbase_inputs() {
                 return Err(TransactionError::CoinbaseInMempool);

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -40,6 +40,20 @@ pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> 
     }
 }
 
+/// Checks that the transaction has enough orchard flags.
+///
+/// For `Transaction::V5` only:
+/// * If `orchard_actions_count` > 0 then at least one of
+/// `ENABLE_SPENDS|ENABLE_OUTPUTS` must be active.
+///
+/// https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
+pub fn has_enough_orchard_flags(tx: &Transaction) -> Result<(), TransactionError> {
+    if !tx.has_enough_orchard_flags() {
+        return Err(TransactionError::NotEnoughFlags);
+    }
+    Ok(())
+}
+
 /// Check that a coinbase transaction has no PrevOut inputs, JoinSplits, or spends.
 ///
 /// A coinbase transaction MUST NOT have any transparent inputs, JoinSplit descriptions,


### PR DESCRIPTION
## Motivation

We need to make sure at least one flag is set in transactions version 5 when the number of actions is at least one. Attempts to close https://github.com/ZcashFoundation/zebra/issues/2433

### Specifications

 > [NU5 onward] If effectiveVersion >= 5 and nActionsOrchard > 0, then at least one of enableSpendsOrchard and enableOutputsOrchard MUST be 1.

https://zips.z.cash/protocol/protocol.pdf#txnconsensus

## Solution

Create a new `has_enough_orchard_flags()` method and call it from the transaction verification. Performance wise i think there is maybe some overlap between this new method and `has_inputs_and_outputs()` but i hope that is minimal.

## Review

Anyone cvan review but will be good if @teor2345 can take a look.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

