### PR TITLE
Update the State RFC to match the current database format

### DIFF
--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -600,24 +600,24 @@ order on byte strings is the numeric ordering).
 
 We use the following rocksdb column families:
 
-| Column Family                 | Keys                   | Values                               | Updates |
-|-------------------------------|------------------------|--------------------------------------|---------|
-| `hash_by_height`              | `block::Height`        | `block::Hash`                        | Never   |
-| `height_by_hash`              | `block::Hash`          | `block::Height`                      | Never   |
-| `block_by_height`             | `block::Height`        | `Block`                              | Never   |
-| `tx_by_hash`                  | `transaction::Hash`    | `TransactionLocation`                | Never   |
-| `utxo_by_outpoint`            | `OutPoint`             | `transparent::Utxo`                  | Delete  |
-| `sprout_nullifiers`           | `sprout::Nullifier`    | `()`                                 | Never   |
-| `sprout_anchors`              | `sprout::tree::Root`   | `()`                                 | Never   |
-| `sprout_note_commitment_tree` | `block::Height`        | `sprout::tree::NoteCommitmentTree`   | Delete  |
-| `sapling_nullifiers`          | `sapling::Nullifier`   | `()`                                 | Never   |
-| `sapling_anchors`             | `sapling::tree::Root`  | `()`                                 | Never   |
-| `sapling_note_commitment_tree`| `block::Height`        | `sapling::tree::NoteCommitmentTree`  | Delete  |
-| `orchard_nullifiers`          | `orchard::Nullifier`   | `()`                                 | Never   |
-| `orchard_anchors`             | `orchard::tree::Root`  | `()`                                 | Never   |
-| `orchard_note_commitment_tree`| `block::Height`        | `orchard::tree::NoteCommitmentTree`  | Delete  |
-| `history_tree`                | `block::Height`        | `zcash_history::Entry`               | Delete  |
-| `tip_chain_value_pool`        | `()`                   | `ValueBalance<NonNegative>`          | Update  |
+| Column Family                  | Keys                   | Values                               | Updates |
+|--------------------------------|------------------------|--------------------------------------|---------|
+| `hash_by_height`               | `block::Height`        | `block::Hash`                        | Never   |
+| `height_by_hash`               | `block::Hash`          | `block::Height`                      | Never   |
+| `block_by_height`              | `block::Height`        | `Block`                              | Never   |
+| `tx_by_hash`                   | `transaction::Hash`    | `TransactionLocation`                | Never   |
+| `utxo_by_outpoint`             | `OutPoint`             | `transparent::Utxo`                  | Delete  |
+| `sprout_nullifiers`            | `sprout::Nullifier`    | `()`                                 | Never   |
+| `sprout_anchors`               | `sprout::tree::Root`   | `()`                                 | Never   |
+| `sprout_note_commitment_tree`  | `block::Height`        | `sprout::tree::NoteCommitmentTree`   | Delete  |
+| `sapling_nullifiers`           | `sapling::Nullifier`   | `()`                                 | Never   |
+| `sapling_anchors`              | `sapling::tree::Root`  | `()`                                 | Never   |
+| `sapling_note_commitment_tree` | `block::Height`        | `sapling::tree::NoteCommitmentTree`  | Delete  |
+| `orchard_nullifiers`           | `orchard::Nullifier`   | `()`                                 | Never   |
+| `orchard_anchors`              | `orchard::tree::Root`  | `()`                                 | Never   |
+| `orchard_note_commitment_tree` | `block::Height`        | `orchard::tree::NoteCommitmentTree`  | Delete  |
+| `history_tree`                 | `block::Height`        | `zcash_history::Entry`               | Delete  |
+| `tip_chain_value_pool`         | `()`                   | `ValueBalance<NonNegative>`          | Update  |
 
 Zcash structures are encoded using `ZcashSerialize`/`ZcashDeserialize`.
 Other structures are encoded using `IntoDisk`/`FromDisk`.
@@ -626,8 +626,8 @@ Block and Transaction Data:
 - `Height`: 32 bits, big-endian, unsigned
 - `TransactionIndex`: 32 bits, big-endian, unsigned
 - `TransactionLocation`: `Height \|\| TransactionIndex`
-- `TransferIndex`: 32 bits, big-endian, unsigned
-- `OutPoint`: `transaction::Hash \|\| TransferIndex`
+- `TransparentOutputIndex`: 32 bits, big-endian, unsigned
+- `OutPoint`: `transaction::Hash \|\| TransparentOutputIndex`
 - `IsFromCoinbase` : 8 bits, boolean, zero or one
 - `Utxo`: `Height \|\| IsFromCoinbase \|\| Output`
 

--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -616,7 +616,7 @@ We use the following rocksdb column families:
 | `orchard_nullifiers`           | `orchard::Nullifier`   | `()`                                 | Never   |
 | `orchard_anchors`              | `orchard::tree::Root`  | `()`                                 | Never   |
 | `orchard_note_commitment_tree` | `block::Height`        | `orchard::tree::NoteCommitmentTree`  | Delete  |
-| `history_tree`                 | `block::Height`        | `NonEmptyHistoryTree`               | Delete  |
+| `history_tree`                 | `block::Height`        | `NonEmptyHistoryTree`                | Delete  |
 | `tip_chain_value_pool`         | `()`                   | `ValueBalance`                       | Update  |
 
 Zcash structures are encoded using `ZcashSerialize`/`ZcashDeserialize`.

--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -617,7 +617,7 @@ We use the following rocksdb column families:
 | `orchard_anchors`              | `orchard::tree::Root`  | `()`                                 | Never   |
 | `orchard_note_commitment_tree` | `block::Height`        | `orchard::tree::NoteCommitmentTree`  | Delete  |
 | `history_tree`                 | `block::Height`        | `zcash_history::Entry`               | Delete  |
-| `tip_chain_value_pool`         | `()`                   | `ValueBalance<NonNegative>`          | Update  |
+| `tip_chain_value_pool`         | `()`                   | `ValueBalance`                       | Update  |
 
 Zcash structures are encoded using `ZcashSerialize`/`ZcashDeserialize`.
 Other structures are encoded using `IntoDisk`/`FromDisk`.

--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -616,7 +616,7 @@ We use the following rocksdb column families:
 | `orchard_nullifiers`           | `orchard::Nullifier`   | `()`                                 | Never   |
 | `orchard_anchors`              | `orchard::tree::Root`  | `()`                                 | Never   |
 | `orchard_note_commitment_tree` | `block::Height`        | `orchard::tree::NoteCommitmentTree`  | Delete  |
-| `history_tree`                 | `block::Height`        | `zcash_history::Entry`               | Delete  |
+| `history_tree`                 | `block::Height`        | `NonEmptyHistoryTree`               | Delete  |
 | `tip_chain_value_pool`         | `()`                   | `ValueBalance`                       | Update  |
 
 Zcash structures are encoded using `ZcashSerialize`/`ZcashDeserialize`.
@@ -639,7 +639,7 @@ Amounts:
 
 Derived Formats:
 - `*::NoteCommitmentTree`: `bincode` using `serde`
-- `zcash_history::Entry`: `bincode` using `serde`, using `zcash_history`'s `serde` implementation
+- `NonEmptyHistoryTree`: `bincode` using `serde`, using `zcash_history`'s `serde` implementation
 
 ### Implementing consensus rules using rocksdb
 [rocksdb-consensus-rules]: #rocksdb-consensus-rules

--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -635,7 +635,7 @@ We use big-endian encoding for keys, to allow database index prefix searches.
 
 Amounts:
 - `Amount`: 64 bits, little-endian, signed
-- `ValueBalance<NonNegative>`: `[Amount; 4]`
+- `ValueBalance`: `[Amount; 4]`
 
 Derived Formats:
 - `*::NoteCommitmentTree`: `bincode` using `serde`


### PR DESCRIPTION
## Motivation

This PR brings Zebra's State RFC up-to-date with the current database format. (Including upcoming Sprout changes.)

This is unexpected client planning work in sprint 24.

## Review

Anyone can review this low-priority PR.

### Reviewer Checklist

  - [x] Design makes sense
  - [x] Design matches implementation

## Follow Up Work

- #3137