### PR TITLE
Add .cargo/config.toml with rustflags = -O to optimize test runtimes

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-O"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,9 @@
-[build]
-rustflags = ["-O"]
+# Some of Zebra's tests are really slow without optimisations turned on,
+# so we use basic optimisations in dev and test builds.
+# (release and bench builds use optimisation level 2 by default.)
+
+[profile.dev]
+opt-level = 1
+
+[profile.test]
+opt-level = 1

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@
 # Vscode detrius
 .vscode/
 .zebra-state/
-.cargo/
 # Nix configs
 shell.nix


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

When writing tests for #2645 , I created some tests that took over 5 minutes to run. When run with the rustc `-O` flag, they take ~30 seconds to run.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Add a `.cargo/config.toml` config file to provide `-O` as the rust flags for all compilations for our builds by default.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

@jvff @teor2345 
