### PR TITLE
Check MAX_BLOCK_SIGOPS in the block verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,16 +948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
-dependencies = [
- "quote 1.0.7",
- "syn 1.0.60",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,12 +1015,6 @@ dependencies = [
  "serde",
  "uuid",
 ]
-
-[[package]]
-name = "diff"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
@@ -2282,15 +2266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "output_vt100"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "owning_ref"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2505,18 +2480,6 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
-
-[[package]]
-name = "pretty_assertions"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0cfe1b2403f172ba0f234e500906ee0a3e493fb81092dac23ebefe129301cc"
-dependencies = [
- "ansi_term 0.12.1",
- "ctor",
- "diff",
- "output_vt100",
-]
 
 [[package]]
 name = "proc-macro-error"
@@ -4631,7 +4594,6 @@ dependencies = [
  "lazy_static",
  "once_cell",
  "owo-colors 3.1.0",
- "pretty_assertions",
  "proptest",
  "rand 0.8.4",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "zcash_script"
 version = "0.1.6-alpha.0"
-source = "git+https://github.com/ZcashFoundation/zcash_script.git?rev=1caa29e975405400983f679a376fb1c86527d5f2#1caa29e975405400983f679a376fb1c86527d5f2"
+source = "git+https://github.com/ZcashFoundation/zcash_script.git?rev=0cb1aa5dd159cb205e5cae9683ca976df60b6b21#0cb1aa5dd159cb205e5cae9683ca976df60b6b21"
 dependencies = [
  "bindgen 0.58.1",
  "blake2b_simd",

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -11,7 +11,7 @@ pub mod merkle;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod arbitrary;
-#[cfg(any(test, feature = "bench"))]
+#[cfg(any(test, feature = "bench", feature = "proptest-impl"))]
 pub mod tests;
 
 use std::{collections::HashMap, convert::TryInto, fmt, ops::Neg};

--- a/zebra-chain/src/block/tests.rs
+++ b/zebra-chain/src/block/tests.rs
@@ -1,7 +1,7 @@
 //! Tests for Zebra blocks
 
 // XXX generate should be rewritten as strategies
-#[cfg(any(test, feature = "bench"))]
+#[cfg(any(test, feature = "bench", feature = "proptest-impl"))]
 pub mod generate;
 #[cfg(test)]
 mod preallocate;

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -51,6 +51,6 @@ tokio = { version = "1.13.0", features = ["full"] }
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.25"
 
-zebra-chain = { path = "../zebra-chain", features = ["proptest-impl", "bench"] }
+zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/" }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -51,6 +51,6 @@ tokio = { version = "1.13.0", features = ["full"] }
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.25"
 
-zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", features = ["proptest-impl", "bench"] }
 zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/" }

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -76,6 +76,11 @@ pub enum VerifyBlockError {
     Transaction(#[from] TransactionError),
 }
 
+/// The maximum allowed number of legacy signature check operations in a block.
+///
+/// https://github.com/zcash/zcash/blob/bad7f7eadbbb3466bebe3354266c7f69f607fcfd/src/consensus/consensus.h#L30
+pub const MAX_BLOCK_SIGOPS: u64 = 20_000;
+
 impl<S, V> BlockVerifier<S, V>
 where
     S: Service<zs::Request, Response = zs::Response, Error = BoxError> + Send + Clone + 'static,
@@ -119,7 +124,6 @@ where
         // We don't include the block hash, because it's likely already in a parent span
         let span = tracing::debug_span!("block", height = ?block.coinbase_height());
 
-        // TODO(jlusby): Error = Report, handle errors from state_service.
         async move {
             let hash = block.hash();
             // Check that this block is actually a new block.
@@ -143,6 +147,9 @@ where
             let height = block
                 .coinbase_height()
                 .ok_or(BlockError::MissingHeight(hash))?;
+
+            // TODO: support block heights up to u32::MAX (#1113)
+            // In practice, these blocks are invalid anyway, because their parent block doesn't exist.
             if height > block::Height::MAX {
                 Err(BlockError::MaxHeight(height, hash, block::Height::MAX))?;
             }
@@ -197,12 +204,25 @@ where
             }
             tracing::trace!(len = async_checks.len(), "built async tx checks");
 
+            let mut legacy_sigop_count = 0;
+
             use futures::StreamExt;
             while let Some(result) = async_checks.next().await {
                 tracing::trace!(?result, remaining = async_checks.len());
-                result
+                let response = result
                     .map_err(Into::into)
                     .map_err(VerifyBlockError::Transaction)?;
+                legacy_sigop_count += response
+                    .legacy_sigop_count()
+                    .expect("block transaction responses must have a legacy sigop count");
+            }
+
+            if legacy_sigop_count > MAX_BLOCK_SIGOPS {
+                Err(BlockError::TooManyTransparentSignatureOperations {
+                    height,
+                    hash,
+                    legacy_sigop_count,
+                })?;
             }
 
             let new_outputs = Arc::try_unwrap(known_utxos)

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -78,6 +78,10 @@ pub enum VerifyBlockError {
 
 /// The maximum allowed number of legacy signature check operations in a block.
 ///
+/// This consensus rule is not documented, so Zebra follows the `zcashd` implementation.
+/// We re-use some `zcashd` C++ script code via `zebra-script` and `zcash_script`.
+///
+/// See:
 /// https://github.com/zcash/zcash/blob/bad7f7eadbbb3466bebe3354266c7f69f607fcfd/src/consensus/consensus.h#L30
 pub const MAX_BLOCK_SIGOPS: u64 = 20_000;
 

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 use zebra_chain::{orchard, sapling, sprout, transparent};
 
-use crate::BoxError;
+use crate::{block::MAX_BLOCK_SIGOPS, BoxError};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
@@ -208,4 +208,14 @@ pub enum BlockError {
 
     #[error("transaction has wrong consensus branch id for block network upgrade")]
     WrongTransactionConsensusBranchId,
+
+    #[error(
+        "block {height:?} {hash:?} has {legacy_sigop_count} legacy transparent signature operations, \
+         but the limit is {MAX_BLOCK_SIGOPS}"
+    )]
+    TooManyTransparentSignatureOperations {
+        height: zebra_chain::block::Height,
+        hash: zebra_chain::block::Hash,
+        legacy_sigop_count: u64,
+    },
 }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -118,6 +118,10 @@ pub enum Response {
         ///
         /// https://zips.z.cash/protocol/protocol.pdf#transactions
         miner_fee: Option<Amount<NonNegative>>,
+
+        /// The number of legacy signature operations in this transaction's
+        /// transparent inputs and outputs.
+        legacy_sigop_count: u64,
     },
 
     /// A response to a mempool transaction verification request.
@@ -224,6 +228,20 @@ impl Response {
         }
     }
 
+    /// The number of legacy transparent signature operations in this transaction's
+    /// inputs and outputs.
+    ///
+    /// Zebra does not check the legacy sigop count for mempool transactions,
+    /// because it is a standard rule (not a consensus rule).
+    pub fn legacy_sigop_count(&self) -> Option<u64> {
+        match self {
+            Response::Block {
+                legacy_sigop_count, ..
+            } => Some(*legacy_sigop_count),
+            Response::Mempool { .. } => None,
+        }
+    }
+
     /// Returns true if the request is a mempool request.
     pub fn is_mempool(&self) -> bool {
         match self {
@@ -289,16 +307,14 @@ where
             // Note: this rule originally applied to Sapling, but we assume it also applies to Orchard.
             //
             // https://zips.z.cash/zip-0213#specification
+
+            let cached_ffi_transaction = Arc::new(CachedFfiTransaction::new(tx.clone()));
             let async_checks = match tx.as_ref() {
                 Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
                     tracing::debug!(?tx, "got transaction with wrong version");
                     return Err(TransactionError::WrongVersion);
                 }
                 Transaction::V4 {
-                    inputs,
-                    // outputs,
-                    // lock_time,
-                    // expiry_height,
                     joinsplit_data,
                     sapling_shielded_data,
                     ..
@@ -306,13 +322,12 @@ where
                     &req,
                     network,
                     script_verifier,
-                    inputs,
+                    cached_ffi_transaction.clone(),
                     utxo_sender,
                     joinsplit_data,
                     sapling_shielded_data,
                 )?,
                 Transaction::V5 {
-                    inputs,
                     sapling_shielded_data,
                     orchard_shielded_data,
                     ..
@@ -320,7 +335,7 @@ where
                     &req,
                     network,
                     script_verifier,
-                    inputs,
+                    cached_ffi_transaction.clone(),
                     utxo_sender,
                     sapling_shielded_data,
                     orchard_shielded_data,
@@ -351,7 +366,11 @@ where
             }
 
             let rsp = match req {
-                Request::Block { .. } => Response::Block { tx_id, miner_fee },
+                Request::Block { .. } => Response::Block {
+                    tx_id,
+                    miner_fee,
+                    legacy_sigop_count: cached_ffi_transaction.legacy_sigop_count()?,
+                },
                 Request::Mempool { transaction, .. } => Response::Mempool {
                     transaction: VerifiedUnminedTx::new(
                         transaction,
@@ -389,14 +408,14 @@ where
     ///   for more information)
     /// - the `network` to consider when verifying
     /// - the `script_verifier` to use for verifying the transparent transfers
-    /// - the transparent `inputs` in the transaction
+    /// - the prepared `cached_ffi_transaction` used by the script verifier
     /// - the Sprout `joinsplit_data` shielded data in the transaction
     /// - the `sapling_shielded_data` in the transaction
     fn verify_v4_transaction(
         request: &Request,
         network: Network,
         script_verifier: script::Verifier<ZS>,
-        inputs: &[transparent::Input],
+        cached_ffi_transaction: Arc<CachedFfiTransaction>,
         utxo_sender: mpsc::UnboundedSender<script::Response>,
         joinsplit_data: &Option<transaction::JoinSplitData<Groth16Proof>>,
         sapling_shielded_data: &Option<sapling::ShieldedData<sapling::PerSpendAnchor>>,
@@ -412,7 +431,7 @@ where
             request,
             network,
             script_verifier,
-            inputs,
+            cached_ffi_transaction,
             utxo_sender,
         )?
         .and(Self::verify_sprout_shielded_data(
@@ -471,14 +490,14 @@ where
     ///   for more information)
     /// - the `network` to consider when verifying
     /// - the `script_verifier` to use for verifying the transparent transfers
-    /// - the transparent `inputs` in the transaction
+    /// - the prepared `cached_ffi_transaction` used by the script verifier
     /// - the sapling shielded data of the transaction, if any
     /// - the orchard shielded data of the transaction, if any
     fn verify_v5_transaction(
         request: &Request,
         network: Network,
         script_verifier: script::Verifier<ZS>,
-        inputs: &[transparent::Input],
+        cached_ffi_transaction: Arc<CachedFfiTransaction>,
         utxo_sender: mpsc::UnboundedSender<script::Response>,
         sapling_shielded_data: &Option<sapling::ShieldedData<sapling::SharedAnchor>>,
         orchard_shielded_data: &Option<orchard::ShieldedData>,
@@ -494,7 +513,7 @@ where
             request,
             network,
             script_verifier,
-            inputs,
+            cached_ffi_transaction,
             utxo_sender,
         )?
         .and(Self::verify_sapling_shielded_data(
@@ -508,9 +527,7 @@ where
 
         // TODO:
         // - verify orchard shielded pool (ZIP-224) (#2105)
-        // - ZIP-244 (#1874)
-        // - remaining consensus rules (#2379)
-        // - remove `should_panic` from tests
+        // - shielded input and output limits? (#2379)
     }
 
     /// Verifies if a V5 `transaction` is supported by `network_upgrade`.
@@ -541,13 +558,15 @@ where
         }
     }
 
-    /// Verifies if a transaction's transparent `inputs` are valid using the provided
-    /// `script_verifier`.
+    /// Verifies if a transaction's transparent inputs are valid using the provided
+    /// `script_verifier` and `cached_ffi_transaction`.
+    ///
+    /// Returns script verification responses via the `utxo_sender`.
     fn verify_transparent_inputs_and_outputs(
         request: &Request,
         network: Network,
         script_verifier: script::Verifier<ZS>,
-        inputs: &[transparent::Input],
+        cached_ffi_transaction: Arc<CachedFfiTransaction>,
         utxo_sender: mpsc::UnboundedSender<script::Response>,
     ) -> Result<AsyncChecks, TransactionError> {
         let transaction = request.transaction();
@@ -557,9 +576,9 @@ where
             // Coinbase transactions don't have any PrevOut inputs.
             Ok(AsyncChecks::new())
         } else {
-            // feed all of the inputs to the script and shielded verifiers
+            // feed all of the inputs to the script verifier
             // the script_verifier also checks transparent sighashes, using its own implementation
-            let cached_ffi_transaction = Arc::new(CachedFfiTransaction::new(transaction));
+            let inputs = transaction.inputs();
             let known_utxos = request.known_utxos();
             let upgrade = request.upgrade(network);
 

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -8,8 +8,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zcash_script = { git = "https://github.com/ZcashFoundation/zcash_script.git", rev = "1caa29e975405400983f679a376fb1c86527d5f2" }
+zcash_script = { git = "https://github.com/ZcashFoundation/zcash_script.git", rev = "0cb1aa5dd159cb205e5cae9683ca976df60b6b21" }
+
 zebra-chain = { path = "../zebra-chain" }
+
 thiserror = "1.0.30"
 displaydoc = "0.2.2"
 

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -78,6 +78,7 @@ impl CachedFfiTransaction {
         let tx_to_len = tx_to.len() as u32;
         let mut err = 0;
 
+        // SAFETY: the tx_to fields are created from a Rust vector
         let precomputed = unsafe {
             zcash_script::zcash_script_new_precomputed_tx(tx_to_ptr, tx_to_len, &mut err)
         };
@@ -132,6 +133,8 @@ impl CachedFfiTransaction {
 
         let mut err = 0;
 
+        // SAFETY: `new` makes sure `self.precomputed` is not NULL
+        //         the script fields are created from a Rust slice
         let ret = unsafe {
             zcash_script::zcash_script_verify_precomputed(
                 self.precomputed,
@@ -157,6 +160,7 @@ impl CachedFfiTransaction {
     pub fn legacy_sigop_count(&self) -> Result<u64, Error> {
         let mut err = 0;
 
+        // SAFETY: `new` makes sure `self.precomputed` is not NULL
         let ret = unsafe {
             zcash_script::zcash_script_legacy_sigop_count_precomputed(self.precomputed, &mut err)
         };
@@ -204,6 +208,7 @@ unsafe impl Sync for CachedFfiTransaction {}
 
 impl Drop for CachedFfiTransaction {
     fn drop(&mut self) {
+        // SAFETY: `new` makes sure `self.precomputed` is not NULL
         unsafe { zcash_script::zcash_script_free_precomputed_tx(self.precomputed) };
     }
 }

--- a/zebra-state/src/service/non_finalized_state/queued_blocks.rs
+++ b/zebra-state/src/service/non_finalized_state/queued_blocks.rs
@@ -180,7 +180,6 @@ mod tests {
 
     use crate::{arbitrary::Prepare, tests::FakeChainHelper};
 
-    use self::assert_eq;
     use super::*;
 
     // Quick helper trait for making queued blocks with throw away channels

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -20,8 +20,6 @@ use crate::{
     Config,
 };
 
-use self::assert_eq;
-
 #[test]
 fn construct_empty() {
     zebra_test::init();

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -21,7 +21,6 @@ futures = "0.3.17"
 
 color-eyre = "0.5.11"
 owo-colors = "3.1.0"
-pretty_assertions = "1.0.0"
 spandoc = "0.2.0"
 thiserror = "1.0.30"
 tracing = "0.1.29"

--- a/zebra-test/src/prelude.rs
+++ b/zebra-test/src/prelude.rs
@@ -6,5 +6,4 @@ pub use std::process::Stdio;
 pub use color_eyre;
 pub use color_eyre::eyre;
 pub use eyre::Result;
-pub use pretty_assertions::{assert_eq, assert_ne};
 pub use proptest::prelude::*;


### PR DESCRIPTION
## Motivation

Zebra needs to check the `MAX_BLOCK_SIGOPS` consensus rule.

## Solution

Zebra:
- Add legacy sigops counts to zebra-script
- Return legacy sigops in transaction verifier responses
- Check legacy sigops in the block verifier
- Test `MAX_BLOCK_SIGOPS` on large generated blocks and historical blocks

Dependency updates:
- zcash_script changes: https://github.com/ZcashFoundation/zcash_script/pull/25
- zcashd changes: https://github.com/zcash/zcash/pull/5373

Closes #3015

### Dependency Stability

I tagged the `zcash_script` commit that Zebra depends on as:
https://github.com/ZcashFoundation/zcash_script/releases/tag/v0.1.6-alpha.1-zebra-v1.0.0-beta.0

I tagged the `zcashd` commit in the submodule as:
https://github.com/ZcashFoundation/zcashd/releases/tag/v4.5.1-1-zcash-script-zebra-v1.0.0-beta.0

These tags will make sure we don't accidentally delete the commits we're depending on.

## Review

@jvff did the `zcash_script` and Zebra reviews, so @oxarbitrage can do the `zcashd` review.

### Reviewer Checklist

  - [ ] **Unsafe code** has up-to-date safety comments
  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

