### PR TITLE
Shut down channels and tasks on PeerSet Drop

### DIFF
--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -297,6 +297,7 @@ where
         for guard in self.guards.iter() {
             guard.abort();
         }
+        self.handle_rx.close();
 
         // TODO: implement graceful shutdown for InventoryRegistry
     }

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -283,10 +283,10 @@ where
 
                 // The tasks have been sent, but not consumed.
                 Ok(handles) => {
-                    // Currently, the peer set treats no backgound tasks as an error.
+                    // Currently, the peer set treats an empty background task set as an error.
                     //
                     // TODO: refactor `handle_rx` and `guards` into an enum
-                    //       representing the background task state: Waiting/Running/Shutdown.
+                    //       for the background task state: Waiting/Running/Shutdown.
                     assert!(
                         !handles.is_empty(),
                         "the peer set requires at least one background task"
@@ -304,7 +304,7 @@ where
                 // Correctness: the peer set must receive at least one task.
                 //
                 // TODO: refactor `handle_rx` and `guards` into an enum
-                //       representing the background task state: Waiting/Running/Shutdown.
+                //       for the background task state: Waiting/Running/Shutdown.
                 Err(TryRecvError::Closed) => {
                     Some(Err("all peer set background tasks have exited".into()))
                 }
@@ -339,7 +339,7 @@ where
             guard.abort();
         }
 
-        // TODO: implement graceful shutdown for InventoryRegistry
+        // TODO: implement graceful shutdown for InventoryRegistry (#1678)
     }
 
     fn poll_unready(&mut self, cx: &mut Context<'_>) {


### PR DESCRIPTION
## Motivation

We want to shut down the peer set properly. We also want to detect peer and background task errors during shutdown.

This is a partial fix for #1678 and #1351, before we modify the peer set in #2262.

## Solution

- when the peer set shuts down, stop background tasks, close channels, and drop peers
- shut down the peer set when it is dropped

## Review

This is a fix from @jvff's review https://github.com/ZcashFoundation/zebra/pull/3072#discussion_r752256664
But the changes were originally part of PR #3071.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Keep implementing shut down for the rest of Zebra
Give the peer set an explicit shutdown handle?