### PR TITLE
Integrate JoinSplit verifier

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -1020,7 +1020,7 @@ impl Transaction {
     }
 
     /// Returns the `vpub_old` fields from `JoinSplit`s in this transaction,
-    /// regardless of version.
+    /// regardless of version, in the order they appear in the transaction.
     ///
     /// These values are added to the sprout chain value pool,
     /// and removed from the value pool of this transaction.
@@ -1067,7 +1067,7 @@ impl Transaction {
     }
 
     /// Modify the `vpub_old` fields from `JoinSplit`s in this transaction,
-    /// regardless of version.
+    /// regardless of version, in the order they appear in the transaction.
     ///
     /// See `output_values_to_sprout` for details.
     #[cfg(any(test, feature = "proptest-impl"))]
@@ -1116,7 +1116,7 @@ impl Transaction {
     }
 
     /// Returns the `vpub_new` fields from `JoinSplit`s in this transaction,
-    /// regardless of version.
+    /// regardless of version, in the order they appear in the transaction.
     ///
     /// These values are removed from the value pool of this transaction.
     /// and added to the sprout chain value pool.
@@ -1163,7 +1163,7 @@ impl Transaction {
     }
 
     /// Modify the `vpub_new` fields from `JoinSplit`s in this transaction,
-    /// regardless of version.
+    /// regardless of version, in the order they appear in the transaction.
     ///
     /// See `input_values_from_sprout` for details.
     #[cfg(any(test, feature = "proptest-impl"))]

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -153,6 +153,9 @@ pub enum TransactionError {
     #[error("Downcast from BoxError to redjubjub::Error failed")]
     InternalDowncastError(String),
 
+    #[error("either vpub_old or vpub_new must be zero")]
+    BothVPubsNonZero,
+
     #[error("adding to the sprout pool is disabled after Canopy")]
     DisabledAddToSproutPool,
 

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -130,12 +130,12 @@ pub enum TransactionError {
     #[error("spend description cv and rk MUST NOT be of small order")]
     SmallOrder,
 
-    // XXX change this when we align groth16 verifier errors with bellman
-    // and add a from annotation when the error type is more precise
+    // XXX: the underlying error is bellman::VerificationError, but it does not implement
+    // Arbitrary as required here.
     #[error("spend proof MUST be valid given a primary input formed from the other fields except spendAuthSig")]
-    Groth16,
+    Groth16(String),
 
-    // XXX: the underlying error is io::Error, but it does not implement Clone as required here
+    // XXX: the underlying error is io::Error, but it does not implement Clone as required here.
     #[error("Groth16 proof is malformed")]
     MalformedGroth16(String),
 

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -135,6 +135,10 @@ pub enum TransactionError {
     #[error("spend proof MUST be valid given a primary input formed from the other fields except spendAuthSig")]
     Groth16,
 
+    // XXX: the underlying error is io::Error, but it does not implement Clone as required here
+    #[error("Groth16 proof is malformed")]
+    MalformedGroth16(String),
+
     #[error(
         "Sprout joinSplitSig MUST represent a valid signature under joinSplitPubKey of dataToBeSigned"
     )]

--- a/zebra-consensus/src/primitives/groth16.rs
+++ b/zebra-consensus/src/primitives/groth16.rs
@@ -2,6 +2,7 @@
 
 use std::{
     convert::{TryFrom, TryInto},
+    error::Error,
     fmt,
     future::Future,
     mem,
@@ -128,8 +129,13 @@ pub static JOINSPLIT_VERIFIER: Lazy<ServiceFn<fn(Item) -> Ready<Result<(), Boxed
         // function (which is possible because it doesn't capture any state).
         tower::service_fn(
             (|item: Item| {
+                // Workaround bug in `bellman::VerificationError` fmt::Display
+                // implementation https://github.com/zkcrypto/bellman/pull/77
+                #[allow(deprecated)]
                 ready(
                     item.verify_single(&GROTH16_PARAMETERS.sprout.joinsplit_prepared_verifying_key)
+                        // When that is fixed, change to `e.to_string()`
+                        .map_err(|e| TransactionError::Groth16(e.description().to_string()))
                         .map_err(tower_fallback::BoxedError::from),
                 )
             }) as fn(_) -> _,

--- a/zebra-consensus/src/primitives/groth16/tests.rs
+++ b/zebra-consensus/src/primitives/groth16/tests.rs
@@ -11,7 +11,7 @@ use zebra_chain::{
     transaction::Transaction,
 };
 
-use crate::primitives::groth16::{self, *};
+use crate::primitives::groth16::*;
 
 async fn verify_groth16_spends_and_outputs<V>(
     spend_verifier: &mut V,
@@ -38,9 +38,9 @@ where
             tracing::trace!(?spend);
 
             let spend_rsp = spend_verifier.ready().await?.call(
-                groth16::ItemWrapper::try_from(&DescriptionWrapper(spend))
-                    .map_err(tower_fallback::BoxedError::from)?
-                    .into(),
+                DescriptionWrapper(&spend)
+                    .try_into()
+                    .map_err(tower_fallback::BoxedError::from)?,
             );
 
             async_checks.push(spend_rsp);
@@ -50,9 +50,9 @@ where
             tracing::trace!(?output);
 
             let output_rsp = output_verifier.ready().await?.call(
-                groth16::ItemWrapper::try_from(&DescriptionWrapper(output.clone()))
-                    .map_err(tower_fallback::BoxedError::from)?
-                    .into(),
+                DescriptionWrapper(output)
+                    .try_into()
+                    .map_err(tower_fallback::BoxedError::from)?,
             );
 
             async_checks.push(output_rsp);
@@ -154,9 +154,9 @@ where
             tracing::trace!(?modified_output);
 
             let output_rsp = output_verifier.ready().await?.call(
-                groth16::ItemWrapper::try_from(&DescriptionWrapper(modified_output.clone()))
-                    .map_err(tower_fallback::BoxedError::from)?
-                    .into(),
+                DescriptionWrapper(&modified_output)
+                    .try_into()
+                    .map_err(tower_fallback::BoxedError::from)?,
             );
 
             async_checks.push(output_rsp);
@@ -229,9 +229,9 @@ where
                 .sprout_joinsplit_pub_key()
                 .expect("pub key must exist since there are joinsplits");
             let joinsplit_rsp = verifier.ready().await?.call(
-                groth16::ItemWrapper::try_from(&DescriptionWrapper((joinsplit, &pub_key)))
-                    .map_err(tower_fallback::BoxedError::from)?
-                    .into(),
+                DescriptionWrapper(&(joinsplit, &pub_key))
+                    .try_into()
+                    .map_err(tower_fallback::BoxedError::from)?,
             );
 
             async_checks.push(joinsplit_rsp);
@@ -294,9 +294,9 @@ where
     tracing::trace!(?joinsplit);
 
     let joinsplit_rsp = verifier.ready().await?.call(
-        groth16::ItemWrapper::try_from(&DescriptionWrapper((joinsplit, pub_key)))
-            .map_err(tower_fallback::BoxedError::from)?
-            .into(),
+        DescriptionWrapper(&(joinsplit, pub_key))
+            .try_into()
+            .map_err(tower_fallback::BoxedError::from)?,
     );
 
     async_checks.push(joinsplit_rsp);
@@ -415,9 +415,9 @@ where
             // which will make the verification fail.
             let modified_pub_key = [0x42; 32].into();
             let joinsplit_rsp = verifier.ready().await?.call(
-                groth16::ItemWrapper::try_from(&DescriptionWrapper((joinsplit, &modified_pub_key)))
-                    .map_err(tower_fallback::BoxedError::from)?
-                    .into(),
+                DescriptionWrapper(&(joinsplit, &modified_pub_key))
+                    .try_into()
+                    .map_err(tower_fallback::BoxedError::from)?,
             );
 
             async_checks.push(joinsplit_rsp);

--- a/zebra-consensus/src/primitives/groth16/tests.rs
+++ b/zebra-consensus/src/primitives/groth16/tests.rs
@@ -37,10 +37,11 @@ where
         for spend in spends {
             tracing::trace!(?spend);
 
-            let spend_rsp = spend_verifier
-                .ready()
-                .await?
-                .call(groth16::ItemWrapper::from(&spend).into());
+            let spend_rsp = spend_verifier.ready().await?.call(
+                groth16::ItemWrapper::try_from(&DescriptionWrapper(spend))
+                    .map_err(tower_fallback::BoxedError::from)?
+                    .into(),
+            );
 
             async_checks.push(spend_rsp);
         }
@@ -48,10 +49,11 @@ where
         for output in outputs {
             tracing::trace!(?output);
 
-            let output_rsp = output_verifier
-                .ready()
-                .await?
-                .call(groth16::ItemWrapper::from(output).into());
+            let output_rsp = output_verifier.ready().await?.call(
+                groth16::ItemWrapper::try_from(&DescriptionWrapper(output.clone()))
+                    .map_err(tower_fallback::BoxedError::from)?
+                    .into(),
+            );
 
             async_checks.push(output_rsp);
         }
@@ -151,10 +153,11 @@ where
 
             tracing::trace!(?modified_output);
 
-            let output_rsp = output_verifier
-                .ready()
-                .await?
-                .call(groth16::ItemWrapper::from(&modified_output).into());
+            let output_rsp = output_verifier.ready().await?.call(
+                groth16::ItemWrapper::try_from(&DescriptionWrapper(modified_output.clone()))
+                    .map_err(tower_fallback::BoxedError::from)?
+                    .into(),
+            );
 
             async_checks.push(output_rsp);
         }
@@ -225,10 +228,11 @@ where
             let pub_key = tx
                 .sprout_joinsplit_pub_key()
                 .expect("pub key must exist since there are joinsplits");
-            let joinsplit_rsp = verifier
-                .ready()
-                .await?
-                .call(groth16::ItemWrapper::from(&(joinsplit, &pub_key)).into());
+            let joinsplit_rsp = verifier.ready().await?.call(
+                groth16::ItemWrapper::try_from(&DescriptionWrapper((joinsplit, &pub_key)))
+                    .map_err(tower_fallback::BoxedError::from)?
+                    .into(),
+            );
 
             async_checks.push(joinsplit_rsp);
         }
@@ -289,10 +293,11 @@ where
 
     tracing::trace!(?joinsplit);
 
-    let joinsplit_rsp = verifier
-        .ready()
-        .await?
-        .call(groth16::ItemWrapper::from(&(joinsplit, pub_key)).into());
+    let joinsplit_rsp = verifier.ready().await?.call(
+        groth16::ItemWrapper::try_from(&DescriptionWrapper((joinsplit, pub_key)))
+            .map_err(tower_fallback::BoxedError::from)?
+            .into(),
+    );
 
     async_checks.push(joinsplit_rsp);
 
@@ -409,10 +414,11 @@ where
             // Use an arbitrary public key which is not the correct one,
             // which will make the verification fail.
             let modified_pub_key = [0x42; 32].into();
-            let joinsplit_rsp = verifier
-                .ready()
-                .await?
-                .call(groth16::ItemWrapper::from(&(joinsplit, &modified_pub_key)).into());
+            let joinsplit_rsp = verifier.ready().await?.call(
+                groth16::ItemWrapper::try_from(&DescriptionWrapper((joinsplit, &modified_pub_key)))
+                    .map_err(tower_fallback::BoxedError::from)?
+                    .into(),
+            );
 
             async_checks.push(joinsplit_rsp);
         }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -315,7 +315,10 @@ where
                 check::non_coinbase_expiry_height(&req.height(), &tx)?;
             }
 
-            // Either v_{pub}^{old} or v_{pub}^{new} MUST be zero.
+            // Consensus rule:
+            //
+            // > Either v_{pub}^{old} or v_{pub}^{new} MUST be zero.
+            //
             // https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc
             check::joinsplit_has_vpub_zero(&tx)?;
 
@@ -650,6 +653,8 @@ where
                 // resulting future to our collection of async
                 // checks that (at a minimum) must pass for the
                 // transaction to verify.
+                //
+                // https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc
                 checks.push(primitives::groth16::JOINSPLIT_VERIFIER.oneshot(
                     DescriptionWrapper(&(joinsplit, &joinsplit_data.pub_key)).try_into()?,
                 ));

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -2,7 +2,7 @@
 //!
 use std::{
     collections::HashMap,
-    convert::TryFrom,
+    convert::TryInto,
     future::Future,
     iter::FromIterator,
     pin::Pin,
@@ -650,15 +650,9 @@ where
                 // resulting future to our collection of async
                 // checks that (at a minimum) must pass for the
                 // transaction to verify.
-                checks.push(
-                    primitives::groth16::JOINSPLIT_VERIFIER.oneshot(
-                        primitives::groth16::ItemWrapper::try_from(&DescriptionWrapper((
-                            joinsplit,
-                            &joinsplit_data.pub_key,
-                        )))?
-                        .into(),
-                    ),
-                );
+                checks.push(primitives::groth16::JOINSPLIT_VERIFIER.oneshot(
+                    DescriptionWrapper(&(joinsplit, &joinsplit_data.pub_key)).try_into()?,
+                ));
             }
 
             // Consensus rule: The joinSplitSig MUST represent a
@@ -712,12 +706,9 @@ where
                 // checks that (at a minimum) must pass for the
                 // transaction to verify.
                 async_checks.push(
-                    primitives::groth16::SPEND_VERIFIER.clone().oneshot(
-                        primitives::groth16::ItemWrapper::try_from(&DescriptionWrapper(
-                            spend.clone(),
-                        ))?
-                        .into(),
-                    ),
+                    primitives::groth16::SPEND_VERIFIER
+                        .clone()
+                        .oneshot(DescriptionWrapper(&spend).try_into()?),
                 );
 
                 // Consensus rule: The spend authorization signature
@@ -754,12 +745,9 @@ where
                 // checks that (at a minimum) must pass for the
                 // transaction to verify.
                 async_checks.push(
-                    primitives::groth16::OUTPUT_VERIFIER.clone().oneshot(
-                        primitives::groth16::ItemWrapper::try_from(&DescriptionWrapper(
-                            output.clone(),
-                        ))?
-                        .into(),
-                    ),
+                    primitives::groth16::OUTPUT_VERIFIER
+                        .clone()
+                        .oneshot(DescriptionWrapper(output).try_into()?),
                 );
             }
 

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -167,7 +167,7 @@ pub fn output_cv_epk_not_small_order(output: &Output) -> Result<(), TransactionE
 /// Check if JoinSplits in the transaction have one of its v_{pub} values equal
 /// to zero.
 ///
-/// https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc
+/// <https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc>
 pub fn joinsplit_has_vpub_zero(tx: &Transaction) -> Result<(), TransactionError> {
     let zero = Amount::<NonNegative>::try_from(0).expect("an amount of 0 is always valid");
 

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -164,6 +164,27 @@ pub fn output_cv_epk_not_small_order(output: &Output) -> Result<(), TransactionE
     }
 }
 
+/// Check if JoinSplits in the transaction have one of its v_{pub} values equal
+/// to zero.
+///
+/// https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc
+pub fn joinsplit_has_vpub_zero(tx: &Transaction) -> Result<(), TransactionError> {
+    let zero = Amount::<NonNegative>::try_from(0).expect("an amount of 0 is always valid");
+
+    let vpub_pairs = tx
+        .output_values_to_sprout()
+        .zip(tx.input_values_from_sprout());
+    for (vpub_old, vpub_new) in vpub_pairs {
+        // > Either v_{pub}^{old} or v_{pub}^{new} MUST be zero.
+        // https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc
+        if *vpub_old != zero && *vpub_new != zero {
+            return Err(TransactionError::BothVPubsNonZero);
+        }
+    }
+
+    Ok(())
+}
+
 /// Check if a transaction is adding to the sprout pool after Canopy
 /// network upgrade given a block height and a network.
 ///

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -904,14 +904,17 @@ fn v4_with_signed_sprout_transfer_is_accepted() {
     zebra_test::init();
     zebra_test::RUNTIME.block_on(async {
         let network = Network::Mainnet;
-        let network_upgrade = NetworkUpgrade::Canopy;
 
-        let canopy_activation_height = network_upgrade
-            .activation_height(network)
-            .expect("Canopy activation height is not set");
+        let (height, transaction) = test_transactions(network)
+            .rev()
+            .filter(|(_, transaction)| {
+                !transaction.has_valid_coinbase_transaction_inputs()
+                    && transaction.inputs().is_empty()
+            })
+            .find(|(_, transaction)| transaction.sprout_groth16_joinsplits().next().is_some())
+            .expect("No transaction found with Groth16 JoinSplits");
 
-        let transaction_block_height =
-            (canopy_activation_height + 10).expect("Canopy activation height is too large");
+        let expected_hash = transaction.unmined_id();
 
         // Initialize the verifier
         let state_service =
@@ -919,38 +922,13 @@ fn v4_with_signed_sprout_transfer_is_accepted() {
         let script_verifier = script::Verifier::new(state_service);
         let verifier = Verifier::new(network, script_verifier);
 
-        // Create a fake Sprout join split
-        let (joinsplit_data, signing_key) = mock_sprout_join_split_data();
-
-        let mut transaction = Transaction::V4 {
-            inputs: vec![],
-            outputs: vec![],
-            lock_time: LockTime::Height(block::Height(0)),
-            expiry_height: (transaction_block_height + 1).expect("expiry height is too large"),
-            joinsplit_data: Some(joinsplit_data),
-            sapling_shielded_data: None,
-        };
-
-        // Sign the transaction
-        let sighash = transaction.sighash(network_upgrade, HashType::ALL, None);
-
-        match &mut transaction {
-            Transaction::V4 {
-                joinsplit_data: Some(joinsplit_data),
-                ..
-            } => joinsplit_data.sig = signing_key.sign(sighash.as_ref()),
-            _ => unreachable!("Mock transaction was created incorrectly"),
-        }
-
-        let expected_hash = transaction.unmined_id();
-
         // Test the transaction verifier
         let result = verifier
             .clone()
             .oneshot(Request::Block {
-                transaction: Arc::new(transaction),
+                transaction,
                 known_utxos: Arc::new(HashMap::new()),
-                height: transaction_block_height,
+                height,
                 time: chrono::MAX_DATETIME,
             })
             .await;
@@ -962,65 +940,74 @@ fn v4_with_signed_sprout_transfer_is_accepted() {
     });
 }
 
-/// Test if an unsigned V4 transaction with a dummy [`sprout::JoinSplit`] is rejected.
+/// Test if an V4 transaction with a modified [`sprout::JoinSplit`] is rejected.
 ///
 /// This test verifies if the transaction verifier correctly rejects the transaction because of the
-/// invalid signature.
+/// invalid JoinSplit.
 #[test]
-fn v4_with_unsigned_sprout_transfer_is_rejected() {
+fn v4_with_modified_joinsplit_is_rejected() {
     zebra_test::init();
     zebra_test::RUNTIME.block_on(async {
-        let network = Network::Mainnet;
-        let network_upgrade = NetworkUpgrade::Canopy;
-
-        let canopy_activation_height = network_upgrade
-            .activation_height(network)
-            .expect("Canopy activation height is not set");
-
-        let transaction_block_height =
-            (canopy_activation_height + 10).expect("Canopy activation height is too large");
-
-        // Initialize the verifier
-        let state_service =
-            service_fn(|_| async { unreachable!("State service should not be called") });
-        let script_verifier = script::Verifier::new(state_service);
-        let verifier = Verifier::new(network, script_verifier);
-
-        // Create a fake Sprout join split
-        let (joinsplit_data, _) = mock_sprout_join_split_data();
-
-        let transaction = Transaction::V4 {
-            inputs: vec![],
-            outputs: vec![],
-            lock_time: LockTime::Height(block::Height(0)),
-            expiry_height: (transaction_block_height + 1).expect("expiry height is too large"),
-            joinsplit_data: Some(joinsplit_data),
-            sapling_shielded_data: None,
-        };
-
-        // Test the transaction verifier
-        let result = verifier
-            .clone()
-            .oneshot(Request::Block {
-                transaction: Arc::new(transaction),
-                known_utxos: Arc::new(HashMap::new()),
-                height: transaction_block_height,
-                time: chrono::MAX_DATETIME,
-            })
-            .await;
-
-        assert_eq!(
-            result,
-            Err(
-                // TODO: Fix error downcast
-                // Err(TransactionError::Ed25519(ed25519::Error::InvalidSignature))
-                TransactionError::InternalDowncastError(
-                    "downcast to known transaction error type failed, original error: InvalidSignature"
-                        .to_string(),
-                )
-            )
-        );
+        v4_with_joinsplit_is_rejected_for_modification(
+            JoinSplitModification::CorruptSignature,
+            // TODO: Fix error downcast
+            // Err(TransactionError::Ed25519(ed25519::Error::InvalidSignature))
+            TransactionError::InternalDowncastError(
+                "downcast to known transaction error type failed, original error: InvalidSignature"
+                    .to_string(),
+            ),
+        )
+        .await;
+        v4_with_joinsplit_is_rejected_for_modification(
+            JoinSplitModification::CorruptProof,
+            TransactionError::Groth16("proof verification failed".to_string()),
+        )
+        .await;
+        v4_with_joinsplit_is_rejected_for_modification(
+            JoinSplitModification::ZeroProof,
+            TransactionError::MalformedGroth16("invalid G1".to_string()),
+        )
+        .await;
     });
+}
+
+async fn v4_with_joinsplit_is_rejected_for_modification(
+    modification: JoinSplitModification,
+    expected_error: TransactionError,
+) {
+    let network = Network::Mainnet;
+
+    let (height, mut transaction) = test_transactions(network)
+        .rev()
+        .filter(|(_, transaction)| {
+            !transaction.has_valid_coinbase_transaction_inputs() && transaction.inputs().is_empty()
+        })
+        .find(|(_, transaction)| transaction.sprout_groth16_joinsplits().next().is_some())
+        .expect("No transaction found with Groth16 JoinSplits");
+
+    modify_joinsplit(
+        Arc::get_mut(&mut transaction).expect("Transaction only has one active reference"),
+        modification,
+    );
+
+    // Initialize the verifier
+    let state_service =
+        service_fn(|_| async { unreachable!("State service should not be called") });
+    let script_verifier = script::Verifier::new(state_service);
+    let verifier = Verifier::new(network, script_verifier);
+
+    // Test the transaction verifier
+    let result = verifier
+        .clone()
+        .oneshot(Request::Block {
+            transaction,
+            known_utxos: Arc::new(HashMap::new()),
+            height,
+            time: chrono::MAX_DATETIME,
+        })
+        .await;
+
+    assert_eq!(result, Err(expected_error));
 }
 
 /// Test if a V4 transaction with Sapling spends is accepted by the verifier.
@@ -1474,6 +1461,63 @@ fn mock_sprout_join_split_data() -> (JoinSplitData<Groth16Proof>, ed25519::Signi
     };
 
     (joinsplit_data, signing_key)
+}
+
+/// A type of JoinSplit modification to test.
+#[derive(Clone, Copy)]
+enum JoinSplitModification {
+    // Corrupt a signature, making it invalid.
+    CorruptSignature,
+    // Corrupt a proof, making it invalid, but still well-formed.
+    CorruptProof,
+    // Make a proof all-zeroes, making it malformed.
+    ZeroProof,
+}
+
+/// Modify a JoinSplit in the transaction following the given modification type.
+fn modify_joinsplit(transaction: &mut Transaction, modification: JoinSplitModification) {
+    match transaction {
+        Transaction::V4 {
+            joinsplit_data: Some(ref mut joinsplit_data),
+            ..
+        } => modify_joinsplit_data(joinsplit_data, modification),
+        _ => unreachable!("Transaction has no JoinSplit shielded data"),
+    }
+}
+
+/// Modify a [`JoinSplitData`] following the given modification type.
+fn modify_joinsplit_data(
+    joinsplit_data: &mut JoinSplitData<Groth16Proof>,
+    modification: JoinSplitModification,
+) {
+    match modification {
+        JoinSplitModification::CorruptSignature => {
+            let mut sig_bytes: [u8; 64] = joinsplit_data.sig.into();
+            // Flip a bit from an arbitrary byte of the signature.
+            sig_bytes[10] ^= 0x01;
+            joinsplit_data.sig = sig_bytes.into();
+        }
+        JoinSplitModification::CorruptProof => {
+            let joinsplit = joinsplit_data
+                .joinsplits_mut()
+                .next()
+                .expect("must have a JoinSplit");
+            {
+                // A proof is composed of three field elements, the first and last having 48 bytes.
+                // (The middle one has 96 bytes.) To corrupt the proof without making it malformed,
+                // simply swap those first and last elements.
+                let (first, rest) = joinsplit.zkproof.0.split_at_mut(48);
+                first.swap_with_slice(&mut rest[96..144]);
+            }
+        }
+        JoinSplitModification::ZeroProof => {
+            let joinsplit = joinsplit_data
+                .joinsplits_mut()
+                .next()
+                .expect("must have a JoinSplit");
+            joinsplit.zkproof.0 = [0; 192];
+        }
+    }
 }
 
 /// Duplicate a Sapling spend inside a `transaction`.


### PR DESCRIPTION
## Motivation

We need to validate JoinSplit Groth16 proofs in order to be a fully validating node.

### Specifications

https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc

![image](https://user-images.githubusercontent.com/35766/145439084-73c6c8ec-c656-4bcc-a097-f76149b488f3.png)

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

Of the above rules:

- The first should be already be covered by the parser;
- The second is implemented by this PR;
- The third seemed to be missing and is also implemented by this PR;
- The fourth was already implemented.

While developing this PR I identified an issue where all-zeroes proofs (or any malformed proof) would make Zebra panic. This PR adds a test for that and handles it by propagating the error while reading the proof into `bellman`. Ideally we'd like to that while parsing the transaction, but that would require a lot of code changes, so it was postponed and tracked in https://github.com/ZcashFoundation/zebra/issues/3179

This PR changes existing tests which would no longer pass since they used dummy generated transaction. They were changed to use an existing transaction, which is modified as needed.

Closes https://github.com/ZcashFoundation/zebra/issues/1835

## Review

Need to merge https://github.com/ZcashFoundation/zebra/pull/3128 first.

@dconnolly and/or @upbqdn can review it.

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [x] Tests for Expected Behaviour
  - [x] Tests for Errors

## Follow Up Work

Improve type safety in https://github.com/ZcashFoundation/zebra/issues/3179
