### PR TITLE
3. Cleanup internal network request handler, fix unused request logging

### DIFF
--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -1049,7 +1049,7 @@ where
                 [] => {
                     debug!(%msg, "ignoring empty inv");
 
-                    // This might be a minor protocol error, or it might mean "not found"
+                    // This might be a minor protocol error, or it might mean "not found".
                     Unused
                 }
                 [InventoryHash::Block(_), InventoryHash::Block(_), ..] => {
@@ -1085,7 +1085,7 @@ where
                 [] => {
                     debug!(%msg, "ignoring empty getdata");
 
-                    // This might be a minor protocol error, or it might mean "not found"
+                    // This might be a minor protocol error, or it might mean "not found".
                     Unused
                 }
                 _ => {


### PR DESCRIPTION
## Motivation

In PRs #3293 and #3294, we modify Zebra's internal request handling so it is simpler and more reliable.

This PR removes some workarounds and duplicate code that aren't needed any more.

## Solution

- Replace sending immediate responses with the new finished response handler code
- Remove special cases and wrapper structs that aren't needed any more
- Fix unused request logging

## Review

This PR is ready for review, but it's based on PR #3294, so we should keep it in draft until that PR merges.

@upbqdn can review this PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs

I've tested this PR locally, and the regression in the address book metrics stays resolved.

It's hard to test this PR, because we don't have a lot of connection state handling tests. We should have better tests after we implement #1592.
