### PR TITLE
Add missing nSpendsSapling limit check

### DIFF
--- a/zebra-chain/src/sapling/spend.rs
+++ b/zebra-chain/src/sapling/spend.rs
@@ -262,7 +262,15 @@ pub(crate) const SHARED_ANCHOR_SPEND_SIZE: u64 = SHARED_ANCHOR_SPEND_PREFIX_SIZE
 /// The maximum number of sapling spends in a valid Zcash on-chain transaction V4.
 impl TrustedPreallocate for Spend<PerSpendAnchor> {
     fn max_allocation() -> u64 {
-        (MAX_BLOCK_BYTES - 1) / ANCHOR_PER_SPEND_SIZE
+        const MAX: u64 = (MAX_BLOCK_BYTES - 1) / ANCHOR_PER_SPEND_SIZE;
+        // > [NU5 onward] nSpendsSapling, nOutputsSapling, and nActionsOrchard MUST all be less than 2^16.
+        // https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
+        // This acts as nSpendsSapling and is therefore subject to the rule.
+        // The maximum value is actually smaller due to the block size limit,
+        // but we ensure the 2^16 limit with a static assertion.
+        // (The check is not required pre-NU5, but it doesn't cause problems.)
+        static_assertions::const_assert!(MAX < (1 << 16));
+        MAX
     }
 }
 


### PR DESCRIPTION
## Motivation

I missed a check in https://github.com/ZcashFoundation/zebra/pull/3069/ for Sapling spends in V4 transactions which are still subject to the consensus rule.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

Add the missing check

## Review

Anyone can review; not urgent. @teor2345 identified the missing check.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
