### PR TITLE
Add `peer::Client` tests with zero and multiple readiness checks

### DIFF
--- a/zebra-network/src/peer/client/tests/vectors.rs
+++ b/zebra-network/src/peer/client/tests/vectors.rs
@@ -1,9 +1,24 @@
 //! Fixed peer [`Client`] test vectors.
 
+use tower::ServiceExt;
+
 use zebra_test::service_extensions::IsReady;
 
 use crate::{peer::ClientTestHarness, PeerError};
 
+/// Test that a newly initialized client functions correctly before it is polled.
+#[tokio::test]
+async fn client_service_ok_without_readiness_check() {
+    zebra_test::init();
+
+    let (_client, mut harness) = ClientTestHarness::build().finish();
+
+    assert!(harness.current_error().is_none());
+    assert!(harness.wants_connection_heartbeats());
+    assert!(harness.try_to_receive_outbound_client_request().is_empty());
+}
+
+/// Test that a newly initialized client functions correctly after it is polled.
 #[tokio::test]
 async fn client_service_ready_ok() {
     zebra_test::init();
@@ -16,6 +31,37 @@ async fn client_service_ready_ok() {
     assert!(harness.try_to_receive_outbound_client_request().is_empty());
 }
 
+/// Test that a client functions correctly if its readiness future is dropped.
+#[tokio::test]
+async fn client_service_ready_drop_ok() {
+    zebra_test::init();
+
+    let (mut client, mut harness) = ClientTestHarness::build().finish();
+
+    std::mem::drop(client.ready());
+
+    assert!(client.is_ready().await);
+    assert!(harness.current_error().is_none());
+    assert!(harness.wants_connection_heartbeats());
+    assert!(harness.try_to_receive_outbound_client_request().is_empty());
+}
+
+/// Test that a client functions correctly if it is polled for readiness multiple times.
+#[tokio::test]
+async fn client_service_ready_multiple_ok() {
+    zebra_test::init();
+
+    let (mut client, mut harness) = ClientTestHarness::build().finish();
+
+    assert!(client.is_ready().await);
+    assert!(client.is_ready().await);
+
+    assert!(harness.current_error().is_none());
+    assert!(harness.wants_connection_heartbeats());
+    assert!(harness.try_to_receive_outbound_client_request().is_empty());
+}
+
+/// Test that clients propagate errors from their heartbeat tasks.
 #[tokio::test]
 async fn client_service_ready_heartbeat_exit() {
     zebra_test::init();
@@ -30,6 +76,7 @@ async fn client_service_ready_heartbeat_exit() {
     assert!(harness.try_to_receive_outbound_client_request().is_closed());
 }
 
+/// Test that clients propagate errors from their connection tasks.
 #[tokio::test]
 async fn client_service_ready_request_drop() {
     zebra_test::init();
@@ -44,6 +91,7 @@ async fn client_service_ready_request_drop() {
     assert!(!harness.wants_connection_heartbeats());
 }
 
+/// Test that clients error when their connection task closes the request channel.
 #[tokio::test]
 async fn client_service_ready_request_close() {
     zebra_test::init();
@@ -73,6 +121,7 @@ async fn client_service_ready_error_in_slot() {
     assert!(harness.try_to_receive_outbound_client_request().is_closed());
 }
 
+/// Test that clients error when multiple error conditions occur at the same time.
 #[tokio::test]
 async fn client_service_ready_multiple_errors() {
     zebra_test::init();
@@ -88,6 +137,7 @@ async fn client_service_ready_multiple_errors() {
     assert!(harness.try_to_receive_outbound_client_request().is_closed());
 }
 
+/// Test that clients register an error and cleanup channels correctly when the client is dropped.
 #[tokio::test]
 async fn client_service_drop_cleanup() {
     zebra_test::init();


### PR DESCRIPTION
## Motivation

This PR tests that `peer::Client`s behave correctly when:
- they haven't had a readiness poll yet
- they have multiple readiness polls
- their readiness polls are dropped

These are things that the `PeerSet` actually does, so we should test that they work. (Except for the dropped poll future, which we might not do explicitly yet. But that's worth testing for anyway, because we will probably do it eventually.)

These tests are a medium priority, because we're actively modifying this code.

## Review

@jvff reviewed some of these tests in other PRs. But maybe @oxarbitrage can help with this review instead?

This PR can merge with or after PR #3241. It's not a blocker for PR #3241.

### Reviewer Checklist

  - [ ] Existing tests pass

