### PR TITLE
Update zcash_script dependency with the latest Orchard module structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "zcash_script"
 version = "0.1.6-alpha.0"
-source = "git+https://github.com/ZcashFoundation/zcash_script.git?rev=0cb1aa5dd159cb205e5cae9683ca976df60b6b21#0cb1aa5dd159cb205e5cae9683ca976df60b6b21"
+source = "git+https://github.com/ZcashFoundation/zcash_script.git?rev=b59c7dd515e4283007be3af08731ca2d12db7b54#b59c7dd515e4283007be3af08731ca2d12db7b54"
 dependencies = [
  "bindgen 0.58.1",
  "blake2b_simd",

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zcash_script = { git = "https://github.com/ZcashFoundation/zcash_script.git", rev = "0cb1aa5dd159cb205e5cae9683ca976df60b6b21" }
+zcash_script = { git = "https://github.com/ZcashFoundation/zcash_script.git", rev = "b59c7dd515e4283007be3af08731ca2d12db7b54" }
 
 zebra-chain = { path = "../zebra-chain" }
 


### PR DESCRIPTION
## Motivation

This PR updates to the `zcash_script` version in https://github.com/ZcashFoundation/zcash_script/pull/27

It's part of ticket #2982.