### PR TITLE
Disconnect from outdated peers on network upgrade

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -200,7 +200,10 @@ pub const EWMA_DEFAULT_RTT: Duration = Duration::from_secs(REQUEST_TIMEOUT.as_se
 ///
 /// This should be much larger than the `SYNC_RESTART_TIMEOUT`, so we choose
 /// better peers when we restart the sync.
-pub const EWMA_DECAY_TIME: Duration = Duration::from_secs(200);
+pub const EWMA_DECAY_TIME_NANOS: f64 = 200.0 * NANOS_PER_SECOND;
+
+/// The number of nanoseconds in one second.
+const NANOS_PER_SECOND: f64 = 1_000_000_000.0;
 
 lazy_static! {
     /// The minimum network protocol version accepted by this crate for each network,
@@ -279,7 +282,10 @@ mod tests {
         assert!(EWMA_DEFAULT_RTT > REQUEST_TIMEOUT,
                 "The default EWMA RTT should be higher than the request timeout, so new peers are required to prove they are fast, before we prefer them to other peers.");
 
-        assert!(EWMA_DECAY_TIME > REQUEST_TIMEOUT,
+        let request_timeout_nanos = REQUEST_TIMEOUT.as_secs_f64()
+            + f64::from(REQUEST_TIMEOUT.subsec_nanos()) * NANOS_PER_SECOND;
+
+        assert!(EWMA_DECAY_TIME_NANOS > request_timeout_nanos,
                 "The EWMA decay time should be higher than the request timeout, so timed out peers are penalised by the EWMA.");
     }
 

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -10,6 +10,8 @@ mod connector;
 mod error;
 /// Performs peer handshakes.
 mod handshake;
+/// Tracks the load on a `Client` service.
+mod load_tracked_client;
 
 use client::{ClientRequest, ClientRequestReceiver, InProgressClientRequest, MustUseOneshotSender};
 
@@ -18,3 +20,4 @@ pub use connection::Connection;
 pub use connector::{Connector, OutboundConnectorRequest};
 pub use error::{ErrorSlot, HandshakeError, PeerError, SharedPeerError};
 pub use handshake::{ConnectedAddr, Handshake, HandshakeRequest};
+pub use load_tracked_client::LoadTrackedClient;

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -12,6 +12,8 @@ mod error;
 mod handshake;
 /// Tracks the load on a `Client` service.
 mod load_tracked_client;
+/// Watches for chain tip height updates to determine the minimum support peer protocol version.
+mod minimum_peer_version;
 
 use client::{ClientRequest, ClientRequestReceiver, InProgressClientRequest, MustUseOneshotSender};
 
@@ -21,3 +23,4 @@ pub use connector::{Connector, OutboundConnectorRequest};
 pub use error::{ErrorSlot, HandshakeError, PeerError, SharedPeerError};
 pub use handshake::{ConnectedAddr, Handshake, HandshakeRequest};
 pub use load_tracked_client::LoadTrackedClient;
+pub use minimum_peer_version::MinimumPeerVersion;

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -15,7 +15,12 @@ mod load_tracked_client;
 /// Watches for chain tip height updates to determine the minimum support peer protocol version.
 mod minimum_peer_version;
 
-use client::{ClientRequest, ClientRequestReceiver, InProgressClientRequest, MustUseOneshotSender};
+#[cfg(not(test))]
+use client::ClientRequest;
+#[cfg(test)]
+pub(crate) use client::ClientRequest;
+
+use client::{ClientRequestReceiver, InProgressClientRequest, MustUseOneshotSender};
 
 pub use client::Client;
 pub use connection::Connection;

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -11,7 +11,10 @@ use futures::{
 };
 use tower::Service;
 
-use crate::protocol::internal::{Request, Response};
+use crate::protocol::{
+    external::types::Version,
+    internal::{Request, Response},
+};
 
 use super::{ErrorSlot, PeerError, SharedPeerError};
 
@@ -28,6 +31,9 @@ pub struct Client {
     ///
     /// `None` unless the connection or client have errored.
     pub(crate) error_slot: ErrorSlot,
+
+    /// The peer connection's protocol version.
+    pub(crate) version: Version,
 }
 
 /// A message from the `peer::Client` to the `peer::Server`.

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -7,7 +7,7 @@ use std::{
 
 use futures::prelude::*;
 use tokio::net::TcpStream;
-use tower::{discover::Change, Service, ServiceExt};
+use tower::{Service, ServiceExt};
 use tracing_futures::Instrument;
 
 use zebra_chain::chain_tip::{ChainTip, NoChainTip};
@@ -57,7 +57,7 @@ where
     S::Future: Send,
     C: ChainTip + Clone + Send + 'static,
 {
-    type Response = Change<SocketAddr, Client>;
+    type Response = (SocketAddr, Client);
     type Error = BoxError;
     type Future =
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
@@ -86,7 +86,7 @@ where
                     connection_tracker,
                 })
                 .await?;
-            Ok(Change::Insert(addr, client))
+            Ok((addr, client))
         }
         .instrument(connector_span)
         .boxed()

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -30,7 +30,9 @@ use zebra_chain::{
 use crate::{
     constants,
     meta_addr::MetaAddrChange,
-    peer::{Client, ClientRequest, Connection, ErrorSlot, HandshakeError, PeerError},
+    peer::{
+        Client, ClientRequest, Connection, ErrorSlot, HandshakeError, MinimumPeerVersion, PeerError,
+    },
     peer_set::ConnectionTracker,
     protocol::{
         external::{types::*, AddrInVersion, Codec, InventoryHash, Message},
@@ -59,7 +61,7 @@ pub struct Handshake<S, C = NoChainTip> {
     our_services: PeerServices,
     relay: bool,
     parent_span: Span,
-    latest_chain_tip: C,
+    minimum_peer_version: MinimumPeerVersion<C>,
 }
 
 /// The peer address that we are handshaking with.
@@ -420,6 +422,8 @@ where
         let user_agent = self.user_agent.unwrap_or_else(|| "".to_string());
         let our_services = self.our_services.unwrap_or_else(PeerServices::empty);
         let relay = self.relay.unwrap_or(false);
+        let network = config.network;
+        let minimum_peer_version = MinimumPeerVersion::new(self.latest_chain_tip, network);
 
         Ok(Handshake {
             config,
@@ -431,7 +435,7 @@ where
             our_services,
             relay,
             parent_span: Span::current(),
-            latest_chain_tip: self.latest_chain_tip,
+            minimum_peer_version,
         })
     }
 }
@@ -473,7 +477,7 @@ pub async fn negotiate_version(
     user_agent: String,
     our_services: PeerServices,
     relay: bool,
-    latest_chain_tip: impl ChainTip,
+    mut minimum_peer_version: MinimumPeerVersion<impl ChainTip>,
 ) -> Result<(Version, PeerServices, SocketAddr), HandshakeError> {
     // Create a random nonce for this connection
     let local_nonce = Nonce::default();
@@ -589,8 +593,7 @@ pub async fn negotiate_version(
 
     // SECURITY: Reject connections to peers on old versions, because they might not know about all
     // network upgrades and could lead to chain forks or slower block propagation.
-    let height = latest_chain_tip.best_tip_height();
-    let min_version = Version::min_remote_for_height(config.network, height);
+    let min_version = minimum_peer_version.current();
     if remote_version < min_version {
         debug!(
             remote_ip = ?their_addr,
@@ -716,7 +719,7 @@ where
         let user_agent = self.user_agent.clone();
         let our_services = self.our_services;
         let relay = self.relay;
-        let latest_chain_tip = self.latest_chain_tip.clone();
+        let minimum_peer_version = self.minimum_peer_version.clone();
 
         let fut = async move {
             debug!(
@@ -747,7 +750,7 @@ where
                     user_agent,
                     our_services,
                     relay,
-                    latest_chain_tip,
+                    minimum_peer_version,
                 ),
             )
             .await??;

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -792,6 +792,7 @@ where
                 shutdown_tx: Some(shutdown_tx),
                 server_tx: server_tx.clone(),
                 error_slot: slot.clone(),
+                version: remote_version,
             };
 
             let (peer_tx, peer_rx) = peer_conn.split();

--- a/zebra-network/src/peer/load_tracked_client.rs
+++ b/zebra-network/src/peer/load_tracked_client.rs
@@ -1,0 +1,71 @@
+//! A peer connection service wrapper type to handle load tracking and provide access to the
+//! reported protocol version.
+
+use std::task::{Context, Poll};
+
+use tower::{
+    load::{Load, PeakEwma},
+    Service,
+};
+
+use crate::{
+    constants::{EWMA_DECAY_TIME_NANOS, EWMA_DEFAULT_RTT},
+    peer::Client,
+    protocol::external::types::Version,
+};
+
+/// A client service wrapper that keeps track of its load.
+///
+/// It also keeps track of the peer's reported protocol version.
+pub struct LoadTrackedClient {
+    service: PeakEwma<Client>,
+    version: Version,
+}
+
+/// Create a new [`LoadTrackedClient`] wrapping the provided `client` service.
+impl From<Client> for LoadTrackedClient {
+    fn from(client: Client) -> Self {
+        let version = client.version;
+
+        let service = PeakEwma::new(
+            client,
+            EWMA_DEFAULT_RTT,
+            EWMA_DECAY_TIME_NANOS,
+            tower::load::CompleteOnResponse::default(),
+        );
+
+        LoadTrackedClient { service, version }
+    }
+}
+
+impl LoadTrackedClient {
+    /// Retrieve the peer's reported protocol version.
+    pub fn version(&self) -> Version {
+        self.version
+    }
+}
+
+impl<Request> Service<Request> for LoadTrackedClient
+where
+    Client: Service<Request>,
+{
+    type Response = <Client as Service<Request>>::Response;
+    type Error = <Client as Service<Request>>::Error;
+    type Future = <PeakEwma<Client> as Service<Request>>::Future;
+
+    fn poll_ready(&mut self, context: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(context)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        self.service.call(request)
+    }
+}
+
+impl Load for LoadTrackedClient {
+    type Metric = <PeakEwma<Client> as Load>::Metric;
+
+    fn load(&self) -> Self::Metric {
+        self.service.load()
+    }
+}

--- a/zebra-network/src/peer/minimum_peer_version.rs
+++ b/zebra-network/src/peer/minimum_peer_version.rs
@@ -1,0 +1,80 @@
+use zebra_chain::{chain_tip::ChainTip, parameters::Network};
+
+use crate::protocol::external::types::Version;
+
+/// A helper type to monitor the chain tip in order to determine the minimum peer protocol version
+/// that is currently supported.
+pub struct MinimumPeerVersion<C> {
+    network: Network,
+    chain_tip: C,
+    current_minimum: Version,
+    has_changed: bool,
+}
+
+impl<C> MinimumPeerVersion<C>
+where
+    C: ChainTip,
+{
+    /// Create a new [`MinimumPeerVersion`] to track the minimum supported peer protocol version
+    /// for the current `chain_tip` on the `network`.
+    pub fn new(chain_tip: C, network: Network) -> Self {
+        MinimumPeerVersion {
+            network,
+            chain_tip,
+            current_minimum: Version::min_remote_for_height(network, None),
+            has_changed: true,
+        }
+    }
+
+    /// Check if the minimum supported peer version has changed since the last time this was
+    /// called.
+    ///
+    /// The first call returns the current minimum version, and subsequent calls return [`None`]
+    /// until the minimum version changes. When that happens, the next call returns the new minimum
+    /// version, and subsequent calls return [`None`] again until the minimum version changes once
+    /// more.
+    pub fn changed(&mut self) -> Option<Version> {
+        self.update();
+
+        if self.has_changed {
+            self.has_changed = false;
+            Some(self.current_minimum)
+        } else {
+            None
+        }
+    }
+
+    /// Retrieve the current minimum supported peer protocol version.
+    pub fn current(&mut self) -> Version {
+        self.update();
+        self.current_minimum
+    }
+
+    /// Check the current chain tip height to determine the minimum peer version, and detect if it
+    /// has changed.
+    fn update(&mut self) {
+        let height = self.chain_tip.best_tip_height();
+        let new_minimum = Version::min_remote_for_height(self.network, height);
+
+        if self.current_minimum != new_minimum {
+            self.current_minimum = new_minimum;
+            self.has_changed = true;
+        }
+    }
+}
+
+/// A custom [`Clone`] implementation to ensure that the first call to
+/// [`MinimumPeerVersion::changed`] after the clone will always return the current version.
+impl<C> Clone for MinimumPeerVersion<C>
+where
+    C: Clone,
+{
+    fn clone(&self) -> Self {
+        MinimumPeerVersion {
+            network: self.network,
+            chain_tip: self.chain_tip.clone(),
+            current_minimum: self.current_minimum,
+            has_changed: true,
+        }
+    }
+}

--- a/zebra-network/src/peer/minimum_peer_version.rs
+++ b/zebra-network/src/peer/minimum_peer_version.rs
@@ -2,6 +2,9 @@ use zebra_chain::{chain_tip::ChainTip, parameters::Network};
 
 use crate::protocol::external::types::Version;
 
+#[cfg(any(test, feature = "proptest-impl"))]
+mod tests;
+
 /// A helper type to monitor the chain tip in order to determine the minimum peer protocol version
 /// that is currently supported.
 pub struct MinimumPeerVersion<C> {

--- a/zebra-network/src/peer/minimum_peer_version/tests.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use tokio::sync::watch;
 
-use zebra_chain::{block, chain_tip::ChainTip, transaction};
+use zebra_chain::{block, chain_tip::ChainTip, parameters::Network, transaction};
+
+use super::MinimumPeerVersion;
 
 #[cfg(test)]
 mod prop;
@@ -42,5 +44,14 @@ impl ChainTip for MockChainTip {
 
     fn best_tip_mined_transaction_ids(&self) -> Arc<[transaction::Hash]> {
         unreachable!("Method not used in `MinimumPeerVersion` tests");
+    }
+}
+
+impl MinimumPeerVersion<MockChainTip> {
+    pub fn with_mock_chain_tip(network: Network) -> (Self, watch::Sender<Option<block::Height>>) {
+        let (chain_tip, best_tip_height) = MockChainTip::new();
+        let minimum_peer_version = MinimumPeerVersion::new(chain_tip, network);
+
+        (minimum_peer_version, best_tip_height)
     }
 }

--- a/zebra-network/src/peer/minimum_peer_version/tests.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use tokio::sync::watch;
+
+use zebra_chain::{block, chain_tip::ChainTip, transaction};
+
+#[cfg(test)]
+mod prop;
+
+/// A mock [`ChainTip`] implementation that allows setting the `best_tip_height` externally.
+#[derive(Clone)]
+pub struct MockChainTip {
+    best_tip_height: watch::Receiver<Option<block::Height>>,
+}
+
+impl MockChainTip {
+    /// Create a new [`MockChainTip`].
+    ///
+    /// Returns the [`MockChainTip`] instance and the endpoint to modiy the current best tip
+    /// height.
+    ///
+    /// Initially, the best tip height is [`None`].
+    pub fn new() -> (Self, watch::Sender<Option<block::Height>>) {
+        let (sender, receiver) = watch::channel(None);
+
+        let mock_chain_tip = MockChainTip {
+            best_tip_height: receiver,
+        };
+
+        (mock_chain_tip, sender)
+    }
+}
+
+impl ChainTip for MockChainTip {
+    fn best_tip_height(&self) -> Option<block::Height> {
+        *self.best_tip_height.borrow()
+    }
+
+    fn best_tip_hash(&self) -> Option<block::Hash> {
+        unreachable!("Method not used in `MinimumPeerVersion` tests");
+    }
+
+    fn best_tip_mined_transaction_ids(&self) -> Arc<[transaction::Hash]> {
+        unreachable!("Method not used in `MinimumPeerVersion` tests");
+    }
+}

--- a/zebra-network/src/peer/minimum_peer_version/tests/prop.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests/prop.rs
@@ -1,0 +1,25 @@
+use proptest::prelude::*;
+
+use zebra_chain::{block, parameters::Network};
+
+use crate::{peer::MinimumPeerVersion, protocol::external::types::Version};
+
+proptest! {
+    /// Test if the calculated minimum peer version is correct.
+    #[test]
+    fn minimum_peer_version_is_correct(
+        network in any::<Network>(),
+        block_height in any::<Option<block::Height>>(),
+    ) {
+        let (mut minimum_peer_version, best_tip_height) =
+            MinimumPeerVersion::with_mock_chain_tip(network);
+
+        best_tip_height
+            .send(block_height)
+            .expect("receiving endpoint lives as long as `minimum_peer_version`");
+
+        let expected_minimum_version = Version::min_remote_for_height(network, block_height);
+
+        prop_assert_eq!(minimum_peer_version.current(), expected_minimum_version);
+    }
+}

--- a/zebra-network/src/peer/minimum_peer_version/tests/prop.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests/prop.rs
@@ -22,4 +22,24 @@ proptest! {
 
         prop_assert_eq!(minimum_peer_version.current(), expected_minimum_version);
     }
+
+    /// Test if the calculated minimum peer version changes with the tip height.
+    #[test]
+    fn minimum_peer_version_is_updated_with_chain_tip(
+        network in any::<Network>(),
+        block_heights in any::<Vec<Option<block::Height>>>(),
+    ) {
+        let (mut minimum_peer_version, best_tip_height) =
+            MinimumPeerVersion::with_mock_chain_tip(network);
+
+        for block_height in block_heights {
+            best_tip_height
+                .send(block_height)
+                .expect("receiving endpoint lives as long as `minimum_peer_version`");
+
+            let expected_minimum_version = Version::min_remote_for_height(network, block_height);
+
+            prop_assert_eq!(minimum_peer_version.current(), expected_minimum_version);
+        }
+    }
 }

--- a/zebra-network/src/peer/minimum_peer_version/tests/prop.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests/prop.rs
@@ -42,4 +42,41 @@ proptest! {
             prop_assert_eq!(minimum_peer_version.current(), expected_minimum_version);
         }
     }
+
+    /// Test if the minimum peer version changes are correctly tracked.
+    #[test]
+    fn minimum_peer_version_reports_changes_correctly(
+        network in any::<Network>(),
+        block_height_updates in any::<Vec<Option<Option<block::Height>>>>(),
+    ) {
+        let (mut minimum_peer_version, best_tip_height) =
+            MinimumPeerVersion::with_mock_chain_tip(network);
+
+        let mut current_minimum_version = Version::min_remote_for_height(network, None);
+        let mut expected_minimum_version = Some(current_minimum_version);
+
+        prop_assert_eq!(minimum_peer_version.changed(), expected_minimum_version);
+
+        for update in block_height_updates {
+            if let Some(new_block_height) = update {
+                best_tip_height
+                    .send(new_block_height)
+                    .expect("receiving endpoint lives as long as `minimum_peer_version`");
+
+                let new_minimum_version = Version::min_remote_for_height(network, new_block_height);
+
+                expected_minimum_version = if new_minimum_version != current_minimum_version {
+                    Some(new_minimum_version)
+                } else {
+                    None
+                };
+
+                current_minimum_version = new_minimum_version;
+            } else {
+                expected_minimum_version = None;
+            }
+
+            prop_assert_eq!(minimum_peer_version.changed(), expected_minimum_version);
+        }
+    }
 }

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -31,7 +31,7 @@ use crate::{
     address_book_updater::AddressBookUpdater,
     constants,
     meta_addr::{MetaAddr, MetaAddrChange},
-    peer::{self, HandshakeRequest, OutboundConnectorRequest},
+    peer::{self, HandshakeRequest, MinimumPeerVersion, OutboundConnectorRequest},
     peer_set::{set::MorePeers, ActiveConnectionCounter, CandidateSet, ConnectionTracker, PeerSet},
     AddressBook, BoxError, Config, Request, Response,
 };
@@ -121,7 +121,7 @@ where
             .with_address_book_updater(address_book_updater.clone())
             .with_advertised_services(PeerServices::NODE_NETWORK)
             .with_user_agent(crate::constants::USER_AGENT.to_string())
-            .with_latest_chain_tip(latest_chain_tip)
+            .with_latest_chain_tip(latest_chain_tip.clone())
             .want_transactions(true)
             .finish()
             .expect("configured all required parameters");
@@ -158,6 +158,7 @@ where
         handle_rx,
         inv_receiver,
         address_book.clone(),
+        MinimumPeerVersion::new(latest_chain_tip, config.network),
     );
     let peer_set = Buffer::new(BoxService::new(peer_set), constants::PEERSET_BUFFER_SIZE);
 

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -714,8 +714,8 @@ where
             }
             HandshakeConnected { address, client } => {
                 debug!(candidate.addr = ?address, "successfully dialed new peer");
-                // successes are handled by an independent task, so they
-                // shouldn't hang
+                // successes are handled by an independent task, except for `candidates.update` in
+                // this task, which has a timeout, so they shouldn't hang
                 peerset_tx.send(Ok((address, client))).await?;
             }
             HandshakeFailed { failed_addr } => {

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -45,7 +45,7 @@ use crate::{
         set::MorePeers,
         ActiveConnectionCounter, CandidateSet,
     },
-    protocol::types::PeerServices,
+    protocol::{external::types::Version, types::PeerServices},
     AddressBook, BoxError, Config, Request, Response,
 };
 
@@ -359,6 +359,7 @@ async fn crawler_peer_limit_one_connect_ok_then_drop() {
                 shutdown_tx: Some(shutdown_tx),
                 server_tx,
                 error_slot,
+                version: Version(1),
             };
 
             // Fake the connection closing.
@@ -431,6 +432,7 @@ async fn crawler_peer_limit_one_connect_ok_stay_open() {
                 shutdown_tx: Some(shutdown_tx),
                 server_tx,
                 error_slot,
+                version: Version(1),
             };
 
             // Make the connection staying open.
@@ -550,6 +552,7 @@ async fn crawler_peer_limit_default_connect_ok_then_drop() {
                 shutdown_tx: Some(shutdown_tx),
                 server_tx,
                 error_slot,
+                version: Version(1),
             };
 
             // Fake the connection closing.
@@ -624,6 +627,7 @@ async fn crawler_peer_limit_default_connect_ok_stay_open() {
                 shutdown_tx: Some(shutdown_tx),
                 server_tx,
                 error_slot,
+                version: Version(1),
             };
 
             // Make the connection staying open.
@@ -775,6 +779,7 @@ async fn listener_peer_limit_one_handshake_ok_then_drop() {
             shutdown_tx: Some(shutdown_tx),
             server_tx,
             error_slot,
+            version: Version(1),
         };
 
         // Actually close the connection.
@@ -851,6 +856,7 @@ async fn listener_peer_limit_one_handshake_ok_stay_open() {
                 shutdown_tx: Some(shutdown_tx),
                 server_tx,
                 error_slot,
+                version: Version(1),
             };
 
             // Make the connection staying open.
@@ -979,6 +985,7 @@ async fn listener_peer_limit_default_handshake_ok_then_drop() {
             shutdown_tx: Some(shutdown_tx),
             server_tx,
             error_slot,
+            version: Version(1),
         };
 
         // Actually close the connection.
@@ -1055,6 +1062,7 @@ async fn listener_peer_limit_default_handshake_ok_stay_open() {
                 shutdown_tx: Some(shutdown_tx),
                 server_tx,
                 error_slot,
+                version: Version(1),
             };
 
             // Make the connection staying open.

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -26,7 +26,7 @@ use futures::{
     FutureExt, StreamExt,
 };
 use tokio::{net::TcpStream, task::JoinHandle};
-use tower::{discover::Change, service_fn, Service};
+use tower::{service_fn, Service};
 use tracing::Span;
 
 use zebra_chain::{chain_tip::NoChainTip, parameters::Network, serialization::DateTime32};
@@ -40,7 +40,7 @@ use crate::{
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
-            PeerChange,
+            DiscoveredPeer,
         },
         set::MorePeers,
         ActiveConnectionCounter, CandidateSet,
@@ -367,7 +367,7 @@ async fn crawler_peer_limit_one_connect_ok_then_drop() {
             // Give the crawler time to get the message.
             tokio::task::yield_now().await;
 
-            Ok(Change::Insert(addr, fake_client))
+            Ok((addr, fake_client))
         });
 
     let (config, mut peerset_rx) =
@@ -380,7 +380,7 @@ async fn crawler_peer_limit_one_connect_ok_then_drop() {
             // A peer handshake succeeded.
             Ok(Some(peer_result)) => {
                 assert!(
-                    matches!(peer_result, Ok(Change::Insert(_, _))),
+                    matches!(peer_result, Ok((_, _))),
                     "unexpected connection error: {:?}\n\
                      {} previous peers succeeded",
                     peer_result,
@@ -438,7 +438,7 @@ async fn crawler_peer_limit_one_connect_ok_stay_open() {
                 .unbounded_send(connection_tracker)
                 .expect("unexpected error sending to unbounded channel");
 
-            Ok(Change::Insert(addr, fake_client))
+            Ok((addr, fake_client))
         }
     });
 
@@ -452,7 +452,7 @@ async fn crawler_peer_limit_one_connect_ok_stay_open() {
             // A peer handshake succeeded.
             Ok(Some(peer_change_result)) => {
                 assert!(
-                    matches!(peer_change_result, Ok(Change::Insert(_, _))),
+                    matches!(peer_change_result, Ok((_, _))),
                     "unexpected connection error: {:?}\n\
                      {} previous peers succeeded",
                     peer_change_result,
@@ -558,7 +558,7 @@ async fn crawler_peer_limit_default_connect_ok_then_drop() {
             // Give the crawler time to get the message.
             tokio::task::yield_now().await;
 
-            Ok(Change::Insert(addr, fake_client))
+            Ok((addr, fake_client))
         });
 
     // TODO: tweak the crawler timeouts and rate-limits so we get over the actual limit
@@ -573,7 +573,7 @@ async fn crawler_peer_limit_default_connect_ok_then_drop() {
             // A peer handshake succeeded.
             Ok(Some(peer_result)) => {
                 assert!(
-                    matches!(peer_result, Ok(Change::Insert(_, _))),
+                    matches!(peer_result, Ok((_, _))),
                     "unexpected connection error: {:?}\n\
                      {} previous peers succeeded",
                     peer_result,
@@ -631,7 +631,7 @@ async fn crawler_peer_limit_default_connect_ok_stay_open() {
                 .unbounded_send(connection_tracker)
                 .expect("unexpected error sending to unbounded channel");
 
-            Ok(Change::Insert(addr, fake_client))
+            Ok((addr, fake_client))
         }
     });
 
@@ -646,7 +646,7 @@ async fn crawler_peer_limit_default_connect_ok_stay_open() {
             // A peer handshake succeeded.
             Ok(Some(peer_change_result)) => {
                 assert!(
-                    matches!(peer_change_result, Ok(Change::Insert(_, _))),
+                    matches!(peer_change_result, Ok((_, _))),
                     "unexpected connection error: {:?}\n\
                      {} previous peers succeeded",
                     peer_change_result,
@@ -797,7 +797,7 @@ async fn listener_peer_limit_one_handshake_ok_then_drop() {
             // A peer handshake succeeded.
             Ok(Some(peer_result)) => {
                 assert!(
-                    matches!(peer_result, Ok(Change::Insert(_, _))),
+                    matches!(peer_result, Ok((_, _))),
                     "unexpected connection error: {:?}\n\
                      {} previous peers succeeded",
                     peer_result,
@@ -872,7 +872,7 @@ async fn listener_peer_limit_one_handshake_ok_stay_open() {
             // A peer handshake succeeded.
             Ok(Some(peer_change_result)) => {
                 assert!(
-                    matches!(peer_change_result, Ok(Change::Insert(_, _))),
+                    matches!(peer_change_result, Ok((_, _))),
                     "unexpected connection error: {:?}\n\
                      {} previous peers succeeded",
                     peer_change_result,
@@ -1001,7 +1001,7 @@ async fn listener_peer_limit_default_handshake_ok_then_drop() {
             // A peer handshake succeeded.
             Ok(Some(peer_result)) => {
                 assert!(
-                    matches!(peer_result, Ok(Change::Insert(_, _))),
+                    matches!(peer_result, Ok((_, _))),
                     "unexpected connection error: {:?}\n\
                      {} previous peers succeeded",
                     peer_result,
@@ -1076,7 +1076,7 @@ async fn listener_peer_limit_default_handshake_ok_stay_open() {
             // A peer handshake succeeded.
             Ok(Some(peer_change_result)) => {
                 assert!(
-                    matches!(peer_change_result, Ok(Change::Insert(_, _))),
+                    matches!(peer_change_result, Ok((_, _))),
                     "unexpected connection error: {:?}\n\
                      {} previous peers succeeded",
                     peer_change_result,
@@ -1308,13 +1308,10 @@ where
 async fn spawn_crawler_with_peer_limit<C>(
     peerset_initial_target_size: impl Into<Option<usize>>,
     outbound_connector: C,
-) -> (Config, mpsc::Receiver<PeerChange>)
+) -> (Config, mpsc::Receiver<DiscoveredPeer>)
 where
-    C: Service<
-            OutboundConnectorRequest,
-            Response = Change<SocketAddr, peer::Client>,
-            Error = BoxError,
-        > + Clone
+    C: Service<OutboundConnectorRequest, Response = (SocketAddr, peer::Client), Error = BoxError>
+        + Clone
         + Send
         + 'static,
     C::Future: Send + 'static,
@@ -1358,7 +1355,7 @@ where
     let address_book = Arc::new(std::sync::Mutex::new(address_book));
 
     // Make the channels large enough to hold all the peers.
-    let (peerset_tx, peerset_rx) = mpsc::channel::<PeerChange>(over_limit_peers);
+    let (peerset_tx, peerset_rx) = mpsc::channel::<DiscoveredPeer>(over_limit_peers);
     let (mut demand_tx, demand_rx) = mpsc::channel::<MorePeers>(over_limit_peers);
 
     let candidates = CandidateSet::new(address_book.clone(), nil_peer_set);
@@ -1421,7 +1418,7 @@ where
 async fn spawn_inbound_listener_with_peer_limit<S>(
     peerset_initial_target_size: impl Into<Option<usize>>,
     listen_handshaker: S,
-) -> (Config, mpsc::Receiver<PeerChange>)
+) -> (Config, mpsc::Receiver<DiscoveredPeer>)
 where
     S: Service<peer::HandshakeRequest, Response = peer::Client, Error = BoxError>
         + Clone
@@ -1446,7 +1443,7 @@ where
     // Make enough inbound connections to go over the limit, even if the limit is zero.
     // Make the channels large enough to hold all the connections.
     let over_limit_connections = config.peerset_inbound_connection_limit() * 2 + 1;
-    let (peerset_tx, peerset_rx) = mpsc::channel::<PeerChange>(over_limit_connections);
+    let (peerset_tx, peerset_rx) = mpsc::channel::<DiscoveredPeer>(over_limit_connections);
 
     // Start listening for connections.
     let listen_fut = accept_inbound_connections(
@@ -1522,15 +1519,12 @@ async fn spawn_add_initial_peers<C>(
     outbound_connector: C,
 ) -> (
     JoinHandle<Result<ActiveConnectionCounter, BoxError>>,
-    mpsc::Receiver<PeerChange>,
+    mpsc::Receiver<DiscoveredPeer>,
     JoinHandle<Result<(), BoxError>>,
 )
 where
-    C: Service<
-            OutboundConnectorRequest,
-            Response = Change<SocketAddr, peer::Client>,
-            Error = BoxError,
-        > + Clone
+    C: Service<OutboundConnectorRequest, Response = (SocketAddr, peer::Client), Error = BoxError>
+        + Clone
         + Send
         + 'static,
     C::Future: Send + 'static,
@@ -1556,7 +1550,7 @@ where
         ..Config::default()
     };
 
-    let (peerset_tx, peerset_rx) = mpsc::channel::<PeerChange>(peer_count + 1);
+    let (peerset_tx, peerset_rx) = mpsc::channel::<DiscoveredPeer>(peer_count + 1);
 
     let (_address_book, address_book_updater, address_book_updater_guard) =
         AddressBookUpdater::spawn(&config, unused_v4);

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -87,6 +87,9 @@ use crate::{
     AddressBook, BoxError, Config,
 };
 
+#[cfg(test)]
+mod tests;
+
 /// A signal sent by the [`PeerSet`] when it has no ready peers, and gets a request from Zebra.
 ///
 /// In response to this signal, the crawler tries to open more peer connections.

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -73,6 +73,7 @@ use tower::{
 };
 
 use crate::{
+    peer::LoadTrackedClient,
     peer_set::{
         unready_service::{Error as UnreadyError, UnreadyService},
         InventoryRegistry,
@@ -108,12 +109,8 @@ pub struct CancelClientWork;
 /// Otherwise, malicious peers could interfere with other peers' `PeerSet` state.
 pub struct PeerSet<D>
 where
-    D: Discover<Key = SocketAddr> + Unpin,
-    D::Service: Service<Request, Response = Response> + Load,
+    D: Discover<Key = SocketAddr, Service = LoadTrackedClient> + Unpin,
     D::Error: Into<BoxError>,
-    <D::Service as Service<Request>>::Error: Into<BoxError> + 'static,
-    <D::Service as Service<Request>>::Future: Send + 'static,
-    <D::Service as Load>::Metric: Debug,
 {
     /// Provides new and deleted peer [`Change`]s to the peer set,
     /// via the [`Discover`] trait implementation.
@@ -176,12 +173,8 @@ where
 
 impl<D> Drop for PeerSet<D>
 where
-    D: Discover<Key = SocketAddr> + Unpin,
-    D::Service: Service<Request, Response = Response> + Load,
+    D: Discover<Key = SocketAddr, Service = LoadTrackedClient> + Unpin,
     D::Error: Into<BoxError>,
-    <D::Service as Service<Request>>::Error: Into<BoxError> + 'static,
-    <D::Service as Service<Request>>::Future: Send + 'static,
-    <D::Service as Load>::Metric: Debug,
 {
     fn drop(&mut self) {
         self.shut_down_tasks_and_channels()
@@ -190,12 +183,8 @@ where
 
 impl<D> PeerSet<D>
 where
-    D: Discover<Key = SocketAddr> + Unpin,
-    D::Service: Service<Request, Response = Response> + Load,
+    D: Discover<Key = SocketAddr, Service = LoadTrackedClient> + Unpin,
     D::Error: Into<BoxError>,
-    <D::Service as Service<Request>>::Error: Into<BoxError> + 'static,
-    <D::Service as Service<Request>>::Future: Send + 'static,
-    <D::Service as Load>::Metric: Debug,
 {
     /// Construct a peerset which uses `discover` to manage peer connections.
     ///
@@ -376,8 +365,7 @@ where
                 }
 
                 // Unready -> Errored
-                Poll::Ready(Some(Err((key, UnreadyError::Inner(e))))) => {
-                    let error = e.into();
+                Poll::Ready(Some(Err((key, UnreadyError::Inner(error))))) => {
                     debug!(%error, "service failed while unready, dropping service");
 
                     let cancel = self.cancel_handles.remove(&key);
@@ -729,12 +717,8 @@ where
 
 impl<D> Service<Request> for PeerSet<D>
 where
-    D: Discover<Key = SocketAddr> + Unpin,
-    D::Service: Service<Request, Response = Response> + Load,
+    D: Discover<Key = SocketAddr, Service = LoadTrackedClient> + Unpin,
     D::Error: Into<BoxError>,
-    <D::Service as Service<Request>>::Error: Into<BoxError> + 'static,
-    <D::Service as Service<Request>>::Future: Send + 'static,
-    <D::Service as Load>::Metric: Debug,
 {
     type Response = Response;
     type Error = BoxError;
@@ -772,8 +756,7 @@ where
                         trace!("preselected service is no longer ready, moving to unready list");
                         self.push_unready(key, service);
                     }
-                    Poll::Ready(Err(e)) => {
-                        let error = e.into();
+                    Poll::Ready(Err(error)) => {
                         trace!(%error, "preselected service failed, dropping it");
                         std::mem::drop(service);
                     }

--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -1,0 +1,50 @@
+use futures::channel::{mpsc, oneshot};
+
+use crate::{
+    peer::{Client, ClientRequest, ErrorSlot, LoadTrackedClient},
+    protocol::external::types::Version,
+};
+
+/// A handle to a mocked [`Client`] instance.
+struct MockedClientHandle {
+    _request_receiver: mpsc::Receiver<ClientRequest>,
+    shutdown_receiver: oneshot::Receiver<()>,
+    version: Version,
+}
+
+impl MockedClientHandle {
+    /// Create a new mocked [`Client`] instance, returning it together with a handle to track it.
+    pub fn new(version: Version) -> (Self, LoadTrackedClient) {
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        let (request_sender, _request_receiver) = mpsc::channel(1);
+
+        let client = Client {
+            shutdown_tx: Some(shutdown_sender),
+            server_tx: request_sender,
+            error_slot: ErrorSlot::default(),
+            version,
+        };
+
+        let handle = MockedClientHandle {
+            _request_receiver,
+            shutdown_receiver,
+            version,
+        };
+
+        (handle, client.into())
+    }
+
+    /// Gets the peer protocol version associated to the [`Client`].
+    pub fn version(&self) -> Version {
+        self.version
+    }
+
+    /// Checks if the [`Client`] instance has not been dropped, which would have disconnected from
+    /// the peer.
+    pub fn is_connected(&mut self) -> bool {
+        match self.shutdown_receiver.try_recv() {
+            Ok(None) => true,
+            Ok(Some(())) | Err(oneshot::Canceled) => false,
+        }
+    }
+}

--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -371,8 +371,8 @@ impl Arbitrary for BlockHeightPairAcrossNetworkUpgrades {
             .prop_map(|(network, before_upgrade_height, after_upgrade_height)| {
                 BlockHeightPairAcrossNetworkUpgrades {
                     network,
-                    before_upgrade: dbg!(block::Height(before_upgrade_height)),
-                    after_upgrade: dbg!(block::Height(after_upgrade_height)),
+                    before_upgrade: block::Height(before_upgrade_height),
+                    after_upgrade: block::Height(after_upgrade_height),
                 }
             })
             .boxed()

--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -1,9 +1,22 @@
-use futures::channel::{mpsc, oneshot};
+use std::net::SocketAddr;
+
+use futures::{
+    channel::{mpsc, oneshot},
+    stream, Stream, StreamExt,
+};
+use proptest::{collection::vec, prelude::any};
+use proptest_derive::Arbitrary;
+use tower::{discover::Change, BoxError};
 
 use crate::{
     peer::{Client, ClientRequest, ErrorSlot, LoadTrackedClient},
     protocol::external::types::Version,
 };
+
+/// The maximum number of arbitrary peers to generate in [`PeerVersions`].
+///
+/// This affects the maximum number of peer connections added to the [`PeerSet`] during the tests.
+const MAX_PEERS: usize = 20;
 
 /// A handle to a mocked [`Client`] instance.
 struct MockedClientHandle {
@@ -46,5 +59,65 @@ impl MockedClientHandle {
             Ok(None) => true,
             Ok(Some(())) | Err(oneshot::Canceled) => false,
         }
+    }
+}
+
+/// A helper type to generate arbitrary peer versions which can then become mock peer services.
+#[derive(Arbitrary, Debug)]
+struct PeerVersions {
+    #[proptest(strategy = "vec(any::<Version>(), 1..MAX_PEERS)")]
+    peer_versions: Vec<Version>,
+}
+
+impl PeerVersions {
+    /// Convert the arbitrary peer versions into mock peer services.
+    ///
+    /// Each peer versions results in a mock peer service, which is returned as a tuple. The first
+    /// element is the [`LeadTrackedClient`], which is the actual service for the peer connection.
+    /// The second element is a [`MockedClientHandle`], which contains the open endpoints of the
+    /// mock channels used by the peer service.
+    pub fn mock_peers(&self) -> (Vec<LoadTrackedClient>, Vec<MockedClientHandle>) {
+        let mut clients = Vec::with_capacity(self.peer_versions.len());
+        let mut handles = Vec::with_capacity(self.peer_versions.len());
+
+        for peer_version in &self.peer_versions {
+            let (handle, client) = MockedClientHandle::new(*peer_version);
+
+            clients.push(client);
+            handles.push(handle);
+        }
+
+        (clients, handles)
+    }
+
+    /// Convert the arbitrary peer versions into mock peer services available through a
+    /// [`Discover`] compatible stream.
+    ///
+    /// A tuple is returned, where the first item is a stream with the mock peers available through
+    /// a [`Discover`] interface, and the second is a list of handles to the mocked services.
+    ///
+    /// The returned stream never finishes, so it is ready to be passed to the [`PeerSet`]
+    /// constructor.
+    ///
+    /// See [`Self::mock_peers`] for details on how the peers are mocked and on what the handles
+    /// contain.
+    pub fn mock_peer_discovery(
+        &self,
+    ) -> (
+        impl Stream<Item = Result<Change<SocketAddr, LoadTrackedClient>, BoxError>>,
+        Vec<MockedClientHandle>,
+    ) {
+        let (clients, handles) = self.mock_peers();
+        let fake_ports = 1_u16..;
+
+        let discovered_peers_iterator = fake_ports.zip(clients).map(|(port, client)| {
+            let peer_address = SocketAddr::new([127, 0, 0, 1].into(), port);
+
+            Ok(Change::Insert(peer_address, client))
+        });
+
+        let discovered_peers = stream::iter(discovered_peers_iterator).chain(stream::pending());
+
+        (discovered_peers, handles)
     }
 }

--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -23,6 +23,9 @@ use crate::{
     AddressBook, Config,
 };
 
+#[cfg(test)]
+mod prop;
+
 /// The maximum number of arbitrary peers to generate in [`PeerVersions`].
 ///
 /// This affects the maximum number of peer connections added to the [`PeerSet`] during the tests.

--- a/zebra-network/src/peer_set/set/tests/prop.rs
+++ b/zebra-network/src/peer_set/set/tests/prop.rs
@@ -1,0 +1,92 @@
+use std::net::SocketAddr;
+
+use futures::FutureExt;
+use proptest::prelude::*;
+use tower::{discover::Discover, BoxError, ServiceExt};
+
+use zebra_chain::{block, chain_tip::ChainTip, parameters::Network};
+
+use super::{MockedClientHandle, PeerSetBuilder, PeerVersions};
+use crate::{
+    peer::{LoadTrackedClient, MinimumPeerVersion},
+    peer_set::PeerSet,
+    protocol::external::types::Version,
+};
+
+proptest! {
+    /// Check if discovered outdated peers are immediately dropped by the [`PeerSet`].
+    #[test]
+    fn only_non_outdated_peers_are_accepted(
+        network in any::<Network>(),
+        block_height in any::<block::Height>(),
+        peer_versions in any::<PeerVersions>(),
+    ) {
+        let runtime = zebra_test::init_async();
+
+        let (discovered_peers, mut handles) = peer_versions.mock_peer_discovery();
+        let (mut minimum_peer_version, best_tip_height) =
+            MinimumPeerVersion::with_mock_chain_tip(network);
+
+        best_tip_height
+            .send(Some(block_height))
+            .expect("receiving endpoint lives as long as `minimum_peer_version`");
+
+        let current_minimum_version = minimum_peer_version.current();
+
+        runtime.block_on(async move {
+            let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+                .with_discover(discovered_peers)
+                .with_minimum_peer_version(minimum_peer_version)
+                .build();
+
+            check_if_only_up_to_date_peers_are_live(
+                &mut peer_set,
+                &mut handles,
+                current_minimum_version,
+            )?;
+
+            Ok::<_, TestCaseError>(())
+        })?;
+    }
+}
+
+/// Check if only peers with up-to-date protocol versions are live.
+///
+/// This will poll the `peer_set` to allow it to drop outdated peers, and then check the peer
+/// `handles` to assert that only up-to-date peers are kept by the `peer_set`.
+fn check_if_only_up_to_date_peers_are_live<D, C>(
+    peer_set: &mut PeerSet<D, C>,
+    handles: &mut Vec<MockedClientHandle>,
+    minimum_version: Version,
+) -> Result<(), TestCaseError>
+where
+    D: Discover<Key = SocketAddr, Service = LoadTrackedClient> + Unpin,
+    D::Error: Into<BoxError>,
+    C: ChainTip,
+{
+    // Force `poll_discover` to be called to process all discovered peers.
+    let poll_result = peer_set.ready().now_or_never();
+    let all_peers_are_outdated = handles
+        .iter()
+        .all(|handle| handle.version() < minimum_version);
+
+    if all_peers_are_outdated {
+        prop_assert!(matches!(poll_result, None));
+    } else {
+        prop_assert!(matches!(poll_result, Some(Ok(_))));
+    }
+
+    for handle in handles {
+        let is_outdated = handle.version() < minimum_version;
+        let is_connected = handle.is_connected();
+
+        prop_assert!(
+            is_connected != is_outdated,
+            "is_connected: {}, is_outdated: {}",
+            is_connected,
+            is_outdated,
+        );
+    }
+
+    Ok(())
+}

--- a/zebra-network/src/peer_set/set/tests/prop.rs
+++ b/zebra-network/src/peer_set/set/tests/prop.rs
@@ -6,7 +6,9 @@ use tower::{discover::Discover, BoxError, ServiceExt};
 
 use zebra_chain::{block, chain_tip::ChainTip, parameters::Network};
 
-use super::{MockedClientHandle, PeerSetBuilder, PeerVersions};
+use super::{
+    BlockHeightPairAcrossNetworkUpgrades, MockedClientHandle, PeerSetBuilder, PeerVersions,
+};
 use crate::{
     peer::{LoadTrackedClient, MinimumPeerVersion},
     peer_set::PeerSet,
@@ -43,6 +45,47 @@ proptest! {
                 &mut peer_set,
                 &mut handles,
                 current_minimum_version,
+            )?;
+
+            Ok::<_, TestCaseError>(())
+        })?;
+    }
+
+    /// Check if peers that become outdated after a network upgrade are dropped by the [`PeerSet`].
+    #[test]
+    fn outdated_peers_are_dropped_on_network_upgrade(
+        block_heights in any::<BlockHeightPairAcrossNetworkUpgrades>(),
+        peer_versions in any::<PeerVersions>(),
+    ) {
+        let runtime = zebra_test::init_async();
+
+        let (discovered_peers, mut handles) = peer_versions.mock_peer_discovery();
+        let (mut minimum_peer_version, best_tip_height) =
+            MinimumPeerVersion::with_mock_chain_tip(block_heights.network);
+
+        best_tip_height
+            .send(Some(dbg!(block_heights.before_upgrade)))
+            .expect("receiving endpoint lives as long as `minimum_peer_version`");
+
+        runtime.block_on(async move {
+            let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+                .with_discover(discovered_peers)
+                .with_minimum_peer_version(minimum_peer_version.clone())
+                .build();
+
+            check_if_only_up_to_date_peers_are_live(
+                &mut peer_set,
+                &mut handles,
+                dbg!(minimum_peer_version.current()),
+            )?;
+
+            best_tip_height.send(Some(dbg!(block_heights.after_upgrade)))
+            .expect("receiving endpoint lives as long as `minimum_peer_version`");
+
+            check_if_only_up_to_date_peers_are_live(
+                &mut peer_set,
+                &mut handles,
+                dbg!(minimum_peer_version.current()),
             )?;
 
             Ok::<_, TestCaseError>(())

--- a/zebra-network/src/peer_set/set/tests/prop.rs
+++ b/zebra-network/src/peer_set/set/tests/prop.rs
@@ -64,7 +64,7 @@ proptest! {
             MinimumPeerVersion::with_mock_chain_tip(block_heights.network);
 
         best_tip_height
-            .send(Some(dbg!(block_heights.before_upgrade)))
+            .send(Some(block_heights.before_upgrade))
             .expect("receiving endpoint lives as long as `minimum_peer_version`");
 
         runtime.block_on(async move {
@@ -76,16 +76,17 @@ proptest! {
             check_if_only_up_to_date_peers_are_live(
                 &mut peer_set,
                 &mut handles,
-                dbg!(minimum_peer_version.current()),
+                minimum_peer_version.current(),
             )?;
 
-            best_tip_height.send(Some(dbg!(block_heights.after_upgrade)))
-            .expect("receiving endpoint lives as long as `minimum_peer_version`");
+            best_tip_height
+                .send(Some(block_heights.after_upgrade))
+                .expect("receiving endpoint lives as long as `minimum_peer_version`");
 
             check_if_only_up_to_date_peers_are_live(
                 &mut peer_set,
                 &mut handles,
-                dbg!(minimum_peer_version.current()),
+                minimum_peer_version.current(),
             )?;
 
             Ok::<_, TestCaseError>(())

--- a/zebra-network/src/protocol/external/arbitrary.rs
+++ b/zebra-network/src/protocol/external/arbitrary.rs
@@ -9,7 +9,7 @@ use zebra_chain::{block, transaction};
 
 use super::{
     addr::{canonical_socket_addr, ipv6_mapped_socket_addr},
-    types::PeerServices,
+    types::{PeerServices, Version},
     InventoryHash, Message,
 };
 
@@ -110,6 +110,18 @@ impl Message {
             .prop_map(Message::GetData)
             .boxed()
     }
+}
+
+impl Arbitrary for Version {
+    type Parameters = ();
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        prop_oneof![170_002_u32..=170_015, 0_u32..]
+            .prop_map(Version)
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
 }
 
 /// Returns a random canonical Zebra `SocketAddr`.

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -38,7 +38,6 @@ impl From<Network> for Magic {
 
 /// A protocol version number.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct Version(pub u32);
 
 impl fmt::Display for Version {


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
Zebra should disconnect from outdated peers when a network upgrade is activated.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->
> Overwinter nodes should take steps to:
>
> [...]
> - disconnect any existing connections to pre-Overwinter nodes.

https://zips.z.cash/zip-0201#rejecting-pre-overwinter-connections

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
- create a `LoadTrackedClient` that wraps a load tracked client service and keeps track of the peer's reported protocol version
- create a `PeerDiscoverer` type that prepares discovered peers into `LoadTrackedClient`s
- disconnect from outdated peers stored in `ready_services` once the minimum peer version changes
- avoid adding unready services for outdated peers
- avoid adding ready services for outdated peers

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 can review this. It's still in draft because I haven't written any tests yet.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
