### PR TITLE
Update format of funding stream consensus rule

### DIFF
--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -135,10 +135,14 @@ pub fn subsidy_is_valid(block: &Block, network: Network) -> Result<(), BlockErro
         let funding_streams = subsidy::funding_streams::funding_stream_values(height, network)
             .expect("We always expect a funding stream hashmap response even if empty");
 
-        // Consensus rule:[Canopy onward] The coinbase transaction at block height `height`
-        // MUST contain at least one output per funding stream `fs` active at `height`,
-        // that pays `fs.Value(height)` zatoshi in the prescribed way to the stream's
-        // recipient address represented by `fs.AddressList[fs.AddressIndex(height)]
+        // # Consensus
+        //
+        // > [Canopy onward] The coinbase transaction at block height `height`
+        // > MUST contain at least one output per funding stream `fs` active at `height`,
+        // > that pays `fs.Value(height)` zatoshi in the prescribed way to the stream's
+        // > recipient address represented by `fs.AddressList[fs.AddressIndex(height)]
+        //
+        // https://zips.z.cash/protocol/protocol.pdf#fundingstreams
         for (receiver, expected_amount) in funding_streams {
             let address =
                 subsidy::funding_streams::funding_stream_address(height, network, receiver);


### PR DESCRIPTION
## Motivation

Check funding stream consensus rule is implemented and documented based in the agreed format.

Closes https://github.com/ZcashFoundation/zebra/issues/3228

## Solution

The rule is up to date so this PR just change the rule quote to the new format. I didn't quoted the items the rule has as i think they are not needed but i can add if anyone think they are.

## Review

I think anyone can review, there is no code changes here.

