### PR TITLE
Ignore NotFound errors in the syncer

### DIFF
--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -47,9 +47,6 @@ pub enum PeerError {
     #[error("Internal services over capacity")]
     Overloaded,
 
-    // TODO: stop closing connections on these errors (#2107)
-    //       log info or debug logs instead
-    //
     /// We requested data that the peer couldn't find.
     #[error("Remote peer could not find items: {0:?}")]
     NotFound(Vec<InventoryHash>),


### PR DESCRIPTION
## Motivation

After PR #3120, the syncer logs a lot of `NotFound` block messages, and resets the sync each time.

But instead, the syncer should just keep going, and try the block again.

## Solution

- Ignore `NotFound` errors in the syncer
- Optimise the string checks in the syncer

## Review

Anyone can review this PR, it blocks tagging the next beta release.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors


