### PR TITLE
Silence expected anchor errors in tests

### DIFF
--- a/zebra-state/src/service/check/anchors.rs
+++ b/zebra-state/src/service/check/anchors.rs
@@ -72,12 +72,17 @@ pub(crate) fn anchors_refer_to_earlier_treestates(
                     && !finalized_state.contains_sprout_anchor(&joinsplit.anchor)
                     && (!interstitial_roots.contains(&joinsplit.anchor))
                 {
-                    // TODO: some block after ~1_200_000 is reaching here.
+                    // TODO: This check fails near:
+                    // - mainnet block 1_047_908
+                    //   with anchor 019c435cd1e8aca9a4165f7e126ac6e548952439d50213f4d15c546df9d49b61
+                    // - testnet block 1_057_737
+                    //   with anchor 3ad623811ffa4fe8498b23f3d6bb4e086dca32269afef6c8e572fd9ee6d0c0ea
+                    //
                     // Restore after finding the cause and fixing it.
                     // return Err(ValidateContextError::UnknownSproutAnchor {
                     //     anchor: joinsplit.anchor,
                     // });
-                    tracing::error!(?joinsplit.anchor, ?prepared.height, ?prepared.hash, "failed to find sprout anchor")
+                    tracing::warn!(?joinsplit.anchor, ?prepared.height, ?prepared.hash, "failed to find sprout anchor")
                 }
 
                 tracing::debug!(?joinsplit.anchor, "validated sprout anchor");

--- a/zebra-test/src/lib.rs
+++ b/zebra-test/src/lib.rs
@@ -67,6 +67,7 @@ pub fn init() {
                 .unwrap()
                 .add_directive("zebra_consensus=error".parse().unwrap())
                 .add_directive("zebra_network=error".parse().unwrap())
+                .add_directive("zebra_state=error".parse().unwrap())
                 .add_directive("zebrad=error".parse().unwrap())
         });
 


### PR DESCRIPTION
## Motivation

PR #3206 added some error logs to Zebra's tests, but those errors are actually expected in the tests.

## Solution

- downgrade the logs to warn
- disable warnings in zebra-state in the tests

## Review

@conradoplg can review this PR.

### Reviewer Checklist

  - [ ] Tests pass without logging errors

## Follow Up Work

- #3236 