### PR TITLE
Make the Zebra state RFC match the lightwalletd draft design

### DIFF
--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -608,7 +608,7 @@ We use the following rocksdb column families:
 | `tx_by_location`               | `TransactionLocation`  | `Transaction`                       | Never   |
 | `hash_by_tx`                   | `TransactionLocation`  | `transaction::Hash`                 | Never   |
 | `tx_by_hash`                   | `transaction::Hash`    | `TransactionLocation`               | Never   |
-| `utxo_by_outpoint`             | `OutLocation`          | `transparent::Utxo`                 | Delete  |
+| `utxo_by_outpoint`             | `OutLocation`          | `transparent::Output`               | Delete  |
 | `balance_by_transparent_addr`  | `transparent::Address` | `Amount \|\| FirstOutLocation`      | Update  |
 | `utxo_by_transparent_addr_loc` | `FirstOutLocation`     | `AtLeastOne<OutLocation>`           | Up/Del  |
 | `tx_by_transparent_addr_loc`   | `FirstOutLocation`     | `AtLeastOne<TransactionLocation>`   | Append  |


### PR DESCRIPTION
## Motivation

In PR #3376 we said:
> The type of values in the utxo_by_outpoint column is the documentation is out of date.

But the draft `lightwalletd` database design uses `Output` in `utxo_by_outpoint` to reduce database size.

So the type is not outdated, it just hasn't been implemented yet.

This PR reverts ZcashFoundation/zebra#3376.

## Review

@conradoplg I'm not sure exactly what we should do here.

Do you want the design to match the `lightwalletd` draft, or the current Zebra database?
Is it worth keeping the `lightwalletd` changes in a separate RFC, and merging them in once we start that work?