### PR TITLE
Add mergify merging queues

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,6 +5,7 @@ queue_rules:
     conditions:
       - check-success=CI
       - check-success=Coverage
+      - check-sucess=pull-request
 
   - name: medium
     speculative_checks: 2
@@ -12,6 +13,7 @@ queue_rules:
     conditions:
       - check-success=CI
       - check-success=Coverage
+      - check-sucess=pull-request
 
   - name: default
     speculative_checks: 2
@@ -19,24 +21,24 @@ queue_rules:
     conditions:
       - check-success=CI
       - check-success=Coverage
+      - check-sucess=pull-request
 
 pull_request_rules:
   - name: automatic update for PR marked as “Ready-to-Go“
     conditions:
       - -conflict # skip PRs with conflicts
       - -draft # filter-out GH draft PRs
-      - label="Ready-to-Go"
     actions:
       update:
 
   - name: move to critical queue when CI passes with 1 review and not WIP targeting main
     conditions:
       - "#approved-reviews-by>=1"
+      - -draft
       - base=main
       - check-success=CI
       - check-success=Coverage
       - "label~=^P-Critical"
-      - label!=work-in-progress
       - label!=do-not-merge
     actions:
       queue:
@@ -45,11 +47,11 @@ pull_request_rules:
   - name: move to high queue when CI passes with 1 review and not WIP targeting main
     conditions:
       - "#approved-reviews-by>=1"
+      - -draft
       - base=main
       - check-success=CI
       - check-success=Coverage
       - "label~=^P-High"
-      - label!=work-in-progress
       - label!=do-not-merge
     actions:
       queue:
@@ -58,12 +60,12 @@ pull_request_rules:
   - name: move to default queue when CI passes with 1 review and not WIP targeting main
     conditions:
       - "#approved-reviews-by>=1"
+      - -draft
       - base=main
       - check-success=CI
       - check-success=Coverage
       - "-label~=^P-High"
       - "-label~=^P-Critical"
-      - label!=work-in-progress
       - label!=do-not-merge
     actions:
       queue:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,70 @@
+queue_rules:
+  - name: urgent
+    speculative_checks: 2
+    batch_size: 2
+    conditions:
+      - check-success=CI
+      - check-success=Coverage
+
+  - name: medium
+    conditions:
+    speculative_checks: 2
+    batch_size: 3
+      - check-success=CI
+      - check-success=Coverage
+
+  - name: default
+    conditions:
+    speculative_checks: 2
+    batch_size: 4
+      - check-success=CI
+      - check-success=Coverage
+
+pull_request_rules:
+  - name: automatic update for PR marked as “Ready-to-Go“
+    conditions:
+      - -conflict # skip PRs with conflicts
+      - -draft # filter-out GH draft PRs
+      - label="Ready-to-Go"
+    actions:
+      update:
+
+  - name: move to critical queue when CI passes with 1 review and not WIP targeting main
+    conditions:
+      - "#approved-reviews-by>=1"
+      - base=main
+      - check-success=CI
+      - check-success=Coverage
+      - "label~=^P-Critical"
+      - label!=work-in-progress
+      - label!=do-not-merge
+    actions:
+      queue:
+        name: urgent
+
+  - name: move to high queue when CI passes with 1 review and not WIP targeting main
+    conditions:
+      - "#approved-reviews-by>=1"
+      - base=main
+      - check-success=CI
+      - check-success=Coverage
+      - "label~=^P-High"
+      - label!=work-in-progress
+      - label!=do-not-merge
+    actions:
+      queue:
+        name: medium
+
+  - name: move to default queue when CI passes with 1 review and not WIP targeting main
+    conditions:
+      - "#approved-reviews-by>=1"
+      - base=main
+      - check-success=CI
+      - check-success=Coverage
+      - "-label~=^P-High"
+      - "-label~=^P-Critical"
+      - label!=work-in-progress
+      - label!=do-not-merge
+    actions:
+      queue:
+        name: default

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,16 +7,16 @@ queue_rules:
       - check-success=Coverage
 
   - name: medium
-    conditions:
     speculative_checks: 2
     batch_size: 3
+    conditions:
       - check-success=CI
       - check-success=Coverage
 
   - name: default
-    conditions:
     speculative_checks: 2
     batch_size: 4
+    conditions:
       - check-success=CI
       - check-success=Coverage
 

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,7 +5,7 @@ queue_rules:
     conditions:
       - check-success=CI
       - check-success=Coverage
-      - check-sucess=pull-request
+      - check-success=pull-request
 
   - name: medium
     speculative_checks: 2
@@ -13,7 +13,7 @@ queue_rules:
     conditions:
       - check-success=CI
       - check-success=Coverage
-      - check-sucess=pull-request
+      - check-success=pull-request
 
   - name: default
     speculative_checks: 2
@@ -21,7 +21,7 @@ queue_rules:
     conditions:
       - check-success=CI
       - check-success=Coverage
-      - check-sucess=pull-request
+      - check-success=pull-request
 
 pull_request_rules:
   - name: automatic update for PR marked as “Ready-to-Go“


### PR DESCRIPTION
## Motivation
1. Speed up merge times by prioritizing, queueing, and automatically merging Pull Requests 
2. Parallelize the CI process while in the queue, to reduce the time it takes for multiple PRs to be merged

## Solution

Previous:
- Use bors-ng was the proposed solution at first to solve this problem (#3201), but this required creating extra branches, using public bots, and some additional constraints which made Mergify a better option.

Actual
- Use Mergify as it respects Githubs branch protection rules, it also allows for multiple actions to help with the queueing process https://docs.mergify.com/actions/

This PR must ensures that the actual labels for prioritization are being used (5 in total) and distributed in 3 different queues (urgent, medium and default)
- :ambulance: P-Critical --> urgent
- :fire: P-High --> urgent
- :zap: P-Medium --> medium
- :snowflake: P-Low --> default
- :sparkles: P-Optional --> default

For a PR to be assigned to a queue all these conditions must be met:
- Targeting the **main** branch
- Having one or more reviews
- CI tests must be green
- Not being a `draft` PR
- Not having the labels ~~work-in-progress~~ or `do-not-merge`

## Review
@dconnolly @teor2345 

### Reviewer Checklist
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work
- Use our bot
- Consider dependabot on the configuration
- Add extra actions

Closes #3201 