### PR TITLE
Security: Drop blocks that are a long way ahead of the tip

### DIFF
--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -76,9 +76,18 @@ where
         + 'static,
     V::Future: Send + 'static,
 {
-    block: BlockVerifier<S, V>,
+    /// The checkpointing block verifier.
+    ///
+    /// Always used for blocks before `Canopy`, optionally used for the entire checkpoint list.
     checkpoint: CheckpointVerifier<S>,
+
+    /// The highest permitted checkpoint block.
+    ///
+    /// This height must be in the `checkpoint` verifier's checkpoint list.
     max_checkpoint_height: block::Height,
+
+    /// The full block verifier, used for blocks after `max_checkpoint_height`.
+    block: BlockVerifier<S, V>,
 }
 
 /// An error while semantically verifying a block.
@@ -248,9 +257,9 @@ where
     let block = BlockVerifier::new(network, state_service.clone(), transaction.clone());
     let checkpoint = CheckpointVerifier::from_checkpoint_list(list, network, tip, state_service);
     let chain = ChainVerifier {
-        block,
         checkpoint,
         max_checkpoint_height,
+        block,
     };
 
     let chain = Buffer::new(BoxService::new(chain), VERIFIER_BUFFER_BOUND);

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -125,7 +125,7 @@ impl StartCmd {
             state.clone(),
             tx_verifier,
             sync_status.clone(),
-            latest_chain_tip,
+            latest_chain_tip.clone(),
             chain_tip_change.clone(),
         );
         let mempool = BoxService::new(mempool);
@@ -137,6 +137,7 @@ impl StartCmd {
             block_verifier: chain_verifier,
             mempool: mempool.clone(),
             state,
+            latest_chain_tip,
         };
         setup_tx
             .send(setup_data)

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -114,8 +114,9 @@ impl StartCmd {
         let (syncer, sync_status) = ChainSync::new(
             &config,
             peer_set.clone(),
-            state.clone(),
             chain_verifier.clone(),
+            state.clone(),
+            latest_chain_tip.clone(),
         );
 
         info!("initializing mempool");

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -68,6 +68,9 @@ pub struct InboundSetupData {
 
     /// A service that manages cached blockchain state.
     pub state: State,
+
+    /// Allows efficient access to the best tip of the blockchain.
+    pub latest_chain_tip: zs::LatestChainTip,
 }
 
 /// Tracks the internal state of the [`Inbound`] service during setup.
@@ -199,12 +202,14 @@ impl Service<zn::Request> for Inbound {
                         block_verifier,
                         mempool,
                         state,
+                        latest_chain_tip,
                     } = setup_data;
 
                     let block_downloads = Box::pin(BlockDownloads::new(
                         Timeout::new(block_download_peer_set.clone(), BLOCK_DOWNLOAD_TIMEOUT),
                         Timeout::new(block_verifier, BLOCK_VERIFY_TIMEOUT),
                         state.clone(),
+                        latest_chain_tip,
                     ));
 
                     result = Ok(());

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -227,6 +227,12 @@ where
                 .oneshot(zn::Request::BlocksByHash(std::iter::once(hash).collect()))
                 .await?
             {
+                assert_eq!(
+                    blocks.len(),
+                    1,
+                    "wrong number of blocks in response to a single hash"
+                );
+
                 blocks
                     .into_iter()
                     .next()

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -47,7 +47,7 @@ type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// Since Zebra keeps an `inv` index, inbound downloads for malicious blocks
 /// will be directed to the malicious node that originally gossiped the hash.
 /// Therefore, this attack can be carried out by a single malicious node.
-const MAX_INBOUND_CONCURRENCY: usize = 10;
+const MAX_INBOUND_CONCURRENCY: usize = 20;
 
 /// The action taken in response to a peer's gossiped block hash.
 pub enum DownloadAction {

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -242,7 +242,9 @@ where
             };
             metrics::counter!("gossip.downloaded.block.count", 1);
 
-            // Security & Performance: reject blocks that are too far ahead of our tip
+            // Security & Performance: reject blocks that are too far ahead of our tip.
+            // Avoids denial of service attacks, and reduces wasted work on high blocks
+            // that will timeout before being verified.
             let tip_height = latest_chain_tip.best_tip_height();
 
             let max_lookahead_height = if let Some(tip_height) = tip_height {

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -191,7 +191,7 @@ where
         }
 
         if self.pending.len() >= MAX_INBOUND_CONCURRENCY {
-            tracing::info!(
+            tracing::debug!(
                 ?hash,
                 queue_len = self.pending.len(),
                 ?MAX_INBOUND_CONCURRENCY,

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -289,7 +289,7 @@ where
 
                     Err("gossiped block height too far ahead")?;
                 } else if block_height < min_accepted_height {
-                    tracing::info!(
+                    tracing::debug!(
                         ?hash,
                         ?block_height,
                         ?tip_height,

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -183,7 +183,9 @@ where
                 ?MAX_INBOUND_CONCURRENCY,
                 "block hash already queued for inbound download: ignored block"
             );
+
             metrics::gauge!("gossip.queued.block.count", self.pending.len() as _);
+            metrics::counter!("gossip.already.queued.dropped.block.hash.count", 1);
 
             return DownloadAction::AlreadyQueued;
         }
@@ -195,7 +197,9 @@ where
                 ?MAX_INBOUND_CONCURRENCY,
                 "too many blocks queued for inbound download: ignored block"
             );
+
             metrics::gauge!("gossip.queued.block.count", self.pending.len() as _);
+            metrics::counter!("gossip.full.queue.dropped.block.hash.count", 1);
 
             return DownloadAction::FullQueue;
         }

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -647,7 +647,7 @@ async fn setup(
         state_service.clone(),
         buffered_tx_verifier.clone(),
         sync_status.clone(),
-        latest_chain_tip,
+        latest_chain_tip.clone(),
         chain_tip_change.clone(),
     );
 
@@ -677,6 +677,7 @@ async fn setup(
         block_verifier,
         mempool: mempool_service.clone(),
         state: state_service.clone(),
+        latest_chain_tip,
     };
     let r = setup_tx.send(setup_data);
     // We can't expect or unwrap because the returned Result does not implement Debug

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -566,6 +566,9 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
     Ok(())
 }
 
+/// Test that the inbound downloader rejects blocks above the lookahead limit.
+///
+/// TODO: also test that it rejects blocks behind the tip limit. (Needs ~100 fake blocks.)
 #[tokio::test]
 async fn inbound_block_height_lookahead_limit() -> Result<(), crate::BoxError> {
     // Get services

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -219,7 +219,7 @@ pub struct Mempool {
     /// If the state's best chain tip has reached this height, always enable the mempool.
     debug_enable_at_height: Option<Height>,
 
-    /// Allow efficient access to the best tip of the blockchain.
+    /// Allows efficient access to the best tip of the blockchain.
     latest_chain_tip: zs::LatestChainTip,
 
     /// Allows the detection of newly added chain tip blocks,

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -81,6 +81,15 @@ pub const MIN_LOOKAHEAD_LIMIT: usize = zebra_consensus::MAX_CHECKPOINT_HEIGHT_GA
 /// See [`MIN_LOOKAHEAD_LIMIT`] for details.
 pub const DEFAULT_LOOKAHEAD_LIMIT: usize = zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP * 5;
 
+/// The expected maximum number of hashes in an ObtainTips or ExtendTips response.
+///
+/// This is used to allow block heights that are slightly beyond the lookahead limit,
+/// but still limit the number of blocks in the pipeline between the downloader and
+/// the state.
+///
+/// See [`MIN_LOOKAHEAD_LIMIT`] for details.
+pub const MAX_TIPS_RESPONSE_HASH_COUNT: usize = 500;
+
 /// Controls how long we wait for a tips response to return.
 ///
 /// ## Correctness
@@ -749,10 +758,6 @@ where
             BlockDownloadVerifyError::CancelledDuringDownload
             | BlockDownloadVerifyError::CancelledDuringVerification => {
                 tracing::debug!(error = ?e, "block verification was cancelled, continuing");
-                false
-            }
-            BlockDownloadVerifyError::AboveLookaheadHeightLimit => {
-                tracing::debug!(error = ?e, "block height was above lookahead limit, continuing");
                 false
             }
 

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -180,6 +180,7 @@ where
     #[instrument(level = "debug", skip(self), fields(%hash))]
     pub async fn download_and_verify(&mut self, hash: block::Hash) -> Result<(), Report> {
         if self.cancel_handles.contains_key(&hash) {
+            metrics::counter!("sync.already.queued.dropped.block.hash.count", 1);
             return Err(eyre!("duplicate hash queued for download: {:?}", hash));
         }
 

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -27,6 +27,9 @@ use zebra_state as zs;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+/// We allow an extra checkpoint's worth of blocks in the verifier and state queues.
+const EXTRA_DOWNLOADS_LOOKAHEAD: usize = zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP;
+
 #[derive(Copy, Clone, Debug)]
 pub(super) struct AlwaysHedge;
 
@@ -240,7 +243,8 @@ where
                 let tip_height = latest_chain_tip.best_tip_height();
 
                 let max_lookahead_height = if let Some(tip_height) = tip_height {
-                    let lookahead = i32::try_from(lookahead_limit).expect("fits in i32");
+                    let lookahead = i32::try_from(lookahead_limit + EXTRA_DOWNLOADS_LOOKAHEAD)
+                        .expect("fits in i32");
                     (tip_height + lookahead).expect("tip is much lower than Height::MAX")
                 } else {
                     let genesis_lookahead =

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -27,8 +27,8 @@ use zebra_state as zs;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-/// We allow an extra checkpoint's worth of blocks in the verifier and state queues.
-const EXTRA_DOWNLOADS_LOOKAHEAD: usize = zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP;
+/// We allow an extra two checkpoints' worth of blocks in the verifier and state queues.
+const EXTRA_DOWNLOADS_LOOKAHEAD: usize = 2 * zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP;
 
 #[derive(Copy, Clone, Debug)]
 pub(super) struct AlwaysHedge;

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -191,6 +191,12 @@ where
                 };
 
                 let block = if let zn::Response::Blocks(blocks) = rsp {
+                    assert_eq!(
+                        blocks.len(),
+                        1,
+                        "wrong number of blocks in response to a single hash"
+                    );
+
                     blocks
                         .into_iter()
                         .next()

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -317,7 +317,7 @@ where
                         // (or blocks far ahead of the current state tip).
                         Err(BlockDownloadVerifyError::AboveLookaheadHeightLimit)?;
                     } else if block_height < min_accepted_height {
-                        tracing::info!(
+                        tracing::debug!(
                             ?hash,
                             ?block_height,
                             ?tip_height,


### PR DESCRIPTION
## Motivation

Zebra downloads blocks that are a long way ahead of the tip, and leaves them in its verification pipeline until they expire (3-10 minutes?). This is a denial of service risk.

It also causes performance issues, and sync slowness issues.

Closes #1389.

## Solution

- Drop gossiped blocks that are a long way ahead of the tip (non-finalized + 20 blocks)
    - Add tests for the gossiped block lookahead limit
- Drop synced blocks that are a long way ahead of the tip (non-finalized + 3000 blocks)
- Drop gossiped and synced blocks that are behind the finalized tip (non-finalized - 100 blocks)

I'll do tests for synced blocks in a separate PR, they're a bit trickier.

## Review

@jvff or @dconnolly can review this PR.

This is urgent because syncs are very slow, and #3191 or #3244 should help fix that.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- #862 