### PR TITLE
T2. Add isolated Tor connection API, but don't enable it by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74f5722bc48763cb9d81d8427ca05b6aa2842f6632cf8e4c0a29eef9baececcc"
 dependencies = [
- "darling",
+ "darling 0.10.2",
  "ident_case",
  "proc-macro2 1.0.34",
  "quote 1.0.10",
@@ -77,6 +77,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cipher",
  "cpufeatures",
+ "ctr",
  "opaque-debug",
 ]
 
@@ -152,6 +153,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
 
 [[package]]
+name = "arti-client"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "derive_builder",
+ "directories",
+ "futures",
+ "humantime-serde",
+ "serde",
+ "thiserror",
+ "tor-chanmgr",
+ "tor-circmgr",
+ "tor-config",
+ "tor-dirmgr",
+ "tor-persist",
+ "tor-proto",
+ "tor-rtcompat",
+ "tracing",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443ccbb270374a2b1055fc72da40e1f237809cd6bb0e97e66d264cd138473a6"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "pin-project-lite",
+ "xz2",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +211,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+dependencies = [
+ "proc-macro2 1.0.34",
+ "quote 1.0.10",
+ "syn 1.0.83",
+]
+
+[[package]]
+name = "async_executors"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b13b311cd10e80105651ad640a6741991d147787badb4141e8e1b7fd59816f5"
+dependencies = [
+ "blanket",
+ "futures-core",
+ "futures-task",
+ "futures-util",
+ "pin-project 1.0.7",
+ "rustc_version 0.4.0",
+ "tokio",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "atomic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
+dependencies = [
+ "autocfg 1.0.1",
+]
+
+[[package]]
 name = "atomic-shim"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +277,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
@@ -308,10 +400,10 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0830ae4cc96b0617cc912970c2b17e89456fecbf55e8eed53a956f37ab50c41"
 dependencies = [
- "hmac",
+ "hmac 0.11.0",
  "pbkdf2",
  "rand 0.8.4",
- "sha2",
+ "sha2 0.9.8",
  "unicode-normalization",
  "zeroize",
 ]
@@ -372,10 +464,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "blanket"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b04ce3d2372d05d1ef4ea3fdf427da6ae3c17ca06d688a107b5344836276bc3"
+dependencies = [
+ "proc-macro2 1.0.34",
+ "quote 1.0.10",
+ "syn 1.0.83",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
  "generic-array",
 ]
@@ -410,12 +522,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bounded-vec-deque"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2225b558afc76c596898f5f1b3fc35cfce0eb1b13635cbd7d1b2a7177dc10ccd"
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 dependencies = [
- "sha2",
+ "sha2 0.9.8",
 ]
 
 [[package]]
@@ -459,6 +577,11 @@ name = "canonical-path"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
+
+[[package]]
+name = "caret"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
 
 [[package]]
 name = "cast"
@@ -534,7 +657,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.44",
  "winapi",
 ]
 
@@ -583,6 +706,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "coarsetime"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "441947d9f3582f20b35fdd2bc5ada3a8c74c9ea380d66268607cb399b510ee08"
+dependencies = [
+ "libc",
+ "once_cell",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "color-backtrace"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,10 +757,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -691,7 +854,7 @@ dependencies = [
  "crossbeam-channel 0.4.4",
  "crossbeam-deque 0.7.3",
  "crossbeam-epoch 0.8.2",
- "crossbeam-queue",
+ "crossbeam-queue 0.2.3",
  "crossbeam-utils 0.7.2",
 ]
 
@@ -752,7 +915,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "cfg-if 0.1.10",
  "crossbeam-utils 0.7.2",
  "lazy_static",
@@ -786,6 +949,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b979d76c9fcb84dffc80a73f7290da0f83e4c95773494674cb44b76d13a7a110"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.5",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,7 +974,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "cfg-if 0.1.10",
  "lazy_static",
 ]
@@ -827,6 +1000,26 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "crypto-mac"
@@ -861,13 +1054,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "rand_core 0.5.1",
  "serde",
  "subtle",
@@ -880,8 +1082,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.10.2",
+ "darling_macro 0.10.2",
+]
+
+[[package]]
+name = "darling"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
+dependencies = [
+ "darling_core 0.12.4",
+ "darling_macro 0.12.4",
 ]
 
 [[package]]
@@ -899,12 +1111,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.34",
+ "quote 1.0.10",
+ "strsim 0.10.0",
+ "syn 1.0.83",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
- "darling_core",
+ "darling_core 0.10.2",
+ "quote 1.0.10",
+ "syn 1.0.83",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
+dependencies = [
+ "darling_core 0.12.4",
  "quote 1.0.10",
  "syn 1.0.83",
 ]
@@ -930,12 +1167,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
+dependencies = [
+ "const-oid",
+ "crypto-bigint",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
+dependencies = [
+ "darling 0.12.4",
+ "proc-macro2 1.0.34",
+ "quote 1.0.10",
+ "syn 1.0.83",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.83",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2 1.0.34",
+ "quote 1.0.10",
+ "rustc_version 0.4.0",
+ "syn 1.0.83",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+dependencies = [
+ "block-buffer 0.10.0",
+ "crypto-common",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -957,10 +1260,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
@@ -979,6 +1303,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74e1069e39f1454367eb2de793ed062fac4c35c2934b76a81d90dd9abcd28816"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "merlin",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.8",
+ "zeroize",
+]
+
+[[package]]
 name = "ed25519-zebra"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,7 +1336,7 @@ dependencies = [
  "hex",
  "rand_core 0.6.3",
  "serde",
- "sha2",
+ "sha2 0.9.8",
  "thiserror",
  "zeroize",
 ]
@@ -1067,6 +1415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+
+[[package]]
 name = "eyre"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1429,18 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1115,6 +1481,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1517,16 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1283,8 +1674,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1405,6 +1798,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "hdrhistogram"
 version = "6.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,13 +1845,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f41e9c77b6fc05b57497b960aad55942a9bbc5b20e1e623cf7fb1868f695d1"
+dependencies = [
+ "hmac 0.12.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddca131f3e7f2ce2df364b57949a9d47915cfbd35e46cfee355ccebbf794d6a2"
+dependencies = [
+ "digest 0.10.1",
 ]
 
 [[package]]
@@ -1502,6 +1922,16 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac34a56cfd4acddb469cc7fff187ed5ac36f498ba085caf8bbc725e3ff474058"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"
@@ -1577,7 +2007,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "hashbrown",
 ]
 
@@ -1676,10 +2106,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -1734,6 +2173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cafc7c74096c336d9d27145f7ebd4f4b6f95ba16aa5a282387267e6925cb58"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,6 +2223,17 @@ dependencies = [
  "scoped-tls",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb4b7c3eddad11d3af9e86c487607d2d2442d185d848575365c4856ba96d619"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1819,12 +2279,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memmap2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3179b85e1fd8b14447cbebadb75e45a1002f541b925f0bfec366d56a81c56d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1833,7 +2302,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1843,6 +2312,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f69d25cd7528769ad3d897e99eb942774bff8b23165012af490351a44c5b583b"
 dependencies = [
  "nonempty",
+]
+
+[[package]]
+name = "merlin"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e261cf0f8b3c42ded9f7d2bb59dea03aa52bc8a1cbc7482f9fc3fd1229d3b42"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.5.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -1927,7 +2408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
  "adler",
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1970,6 +2451,24 @@ dependencies = [
 name = "multiset"
 version = "0.0.5"
 source = "git+https://github.com/jmitchell/multiset?rev=91ef8550b518f75ae87ae0d8771150f259fd34d5#91ef8550b518f75ae87ae0d8771150f259fd34d5"
+
+[[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "nibble_vec"
@@ -2028,9 +2527,27 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4547ee5541c18742396ae2c895d0717d0f886d8823b8399cdaf7b07d63ad0480"
+dependencies = [
+ "autocfg 0.1.7",
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.4",
+ "smallvec 1.7.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2049,7 +2566,18 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2059,7 +2587,8 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
+ "libm",
 ]
 
 [[package]]
@@ -2095,6 +2624,39 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+dependencies = [
+ "autocfg 1.0.1",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "orchard"
@@ -2137,7 +2699,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac8f4a4a06c811aa24b151dbb3fe19f687cb52e0d5cca0493671ed88f973970"
 dependencies = [
- "quickcheck",
+ "quickcheck 0.9.2",
  "quickcheck_macros",
 ]
 
@@ -2240,10 +2802,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e93a3b1cc0510b03020f33f21e62acdde3dcaef432edc95bea377fbd4c2cd4"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.4",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro-hack",
+ "proc-macro2 1.0.34",
+ "quote 1.0.10",
+ "syn 1.0.83",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -2298,6 +2913,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "116bee8279d783c0cf370efa1a94632f2108e5ef0bb32df31f051647810a4e2c"
+dependencies = [
+ "der",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
+dependencies = [
+ "der",
+ "pem-rfc7468",
+ "pkcs1",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,6 +2979,20 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "postage"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a63d25391d04a097954b76aba742b6b5b74f213dfe3dbaeeb36e8ddc1c657f0b"
+dependencies = [
+ "atomic",
+ "crossbeam-queue 0.3.3",
+ "futures",
+ "pin-project 1.0.7",
+ "static_assertions",
+ "thiserror",
 ]
 
 [[package]]
@@ -2468,6 +3121,15 @@ dependencies = [
  "log",
  "rand 0.7.3",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "rand 0.8.4",
 ]
 
 [[package]]
@@ -2620,7 +3282,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "crossbeam-deque 0.8.0",
  "either",
  "rayon-core",
@@ -2646,7 +3308,7 @@ source = "git+https://github.com/str4d/redjubjub.git?rev=416a6a8ebf8bd42c114c938
 dependencies = [
  "blake2b_simd",
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "group",
  "jubjub",
  "pasta_curves",
@@ -2663,7 +3325,7 @@ source = "git+https://github.com/ZcashFoundation/redjubjub.git?rev=a32ae3fc871bc
 dependencies = [
  "blake2b_simd",
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "jubjub",
  "rand_core 0.6.3",
  "serde",
@@ -2770,6 +3432,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "retain_mut"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11000e6ba5020e53e7cc26f73b91ae7d5496b4977851479edb66b694c0675c21"
+
+[[package]]
+name = "retry-error"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+
+[[package]]
 name = "rgb"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,8 +3472,8 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -2821,6 +3494,42 @@ checksum = "7a62eca5cacf2c8261128631bed9f045598d40bfbe4b29f5163f0f802f8f44a7"
 dependencies = [
  "libc",
  "librocksdb-sys",
+]
+
+[[package]]
+name = "rsa"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c2603e2823634ab331437001b411b9ed11660fbc4066f3908c84a9439260d"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "lazy_static",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand 0.8.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba4d3462c8b2e4d7f4fcfcf2b296dc6b65404fbbc7b63daa37fd485c149daf7"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "memchr",
+ "smallvec 1.7.0",
+ "time 0.3.5",
 ]
 
 [[package]]
@@ -2921,6 +3630,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sanitize-filename"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf18934a12018228c5b55a6dae9df5d0641e3566b3630cb46cc55564068e7c2f"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,6 +3708,29 @@ checksum = "9182278ed645df3477a9c27bfee0621c621aa16f6972635f7f795dae3d81070f"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3148,16 +3900,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.1",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.1",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f935e31cf406e8c0e96c2815a5516181b7004ae8c5f296293221e9b1e356bd"
+dependencies = [
+ "digest 0.10.1",
+ "keccak",
 ]
 
 [[package]]
@@ -3168,6 +3952,15 @@ checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
 dependencies = [
  "lazy_static",
  "loom",
+]
+
+[[package]]
+name = "shellexpand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
+dependencies = [
+ "dirs-next",
 ]
 
 [[package]]
@@ -3194,6 +3987,30 @@ checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "signature"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a762b1c38b9b990c694b9c2f8abe3372ce6a9ceaae6bca39cfc46e054f45745"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time 0.3.5",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -3273,6 +4090,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spki"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
+dependencies = [
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3301,6 +4127,12 @@ name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
@@ -3445,6 +4277,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+dependencies = [
+ "itoa 0.4.8",
+ "libc",
+ "quickcheck 1.0.3",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3501,6 +4351,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3544,6 +4404,7 @@ checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "log",
  "pin-project-lite",
@@ -3557,6 +4418,375 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tor-bytes"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "arrayref",
+ "bytes",
+ "digest 0.10.1",
+ "generic-array",
+ "getrandom 0.2.3",
+ "signature",
+ "thiserror",
+ "tor-llcrypto",
+]
+
+[[package]]
+name = "tor-cell"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "arrayref",
+ "bitflags",
+ "bytes",
+ "caret",
+ "rand 0.8.4",
+ "thiserror",
+ "tor-bytes",
+ "tor-cert",
+ "tor-linkspec",
+ "tor-llcrypto",
+]
+
+[[package]]
+name = "tor-cert"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "caret",
+ "digest 0.10.1",
+ "signature",
+ "tor-bytes",
+ "tor-checkable",
+ "tor-llcrypto",
+]
+
+[[package]]
+name = "tor-chanmgr"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "async-trait",
+ "futures",
+ "thiserror",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-proto",
+ "tor-rtcompat",
+ "tracing",
+]
+
+[[package]]
+name = "tor-checkable"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "signature",
+ "thiserror",
+ "tor-llcrypto",
+]
+
+[[package]]
+name = "tor-circmgr"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "async-trait",
+ "bounded-vec-deque",
+ "derive_builder",
+ "futures",
+ "humantime-serde",
+ "itertools 0.10.3",
+ "pin-project 1.0.7",
+ "rand 0.8.4",
+ "retry-error",
+ "serde",
+ "static_assertions",
+ "thiserror",
+ "tor-chanmgr",
+ "tor-config",
+ "tor-guardmgr",
+ "tor-linkspec",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-rtcompat",
+ "tracing",
+ "weak-table",
+]
+
+[[package]]
+name = "tor-config"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "derive_builder",
+ "directories",
+ "once_cell",
+ "serde",
+ "shellexpand",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "tor-consdiff"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "digest 0.10.1",
+ "hex",
+ "thiserror",
+ "tor-llcrypto",
+]
+
+[[package]]
+name = "tor-dirclient"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "async-compression",
+ "base64 0.13.0",
+ "futures",
+ "hex",
+ "http",
+ "httparse",
+ "httpdate",
+ "memchr",
+ "thiserror",
+ "tor-circmgr",
+ "tor-llcrypto",
+ "tor-netdoc",
+ "tor-proto",
+ "tor-rtcompat",
+ "tracing",
+]
+
+[[package]]
+name = "tor-dirmgr"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "async-trait",
+ "base64 0.13.0",
+ "derive_builder",
+ "digest 0.10.1",
+ "event-listener",
+ "fslock",
+ "futures",
+ "hex",
+ "humantime-serde",
+ "itertools 0.10.3",
+ "memmap2",
+ "postage",
+ "rand 0.8.4",
+ "retry-error",
+ "rusqlite",
+ "serde",
+ "signature",
+ "thiserror",
+ "time 0.3.5",
+ "tor-checkable",
+ "tor-circmgr",
+ "tor-config",
+ "tor-consdiff",
+ "tor-dirclient",
+ "tor-llcrypto",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-rtcompat",
+ "tracing",
+]
+
+[[package]]
+name = "tor-guardmgr"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "derive_builder",
+ "futures",
+ "humantime-serde",
+ "itertools 0.10.3",
+ "pin-project 1.0.7",
+ "rand 0.8.4",
+ "retain_mut",
+ "serde",
+ "thiserror",
+ "tor-config",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-netdir",
+ "tor-persist",
+ "tor-proto",
+ "tor-rtcompat",
+ "tor-units",
+ "tracing",
+]
+
+[[package]]
+name = "tor-linkspec"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "tor-bytes",
+ "tor-llcrypto",
+ "tor-protover",
+]
+
+[[package]]
+name = "tor-llcrypto"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "aes",
+ "arrayref",
+ "base64 0.13.0",
+ "curve25519-dalek",
+ "digest 0.10.1",
+ "ed25519-dalek",
+ "getrandom 0.2.3",
+ "hex",
+ "rand_core 0.5.1",
+ "rand_core 0.6.3",
+ "rsa",
+ "serde",
+ "sha-1",
+ "sha2 0.10.1",
+ "sha3",
+ "signature",
+ "simple_asn1",
+ "subtle",
+ "thiserror",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "tor-netdir"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "bitflags",
+ "derive_builder",
+ "derive_more",
+ "rand 0.8.4",
+ "serde",
+ "signature",
+ "thiserror",
+ "tor-checkable",
+ "tor-config",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-netdoc",
+ "tor-protover",
+ "tor-units",
+ "tracing",
+]
+
+[[package]]
+name = "tor-netdoc"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "base64 0.13.0",
+ "bitflags",
+ "digest 0.10.1",
+ "hex",
+ "once_cell",
+ "phf",
+ "serde",
+ "signature",
+ "thiserror",
+ "time 0.3.5",
+ "tor-bytes",
+ "tor-cert",
+ "tor-checkable",
+ "tor-llcrypto",
+ "tor-protover",
+ "weak-table",
+]
+
+[[package]]
+name = "tor-persist"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "fslock",
+ "sanitize-filename",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "tor-proto"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "arrayref",
+ "asynchronous-codec",
+ "bytes",
+ "cipher",
+ "coarsetime",
+ "digest 0.10.1",
+ "futures",
+ "generic-array",
+ "hkdf",
+ "hmac 0.12.0",
+ "rand 0.8.4",
+ "rand_core 0.6.3",
+ "subtle",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tor-bytes",
+ "tor-cell",
+ "tor-cert",
+ "tor-checkable",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-protover",
+ "tracing",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "tor-protover"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "caret",
+ "thiserror",
+]
+
+[[package]]
+name = "tor-rtcompat"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "async-trait",
+ "async_executors",
+ "futures",
+ "native-tls",
+ "pin-project 1.0.7",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+]
+
+[[package]]
+name = "tor-units"
+version = "0.0.2"
+source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+dependencies = [
+ "derive_more",
+ "thiserror",
 ]
 
 [[package]]
@@ -3966,6 +5196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,6 +5266,12 @@ name = "wasm-bindgen-shared"
 version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
+
+[[package]]
+name = "weak-table"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
@@ -4152,6 +5394,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xz2"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "zcash_encoding"
 version = "0.0.0"
 source = "git+https://github.com/ZcashFoundation/librustzcash.git?tag=0.5.1-zebra-v1.0.0-beta.4#80d5b049b8e8127671026320a1c22841035345a4"
@@ -4213,7 +5464,7 @@ dependencies = [
  "pasta_curves",
  "rand 0.8.4",
  "rand_core 0.6.3",
- "sha2",
+ "sha2 0.9.8",
  "subtle",
  "zcash_encoding",
  "zcash_note_encryption",
@@ -4241,7 +5492,7 @@ dependencies = [
 [[package]]
 name = "zcash_script"
 version = "0.1.6-alpha.0"
-source = "git+https://github.com/ZcashFoundation/zcash_script.git?rev=70738fc9b143c2a23df7c138c87c95b398273402#70738fc9b143c2a23df7c138c87c95b398273402"
+source = "git+https://github.com/ZcashFoundation/zcash_script.git?rev=270d32d192c5880f911acf21ef100caa128e6179#270d32d192c5880f911acf21ef100caa128e6179"
 dependencies = [
  "bindgen",
  "blake2b_simd",
@@ -4297,7 +5548,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde-big-array",
- "sha2",
+ "sha2 0.9.8",
  "spandoc",
  "static_assertions",
  "subtle",
@@ -4362,6 +5613,7 @@ dependencies = [
 name = "zebra-network"
 version = "1.0.0-beta.3"
 dependencies = [
+ "arti-client",
  "bitflags",
  "byteorder",
  "bytes",
@@ -4382,6 +5634,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml",
+ "tor-rtcompat",
  "tower",
  "tracing",
  "tracing-error",
@@ -4544,4 +5797,33 @@ dependencies = [
  "quote 1.0.10",
  "syn 1.0.83",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.7.0+zstd.1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9428752481d8372e15b1bf779ea518a179ad6c771cca2d2c60e4fbff3cc2cd52"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "3.1.0+zstd.1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa1926623ad7fe406e090555387daf73db555b948134b4d73eac5eb08fb666d"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.5.0+zstd.1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e6c094340240369025fc6b731b054ee2a834328fa584310ac96aa4baebdc465"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,9 +1410,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
@@ -2086,9 +2086,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
 
 [[package]]
 name = "libgit2-sys"
@@ -2556,6 +2556,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71a1eb3a36534514077c1e079ada2fb170ef30c47d203aa6916138cf882ecd52"
+dependencies = [
  "libc",
 ]
 
@@ -3488,7 +3497,7 @@ dependencies = [
  "libsqlite3-sys",
  "memchr",
  "smallvec 1.7.0",
- "time 0.3.5",
+ "time 0.3.6",
 ]
 
 [[package]]
@@ -3684,9 +3693,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+checksum = "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3837,9 +3846,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.75"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -3955,7 +3964,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.5",
+ "time 0.3.6",
 ]
 
 [[package]]
@@ -4230,12 +4239,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+checksum = "c8d54b9298e05179c335de2b9645d061255bcd5155f843b3e328d2cfe0a5b413"
 dependencies = [
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "libc",
+ "num_threads",
  "quickcheck 1.0.3",
  "time-macros",
 ]
@@ -4550,7 +4560,7 @@ dependencies = [
  "serde",
  "signature",
  "thiserror",
- "time 0.3.5",
+ "time 0.3.6",
  "tor-checkable",
  "tor-circmgr",
  "tor-config",
@@ -4666,7 +4676,7 @@ dependencies = [
  "serde",
  "signature",
  "thiserror",
- "time 0.3.5",
+ "time 0.3.6",
  "tor-bytes",
  "tor-cert",
  "tor-checkable",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,12 +155,12 @@ checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
 [[package]]
 name = "arti-client"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82afccf16bae03285ee6746d08364dc99b80bf20b397b40231d73db76ee47cc5"
 dependencies = [
  "derive_builder",
  "directories",
  "futures",
- "humantime-serde",
  "serde",
  "thiserror",
  "tor-chanmgr",
@@ -400,10 +400,10 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0830ae4cc96b0617cc912970c2b17e89456fecbf55e8eed53a956f37ab50c41"
 dependencies = [
- "hmac 0.11.0",
+ "hmac",
  "pbkdf2",
  "rand 0.8.4",
- "sha2 0.9.8",
+ "sha2",
  "unicode-normalization",
  "zeroize",
 ]
@@ -480,15 +480,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
-dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -533,7 +525,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 dependencies = [
- "sha2 0.9.8",
+ "sha2",
 ]
 
 [[package]]
@@ -581,7 +573,8 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 [[package]]
 name = "caret"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ceecd3900815c745fc6b1cfec1f58d52e268b5838f89e81f62e405a31670e2"
 
 [[package]]
 name = "cast"
@@ -1013,15 +1006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "crypto-mac"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,7 +1053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "rand_core 0.5.1",
  "serde",
  "subtle",
@@ -1230,18 +1214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
-dependencies = [
- "block-buffer 0.10.0",
- "crypto-common",
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "directories"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,7 +1294,7 @@ dependencies = [
  "merlin",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.8",
+ "sha2",
  "zeroize",
 ]
 
@@ -1336,7 +1308,7 @@ dependencies = [
  "hex",
  "rand_core 0.6.3",
  "serde",
- "sha2 0.9.8",
+ "sha2",
  "thiserror",
  "zeroize",
 ]
@@ -1413,12 +1385,6 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
 ]
-
-[[package]]
-name = "event-listener"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "eyre"
@@ -1846,11 +1812,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f41e9c77b6fc05b57497b960aad55942a9bbc5b20e1e623cf7fb1868f695d1"
+checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
 dependencies = [
- "hmac 0.12.0",
+ "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -1860,16 +1827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddca131f3e7f2ce2df364b57949a9d47915cfbd35e46cfee355ccebbf794d6a2"
-dependencies = [
- "digest 0.10.1",
+ "digest",
 ]
 
 [[package]]
@@ -3308,7 +3266,7 @@ source = "git+https://github.com/str4d/redjubjub.git?rev=416a6a8ebf8bd42c114c938
 dependencies = [
  "blake2b_simd",
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "group",
  "jubjub",
  "pasta_curves",
@@ -3325,7 +3283,7 @@ source = "git+https://github.com/ZcashFoundation/redjubjub.git?rev=a32ae3fc871bc
 dependencies = [
  "blake2b_simd",
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "jubjub",
  "rand_core 0.6.3",
  "serde",
@@ -3440,7 +3398,8 @@ checksum = "11000e6ba5020e53e7cc26f73b91ae7d5496b4977851479edb66b694c0675c21"
 [[package]]
 name = "retry-error"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0cb6e2859e29280664e192b37e0a698cef381fec81783f9efa3e5b0ffbaf8f"
 
 [[package]]
 name = "rgb"
@@ -3472,8 +3431,8 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
+ "block-buffer",
+ "digest",
  "opaque-debug",
 ]
 
@@ -3503,7 +3462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c2603e2823634ab331437001b411b9ed11660fbc4066f3908c84a9439260d"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "lazy_static",
  "num-bigint-dig",
  "num-integer",
@@ -3901,13 +3860,15 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.10.0"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.1",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -3916,32 +3877,23 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.9.0",
+ "digest",
  "opaque-debug",
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.10.1",
-]
-
-[[package]]
 name = "sha3"
-version = "0.10.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f935e31cf406e8c0e96c2815a5516181b7004ae8c5f296293221e9b1e356bd"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
- "digest 0.10.1",
+ "block-buffer",
+ "digest",
  "keccak",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4423,11 +4375,12 @@ dependencies = [
 [[package]]
 name = "tor-bytes"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c0644e92d1621b699ede184c9e3aee1a315af351be4c68816bb4b40e4c0f2fa"
 dependencies = [
  "arrayref",
  "bytes",
- "digest 0.10.1",
+ "crypto-mac",
  "generic-array",
  "getrandom 0.2.3",
  "signature",
@@ -4438,7 +4391,8 @@ dependencies = [
 [[package]]
 name = "tor-cell"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5e8b4bb2f7fb66e924d0b1c0b8a189c33f8c96a273164ef40d37e94f1dbda4"
 dependencies = [
  "arrayref",
  "bitflags",
@@ -4455,10 +4409,11 @@ dependencies = [
 [[package]]
 name = "tor-cert"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e4157b94753f8a92d05c549b0d9fc3a3b504ca5fc420f867d3f4f7c45e93f2b"
 dependencies = [
  "caret",
- "digest 0.10.1",
+ "digest",
  "signature",
  "tor-bytes",
  "tor-checkable",
@@ -4468,7 +4423,8 @@ dependencies = [
 [[package]]
 name = "tor-chanmgr"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae5a2add018f57300b060a496edae72a538dfc55d1136024f2dc5c9b95cb3c76"
 dependencies = [
  "async-trait",
  "futures",
@@ -4483,7 +4439,8 @@ dependencies = [
 [[package]]
 name = "tor-checkable"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24da70bb1d9e079935511abbdecba2c408a404d5a826562b1ae391b691e66aa4"
 dependencies = [
  "signature",
  "thiserror",
@@ -4493,7 +4450,8 @@ dependencies = [
 [[package]]
 name = "tor-circmgr"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "275176362427f4cb5311f6e4f43eef00201d6395635536863def9703535b414d"
 dependencies = [
  "async-trait",
  "bounded-vec-deque",
@@ -4523,7 +4481,8 @@ dependencies = [
 [[package]]
 name = "tor-config"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca550d4c9cdbe57c3c517f75e29877ab060c1ab1888686ef3d396a4b63b37d2"
 dependencies = [
  "derive_builder",
  "directories",
@@ -4531,15 +4490,15 @@ dependencies = [
  "serde",
  "shellexpand",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
 name = "tor-consdiff"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7e43aaa30b9bf401f8a617fcbbbefb1632145c79277bf93836ccc50615cdca"
 dependencies = [
- "digest 0.10.1",
+ "digest",
  "hex",
  "thiserror",
  "tor-llcrypto",
@@ -4548,7 +4507,8 @@ dependencies = [
 [[package]]
 name = "tor-dirclient"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd32caaeeb2d67a4e93851c41a87be214c1d241e800932dbfea8a9622fa4088"
 dependencies = [
  "async-compression",
  "base64 0.13.0",
@@ -4570,13 +4530,13 @@ dependencies = [
 [[package]]
 name = "tor-dirmgr"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e7e7f87d6b7a15e399633fe91078ac30291d7a3ea3828eb7d4e6d22e52bbfa"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
  "derive_builder",
- "digest 0.10.1",
- "event-listener",
+ "digest",
  "fslock",
  "futures",
  "hex",
@@ -4606,7 +4566,8 @@ dependencies = [
 [[package]]
 name = "tor-guardmgr"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66f560eb3a180180913b8deb6ed3421b067cb3ce831a444db515c3463f146274"
 dependencies = [
  "derive_builder",
  "futures",
@@ -4631,7 +4592,8 @@ dependencies = [
 [[package]]
 name = "tor-linkspec"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46503332a81bd3e6bfc0ce0343c7ed37f4a47fbb564c65afa8a1d8f2fabbc79c"
 dependencies = [
  "tor-bytes",
  "tor-llcrypto",
@@ -4641,13 +4603,14 @@ dependencies = [
 [[package]]
 name = "tor-llcrypto"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60300810f34eee1c53dde549de98534b8c770283b69fa3546e16b757db06757"
 dependencies = [
  "aes",
  "arrayref",
  "base64 0.13.0",
  "curve25519-dalek",
- "digest 0.10.1",
+ "digest",
  "ed25519-dalek",
  "getrandom 0.2.3",
  "hex",
@@ -4656,7 +4619,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha-1",
- "sha2 0.10.1",
+ "sha2",
  "sha3",
  "signature",
  "simple_asn1",
@@ -4669,9 +4632,9 @@ dependencies = [
 [[package]]
 name = "tor-netdir"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d262e00faf3e825b2defd3aad9360fb6f11efcff159793776f0198318b51f40b"
 dependencies = [
- "bitflags",
  "derive_builder",
  "derive_more",
  "rand 0.8.4",
@@ -4691,11 +4654,12 @@ dependencies = [
 [[package]]
 name = "tor-netdoc"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d86c132e5f474e2793ab81769094b030c7363a142b91468ebe1307c8a170ce"
 dependencies = [
  "base64 0.13.0",
  "bitflags",
- "digest 0.10.1",
+ "digest",
  "hex",
  "once_cell",
  "phf",
@@ -4714,7 +4678,8 @@ dependencies = [
 [[package]]
 name = "tor-persist"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93e8e09835be94b1a457c747b1d5a35bdd0949177303d651b10760469510864"
 dependencies = [
  "fslock",
  "sanitize-filename",
@@ -4726,18 +4691,20 @@ dependencies = [
 [[package]]
 name = "tor-proto"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4216662a62ff41277f930488f5cd9dee68dc53873376bb1c9fe3a16620c73ee7"
 dependencies = [
  "arrayref",
  "asynchronous-codec",
  "bytes",
  "cipher",
  "coarsetime",
- "digest 0.10.1",
+ "crypto-mac",
+ "digest",
  "futures",
  "generic-array",
  "hkdf",
- "hmac 0.12.0",
+ "hmac",
  "rand 0.8.4",
  "rand_core 0.6.3",
  "subtle",
@@ -4759,7 +4726,8 @@ dependencies = [
 [[package]]
 name = "tor-protover"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389029d67d6679fc0fc23e901868256f1f0a290adf1eddcdcd49501f30df61e1"
 dependencies = [
  "caret",
  "thiserror",
@@ -4768,7 +4736,8 @@ dependencies = [
 [[package]]
 name = "tor-rtcompat"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8935238722b33676922c70eb4e1eef408ef9d413e57cf1cb05ca237ae04353e3"
 dependencies = [
  "async-trait",
  "async_executors",
@@ -4783,7 +4752,8 @@ dependencies = [
 [[package]]
 name = "tor-units"
 version = "0.0.2"
-source = "git+https://gitlab.torproject.org/tpo/core/arti.git?rev=0be9558629d6a02181b3a321398cf8a027b1e12e#0be9558629d6a02181b3a321398cf8a027b1e12e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe8e97d6224af35259019ff3e68125370d5bba048f6a80d87d5d11ab9ec3947"
 dependencies = [
  "derive_more",
  "thiserror",
@@ -5464,7 +5434,7 @@ dependencies = [
  "pasta_curves",
  "rand 0.8.4",
  "rand_core 0.6.3",
- "sha2 0.9.8",
+ "sha2",
  "subtle",
  "zcash_encoding",
  "zcash_note_encryption",
@@ -5548,7 +5518,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde-big-array",
- "sha2 0.9.8",
+ "sha2",
  "spandoc",
  "static_assertions",
  "subtle",

--- a/deny.toml
+++ b/deny.toml
@@ -68,6 +68,9 @@ skip-tree = [
 
     # wait for lots of crates in the tokio ecosystem to upgrade
     { name = "socket2", version = "=0.3.16" },
+
+    # wait for arti to stabilise
+    { name = "arti-client" },
 ]
 
 # This section is considered when running `cargo deny check sources`.
@@ -85,6 +88,8 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
+    "https://gitlab.torproject.org/tpo/core/arti.git",
+
     # ticket #2982: librustzcash and orchard git versions
     "https://github.com/str4d/redjubjub",
 

--- a/deny.toml
+++ b/deny.toml
@@ -88,8 +88,6 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    "https://gitlab.torproject.org/tpo/core/arti.git",
-
     # ticket #2982: librustzcash and orchard git versions
     "https://github.com/str4d/redjubjub",
 

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -32,6 +32,13 @@ tracing = "0.1"
 tracing-futures = "0.2"
 tracing-error = { version = "0.1.2", features = ["traced-error"] }
 
+# Use the latest working arti version
+# This commit is from 2021-12-22, later commits fail arti's CI
+#
+# TODO: default-features = false
+arti-client = { git = "https://gitlab.torproject.org/tpo/core/arti.git", rev = "0be9558629d6a02181b3a321398cf8a027b1e12e" }
+tor-rtcompat  = { git = "https://gitlab.torproject.org/tpo/core/arti.git", rev = "0be9558629d6a02181b3a321398cf8a027b1e12e" }
+
 zebra-chain = { path = "../zebra-chain" }
 
 [dev-dependencies]

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+tor = ["arti-client", "tor-rtcompat"]
+
 [dependencies]
 bitflags = "1.2"
 byteorder = "1.4"
@@ -32,12 +36,9 @@ tracing = "0.1"
 tracing-futures = "0.2"
 tracing-error = { version = "0.1.2", features = ["traced-error"] }
 
-# Use the latest working arti version
-# This commit is from 2021-12-22, later commits fail arti's CI
-#
-# TODO: default-features = false
-arti-client = { git = "https://gitlab.torproject.org/tpo/core/arti.git", rev = "0be9558629d6a02181b3a321398cf8a027b1e12e" }
-tor-rtcompat  = { git = "https://gitlab.torproject.org/tpo/core/arti.git", rev = "0be9558629d6a02181b3a321398cf8a027b1e12e" }
+# tor dependencies
+arti-client = { version = "0.0.2", optional = true }
+tor-rtcompat  = { version = "0.0.2", optional = true }
 
 zebra-chain = { path = "../zebra-chain" }
 

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -101,12 +101,17 @@ impl Config {
         self.peerset_outbound_connection_limit() + self.peerset_inbound_connection_limit()
     }
 
-    /// Get the initial seed peers based on the configured network.
-    pub async fn initial_peers(&self) -> HashSet<SocketAddr> {
+    /// Returns the initial seed peer hostnames for the configured network.
+    pub fn initial_peer_hostnames(&self) -> &HashSet<String> {
         match self.network {
-            Network::Mainnet => Config::resolve_peers(&self.initial_mainnet_peers).await,
-            Network::Testnet => Config::resolve_peers(&self.initial_testnet_peers).await,
+            Network::Mainnet => &self.initial_mainnet_peers,
+            Network::Testnet => &self.initial_testnet_peers,
         }
+    }
+
+    /// Resolve initial seed peer IP addresses, based on the configured network.
+    pub async fn initial_peers(&self) -> HashSet<SocketAddr> {
+        Config::resolve_peers(self.initial_peer_hostnames()).await
     }
 
     /// Concurrently resolves `peers` into zero or more IP addresses, with a

--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 // TODO: tor feature
-mod tor;
+pub(crate) mod tor;
 
 #[cfg(test)]
 mod tests;
@@ -94,6 +94,8 @@ where
 ///
 /// Transactions sent over this connection can be linked to the sending and receiving IP address
 /// by passive internet observers.
+///
+/// Prefer [`connect_isolated_run_tor`](tor::connect_isolated_run_tor) if available.
 pub fn connect_isolated_tcp_direct(
     network: Network,
     addr: SocketAddr,

--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -17,6 +17,9 @@ use crate::{
     BoxError, Config, Request, Response,
 };
 
+// TODO: tor feature
+mod tor;
+
 #[cfg(test)]
 mod tests;
 

--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -47,13 +47,13 @@ mod tests;
 ///                  or a Tor client [`DataStream`].
 ///
 /// - `user_agent`: a valid BIP14 user-agent, e.g., the empty string.
-pub fn connect_isolated<AsyncReadWrite>(
+pub fn connect_isolated<PeerTransport>(
     network: Network,
-    data_stream: AsyncReadWrite,
+    data_stream: PeerTransport,
     user_agent: String,
 ) -> impl Future<Output = Result<BoxService<Request, Response, BoxError>, BoxError>>
 where
-    AsyncReadWrite: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    PeerTransport: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     let config = Config {
         network,

--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -17,7 +17,7 @@ use crate::{
     BoxError, Config, Request, Response,
 };
 
-// TODO: tor feature
+#[cfg(feature = "tor")]
 pub(crate) mod tor;
 
 #[cfg(test)]

--- a/zebra-network/src/isolated/tests/vectors.rs
+++ b/zebra-network/src/isolated/tests/vectors.rs
@@ -46,61 +46,9 @@ async fn connect_isolated_sends_anonymised_version_message_tcp_net(network: Netw
 
     let (inbound_conn, _) = listener.accept().await.unwrap();
 
-    let mut inbound_stream =
-        Framed::new(inbound_conn, Codec::builder().for_network(network).finish());
+    let inbound_stream = Framed::new(inbound_conn, Codec::builder().for_network(network).finish());
 
-    // We don't need to send any bytes to get a version message.
-    if let Message::Version {
-        version,
-        services,
-        timestamp,
-        address_recv,
-        address_from,
-        nonce: _,
-        user_agent,
-        start_height,
-        relay,
-    } = inbound_stream
-        .next()
-        .await
-        .expect("stream item")
-        .expect("item is Ok(msg)")
-    {
-        // Check that the version message sent by connect_isolated
-        // anonymises all the fields that it possibly can.
-        //
-        // The version field needs to be accurate, because it controls protocol features.
-        // The nonce must be randomised for security.
-        //
-        // SECURITY TODO: check if the timestamp field can be zeroed, to remove another distinguisher (#3300)
-
-        let mut fixed_isolated_addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
-        fixed_isolated_addr.set_port(network.default_port());
-
-        // Required fields should be accurate and match most other peers.
-        // (We can't test nonce randomness here.)
-        assert_eq!(version, CURRENT_NETWORK_PROTOCOL_VERSION);
-        assert_eq!(timestamp.timestamp() % (5 * 60), 0);
-
-        // Other fields should be empty or zeroed.
-        assert_eq!(services, PeerServices::empty());
-        assert_eq!(
-            address_recv,
-            // Since we're connecting to the peer, we expect it to have the node flag.
-            //
-            // SECURITY TODO: should this just be zeroed anyway? (#3300)
-            AddrInVersion::new(fixed_isolated_addr, PeerServices::NODE_NETWORK),
-        );
-        assert_eq!(
-            address_from,
-            AddrInVersion::new(fixed_isolated_addr, PeerServices::empty()),
-        );
-        assert_eq!(user_agent, "");
-        assert_eq!(start_height.0, 0);
-        assert!(!relay);
-    } else {
-        panic!("handshake did not send version message");
-    }
+    check_version_message(network, inbound_stream).await;
 
     // Let the spawned task run for a short time.
     tokio::time::sleep(Duration::from_secs(1)).await;
@@ -142,11 +90,41 @@ async fn connect_isolated_sends_anonymised_version_message_mem_net(network: Netw
     let mut outbound_join_handle =
         tokio::spawn(connect_isolated(network, outbound_stream, "".to_string()));
 
-    let mut inbound_stream = Framed::new(
+    let inbound_stream = Framed::new(
         inbound_stream,
         Codec::builder().for_network(network).finish(),
     );
 
+    check_version_message(network, inbound_stream).await;
+
+    // Let the spawned task run for a short time.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Make sure that the isolated connection did not:
+    // - panic, or
+    // - return a service.
+    //
+    // This test doesn't send a version message on `inbound_conn`,
+    // so providing a service is incorrect behaviour.
+    // (But a timeout error would be acceptable.)
+    let outbound_result = futures::poll!(&mut outbound_join_handle);
+    assert!(matches!(
+        outbound_result,
+        Poll::Pending | Poll::Ready(Ok(Err(_)))
+    ));
+
+    outbound_join_handle.abort();
+}
+
+/// Wait to receive a version message on `inbound_stream`,
+/// then check that it is correctly anonymised.
+#[track_caller]
+async fn check_version_message<PeerTransport>(
+    network: Network,
+    mut inbound_stream: Framed<PeerTransport, Codec>,
+) where
+    PeerTransport: AsyncRead + Unpin,
+{
     // We don't need to send any bytes to get a version message.
     if let Message::Version {
         version,
@@ -199,22 +177,4 @@ async fn connect_isolated_sends_anonymised_version_message_mem_net(network: Netw
     } else {
         panic!("handshake did not send version message");
     }
-
-    // Let the spawned task run for a short time.
-    tokio::time::sleep(Duration::from_secs(1)).await;
-
-    // Make sure that the isolated connection did not:
-    // - panic, or
-    // - return a service.
-    //
-    // This test doesn't send a version message on `inbound_conn`,
-    // so providing a service is incorrect behaviour.
-    // (But a timeout error would be acceptable.)
-    let outbound_result = futures::poll!(&mut outbound_join_handle);
-    assert!(matches!(
-        outbound_result,
-        Poll::Pending | Poll::Ready(Ok(Err(_)))
-    ));
-
-    outbound_join_handle.abort();
 }

--- a/zebra-network/src/isolated/tests/vectors.rs
+++ b/zebra-network/src/isolated/tests/vectors.rs
@@ -125,7 +125,7 @@ async fn connect_isolated_sends_anonymised_version_message_tcp_net(network: Netw
 /// when sent in-memory.
 ///
 /// This test also:
-/// - checks `AsyncReadWrite` support, and
+/// - checks `PeerTransport` support, and
 /// - runs even if network tests are disabled.
 #[tokio::test]
 async fn connect_isolated_sends_anonymised_version_message_mem() {

--- a/zebra-network/src/isolated/tor.rs
+++ b/zebra-network/src/isolated/tor.rs
@@ -7,6 +7,9 @@ use zebra_chain::parameters::Network;
 
 use crate::{connect_isolated, BoxError, Request, Response};
 
+#[cfg(test)]
+mod tests;
+
 /// Creates a Zcash peer connection to `hostname` via Tor.
 /// This connection is completely isolated from all other node state.
 ///

--- a/zebra-network/src/isolated/tor.rs
+++ b/zebra-network/src/isolated/tor.rs
@@ -1,6 +1,9 @@
 //! Uses tor to create isolated and anonymised connections to specific peers.
 
+use std::sync::{Arc, Mutex};
+
 use arti_client::{TorAddr, TorClient, TorClientConfig};
+use tor_rtcompat::tokio::TokioRuntimeHandle;
 use tower::util::BoxService;
 
 use zebra_chain::parameters::Network;
@@ -9,6 +12,15 @@ use crate::{connect_isolated, BoxError, Request, Response};
 
 #[cfg(test)]
 mod tests;
+
+lazy_static::lazy_static! {
+    /// The shared isolated [`TorClient`] instance.
+    ///
+    /// TODO: turn this into a tower service that takes a hostname, and returns an `arti_client::DataStream`
+    ///       (or a task that updates a watch channel when it's done?)
+    pub static ref SHARED_TOR_CLIENT: Arc<Mutex<Option<TorClient<TokioRuntimeHandle>>>> =
+        Arc::new(Mutex::new(None));
+}
 
 /// Creates a Zcash peer connection to `hostname` via Tor.
 /// This connection is completely isolated from all other node state.
@@ -34,10 +46,46 @@ pub async fn connect_isolated_tor(
     user_agent: String,
 ) -> Result<BoxService<Request, Response, BoxError>, BoxError> {
     let addr = TorAddr::from(hostname)?;
-    let runtime = tor_rtcompat::tokio::current_runtime()?;
 
-    let tor_client = TorClient::bootstrap(runtime, TorClientConfig::default()).await?;
+    // Initialize or clone the shared tor client instance
+    let tor_client = match cloned_tor_client() {
+        Some(tor_client) => tor_client,
+        None => new_tor_client().await?,
+    };
+
     let tor_stream = tor_client.connect(addr, None).await?;
 
     connect_isolated(network, tor_stream, user_agent).await
+}
+
+/// Returns a new tor client instance, and updates [`SHARED_TOR_CLIENT`].
+///
+/// If there is a bootstrap error, [`SHARED_TOR_CLIENT`] is not modified.
+async fn new_tor_client() -> Result<TorClient<TokioRuntimeHandle>, BoxError> {
+    let runtime = tokio::runtime::Handle::current();
+    let runtime = TokioRuntimeHandle::new(runtime);
+    let tor_client = TorClient::bootstrap(runtime, TorClientConfig::default()).await?;
+
+    // # Correctness
+    //
+    // It is ok for multiple tasks to race, because all tor clients have identical configs.
+    // And all connections are isolated, regardless of whether they use a new or cloned client.
+    // (Any replaced clients will be dropped.)
+    let mut shared_tor_client = SHARED_TOR_CLIENT
+        .lock()
+        .expect("panic in shared tor client mutex guard");
+    *shared_tor_client = Some(tor_client.isolated_client());
+
+    Ok(tor_client)
+}
+
+/// Returns an isolated tor client instance by cloning [`SHARED_TOR_CLIENT`].
+///
+/// If [`new_tor_client`] has not run successfully yet, returns `None`.
+fn cloned_tor_client() -> Option<TorClient<TokioRuntimeHandle>> {
+    SHARED_TOR_CLIENT
+        .lock()
+        .expect("panic in shared tor client mutex guard")
+        .as_ref()
+        .map(TorClient::isolated_client)
 }

--- a/zebra-network/src/isolated/tor.rs
+++ b/zebra-network/src/isolated/tor.rs
@@ -1,0 +1,40 @@
+//! Uses tor to create isolated and anonymised connections to specific peers.
+
+use arti_client::{TorAddr, TorClient, TorClientConfig};
+use tower::util::BoxService;
+
+use zebra_chain::parameters::Network;
+
+use crate::{connect_isolated, BoxError, Request, Response};
+
+/// Creates a Zcash peer connection to `hostname` via Tor.
+/// This connection is completely isolated from all other node state.
+///
+/// See [`connect_isolated`] for details.
+///
+/// # Privacy
+///
+/// The sender IP address is anonymised using Tor.
+/// But transactions sent over this connection can still be linked to the receiving IP address
+/// by passive internet observers.
+/// This happens because the Zcash network protocol uses unencrypted TCP connections.
+///
+/// `hostname` should be a DNS name for the Tor exit to look up, or a hard-coded IP address.
+/// If the application does a local DNS lookup on a hostname, and passes the IP address to this function,
+/// passive internet observers can link the hostname to the sender's IP address.
+///
+/// For details, see
+/// [`TorAddr`](https://tpo.pages.torproject.net/core/doc/rust/arti_client/struct.TorAddr.html).
+pub async fn connect_isolated_tor(
+    network: Network,
+    hostname: String,
+    user_agent: String,
+) -> Result<BoxService<Request, Response, BoxError>, BoxError> {
+    let addr = TorAddr::from(hostname)?;
+    let runtime = tor_rtcompat::tokio::current_runtime()?;
+
+    let tor_client = TorClient::bootstrap(runtime, TorClientConfig::default()).await?;
+    let tor_stream = tor_client.connect(addr, None).await?;
+
+    connect_isolated(network, tor_stream, user_agent).await
+}

--- a/zebra-network/src/isolated/tor/tests.rs
+++ b/zebra-network/src/isolated/tor/tests.rs
@@ -1,0 +1,3 @@
+//! Tests for isolated Tor connections.
+
+mod vectors;

--- a/zebra-network/src/isolated/tor/tests/vectors.rs
+++ b/zebra-network/src/isolated/tor/tests/vectors.rs
@@ -1,0 +1,92 @@
+//! Fixed test vectors for isolated Zebra connections.
+
+use std::time::Duration;
+
+use crate::Config;
+
+use super::super::*;
+
+use futures::stream::FuturesUnordered;
+use tokio_stream::StreamExt;
+use Network::*;
+
+/// The maximum allowed test runtime.
+const MAX_TEST_DURATION: Duration = Duration::from_secs(20);
+
+/// Test that `connect_isolated` doesn't panic when used over Tor.
+///
+/// (We can't connect to ourselves over Tor, so there's not much more we can do here.)
+#[tokio::test]
+async fn connect_isolated_run_tor_once() {
+    zebra_test::init();
+
+    if zebra_test::net::zebra_skip_network_tests() {
+        return;
+    }
+
+    // These tests might take a long time on machines where Tor is censored.
+
+    // Pick a mainnet seeder hostname, it doesn't matter which one.
+    let config = Config::default();
+    let seeder_hostname = config
+        .initial_peer_hostnames()
+        .iter()
+        .next()
+        .unwrap()
+        .clone();
+
+    connect_isolated_run_tor_once_with(Mainnet, seeder_hostname).await;
+}
+
+/// Test that `connect_isolated` can use multiple isolated Tor connections at the same time.
+///
+/// Use the multi-threaded runtime to test concurrent Tor instances.
+#[tokio::test(flavor = "multi_thread")]
+async fn connect_isolated_run_tor_multi() {
+    zebra_test::init();
+
+    if zebra_test::net::zebra_skip_network_tests() {
+        return;
+    }
+
+    // These tests might take a long time on machines where Tor is censored.
+
+    let mut isolated_conns = FuturesUnordered::new();
+
+    // Use all the seeder hostnames for each network
+    for network in [Mainnet, Testnet] {
+        let config = Config {
+            network,
+            ..Config::default()
+        };
+
+        for seeder_hostname in config.initial_peer_hostnames().iter().cloned() {
+            let conn = connect_isolated_run_tor_once_with(network, seeder_hostname);
+            isolated_conns.push(conn);
+        }
+    }
+
+    // Wait for all the connections to complete (or timeout)
+    while let Some(()) = isolated_conns.next().await {}
+}
+
+async fn connect_isolated_run_tor_once_with(network: Network, hostname: String) {
+    // Connection errors are detected and ignored using the JoinHandle.
+    // (They might also make the test hang.)
+    let mut outbound_join_handle =
+        tokio::spawn(connect_isolated_tor(network, hostname, "".to_string()));
+
+    // Let the spawned task run for a long time.
+    let outbound_join_handle_timeout =
+        tokio::time::timeout(MAX_TEST_DURATION, &mut outbound_join_handle);
+
+    // Make sure that the isolated connection did not panic.
+    //
+    // We can't control network reliability in the test, so the only bad outcome is a panic.
+    // We make the test pass if there are network errors, if we get a valid running service,
+    // or if we are still waiting for Tor or the handshake.
+    let outbound_result = outbound_join_handle_timeout.await;
+    assert!(matches!(outbound_result, Ok(Ok(_)) | Err(_),));
+
+    outbound_join_handle.abort();
+}

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -156,7 +156,7 @@ mod protocol;
 pub use crate::{
     address_book::AddressBook,
     config::Config,
-    isolated::{connect_isolated, connect_isolated_tcp_direct},
+    isolated::{connect_isolated, connect_isolated_tcp_direct, tor::connect_isolated_tor},
     meta_addr::PeerAddrState,
     peer::{HandshakeError, PeerError, SharedPeerError},
     peer_set::init,

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -153,10 +153,13 @@ mod peer_set;
 mod policies;
 mod protocol;
 
+#[cfg(feature = "tor")]
+pub use crate::isolated::tor::connect_isolated_tor;
+
 pub use crate::{
     address_book::AddressBook,
     config::Config,
-    isolated::{connect_isolated, connect_isolated_tcp_direct, tor::connect_isolated_tor},
+    isolated::{connect_isolated, connect_isolated_tcp_direct},
     meta_addr::PeerAddrState,
     peer::{HandshakeError, PeerError, SharedPeerError},
     peer_set::init,

--- a/zebra-test/src/lib.rs
+++ b/zebra-test/src/lib.rs
@@ -71,6 +71,7 @@ pub fn init() {
                 .add_directive("zebra_network=error".parse().unwrap())
                 .add_directive("zebra_state=error".parse().unwrap())
                 .add_directive("zebrad=error".parse().unwrap())
+                .add_directive("tor_circmgr=error".parse().unwrap())
         });
 
         tracing_subscriber::registry()


### PR DESCRIPTION
## Motivation

When Zebra sends user-generated transactions over the internet, the transaction IDs can be linked to the sending and receiving IP addresses. This can link people with specific Zcash transfers. (But the amount of information disclosed is much less for fully shielded transactions.)

But if we send user-generated transactions over Tor, it's much harder to link them to the sender's IP address.

It's ok to merge this PR because:
- the Tor code changes are in a new API, in a newly created separate Rust modules
- the Tor feature is off by default at compile-time, and it uses a function that isn't called by other code at runtime
- the `arti` dependency is a specific public crate patch release, so it won't change unless we change it
- it will take us less effort to update to each new `arti` release

## Solution

Tor API:
- Add a method for isolated anonymised Tor connections to a specific hostname, closes #1643
- Use a shared tor client instance for all isolated connections

Dependencies:
- Add arti as a zebra-network dependency
    - This upgrades a bunch of dependencies in the lockfile, but we'll have to do those upgrades eventually anyway
- Make tor support optional, activate it via a new "tor" feature 

Tests:
- Add tests for isolated tor connections
- Silence a spurious tor warning in tests

Close #1643

## Review

This PR is ready for review, but it's based on PR #3302, so we should keep it in draft until that PR merges.

Let's assign reviewers when people are back from leave.

### Reviewer Checklist

  - [ ] Code compiles and tests pass with `cargo test --features tor`
