### PR TITLE
Use prepared Groth16 keys for non-batch Sapling validation

### DIFF
--- a/zebra-consensus/src/primitives/groth16/tests.rs
+++ b/zebra-consensus/src/primitives/groth16/tests.rs
@@ -62,21 +62,18 @@ where
 #[tokio::test]
 async fn verify_sapling_groth16() {
     // Use separate verifiers so shared batch tasks aren't killed when the test ends (#2390)
-    let mut spend_verifier =
-        Fallback::new(
-            Batch::new(
-                Verifier::new(&GROTH16_PARAMETERS.sapling.spend.vk),
-                crate::primitives::MAX_BATCH_SIZE,
-                crate::primitives::MAX_BATCH_LATENCY,
-            ),
-            tower::service_fn(
-                (|item: Item| {
-                    ready(item.verify_single(&prepare_verifying_key(
-                        &GROTH16_PARAMETERS.sapling.spend.vk,
-                    )))
-                }) as fn(_) -> _,
-            ),
-        );
+    let mut spend_verifier = Fallback::new(
+        Batch::new(
+            Verifier::new(&GROTH16_PARAMETERS.sapling.spend.vk),
+            crate::primitives::MAX_BATCH_SIZE,
+            crate::primitives::MAX_BATCH_LATENCY,
+        ),
+        tower::service_fn(
+            (|item: Item| {
+                ready(item.verify_single(&GROTH16_PARAMETERS.sapling.spend_prepared_verifying_key))
+            }) as fn(_) -> _,
+        ),
+    );
     let mut output_verifier = Fallback::new(
         Batch::new(
             Verifier::new(&GROTH16_PARAMETERS.sapling.output.vk),
@@ -85,9 +82,7 @@ async fn verify_sapling_groth16() {
         ),
         tower::service_fn(
             (|item: Item| {
-                ready(item.verify_single(&prepare_verifying_key(
-                    &GROTH16_PARAMETERS.sapling.output.vk,
-                )))
+                ready(item.verify_single(&GROTH16_PARAMETERS.sapling.output_prepared_verifying_key))
             }) as fn(_) -> _,
         ),
     );
@@ -163,9 +158,7 @@ async fn correctly_err_on_invalid_output_proof() {
         ),
         tower::service_fn(
             (|item: Item| {
-                ready(item.verify_single(&prepare_verifying_key(
-                    &GROTH16_PARAMETERS.sapling.output.vk,
-                )))
+                ready(item.verify_single(&GROTH16_PARAMETERS.sapling.output_prepared_verifying_key))
             }) as fn(_) -> _,
         ),
     );


### PR DESCRIPTION
## Motivation

Zebra's Sapling proof validation prepares the validation key every time we do non-batch validation. But the parameter loader also creates a prepared copy of the key.

I think we can verify slightly faster if we re-use the prepared key.

This is related to #322, but it's not required.

## Solution

- Stop preparing the same key for every non-batch Sapling proof

This PR is based on PR #3091 to avoid unrelated test failures.

## Review

I need a cryptographer to review this change.

@conradoplg if you're not sure, let's wait and ask Deirdre next week?

### Reviewer Checklist

  - [ ] Code change is correct
  - [ ] Existing tests pass
