### PR TITLE
Document chain value balances consensus rules with new format

### DIFF
--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -151,8 +151,6 @@ impl ValueBalance<NegativeAllowed> {
     /// This rule applies to Block and Mempool transactions.
     ///
     /// Design: <https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/rfcs/0012-value-pools.md#definitions>
-    //
-    // TODO: move this method to Transaction, so it can handle coinbase transactions as well?
     pub fn remaining_transaction_value(&self) -> Result<Amount<NonNegative>, amount::Error> {
         // Calculated by summing the transparent, sprout, sapling, and orchard value balances,
         // as specified in:
@@ -189,12 +187,13 @@ impl ValueBalance<NonNegative> {
     /// Individual transactions have a value pool that must be non-negative,
     /// so the Transparent chain value pool balance (which is the sum of all the value pools for each
     /// transaction and for each block in the chain) must be non-negative too.
+    ///
     /// > The remaining value in the transparent transaction value pool MUST be nonnegative.
     ///
     /// <https://zips.z.cash/protocol/protocol.pdf#transactions>
     ///
     /// > Nodes MAY relay transactions even if one or more of them cannot be mined due to the
-    /// > aforementioned restriction."
+    /// > aforementioned restriction.
     ///
     /// <https://zips.z.cash/zip-0209#specification>
     ///

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -155,6 +155,7 @@ impl ValueBalance<NegativeAllowed> {
         // Calculated by summing the transparent, sprout, sapling, and orchard value balances,
         // as specified in:
         // https://zebra.zfnd.org/dev/rfcs/0012-value-pools.html#definitions
+        // This will error if the chain value pool balance gets negative with the change.
         (self.transparent + self.sprout + self.sapling + self.orchard)?.constrain::<NonNegative>()
     }
 }
@@ -208,6 +209,7 @@ impl ValueBalance<NonNegative> {
     ) -> Result<ValueBalance<NonNegative>, ValueBalanceError> {
         let chain_value_pool_change = block.borrow().chain_value_pool_change(utxos)?;
 
+        // This will error if the chain value pool balance gets negative with the change.
         self.add_chain_value_pool_change(chain_value_pool_change)
     }
 
@@ -281,7 +283,6 @@ impl ValueBalance<NonNegative> {
             .expect("conversion from NonNegative to NegativeAllowed is always valid");
         chain_value_pool = (chain_value_pool + chain_value_pool_change)?;
 
-        // This will error if the chain value pool balance gets negative with the change.
         chain_value_pool.constrain()
     }
 


### PR DESCRIPTION
## Motivation

We want to change the doc of this rules to follow a new format standard for easier consensus rule searching in Zebra.

Close https://github.com/ZcashFoundation/zebra/issues/3221
Close https://github.com/ZcashFoundation/zebra/issues/3219
Close https://github.com/ZcashFoundation/zebra/issues/3220

Additionally the consensus rule about the transparent value pool inside the transaction itself was also updated ~~(this does not have an open issue as far as i know)~~

Close #3209

## Solution

As we implement the chain value balances rules in the same function i decided to document all together in a single PR. 

## Review

Anyone can review, no code is changed.
