### PR TITLE
deny.toml: skip orchard and equihash instead of zcash_primitives

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -41,7 +41,10 @@ skip-tree = [
     { name = "fpe", version = "=0.4.0" },
 
     # ticket #2982: librustzcash and orchard git versions
-    { name = "zcash_primitives", version = "=0.5.0" },
+    # Note that the equihash duplication is probably because `zcash_primitives`
+    # (which imports it with a path import) is being imported as a git dependency.
+    { name = "equihash", version = "=0.1.0" },
+    { name = "orchard", version = "=0.0.0" },
 
     # ticket #2983: criterion dependencies
     { name = "criterion", version = "=0.3.4" },


### PR DESCRIPTION
## Motivation

Investigating crates duplicated by `zcash_primitives` I realized what's being duplicated is actually `equihash` and some `orchard` dependencies. (Which I didn't investigate further because we're going to update it soon).

This does not solve https://github.com/ZcashFoundation/zebra/issues/2982 but helps clarify what's going on.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

This is not urgent and anyone can review.

Change `deny.toml` to skip `orchard` and `equihash` instead of `zcash_primitives`.

Part of https://github.com/ZcashFoundation/zebra/issues/2982

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
