### PR TITLE
Enforce Rust edition 2021

### DIFF
--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -3,7 +3,7 @@ name = "tower-batch"
 version = "0.2.19"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 futures = "0.3.19"

--- a/tower-batch/src/lib.rs
+++ b/tower-batch/src/lib.rs
@@ -89,6 +89,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
 #![deny(clippy::await_holding_lock)]
+#![deny(rust_2021_compatibility)]
 #![forbid(unsafe_code)]
 
 pub mod error;

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -3,7 +3,7 @@ name = "tower-fallback"
 version = "0.2.15"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 tower = "0.4"

--- a/tower-fallback/src/lib.rs
+++ b/tower-fallback/src/lib.rs
@@ -14,6 +14,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
 #![deny(clippy::await_holding_lock)]
+#![deny(rust_2021_compatibility)]
 #![forbid(unsafe_code)]
 
 pub mod future;

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -3,7 +3,7 @@ name = "zebra-chain"
 version = "1.0.0-beta.3"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -10,6 +10,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
 #![deny(clippy::await_holding_lock)]
+#![deny(rust_2021_compatibility)]
 #![forbid(unsafe_code)]
 // Required by bitvec! macro
 #![recursion_limit = "256"]

--- a/zebra-chain/src/primitives/redpallas/verification_key.rs
+++ b/zebra-chain/src/primitives/redpallas/verification_key.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, marker::PhantomData};
+use std::marker::PhantomData;
 
 use group::{cofactor::CofactorGroup, GroupEncoding};
 use halo2::{arithmetic::FieldExt, pasta::pallas};
@@ -95,7 +95,6 @@ impl<T: SigType> TryFrom<[u8; 32]> for VerificationKey<T> {
     type Error = Error;
 
     fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
-        use std::convert::TryInto;
         VerificationKeyBytes::from(bytes).try_into()
     }
 }

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -311,8 +311,6 @@ impl ValueBalance<NonNegative> {
     /// The resulting [`ValueBalance`] will have half of the MAX_MONEY amount on each pool.
     #[cfg(any(test, feature = "proptest-impl"))]
     pub fn fake_populated_pool() -> ValueBalance<NonNegative> {
-        use std::convert::TryFrom;
-
         let mut fake_value_pool = ValueBalance::zero();
 
         let fake_transparent_value_balance =

--- a/zebra-client/Cargo.toml
+++ b/zebra-client/Cargo.toml
@@ -3,7 +3,7 @@ name = "zebra-client"
 version = "1.0.0-beta.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/zebra-client/src/lib.rs
+++ b/zebra-client/src/lib.rs
@@ -7,4 +7,5 @@
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
 #![deny(clippy::await_holding_lock)]
+#![deny(rust_2021_compatibility)]
 #![forbid(unsafe_code)]

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -3,7 +3,7 @@ name = "zebra-consensus"
 version = "1.0.0-beta.3"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -38,6 +38,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
 #![deny(clippy::await_holding_lock)]
+#![deny(rust_2021_compatibility)]
 #![forbid(unsafe_code)]
 
 mod block;
@@ -54,9 +55,7 @@ pub mod chain;
 pub mod error;
 
 pub use block::VerifyBlockError;
-pub use checkpoint::VerifyCheckpointError;
-pub use checkpoint::MAX_CHECKPOINT_BYTE_COUNT;
-pub use checkpoint::MAX_CHECKPOINT_HEIGHT_GAP;
+pub use checkpoint::{VerifyCheckpointError, MAX_CHECKPOINT_BYTE_COUNT, MAX_CHECKPOINT_HEIGHT_GAP};
 pub use config::Config;
 pub use error::BlockError;
 pub use primitives::groth16;

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -3,7 +3,7 @@ name = "zebra-network"
 version = "1.0.0-beta.3"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -37,6 +37,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
 #![deny(clippy::await_holding_lock)]
+#![deny(rust_2021_compatibility)]
 #![forbid(unsafe_code)]
 
 #[macro_use]

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -184,7 +184,7 @@ impl Codec {
     /// for large data structures like lists, blocks, and transactions.
     /// See #1774.
     fn body_length(&self, msg: &Message) -> usize {
-        let mut writer = FakeWriter { 0: 0 };
+        let mut writer = FakeWriter(0);
 
         self.write_body(msg, &mut writer)
             .expect("writer should never fail");

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -3,7 +3,7 @@ name = "zebra-rpc"
 version = "1.0.0-beta.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/zebra-rpc/src/lib.rs
+++ b/zebra-rpc/src/lib.rs
@@ -7,4 +7,5 @@
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
 #![deny(clippy::await_holding_lock)]
+#![deny(rust_2021_compatibility)]
 #![forbid(unsafe_code)]

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -3,7 +3,7 @@ name = "zebra-script"
 version = "1.0.0-beta.3"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -6,6 +6,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
 #![deny(clippy::await_holding_lock)]
+#![deny(rust_2021_compatibility)]
 // we allow unsafe code, so we can call zcash_script
 
 use std::{convert::TryInto, sync::Arc};

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -3,7 +3,7 @@ name = "zebra-state"
 version = "1.0.0-beta.3"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 proptest-impl = ["proptest", "proptest-derive", "zebra-test"]

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -15,6 +15,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
 #![deny(clippy::await_holding_lock)]
+#![deny(rust_2021_compatibility)]
 #![forbid(unsafe_code)]
 
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -3,7 +3,7 @@ name = "zebra-test"
 version = "1.0.0-beta.3"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/zebra-test/src/lib.rs
+++ b/zebra-test/src/lib.rs
@@ -6,6 +6,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
 #![deny(clippy::await_holding_lock)]
+#![deny(rust_2021_compatibility)]
 #![forbid(unsafe_code)]
 // Each lazy_static variable uses additional recursion
 #![recursion_limit = "512"]

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -3,7 +3,7 @@ name = "zebra-utils"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 version = "1.0.0-beta.3"
-edition = "2018"
+edition = "2021"
 # Prevent accidental publication of this utility crate.
 publish = false
 

--- a/zebra-utils/src/lib.rs
+++ b/zebra-utils/src/lib.rs
@@ -8,4 +8,5 @@
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
 #![deny(clippy::await_holding_lock)]
+#![deny(rust_2021_compatibility)]
 #![forbid(unsafe_code)]

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -3,7 +3,7 @@ name = "zebrad"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 version = "1.0.0-beta.3"
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/ZcashFoundation/zebra"
 # make `cargo run` use `zebrad` by default
 # when run in the workspace directory

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -21,6 +21,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::try_err)]
 #![deny(clippy::await_holding_lock)]
+#![deny(rust_2021_compatibility)]
 #![forbid(unsafe_code)]
 // Tracing causes false positives on this lint:
 // https://github.com/tokio-rs/tracing/issues/553


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

We've wanted to comply with Rust 2021 edition for a bit: 
https://github.com/ZcashFoundation/zebra/issues/2709

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Upgraded the `Cargo.toml`s to `edition = 2021`, did a little `cargo fix --edition` in each crate, ran tests, did a little `clippy fix`, and only had to tweak a few lines. 🎉

Resolves https://github.com/ZcashFoundation/zebra/issues/2709
## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

Anyone can review, maybe @jvff @conradoplg 

### Reviewer Checklist

  - [ ] All tests and clippy pass

