### PR TITLE
Refactor code to avoid incorrect clippy::unnecessary_to_owned lint

### DIFF
--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -551,7 +551,8 @@ where
     let mut spent_outputs = HashMap::new();
 
     // fixup the transparent spends
-    for mut input in transaction.inputs().to_vec().into_iter() {
+    let original_inputs = transaction.inputs().to_vec();
+    for mut input in original_inputs.into_iter() {
         if input.outpoint().is_some() {
             // the transparent chain value pool is the sum of unspent UTXOs,
             // so we don't need to check it separately, because we only spend unspent UTXOs


### PR DESCRIPTION
## Motivation

There's a new clippy lint on nightly that triggers on some complicated Zebra code.

The lint is wrong, but the code could be simpler anyway.

## Review

Anyone can review this low priority PR.

### Reviewer Checklist

  - [x] Existing tests pass