### PR TITLE
2. Cache unsolicited address messages, and use them as responses

### DIFF
--- a/zebra-network/src/peer/connection/tests/vectors.rs
+++ b/zebra-network/src/peer/connection/tests/vectors.rs
@@ -43,6 +43,7 @@ async fn connection_run_loop_ok() {
     let connection = Connection {
         state: State::AwaitingRequest,
         request_timer: None,
+        cached_addrs: Vec::new(),
         svc: unused_inbound_service,
         client_rx: ClientRequestReceiver::from(client_rx),
         error_slot: shared_error_slot.clone(),
@@ -103,6 +104,7 @@ async fn connection_run_loop_future_drop() {
     let connection = Connection {
         state: State::AwaitingRequest,
         request_timer: None,
+        cached_addrs: Vec::new(),
         svc: unused_inbound_service,
         client_rx: ClientRequestReceiver::from(client_rx),
         error_slot: shared_error_slot.clone(),
@@ -152,6 +154,7 @@ async fn connection_run_loop_client_close() {
     let connection = Connection {
         state: State::AwaitingRequest,
         request_timer: None,
+        cached_addrs: Vec::new(),
         svc: unused_inbound_service,
         client_rx: ClientRequestReceiver::from(client_rx),
         error_slot: shared_error_slot.clone(),
@@ -208,6 +211,7 @@ async fn connection_run_loop_client_drop() {
     let connection = Connection {
         state: State::AwaitingRequest,
         request_timer: None,
+        cached_addrs: Vec::new(),
         svc: unused_inbound_service,
         client_rx: ClientRequestReceiver::from(client_rx),
         error_slot: shared_error_slot.clone(),
@@ -263,6 +267,7 @@ async fn connection_run_loop_inbound_close() {
     let connection = Connection {
         state: State::AwaitingRequest,
         request_timer: None,
+        cached_addrs: Vec::new(),
         svc: unused_inbound_service,
         client_rx: ClientRequestReceiver::from(client_rx),
         error_slot: shared_error_slot.clone(),
@@ -319,6 +324,7 @@ async fn connection_run_loop_inbound_drop() {
     let connection = Connection {
         state: State::AwaitingRequest,
         request_timer: None,
+        cached_addrs: Vec::new(),
         svc: unused_inbound_service,
         client_rx: ClientRequestReceiver::from(client_rx),
         error_slot: shared_error_slot.clone(),
@@ -379,6 +385,7 @@ async fn connection_run_loop_failed() {
     let connection = Connection {
         state: State::Failed,
         request_timer: None,
+        cached_addrs: Vec::new(),
         svc: unused_inbound_service,
         client_rx: ClientRequestReceiver::from(client_rx),
         error_slot: shared_error_slot.clone(),

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -915,6 +915,7 @@ where
             let server = Connection {
                 state: connection::State::AwaitingRequest,
                 request_timer: None,
+                cached_addrs: Vec::new(),
                 svc: inbound_service,
                 client_rx: server_rx.into(),
                 error_slot: error_slot.clone(),


### PR DESCRIPTION
## Motivation

Zebra's address crawler is fragile - small changes can cause significant regressions.

This PR caches unsolicited address messages, so that new addresses are always available when Zebra wants them.

## Solution

- Cache unsolicited address messages
- Prefer multi-address messages to single-address messages
- Provide cached addresses to Zebra in response to address requests

Closes #3110 

## Review

This PR is ready for review.

@dconnolly can review this PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs

I've tested this PR locally, and the regression in the address book metrics is resolved. (We see thousands of addresses on mainnet, and over a hundred on testnet.) The number of peer addresses rises rapidly, and gets full after a few hours. And Zebra doesn't hang any more, even after a few days.

It's hard to test this PR, because the timing issues are subtle, and don't show up in some network environments. We should have better tests after we implement #1592.
