### PR TITLE
Stop asking users to report peer errors, fix a common peer error

### DIFF
--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -71,6 +71,7 @@ pub use crate::{
     config::Config,
     isolated::connect_isolated,
     meta_addr::PeerAddrState,
+    peer::{HandshakeError, PeerError, SharedPeerError},
     peer_set::init,
     policies::{RetryErrors, RetryLimit},
     protocol::internal::{Request, Response},

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -28,37 +28,32 @@ pub enum PeerError {
     /// The remote peer closed the connection.
     #[error("Peer closed connection")]
     ConnectionClosed,
+
     /// The remote peer did not respond to a [`peer::Client`] request in time.
     #[error("Client request timed out")]
     ClientRequestTimeout,
+
     /// A serialization error occurred while reading or writing a message.
     #[error("Serialization error: {0}")]
     Serialization(#[from] SerializationError),
+
     /// A badly-behaved remote peer sent a handshake message after the handshake was
     /// already complete.
     #[error("Remote peer sent handshake messages after handshake")]
     DuplicateHandshake,
+
     /// This node's internal services were overloaded, so the connection was dropped
     /// to shed load.
     #[error("Internal services over capacity")]
     Overloaded,
+
+    // TODO: stop closing connections on these errors (#2107)
+    //       log info or debug logs instead
+    //
     /// A peer sent us a message we don't support.
     #[error("Remote peer sent an unsupported message type: {0}")]
     UnsupportedMessage(&'static str),
-    /// A peer sent us a message we couldn't interpret in context.
-    #[error("Remote peer sent an uninterpretable message: {0}")]
-    WrongMessage(&'static str),
-    /// We got a `Reject` message. This does not necessarily mean that
-    /// the peer connection is in a bad state, but for the time being
-    /// we are considering it a PeerError.
-    // TODO: Create a different error type (more at the application
-    // level than network/connection level) that will include the
-    // appropriate error when a `Reject` message is received.
-    #[error("Received a Reject message")]
-    Rejected,
-    /// The remote peer responded with a block we didn't ask for.
-    #[error("Remote peer responded with a block we didn't ask for.")]
-    WrongBlock,
+
     /// We requested data that the peer couldn't find.
     #[error("Remote peer could not find items: {0:?}")]
     NotFound(Vec<InventoryHash>),

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -286,9 +286,14 @@ impl Application for ZebradApp {
                     true
                 }
                 color_eyre::ErrorKind::Recoverable(error) => {
-                    // type checks should be faster than string conversions
+                    // Type checks should be faster than string conversions.
+                    //
+                    // Don't ask users to create bug reports for timeouts and peer errors.
                     if error.is::<tower::timeout::error::Elapsed>()
                         || error.is::<tokio::time::error::Elapsed>()
+                        || error.is::<zebra_network::PeerError>()
+                        || error.is::<zebra_network::SharedPeerError>()
+                        || error.is::<zebra_network::HandshakeError>()
                     {
                         return false;
                     }


### PR DESCRIPTION
## Motivation

Zebra asks users to report peer errors, but there's nothing that Zebra developers can do to fix most of those errors.
This PR fixes one of the errors we can fix. #2107 should fix the rest.

This is unexpected work in sprint 22.

## Solution

- Stop treating inv with mixed item types as a connection error. Instead, ignore any unexpected item types.
- Remove unused connection errors. We'll remove more errors in #2107.
- Stop asking users to create bug reports for peer errors.

Closes #3052.

## Review

Anyone can review this low-priority bug fix.

### Reviewer Checklist

  - [ ] Code handles network messages correctly

This code needs to be refactored before we can unit test it. But it's tested by the `zebrad` acceptance tests.

## Follow Up Work

- #2107