### PR TITLE
Fix syncer download order and add sync tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4564,6 +4564,7 @@ dependencies = [
  "futures",
  "gumdrop",
  "hyper",
+ "indexmap",
  "inferno",
  "lazy_static",
  "metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4376,6 +4376,7 @@ dependencies = [
  "static_assertions",
  "subtle",
  "thiserror",
+ "tokio",
  "tracing",
  "uint",
  "x25519-dalek",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [features]
 default = []
-proptest-impl = ["proptest", "proptest-derive", "zebra-test", "rand", "rand_chacha"]
+proptest-impl = ["proptest", "proptest-derive", "zebra-test", "rand", "rand_chacha", "tokio"]
 bench = ["zebra-test"]
 
 [dependencies]
@@ -60,6 +60,7 @@ proptest-derive = { version = "0.3.0", optional = true }
 
 rand = { version = "0.8", optional = true }
 rand_chacha = { version = "0.3", optional = true }
+tokio = { version = "1.15.0", optional = true }
 
 # ZF deps
 ed25519-zebra = "3.0.0"

--- a/zebra-chain/src/chain_tip.rs
+++ b/zebra-chain/src/chain_tip.rs
@@ -4,6 +4,9 @@ use std::sync::Arc;
 
 use crate::{block, transaction};
 
+#[cfg(any(test, feature = "proptest-impl"))]
+pub mod mock;
+
 /// An interface for querying the chain tip.
 ///
 /// This trait helps avoid dependencies between:

--- a/zebra-chain/src/chain_tip/mock.rs
+++ b/zebra-chain/src/chain_tip/mock.rs
@@ -6,6 +6,9 @@ use tokio::sync::watch;
 
 use crate::{block, chain_tip::ChainTip, transaction};
 
+/// A sender that sets the `best_tip_height` of a [`MockChainTip`].]
+pub type MockChainTipSender = watch::Sender<Option<block::Height>>;
+
 /// A mock [`ChainTip`] implementation that allows setting the `best_tip_height` externally.
 #[derive(Clone, Debug)]
 pub struct MockChainTip {
@@ -19,7 +22,7 @@ impl MockChainTip {
     /// height.
     ///
     /// Initially, the best tip height is [`None`].
-    pub fn new() -> (Self, watch::Sender<Option<block::Height>>) {
+    pub fn new() -> (Self, MockChainTipSender) {
         let (sender, receiver) = watch::channel(None);
 
         let mock_chain_tip = MockChainTip {

--- a/zebra-chain/src/chain_tip/mock.rs
+++ b/zebra-chain/src/chain_tip/mock.rs
@@ -1,0 +1,45 @@
+//! Mock [`ChainTip`]s for use in tests.
+
+use std::sync::Arc;
+
+use tokio::sync::watch;
+
+use crate::{block, chain_tip::ChainTip, transaction};
+
+/// A mock [`ChainTip`] implementation that allows setting the `best_tip_height` externally.
+#[derive(Clone, Debug)]
+pub struct MockChainTip {
+    best_tip_height: watch::Receiver<Option<block::Height>>,
+}
+
+impl MockChainTip {
+    /// Create a new [`MockChainTip`].
+    ///
+    /// Returns the [`MockChainTip`] instance and the endpoint to modiy the current best tip
+    /// height.
+    ///
+    /// Initially, the best tip height is [`None`].
+    pub fn new() -> (Self, watch::Sender<Option<block::Height>>) {
+        let (sender, receiver) = watch::channel(None);
+
+        let mock_chain_tip = MockChainTip {
+            best_tip_height: receiver,
+        };
+
+        (mock_chain_tip, sender)
+    }
+}
+
+impl ChainTip for MockChainTip {
+    fn best_tip_height(&self) -> Option<block::Height> {
+        *self.best_tip_height.borrow()
+    }
+
+    fn best_tip_hash(&self) -> Option<block::Hash> {
+        unreachable!("Method not used in `MinimumPeerVersion` tests");
+    }
+
+    fn best_tip_mined_transaction_ids(&self) -> Arc<[transaction::Hash]> {
+        unreachable!("Method not used in `MinimumPeerVersion` tests");
+    }
+}

--- a/zebra-chain/src/chain_tip/mock.rs
+++ b/zebra-chain/src/chain_tip/mock.rs
@@ -39,10 +39,10 @@ impl ChainTip for MockChainTip {
     }
 
     fn best_tip_hash(&self) -> Option<block::Hash> {
-        unreachable!("Method not used in `MinimumPeerVersion` tests");
+        unreachable!("Method not used in tests");
     }
 
     fn best_tip_mined_transaction_ids(&self) -> Arc<[transaction::Hash]> {
-        unreachable!("Method not used in `MinimumPeerVersion` tests");
+        unreachable!("Method not used in tests");
     }
 }

--- a/zebra-network/src/peer/minimum_peer_version/tests.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests.rs
@@ -1,51 +1,13 @@
-use std::sync::Arc;
+//! Test utilities and tests for minimum network peer version requirements.
 
 use tokio::sync::watch;
 
-use zebra_chain::{block, chain_tip::ChainTip, parameters::Network, transaction};
+use zebra_chain::{block, chain_tip::mock::MockChainTip, parameters::Network};
 
 use super::MinimumPeerVersion;
 
 #[cfg(test)]
 mod prop;
-
-/// A mock [`ChainTip`] implementation that allows setting the `best_tip_height` externally.
-#[derive(Clone)]
-pub struct MockChainTip {
-    best_tip_height: watch::Receiver<Option<block::Height>>,
-}
-
-impl MockChainTip {
-    /// Create a new [`MockChainTip`].
-    ///
-    /// Returns the [`MockChainTip`] instance and the endpoint to modiy the current best tip
-    /// height.
-    ///
-    /// Initially, the best tip height is [`None`].
-    pub fn new() -> (Self, watch::Sender<Option<block::Height>>) {
-        let (sender, receiver) = watch::channel(None);
-
-        let mock_chain_tip = MockChainTip {
-            best_tip_height: receiver,
-        };
-
-        (mock_chain_tip, sender)
-    }
-}
-
-impl ChainTip for MockChainTip {
-    fn best_tip_height(&self) -> Option<block::Height> {
-        *self.best_tip_height.borrow()
-    }
-
-    fn best_tip_hash(&self) -> Option<block::Hash> {
-        unreachable!("Method not used in `MinimumPeerVersion` tests");
-    }
-
-    fn best_tip_mined_transaction_ids(&self) -> Arc<[transaction::Hash]> {
-        unreachable!("Method not used in `MinimumPeerVersion` tests");
-    }
-}
 
 impl MinimumPeerVersion<MockChainTip> {
     pub fn with_mock_chain_tip(network: Network) -> (Self, watch::Sender<Option<block::Height>>) {

--- a/zebra-network/src/peer/minimum_peer_version/tests.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests.rs
@@ -1,8 +1,9 @@
 //! Test utilities and tests for minimum network peer version requirements.
 
-use tokio::sync::watch;
-
-use zebra_chain::{block, chain_tip::mock::MockChainTip, parameters::Network};
+use zebra_chain::{
+    chain_tip::mock::{MockChainTip, MockChainTipSender},
+    parameters::Network,
+};
 
 use super::MinimumPeerVersion;
 
@@ -10,7 +11,7 @@ use super::MinimumPeerVersion;
 mod prop;
 
 impl MinimumPeerVersion<MockChainTip> {
-    pub fn with_mock_chain_tip(network: Network) -> (Self, watch::Sender<Option<block::Height>>) {
+    pub fn with_mock_chain_tip(network: Network) -> (Self, MockChainTipSender) {
         let (chain_tip, best_tip_height) = MockChainTip::new();
         let minimum_peer_version = MinimumPeerVersion::new(chain_tip, network);
 

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -18,6 +18,7 @@ zebra-state = { path = "../zebra-state" }
 abscissa_core = "0.5"
 chrono = "0.4"
 gumdrop = "0.7"
+indexmap = "1.7.0"
 lazy_static = "1.4.0"
 serde = { version = "1", features = ["serde_derive"] }
 toml = "0.5"

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -144,9 +144,9 @@ impl StartCmd {
             .send(setup_data)
             .map_err(|_| eyre!("could not send setup data to inbound service"))?;
 
-        let syncer_error_future = syncer.sync();
+        let syncer_task_handle = tokio::spawn(syncer.sync());
 
-        let mut sync_gossip_task_handle = tokio::spawn(sync::gossip_best_tip_block_hashes(
+        let mut block_gossip_task_handle = tokio::spawn(sync::gossip_best_tip_block_hashes(
             sync_status.clone(),
             chain_tip_change.clone(),
             peer_set.clone(),
@@ -169,11 +169,10 @@ impl StartCmd {
 
         info!("spawned initial Zebra tasks");
 
-        // TODO: spawn the syncer task, after making the PeerSet marker::Sync and marker::Send
-        //       turn these tasks into a FuturesUnordered?
+        // TODO: put tasks into an ongoing FuturesUnordered and a startup FuturesUnordered?
 
-        // ongoing futures & tasks
-        pin!(syncer_error_future);
+        // ongoing tasks
+        pin!(syncer_task_handle);
         pin!(mempool_crawler_task_handle);
         pin!(mempool_queue_checker_task_handle);
         pin!(tx_gossip_task_handle);
@@ -187,12 +186,11 @@ impl StartCmd {
             let mut exit_when_task_finishes = true;
 
             let result = select! {
-                // We don't spawn the syncer future into a separate task yet.
-                // So syncer panics automatically propagate to the main zebrad task.
-                sync_result = &mut syncer_error_future => sync_result
+                sync_result = &mut syncer_task_handle => sync_result
+                    .expect("unexpected panic in the syncer task")
                     .map(|_| info!("syncer task exited")),
 
-                sync_gossip_result = &mut sync_gossip_task_handle => sync_gossip_result
+                block_gossip_result = &mut block_gossip_task_handle => block_gossip_result
                     .expect("unexpected panic in the chain tip block gossip task")
                     .map(|_| info!("chain tip block gossip task exited"))
                     .map_err(|e| eyre!(e)),
@@ -238,11 +236,9 @@ impl StartCmd {
 
         info!("exiting Zebra because an ongoing task exited: stopping other tasks");
 
-        // futures
-        std::mem::drop(syncer_error_future);
-
         // ongoing tasks
-        sync_gossip_task_handle.abort();
+        syncer_task_handle.abort();
+        block_gossip_task_handle.abort();
         mempool_crawler_task_handle.abort();
         mempool_queue_checker_task_handle.abort();
         tx_gossip_task_handle.abort();

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -817,6 +817,14 @@ where
                 tracing::debug!(error = ?e, "block verification was cancelled, continuing");
                 false
             }
+            BlockDownloadVerifyError::BehindTipHeightLimit => {
+                tracing::debug!(
+                    error = ?e,
+                    "block height is behind the current state tip, \
+                     assuming the syncer will eventually catch up to the state, continuing"
+                );
+                false
+            }
 
             // String matches
             BlockDownloadVerifyError::Invalid(VerifyChainError::Block(
@@ -848,6 +856,7 @@ where
                 if err_str.contains("AlreadyVerified")
                     || err_str.contains("AlreadyInChain")
                     || err_str.contains("Cancelled")
+                    || err_str.contains("BehindTipHeight")
                     || err_str.contains("block is already committed to the state")
                     || err_str.contains("NotFound")
                 {

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -94,9 +94,13 @@ pub enum BlockDownloadVerifyError {
 #[derive(Debug)]
 pub struct Downloads<ZN, ZV>
 where
-    ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + 'static,
+    ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Sync + 'static,
     ZN::Future: Send,
-    ZV: Service<Arc<Block>, Response = block::Hash, Error = BoxError> + Send + Clone + 'static,
+    ZV: Service<Arc<Block>, Response = block::Hash, Error = BoxError>
+        + Send
+        + Sync
+        + Clone
+        + 'static,
     ZV::Future: Send,
 {
     // Services
@@ -127,9 +131,13 @@ where
 
 impl<ZN, ZV> Stream for Downloads<ZN, ZV>
 where
-    ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + 'static,
+    ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Sync + 'static,
     ZN::Future: Send,
-    ZV: Service<Arc<Block>, Response = block::Hash, Error = BoxError> + Send + Clone + 'static,
+    ZV: Service<Arc<Block>, Response = block::Hash, Error = BoxError>
+        + Send
+        + Sync
+        + Clone
+        + 'static,
     ZV::Future: Send,
 {
     type Item = Result<block::Hash, BlockDownloadVerifyError>;
@@ -168,9 +176,13 @@ where
 
 impl<ZN, ZV> Downloads<ZN, ZV>
 where
-    ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + 'static,
+    ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Sync + 'static,
     ZN::Future: Send,
-    ZV: Service<Arc<Block>, Response = block::Hash, Error = BoxError> + Send + Clone + 'static,
+    ZV: Service<Arc<Block>, Response = block::Hash, Error = BoxError>
+        + Send
+        + Sync
+        + Clone
+        + 'static,
     ZV::Future: Send,
 {
     /// Initialize a new download stream with the provided `network` and
@@ -395,7 +407,7 @@ where
     }
 
     /// Get the number of currently in-flight download tasks.
-    pub fn in_flight(&self) -> usize {
+    pub fn in_flight(&mut self) -> usize {
         self.pending.len()
     }
 }

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -36,17 +36,20 @@ type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// `lookahead_limit / VERIFICATION_PIPELINE_SCALING_DIVISOR`.
 ///
 /// For the default lookahead limit, the extra number of blocks is
-/// `2 * MAX_TIPS_RESPONSE_HASH_COUNT`.
+/// `4 * MAX_TIPS_RESPONSE_HASH_COUNT`.
 ///
-/// This allows the verifier and state queues to hold an extra two tips responses worth of blocks,
+/// This allows the verifier and state queues to hold a few extra tips responses worth of blocks,
 /// even if the syncer queue is full. Any unused capacity is shared between both queues.
+///
+/// If this capacity is exceeded, the downloader will start failing download blocks with
+/// [`BlockDownloadVerifyError::AboveLookaheadHeightLimit`], and the syncer will reset.
 ///
 /// Since the syncer queue is limited to the `lookahead_limit`,
 /// the rest of the capacity is reserved for the other queues.
 /// There is no reserved capacity for the syncer queue:
 /// if the other queues stay full, the syncer will eventually time out and reset.
 const VERIFICATION_PIPELINE_SCALING_DIVISOR: usize =
-    DEFAULT_LOOKAHEAD_LIMIT / (2 * MAX_TIPS_RESPONSE_HASH_COUNT);
+    DEFAULT_LOOKAHEAD_LIMIT / (4 * MAX_TIPS_RESPONSE_HASH_COUNT);
 
 #[derive(Copy, Clone, Debug)]
 pub(super) struct AlwaysHedge;

--- a/zebrad/src/components/sync/tests.rs
+++ b/zebrad/src/components/sync/tests.rs
@@ -1,1 +1,4 @@
+//! Syncer tests
+
 mod timing;
+mod vectors;

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -25,13 +25,13 @@ use crate::{
     config::ZebradConfig,
 };
 
-/// Maximum time to wait for a network service request.
+/// Maximum time to wait for a request to any test service.
 ///
 /// The default [`MockService`] value can be too short for some of these tests that take a little
-/// longer than expected to actually send the network request.
+/// longer than expected to actually send the request.
 ///
 /// Increasing this value causes the tests to take longer to complete, so it can't be too large.
-const MAX_PEER_SET_REQUEST_DELAY: Duration = Duration::from_millis(500);
+const MAX_SERVICE_REQUEST_DELAY: Duration = Duration::from_millis(500);
 
 /// Test that the syncer downloads genesis, blocks 1-2 using obtain_tips, and blocks 3-4 using extend_tips.
 ///
@@ -942,13 +942,20 @@ fn setup() -> (
         ..Default::default()
     };
 
+    // These tests run multiple tasks in parallel.
+    // So machines under heavy load need a longer delay.
+    // (For example, CI machines with limited cores.)
     let peer_set = MockService::build()
-        .with_max_request_delay(MAX_PEER_SET_REQUEST_DELAY)
+        .with_max_request_delay(MAX_SERVICE_REQUEST_DELAY)
         .for_unit_tests();
 
-    let chain_verifier = MockService::build().for_unit_tests();
+    let chain_verifier = MockService::build()
+        .with_max_request_delay(MAX_SERVICE_REQUEST_DELAY)
+        .for_unit_tests();
 
-    let state_service = MockService::build().for_unit_tests();
+    let state_service = MockService::build()
+        .with_max_request_delay(MAX_SERVICE_REQUEST_DELAY)
+        .for_unit_tests();
 
     let (mock_chain_tip, mock_chain_tip_sender) = MockChainTip::new();
 

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -260,6 +260,238 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     Ok(())
 }
 
+/// Test that the syncer downloads genesis, blocks 1-2 using obtain_tips, and blocks 3-4 using extend_tips,
+/// with duplicate block hashes.
+///
+/// This test also makes sure that the syncer downloads blocks in order.
+#[tokio::test(flavor = "multi_thread")]
+async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
+    // Get services
+    let (
+        chain_sync_future,
+        _sync_status,
+        mut chain_verifier,
+        mut peer_set,
+        mut state_service,
+        _mock_chain_tip_sender,
+    ) = setup();
+
+    // Get blocks
+    let block0: Arc<Block> =
+        zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES.zcash_deserialize_into()?;
+    let block0_hash = block0.hash();
+
+    let block1: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let block1_hash = block1.hash();
+
+    let block2: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_2_BYTES.zcash_deserialize_into()?;
+    let block2_hash = block2.hash();
+
+    let block3: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_3_BYTES.zcash_deserialize_into()?;
+    let block3_hash = block3.hash();
+
+    let block4: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_4_BYTES.zcash_deserialize_into()?;
+    let block4_hash = block4.hash();
+
+    let block5: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_5_BYTES.zcash_deserialize_into()?;
+    let block5_hash = block5.hash();
+
+    // Start the syncer
+    let chain_sync_task_handle = tokio::spawn(chain_sync_future);
+
+    // ChainSync::request_genesis
+
+    // State is checked for genesis
+    state_service
+        .expect_request(zs::Request::Depth(block0_hash))
+        .await
+        .respond(zs::Response::Depth(None));
+
+    // Block 0 is fetched and committed to the state
+    peer_set
+        .expect_request(zn::Request::BlocksByHash(iter::once(block0_hash).collect()))
+        .await
+        .respond(zn::Response::Blocks(vec![block0.clone()]));
+
+    chain_verifier
+        .expect_request(block0)
+        .await
+        .respond(block0_hash);
+
+    // Check that nothing unexpected happened.
+    // We expect more requests to the state service, because the syncer keeps on running.
+    peer_set.expect_no_requests().await;
+    chain_verifier.expect_no_requests().await;
+
+    // State is checked for genesis again
+    state_service
+        .expect_request(zs::Request::Depth(block0_hash))
+        .await
+        .respond(zs::Response::Depth(Some(0)));
+
+    // ChainSync::obtain_tips
+
+    // State is asked for a block locator.
+    state_service
+        .expect_request(zs::Request::BlockLocator)
+        .await
+        .respond(zs::Response::BlockLocator(vec![block0_hash]));
+
+    // Network is sent the block locator
+    peer_set
+        .expect_request(zn::Request::FindBlocks {
+            known_blocks: vec![block0_hash],
+            stop: None,
+        })
+        .await
+        .respond(zn::Response::BlockHashes(vec![
+            block1_hash,
+            block1_hash,
+            block1_hash, // tip
+            block2_hash, // expected_next
+            block3_hash, // (discarded - last hash, possibly incorrect)
+        ]));
+
+    // State is checked for the first unknown block (block 1)
+    state_service
+        .expect_request(zs::Request::Depth(block1_hash))
+        .await
+        .respond(zs::Response::Depth(None));
+
+    // Clear remaining block locator requests
+    for _ in 0..(sync::FANOUT - 1) {
+        peer_set
+            .expect_request(zn::Request::FindBlocks {
+                known_blocks: vec![block0_hash],
+                stop: None,
+            })
+            .await
+            .respond(Err(zn::BoxError::from("synthetic test obtain tips error")));
+    }
+
+    // Check that nothing unexpected happened.
+    peer_set.expect_no_requests().await;
+    chain_verifier.expect_no_requests().await;
+
+    // State is checked for all non-tip blocks (blocks 1 & 2) in response order
+    state_service
+        .expect_request(zs::Request::Depth(block1_hash))
+        .await
+        .respond(zs::Response::Depth(None));
+    state_service
+        .expect_request(zs::Request::Depth(block2_hash))
+        .await
+        .respond(zs::Response::Depth(None));
+
+    // Blocks 1 & 2 are fetched in order, then verified concurrently
+    peer_set
+        .expect_request(zn::Request::BlocksByHash(iter::once(block1_hash).collect()))
+        .await
+        .respond(zn::Response::Blocks(vec![block1.clone()]));
+    peer_set
+        .expect_request(zn::Request::BlocksByHash(iter::once(block2_hash).collect()))
+        .await
+        .respond(zn::Response::Blocks(vec![block2.clone()]));
+
+    // We can't guarantee the verification request order
+    let mut remaining_blocks: HashMap<block::Hash, Arc<Block>> =
+        [(block1_hash, block1), (block2_hash, block2)]
+            .iter()
+            .cloned()
+            .collect();
+
+    for _ in 1..=2 {
+        chain_verifier
+            .expect_request_that(|req| remaining_blocks.remove(&req.hash()).is_some())
+            .await
+            .respond_with(|req| req.hash());
+    }
+    assert_eq!(
+        remaining_blocks,
+        HashMap::new(),
+        "expected all non-tip blocks to be verified by obtain tips"
+    );
+
+    // Check that nothing unexpected happened.
+    chain_verifier.expect_no_requests().await;
+    state_service.expect_no_requests().await;
+
+    // ChainSync::extend_tips
+
+    // Network is sent a block locator based on the tip
+    peer_set
+        .expect_request(zn::Request::FindBlocks {
+            known_blocks: vec![block1_hash],
+            stop: None,
+        })
+        .await
+        .respond(zn::Response::BlockHashes(vec![
+            block2_hash, // tip (discarded - already fetched)
+            block3_hash, // expected_next
+            block4_hash,
+            block3_hash,
+            block4_hash,
+            block5_hash, // (discarded - last hash, possibly incorrect)
+        ]));
+
+    // Clear remaining block locator requests
+    for _ in 0..(sync::FANOUT - 1) {
+        peer_set
+            .expect_request(zn::Request::FindBlocks {
+                known_blocks: vec![block1_hash],
+                stop: None,
+            })
+            .await
+            .respond(Err(zn::BoxError::from("synthetic test extend tips error")));
+    }
+
+    // Check that nothing unexpected happened.
+    chain_verifier.expect_no_requests().await;
+    state_service.expect_no_requests().await;
+
+    // Blocks 3 & 4 are fetched in order, then verified concurrently
+    peer_set
+        .expect_request(zn::Request::BlocksByHash(iter::once(block3_hash).collect()))
+        .await
+        .respond(zn::Response::Blocks(vec![block3.clone()]));
+    peer_set
+        .expect_request(zn::Request::BlocksByHash(iter::once(block4_hash).collect()))
+        .await
+        .respond(zn::Response::Blocks(vec![block4.clone()]));
+
+    // We can't guarantee the verification request order
+    let mut remaining_blocks: HashMap<block::Hash, Arc<Block>> =
+        [(block3_hash, block3), (block4_hash, block4)]
+            .iter()
+            .cloned()
+            .collect();
+
+    for _ in 3..=4 {
+        chain_verifier
+            .expect_request_that(|req| remaining_blocks.remove(&req.hash()).is_some())
+            .await
+            .respond_with(|req| req.hash());
+    }
+    assert_eq!(
+        remaining_blocks,
+        HashMap::new(),
+        "expected all non-tip blocks to be verified by extend tips"
+    );
+
+    // Check that nothing unexpected happened.
+    chain_verifier.expect_no_requests().await;
+    state_service.expect_no_requests().await;
+
+    let chain_sync_result = chain_sync_task_handle.now_or_never();
+    assert!(
+        matches!(chain_sync_result, None),
+        "unexpected error or panic in chain sync task: {:?}",
+        chain_sync_result,
+    );
+
+    Ok(())
+}
+
 /// Test that zebra-network rejects blocks with the wrong hash.
 #[tokio::test]
 async fn sync_block_wrong_hash() -> Result<(), crate::BoxError> {


### PR DESCRIPTION
## Motivation

We want the syncer to download blocks in chain order, as documented.

We want to make sure that the syncer correctly drops blocks that are a long way ahead of the state tip.
This is a follow-up test for PR #3167 for ticket #1389.

## Solution

`ChainSync` bug fixes:
- Download synced blocks in chain order, not arbitrary `HashSet` order
    - This adds a direct dependency on `indexmap` (multiple Zebra dependencies already use `indexmap`)
- Increase the syncer lookahead height limit, because in-order syncs are more efficient
- Spawn the syncer into its own task - closes #3114

Extra Tests:
- Add `ChainSync` tests for `obtain_tips`, `extend_tips`, and wrong block hashes
- Add block too high tests for `obtain_tips` and `extend_tips`
- Add `ChainSync` tests for duplicate `FindBlocks` response hashes 

Make some futures `std::marker::Send` or `std::marker::Sync`, so they can be spawned: 
- Refactor so that `RetryLimit::Future` is `std::marker::Sync`
- Make the `ChainSync::sync` future `std::marker::Send` by spawning tips futures

Improve test harnesses:
- Improve `MockService` failure messages
- Add closure-based responses to the `MockService` API
- Move `MockChainTip` to `zebra-chain`
- Add a `MockChainTipSender` type alias
- Support `MockChainTip` in `ChainSync` and its downloader

## Review

I'm not sure who is around to review this PR, maybe @upbqdn?

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [x] Tests for Expected Behaviour
  - [x] Tests for Errors

