### PR TITLE
Ignore unexpected block responses to fix error cascade when synchronizing blocks

### DIFF
--- a/zebra-network/src/peer/connection/tests.rs
+++ b/zebra-network/src/peer/connection/tests.rs
@@ -16,6 +16,7 @@ use crate::{
     Request, Response,
 };
 
+mod prop;
 mod vectors;
 
 /// Creates a new [`Connection`] instance for testing.

--- a/zebra-network/src/peer/connection/tests.rs
+++ b/zebra-network/src/peer/connection/tests.rs
@@ -1,3 +1,66 @@
 //! Tests for peer connections
 
+use std::io;
+
+use futures::{channel::mpsc, sink::SinkMapErr, SinkExt};
+
+use zebra_chain::serialization::SerializationError;
+use zebra_test::mock_service::MockService;
+
+use crate::{
+    peer::{
+        client::ClientRequestReceiver, connection::State, ClientRequest, Connection, ErrorSlot,
+    },
+    peer_set::ActiveConnectionCounter,
+    protocol::external::Message,
+    Request, Response,
+};
+
 mod vectors;
+
+/// Creates a new [`Connection`] instance for testing.
+fn new_test_connection<A>() -> (
+    Connection<
+        MockService<Request, Response, A>,
+        SinkMapErr<mpsc::UnboundedSender<Message>, fn(mpsc::SendError) -> SerializationError>,
+    >,
+    mpsc::Sender<ClientRequest>,
+    MockService<Request, Response, A>,
+    mpsc::UnboundedReceiver<Message>,
+    ErrorSlot,
+) {
+    let mock_inbound_service = MockService::build().finish();
+    let (client_tx, client_rx) = mpsc::channel(1);
+    let shared_error_slot = ErrorSlot::default();
+    let (peer_outbound_tx, peer_outbound_rx) = mpsc::unbounded();
+
+    let error_converter: fn(mpsc::SendError) -> SerializationError = |_| {
+        io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "peer outbound message stream was closed",
+        )
+        .into()
+    };
+    let peer_tx = peer_outbound_tx.sink_map_err(error_converter);
+
+    let connection = Connection {
+        state: State::AwaitingRequest,
+        request_timer: None,
+        cached_addrs: Vec::new(),
+        svc: mock_inbound_service.clone(),
+        client_rx: ClientRequestReceiver::from(client_rx),
+        error_slot: shared_error_slot.clone(),
+        peer_tx,
+        connection_tracker: ActiveConnectionCounter::new_counter().track_connection(),
+        metrics_label: "test".to_string(),
+        last_metrics_state: None,
+    };
+
+    (
+        connection,
+        client_tx,
+        mock_inbound_service,
+        peer_outbound_rx,
+        shared_error_slot,
+    )
+}

--- a/zebra-network/src/peer/connection/tests/prop.rs
+++ b/zebra-network/src/peer/connection/tests/prop.rs
@@ -1,0 +1,154 @@
+use std::{collections::HashSet, env, mem, sync::Arc};
+
+use futures::{
+    channel::{mpsc, oneshot},
+    sink::SinkMapErr,
+    SinkExt, StreamExt,
+};
+use proptest::prelude::*;
+use tracing::Span;
+
+use zebra_chain::{
+    block::{self, Block},
+    serialization::SerializationError,
+};
+use zebra_test::mock_service::{MockService, PropTestAssertion};
+
+use crate::{
+    peer::{connection::Connection, ClientRequest, ErrorSlot},
+    protocol::external::Message,
+    Request, Response, SharedPeerError,
+};
+
+proptest! {
+    // The default value of proptest cases (256) causes this test to take more than ten seconds on
+    // most machines, so this reduces the value a little to reduce the test time.
+    // Set the PROPTEST_CASES env var to override this default.
+    #![proptest_config(
+        proptest::test_runner::Config::with_cases(env::var("PROPTEST_CASES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(32))
+    )]
+
+    #[test]
+    fn connection_is_not_desynchronized_when_request_is_cancelled(
+        first_block in any::<Arc<Block>>(),
+        second_block in any::<Arc<Block>>(),
+    ) {
+        let runtime = zebra_test::init_async();
+
+        runtime.block_on(async move {
+            // The real stream and sink are from a split TCP connection,
+            // but that doesn't change how the state machine behaves.
+            let (mut peer_inbound_tx, peer_inbound_rx) = mpsc::channel(1);
+
+            let (
+                connection,
+                mut client_tx,
+                mut inbound_service,
+                mut peer_outbound_messages,
+                shared_error_slot,
+            ) = new_test_connection();
+
+            let connection_task = tokio::spawn(connection.run(peer_inbound_rx));
+
+            let response_to_first_request = send_block_request(
+                first_block.hash(),
+                &mut client_tx,
+                &mut peer_outbound_messages,
+            )
+            .await;
+
+            // Cancel first request.
+            mem::drop(response_to_first_request);
+
+            let response_to_second_request = send_block_request(
+                second_block.hash(),
+                &mut client_tx,
+                &mut peer_outbound_messages,
+            )
+            .await;
+
+            // Reply to first request
+            peer_inbound_tx
+                .send(Ok(Message::Block(first_block)))
+                .await
+                .expect("Failed to send response to first block request");
+
+            // Reply to second request
+            peer_inbound_tx
+                .send(Ok(Message::Block(second_block.clone())))
+                .await
+                .expect("Failed to send response to second block request");
+
+            // Check second response is correctly received
+            let receive_response_result = response_to_second_request.await;
+
+            prop_assert!(receive_response_result.is_ok());
+            let response_result = receive_response_result.unwrap();
+
+            prop_assert!(response_result.is_ok());
+            let response = response_result.unwrap();
+
+            prop_assert_eq!(response, Response::Blocks(vec![second_block]));
+
+            // Check the state after the response
+            let error = shared_error_slot.try_get_error();
+            assert!(matches!(error, None));
+
+            inbound_service.expect_no_requests().await?;
+
+            // Stop the connection thread
+            mem::drop(peer_inbound_tx);
+
+            let connection_task_result = connection_task.await;
+            prop_assert!(connection_task_result.is_ok());
+
+            Ok(())
+        })?;
+    }
+}
+
+/// Creates a new [`Connection`] instance for property tests.
+fn new_test_connection() -> (
+    Connection<
+        MockService<Request, Response, PropTestAssertion>,
+        SinkMapErr<mpsc::UnboundedSender<Message>, fn(mpsc::SendError) -> SerializationError>,
+    >,
+    mpsc::Sender<ClientRequest>,
+    MockService<Request, Response, PropTestAssertion>,
+    mpsc::UnboundedReceiver<Message>,
+    ErrorSlot,
+) {
+    super::new_test_connection()
+}
+
+async fn send_block_request(
+    block: block::Hash,
+    client_requests: &mut mpsc::Sender<ClientRequest>,
+    outbound_messages: &mut mpsc::UnboundedReceiver<Message>,
+) -> oneshot::Receiver<Result<Response, SharedPeerError>> {
+    let (response_sender, response_receiver) = oneshot::channel();
+
+    let request = Request::BlocksByHash(HashSet::from_iter([block]));
+    let client_request = ClientRequest {
+        request,
+        tx: response_sender,
+        span: Span::none(),
+    };
+
+    client_requests
+        .send(client_request)
+        .await
+        .expect("failed to send block request to connection task");
+
+    let request_message = outbound_messages
+        .next()
+        .await
+        .expect("First block request message not sent");
+
+    assert_eq!(request_message, Message::GetData(vec![block.into()]));
+
+    response_receiver
+}

--- a/zebra-network/src/peer/connection/tests/vectors.rs
+++ b/zebra-network/src/peer/connection/tests/vectors.rs
@@ -4,18 +4,16 @@
 //! - connection tests when awaiting requests (#3232)
 //! - connection tests with closed/dropped peer_outbound_tx (#3233)
 
-use std::io;
-
-use futures::{channel::mpsc, sink::SinkMapErr, FutureExt, SinkExt, StreamExt};
+use futures::{channel::mpsc, sink::SinkMapErr, FutureExt, StreamExt};
 
 use zebra_chain::serialization::SerializationError;
 use zebra_test::mock_service::{MockService, PanicAssertion};
 
 use crate::{
     peer::{
-        client::ClientRequestReceiver, connection::State, ClientRequest, Connection, ErrorSlot,
+        connection::{Connection, State},
+        ClientRequest, ErrorSlot,
     },
-    peer_set::ActiveConnectionCounter,
     protocol::external::Message,
     PeerError, Request, Response,
 };
@@ -275,7 +273,7 @@ async fn connection_run_loop_failed() {
     inbound_service.expect_no_requests().await;
 }
 
-/// Creates a new [`Connection`] instance for testing.
+/// Creates a new [`Connection`] instance for unit tests.
 fn new_test_connection() -> (
     Connection<
         MockService<Request, Response, PanicAssertion>,
@@ -286,38 +284,5 @@ fn new_test_connection() -> (
     mpsc::UnboundedReceiver<Message>,
     ErrorSlot,
 ) {
-    let mock_inbound_service = MockService::build().for_unit_tests();
-    let (client_tx, client_rx) = mpsc::channel(1);
-    let shared_error_slot = ErrorSlot::default();
-    let (peer_outbound_tx, peer_outbound_rx) = mpsc::unbounded();
-
-    let error_converter: fn(mpsc::SendError) -> SerializationError = |_| {
-        io::Error::new(
-            io::ErrorKind::BrokenPipe,
-            "peer outbound message stream was closed",
-        )
-        .into()
-    };
-    let peer_tx = peer_outbound_tx.sink_map_err(error_converter);
-
-    let connection = Connection {
-        state: State::AwaitingRequest,
-        request_timer: None,
-        cached_addrs: Vec::new(),
-        svc: mock_inbound_service.clone(),
-        client_rx: ClientRequestReceiver::from(client_rx),
-        error_slot: shared_error_slot.clone(),
-        peer_tx,
-        connection_tracker: ActiveConnectionCounter::new_counter().track_connection(),
-        metrics_label: "test".to_string(),
-        last_metrics_state: None,
-    };
-
-    (
-        connection,
-        client_tx,
-        mock_inbound_service,
-        peer_outbound_rx,
-        shared_error_slot,
-    )
+    super::new_test_connection()
 }

--- a/zebra-network/src/peer/connection/tests/vectors.rs
+++ b/zebra-network/src/peer/connection/tests/vectors.rs
@@ -6,52 +6,30 @@
 
 use futures::{channel::mpsc, FutureExt};
 use tokio_util::codec::FramedWrite;
-use tower::service_fn;
+
 use zebra_chain::parameters::Network;
+use zebra_test::mock_service::{MockService, PanicAssertion};
 
 use crate::{
-    peer::{client::ClientRequestReceiver, connection::State, Connection, ErrorSlot},
+    peer::{
+        client::ClientRequestReceiver, connection::State, ClientRequest, Connection, ErrorSlot,
+    },
     peer_set::ActiveConnectionCounter,
     protocol::external::Codec,
-    PeerError,
+    PeerError, Request, Response,
 };
 
 #[tokio::test]
 async fn connection_run_loop_ok() {
     zebra_test::init();
 
-    let (client_tx, client_rx) = mpsc::channel(1);
-
     // The real stream and sink are from a split TCP connection,
     // but that doesn't change how the state machine behaves.
     let (peer_inbound_tx, peer_inbound_rx) = mpsc::channel(1);
 
     let mut peer_outbound_bytes = Vec::<u8>::new();
-    let peer_outbound_tx = FramedWrite::new(
-        &mut peer_outbound_bytes,
-        Codec::builder()
-            .for_network(Network::Mainnet)
-            .with_metrics_addr_label("test".into())
-            .finish(),
-    );
 
-    let unused_inbound_service =
-        service_fn(|_| async { unreachable!("inbound service should never be called") });
-
-    let shared_error_slot = ErrorSlot::default();
-
-    let connection = Connection {
-        state: State::AwaitingRequest,
-        request_timer: None,
-        cached_addrs: Vec::new(),
-        svc: unused_inbound_service,
-        client_rx: ClientRequestReceiver::from(client_rx),
-        error_slot: shared_error_slot.clone(),
-        peer_tx: peer_outbound_tx,
-        connection_tracker: ActiveConnectionCounter::new_counter().track_connection(),
-        metrics_label: "test".to_string(),
-        last_metrics_state: None,
-    };
+    let (connection, client_tx, shared_error_slot) = new_test_connection(&mut peer_outbound_bytes);
 
     let connection = connection.run(peer_inbound_rx);
 
@@ -83,36 +61,13 @@ async fn connection_run_loop_ok() {
 async fn connection_run_loop_future_drop() {
     zebra_test::init();
 
-    let (client_tx, client_rx) = mpsc::channel(1);
-
+    // The real stream and sink are from a split TCP connection,
+    // but that doesn't change how the state machine behaves.
     let (peer_inbound_tx, peer_inbound_rx) = mpsc::channel(1);
 
     let mut peer_outbound_bytes = Vec::<u8>::new();
-    let peer_outbound_tx = FramedWrite::new(
-        &mut peer_outbound_bytes,
-        Codec::builder()
-            .for_network(Network::Mainnet)
-            .with_metrics_addr_label("test".into())
-            .finish(),
-    );
 
-    let unused_inbound_service =
-        service_fn(|_| async { unreachable!("inbound service should never be called") });
-
-    let shared_error_slot = ErrorSlot::default();
-
-    let connection = Connection {
-        state: State::AwaitingRequest,
-        request_timer: None,
-        cached_addrs: Vec::new(),
-        svc: unused_inbound_service,
-        client_rx: ClientRequestReceiver::from(client_rx),
-        error_slot: shared_error_slot.clone(),
-        peer_tx: peer_outbound_tx,
-        connection_tracker: ActiveConnectionCounter::new_counter().track_connection(),
-        metrics_label: "test".to_string(),
-        last_metrics_state: None,
-    };
+    let (connection, client_tx, shared_error_slot) = new_test_connection(&mut peer_outbound_bytes);
 
     let connection = connection.run(peer_inbound_rx);
 
@@ -133,36 +88,14 @@ async fn connection_run_loop_future_drop() {
 async fn connection_run_loop_client_close() {
     zebra_test::init();
 
-    let (mut client_tx, client_rx) = mpsc::channel(1);
-
+    // The real stream and sink are from a split TCP connection,
+    // but that doesn't change how the state machine behaves.
     let (peer_inbound_tx, peer_inbound_rx) = mpsc::channel(1);
 
     let mut peer_outbound_bytes = Vec::<u8>::new();
-    let peer_outbound_tx = FramedWrite::new(
-        &mut peer_outbound_bytes,
-        Codec::builder()
-            .for_network(Network::Mainnet)
-            .with_metrics_addr_label("test".into())
-            .finish(),
-    );
 
-    let unused_inbound_service =
-        service_fn(|_| async { unreachable!("inbound service should never be called") });
-
-    let shared_error_slot = ErrorSlot::default();
-
-    let connection = Connection {
-        state: State::AwaitingRequest,
-        request_timer: None,
-        cached_addrs: Vec::new(),
-        svc: unused_inbound_service,
-        client_rx: ClientRequestReceiver::from(client_rx),
-        error_slot: shared_error_slot.clone(),
-        peer_tx: peer_outbound_tx,
-        connection_tracker: ActiveConnectionCounter::new_counter().track_connection(),
-        metrics_label: "test".to_string(),
-        last_metrics_state: None,
-    };
+    let (connection, mut client_tx, shared_error_slot) =
+        new_test_connection(&mut peer_outbound_bytes);
 
     let connection = connection.run(peer_inbound_rx);
 
@@ -190,36 +123,13 @@ async fn connection_run_loop_client_close() {
 async fn connection_run_loop_client_drop() {
     zebra_test::init();
 
-    let (client_tx, client_rx) = mpsc::channel(1);
-
+    // The real stream and sink are from a split TCP connection,
+    // but that doesn't change how the state machine behaves.
     let (peer_inbound_tx, peer_inbound_rx) = mpsc::channel(1);
 
     let mut peer_outbound_bytes = Vec::<u8>::new();
-    let peer_outbound_tx = FramedWrite::new(
-        &mut peer_outbound_bytes,
-        Codec::builder()
-            .for_network(Network::Mainnet)
-            .with_metrics_addr_label("test".into())
-            .finish(),
-    );
 
-    let unused_inbound_service =
-        service_fn(|_| async { unreachable!("inbound service should never be called") });
-
-    let shared_error_slot = ErrorSlot::default();
-
-    let connection = Connection {
-        state: State::AwaitingRequest,
-        request_timer: None,
-        cached_addrs: Vec::new(),
-        svc: unused_inbound_service,
-        client_rx: ClientRequestReceiver::from(client_rx),
-        error_slot: shared_error_slot.clone(),
-        peer_tx: peer_outbound_tx,
-        connection_tracker: ActiveConnectionCounter::new_counter().track_connection(),
-        metrics_label: "test".to_string(),
-        last_metrics_state: None,
-    };
+    let (connection, client_tx, shared_error_slot) = new_test_connection(&mut peer_outbound_bytes);
 
     let connection = connection.run(peer_inbound_rx);
 
@@ -246,36 +156,13 @@ async fn connection_run_loop_client_drop() {
 async fn connection_run_loop_inbound_close() {
     zebra_test::init();
 
-    let (client_tx, client_rx) = mpsc::channel(1);
-
+    // The real stream and sink are from a split TCP connection,
+    // but that doesn't change how the state machine behaves.
     let (mut peer_inbound_tx, peer_inbound_rx) = mpsc::channel(1);
 
     let mut peer_outbound_bytes = Vec::<u8>::new();
-    let peer_outbound_tx = FramedWrite::new(
-        &mut peer_outbound_bytes,
-        Codec::builder()
-            .for_network(Network::Mainnet)
-            .with_metrics_addr_label("test".into())
-            .finish(),
-    );
 
-    let unused_inbound_service =
-        service_fn(|_| async { unreachable!("inbound service should never be called") });
-
-    let shared_error_slot = ErrorSlot::default();
-
-    let connection = Connection {
-        state: State::AwaitingRequest,
-        request_timer: None,
-        cached_addrs: Vec::new(),
-        svc: unused_inbound_service,
-        client_rx: ClientRequestReceiver::from(client_rx),
-        error_slot: shared_error_slot.clone(),
-        peer_tx: peer_outbound_tx,
-        connection_tracker: ActiveConnectionCounter::new_counter().track_connection(),
-        metrics_label: "test".to_string(),
-        last_metrics_state: None,
-    };
+    let (connection, client_tx, shared_error_slot) = new_test_connection(&mut peer_outbound_bytes);
 
     let connection = connection.run(peer_inbound_rx);
 
@@ -303,36 +190,13 @@ async fn connection_run_loop_inbound_close() {
 async fn connection_run_loop_inbound_drop() {
     zebra_test::init();
 
-    let (client_tx, client_rx) = mpsc::channel(1);
-
+    // The real stream and sink are from a split TCP connection,
+    // but that doesn't change how the state machine behaves.
     let (peer_inbound_tx, peer_inbound_rx) = mpsc::channel(1);
 
     let mut peer_outbound_bytes = Vec::<u8>::new();
-    let peer_outbound_tx = FramedWrite::new(
-        &mut peer_outbound_bytes,
-        Codec::builder()
-            .for_network(Network::Mainnet)
-            .with_metrics_addr_label("test".into())
-            .finish(),
-    );
 
-    let unused_inbound_service =
-        service_fn(|_| async { unreachable!("inbound service should never be called") });
-
-    let shared_error_slot = ErrorSlot::default();
-
-    let connection = Connection {
-        state: State::AwaitingRequest,
-        request_timer: None,
-        cached_addrs: Vec::new(),
-        svc: unused_inbound_service,
-        client_rx: ClientRequestReceiver::from(client_rx),
-        error_slot: shared_error_slot.clone(),
-        peer_tx: peer_outbound_tx,
-        connection_tracker: ActiveConnectionCounter::new_counter().track_connection(),
-        metrics_label: "test".to_string(),
-        last_metrics_state: None,
-    };
+    let (connection, client_tx, shared_error_slot) = new_test_connection(&mut peer_outbound_bytes);
 
     let connection = connection.run(peer_inbound_rx);
 
@@ -359,41 +223,20 @@ async fn connection_run_loop_inbound_drop() {
 async fn connection_run_loop_failed() {
     zebra_test::init();
 
-    let (client_tx, client_rx) = mpsc::channel(1);
-
+    // The real stream and sink are from a split TCP connection,
+    // but that doesn't change how the state machine behaves.
     let (peer_inbound_tx, peer_inbound_rx) = mpsc::channel(1);
 
     let mut peer_outbound_bytes = Vec::<u8>::new();
-    let peer_outbound_tx = FramedWrite::new(
-        &mut peer_outbound_bytes,
-        Codec::builder()
-            .for_network(Network::Mainnet)
-            .with_metrics_addr_label("test".into())
-            .finish(),
-    );
 
-    let unused_inbound_service =
-        service_fn(|_| async { unreachable!("inbound service should never be called") });
-
-    let shared_error_slot = ErrorSlot::default();
+    let (mut connection, client_tx, shared_error_slot) =
+        new_test_connection(&mut peer_outbound_bytes);
 
     // Simulate an internal connection error.
+    connection.state = State::Failed;
     shared_error_slot
         .try_update_error(PeerError::ClientRequestTimeout.into())
         .expect("unexpected previous error in tests");
-
-    let connection = Connection {
-        state: State::Failed,
-        request_timer: None,
-        cached_addrs: Vec::new(),
-        svc: unused_inbound_service,
-        client_rx: ClientRequestReceiver::from(client_rx),
-        error_slot: shared_error_slot.clone(),
-        peer_tx: peer_outbound_tx,
-        connection_tracker: ActiveConnectionCounter::new_counter().track_connection(),
-        metrics_label: "test".to_string(),
-        last_metrics_state: None,
-    };
 
     let connection = connection.run(peer_inbound_rx);
 
@@ -414,4 +257,42 @@ async fn connection_run_loop_failed() {
     // We need to drop the future, because it holds a mutable reference to the bytes.
     std::mem::drop(connection_guard);
     assert_eq!(peer_outbound_bytes, Vec::<u8>::new());
+}
+
+/// Creates a new [`Connection`] instance for testing.
+fn new_test_connection(
+    peer_outbound_bytes: &mut Vec<u8>,
+) -> (
+    Connection<MockService<Request, Response, PanicAssertion>, FramedWrite<&mut Vec<u8>, Codec>>,
+    mpsc::Sender<ClientRequest>,
+    ErrorSlot,
+) {
+    let (client_tx, client_rx) = mpsc::channel(1);
+
+    let peer_outbound_tx = FramedWrite::new(
+        peer_outbound_bytes,
+        Codec::builder()
+            .for_network(Network::Mainnet)
+            .with_metrics_addr_label("test".into())
+            .finish(),
+    );
+
+    let unused_inbound_service = MockService::build().for_unit_tests();
+
+    let shared_error_slot = ErrorSlot::default();
+
+    let connection = Connection {
+        state: State::AwaitingRequest,
+        request_timer: None,
+        cached_addrs: Vec::new(),
+        svc: unused_inbound_service,
+        client_rx: ClientRequestReceiver::from(client_rx),
+        error_slot: shared_error_slot.clone(),
+        peer_tx: peer_outbound_tx,
+        connection_tracker: ActiveConnectionCounter::new_counter().track_connection(),
+        metrics_label: "test".to_string(),
+        last_metrics_state: None,
+    };
+
+    (connection, client_tx, shared_error_slot)
 }

--- a/zebra-network/src/protocol/internal/response.rs
+++ b/zebra-network/src/protocol/internal/response.rs
@@ -11,7 +11,7 @@ use std::{fmt, sync::Arc};
 use proptest_derive::Arbitrary;
 
 /// A response to a network request, represented in internal format.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum Response {
     /// Do not send any response to this request.

--- a/zebra-test/src/mock_service.rs
+++ b/zebra-test/src/mock_service.rs
@@ -256,7 +256,7 @@ impl MockServiceBuilder {
     /// Note that this is used by both [`Self::for_prop_tests`] and [`Self::for_unit_tests`], the
     /// only difference being the `Assertion` generic type parameter, which Rust infers
     /// automatically.
-    fn finish<Request, Response, Assertion, Error>(
+    pub fn finish<Request, Response, Assertion, Error>(
         self,
     ) -> MockService<Request, Response, Assertion, Error> {
         let proxy_channel_size = self


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
Zebra is having some block synchronization issues, which seems to be caused by the block synchronizer restarting every few minutes.

After investigating the issue, the cause was found to be that the connection to a remote peer become "unsynchronized". What happened was:

1. Local peer requests a block to the remote peer
2. The request is cancelled (this is normal, it can happen due to a timeout or due to a hedge request finishing first)
3. A second request is sent to the remote peer
4. The remote peer responds to the first request
5. The local peer thinks it's a response to the second request, and thinks the remote peer sent an incorrect block, so it returns an error
6. The local peer sends a third block request to the remote peer
7. The remote peer responds to the second request
8. The local peer thinks it's a response to the third request, ...

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Ignore responses with the incorrect block hash. That way there's a chance that a response received later has the correct block hash. If the remote peer did send out the incorrect block, the request will timeout anyway.

This fixes #3352.

The changes are simple, but I had to refactor the tests to be able to write a test case to reproduce the scenario. The test became a property test, and should now help us catch a regression to the error cascade behavior in the future.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@oxarbitrage can review this.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
