### PR TITLE
Updated utxo_by_outpoint column value type in documentation

### DIFF
--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -608,7 +608,7 @@ We use the following rocksdb column families:
 | `tx_by_location`               | `TransactionLocation`  | `Transaction`                       | Never   |
 | `hash_by_tx`                   | `TransactionLocation`  | `transaction::Hash`                 | Never   |
 | `tx_by_hash`                   | `transaction::Hash`    | `TransactionLocation`               | Never   |
-| `utxo_by_outpoint`             | `OutLocation`          | `transparent::Output`               | Delete  |
+| `utxo_by_outpoint`             | `OutLocation`          | `transparent::Utxo`                 | Delete  |
 | `balance_by_transparent_addr`  | `transparent::Address` | `Amount \|\| FirstOutLocation`      | Update  |
 | `utxo_by_transparent_addr_loc` | `FirstOutLocation`     | `AtLeastOne<OutLocation>`           | Up/Del  |
 | `tx_by_transparent_addr_loc`   | `FirstOutLocation`     | `AtLeastOne<TransactionLocation>`   | Append  |


### PR DESCRIPTION
## Motivation

The type of values in the `utxo_by_outpoint` column is the documentation is out of date.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

Minor documentation fix, anyone can review.

Updates documentation to match the code.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
