### PR TITLE
Use 2022-01-14 nightly to workaround coverage issue

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,10 @@ jobs:
 
       - uses: actions-rs/toolchain@v1.0.7
         with:
-          toolchain: nightly
+          # Pinned to workaround issue making cargo-llvm-cov fail, see
+          # https://github.com/taiki-e/cargo-llvm-cov/issues/128
+          # TODO: restore to just `nightly` after it's fixed
+          toolchain: nightly-2022-01-14
           override: true
           profile: minimal
           components: llvm-tools-preview


### PR DESCRIPTION
`rustc` broke `cargo-llvm-cov` which we use for coverage, which is making our CI fail: https://github.com/taiki-e/cargo-llvm-cov/issues/128

The workaround is to pin to a older version of the nightly rust.

## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
