### PR TITLE
Revert "Stop ignoring some completed Responses"

### DIFF
--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -593,6 +593,14 @@ where
 
                             self.update_state_metrics(None);
 
+                            // # Correctness
+                            //
+                            // Handle any unsolicited messages first, to clear the queue.
+                            // Then check for responses to our request messages.
+                            //
+                            // This significantly reduces our message failure rate.
+                            // (Otherwise, every unsolicited message can disrupt our pending request.)
+
                             // If the message was not consumed, check whether it
                             // should be handled as a request.
                             if let Some(msg) = request_msg {


### PR DESCRIPTION
## Motivation

This reverts commit 0383562e1098ee2b49a4b5dd1b37646e6512782f from PR #3120,
but keeps the metrics and logging changes since that commit.

This should fix slow sync speeds.

Zebra needs to clear unsolicited messages from peers, before it checks for responses to its messages. (Otherwise, every unsolicited message can cause a request failure.)

## Review

@conradoplg can test this PR.

### Reviewer Checklist

  - [x] Sync is faster than the current `main` branch

