### PR TITLE
Add diagnostics for peer set hangs

### DIFF
--- a/grafana/network_health.json
+++ b/grafana/network_health.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 4,
-  "iteration": 1614572684426,
+  "iteration": 1639361606831,
   "links": [],
   "panels": [
     {
@@ -26,16 +26,14 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
         "h": 6,
-        "w": 12,
+        "w": 6,
         "x": 0,
         "y": 0
       },
@@ -57,7 +55,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -76,6 +74,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "exemplar": true,
           "expr": "sum(rate(zcash_net_in_bytes_total{job=\"$job\"}[1s]))",
           "hide": false,
           "interval": "",
@@ -109,6 +108,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:93",
           "format": "bytes",
           "label": null,
           "logBase": 1,
@@ -117,6 +117,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:94",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -137,21 +138,19 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
         "h": 6,
-        "w": 12,
-        "x": 12,
+        "w": 6,
+        "x": 6,
         "y": 0
       },
       "hiddenSeries": false,
-      "id": 8,
+      "id": 12,
       "legend": {
         "avg": false,
         "current": false,
@@ -168,18 +167,18 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1614572684426,
+      "repeatIteration": 1639361606831,
       "repeatPanelId": 2,
       "scopedVars": {
         "job": {
           "selected": false,
-          "text": "zebrad-testnet",
-          "value": "zebrad-testnet"
+          "text": "zebrad-mainnet-tmp",
+          "value": "zebrad-mainnet-tmp"
         }
       },
       "seriesOverrides": [],
@@ -188,6 +187,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "exemplar": true,
           "expr": "sum(rate(zcash_net_in_bytes_total{job=\"$job\"}[1s]))",
           "hide": false,
           "interval": "",
@@ -221,6 +221,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:93",
           "format": "bytes",
           "label": null,
           "logBase": 1,
@@ -229,6 +230,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:94",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -249,16 +251,240 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 9,
-        "w": 12,
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1639361606831,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet",
+          "value": "zebrad-testnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(zcash_net_in_bytes_total{job=\"$job\"}[1s]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "bytes read [1s]",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(zcash_net_out_bytes_total{job=\"$job\"}[1s]))",
+          "interval": "",
+          "legendFormat": "bytes written [1s]",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "bytes - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:93",
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:94",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 14,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1639361606831,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet-tmp",
+          "value": "zebrad-testnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(zcash_net_in_bytes_total{job=\"$job\"}[1s]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "bytes read [1s]",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(zcash_net_out_bytes_total{job=\"$job\"}[1s]))",
+          "interval": "",
+          "legendFormat": "bytes written [1s]",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "bytes - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:93",
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:94",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 6,
         "x": 0,
         "y": 6
       },
@@ -280,7 +506,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -365,21 +591,19 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
+        "h": 6,
+        "w": 6,
+        "x": 6,
         "y": 6
       },
       "hiddenSeries": false,
-      "id": 9,
+      "id": 15,
       "legend": {
         "avg": false,
         "current": false,
@@ -396,12 +620,127 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "repeatDirection": "h",
-      "repeatIteration": 1614572684426,
+      "repeatIteration": 1639361606831,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-mainnet-tmp",
+          "value": "zebrad-mainnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "zcash_net_peers{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "total peers",
+          "refId": "A"
+        },
+        {
+          "expr": "pool_num_ready{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "ready peers",
+          "refId": "B"
+        },
+        {
+          "expr": "pool_num_unready{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "unready peers",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "peer readiness - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 6
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1639361606831,
       "repeatPanelId": 6,
       "scopedVars": {
         "job": {
@@ -482,18 +821,131 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 9,
-        "w": 12,
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 6
+      },
+      "hiddenSeries": false,
+      "id": 17,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "repeatIteration": 1639361606831,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet-tmp",
+          "value": "zebrad-testnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "zcash_net_peers{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "total peers",
+          "refId": "A"
+        },
+        {
+          "expr": "pool_num_ready{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "ready peers",
+          "refId": "B"
+        },
+        {
+          "expr": "pool_num_unready{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "unready peers",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "peer readiness - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 6,
         "x": 0,
-        "y": 15
+        "y": 12
       },
       "hiddenSeries": false,
       "id": 7,
@@ -513,7 +965,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -616,21 +1068,19 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 15
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 12
       },
       "hiddenSeries": false,
-      "id": 10,
+      "id": 18,
       "legend": {
         "avg": false,
         "current": false,
@@ -647,11 +1097,144 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.2",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1614572684426,
+      "repeatIteration": 1639361606831,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-mainnet-tmp",
+          "value": "zebrad-mainnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "candidate_set_disconnected{job=\"$job\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "recently stopped peers",
+          "refId": "A"
+        },
+        {
+          "expr": "candidate_set_failed{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "failed candidates",
+          "refId": "B"
+        },
+        {
+          "expr": "candidate_set_gossiped{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "never attempted candidates",
+          "refId": "C"
+        },
+        {
+          "expr": "candidate_set_pending{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "connection attempt pending",
+          "refId": "D"
+        },
+        {
+          "expr": "candidate_set_responded{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "recent peers",
+          "refId": "E"
+        },
+        {
+          "expr": "candidate_set_recently_live{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "recently live peers",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "candidate set - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 12
+      },
+      "hiddenSeries": false,
+      "id": 19,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1639361606831,
       "repeatPanelId": 7,
       "scopedVars": {
         "job": {
@@ -743,10 +1326,566 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 12
+      },
+      "hiddenSeries": false,
+      "id": 20,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1639361606831,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet-tmp",
+          "value": "zebrad-testnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "candidate_set_disconnected{job=\"$job\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "recently stopped peers",
+          "refId": "A"
+        },
+        {
+          "expr": "candidate_set_failed{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "failed candidates",
+          "refId": "B"
+        },
+        {
+          "expr": "candidate_set_gossiped{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "never attempted candidates",
+          "refId": "C"
+        },
+        {
+          "expr": "candidate_set_pending{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "connection attempt pending",
+          "refId": "D"
+        },
+        {
+          "expr": "candidate_set_responded{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "recent peers",
+          "refId": "E"
+        },
+        {
+          "expr": "candidate_set_recently_live{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "recently live peers",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "candidate set - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "job",
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-mainnet",
+          "value": "zebrad-mainnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "sum by(command) (zebra_net_connection_state{job=\"$job\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "connection state - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:76",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:77",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 21,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1639361606831,
+      "repeatPanelId": 11,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-mainnet-tmp",
+          "value": "zebrad-mainnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "sum by(command) (zebra_net_connection_state{job=\"$job\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "connection state - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:76",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:77",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 22,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1639361606831,
+      "repeatPanelId": 11,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet",
+          "value": "zebrad-testnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "sum by(command) (zebra_net_connection_state{job=\"$job\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "connection state - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:76",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:77",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 23,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatIteration": 1639361606831,
+      "repeatPanelId": 11,
+      "scopedVars": {
+        "job": {
+          "selected": false,
+          "text": "zebrad-testnet-tmp",
+          "value": "zebrad-testnet-tmp"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "sum by(command) (zebra_net_connection_state{job=\"$job\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "connection state - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:76",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:77",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -754,7 +1893,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "All"
           ],
@@ -764,13 +1903,18 @@
         },
         "datasource": "Prometheus-Zebra",
         "definition": "label_values(zcash_net_in_bytes_total, job)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "job",
         "options": [],
-        "query": "label_values(zcash_net_in_bytes_total, job)",
+        "query": {
+          "query": "label_values(zcash_net_in_bytes_total, job)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -795,5 +1939,5 @@
   "timezone": "",
   "title": "network health",
   "uid": "320aS_dMk",
-  "version": 12
+  "version": 6
 }

--- a/grafana/network_messages.json
+++ b/grafana/network_messages.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 6,
-  "iteration": 1629935221644,
+  "iteration": 1639353633483,
   "links": [],
   "panels": [
     {
@@ -33,9 +33,233 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 9,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "job",
+      "scopedVars": {
+        "job": {
+          "selected": true,
+          "text": "zebrad-mainnet",
+          "value": "zebrad-mainnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (command) (zebra_net_in_requests{job=\"$job\"})",
+          "interval": "",
+          "legendFormat": "Req::{{command}}",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum by (command) (zebra_net_out_responses{job=\"$job\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Rsp::{{command}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "inbound requests & responses - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "job",
+      "scopedVars": {
+        "job": {
+          "selected": true,
+          "text": "zebrad-mainnet",
+          "value": "zebrad-mainnet"
+        }
+      },
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (command) (zebra_net_out_requests{job=\"$job\"})",
+          "interval": "",
+          "legendFormat": "Req::{{command}}",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum by (command) (zebra_net_in_responses{job=\"$job\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Rsp::{{command}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "outbound requests & responses - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 18
       },
       "hiddenSeries": false,
       "id": 2,
@@ -62,7 +286,7 @@
       "repeat": "job",
       "scopedVars": {
         "job": {
-          "selected": false,
+          "selected": true,
           "text": "zebrad-mainnet",
           "value": "zebrad-mainnet"
         }
@@ -137,114 +361,9 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "hiddenSeries": false,
-      "id": 12,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.7",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "repeatIteration": 1629935221644,
-      "repeatPanelId": 2,
-      "scopedVars": {
-        "job": {
-          "selected": false,
-          "text": "zebrad-testnet",
-          "value": "zebrad-testnet"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "sum by (command) (zcash_net_in_messages{job=\"$job\"})",
-          "interval": "",
-          "legendFormat": "{{command}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "inbound message types - $job",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:65",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:66",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 9
+        "y": 27
       },
       "hiddenSeries": false,
       "id": 4,
@@ -271,7 +390,7 @@
       "repeat": "job",
       "scopedVars": {
         "job": {
-          "selected": false,
+          "selected": true,
           "text": "zebrad-mainnet",
           "value": "zebrad-mainnet"
         }
@@ -346,114 +465,9 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 9
-      },
-      "hiddenSeries": false,
-      "id": 13,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.7",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "repeatIteration": 1629935221644,
-      "repeatPanelId": 4,
-      "scopedVars": {
-        "job": {
-          "selected": false,
-          "text": "zebrad-testnet",
-          "value": "zebrad-testnet"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "sum by (command) (zcash_net_out_messages{job=\"$job\"})",
-          "interval": "",
-          "legendFormat": "{{command}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "outbound message types - $job",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:65",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:66",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 18
+        "y": 36
       },
       "hiddenSeries": false,
       "id": 7,
@@ -480,7 +494,7 @@
       "repeat": "job",
       "scopedVars": {
         "job": {
-          "selected": false,
+          "selected": true,
           "text": "zebrad-mainnet",
           "value": "zebrad-mainnet"
         }
@@ -555,114 +569,9 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 18
-      },
-      "hiddenSeries": false,
-      "id": 14,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.7",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "repeatIteration": 1629935221644,
-      "repeatPanelId": 7,
-      "scopedVars": {
-        "job": {
-          "selected": false,
-          "text": "zebrad-testnet",
-          "value": "zebrad-testnet"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "sum by (addr) (zcash_net_in_messages{job=\"$job\"})",
-          "interval": "",
-          "legendFormat": "{{command}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "inbound message peers - $job",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:65",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:66",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 27
+        "y": 45
       },
       "hiddenSeries": false,
       "id": 11,
@@ -689,114 +598,9 @@
       "repeat": "job",
       "scopedVars": {
         "job": {
-          "selected": false,
+          "selected": true,
           "text": "zebrad-mainnet",
           "value": "zebrad-mainnet"
-        }
-      },
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "sum by (addr) (zcash_net_out_messages{job=\"$job\"})",
-          "interval": "",
-          "legendFormat": "{{command}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "outbound message peers - $job",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:65",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "$$hashKey": "object:66",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 27
-      },
-      "hiddenSeries": false,
-      "id": 15,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.7",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "repeatIteration": 1629935221644,
-      "repeatPanelId": 11,
-      "scopedVars": {
-        "job": {
-          "selected": false,
-          "text": "zebrad-testnet",
-          "value": "zebrad-testnet"
         }
       },
       "seriesOverrides": [],
@@ -864,12 +668,13 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
+          "selected": true,
+          "tags": [],
           "text": [
-            "All"
+            "zebrad-mainnet"
           ],
           "value": [
-            "$__all"
+            "zebrad-mainnet"
           ]
         },
         "datasource": null,
@@ -899,12 +704,12 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "network messages",
   "uid": "YQ3yxiVnk",
-  "version": 6
+  "version": 8
 }

--- a/grafana/network_messages.json
+++ b/grafana/network_messages.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 6,
-  "iteration": 1639353633483,
+  "iteration": 1639360549666,
   "links": [],
   "panels": [
     {
@@ -262,6 +262,103 @@
         "y": 18
       },
       "hiddenSeries": false,
+      "id": 14,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "job",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (command) (zebra_net_out_requests_canceled{job=\"$job\"})",
+          "interval": "",
+          "legendFormat": "Req::{{command}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "canceled outbound requests - $job",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "avg": false,
@@ -363,7 +460,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 36
       },
       "hiddenSeries": false,
       "id": 4,
@@ -467,7 +564,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 45
       },
       "hiddenSeries": false,
       "id": 7,
@@ -571,7 +668,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 54
       },
       "hiddenSeries": false,
       "id": 11,
@@ -668,8 +765,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
-          "tags": [],
+          "selected": false,
           "text": [
             "zebrad-mainnet"
           ],
@@ -711,5 +807,5 @@
   "timezone": "",
   "title": "network messages",
   "uid": "YQ3yxiVnk",
-  "version": 8
+  "version": 9
 }

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -18,7 +18,7 @@ mod minimum_peer_version;
 #[cfg(not(test))]
 use client::ClientRequest;
 #[cfg(test)]
-pub(crate) use client::ClientRequest;
+pub(crate) use client::{CancelHeartbeatTask, ClientRequest};
 
 use client::{ClientRequestReceiver, InProgressClientRequest, MustUseOneshotSender};
 

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -958,8 +958,9 @@ where
                 // send a response before dropping tx.
                 let _ = tx.send(Ok(Response::Nil));
                 self.state = AwaitingRequest;
-                // TODO: is this timer ever actually used?
-                self.request_timer = Some(Box::pin(sleep(constants::REQUEST_TIMEOUT)));
+                // We only need a timer when we're waiting for a response.
+                // (And we don't want to accidentally re-use old timers.)
+                self.request_timer = None;
             }
             Ok((new_state @ AwaitingResponse { .. }, None)) => {
                 self.state = new_state;

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -7,7 +7,7 @@
 //! And it's unclear if these assumptions match the `zcashd` implementation.
 //! It should be refactored into a cleaner set of request/response pairs (#1515).
 
-use std::{collections::HashSet, fmt, pin::Pin, sync::Arc};
+use std::{borrow::Cow, collections::HashSet, fmt, pin::Pin, sync::Arc};
 
 use futures::{
     future::{self, Either},
@@ -93,21 +93,21 @@ impl fmt::Display for Handler {
 
 impl Handler {
     /// Returns the Zebra internal handler type as a string.
-    pub fn command(&self) -> String {
+    pub fn command(&self) -> Cow<'static, str> {
         match self {
-            Handler::Finished(Ok(response)) => format!("Finished({})", response.command()),
-            Handler::Finished(Err(error)) => format!("Finished({})", error.kind()),
+            Handler::Finished(Ok(response)) => format!("Finished({})", response.command()).into(),
+            Handler::Finished(Err(error)) => format!("Finished({})", error.kind()).into(),
 
-            Handler::Ping(_) => "Ping".to_string(),
-            Handler::Peers => "Peers".to_string(),
+            Handler::Ping(_) => "Ping".into(),
+            Handler::Peers => "Peers".into(),
 
-            Handler::FindBlocks { .. } => "FindBlocks".to_string(),
-            Handler::FindHeaders { .. } => "FindHeaders".to_string(),
+            Handler::FindBlocks { .. } => "FindBlocks".into(),
+            Handler::FindHeaders { .. } => "FindHeaders".into(),
 
-            Handler::BlocksByHash { .. } => "BlocksByHash".to_string(),
-            Handler::TransactionsById { .. } => "TransactionsById".to_string(),
+            Handler::BlocksByHash { .. } => "BlocksByHash".into(),
+            Handler::TransactionsById { .. } => "TransactionsById".into(),
 
-            Handler::MempoolTransactionIds => "MempoolTransactionIds".to_string(),
+            Handler::MempoolTransactionIds => "MempoolTransactionIds".into(),
         }
     }
 
@@ -396,13 +396,13 @@ impl fmt::Display for State {
 
 impl State {
     /// Returns the Zebra internal state as a string.
-    pub fn command(&self) -> String {
+    pub fn command(&self) -> Cow<'static, str> {
         match self {
-            State::AwaitingRequest => "AwaitingRequest".to_string(),
+            State::AwaitingRequest => "AwaitingRequest".into(),
             State::AwaitingResponse { handler, .. } => {
-                format!("AwaitingResponse({})", handler.command())
+                format!("AwaitingResponse({})", handler.command()).into()
             }
-            State::Failed => "Failed".to_string(),
+            State::Failed => "Failed".into(),
         }
     }
 }
@@ -451,7 +451,7 @@ pub struct Connection<S, Tx> {
     pub(super) metrics_label: String,
 
     /// The state for this peer, when the metrics were last updated.
-    pub(super) last_metrics_state: Option<String>,
+    pub(super) last_metrics_state: Option<Cow<'static, str>>,
 }
 
 impl<S, Tx> Connection<S, Tx>
@@ -1240,7 +1240,7 @@ impl<S, Tx> Connection<S, Tx> {
     /// using `extra_state_info` as additional state information.
     fn update_state_metrics(&mut self, extra_state_info: impl Into<Option<String>>) {
         let current_metrics_state = if let Some(extra_state_info) = extra_state_info.into() {
-            format!("{}::{}", self.state.command(), extra_state_info)
+            format!("{}::{}", self.state.command(), extra_state_info).into()
         } else {
             self.state.command()
         };

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -184,7 +184,7 @@ impl Handler {
                     if !transactions.is_empty() {
                         // if our peers start sending mixed solicited and unsolicited transactions,
                         // we should update this code to handle those responses
-                        error!("unexpected transaction from peer: transaction responses should be sent in a continuous batch, followed by notfound. Using partial received transactions as the peer response");
+                        info!("unexpected transaction from peer: transaction responses should be sent in a continuous batch, followed by notfound. Using partial received transactions as the peer response");
                         // TODO: does the caller need a list of missing transactions? (#1515)
                         Handler::Finished(Ok(Response::Transactions(transactions)))
                     } else {
@@ -217,11 +217,11 @@ impl Handler {
                 if missing_transaction_ids != pending_ids {
                     trace!(?missing_invs, ?missing_transaction_ids, ?pending_ids);
                     // if these errors are noisy, we should replace them with debugs
-                    error!("unexpected notfound message from peer: all remaining transaction hashes should be listed in the notfound. Using partial received transactions as the peer response");
+                    info!("unexpected notfound message from peer: all remaining transaction hashes should be listed in the notfound. Using partial received transactions as the peer response");
                 }
                 if missing_transaction_ids.len() != missing_invs.len() {
                     trace!(?missing_invs, ?missing_transaction_ids, ?pending_ids);
-                    error!("unexpected notfound message from peer: notfound contains duplicate hashes or non-transaction hashes. Using partial received transactions as the peer response");
+                    info!("unexpected notfound message from peer: notfound contains duplicate hashes or non-transaction hashes. Using partial received transactions as the peer response");
                 }
 
                 if !transactions.is_empty() {
@@ -316,11 +316,11 @@ impl Handler {
                 if missing_blocks != pending_hashes {
                     trace!(?items, ?missing_blocks, ?pending_hashes);
                     // if these errors are noisy, we should replace them with debugs
-                    error!("unexpected notfound message from peer: all remaining block hashes should be listed in the notfound. Using partial received blocks as the peer response");
+                    info!("unexpected notfound message from peer: all remaining block hashes should be listed in the notfound. Using partial received blocks as the peer response");
                 }
                 if missing_blocks.len() != items.len() {
                     trace!(?items, ?missing_blocks, ?pending_hashes);
-                    error!("unexpected notfound message from peer: notfound contains duplicate hashes or non-block hashes. Using partial received blocks as the peer response");
+                    info!("unexpected notfound message from peer: notfound contains duplicate hashes or non-block hashes. Using partial received blocks as the peer response");
                 }
 
                 if !blocks.is_empty() {
@@ -1154,7 +1154,7 @@ where
         let rsp = match self.svc.call(req.clone()).await {
             Err(e) => {
                 if e.is::<Overloaded>() {
-                    tracing::warn!("inbound service is overloaded, closing connection");
+                    tracing::info!("inbound service is overloaded, closing connection");
                     metrics::counter!("pool.closed.loadshed", 1);
                     self.fail_with(PeerError::Overloaded);
                 } else {
@@ -1162,10 +1162,10 @@ where
                     // them to disconnect, and we might be using them to sync blocks.
                     // For similar reasons, we don't want to fail_with() here - we
                     // only close the connection if the peer is doing something wrong.
-                    error!(%e,
-                           connection_state = ?self.state,
-                           client_receiver = ?self.client_rx,
-                           "error processing peer request");
+                    info!(%e,
+                          connection_state = ?self.state,
+                          client_receiver = ?self.client_rx,
+                          "error processing peer request");
                 }
                 return;
             }

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -96,7 +96,7 @@ impl Handler {
     pub fn command(&self) -> String {
         match self {
             Handler::Finished(Ok(response)) => format!("Finished({})", response.command()),
-            Handler::Finished(Err(error)) => format!("Finished({})", error),
+            Handler::Finished(Err(error)) => format!("Finished({})", error.kind()),
 
             Handler::Ping(_) => "Ping".to_string(),
             Handler::Peers => "Peers".to_string(),

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -643,8 +643,11 @@ where
                                 // Special case: ping timeouts fail the connection.
                                 State::AwaitingResponse {
                                     handler: Handler::Ping(_),
+                                    tx,
                                     ..
                                 } => {
+                                    let e = SharedPeerError::from(e);
+                                    let _ = tx.send(Err(e.clone()));
                                     self.fail_with(e);
                                     State::Failed
                                 }

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -1264,11 +1264,11 @@ impl<S, Tx> Connection<S, Tx> {
 
     /// Erase the connection state metrics for this connection.
     fn erase_state_metrics(&mut self) {
-        if self.last_metrics_state.is_some() {
+        if let Some(last_metrics_state) = self.last_metrics_state.take() {
             metrics::gauge!(
                 "zebra.net.connection.state",
                 0.0,
-                "command" => self.last_metrics_state.take().expect("just checked for None"),
+                "command" => last_metrics_state,
                 "addr" => self.metrics_label.clone(),
             );
         }

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -56,6 +56,22 @@ pub enum PeerError {
     NotFound(Vec<InventoryHash>),
 }
 
+impl PeerError {
+    /// Returns the Zebra internal handler type as a string.
+    pub fn kind(&self) -> String {
+        match self {
+            PeerError::ConnectionClosed => "ConnectionClosed".into(),
+            PeerError::ConnectionDropped => "ConnectionDropped".into(),
+            PeerError::ClientRequestTimeout => "ClientRequestTimeout".into(),
+            // TODO: add error kinds or summaries to `SerializationError`
+            PeerError::Serialization(inner) => format!("Serialization({})", inner),
+            PeerError::DuplicateHandshake => "DuplicateHandshake".into(),
+            PeerError::Overloaded => "Overloaded".into(),
+            PeerError::NotFound(_) => "NotFound".into(),
+        }
+    }
+}
+
 /// A shared error slot for peer errors.
 ///
 /// # Correctness

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -29,6 +29,10 @@ pub enum PeerError {
     #[error("Peer closed connection")]
     ConnectionClosed,
 
+    /// Zebra dropped the [`Connection`].
+    #[error("Internal connection dropped")]
+    ConnectionDropped,
+
     /// The remote peer did not respond to a [`peer::Client`] request in time.
     #[error("Client request timed out")]
     ClientRequestTimeout,

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -105,8 +105,7 @@ impl ErrorSlot {
         let mut guard = self.0.lock().expect("error mutex should be unpoisoned");
 
         if let Some(original_error) = guard.clone() {
-            error!(?original_error, new_error = ?e, "peer connection already errored");
-            Err(AlreadyErrored)
+            Err(AlreadyErrored { original_error })
         } else {
             *guard = Some(e);
             Ok(())
@@ -114,8 +113,12 @@ impl ErrorSlot {
     }
 }
 
-/// The `ErrorSlot` already contains an error.
-pub struct AlreadyErrored;
+/// Error used when the `ErrorSlot` already contains an error.
+#[derive(Clone, Debug)]
+pub struct AlreadyErrored {
+    /// The original error in the error slot.
+    pub original_error: SharedPeerError,
+}
 
 /// An error during a handshake with a remote peer.
 #[derive(Error, Debug)]

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use thiserror::Error;
 
@@ -58,13 +58,13 @@ pub enum PeerError {
 
 impl PeerError {
     /// Returns the Zebra internal handler type as a string.
-    pub fn kind(&self) -> String {
+    pub fn kind(&self) -> Cow<'static, str> {
         match self {
             PeerError::ConnectionClosed => "ConnectionClosed".into(),
             PeerError::ConnectionDropped => "ConnectionDropped".into(),
             PeerError::ClientRequestTimeout => "ClientRequestTimeout".into(),
             // TODO: add error kinds or summaries to `SerializationError`
-            PeerError::Serialization(inner) => format!("Serialization({})", inner),
+            PeerError::Serialization(inner) => format!("Serialization({})", inner).into(),
             PeerError::DuplicateHandshake => "DuplicateHandshake".into(),
             PeerError::Overloaded => "Overloaded".into(),
             PeerError::NotFound(_) => "NotFound".into(),

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -925,6 +925,7 @@ where
                 peer_tx,
                 connection_tracker,
                 metrics_label: connected_addr.get_transient_addr_label(),
+                last_metrics_state: None,
             };
 
             tokio::spawn(

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -924,6 +924,7 @@ where
                 error_slot: slot,
                 peer_tx,
                 connection_tracker,
+                metrics_label: connected_addr.get_transient_addr_label(),
             };
 
             tokio::spawn(

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -809,7 +809,7 @@ where
                 metrics::counter!(
                     "zcash.net.out.messages",
                     1,
-                    "command" => msg.to_string(),
+                    "command" => msg.command(),
                     "addr" => connected_addr.get_transient_addr_label(),
                 );
                 // We need to use future::ready rather than an async block here,
@@ -840,7 +840,7 @@ where
                                 metrics::counter!(
                                     "zcash.net.in.messages",
                                     1,
-                                    "command" => msg.to_string(),
+                                    "command" => msg.command(),
                                     "addr" => connected_addr.get_transient_addr_label(),
                                 );
 

--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -21,7 +21,10 @@ use zebra_chain::{
 
 use super::MorePeers;
 use crate::{
-    peer::{Client, ClientRequest, ErrorSlot, LoadTrackedClient, MinimumPeerVersion},
+    peer::{
+        CancelHeartbeatTask, Client, ClientRequest, ErrorSlot, LoadTrackedClient,
+        MinimumPeerVersion,
+    },
     peer_set::PeerSet,
     protocol::external::{types::Version, InventoryHash},
     AddressBook, Config,
@@ -38,7 +41,7 @@ const MAX_PEERS: usize = 20;
 /// A handle to a mocked [`Client`] instance.
 struct MockedClientHandle {
     _request_receiver: mpsc::Receiver<ClientRequest>,
-    shutdown_receiver: oneshot::Receiver<()>,
+    shutdown_receiver: oneshot::Receiver<CancelHeartbeatTask>,
     version: Version,
 }
 
@@ -74,7 +77,7 @@ impl MockedClientHandle {
     pub fn is_connected(&mut self) -> bool {
         match self.shutdown_receiver.try_recv() {
             Ok(None) => true,
-            Ok(Some(())) | Err(oneshot::Canceled) => false,
+            Ok(Some(CancelHeartbeatTask)) | Err(oneshot::Canceled) => false,
         }
     }
 }

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -426,3 +426,30 @@ impl fmt::Display for Message {
         })
     }
 }
+
+impl Message {
+    /// Returns the Zcash protocol message command as a string.
+    pub fn command(&self) -> &'static str {
+        match self {
+            Message::Version { .. } => "version",
+            Message::Verack => "verack",
+            Message::Ping(_) => "ping",
+            Message::Pong(_) => "pong",
+            Message::Reject { .. } => "reject",
+            Message::GetAddr => "getaddr",
+            Message::Addr(_) => "addr",
+            Message::GetBlocks { .. } => "getblocks",
+            Message::Inv(_) => "inv",
+            Message::GetHeaders { .. } => "getheaders",
+            Message::Headers(_) => "headers",
+            Message::GetData(_) => "getdata",
+            Message::Block(_) => "block",
+            Message::Tx(_) => "tx",
+            Message::NotFound(_) => "notfound",
+            Message::Mempool => "mempool",
+            Message::FilterLoad { .. } => "filterload",
+            Message::FilterAdd { .. } => "filteradd",
+            Message::FilterClear => "filterclear",
+        }
+    }
+}

--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -228,3 +228,25 @@ impl fmt::Display for Request {
         })
     }
 }
+
+impl Request {
+    /// Returns the Zebra internal request type as a string.
+    pub fn command(&self) -> &'static str {
+        match self {
+            Request::Peers => "Peers",
+            Request::Ping(_) => "Ping",
+
+            Request::BlocksByHash(_) => "BlocksByHash",
+            Request::TransactionsById(_) => "TransactionsById",
+
+            Request::FindBlocks { .. } => "FindBlocks",
+            Request::FindHeaders { .. } => "FindHeaders",
+
+            Request::PushTransaction(_) => "PushTransaction",
+            Request::AdvertiseTransactionIds(_) => "AdvertiseTransactionIds",
+
+            Request::AdvertiseBlock(_) => "AdvertiseBlock",
+            Request::MempoolTransactionIds => "MempoolTransactionIds",
+        }
+    }
+}

--- a/zebra-network/src/protocol/internal/response.rs
+++ b/zebra-network/src/protocol/internal/response.rs
@@ -92,3 +92,22 @@ impl fmt::Display for Response {
         })
     }
 }
+
+impl Response {
+    /// Returns the Zebra internal response type as a string.
+    pub fn command(&self) -> &'static str {
+        match self {
+            Response::Nil => "Nil",
+
+            Response::Peers(_) => "Peers",
+
+            Response::Blocks(_) => "Blocks",
+            Response::BlockHashes(_) => "BlockHashes",
+
+            Response::BlockHeaders { .. } => "BlockHeaders",
+
+            Response::Transactions(_) => "Transactions",
+            Response::TransactionIds(_) => "TransactionIds",
+        }
+    }
+}

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -173,6 +173,8 @@ where
                 ?MAX_INBOUND_CONCURRENCY,
                 "block hash already queued for inbound download: ignored block"
             );
+            metrics::gauge!("gossip.queued.block.count", self.pending.len() as _);
+
             return DownloadAction::AlreadyQueued;
         }
 
@@ -183,6 +185,8 @@ where
                 ?MAX_INBOUND_CONCURRENCY,
                 "too many blocks queued for inbound download: ignored block"
             );
+            metrics::gauge!("gossip.queued.block.count", self.pending.len() as _);
+
             return DownloadAction::FullQueue;
         }
 

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -229,9 +229,9 @@ where
         .in_current_span();
 
         let task = tokio::spawn(async move {
-            // TODO: if the verifier and cancel are both ready, which should we
-            //       prefer? (Currently, select! chooses one at random.)
+            // Prefer the cancel handle if both are ready.
             tokio::select! {
+                biased;
                 _ = &mut cancel_rx => {
                     tracing::trace!("task cancelled prior to completion");
                     metrics::counter!("gossip.cancelled.count", 1);

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -358,9 +358,9 @@ where
         .in_current_span();
 
         let task = tokio::spawn(async move {
-            // TODO: if the verifier and cancel are both ready, which should we
-            //       prefer? (Currently, select! chooses one at random.)
+            // Prefer the cancel handle if both are ready.
             tokio::select! {
+                biased;
                 _ = &mut cancel_rx => {
                     tracing::trace!("task cancelled prior to completion");
                     metrics::counter!("mempool.cancelled.verify.tasks.total", 1);

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -263,6 +263,11 @@ where
                 ?MAX_INBOUND_CONCURRENCY,
                 "transaction id already queued for inbound download: ignored transaction"
             );
+            metrics::gauge!(
+                "mempool.currently.queued.transactions",
+                self.pending.len() as _
+            );
+
             return Err(MempoolError::AlreadyQueued);
         }
 
@@ -273,6 +278,11 @@ where
                 ?MAX_INBOUND_CONCURRENCY,
                 "too many transactions queued for inbound download: ignored transaction"
             );
+            metrics::gauge!(
+                "mempool.currently.queued.transactions",
+                self.pending.len() as _
+            );
+
             return Err(MempoolError::FullQueue);
         }
 

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -179,9 +179,9 @@ where
         let mut verifier = self.verifier.clone();
         let task = tokio::spawn(
             async move {
-                // TODO: if the verifier and cancel are both ready, which should
-                //       we prefer? (Currently, select! chooses one at random.)
+                // Prefer the cancel handle if both are ready.
                 let rsp = tokio::select! {
+                    biased;
                     _ = &mut cancel_rx => {
                         tracing::trace!("task cancelled prior to download completion");
                         metrics::counter!("sync.cancelled.download.count", 1);
@@ -205,9 +205,9 @@ where
                     .await
                     .map_err(BlockDownloadVerifyError::VerifierError)?
                     .call(block);
-                // TODO: if the verifier and cancel are both ready, which should
-                //       we prefer? (Currently, select! chooses one at random.)
+                // Prefer the cancel handle if both are ready.
                 let verification = tokio::select! {
+                    biased;
                     _ = &mut cancel_rx => {
                         tracing::trace!("task cancelled prior to verification");
                         metrics::counter!("sync.cancelled.verify.count", 1);


### PR DESCRIPTION
## Motivation

When I was testing PR #3167, the peer set would hang during the initial block download. I don't know if this bug is in the `main` branch, or just in that PR.

So I added some diagnostics for peer set requests and connection state. It also includes some low-risk minor bug fixes.

This is unexpected work in sprint 25, but it's part of the Zebra stable network audit work.

## Solution

Bug fixes:
- Prefer cancel handles in selects, if both are ready
- Delete an unused timer future
- Downgrade some error logs to info

Metrics:
- Fix message metrics to just show the command name
- Add metrics for internal requests and responses
- Add internal requests and responses to the messages dashboard
- Add a canceled metric, and peer addresses to request and response met…
- Add a canceled messages graph
- Add connection state metrics for currently open connections
- Fix the connection state graph using the new metrics
- Fix missed updates to mempool and block gossip metrics

Code Readability:
- Use a named `CancelHeartbeatTask` unit struct for the channel type

## Review

@jvff reviewed PR #3200 -  this PR contains the diagnostics from that PR.

### Reviewer Checklist

  - [ ] Code makes sense
  - [ ] Dashboards work

Diagnostics don't need tests, and the bug fixes are trivial, so they shouldn't need tests.

## Follow Up Work

- #3200