### PR TITLE
Fix deadlock in chain tip watch channel

### DIFF
--- a/book/src/dev/rfcs/0011-async-rust-in-zebra.md
+++ b/book/src/dev/rfcs/0011-async-rust-in-zebra.md
@@ -564,6 +564,13 @@ For example, [`tokio::sync::watch::Receiver::borrow`](https://docs.rs/tokio/1.15
 holds a read lock, so the borrowed data should always be cloned.
 Use `Arc` for efficient clones if needed.
 
+Never have two active watch borrow guards in the same scope, because that can cause a deadlock. The
+`watch::Sender` may start acquiring a write lock while the first borrow guard is active but the
+second one isn't. That means that the first read lock was acquired, but the second never will be
+because starting to acquire the write lock blocks any other read locks from being acquired. At the
+same time, the write lock will also never finish acquiring, because it waits for all read locks to
+be released, and the first read lock won't be released before the second read lock is acquired.
+
 In all of these cases:
 - make critical sections as short as possible, and
 - do not depend on other tasks or locks inside the critical section.


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
Zebra sometimes hangs and stops synchronizing. I took a couple of core dumps when that happened, and they had Tokio executor threads waiting on mutexes related to the `watch` channel for the chain tip. More specifically,

- one was waiting to acquire a write lock
- one was waiting to acquire a second read lock
- all of the others were waiting to acquire a first read lock

After analyzing the situation, it appears that the `#[instrument]` attributes that called `receiver.borrow()` kept the read lock acquired while the records are populated, and if there were two fields that required a `receiver.borrow()` call, then two read locks are acquired and held at the same time.

What I believe is happening is that under rare situations the write lock starts being when the first lock was acquired but the second hasn't yet. In that case, starting to acquire the write lock blocks further read locks from being acquired (likely to prevent starvation), so the second read lock never gets acquired. At the same time, the write lock never finishes being acquired because it's waiting for the first read lock to be released, which would only happen after the second lock is acquired.

This fixes #3379.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
To prevent the deadlock, at most one read lock should be active in a scope. To help enforce this condition, a new `with_chain_tip_block` method was added, which obtains a single read lock and uses it to record the appropriate fields for instrumentation and to execute a provided block of code provided as a closure.

The other methods were refactored to use the new method, so that the read-lock is used correctly for instrumentation and for the block of code that requires it. Now, the only `receiver.borrow()` call should be in the `with_chain_tip_block`.

I also updated the async guidelines to warn about the deadlock issue with `watch::Receiver`s.

### Tests

I tried to write a test for this issue, so that we can detect any regressions. However, after a lot of effort I couldn't get something that could deterministically reproduce the issue without the fix. It seems to be hard to trigger, and requires a lot of parallelism and time, so I decided to not include a test for now.

We can try to write something again in the future.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
Anyone from the team can review this.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
