### PR TITLE
Take ownership in IsReady, to avoid capacity exhaustion

### DIFF
--- a/zebra-network/src/peer/client/tests/vectors.rs
+++ b/zebra-network/src/peer/client/tests/vectors.rs
@@ -8,7 +8,7 @@ use crate::{peer::ClientTestHarness, PeerError};
 async fn client_service_ready_ok() {
     zebra_test::init();
 
-    let (mut client, mut harness) = ClientTestHarness::build().finish();
+    let (client, mut harness) = ClientTestHarness::build().finish();
 
     assert!(client.is_ready().await);
     assert!(harness.current_error().is_none());
@@ -20,7 +20,7 @@ async fn client_service_ready_ok() {
 async fn client_service_ready_heartbeat_exit() {
     zebra_test::init();
 
-    let (mut client, mut harness) = ClientTestHarness::build().finish();
+    let (client, mut harness) = ClientTestHarness::build().finish();
 
     harness.set_error(PeerError::HeartbeatTaskExited);
     harness.drop_heartbeat_shutdown_receiver();
@@ -34,7 +34,7 @@ async fn client_service_ready_heartbeat_exit() {
 async fn client_service_ready_request_drop() {
     zebra_test::init();
 
-    let (mut client, mut harness) = ClientTestHarness::build().finish();
+    let (client, mut harness) = ClientTestHarness::build().finish();
 
     harness.set_error(PeerError::ConnectionDropped);
     harness.drop_outbound_client_request_receiver();
@@ -48,7 +48,7 @@ async fn client_service_ready_request_drop() {
 async fn client_service_ready_request_close() {
     zebra_test::init();
 
-    let (mut client, mut harness) = ClientTestHarness::build().finish();
+    let (client, mut harness) = ClientTestHarness::build().finish();
 
     harness.set_error(PeerError::ConnectionClosed);
     harness.close_outbound_client_request_receiver();
@@ -63,7 +63,7 @@ async fn client_service_ready_request_close() {
 async fn client_service_ready_error_in_slot() {
     zebra_test::init();
 
-    let (mut client, mut harness) = ClientTestHarness::build().finish();
+    let (client, mut harness) = ClientTestHarness::build().finish();
 
     harness.set_error(PeerError::Overloaded);
 
@@ -77,7 +77,7 @@ async fn client_service_ready_error_in_slot() {
 async fn client_service_ready_multiple_errors() {
     zebra_test::init();
 
-    let (mut client, mut harness) = ClientTestHarness::build().finish();
+    let (client, mut harness) = ClientTestHarness::build().finish();
 
     harness.set_error(PeerError::DuplicateHandshake);
     harness.drop_heartbeat_shutdown_receiver();

--- a/zebra-network/src/peer/client/tests/vectors.rs
+++ b/zebra-network/src/peer/client/tests/vectors.rs
@@ -7,6 +7,20 @@ use zebra_test::service_extensions::IsReady;
 use crate::{peer::ClientTestHarness, PeerError};
 
 #[tokio::test]
+async fn client_service_init_ok() {
+    zebra_test::init();
+
+    let (client, mut harness) = ClientTestHarness::build().finish();
+
+    assert!(harness.current_error().is_none());
+    assert!(harness.wants_connection_heartbeats());
+    assert!(harness.try_to_receive_outbound_client_request().is_empty());
+
+    // Do the readiness check last, so we don't have to deal with any capacity limits.
+    assert!(client.is_ready().await);
+}
+
+#[tokio::test]
 async fn client_service_ready_ok() {
     zebra_test::init();
 

--- a/zebra-test/src/service_extensions.rs
+++ b/zebra-test/src/service_extensions.rs
@@ -8,34 +8,53 @@ use now_or_later::NowOrLater;
 /// An extension trait to check if a [`Service`] is immediately ready to be called.
 pub trait IsReady<Request>: Service<Request> {
     /// Check if the [`Service`] is immediately ready to be called.
-    fn is_ready(&mut self) -> BoxFuture<bool>;
+    ///
+    /// Takes ownership of the service, so this method can only be called once.
+    /// Some services will
+    /// [reserve capacity until the next call](https://docs.rs/tower/0.4.11/tower/buffer/struct.Buffer.html#a-note-on-choosing-a-bound).
+    /// So calling this method multiple times risks capacity exhaustion in the service,
+    /// or in the services or channels that it checks for readiness.
+    ///
+    /// TODO: return the service if it is ready (#3261)
+    ///       put a `must_use` on each method
+    ///       fix the self convention: https://rust-lang.github.io/rust-clippy/master/#wrong_self_convention
+    #[allow(clippy::wrong_self_convention)]
+    fn is_ready(self) -> BoxFuture<'static, bool>;
 
     /// Check if the [`Service`] is not ready to be called.
-    fn is_pending(&mut self) -> BoxFuture<bool>;
+    ///
+    /// Takes ownership of the service, so this method can only be called once.
+    /// See [IsReady::is_ready] for details.
+    #[allow(clippy::wrong_self_convention)]
+    fn is_pending(self) -> BoxFuture<'static, bool>;
 
     /// Check if the [`Service`] is not immediately ready because it returns an error.
-    fn is_failed(&mut self) -> BoxFuture<bool>;
+    ///
+    /// Takes ownership of the service, so this method can only be called once.
+    /// See [IsReady::is_ready] for details.
+    #[allow(clippy::wrong_self_convention)]
+    fn is_failed(self) -> BoxFuture<'static, bool>;
 }
 
 impl<S, Request> IsReady<Request> for S
 where
-    S: Service<Request> + Send,
+    S: Service<Request> + Send + 'static,
     Request: 'static,
 {
-    fn is_ready(&mut self) -> BoxFuture<bool> {
-        NowOrLater(self.ready())
+    fn is_ready(self) -> BoxFuture<'static, bool> {
+        NowOrLater(self.ready_oneshot())
             .map(|ready_result| matches!(ready_result, Some(Ok(_))))
             .boxed()
     }
 
-    fn is_pending(&mut self) -> BoxFuture<bool> {
-        NowOrLater(self.ready())
+    fn is_pending(self) -> BoxFuture<'static, bool> {
+        NowOrLater(self.ready_oneshot())
             .map(|ready_result| ready_result.is_none())
             .boxed()
     }
 
-    fn is_failed(&mut self) -> BoxFuture<bool> {
-        NowOrLater(self.ready())
+    fn is_failed(self) -> BoxFuture<'static, bool> {
+        NowOrLater(self.ready_oneshot())
             .map(|ready_result| matches!(ready_result, Some(Err(_))))
             .boxed()
     }

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -2,7 +2,7 @@
 //!
 //! It is used when Zebra is a long way behind the current chain tip.
 
-use std::{collections::HashSet, pin::Pin, sync::Arc, time::Duration};
+use std::{collections::HashSet, pin::Pin, sync::Arc, task::Poll, time::Duration};
 
 use color_eyre::eyre::{eyre, Report};
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -12,7 +12,6 @@ use tower::{
     Service, ServiceExt,
 };
 
-use now_or_later::NowOrLater;
 use zebra_chain::{
     block::{self, Block},
     parameters::genesis_hash,
@@ -343,7 +342,7 @@ where
 
             while !self.prospective_tips.is_empty() {
                 // Check whether any block tasks are currently ready:
-                while let Some(Some(rsp)) = NowOrLater(self.downloads.next()).await {
+                while let Poll::Ready(Some(rsp)) = futures::poll!(self.downloads.next()) {
                     match rsp {
                         Ok(hash) => {
                             tracing::trace!(?hash, "verified and committed block to state");


### PR DESCRIPTION
## Motivation

The new `IsReady` API in PR #3241 is easy to use in ways that create test bugs, or hide production bugs.

## Solution

- take ownership of the service when calling `IsReady` methods
- document the constraints on the methods

## Review

@jvff asked me to open a ticket for these changes in https://github.com/ZcashFoundation/zebra/pull/3241#discussion_r771871194

This PR contains the parts we can do immediately, it is based on PR #3241, and it is ok to merge into that PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- #3261