### PR TITLE
Do not update PRs to the latest tip automatically

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -30,13 +30,6 @@ queue_rules:
       - check-success=Coverage (+nightly)
 
 pull_request_rules:
-  - name: automatic update for PR marked as “Ready-to-Go“
-    conditions:
-      - -conflict # skip PRs with conflicts
-      - -draft # filter-out GH draft PRs
-    actions:
-      update:
-
   - name: move to urgent queue when CI passes with 1 review and not WIP targeting main
     conditions:
       - "#approved-reviews-by>=1"


### PR DESCRIPTION
## Motivation

This is causing the Mergify bot to commit to each PR, which is also included in the squashed merge as an author.

As the queue merges the head branch (main) to the latest tip before testing with the CI, having all those feature branches constantly updating with Mergify is not needed

## Solution

Auto-update is not needed when using the queue, remove it from the Mergify option.
