### PR TITLE
Speed up CI, and split unrelated and conflicting CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           command: build
           args: --verbose --release
 
-  clippy-cargo-lock:
+  clippy-deps:
     name: Clippy (stable)
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -242,7 +242,20 @@ jobs:
           command: check
           args: --locked --all-features --all-targets
 
-  fmt-deps:
+      # Edit zebra/deny.toml to allow duplicate dependencies
+      - name: Check for dependent crates with different versions
+        uses: EmbarkStudios/cargo-deny-action@v1.2.6
+        with:
+          command: check bans
+          args: --all-features --workspace
+
+      - name: Check crate sources
+        uses: EmbarkStudios/cargo-deny-action@v1.2.6
+        with:
+          command: check sources
+          args: --all-features --workspace
+
+  fmt:
     name: Rustfmt
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -276,16 +289,3 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-
-      # Edit zebra/deny.toml to allow duplicates
-      - name: Check for dependent crates with different versions
-        uses: EmbarkStudios/cargo-deny-action@v1.2.6
-        with:
-          command: check bans
-          args: --all-features --workspace
-
-      - name: Check crate sources
-        uses: EmbarkStudios/cargo-deny-action@v1.2.6
-        with:
-          command: check sources
-          args: --all-features --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: stable
+        rust: [stable]
     env:
       CARGO_INCREMENTAL: 0
       RUST_BACKTRACE: full
@@ -151,7 +151,7 @@ jobs:
       - name: Run tests with fake activation heights
         uses: actions-rs/cargo@v1.0.3
         env:
-          TEST_FAKE_ACTIVATION_HEIGHTS:
+          TEST_FAKE_ACTIVATION_HEIGHTS: ""
         with:
           command: test
           # Note: this only runs the zebra-state crate tests,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,23 @@ jobs:
           echo "LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Skip network tests on Ubuntu and Windows
-        # Ubuntu runners don't have network or DNS configured during test steps.
+        # Ubuntu runners don't have reliable network or DNS during test steps.
         # Windows runners have an unreliable network.
         shell: bash
         if: matrix.os != 'macOS-latest'
         run: echo "ZEBRA_SKIP_NETWORK_TESTS=1" >> $GITHUB_ENV
+
+      - name: Minimise proptest cases on macOS and Windows
+        # We set cases to 1, because some tests already run 1 case by default.
+        # We keep maximum shrink iterations at the default value, because it only happens on failure.
+        #
+        # Windows compilation and tests are slower than other platforms.
+        # macOS runners do extra network tests, so they take longer.
+        shell: bash
+        if: matrix.os != 'ubuntu-latest'
+        run: |
+             echo "PROPTEST_CASES=1" >> $GITHUB_ENV
+             echo "PROPTEST_MAX_SHRINK_ITERS=1024" >> $GITHUB_ENV
 
       - name: Change target output directory on Windows
         # Windows doesn't have enough space on the D: drive, so we redirect the build output to the
@@ -83,11 +95,16 @@ jobs:
 
       - name: Show env vars
         run: |
+            echo "Test env vars:"
             echo "ZEBRA_SKIP_NETWORK_TESTS=${{ env.ZEBRA_SKIP_NETWORK_TESTS }}"
             echo "ZCASH_PARAMS=${{ env.ZCASH_PARAMS }}"
+            echo "PROPTEST_CASES=${{ env.PROPTEST_CASES }}"
+            echo "PROPTEST_MAX_SHRINK_ITERS=${{ env.PROPTEST_MAX_SHRINK_ITERS }}"
+            echo "Common env vars:"
+            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
+            echo "Build env vars:"
             echo "CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}"
             echo "CARGO_TARGET_DIR=${{ env.CARGO_TARGET_DIR }}"
-            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
 
       - name: Run tests
         uses: actions-rs/cargo@v1.0.3
@@ -137,11 +154,16 @@ jobs:
 
       - name: Show env vars
         run: |
+            echo "Test env vars:"
             echo "ZEBRA_SKIP_NETWORK_TESTS=${{ env.ZEBRA_SKIP_NETWORK_TESTS }}"
             echo "ZCASH_PARAMS=${{ env.ZCASH_PARAMS }}"
+            echo "PROPTEST_CASES=${{ env.PROPTEST_CASES }}"
+            echo "PROPTEST_MAX_SHRINK_ITERS=${{ env.PROPTEST_MAX_SHRINK_ITERS }}"
+            echo "Common env vars:"
+            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
+            echo "Build env vars:"
             echo "CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}"
             echo "CARGO_TARGET_DIR=${{ env.CARGO_TARGET_DIR }}"
-            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
 
       # This test changes zebra-chain's activation heights,
       # which can recompile all the Zebra crates,
@@ -190,11 +212,11 @@ jobs:
 
       - name: Show env vars
         run: |
-            echo "ZEBRA_SKIP_NETWORK_TESTS=${{ env.ZEBRA_SKIP_NETWORK_TESTS }}"
-            echo "ZCASH_PARAMS=${{ env.ZCASH_PARAMS }}"
+            echo "Common env vars:"
+            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
+            echo "Build env vars:"
             echo "CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}"
             echo "CARGO_TARGET_DIR=${{ env.CARGO_TARGET_DIR }}"
-            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
 
       - name: Run build without features enabled
         working-directory: ./zebra-chain
@@ -229,11 +251,11 @@ jobs:
 
       - name: Show env vars
         run: |
-            echo "ZEBRA_SKIP_NETWORK_TESTS=${{ env.ZEBRA_SKIP_NETWORK_TESTS }}"
-            echo "ZCASH_PARAMS=${{ env.ZCASH_PARAMS }}"
+            echo "Common env vars:"
+            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
+            echo "Build env vars:"
             echo "CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}"
             echo "CARGO_TARGET_DIR=${{ env.CARGO_TARGET_DIR }}"
-            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
 
       - name: Build
         uses: actions-rs/cargo@v1.0.3
@@ -264,11 +286,11 @@ jobs:
 
       - name: Show env vars
         run: |
-            echo "ZEBRA_SKIP_NETWORK_TESTS=${{ env.ZEBRA_SKIP_NETWORK_TESTS }}"
-            echo "ZCASH_PARAMS=${{ env.ZCASH_PARAMS }}"
+            echo "Common env vars:"
+            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
+            echo "Build env vars:"
             echo "CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}"
             echo "CARGO_TARGET_DIR=${{ env.CARGO_TARGET_DIR }}"
-            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
 
       - name: Run clippy
         uses: actions-rs/clippy-check@v1.0.7
@@ -321,11 +343,11 @@ jobs:
 
       - name: Show env vars
         run: |
-            echo "ZEBRA_SKIP_NETWORK_TESTS=${{ env.ZEBRA_SKIP_NETWORK_TESTS }}"
-            echo "ZCASH_PARAMS=${{ env.ZCASH_PARAMS }}"
+            echo "Common env vars:"
+            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
+            echo "Build env vars:"
             echo "CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}"
             echo "CARGO_TARGET_DIR=${{ env.CARGO_TARGET_DIR }}"
-            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
 
       - name: Check rustfmt
         uses: actions-rs/cargo@v1.0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,15 +95,6 @@ jobs:
           command: test
           args: --verbose --all
 
-      - name: Run tests with fake activation heights
-        uses: actions-rs/cargo@v1.0.3
-        env:
-          TEST_FAKE_ACTIVATION_HEIGHTS:
-        with:
-          command: test
-          # Note: this only runs the zebra-state crate tests, because re-running all the test binaries is slow on Windows
-          args: --verbose --package zebra-state --lib -- with_fake_activation_heights
-
       # Explicitly run any tests that are usually #[ignored]
 
       - name: Run zebrad large sync tests
@@ -114,6 +105,58 @@ jobs:
           command: test
           # Note: this only runs the zebrad acceptance tests, because re-running all the test binaries is slow on Windows
           args: --verbose --package zebrad --test acceptance sync_large_checkpoints_ -- --ignored
+
+  test-fake-activation-heights:
+    name: Build (+${{ matrix.rust }}) zebra-state with fake activation heights on ubuntu-latest
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: stable
+    env:
+      CARGO_INCREMENTAL: 0
+      RUST_BACKTRACE: full
+
+    steps:
+      - uses: actions/checkout@v2.4.0
+        with:
+          persist-credentials: false
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: cargo fetch
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: fetch
+
+      - name: Show env vars
+        run: |
+            echo "ZEBRA_SKIP_NETWORK_TESTS=${{ env.ZEBRA_SKIP_NETWORK_TESTS }}"
+            echo "ZCASH_PARAMS=${{ env.ZCASH_PARAMS }}"
+            echo "CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}"
+            echo "CARGO_TARGET_DIR=${{ env.CARGO_TARGET_DIR }}"
+            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
+
+      # This test changes zebra-chain's activation heights,
+      # which can recompile all the Zebra crates,
+      # so we want its build products to be cached separately.
+      #
+      # Also, we don't want to accidentally use the fake heights in other tests.
+      - name: Run tests with fake activation heights
+        uses: actions-rs/cargo@v1.0.3
+        env:
+          TEST_FAKE_ACTIVATION_HEIGHTS:
+        with:
+          command: test
+          # Note: this only runs the zebra-state crate tests,
+          # because re-running all the test binaries can be slow
+          args: --verbose --package zebra-state --lib -- with_fake_activation_heights
 
   build-chain-no-features:
     name: Build (+${{ matrix.rust }}) zebra-chain w/o features on ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,12 +35,20 @@ jobs:
       - name: Install cargo-llvm-cov cargo command
         run: cargo install cargo-llvm-cov
 
-      - name: Skip network tests on Ubuntu and Windows
-        # Ubuntu runners don't have network or DNS configured during test steps.
-        # Windows runners have an unreliable network.
+      - name: Skip network tests on Ubuntu
+        # Ubuntu runners don't have reliable network or DNS during test steps.
         shell: bash
-        if: matrix.os != 'macOS-latest'
         run: echo "ZEBRA_SKIP_NETWORK_TESTS=1" >> $GITHUB_ENV
+
+      - name: Minimise proptest cases in Coverage tests
+        # We set cases to 1, because some tests already run 1 case by default.
+        # We set maximum shrink iterations to 0, because we don't expect failures in these tests.
+        #
+        # Coverage tests are much slower than other tests, particularly in hot loops.
+        shell: bash
+        run: |
+             echo "PROPTEST_CASES=1" >> $GITHUB_ENV
+             echo "PROPTEST_MAX_SHRINK_ITERS=0" >> $GITHUB_ENV
 
       # Modified from:
       # https://github.com/zcash/librustzcash/blob/c48bb4def2e122289843ddb3cb2984c325c03ca0/.github/workflows/ci.yml#L20-L33
@@ -62,11 +70,16 @@ jobs:
 
       - name: Show env vars
         run: |
+            echo "Test env vars:"
             echo "ZEBRA_SKIP_NETWORK_TESTS=${{ env.ZEBRA_SKIP_NETWORK_TESTS }}"
             echo "ZCASH_PARAMS=${{ env.ZCASH_PARAMS }}"
+            echo "PROPTEST_CASES=${{ env.PROPTEST_CASES }}"
+            echo "PROPTEST_MAX_SHRINK_ITERS=${{ env.PROPTEST_MAX_SHRINK_ITERS }}"
+            echo "Common env vars:"
+            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
+            echo "Build env vars:"
             echo "CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}"
             echo "CARGO_TARGET_DIR=${{ env.CARGO_TARGET_DIR }}"
-            echo "RUST_BACKTRACE=${{ env.RUST_BACKTRACE }}"
 
       - name: Run Zebra tests
         run: cargo llvm-cov --lcov --no-report


### PR DESCRIPTION
## Motivation

1. Our CI test jobs compile `zebra-chain` twice: with standard activation heights, and with fake activation heights. This slows down CI, and makes the cache less effective.

2. It's confusing to have the duplicate dependency checks in the rustfmt job.

3. Coverage proptests are very slow. We never expect them to fail in coverage, so we can just run the minimum.

4. Windows and macOS builds are slower. We don't expect proptests to just fail on a single platform, so we can just run the minimum.

This is unscheduled work in sprint 23. I'm doing it now, because the slow jobs have made developing PRs #3057 and #3085 really slow.

## Solution

- Move fake activation height tests to their own job, and only run them on Ubuntu (the fastest platform). The results should be the same on all platforms.
- Move the duplicate dependency checks to the clippy job.
- Run the minimum number of proptests in coverage builds. The test results should be the same, and proptest coverage changes randomly anyway.
- Run the minimum number of proptests on the slowest platforms (macOS and Windows). The test results should be the same as Ubuntu.

## Review

@deirdre asked for the duplicate dependency change.
I think @conradoplg is also looking for PRs to review.

This PR is required for PR #3085.

### Reviewer Checklist

  - [x] CI jobs make sense
  - [ ] CI passes

## Follow Up Work

I'd like to split build and test steps, so we can see which one is slower. But that might actually increase CI time, depending on how file modification times are handled by each OS, and by the cache. So let's do that after NU5.