### PR TITLE
Add a copy-state zebrad command, which copies blocks between two state services

### DIFF
--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -26,6 +26,7 @@ pub const CONFIG_FILE: &str = "zebrad.toml";
 #[derive(Command, Debug, Options)]
 pub enum ZebradCmd {
     /// The `copy-state` subcommand, used to debug cached chain state
+    // TODO: hide this command from users in release builds (#3279)
     #[options(help = "copy cached chain state (debug only)")]
     CopyState(CopyStateCmd),
 

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -1,12 +1,16 @@
 //! Zebrad Subcommands
 
+mod copy_state;
 mod download;
 mod generate;
 mod start;
 mod version;
 
 use self::ZebradCmd::*;
-use self::{download::DownloadCmd, generate::GenerateCmd, start::StartCmd, version::VersionCmd};
+use self::{
+    copy_state::CopyStateCmd, download::DownloadCmd, generate::GenerateCmd, start::StartCmd,
+    version::VersionCmd,
+};
 
 use crate::config::ZebradConfig;
 
@@ -21,6 +25,10 @@ pub const CONFIG_FILE: &str = "zebrad.toml";
 /// Zebrad Subcommands
 #[derive(Command, Debug, Options)]
 pub enum ZebradCmd {
+    /// The `copy-state` subcommand, used to debug cached chain state
+    #[options(help = "copy cached chain state (debug only)")]
+    CopyState(CopyStateCmd),
+
     /// The `download` subcommand
     #[options(help = "pre-download required parameter files")]
     Download(DownloadCmd),
@@ -49,7 +57,7 @@ impl ZebradCmd {
     pub(crate) fn is_server(&self) -> bool {
         match self {
             // List all the commands, so new commands have to make a choice here
-            Start(_) => true,
+            CopyState(_) | Start(_) => true,
             Download(_) | Generate(_) | Help(_) | Version(_) => false,
         }
     }
@@ -58,6 +66,7 @@ impl ZebradCmd {
 impl Runnable for ZebradCmd {
     fn run(&self) {
         match self {
+            CopyState(cmd) => cmd.run(),
             Download(cmd) => cmd.run(),
             Generate(cmd) => cmd.run(),
             ZebradCmd::Help(cmd) => cmd.run(),

--- a/zebrad/src/commands/copy_state.rs
+++ b/zebrad/src/commands/copy_state.rs
@@ -307,6 +307,8 @@ impl Runnable for CopyStateCmd {
 
         rt.expect("runtime should not already be taken")
             .run(self.start());
+
+        info!("finished cached chain state copy");
     }
 }
 

--- a/zebrad/src/commands/copy_state.rs
+++ b/zebrad/src/commands/copy_state.rs
@@ -37,9 +37,9 @@ use std::{cmp::min, path::PathBuf};
 
 use abscissa_core::{config, Command, FrameworkError, Options, Runnable};
 use color_eyre::eyre::{eyre, Report};
-
 use tokio::time::Instant;
 use tower::{Service, ServiceExt};
+
 use zebra_chain::{block::Height, parameters::Network};
 use zebra_state as old_zs;
 use zebra_state as new_zs;
@@ -51,7 +51,7 @@ use crate::{
     BoxError,
 };
 
-/// How often we log info-level progress locks
+/// How often we log info-level progress messages
 const PROGRESS_HEIGHT_INTERVAL: u32 = 5_000;
 
 /// `copy-state` subcommand

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -268,6 +268,8 @@ impl Runnable for StartCmd {
 
         rt.expect("runtime should not already be taken")
             .run(self.start());
+
+        info!("stopping zebrad");
     }
 }
 

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -1,8 +1,8 @@
 //! `start` subcommand - entry point for starting a zebra node
 //!
-//!  ## Application Structure
+//! ## Application Structure
 //!
-//!  A zebra node consists of the following services and tasks:
+//! A zebra node consists of the following services and tasks:
 //!
 //! Peers:
 //!  * Network Service

--- a/zebrad/src/components/tokio.rs
+++ b/zebrad/src/components/tokio.rs
@@ -59,11 +59,13 @@ impl RuntimeRun for Runtime {
 
         match result {
             Ok(()) => {
+                info!("shutting down Zebra");
+
                 // Don't wait for the runtime to shut down all the tasks.
                 app_writer().shutdown(Shutdown::Graceful);
             }
-            Err(e) => {
-                eprintln!("Error: {:?}", e);
+            Err(error) => {
+                warn!(?error, "shutting down Zebra due to an error");
                 app_writer().shutdown(Shutdown::Forced);
             }
         }


### PR DESCRIPTION
## Motivation

As part of the `lightwalletd` work, we need to make significant changes to Zebra's on-disk database format. But syncing the entire chain takes 2-6 hours, which will make development very slow.

Instead, we can copy blocks from one state directory to another, skipping the network, structural validation, semantic validation, and most contextual validation. (But still confirming that the block data is bound to the block header, because that's required for NU5 anyway.)

Copying blocks between identical state formats takes about 15 minutes with a single-threaded copy.

This draft PR is part of planning the wallet support. We need to know how hard it will be to change the database format, and what we need to do to test those changes.

### Zebra APIs

Since `zebra-state` is a separate crate, and there we can start two state instances, and copy blocks between them.

## Solution

- Initialize `zebrad` as a long-running server command, with all the default components (tracing, metrics, etc.)
- Open two state services
- Copy blocks between them, logging progress at regular intervals
- Verify that the blocks were copied correctly

## Review

Anyone can review this low-priority PR.

### Reviewer Checklist

  - [x] Code makes sense

This is a draft dev-only command, so it doesn't need acceptance tests yet. (We might want to add some when we've used it a bit, and its options are stable.)

## Follow Up Work

- Actually modify the database format
- Modify this command to copy between two different database formats