### PR TITLE
Replace `tempdir` dependency with `tempfile`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,6 +1113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "ff"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,12 +1184,6 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -2582,19 +2585,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2637,21 +2627,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2733,15 +2708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "reddsa"
 version = "0.0.0"
 source = "git+https://github.com/str4d/redjubjub.git?rev=416a6a8ebf8bd42c114c938883016c04f338de72#416a6a8ebf8bd42c114c938883016c04f338de72"
@@ -2781,9 +2747,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.6"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -2795,7 +2761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.0",
- "redox_syscall 0.2.6",
+ "redox_syscall 0.2.10",
 ]
 
 [[package]]
@@ -3449,25 +3415,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
+ "fastrand",
  "libc",
- "rand 0.7.3",
- "redox_syscall 0.1.57",
+ "redox_syscall 0.2.10",
  "remove_dir_all",
  "winapi",
 ]
@@ -4506,7 +4462,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "spandoc",
- "tempdir",
+ "tempfile",
  "thiserror",
  "tokio",
  "tower",
@@ -4529,7 +4485,7 @@ dependencies = [
  "rand 0.8.4",
  "regex",
  "spandoc",
- "tempdir",
+ "tempfile",
  "thiserror",
  "tokio",
  "tower",
@@ -4580,7 +4536,7 @@ dependencies = [
  "sentry",
  "sentry-tracing",
  "serde",
- "tempdir",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml",

--- a/deny.toml
+++ b/deny.toml
@@ -63,7 +63,6 @@ skip-tree = [
     { name = "webpki-roots", version = "=0.18.0" },
 
     # ticket #2980: inferno and orchard/cryptographic dependencies
-    { name = "inferno", version = "=0.10.8" },
     { name = "orchard", version = "=0.0.0" },
 
     # upgrade orchard from deprecated `bigint` to `uint`: https://github.com/zcash/orchard/issues/219

--- a/deny.toml
+++ b/deny.toml
@@ -53,9 +53,6 @@ skip-tree = [
     # ticket #2984: owo-colors dependencies
     { name = "color-eyre", version = "=0.5.11" },
 
-    # tickets #2985 and #2391: tempdir & rand dependencies
-    { name = "tempdir", version = "=0.3.7" },
-
     # ticket #2998: hdrhistogram dependencies
     { name = "hdrhistogram", version = "=6.3.4" },
 

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -29,7 +29,7 @@ regex = "1"
 rlimit = "0.5.4"
 rocksdb = "0.16.0"
 serde = { version = "1", features = ["serde_derive"] }
-tempdir = "0.3.7"
+tempfile = "3.3.0"
 thiserror = "1.0.30"
 tokio = { version = "1.15.0", features = ["sync"] }
 tower = { version = "0.4.11", features = ["buffer", "util"] }
@@ -49,7 +49,6 @@ jubjub = "0.8.0"
 proptest = "0.10.1"
 proptest-derive = "0.3"
 spandoc = "0.2"
-tempdir = "0.3.7"
 tokio = { version = "1.15.0", features = ["full"] }
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::{convert::TryInto, path::PathBuf};
-use tempdir::TempDir;
 use zebra_chain::parameters::Network;
 
 /// Configuration for the state service.
@@ -46,7 +45,9 @@ pub struct Config {
 }
 
 fn gen_temp_path(prefix: &str) -> PathBuf {
-    TempDir::new(prefix)
+    tempfile::Builder::new()
+        .prefix(prefix)
+        .tempdir()
         .expect("temporary directory is created successfully")
         .into_path()
 }

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -28,4 +28,4 @@ tracing-subscriber = "0.2.25"
 tracing-error = "0.1.2"
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3.3.0"

--- a/zebra-test/tests/command.rs
+++ b/zebra-test/tests/command.rs
@@ -7,7 +7,7 @@
 use std::{process::Command, time::Duration};
 
 use color_eyre::eyre::Result;
-use tempdir::TempDir;
+use tempfile::tempdir;
 
 use zebra_test::{command::TestDirExt, prelude::Stdio};
 

--- a/zebra-test/tests/command.rs
+++ b/zebra-test/tests/command.rs
@@ -59,7 +59,7 @@ fn kill_on_timeout_output_continuous_lines() -> Result<()> {
 
     // Without '-v', hexdump hides duplicate lines. But we want duplicate lines
     // in this test.
-    let mut child = TempDir::new("zebra_test")?
+    let mut child = tempdir()?
         .spawn_child_with_command(TEST_CMD, &["-v", "/dev/zero"])?
         .with_timeout(Duration::from_secs(2));
 
@@ -86,7 +86,7 @@ fn finish_before_timeout_output_single_line() -> Result<()> {
         return Ok(());
     }
 
-    let mut child = TempDir::new("zebra_test")?
+    let mut child = tempdir()?
         .spawn_child_with_command(TEST_CMD, &["zebra_test_output"])?
         .with_timeout(Duration::from_secs(2));
 
@@ -115,7 +115,7 @@ fn kill_on_timeout_continuous_output_no_newlines() -> Result<()> {
         return Ok(());
     }
 
-    let mut child = TempDir::new("zebra_test")?
+    let mut child = tempdir()?
         .spawn_child_with_command(TEST_CMD, &["/dev/zero"])?
         .with_timeout(Duration::from_secs(2));
 
@@ -143,7 +143,7 @@ fn finish_before_timeout_short_output_no_newlines() -> Result<()> {
         return Ok(());
     }
 
-    let mut child = TempDir::new("zebra_test")?
+    let mut child = tempdir()?
         .spawn_child_with_command(TEST_CMD, &["zebra_test_output"])?
         .with_timeout(Duration::from_secs(2));
 
@@ -171,7 +171,7 @@ fn kill_on_timeout_no_output() -> Result<()> {
         return Ok(());
     }
 
-    let mut child = TempDir::new("zebra_test")?
+    let mut child = tempdir()?
         .spawn_child_with_command(TEST_CMD, &["120"])?
         .with_timeout(Duration::from_secs(2));
 

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -58,7 +58,7 @@ abscissa_core = { version = "0.5", features = ["testing"] }
 once_cell = "1.9"
 regex = "1.4.6"
 semver = "1.0.3"
-tempdir = "0.3.7"
+tempfile = "3.3.0"
 tokio = { version = "1.15.0", features = ["full", "test-util"] }
 
 proptest = "0.10"

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -524,7 +524,7 @@ fn ephemeral(cache_dir_config: EphemeralConfig, cache_dir_check: EphemeralCheck)
     zebra_test::init();
 
     let mut config = default_test_config()?;
-    let run_dir = TempDir::new("zebrad_tests")?;
+    let run_dir = testdir()?;
 
     let ignored_cache_dir = run_dir.path().join("state");
     if cache_dir_config == EphemeralConfig::MisconfiguredCacheDir {
@@ -1146,7 +1146,7 @@ async fn metrics_endpoint() -> Result<()> {
     let mut config = default_test_config()?;
     config.metrics.endpoint_addr = Some(endpoint.parse().unwrap());
 
-    let dir = TempDir::new("zebrad_tests")?.with_config(&mut config)?;
+    let dir = testdir()?.with_config(&mut config)?;
     let child = dir.spawn_child(&["start"])?;
 
     // Run `zebrad` for a few seconds before testing the endpoint
@@ -1202,7 +1202,7 @@ async fn tracing_endpoint() -> Result<()> {
     let mut config = default_test_config()?;
     config.tracing.endpoint_addr = Some(endpoint.parse().unwrap());
 
-    let dir = TempDir::new("zebrad_tests")?.with_config(&mut config)?;
+    let dir = testdir()?.with_config(&mut config)?;
     let child = dir.spawn_child(&["start"])?;
 
     // Run `zebrad` for a few seconds before testing the endpoint
@@ -1294,7 +1294,7 @@ fn zebra_zcash_listener_conflict() -> Result<()> {
     // Write a configuration that has our created network listen_addr
     let mut config = default_test_config()?;
     config.network.listen_addr = listen_addr.parse().unwrap();
-    let dir1 = TempDir::new("zebrad_tests")?.with_config(&mut config)?;
+    let dir1 = testdir()?.with_config(&mut config)?;
     let regex1 = regex::escape(&format!(
         "Opened Zcash protocol endpoint at {}",
         listen_addr
@@ -1303,7 +1303,7 @@ fn zebra_zcash_listener_conflict() -> Result<()> {
     // From another folder create a configuration with the same listener.
     // `network.listen_addr` will be the same in the 2 nodes.
     // (But since the config is ephemeral, they will have different state paths.)
-    let dir2 = TempDir::new("zebrad_tests")?.with_config(&mut config)?;
+    let dir2 = testdir()?.with_config(&mut config)?;
 
     check_config_conflict(dir1, regex1.as_str(), dir2, PORT_IN_USE_ERROR.as_str())?;
 
@@ -1325,13 +1325,13 @@ fn zebra_metrics_conflict() -> Result<()> {
     // Write a configuration that has our created metrics endpoint_addr
     let mut config = default_test_config()?;
     config.metrics.endpoint_addr = Some(listen_addr.parse().unwrap());
-    let dir1 = TempDir::new("zebrad_tests")?.with_config(&mut config)?;
+    let dir1 = testdir()?.with_config(&mut config)?;
     let regex1 = regex::escape(&format!(r"Opened metrics endpoint at {}", listen_addr));
 
     // From another folder create a configuration with the same endpoint.
     // `metrics.endpoint_addr` will be the same in the 2 nodes.
     // But they will have different Zcash listeners (auto port) and states (ephemeral)
-    let dir2 = TempDir::new("zebrad_tests")?.with_config(&mut config)?;
+    let dir2 = testdir()?.with_config(&mut config)?;
 
     check_config_conflict(dir1, regex1.as_str(), dir2, PORT_IN_USE_ERROR.as_str())?;
 
@@ -1353,13 +1353,13 @@ fn zebra_tracing_conflict() -> Result<()> {
     // Write a configuration that has our created tracing endpoint_addr
     let mut config = default_test_config()?;
     config.tracing.endpoint_addr = Some(listen_addr.parse().unwrap());
-    let dir1 = TempDir::new("zebrad_tests")?.with_config(&mut config)?;
+    let dir1 = testdir()?.with_config(&mut config)?;
     let regex1 = regex::escape(&format!(r"Opened tracing endpoint at {}", listen_addr));
 
     // From another folder create a configuration with the same endpoint.
     // `tracing.endpoint_addr` will be the same in the 2 nodes.
     // But they will have different Zcash listeners (auto port) and states (ephemeral)
-    let dir2 = TempDir::new("zebrad_tests")?.with_config(&mut config)?;
+    let dir2 = testdir()?.with_config(&mut config)?;
 
     check_config_conflict(dir1, regex1.as_str(), dir2, PORT_IN_USE_ERROR.as_str())?;
 
@@ -1376,7 +1376,7 @@ fn zebra_state_conflict() -> Result<()> {
     // A persistent config has a fixed temp state directory, but asks the OS to
     // automatically choose an unused port
     let mut config = persistent_test_config()?;
-    let dir_conflict = TempDir::new("zebrad_tests")?.with_config(&mut config)?;
+    let dir_conflict = testdir()?.with_config(&mut config)?;
 
     // Windows problems with this match will be worked on at #1654
     // We are matching the whole opened path only for unix by now.

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -31,7 +31,7 @@ use color_eyre::{
     eyre::{Result, WrapErr},
     Help,
 };
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 use std::{collections::HashSet, convert::TryInto, path::Path, path::PathBuf, time::Duration};
 
@@ -107,10 +107,13 @@ fn persistent_test_config() -> Result<ZebradConfig> {
 }
 
 fn testdir() -> Result<TempDir> {
-    TempDir::new("zebrad_tests").map_err(Into::into)
+    tempfile::Builder::new()
+        .prefix("zebrad_tests")
+        .tempdir()
+        .map_err(Into::into)
 }
 
-/// Extension trait for methods on `tempdir::TempDir` for using it as a test
+/// Extension trait for methods on `tempfile::TempDir` for using it as a test
 /// directory for `zebrad`.
 trait ZebradTestDirExt
 where


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
`tempdir` is unmaintained and obsoleted by `temfile`.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Change crates to depend on `tempfile` instead of `tempdir`. Use `tempfile::TempDir` where `tempdir::TempDir` was once used. This required changes to either not have a prefix to the temporary name, or to use the `tempfile::Builder` to add a prefix. Finally, the `tempdir` exception in `deny.toml` was removed.

An `inferno` exception in `deny.toml` was also removed, as it seems like it's not needed anymore.

This closes #2985.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
Anyone can review this low priority PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
