### PR TITLE
Example: Replace a now or later instance with the futures::poll! macro

### DIFF
--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -2,7 +2,7 @@
 //!
 //! It is used when Zebra is a long way behind the current chain tip.
 
-use std::{collections::HashSet, pin::Pin, sync::Arc, time::Duration};
+use std::{collections::HashSet, pin::Pin, sync::Arc, task::Poll, time::Duration};
 
 use color_eyre::eyre::{eyre, Report};
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -12,7 +12,6 @@ use tower::{
     Service, ServiceExt,
 };
 
-use now_or_later::NowOrLater;
 use zebra_chain::{
     block::{self, Block},
     parameters::genesis_hash,
@@ -343,7 +342,7 @@ where
 
             while !self.prospective_tips.is_empty() {
                 // Check whether any block tasks are currently ready:
-                while let Some(Some(rsp)) = NowOrLater(self.downloads.next()).await {
+                while let Poll::Ready(Some(rsp)) = futures::poll!(self.downloads.next()) {
                     match rsp {
                         Ok(hash) => {
                             tracing::trace!(?hash, "verified and committed block to state");


### PR DESCRIPTION
## Motivation

This is an example of using the [`futures::poll!` macro](https://docs.rs/futures/latest/futures/macro.poll.html) instead of our custom `NowOrLater`.

`futures::poll!` isn't as convenient as `NowOrLater` in some contexts, because it expands to async code.

Merging this change is optional.

## Review

@jvff or @oxarbitrage might want to look at this example.

### Reviewer Checklist

  - [ ] Existing tests pass