### PR TITLE
Verify Halo2 proofs as part of V5 transaction verification

### DIFF
--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -75,8 +75,8 @@ impl BatchVerifier {
 
 // === END TEMPORARY BATCH HALO2 SUBSTITUTE ===
 
-impl From<zebra_chain::orchard::ShieldedData> for Item {
-    fn from(shielded_data: zebra_chain::orchard::ShieldedData) -> Item {
+impl From<&zebra_chain::orchard::ShieldedData> for Item {
+    fn from(shielded_data: &zebra_chain::orchard::ShieldedData) -> Item {
         use orchard::{circuit, note, primitives::redpallas, tree, value};
 
         let anchor = tree::Anchor::from_bytes(shielded_data.shared_anchor.into()).unwrap();
@@ -108,7 +108,7 @@ impl From<zebra_chain::orchard::ShieldedData> for Item {
 
         Item {
             instances,
-            proof: orchard::circuit::Proof::new(shielded_data.proof.0),
+            proof: orchard::circuit::Proof::new(shielded_data.proof.0.clone()),
         }
     }
 }

--- a/zebra-consensus/src/primitives/halo2/tests.rs
+++ b/zebra-consensus/src/primitives/halo2/tests.rs
@@ -117,7 +117,7 @@ where
     for sd in shielded_data {
         tracing::trace!(?sd);
 
-        let rsp = verifier.ready().await?.call(Item::from(sd));
+        let rsp = verifier.ready().await?.call(Item::from(&sd));
 
         async_checks.push(rsp);
     }
@@ -183,7 +183,7 @@ where
 
         tracing::trace!(?sd);
 
-        let rsp = verifier.ready().await?.call(Item::from(sd));
+        let rsp = verifier.ready().await?.call(Item::from(&sd));
 
         async_checks.push(rsp);
     }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -737,6 +737,22 @@ where
         if let Some(orchard_shielded_data) = orchard_shielded_data {
             for authorized_action in orchard_shielded_data.actions.iter().cloned() {
                 let (action, spend_auth_sig) = authorized_action.into_parts();
+
+                // Consensus rule: The proof 𝜋 MUST be valid given a primary
+                // input (cv, rtOrchard, nf, rk, cm𝑥, enableSpends, enableOutputs)
+                //
+                // https://zips.z.cash/protocol/protocol.pdf#actiondesc
+                //
+                // Queue the verification of the Halo2 proof for each Action
+                // description while adding the resulting future to our
+                // collection of async checks that (at a minimum) must pass for
+                // the transaction to verify.
+                async_checks.push(
+                    primitives::halo2::VERIFIER
+                        .clone()
+                        .oneshot(primitives::halo2::Item::from(orchard_shielded_data)),
+                );
+
                 // Consensus rule: The spend authorization signature
                 // MUST be a valid SpendAuthSig signature over
                 // SigHash using rk as the validating key.


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

We need to verify Halo2 proofs for V5 transactions.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Now that we have an async batch Halo2 verifier service, we can call that from our transaction verifier service.

Our current test vectors do not have V5 transactions with verifiable Halo2 proofs. 👀

Resolves #2105 

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

Anyone can verify.

Our current test vectors do not have V5 transactions with verifiable Halo2 proofs, the halo2 verifier service is currently verifying that it can verify the proofs by themselves, but reviewer can decide if that is sufficient to merge this PR or if we want to block on V5 transactions w/ Halo2 proofs.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors