### PR TITLE
Stop ignoring some peers when updating the address book

### DIFF
--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -752,21 +752,15 @@ impl MetaAddrChange {
 
     /// If this change can create a new `MetaAddr`, return that address.
     pub fn into_new_meta_addr(self) -> Option<MetaAddr> {
-        match self {
-            NewInitial { .. } | NewGossiped { .. } | NewAlternate { .. } | NewLocal { .. } => {
-                Some(MetaAddr {
-                    addr: self.addr(),
-                    services: self.untrusted_services(),
-                    untrusted_last_seen: self.untrusted_last_seen(),
-                    last_response: None,
-                    last_attempt: None,
-                    last_failure: None,
-                    last_connection_state: self.peer_addr_state(),
-                })
-            }
-
-            UpdateAttempt { .. } | UpdateResponded { .. } | UpdateFailed { .. } => None,
-        }
+        Some(MetaAddr {
+            addr: self.addr(),
+            services: self.untrusted_services(),
+            untrusted_last_seen: self.untrusted_last_seen(),
+            last_response: self.last_response(),
+            last_attempt: self.last_attempt(),
+            last_failure: self.last_failure(),
+            last_connection_state: self.peer_addr_state(),
+        })
     }
 
     /// Apply this change to a previous `MetaAddr` from the address book,

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -1,4 +1,4 @@
-//! Test vectors for MetaAddr.
+//! Fixed test cases for MetaAddr and MetaAddrChange.
 
 use std::net::SocketAddr;
 

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -237,7 +237,7 @@ where
 /// Use the provided `outbound_connector` to connect to the configured initial peers,
 /// then send the resulting peer connections over `peerset_tx`.
 ///
-/// Sends any unused initial peers to the `address_book_updater`.
+/// Also sends every initial peer address to the `address_book_updater`.
 #[instrument(skip(config, outbound_connector, peerset_tx, address_book_updater))]
 async fn add_initial_peers<S>(
     config: Config,
@@ -375,9 +375,10 @@ where
 /// Limit the number of `initial_peers` addresses entries to the configured
 /// `peerset_initial_target_size`.
 ///
-/// Returns randomly chosen entries from the provided set of addresses.
+/// Returns randomly chosen entries from the provided set of addresses,
+/// in a random order.
 ///
-/// Sends any unused entries to the `address_book_updater`.
+/// Also sends every initial peer to the `address_book_updater`.
 async fn limit_initial_peers(
     config: &Config,
     address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
@@ -385,27 +386,29 @@ async fn limit_initial_peers(
     let all_peers = config.initial_peers().await;
     let peers_count = all_peers.len();
 
-    if peers_count <= config.peerset_initial_target_size {
-        return all_peers;
+    // # Correctness
+    //
+    // We can't exit early if we only have a few peers,
+    // because we still need to shuffle the connection order.
+
+    if all_peers.len() > config.peerset_initial_target_size {
+        info!(
+            "limiting the initial peers list from {} to {}",
+            peers_count, config.peerset_initial_target_size
+        );
     }
 
-    // Limit the number of initial peers to `config.peerset_initial_target_size`
-    info!(
-        "Limiting the initial peers list from {} to {}",
-        peers_count, config.peerset_initial_target_size
-    );
+    // Split out the `initial_peers` that will be shuffled and returned.
+    let mut initial_peers: Vec<SocketAddr> = all_peers.iter().cloned().collect();
+    let (initial_peers, _unused_peers) =
+        initial_peers.partial_shuffle(&mut rand::thread_rng(), config.peerset_initial_target_size);
 
-    // Split all the peers into the `initial_peers` that will be returned and
-    // `unused_peers` that will be sent to the address book.
-    let mut all_peers: Vec<SocketAddr> = all_peers.into_iter().collect();
-    let (initial_peers, unused_peers) =
-        all_peers.partial_shuffle(&mut rand::thread_rng(), config.peerset_initial_target_size);
-
-    // Send the unused peers to the address book.
-    for peer in unused_peers {
-        let peer_addr = MetaAddr::new_initial_peer(*peer);
+    // Send every initial peer to the address book.
+    // (This treats initial peers the same way we treat gossiped peers.)
+    for peer in all_peers {
+        let peer_addr = MetaAddr::new_initial_peer(peer);
         // `send` only waits when the channel is full.
-        // The address book updater is a separate task, so we will only wait for a short time.
+        // The address book updater runs in its own thread, so we will only wait for a short time.
         let _ = address_book_updater.send(peer_addr).await;
     }
 


### PR DESCRIPTION
## Motivation

Zebra was ignoring some peers when updating the address book.

This could be the cause of issues like #3042.

## Solution

- Correctly apply MetaAddrChanges when there is no existing address book entry
- Add all initial peers to the address book (not just the unused ones)

## Review

This PR is ready for review.

I think @dconnolly can review this PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

I've tested this PR locally, and the crawler and address book metrics look a lot better. The number of peer addresses rises rapidly, and gets full after a few hours. And Zebra doesn't hang any more, even after a few days.