### PR TITLE
Use the correct conditions and merge method in Mergify

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   labels:
   - "A-dependencies"
   - "A-rust"
-  - "P-Low"
+  - "P-Low :snowflake:"
   ignore:
   - dependency-name: tokio-util
     versions:
@@ -23,4 +23,4 @@ updates:
   labels:
   - "A-infrastructure"
   - "A-dependencies"
-  - "P-Low"
+  - "P-Low :snowflake:"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,25 +3,31 @@ queue_rules:
     speculative_checks: 2
     batch_size: 2
     conditions:
-      - check-success=CI
-      - check-success=Coverage
-      - check-success=pull-request
+      - check-success=Test (+stable) on ubuntu-latest
+      - check-success=Test (+stable) on macOS-latest
+      - check-success=Test (+stable) on windows-latest
+      - check-success=pull-request (zealous-zebra)
+      - check-success=Coverage (+nightly)
 
   - name: medium
     speculative_checks: 2
     batch_size: 3
     conditions:
-      - check-success=CI
-      - check-success=Coverage
-      - check-success=pull-request
+      - check-success=Test (+stable) on ubuntu-latest
+      - check-success=Test (+stable) on macOS-latest
+      - check-success=Test (+stable) on windows-latest
+      - check-success=pull-request (zealous-zebra)
+      - check-success=Coverage (+nightly)
 
-  - name: default
+  - name: low
     speculative_checks: 2
     batch_size: 4
     conditions:
-      - check-success=CI
-      - check-success=Coverage
-      - check-success=pull-request
+      - check-success=Test (+stable) on ubuntu-latest
+      - check-success=Test (+stable) on macOS-latest
+      - check-success=Test (+stable) on windows-latest
+      - check-success=pull-request (zealous-zebra)
+      - check-success=Coverage (+nightly)
 
 pull_request_rules:
   - name: automatic update for PR marked as “Ready-to-Go“
@@ -31,42 +37,42 @@ pull_request_rules:
     actions:
       update:
 
-  - name: move to critical queue when CI passes with 1 review and not WIP targeting main
+  - name: move to urgent queue when CI passes with 1 review and not WIP targeting main
     conditions:
       - "#approved-reviews-by>=1"
       - -draft
       - base=main
-      - check-success=CI
-      - check-success=Coverage
-      - "label~=^P-Critical"
+      - or:
+          - "label~=^P-Critical"
+          - "label~=^P-High"
       - label!=do-not-merge
     actions:
       queue:
         name: urgent
+        method: squash
 
-  - name: move to high queue when CI passes with 1 review and not WIP targeting main
+  - name: move to medium queue when CI passes with 1 review and not WIP targeting main
     conditions:
       - "#approved-reviews-by>=1"
       - -draft
       - base=main
-      - check-success=CI
-      - check-success=Coverage
-      - "label~=^P-High"
+      - "label~=^P-Medium"
       - label!=do-not-merge
     actions:
       queue:
         name: medium
+        method: squash
 
-  - name: move to default queue when CI passes with 1 review and not WIP targeting main
+  - name: move to low queue when CI passes with 1 review and not WIP targeting main
     conditions:
       - "#approved-reviews-by>=1"
       - -draft
       - base=main
-      - check-success=CI
-      - check-success=Coverage
-      - "-label~=^P-High"
-      - "-label~=^P-Critical"
+      - or:
+          - "-label~=^P-Low"
+          - "-label~=^P-Optional"
       - label!=do-not-merge
     actions:
       queue:
-        name: default
+        name: low
+        method: squash

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -76,3 +76,16 @@ pull_request_rules:
       queue:
         name: low
         method: squash
+
+  - name: automatic merge for Dependabot pull requests
+    conditions:
+      - "#approved-reviews-by>=1"
+      - author~=^dependabot(|-preview)\[bot\]$
+      - check-success=Test (+stable) on ubuntu-latest
+      - check-success=Test (+stable) on macOS-latest
+      - check-success=Test (+stable) on windows-latest
+      - check-success=pull-request (zealous-zebra)
+      - check-success=Coverage (+nightly)
+    actions:
+      merge:
+        method: squash


### PR DESCRIPTION
## Motivation

- Mergify was not automatically assigning the Pull Requests to a queue nor merging it

## Solution

- Mergify's Status Checks conditions are based on the job name, not the workflow name. As our workflow has dynamic names, each variant must be considered.

- Squash merges are the default being used in the Zebra repo, so Mergify must comply with this configuration.

- Use condition operators for labels in each pull request rule; previously it was expecting both labels to be set. And update names accordingly.

- Also adapt DependaBot configuration to use the recently adapted labels

## Review

@dconnolly @mpguerra 

### Reviewer Checklist
  - [x] Validate conditions on Mergify's validator https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/config-editor?repositoryName=zebra&pullRequestNumber=3337

## Follow Up Work

Being more explicit on the rules, but changes are required in Github Actions before doing this.