### PR TITLE
Upgrade zcash_proofs to get new derived traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=dea8d97d5ed09bdb6673cb64d0a63706f71c2f61#dea8d97d5ed09bdb6673cb64d0a63706f71c2f61"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?tag=0.5.1-zebra-v1.0.0-beta.4#80d5b049b8e8127671026320a1c22841035345a4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -4228,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.0.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=dea8d97d5ed09bdb6673cb64d0a63706f71c2f61#dea8d97d5ed09bdb6673cb64d0a63706f71c2f61"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?tag=0.5.1-zebra-v1.0.0-beta.4#80d5b049b8e8127671026320a1c22841035345a4"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.2.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=dea8d97d5ed09bdb6673cb64d0a63706f71c2f61#dea8d97d5ed09bdb6673cb64d0a63706f71c2f61"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?tag=0.5.1-zebra-v1.0.0-beta.4#80d5b049b8e8127671026320a1c22841035345a4"
 dependencies = [
  "bigint",
  "blake2b_simd",
@@ -4247,7 +4247,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.0.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=dea8d97d5ed09bdb6673cb64d0a63706f71c2f61#dea8d97d5ed09bdb6673cb64d0a63706f71c2f61"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?tag=0.5.1-zebra-v1.0.0-beta.4#80d5b049b8e8127671026320a1c22841035345a4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.5.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=dea8d97d5ed09bdb6673cb64d0a63706f71c2f61#dea8d97d5ed09bdb6673cb64d0a63706f71c2f61"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?tag=0.5.1-zebra-v1.0.0-beta.4#80d5b049b8e8127671026320a1c22841035345a4"
 dependencies = [
  "aes",
  "bip0039",
@@ -4296,7 +4296,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.5.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=dea8d97d5ed09bdb6673cb64d0a63706f71c2f61#dea8d97d5ed09bdb6673cb64d0a63706f71c2f61"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?tag=0.5.1-zebra-v1.0.0-beta.4#80d5b049b8e8127671026320a1c22841035345a4"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,33 +53,27 @@ panic = "abort"
 orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
 
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
-#
-# This zcash_proofs patch doesn't work, maybe because of features?
-#zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
+#       remove these after a new librustzcash release (#2982)
 
 # Use the ZcashFoundation fork where possible, to avoid duplicate dependencies
-equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
-zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
-zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
-zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
+equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", tag = "0.5.1-zebra-v1.0.0-beta.4" }
+zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", tag = "0.5.1-zebra-v1.0.0-beta.4" }
+zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", tag = "0.5.1-zebra-v1.0.0-beta.4" }
+zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", tag = "0.5.1-zebra-v1.0.0-beta.4" }
 
-# TODO: remove these after a new librustzcash release (#2982)
+# This zcash_proofs patch doesn't work, maybe because of features?
+#zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", tag = "0.5.1-zebra-v1.0.0-beta.4" }
 
 # These are librustzcash git requirements specified in its workspace Cargo.toml,
 # that we must replicate here
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "b7bd6246122a6e9ace8edb51553fbf5228906cbb" }
+
 # Replaced by the ZcashFoundation fork above
 #orchard = { git = "https://github.com/zcash/orchard.git", rev = "2c8241f25b943aa05203eacf9905db117c69bd29" }
 
-# Replaced by the ZcashFoundation fork above
 
 # These are librustzcash file requirements specified in its workspace Cargo.toml,
 # that we must replace with git requirements
+#
+# Replaced by the ZcashFoundation fork above
 #zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
-
-# These patches are not strictly required,
-# but they help avoid duplicate dependencies
-#equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
-#zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
-#zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }
-#zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "53d0a51d33a421cb76d3e3124d1e4c1c9036068e" }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -50,10 +50,10 @@ x25519-dalek = { version = "1.2.0", features = ["serde"] }
 orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
 
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
-equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
-zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
-zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
-zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61" }
+equihash = { git = "https://github.com/ZcashFoundation/librustzcash.git", tag = "0.5.1-zebra-v1.0.0-beta.4" }
+zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash.git", tag = "0.5.1-zebra-v1.0.0-beta.4" }
+zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", tag = "0.5.1-zebra-v1.0.0-beta.4" }
+zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", tag = "0.5.1-zebra-v1.0.0-beta.4" }
 
 proptest = { version = "0.10", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -38,7 +38,7 @@ tracing-futures = "0.2.5"
 orchard = { git = "https://github.com/ZcashFoundation/orchard.git", rev = "568e24cd5f129158375d7ac7d98c89ebff4f982f" }
 
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
-zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "dea8d97d5ed09bdb6673cb64d0a63706f71c2f61", features = ["local-prover", "multicore", "download-params"] }
+zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", tag = "0.5.1-zebra-v1.0.0-beta.4", features = ["local-prover", "multicore", "download-params"] }
 
 tower-fallback = { path = "../tower-fallback/" }
 tower-batch = { path = "../tower-batch/" }


### PR DESCRIPTION
## Motivation

@oxarbitrage wants a `Debug` impl for `SaplingParameterPaths` in PR #3306.

This PR upgrades to a `zcash_proofs` version that includes https://github.com/zcash/librustzcash/pull/459/commits/80d5b049b8e8127671026320a1c22841035345a4

The `zcash_proofs` PR will eventually get merged into the next `librustzcash` release.