### PR TITLE
Retry Zcash sprout and sapling parameters download

### DIFF
--- a/zebra-consensus/src/primitives/groth16/params.rs
+++ b/zebra-consensus/src/primitives/groth16/params.rs
@@ -116,29 +116,24 @@ impl Groth16Parameters {
         if !sapling_spend_path.exists() || !sapling_output_path.exists() {
             tracing::info!("downloading Zcash Sapling parameters");
 
-            let mut sapling_retries = 0;
-            while sapling_retries < PARAMETER_DOWNLOAD_MAX_RETRIES {
-                let new_sapling_paths =
-                    zcash_proofs::download_sapling_parameters(Some(PARAMETER_DOWNLOAD_TIMEOUT));
-
-                if new_sapling_paths.is_err() {
-                    sapling_retries += 1;
-                    tracing::info!("error downloading Zcash Sapling parameters, retrying");
-                } else {
-                    assert_eq!(
-                        sapling_spend_path,
-                        new_sapling_paths.as_ref().unwrap().spend
+            let mut retries = 0;
+            while let Err(error) =
+                zcash_proofs::download_sapling_parameters(Some(PARAMETER_DOWNLOAD_TIMEOUT))
+            {
+                retries += 1;
+                if retries >= PARAMETER_DOWNLOAD_MAX_RETRIES {
+                    panic!(
+                        "error downloading Sapling parameter files after {} retries. {:?} {}",
+                        PARAMETER_DOWNLOAD_MAX_RETRIES,
+                        error,
+                        Groth16Parameters::failure_hint(),
                     );
-                    assert_eq!(sapling_output_path, new_sapling_paths.unwrap().output);
-                    break;
+                } else {
+                    tracing::info!(
+                        ?error,
+                        "error downloading Zcash Sapling parameters, retrying"
+                    );
                 }
-            }
-            if sapling_retries == PARAMETER_DOWNLOAD_MAX_RETRIES {
-                panic!(
-                    "error downloading Sapling parameter files after {} retries. {}",
-                    PARAMETER_DOWNLOAD_MAX_RETRIES,
-                    Groth16Parameters::failure_hint()
-                );
             }
         }
     }
@@ -148,25 +143,24 @@ impl Groth16Parameters {
         if !sprout_path.exists() {
             tracing::info!("downloading Zcash Sprout parameters");
 
-            let mut sprout_retries = 0;
-            while sprout_retries < PARAMETER_DOWNLOAD_MAX_RETRIES {
-                let new_sprout_path =
-                    zcash_proofs::download_sprout_parameters(Some(PARAMETER_DOWNLOAD_TIMEOUT));
-
-                if new_sprout_path.is_err() {
-                    sprout_retries += 1;
-                    tracing::info!("error downloading Zcash Sprout parameters, retrying");
+            let mut retries = 0;
+            while let Err(error) =
+                zcash_proofs::download_sprout_parameters(Some(PARAMETER_DOWNLOAD_TIMEOUT))
+            {
+                retries += 1;
+                if retries >= PARAMETER_DOWNLOAD_MAX_RETRIES {
+                    panic!(
+                        "error downloading Sprout parameter files after {} retries. {:?} {}",
+                        PARAMETER_DOWNLOAD_MAX_RETRIES,
+                        error,
+                        Groth16Parameters::failure_hint(),
+                    );
                 } else {
-                    assert_eq!(sprout_path, new_sprout_path.unwrap());
-                    break;
+                    tracing::info!(
+                        ?error,
+                        "error downloading Zcash Sprout parameters, retrying"
+                    );
                 }
-            }
-            if sprout_retries == PARAMETER_DOWNLOAD_MAX_RETRIES {
-                panic!(
-                    "error downloading Sprout parameter files after {} retries. {}",
-                    PARAMETER_DOWNLOAD_MAX_RETRIES,
-                    Groth16Parameters::failure_hint()
-                );
             }
         }
     }

--- a/zebra-consensus/src/primitives/groth16/params.rs
+++ b/zebra-consensus/src/primitives/groth16/params.rs
@@ -1,9 +1,12 @@
 //! Downloading, checking, and loading Groth16 Sapling and Sprout parameters.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use bellman::groth16;
 use bls12_381::Bls12;
+use zcash_proofs::SaplingParameterPaths;
+
+use crate::BoxError;
 
 /// The timeout for each parameter file download, in seconds.
 ///
@@ -62,6 +65,8 @@ impl Groth16Parameters {
     ///
     /// # Panics
     ///
+    /// If the parameters were downloaded to the wrong path.
+    /// After `PARAMETER_DOWNLOAD_MAX_RETRIES` failed download attempts.
     /// If the downloaded or pre-existing parameter files are invalid.
     fn new() -> Groth16Parameters {
         let params_directory = Groth16Parameters::directory();
@@ -69,8 +74,11 @@ impl Groth16Parameters {
         let sapling_output_path = params_directory.join(zcash_proofs::SAPLING_OUTPUT_NAME);
         let sprout_path = params_directory.join(zcash_proofs::SPROUT_NAME);
 
-        Groth16Parameters::sapling(sapling_spend_path.clone(), sapling_output_path.clone());
-        Groth16Parameters::sprout(sprout_path.clone());
+        Groth16Parameters::retry_download_sapling_parameters(
+            &sapling_spend_path,
+            &sapling_output_path,
+        );
+        Groth16Parameters::retry_download_sprout_parameters(&sprout_path);
 
         // TODO: if loading fails, log a message including `failure_hint`
         tracing::info!("checking and loading Zcash Sapling and Sprout parameters");
@@ -110,16 +118,22 @@ impl Groth16Parameters {
     }
 
     /// Download Sapling parameters and retry [`PARAMETER_DOWNLOAD_MAX_RETRIES`] if it fails.
-    fn sapling(sapling_spend_path: PathBuf, sapling_output_path: PathBuf) {
+    ///
+    /// # Panics
+    ///
+    /// If the parameters were downloaded to the wrong path.
+    /// After `PARAMETER_DOWNLOAD_MAX_RETRIES` failed download attempts.
+    fn retry_download_sapling_parameters(sapling_spend_path: &Path, sapling_output_path: &Path) {
         // TODO: instead of the path check, add a zcash_proofs argument to skip hashing existing files
         //       (we check them on load anyway)
         if !sapling_spend_path.exists() || !sapling_output_path.exists() {
             tracing::info!("downloading Zcash Sapling parameters");
 
             let mut retries = 0;
-            while let Err(error) =
-                zcash_proofs::download_sapling_parameters(Some(PARAMETER_DOWNLOAD_TIMEOUT))
-            {
+            while let Err(error) = Groth16Parameters::download_sapling_parameters_once(
+                sapling_spend_path,
+                sapling_output_path,
+            ) {
                 retries += 1;
                 if retries >= PARAMETER_DOWNLOAD_MAX_RETRIES {
                     panic!(
@@ -138,15 +152,37 @@ impl Groth16Parameters {
         }
     }
 
+    /// Try to download the Sapling parameters once, and return the result.
+    ///
+    /// # Panics
+    ///
+    /// If the parameters were downloaded to different paths to `sapling_spend_path`
+    /// or `sapling_output_path`.
+    fn download_sapling_parameters_once(
+        sapling_spend_path: &Path,
+        sapling_output_path: &Path,
+    ) -> Result<SaplingParameterPaths, BoxError> {
+        let new_sapling_paths =
+            zcash_proofs::download_sapling_parameters(Some(PARAMETER_DOWNLOAD_TIMEOUT))?;
+
+        assert_eq!(sapling_spend_path, new_sapling_paths.spend);
+        assert_eq!(sapling_output_path, new_sapling_paths.output);
+
+        Ok(new_sapling_paths)
+    }
+
     /// Download Sprout parameters and retry [`PARAMETER_DOWNLOAD_MAX_RETRIES`] if it fails.
-    fn sprout(sprout_path: PathBuf) {
+    ///
+    /// # Panics
+    ///
+    /// If the parameters were downloaded to the wrong path.
+    /// After `PARAMETER_DOWNLOAD_MAX_RETRIES` failed download attempts.
+    fn retry_download_sprout_parameters(sprout_path: &Path) {
         if !sprout_path.exists() {
             tracing::info!("downloading Zcash Sprout parameters");
 
             let mut retries = 0;
-            while let Err(error) =
-                zcash_proofs::download_sprout_parameters(Some(PARAMETER_DOWNLOAD_TIMEOUT))
-            {
+            while let Err(error) = Groth16Parameters::download_sprout_parameters_once(sprout_path) {
                 retries += 1;
                 if retries >= PARAMETER_DOWNLOAD_MAX_RETRIES {
                     panic!(
@@ -163,5 +199,19 @@ impl Groth16Parameters {
                 }
             }
         }
+    }
+
+    /// Try to download the Sprout parameters once, and return the result.
+    ///
+    /// # Panics
+    ///
+    /// If the parameters were downloaded to a different path to `sprout_path`.
+    fn download_sprout_parameters_once(sprout_path: &Path) -> Result<PathBuf, BoxError> {
+        let new_sprout_path =
+            zcash_proofs::download_sprout_parameters(Some(PARAMETER_DOWNLOAD_TIMEOUT))?;
+
+        assert_eq!(sprout_path, new_sprout_path);
+
+        Ok(new_sprout_path)
     }
 }


### PR DESCRIPTION
## Motivation

We want to retry a few times the Sprout and Sapling parameter download if they fail for whatever reason.

Fixes https://github.com/ZcashFoundation/zebra/issues/3239

## Solution

Retry the downloads if they fail. Number of retries is defined by a constant(currently = 3).

The code can be maybe improved a bit to make it shorter but i think it should work as it is too.

## Review

Anyone can review, the code is pretty simple.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors