### PR TITLE
Automatically download and load sprout parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,11 @@ jobs:
         shell: bash
         run: echo "ZCASH_PARAMS=$(cargo run --example get-params-path)" >> $GITHUB_ENV
       - name: Cache Zcash parameters
-        id: cache-sprout-and-sapling-params
+        id: cache-params
         uses: actions/cache@v2
         with:
           path: ${{ env.ZCASH_PARAMS }}
-          key: ${{ runner.os }}-params
+          key: ${{ runner.os }}-sprout-and-sapling-params
       - name: Fetch Zcash parameters
         if: steps.cache-params.outputs.cache-hit != 'true'
         working-directory: ./zebra-consensus

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,10 @@ jobs:
 
   test:
     name: Test (+${{ matrix.rust }}) on ${{ matrix.os }}
-    # The large timeout is to accommodate Windows builds
-    timeout-minutes: 75
+    # The large timeout is to accommodate:
+    # - Windows builds (75 minutes, typically 30-50 minutes)
+    # - parameter downloads (40 minutes, but only when the cache expires)
+    timeout-minutes: 115
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         shell: bash
         run: echo "ZCASH_PARAMS=$(cargo run --example get-params-path)" >> $GITHUB_ENV
       - name: Cache Zcash parameters
-        id: cache-params
+        id: cache-sprout-and-sapling-params
         uses: actions/cache@v2
         with:
           path: ${{ env.ZCASH_PARAMS }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,7 +58,7 @@ jobs:
         # cargo-llvm-cov doesn't have a silent mode, so we have to extract the path from stderr
         run: echo "ZCASH_PARAMS=$(cargo llvm-cov --lcov --no-report run --example get-params-path 2>&1 >/dev/null | tail -1)" >> $GITHUB_ENV
       - name: Cache Zcash parameters
-        id: cache-params
+        id: cache-sprout-and-sapling-params
         uses: actions/cache@v2
         with:
           path: ${{ env.ZCASH_PARAMS }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,8 +13,10 @@ jobs:
 
   coverage:
     name: Coverage (+nightly)
-    # The large timeout is to accommodate nightly builds
-    timeout-minutes: 60
+    # The large timeout is to accommodate:
+    # - nightly builds (75 minutes, typically 30-50 minutes)
+    # - parameter downloads (40 minutes, but only when the cache expires)
+    timeout-minutes: 115
     runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,11 +58,11 @@ jobs:
         # cargo-llvm-cov doesn't have a silent mode, so we have to extract the path from stderr
         run: echo "ZCASH_PARAMS=$(cargo llvm-cov --lcov --no-report run --example get-params-path 2>&1 >/dev/null | tail -1)" >> $GITHUB_ENV
       - name: Cache Zcash parameters
-        id: cache-sprout-and-sapling-params
+        id: cache-params
         uses: actions/cache@v2
         with:
           path: ${{ env.ZCASH_PARAMS }}
-          key: ${{ runner.os }}-params
+          key: ${{ runner.os }}-sprout-and-sapling-params
       - name: Fetch Zcash parameters
         if: steps.cache-params.outputs.cache-hit != 'true'
         working-directory: ./zebra-consensus

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=53d0a51d33a421cb76d3e3124d1e4c1c9036068e#53d0a51d33a421cb76d3e3124d1e4c1c9036068e"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=1bfffb60b7427bd0333fbc39#1bfffb60b7427bd0333fbc395d2a8ba838082c9b"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.0.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=53d0a51d33a421cb76d3e3124d1e4c1c9036068e#53d0a51d33a421cb76d3e3124d1e4c1c9036068e"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=1bfffb60b7427bd0333fbc39#1bfffb60b7427bd0333fbc395d2a8ba838082c9b"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=53d0a51d33a421cb76d3e3124d1e4c1c9036068e#53d0a51d33a421cb76d3e3124d1e4c1c9036068e"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=1bfffb60b7427bd0333fbc39#1bfffb60b7427bd0333fbc395d2a8ba838082c9b"
 dependencies = [
  "bigint",
  "blake2b_simd",
@@ -4200,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.0.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=53d0a51d33a421cb76d3e3124d1e4c1c9036068e#53d0a51d33a421cb76d3e3124d1e4c1c9036068e"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=1bfffb60b7427bd0333fbc39#1bfffb60b7427bd0333fbc395d2a8ba838082c9b"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -4215,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=53d0a51d33a421cb76d3e3124d1e4c1c9036068e#53d0a51d33a421cb76d3e3124d1e4c1c9036068e"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=1bfffb60b7427bd0333fbc39#1bfffb60b7427bd0333fbc395d2a8ba838082c9b"
 dependencies = [
  "aes",
  "bip0039",
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=53d0a51d33a421cb76d3e3124d1e4c1c9036068e#53d0a51d33a421cb76d3e3124d1e4c1c9036068e"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=1bfffb60b7427bd0333fbc39#1bfffb60b7427bd0333fbc395d2a8ba838082c9b"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=76f1c1549c74010c9be744379b60567eb88c93d4#76f1c1549c74010c9be744379b60567eb88c93d4"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=49bab1eae66d34e007c3ff5240a8bb09eaf28570#49bab1eae66d34e007c3ff5240a8bb09eaf28570"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.0.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=76f1c1549c74010c9be744379b60567eb88c93d4#76f1c1549c74010c9be744379b60567eb88c93d4"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=49bab1eae66d34e007c3ff5240a8bb09eaf28570#49bab1eae66d34e007c3ff5240a8bb09eaf28570"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.2.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=76f1c1549c74010c9be744379b60567eb88c93d4#76f1c1549c74010c9be744379b60567eb88c93d4"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=49bab1eae66d34e007c3ff5240a8bb09eaf28570#49bab1eae66d34e007c3ff5240a8bb09eaf28570"
 dependencies = [
  "bigint",
  "blake2b_simd",
@@ -4200,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.0.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=76f1c1549c74010c9be744379b60567eb88c93d4#76f1c1549c74010c9be744379b60567eb88c93d4"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=49bab1eae66d34e007c3ff5240a8bb09eaf28570#49bab1eae66d34e007c3ff5240a8bb09eaf28570"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -4215,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.5.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=76f1c1549c74010c9be744379b60567eb88c93d4#76f1c1549c74010c9be744379b60567eb88c93d4"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=49bab1eae66d34e007c3ff5240a8bb09eaf28570#49bab1eae66d34e007c3ff5240a8bb09eaf28570"
 dependencies = [
  "aes",
  "bip0039",
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.5.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=76f1c1549c74010c9be744379b60567eb88c93d4#76f1c1549c74010c9be744379b60567eb88c93d4"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=49bab1eae66d34e007c3ff5240a8bb09eaf28570#49bab1eae66d34e007c3ff5240a8bb09eaf28570"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=1bfffb60b7427bd0333fbc39#1bfffb60b7427bd0333fbc395d2a8ba838082c9b"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=b7ff7b69f9fc5feca899e2cd0977d433a568e0c1#b7ff7b69f9fc5feca899e2cd0977d433a568e0c1"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.0.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=1bfffb60b7427bd0333fbc39#1bfffb60b7427bd0333fbc395d2a8ba838082c9b"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=b7ff7b69f9fc5feca899e2cd0977d433a568e0c1#b7ff7b69f9fc5feca899e2cd0977d433a568e0c1"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.2.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=1bfffb60b7427bd0333fbc39#1bfffb60b7427bd0333fbc395d2a8ba838082c9b"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=b7ff7b69f9fc5feca899e2cd0977d433a568e0c1#b7ff7b69f9fc5feca899e2cd0977d433a568e0c1"
 dependencies = [
  "bigint",
  "blake2b_simd",
@@ -4200,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.0.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=1bfffb60b7427bd0333fbc39#1bfffb60b7427bd0333fbc395d2a8ba838082c9b"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=b7ff7b69f9fc5feca899e2cd0977d433a568e0c1#b7ff7b69f9fc5feca899e2cd0977d433a568e0c1"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -4215,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.5.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=1bfffb60b7427bd0333fbc39#1bfffb60b7427bd0333fbc395d2a8ba838082c9b"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=b7ff7b69f9fc5feca899e2cd0977d433a568e0c1#b7ff7b69f9fc5feca899e2cd0977d433a568e0c1"
 dependencies = [
  "aes",
  "bip0039",
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.5.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=1bfffb60b7427bd0333fbc39#1bfffb60b7427bd0333fbc395d2a8ba838082c9b"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=b7ff7b69f9fc5feca899e2cd0977d433a568e0c1#b7ff7b69f9fc5feca899e2cd0977d433a568e0c1"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=49bab1eae66d34e007c3ff5240a8bb09eaf28570#49bab1eae66d34e007c3ff5240a8bb09eaf28570"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=dea8d97d5ed09bdb6673cb64d0a63706f71c2f61#dea8d97d5ed09bdb6673cb64d0a63706f71c2f61"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.0.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=49bab1eae66d34e007c3ff5240a8bb09eaf28570#49bab1eae66d34e007c3ff5240a8bb09eaf28570"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=dea8d97d5ed09bdb6673cb64d0a63706f71c2f61#dea8d97d5ed09bdb6673cb64d0a63706f71c2f61"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.2.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=49bab1eae66d34e007c3ff5240a8bb09eaf28570#49bab1eae66d34e007c3ff5240a8bb09eaf28570"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=dea8d97d5ed09bdb6673cb64d0a63706f71c2f61#dea8d97d5ed09bdb6673cb64d0a63706f71c2f61"
 dependencies = [
  "bigint",
  "blake2b_simd",
@@ -4200,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.0.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=49bab1eae66d34e007c3ff5240a8bb09eaf28570#49bab1eae66d34e007c3ff5240a8bb09eaf28570"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=dea8d97d5ed09bdb6673cb64d0a63706f71c2f61#dea8d97d5ed09bdb6673cb64d0a63706f71c2f61"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -4215,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.5.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=49bab1eae66d34e007c3ff5240a8bb09eaf28570#49bab1eae66d34e007c3ff5240a8bb09eaf28570"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=dea8d97d5ed09bdb6673cb64d0a63706f71c2f61#dea8d97d5ed09bdb6673cb64d0a63706f71c2f61"
 dependencies = [
  "aes",
  "bip0039",
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.5.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=49bab1eae66d34e007c3ff5240a8bb09eaf28570#49bab1eae66d34e007c3ff5240a8bb09eaf28570"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=dea8d97d5ed09bdb6673cb64d0a63706f71c2f61#dea8d97d5ed09bdb6673cb64d0a63706f71c2f61"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=b7ff7b69f9fc5feca899e2cd0977d433a568e0c1#b7ff7b69f9fc5feca899e2cd0977d433a568e0c1"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=76f1c1549c74010c9be744379b60567eb88c93d4#76f1c1549c74010c9be744379b60567eb88c93d4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.0.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=b7ff7b69f9fc5feca899e2cd0977d433a568e0c1#b7ff7b69f9fc5feca899e2cd0977d433a568e0c1"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=76f1c1549c74010c9be744379b60567eb88c93d4#76f1c1549c74010c9be744379b60567eb88c93d4"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.2.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=b7ff7b69f9fc5feca899e2cd0977d433a568e0c1#b7ff7b69f9fc5feca899e2cd0977d433a568e0c1"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=76f1c1549c74010c9be744379b60567eb88c93d4#76f1c1549c74010c9be744379b60567eb88c93d4"
 dependencies = [
  "bigint",
  "blake2b_simd",
@@ -4200,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.0.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=b7ff7b69f9fc5feca899e2cd0977d433a568e0c1#b7ff7b69f9fc5feca899e2cd0977d433a568e0c1"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=76f1c1549c74010c9be744379b60567eb88c93d4#76f1c1549c74010c9be744379b60567eb88c93d4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -4215,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.5.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=b7ff7b69f9fc5feca899e2cd0977d433a568e0c1#b7ff7b69f9fc5feca899e2cd0977d433a568e0c1"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=76f1c1549c74010c9be744379b60567eb88c93d4#76f1c1549c74010c9be744379b60567eb88c93d4"
 dependencies = [
  "aes",
  "bip0039",
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.5.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=b7ff7b69f9fc5feca899e2cd0977d433a568e0c1#b7ff7b69f9fc5feca899e2cd0977d433a568e0c1"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=76f1c1549c74010c9be744379b60567eb88c93d4#76f1c1549c74010c9be744379b60567eb88c93d4"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,15 @@ panic = "abort"
 orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
 
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
-#       zcash_proofs patch doesn't work, maybe because of features?
-#zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc395d2a8ba838082c9b" }
+#
+# This zcash_proofs patch doesn't work, maybe because of features?
+#zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
 
 # Use the ZcashFoundation fork where possible, to avoid duplicate dependencies
-equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
-zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
-zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
-zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
+equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
+zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
+zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
+zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
 
 # TODO: remove these after a new librustzcash release (#2982)
 
@@ -44,7 +45,7 @@ incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.
 #orchard = { git = "https://github.com/zcash/orchard.git", rev = "2c8241f25b943aa05203eacf9905db117c69bd29" }
 
 # Replaced by the ZcashFoundation fork above
-#
+
 # These are librustzcash file requirements specified in its workspace Cargo.toml,
 # that we must replace with git requirements
 #zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,13 @@ orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e2
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
 #
 # This zcash_proofs patch doesn't work, maybe because of features?
-#zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
+#zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
 
 # Use the ZcashFoundation fork where possible, to avoid duplicate dependencies
-equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
-zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
-zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
-zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
+equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
+zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
+zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
+zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
 
 # TODO: remove these after a new librustzcash release (#2982)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,17 +22,18 @@ panic = "abort"
 
 [patch.crates-io]
 
-# TODO: replace with upstream orchard when these changes are merged
-# https://github.com/ZcashFoundation/zebra/issues/3056
+# TODO: replace with upstream orchard (#3056)
 orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
 
-# TODO: replace with upstream librustzcash when these changes are merged (#2982)
-zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "36f3ac751dd8882ca2656fdd38745ab59f4cbccc" }
+# TODO: replace with upstream librustzcash when these changes are merged (#3037)
+#       zcash_proofs patch doesn't work, maybe because of features?
+#zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc395d2a8ba838082c9b" }
 
 # Use the ZcashFoundation fork where possible, to avoid duplicate dependencies
-equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "36f3ac751dd8882ca2656fdd38745ab59f4cbccc" }
-zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "36f3ac751dd8882ca2656fdd38745ab59f4cbccc" }
-zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "36f3ac751dd8882ca2656fdd38745ab59f4cbccc" }
+equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
+zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
+zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
+zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
 
 # TODO: remove these after a new librustzcash release (#2982)
 
@@ -51,6 +52,6 @@ incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.
 # These patches are not strictly required,
 # but they help avoid duplicate dependencies
 #equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
+#zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
 #zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
 #zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,13 @@ orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e2
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
 #
 # This zcash_proofs patch doesn't work, maybe because of features?
-#zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
+#zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
 
 # Use the ZcashFoundation fork where possible, to avoid duplicate dependencies
-equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
-zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
-zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
-zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
+equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
+zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
+zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
+zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
 
 # TODO: remove these after a new librustzcash release (#2982)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,13 @@ orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e2
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
 #
 # This zcash_proofs patch doesn't work, maybe because of features?
-#zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
+#zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
 
 # Use the ZcashFoundation fork where possible, to avoid duplicate dependencies
-equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
-zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
-zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
-zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
+equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
+zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
+zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
+zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
 
 # TODO: remove these after a new librustzcash release (#2982)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,18 @@ panic = "abort"
 
 [patch.crates-io]
 
-# TODO: replace with upstream orchard when these changes are merged
-# https://github.com/ZcashFoundation/zebra/issues/3056
-orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
+# TODO: replace with upstream orchard when these changes are merged (#2982)
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "465afd162ed40427a7452ac151d5b1c4bc5866ea" }
 
-# TODO: remove these after a new librustzcash release.
+# TODO: replace with upstream librustzcash when these changes are merged (#2982)
+zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "36f3ac751dd8882ca2656fdd38745ab59f4cbccc" }
+
+# Use the ZcashFoundation fork where possible, to avoid duplicate dependencies
+equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "36f3ac751dd8882ca2656fdd38745ab59f4cbccc" }
+zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "36f3ac751dd8882ca2656fdd38745ab59f4cbccc" }
+zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "36f3ac751dd8882ca2656fdd38745ab59f4cbccc" }
+
+# TODO: remove these after a new librustzcash release (#2982)
 
 # These are librustzcash git requirements specified in its workspace Cargo.toml,
 # that we must replicate here
@@ -34,13 +41,15 @@ incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.
 # Replaced by the ZcashFoundation fork above
 #orchard = { git = "https://github.com/zcash/orchard.git", rev = "2c8241f25b943aa05203eacf9905db117c69bd29" }
 
+# Replaced by the ZcashFoundation fork above
+#
 # These are librustzcash file requirements specified in its workspace Cargo.toml,
 # that we must replace with git requirements
-zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
+#zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
 
 # These patches are not strictly required,
 # but they help avoid duplicate dependencies
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
+#equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
 zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
+#zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
+#zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,9 @@ panic = "abort"
 
 [patch.crates-io]
 
-# TODO: replace with upstream orchard when these changes are merged (#2982)
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "465afd162ed40427a7452ac151d5b1c4bc5866ea" }
+# TODO: replace with upstream orchard when these changes are merged
+# https://github.com/ZcashFoundation/zebra/issues/3056
+orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
 
 # TODO: replace with upstream librustzcash when these changes are merged (#2982)
 zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "36f3ac751dd8882ca2656fdd38745ab59f4cbccc" }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -49,10 +49,10 @@ x25519-dalek = { version = "1.2.0", features = ["serde"] }
 orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
 
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
-equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
-zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
-zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
-zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
+equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
+zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
+zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
+zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
 
 proptest = { version = "0.10", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -49,10 +49,10 @@ x25519-dalek = { version = "1.2.0", features = ["serde"] }
 orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
 
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
-equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
-zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
-zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
-zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
+equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
+zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
+zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
+zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1" }
 
 proptest = { version = "0.10", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -33,7 +33,6 @@ hex = "0.4"
 incrementalmerkletree = "0.1.0"
 jubjub = "0.8.0"
 lazy_static = "1.4.0"
-orchard = "0.0"
 rand_core = "0.6"
 ripemd160 = "0.9"
 secp256k1 = { version = "0.20.3", features = ["serde"] }
@@ -45,9 +44,15 @@ subtle = "2.4"
 thiserror = "1"
 uint = "0.9.1"
 x25519-dalek = { version = "1.2.0", features = ["serde"] }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
-zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
+
+# TODO: replace with upstream orchard (#3056)
+orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
+
+# TODO: replace with upstream librustzcash when these changes are merged (#3037)
+equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
+zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
+zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
+zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39" }
 
 proptest = { version = "0.10", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
@@ -57,7 +62,6 @@ rand_chacha = { version = "0.3", optional = true }
 
 # ZF deps
 ed25519-zebra = "3.0.0"
-equihash = "0.1"
 # TODO: Update to 0.5 release when published
 redjubjub = { git = "https://github.com/ZcashFoundation/redjubjub.git", rev = "f772176560b0b7daf25eff2460e08dc127ac8407" }
 

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -49,10 +49,10 @@ x25519-dalek = { version = "1.2.0", features = ["serde"] }
 orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
 
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
-equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
-zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
-zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
-zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4" }
+equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
+zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
+zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
+zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
 
 proptest = { version = "0.10", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -49,10 +49,10 @@ x25519-dalek = { version = "1.2.0", features = ["serde"] }
 orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
 
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
-equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
-zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
-zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
-zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570" }
+equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
+zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
+zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
+zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
 
 proptest = { version = "0.10", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -38,7 +38,7 @@ tracing-futures = "0.2.5"
 orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
 
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
-zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1", features = ["local-prover", "multicore", "download-params"] }
+zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4", features = ["local-prover", "multicore", "download-params"] }
 
 tower-fallback = { path = "../tower-fallback/" }
 tower-batch = { path = "../tower-batch/" }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -38,7 +38,7 @@ tracing-futures = "0.2.5"
 orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
 
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
-zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39", features = ["local-prover", "multicore", "download-params"] }
+zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "b7ff7b69f9fc5feca899e2cd0977d433a568e0c1", features = ["local-prover", "multicore", "download-params"] }
 
 tower-fallback = { path = "../tower-fallback/" }
 tower-batch = { path = "../tower-batch/" }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -38,7 +38,7 @@ tracing-futures = "0.2.5"
 orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
 
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
-zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570", features = ["local-prover", "multicore", "download-params"] }
+zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61", features = ["local-prover", "multicore", "download-params"] }
 
 tower-fallback = { path = "../tower-fallback/" }
 tower-batch = { path = "../tower-batch/" }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -37,7 +37,8 @@ tower = { version = "0.4.11", features = ["timeout", "util", "buffer"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
 
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e", features = ["local-prover", "multicore", "download-params"] }
+# TODO: switch to the latest published librustzcash release (#2982)
+zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "36f3ac751dd8882ca2656fdd38745ab59f4cbccc", features = ["local-prover", "multicore", "download-params"] }
 
 tower-fallback = { path = "../tower-fallback/" }
 tower-batch = { path = "../tower-batch/" }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -17,9 +17,6 @@ jubjub = "0.8.0"
 rand = "0.8"
 
 halo2 = "=0.1.0-beta.1"
-# TODO: replace with upstream orchard when these changes are merged
-# https://github.com/ZcashFoundation/zebra/issues/3056
-orchard = "0.0.0"
 
 chrono = "0.4.19"
 dirs = "4.0.0"
@@ -37,8 +34,11 @@ tower = { version = "0.4.11", features = ["timeout", "util", "buffer"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
 
-# TODO: switch to the latest published librustzcash release (#2982)
-zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "36f3ac751dd8882ca2656fdd38745ab59f4cbccc", features = ["local-prover", "multicore", "download-params"] }
+# TODO: replace with upstream orchard (#3056)
+orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
+
+# TODO: replace with upstream librustzcash when these changes are merged (#3037)
+zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "1bfffb60b7427bd0333fbc39", features = ["local-prover", "multicore", "download-params"] }
 
 tower-fallback = { path = "../tower-fallback/" }
 tower-batch = { path = "../tower-batch/" }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -38,7 +38,7 @@ tracing-futures = "0.2.5"
 orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
 
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
-zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "76f1c1549c74010c9be744379b60567eb88c93d4", features = ["local-prover", "multicore", "download-params"] }
+zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "49bab1eae66d34e007c3ff5240a8bb09eaf28570", features = ["local-prover", "multicore", "download-params"] }
 
 tower-fallback = { path = "../tower-fallback/" }
 tower-batch = { path = "../tower-batch/" }

--- a/zebra-consensus/src/primitives/groth16/params.rs
+++ b/zebra-consensus/src/primitives/groth16/params.rs
@@ -5,6 +5,13 @@ use std::path::PathBuf;
 use bellman::groth16;
 use bls12_381::Bls12;
 
+/// The timeout for each parameter file download, in seconds.
+///
+/// Zebra assumes that it's running on at least a 10 Mbps connection.
+/// So the parameter files should download in about 15 minutes using `zebrad download`.
+/// But `zebrad start` downloads blocks at the same time, so we allow some extra time.
+pub const PARAMETER_DOWNLOAD_TIMEOUT: u64 = 60 * 60;
+
 lazy_static::lazy_static! {
     /// Groth16 Zero-Knowledge Proof parameters for the Sapling and Sprout circuits.
     ///
@@ -52,22 +59,26 @@ impl Groth16Parameters {
     /// If the downloaded or pre-existing parameter files are invalid.
     fn new() -> Groth16Parameters {
         tracing::info!("downloading Zcash Sapling parameters if needed");
-        let sapling_paths = zcash_proofs::download_sapling_parameters().unwrap_or_else(|error| {
-            panic!(
-                "error downloading Sapling parameter files: {:?}. {}",
-                error,
-                Groth16Parameters::failure_hint()
-            )
-        });
+        let sapling_paths =
+            zcash_proofs::download_sapling_parameters(Some(PARAMETER_DOWNLOAD_TIMEOUT))
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "error downloading Sapling parameter files: {:?}. {}",
+                        error,
+                        Groth16Parameters::failure_hint()
+                    )
+                });
 
         tracing::info!("downloading Zcash Sprout parameters if needed");
-        let sprout_path = zcash_proofs::download_sprout_parameters().unwrap_or_else(|error| {
-            panic!(
-                "error downloading Sprout parameter files: {:?}. {}",
-                error,
-                Groth16Parameters::failure_hint()
-            )
-        });
+        let sprout_path =
+            zcash_proofs::download_sprout_parameters(Some(PARAMETER_DOWNLOAD_TIMEOUT))
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "error downloading Sprout parameter files: {:?}. {}",
+                        error,
+                        Groth16Parameters::failure_hint()
+                    )
+                });
 
         // TODO: if loading fails, log a message including `failure_hint`
         tracing::info!("checking and loading Zcash Sapling and Sprout parameters");

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -19,6 +19,9 @@
 //!    * verifies blocks using zebra-chain, then stores verified blocks in zebra-state
 //!    * verifies mempool and block transactions using zebra-chain and zebra-script,
 //!      and returns verified mempool transactions for mempool storage
+//!  * Groth16 Parameters Download Task
+//!    * downloads the Sprout and Sapling Groth16 circuit parameter files
+//!    * finishes when the download is complete and the download file hashes have been checked
 //!  * Inbound Service
 //!    * handles requests from peers for network data, chain data, and mempool transactions
 //!    * spawns download and verify tasks for each gossiped block


### PR DESCRIPTION
## Motivation

Zebra needs to download the Sprout parameters, so we can verify Sprout spend proofs.

## Solution

Sprout:
- Add a Sprout download API in https://github.com/zcash/librustzcash/pull/459
- Use that API to download Sprout parameters
- Change the cache key so we don't re-use the Sapling-only parameter cache
- Add a 1 hour timeout to parameter downloads in Zebra
- Increase the CI timeouts by 40 minutes, to allow for the initial Sprout parameter download (it's cached after that)

Sapling:
- Improve the Sapling download API in https://github.com/zcash/librustzcash/pull/459
- Load the Sapling parameters using the improved Sapling API

Test fixes:
- Give other tasks priority, before we spawn the download task

Closes #3037.

### Dependencies

- Tagged the git commit that Zebra depends on as https://github.com/ZcashFoundation/librustzcash/releases/tag/0.5.1-zebra-v1.0.0-beta.2

## Review

@conradoplg is reviewing this PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

Most of the tests will be written as part of #322.

## Follow Up Work

- #322