### PR TITLE
1. Fix some address crawler timing issues

### DIFF
--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -273,7 +273,7 @@ impl AddressBook {
 
         let updated = change.apply_to_meta_addr(previous);
 
-        debug!(
+        trace!(
             ?change,
             ?updated,
             ?previous,

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -273,12 +273,13 @@ impl AddressBook {
 
         let updated = change.apply_to_meta_addr(previous);
 
-        trace!(
+        debug!(
             ?change,
             ?updated,
             ?previous,
             total_peers = self.by_addr.len(),
             recent_peers = self.recently_live_peers(chrono_now).count(),
+            "calculated updated address book entry",
         );
 
         if let Some(updated) = updated {
@@ -303,6 +304,15 @@ impl AddressBook {
 
             self.by_addr.insert(updated.addr, updated);
 
+            debug!(
+                ?change,
+                ?updated,
+                ?previous,
+                total_peers = self.by_addr.len(),
+                recent_peers = self.recently_live_peers(chrono_now).count(),
+                "updated address book entry",
+            );
+
             // Security: Limit the number of peers in the address book.
             //
             // We only delete outdated peers when we have too many peers.
@@ -317,6 +327,14 @@ impl AddressBook {
                     .expect("just checked there is at least one peer");
 
                 self.by_addr.remove(&surplus_peer.addr);
+
+                debug!(
+                    surplus = ?surplus_peer,
+                    ?updated,
+                    total_peers = self.by_addr.len(),
+                    recent_peers = self.recently_live_peers(chrono_now).count(),
+                    "removed surplus address book entry",
+                );
             }
 
             assert!(self.len() <= self.addr_limit);

--- a/zebra-network/src/address_book_updater.rs
+++ b/zebra-network/src/address_book_updater.rs
@@ -58,7 +58,7 @@ impl AddressBookUpdater {
             info!("starting the address book updater");
 
             while let Some(event) = worker_rx.blocking_recv() {
-                debug!(?event, "got address book change");
+                trace!(?event, "got address book change");
 
                 // # Correctness
                 //

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -133,14 +133,19 @@ pub const PEER_GET_ADDR_TIMEOUT: Duration = Duration::from_secs(8);
 
 /// The number of GetAddr requests sent when crawling for new peers.
 ///
-/// ## SECURITY
+/// # Security
 ///
 /// The fanout should be greater than 2, so that Zebra avoids getting a majority
 /// of its initial address book entries from a single peer.
 ///
 /// Zebra regularly crawls for new peers, initiating a new crawl every
 /// [`crawl_new_peer_interval`](crate::config::Config.crawl_new_peer_interval).
-pub const GET_ADDR_FANOUT: usize = 3;
+///
+/// TODO: Restore the fanout to 3, once fanouts are limited to the number of ready peers (#2214)
+///
+/// In #3110, we changed the fanout to 1, to make sure we actually use cached address responses.
+/// With a fanout of 3, we were dropping a lot of responses, because the overall crawl timed out.
+pub const GET_ADDR_FANOUT: usize = 1;
 
 /// The maximum number of addresses allowed in an `addr` or `addrv2` message.
 ///

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -603,22 +603,25 @@ where
 
                             // If the message was not consumed, check whether it
                             // should be handled as a request.
-                            if let Some(msg) = request_msg {
+                            if let Some(msg) = request_msg.clone() {
                                 // do NOT instrument with the request span, this is
                                 // independent work
                                 self.handle_message_as_request(msg).await;
-                            } else {
-                                // Otherwise, check whether the handler is finished
-                                // processing messages and update the state.
-                                //
-                                // Replace the state with a temporary value,
-                                // so we can take ownership of the response sender.
-                                self.state = match std::mem::replace(&mut self.state, State::Failed) {
-                                    State::AwaitingResponse {
-                                        handler: Handler::Finished(response),
-                                        tx,
-                                        ..
-                                    } => {
+                            }
+
+                            // Check whether the handler is finished processing messages,
+                            // and update the state.
+                            // (Some messages can indicate that a response has finished,
+                            // even if the message wasn't consumed by the response.)
+                            //
+                            // Replace the state with a temporary value,
+                            // so we can take ownership of the response sender.
+                            self.state = match std::mem::replace(&mut self.state, State::Failed) {
+                                State::AwaitingResponse {
+                                    handler: Handler::Finished(response),
+                                    tx,
+                                    ..
+                                } => {
                                     if let Ok(response) = response.as_ref() {
                                         debug!(%response, "finished receiving peer response to Zebra request");
                                         // Add a metric for inbound responses to outbound requests.
@@ -631,28 +634,27 @@ where
                                     } else {
                                         debug!(error = ?response, "error in peer response to Zebra request");
                                     }
-                                        let _ = tx.send(response.map_err(Into::into));
-                                        State::AwaitingRequest
-                                    }
-                                    pending @ State::AwaitingResponse { .. } => {
-                                        // Drop the new request message from the remote peer,
-                                        // because we can't process multiple requests at the same time.
-                                        debug!(
-                                            new_request = %request_msg
-                                                .as_ref()
-                                                .map(|m| m.to_string())
-                                                .unwrap_or_else(|| "None".into()),
-                                            awaiting_response = %pending,
+                                    let _ = tx.send(response.map_err(Into::into));
+                                    State::AwaitingRequest
+                                }
+                                pending @ State::AwaitingResponse { .. } => {
+                                    // Drop the new request message from the remote peer,
+                                    // because we can't process multiple requests at the same time.
+                                    debug!(
+                                        new_request = %request_msg
+                                            .as_ref()
+                                            .map(|m| m.to_string())
+                                            .unwrap_or_else(|| "None".into()),
+                                        awaiting_response = %pending,
                                         "ignoring new request while awaiting a response"
-                                        );
-                                        pending
-                                    },
-                                    _ => unreachable!(
-                                        "unexpected failed connection state while AwaitingResponse: client_receiver: {:?}",
-                                        self.client_rx
-                                    ),
-                                };
-                            }
+                                    );
+                                    pending
+                                },
+                                _ => unreachable!(
+                                    "unexpected failed connection state while AwaitingResponse: client_receiver: {:?}",
+                                    self.client_rx
+                                ),
+                            };
                         }
                         Either::Left((Either::Right(_), _peer_fut)) => {
                             trace!(parent: &span, "client request timed out");

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -530,7 +530,7 @@ where
                             if let Some(unhandled_msg) = unhandled_msg {
                                 debug!(
                                     %unhandled_msg,
-                                "ignoring unhandled request while awaiting a request"
+                                    "ignoring unhandled request while awaiting a request"
                                 );
                             }
                         }

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -700,10 +700,13 @@ where
             }
         }
 
+        let error = self.error_slot.try_get_error();
         assert!(
-            self.error_slot.try_get_error().is_some(),
+            error.is_some(),
             "closing connections must call fail_with() or shutdown() to set the error slot"
         );
+
+        self.update_state_metrics(error.expect("checked is_some").to_string());
     }
 
     /// Fail this connection.

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -650,6 +650,12 @@ where
     // - use the `select!` macro for all actions, because the `select` function
     //   is biased towards the first ready future
 
+    info!(
+        crawl_new_peer_interval = ?config.crawl_new_peer_interval,
+        outbound_connections = ?active_outbound_connections.update_count(),
+        "starting the peer address crawler",
+    );
+
     let mut handshakes = FuturesUnordered::new();
     // <FuturesUnordered as Stream> returns None when empty.
     // Keeping an unresolved future in the pool means the stream

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -772,7 +772,7 @@ where
 
         self.last_peer_log = Some(Instant::now());
 
-        let address_metrics = self.address_metrics.borrow();
+        let address_metrics = *self.address_metrics.borrow();
         if unready_services_len == 0 {
             warn!(
                 ?address_metrics,
@@ -799,7 +799,7 @@ where
 
         // Security: make sure we haven't exceeded the connection limit
         if num_peers > self.peerset_total_connection_limit {
-            let address_metrics = self.address_metrics.borrow();
+            let address_metrics = *self.address_metrics.borrow();
             panic!(
                 "unexpectedly exceeded configured peer set connection limit: \n\
                  peers: {:?}, ready: {:?}, unready: {:?}, \n\

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -388,8 +388,10 @@ impl fmt::Display for Message {
                 user_agent,
             ),
             Message::Verack => "verack".to_string(),
+
             Message::Ping(_) => "ping".to_string(),
             Message::Pong(_) => "pong".to_string(),
+
             Message::Reject {
                 message,
                 reason,
@@ -401,25 +403,39 @@ impl fmt::Display for Message {
                 reason,
                 if data.is_some() { "Some" } else { "None" },
             ),
+
             Message::GetAddr => "getaddr".to_string(),
             Message::Addr(addrs) => format!("addr {{ addrs: {} }}", addrs.len()),
+
             Message::GetBlocks { known_blocks, stop } => format!(
                 "getblocks {{ known_blocks: {}, stop: {} }}",
                 known_blocks.len(),
                 if stop.is_some() { "Some" } else { "None" },
             ),
             Message::Inv(invs) => format!("inv {{ invs: {} }}", invs.len()),
+
             Message::GetHeaders { known_blocks, stop } => format!(
                 "getheaders {{ known_blocks: {}, stop: {} }}",
                 known_blocks.len(),
                 if stop.is_some() { "Some" } else { "None" },
             ),
             Message::Headers(headers) => format!("headers {{ headers: {} }}", headers.len()),
+
             Message::GetData(invs) => format!("getdata {{ invs: {} }}", invs.len()),
-            Message::Block(_) => "block".to_string(),
+            Message::Block(block) => format!(
+                "block {{ height: {}, hash: {} }}",
+                block
+                    .coinbase_height()
+                    .as_ref()
+                    .map(|h| h.0.to_string())
+                    .unwrap_or_else(|| "None".into()),
+                block.hash(),
+            ),
             Message::Tx(_) => "tx".to_string(),
             Message::NotFound(invs) => format!("notfound {{ invs: {} }}", invs.len()),
+
             Message::Mempool => "mempool".to_string(),
+
             Message::FilterLoad { .. } => "filterload".to_string(),
             Message::FilterAdd { .. } => "filteradd".to_string(),
             Message::FilterClear => "filterclear".to_string(),

--- a/zebra-network/src/protocol/internal/response.rs
+++ b/zebra-network/src/protocol/internal/response.rs
@@ -79,7 +79,21 @@ impl fmt::Display for Response {
 
             Response::Peers(peers) => format!("Peers {{ peers: {} }}", peers.len()),
 
+            // Display heights for single-block responses (which Zebra requests and expects)
+            Response::Blocks(blocks) if blocks.len() == 1 => {
+                let block = blocks.first().expect("len is 1");
+                format!(
+                    "Block {{ height: {}, hash: {} }}",
+                    block
+                        .coinbase_height()
+                        .as_ref()
+                        .map(|h| h.0.to_string())
+                        .unwrap_or_else(|| "None".into()),
+                    block.hash(),
+                )
+            }
             Response::Blocks(blocks) => format!("Blocks {{ blocks: {} }}", blocks.len()),
+
             Response::BlockHashes(hashes) => format!("BlockHashes {{ hashes: {} }}", hashes.len()),
             Response::BlockHeaders(headers) => {
                 format!("BlockHeaders {{ headers: {} }}", headers.len())


### PR DESCRIPTION
## Motivation

Zebra's address crawler is fragile - small changes can cause significant regressions.

This PR deals with a few different sources of that instability.

## Solution

- Fix a race between the first heartbeat and getaddr requests
- Temporarily reduce the getaddr fanout to 1, until we implement #2214 
- Make sure finished requests are always sent as soon as they are ready
- Simplify the `Connection` awaiting request state machine
- Improve connection metrics and logging

## Review

This PR is ready for review.

Let's assign a reviewer when people are back from leave.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs

I've tested this PR locally, and the crawler and address book metrics look a lot better. The number of peer addresses rises rapidly, and gets full after a few hours. And Zebra doesn't hang any more, even after a few days.

It's hard to test this PR, because the timing issues are subtle, and don't show up in some network environments. We should have better tests after we implement #1592.
