### PR TITLE
Check nSpendsSapling, nOutputsSapling, and nActionsOrchard 2^16 limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4347,6 +4347,7 @@ dependencies = [
  "serde-big-array",
  "sha2",
  "spandoc",
+ "static_assertions",
  "subtle",
  "thiserror",
  "tracing",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -40,6 +40,7 @@ secp256k1 = { version = "0.20.3", features = ["serde"] }
 serde = { version = "1", features = ["serde_derive", "rc"] }
 serde-big-array = "0.3.2"
 sha2 = { version = "0.9.8", features=["compress"] }
+static_assertions = "1.1.0"
 subtle = "2.4"
 thiserror = "1"
 uint = "0.9.1"

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -22,6 +22,9 @@ extern crate serde_big_array;
 #[macro_use]
 extern crate bitflags;
 
+#[macro_use]
+extern crate static_assertions;
+
 pub mod amount;
 pub mod block;
 pub mod chain_tip;

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -22,9 +22,6 @@ extern crate serde_big_array;
 #[macro_use]
 extern crate bitflags;
 
-#[macro_use]
-extern crate static_assertions;
-
 pub mod amount;
 pub mod block;
 pub mod chain_tip;

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -182,7 +182,14 @@ impl TrustedPreallocate for Action {
         // Since a serialized Vec<AuthorizedAction> uses at least one byte for its length,
         // and the signature is required,
         // a valid max allocation can never exceed this size
-        (MAX_BLOCK_BYTES - 1) / AUTHORIZED_ACTION_SIZE
+        const MAX: u64 = (MAX_BLOCK_BYTES - 1) / AUTHORIZED_ACTION_SIZE;
+        // > [NU5 onward] nSpendsSapling, nOutputsSapling, and nActionsOrchard MUST all be less than 2^16.
+        // https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
+        // This acts as nActionsOrchard and is therefore subject to the rule.
+        // The maximum value is actually smaller due to the block size limit,
+        // but we ensure the 2^16 limit with a static assertion.
+        static_assertions::const_assert!(MAX <= (1 << 16));
+        MAX
     }
 }
 

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -188,7 +188,7 @@ impl TrustedPreallocate for Action {
         // This acts as nActionsOrchard and is therefore subject to the rule.
         // The maximum value is actually smaller due to the block size limit,
         // but we ensure the 2^16 limit with a static assertion.
-        static_assertions::const_assert!(MAX <= (1 << 16));
+        static_assertions::const_assert!(MAX < (1 << 16));
         MAX
     }
 }

--- a/zebra-chain/src/sapling/output.rs
+++ b/zebra-chain/src/sapling/output.rs
@@ -224,7 +224,7 @@ impl TrustedPreallocate for OutputInTransactionV4 {
         // The maximum value is actually smaller due to the block size limit,
         // but we ensure the 2^16 limit with a static assertion.
         // (The check is not required pre-NU5, but it doesn't cause problems.)
-        static_assertions::const_assert!(MAX <= (1 << 16));
+        static_assertions::const_assert!(MAX < (1 << 16));
         MAX
     }
 }

--- a/zebra-chain/src/sapling/output.rs
+++ b/zebra-chain/src/sapling/output.rs
@@ -217,7 +217,15 @@ impl TrustedPreallocate for OutputInTransactionV4 {
     fn max_allocation() -> u64 {
         // Since a serialized Vec<Output> uses at least one byte for its length,
         // the max allocation can never exceed (MAX_BLOCK_BYTES - 1) / OUTPUT_SIZE
-        (MAX_BLOCK_BYTES - 1) / OUTPUT_SIZE
+        const MAX: u64 = (MAX_BLOCK_BYTES - 1) / OUTPUT_SIZE;
+        // > [NU5 onward] nSpendsSapling, nOutputsSapling, and nActionsOrchard MUST all be less than 2^16.
+        // https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
+        // This acts as nOutputsSapling and is therefore subject to the rule.
+        // The maximum value is actually smaller due to the block size limit,
+        // but we ensure the 2^16 limit with a static assertion.
+        // (The check is not required pre-NU5, but it doesn't cause problems.)
+        static_assertions::const_assert!(MAX <= (1 << 16));
+        MAX
     }
 }
 

--- a/zebra-chain/src/sapling/spend.rs
+++ b/zebra-chain/src/sapling/spend.rs
@@ -283,7 +283,7 @@ impl TrustedPreallocate for SpendPrefixInTransactionV5 {
         // The maximum value is actually smaller due to the block size limit,
         // but we ensure the 2^16 limit with a static assertion.
         // (The check is not required pre-NU5, but it doesn't cause problems.)
-        static_assertions::const_assert!(MAX <= (1 << 16));
+        static_assertions::const_assert!(MAX < (1 << 16));
         MAX
     }
 }

--- a/zebra-chain/src/sapling/spend.rs
+++ b/zebra-chain/src/sapling/spend.rs
@@ -276,7 +276,15 @@ impl TrustedPreallocate for SpendPrefixInTransactionV5 {
         // Since a serialized Vec<Spend> uses at least one byte for its length,
         // and the associated fields are required,
         // a valid max allocation can never exceed this size
-        (MAX_BLOCK_BYTES - 1) / SHARED_ANCHOR_SPEND_SIZE
+        const MAX: u64 = (MAX_BLOCK_BYTES - 1) / SHARED_ANCHOR_SPEND_SIZE;
+        // > [NU5 onward] nSpendsSapling, nOutputsSapling, and nActionsOrchard MUST all be less than 2^16.
+        // https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
+        // This acts as nSpendsSapling and is therefore subject to the rule.
+        // The maximum value is actually smaller due to the block size limit,
+        // but we ensure the 2^16 limit with a static assertion.
+        // (The check is not required pre-NU5, but it doesn't cause problems.)
+        static_assertions::const_assert!(MAX <= (1 << 16));
+        MAX
     }
 }
 


### PR DESCRIPTION
## Motivation

The spec says

> [NU5 onward] nSpendsSapling, nOutputsSapling, and nActionsOrchard MUST all be less than 2^16.

> [NU5 onward] The rule that nSpendsSapling, nOutputsSapling, and nActionsOrchard MUST all be less than 2^16, is technically redundant because a transaction that could violate this rule would not fit within the 2 MB block size limit. It is included in order to simplify the security argument for balance preservation.

While the check is redudant, it seems useful to add a sanity check to make sure it's being enforced.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

Add static assertions to the current limits (which are derived from the block size) to make sure they are not greater than 2^16.

Closes https://github.com/ZcashFoundation/zebra/issues/2379

## Review

Anyone can review. Not urgent.

Closes https://github.com/ZcashFoundation/zebra/issues/2379

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
