### PR TITLE
Add and use `debug_skip_parameter_preload` config option

### DIFF
--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -211,6 +211,7 @@ where
             // The lazy static initializer does the download, if needed,
             // and the file hash checks.
             lazy_static::initialize(&crate::groth16::GROTH16_PARAMETERS);
+            info!("Groth16 pre-download and check task finished");
         }
     });
 

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -211,7 +211,7 @@ where
             // The lazy static initializer does the download, if needed,
             // and the file hash checks.
             lazy_static::initialize(&crate::groth16::GROTH16_PARAMETERS);
-            info!("Groth16 pre-download and check task finished");
+            tracing::info!("Groth16 pre-download and check task finished");
         }
     });
 

--- a/zebra-consensus/src/chain/tests.rs
+++ b/zebra-consensus/src/chain/tests.rs
@@ -65,7 +65,7 @@ async fn verifiers_from_network(
 ) {
     let state_service = zs::init_test(network);
     let (chain_verifier, _transaction_verifier, _groth16_download_handle) =
-        crate::chain::init(Config::default(), network, state_service.clone()).await;
+        crate::chain::init(Config::default(), network, state_service.clone(), true).await;
 
     // We can drop the download task handle here, because:
     // - if the download task fails, the tests will panic, and
@@ -136,10 +136,12 @@ static STATE_VERIFY_TRANSCRIPT_GENESIS: Lazy<
 async fn verify_checkpoint_test() -> Result<(), Report> {
     verify_checkpoint(Config {
         checkpoint_sync: true,
+        debug_skip_parameter_preload: true,
     })
     .await?;
     verify_checkpoint(Config {
         checkpoint_sync: false,
+        debug_skip_parameter_preload: true,
     })
     .await?;
 
@@ -160,7 +162,7 @@ async fn verify_checkpoint(config: Config) -> Result<(), Report> {
     //
     // Download task panics and timeouts are propagated to the tests that use Groth16 verifiers.
     let (chain_verifier, _transaction_verifier, _groth16_download_handle) =
-        super::init(config.clone(), network, zs::init_test(network)).await;
+        super::init(config.clone(), network, zs::init_test(network), true).await;
 
     // Add a timeout layer
     let chain_verifier =

--- a/zebra-consensus/src/config.rs
+++ b/zebra-consensus/src/config.rs
@@ -12,7 +12,7 @@ pub struct Config {
     /// Future versions of Zebra may change the mandatory checkpoint
     /// height.
     pub checkpoint_sync: bool,
-    /// Skip the download of Groth16 parameters if this option is true.
+    /// Skip the pre-download of Groth16 parameters if this option is true.
     pub debug_skip_parameter_preload: bool,
 }
 

--- a/zebra-consensus/src/config.rs
+++ b/zebra-consensus/src/config.rs
@@ -12,6 +12,8 @@ pub struct Config {
     /// Future versions of Zebra may change the mandatory checkpoint
     /// height.
     pub checkpoint_sync: bool,
+    /// Skip the download of Groth16 parameters if this option is true.
+    pub debug_skip_parameter_preload: bool,
 }
 
 // we like our default configs to be explicit
@@ -21,6 +23,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             checkpoint_sync: false,
+            debug_skip_parameter_preload: false,
         }
     }
 }

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -218,7 +218,6 @@ impl StartCmd {
                             zebra_consensus::groth16::Groth16Parameters::failure_hint())
                         );
 
-                    info!("Groth16 pre-download and check task finished");
                     exit_when_task_finishes = false;
                     Ok(())
                 }

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -106,6 +106,7 @@ impl StartCmd {
                 config.consensus.clone(),
                 config.network.network,
                 state.clone(),
+                config.consensus.debug_skip_parameter_preload,
             )
             .await;
 

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -591,8 +591,13 @@ async fn setup(
 
     // Download task panics and timeouts are propagated to the tests that use Groth16 verifiers.
     let (block_verifier, _transaction_verifier, _groth16_download_handle) =
-        zebra_consensus::chain::init(consensus_config.clone(), network, state_service.clone())
-            .await;
+        zebra_consensus::chain::init(
+            consensus_config.clone(),
+            network,
+            state_service.clone(),
+            true,
+        )
+        .await;
 
     let mut peer_set = MockService::build()
         .with_max_request_delay(MAX_PEER_SET_REQUEST_DELAY)

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -83,11 +83,17 @@ fn default_test_config() -> Result<ZebradConfig> {
         ..mempool::Config::default()
     };
 
+    let consensus = zebra_consensus::Config {
+        debug_skip_parameter_preload: true,
+        ..zebra_consensus::Config::default()
+    };
+
     let config = ZebradConfig {
         network,
         state: zebra_state::Config::ephemeral(),
         sync,
         mempool,
+        consensus,
         ..ZebradConfig::default()
     };
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1010,6 +1010,7 @@ where
     // TODO: add convenience methods?
     config.network.network = network;
     config.state.debug_stop_at_height = Some(height.0);
+    config.consensus.debug_skip_parameter_preload = false;
 
     let dir = PathBuf::from("/zebrad-cache");
     let mut child = dir

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -996,6 +996,7 @@ fn cached_mandatory_checkpoint_test_config() -> Result<ZebradConfig> {
 fn create_cached_database_height<P>(
     network: Network,
     height: Height,
+    debug_skip_parameter_preload: bool,
     test_child_predicate: impl Into<Option<P>>,
 ) -> Result<()>
 where
@@ -1010,7 +1011,7 @@ where
     // TODO: add convenience methods?
     config.network.network = network;
     config.state.debug_stop_at_height = Some(height.0);
-    config.consensus.debug_skip_parameter_preload = false;
+    config.consensus.debug_skip_parameter_preload = debug_skip_parameter_preload;
 
     let dir = PathBuf::from("/zebrad-cache");
     let mut child = dir
@@ -1038,11 +1039,16 @@ where
 
 fn create_cached_database(network: Network) -> Result<()> {
     let height = network.mandatory_checkpoint_height();
-    create_cached_database_height(network, height, |test_child: &mut TestChild<PathBuf>| {
-        // make sure pre-cached databases finish before the mandatory checkpoint
-        test_child.expect_stdout_line_matches("CommitFinalized request")?;
-        Ok(())
-    })
+    create_cached_database_height(
+        network,
+        height,
+        true,
+        |test_child: &mut TestChild<PathBuf>| {
+            // make sure pre-cached databases finish before the mandatory checkpoint
+            test_child.expect_stdout_line_matches("CommitFinalized request")?;
+            Ok(())
+        },
+    )
 }
 
 fn sync_past_mandatory_checkpoint(network: Network) -> Result<()> {
@@ -1050,6 +1056,7 @@ fn sync_past_mandatory_checkpoint(network: Network) -> Result<()> {
     create_cached_database_height(
         network,
         height.unwrap(),
+        false,
         |test_child: &mut TestChild<PathBuf>| {
             // make sure cached database tests finish after the mandatory checkpoint,
             // using the non-finalized state (the checkpoint_sync config must be false)


### PR DESCRIPTION
## Motivation

We want to skip Groth16 parameter download in all the tests we can as they take time and resources.
Closes https://github.com/ZcashFoundation/zebra/issues/3112 if it gets merged.

## Solution

Add a configuration option and an argument to `zebra_consensus::init` function. The way this is implemented is i think the easier as it does not change almost any of the async code in the `start.rs` file. The download task is created and lunched but the real download is never done when the option is true. It is this way to avoid changing the `select!` macro code, which is harder if we want to not even start the download task. <strike>As i am a bit unsure about the approach this pull request will be a draft until i can confirm with someone else.</strike>

## Review

It will be good if @teor2345 can take a look to the approach, apart from that the code is pretty simple so anyone can review.

### Reviewer Checklist

  - [ ] Current tests all pass
  - [ ] Zebra can sync
  - [ ] Optional: Try to confirm we are not downloading any groth16 data in acceptance tests
   
