### PR TITLE
Consolidate standard lints into a cargo config file

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,12 @@
+
+[target.'cfg(all())']
+rustflags = [
+    # Zebra standard lints for Rust 1.58+
+    "-Dunsafe_code",
+    "-Drust_2021_compatibility",
+    "-Dclippy::await_holding_lock",
+
+    "-Wmissing_docs",
+
+    "-Aclippy::try_err",
+]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,6 +7,13 @@ rustflags = [
     "-Dclippy::await_holding_lock",
 
     "-Wmissing_docs",
+    "-Wnonstandard_style",
+    "-Wfuture_incompatible",
 
     "-Aclippy::try_err",
+
+    # TODOs:
+
+    # fix hidden lifetime parameters
+    #"-Wrust_2018_idioms",
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@
 # Vscode detrius
 .vscode/
 .zebra-state/
-.cargo/
 # Nix configs
 shell.nix

--- a/tower-batch/src/lib.rs
+++ b/tower-batch/src/lib.rs
@@ -85,13 +85,6 @@
 //! control logic, as it will receive explicit [`Flush`](BatchControl::Flush)
 //! requests from the wrapper.
 
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![deny(rust_2021_compatibility)]
-#![forbid(unsafe_code)]
-
 pub mod error;
 pub mod future;
 mod layer;

--- a/tower-batch/tests/ed25519.rs
+++ b/tower-batch/tests/ed25519.rs
@@ -1,9 +1,3 @@
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![forbid(unsafe_code)]
-
 use std::{
     future::Future,
     mem,

--- a/tower-batch/tests/worker.rs
+++ b/tower-batch/tests/worker.rs
@@ -1,9 +1,3 @@
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![forbid(unsafe_code)]
-
 use std::time::Duration;
 use tokio_test::{assert_pending, assert_ready, assert_ready_err, task};
 use tower::{Service, ServiceExt};

--- a/tower-fallback/src/lib.rs
+++ b/tower-fallback/src/lib.rs
@@ -10,13 +10,6 @@
 //!
 //! [aws-fallback]: https://aws.amazon.com/builders-library/avoiding-fallback-in-distributed-systems/
 
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![deny(rust_2021_compatibility)]
-#![forbid(unsafe_code)]
-
 pub mod future;
 mod service;
 

--- a/tower-fallback/tests/fallback.rs
+++ b/tower-fallback/tests/fallback.rs
@@ -1,9 +1,3 @@
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![forbid(unsafe_code)]
-
 use tower::{service_fn, Service, ServiceExt};
 use tower_fallback::Fallback;
 

--- a/zebra-chain/benches/block.rs
+++ b/zebra-chain/benches/block.rs
@@ -1,9 +1,5 @@
-// Standard lints
 // Disabled due to warnings in criterion macros
-//#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![forbid(unsafe_code)]
+#![allow(missing_docs)]
 
 use std::io::Cursor;
 

--- a/zebra-chain/benches/redpallas.rs
+++ b/zebra-chain/benches/redpallas.rs
@@ -1,6 +1,7 @@
 //! Benchmarks for batch verifiication of RedPallas signatures.
 
-use std::convert::TryFrom;
+// Disabled due to warnings in criterion macros
+#![allow(missing_docs)]
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use rand::{thread_rng, Rng};

--- a/zebra-chain/build.rs
+++ b/zebra-chain/build.rs
@@ -1,3 +1,8 @@
+//! Build script for zebra-chain.
+//!
+//! Turns the environmental variable `$TEST_FAKE_ACTIVATION_HEIGHTS`
+//! into the Rust configuration `cfg(test_fake_activation_heights)`.
+
 use std::env;
 
 fn main() {

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -6,12 +6,6 @@
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_chain")]
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![deny(rust_2021_compatibility)]
-#![forbid(unsafe_code)]
 // Required by bitvec! macro
 #![recursion_limit = "256"]
 

--- a/zebra-client/src/lib.rs
+++ b/zebra-client/src/lib.rs
@@ -3,9 +3,3 @@
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_client")]
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![deny(rust_2021_compatibility)]
-#![forbid(unsafe_code)]

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -33,13 +33,6 @@
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_consensus")]
-// Standard lints
-// Warn on missing docs for all modules after cleaning the API surface
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![deny(rust_2021_compatibility)]
-#![forbid(unsafe_code)]
 
 mod block;
 mod checkpoint;

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -119,12 +119,6 @@
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_network")]
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![deny(rust_2021_compatibility)]
-#![forbid(unsafe_code)]
 
 #[macro_use]
 extern crate pin_project;

--- a/zebra-rpc/src/lib.rs
+++ b/zebra-rpc/src/lib.rs
@@ -3,9 +3,3 @@
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_rpc")]
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![deny(rust_2021_compatibility)]
-#![forbid(unsafe_code)]

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -2,14 +2,10 @@
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_script")]
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![deny(rust_2021_compatibility)]
-// we allow unsafe code, so we can call zcash_script
+// We allow unsafe code, so we can call zcash_script
+#![allow(unsafe_code)]
 
-use std::{convert::TryInto, sync::Arc};
+use std::sync::Arc;
 
 use displaydoc::Display;
 use thiserror::Error;

--- a/zebra-state/build.rs
+++ b/zebra-state/build.rs
@@ -1,3 +1,8 @@
+//! Build script for zebra-state.
+//!
+//! Turns the environmental variable `$TEST_FAKE_ACTIVATION_HEIGHTS`
+//! into the Rust configuration `cfg(test_fake_activation_heights)`.
+
 use std::env;
 
 fn main() {

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -11,12 +11,6 @@
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_state")]
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![deny(rust_2021_compatibility)]
-#![forbid(unsafe_code)]
 
 #[cfg(any(test, feature = "proptest-impl"))]
 mod arbitrary;

--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -1,9 +1,3 @@
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![forbid(unsafe_code)]
-
 use color_eyre::eyre::Report;
 use once_cell::sync::Lazy;
 use std::sync::Arc;

--- a/zebra-test/src/lib.rs
+++ b/zebra-test/src/lib.rs
@@ -2,12 +2,6 @@
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_test")]
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![deny(rust_2021_compatibility)]
-#![forbid(unsafe_code)]
 // Each lazy_static variable uses additional recursion
 #![recursion_limit = "512"]
 

--- a/zebra-test/src/service_extensions.rs
+++ b/zebra-test/src/service_extensions.rs
@@ -8,12 +8,15 @@ use tower::{Service, ServiceExt};
 /// An extension trait to check if a [`Service`] is immediately ready to be called.
 pub trait IsReady<Request>: Service<Request> {
     /// Poll the [`Service`] once, and return true if it is immediately ready to be called.
+    #[allow(clippy::wrong_self_convention)]
     fn is_ready(&mut self) -> BoxFuture<bool>;
 
     /// Poll the [`Service`] once, and return true if it is pending.
+    #[allow(clippy::wrong_self_convention)]
     fn is_pending(&mut self) -> BoxFuture<bool>;
 
     /// Poll the [`Service`] once, and return true if it has failed.
+    #[allow(clippy::wrong_self_convention)]
     fn is_failed(&mut self) -> BoxFuture<bool>;
 }
 

--- a/zebra-test/tests/command.rs
+++ b/zebra-test/tests/command.rs
@@ -1,9 +1,3 @@
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![forbid(unsafe_code)]
-
 use std::{process::Command, time::Duration};
 
 use color_eyre::eyre::Result;

--- a/zebra-test/tests/transcript.rs
+++ b/zebra-test/tests/transcript.rs
@@ -1,9 +1,3 @@
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![forbid(unsafe_code)]
-
 use tower::{Service, ServiceExt};
 use zebra_test::transcript::ExpectedTranscriptError;
 use zebra_test::transcript::Transcript;

--- a/zebra-utils/src/bin/zebra-checkpoints/main.rs
+++ b/zebra-utils/src/bin/zebra-checkpoints/main.rs
@@ -8,12 +8,6 @@
 //! zebra-consensus accepts an ordered list of checkpoints, starting with the
 //! genesis block. Checkpoint heights can be chosen arbitrarily.
 
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![forbid(unsafe_code)]
-
 use color_eyre::eyre::{ensure, Result};
 use serde_json::Value;
 use std::process::Stdio;

--- a/zebra-utils/src/lib.rs
+++ b/zebra-utils/src/lib.rs
@@ -4,9 +4,3 @@
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_utils")]
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![deny(rust_2021_compatibility)]
-#![forbid(unsafe_code)]

--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -1,3 +1,8 @@
+//! Build script for zebrad.
+//!
+//! Turns Zebra version information into build-time environmental variables,
+//! so that it can be compiled into `zebrad`, and used in diagnostics.
+
 use vergen::{vergen, Config, SemverKind, ShaKind};
 
 /// Disable vergen env vars that could cause spurious reproducible build

--- a/zebrad/src/bin/zebrad/main.rs
+++ b/zebrad/src/bin/zebrad/main.rs
@@ -1,11 +1,5 @@
 //! Main entry point for Zebrad
 
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![forbid(unsafe_code)]
-
 use zebrad::application::APPLICATION;
 
 /// Boot Zebrad

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -17,12 +17,6 @@
 #![doc(html_favicon_url = "https://www.zfnd.org/images/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebrad")]
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![deny(rust_2021_compatibility)]
-#![forbid(unsafe_code)]
 // Tracing causes false positives on this lint:
 // https://github.com/tokio-rs/tracing/issues/553
 #![allow(clippy::cognitive_complexity)]

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -21,12 +21,6 @@
 //! or you have poor network connectivity,
 //! skip all the network tests by setting the `ZEBRA_SKIP_NETWORK_TESTS` environmental variable.
 
-// Standard lints
-#![warn(missing_docs)]
-#![allow(clippy::try_err)]
-#![deny(clippy::await_holding_lock)]
-#![forbid(unsafe_code)]
-
 use color_eyre::{
     eyre::{Result, WrapErr},
     Help,


### PR DESCRIPTION
## Motivation

In PR #3332, we added a Rust 2021 lint to Zebra's library crates. But we forgot to lint acceptance tests, examples, build scripts, and binaries. (These are technically separate crates.)

It would be much easier if we just had all of Zebra's standard lints in one place.

### Specifications

We use cargo's hierarchical config structure to apply the lints to every crate:
https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure

This is similar to Embark Studio's lint configuration:
https://github.com/EmbarkStudios/rust-ecosystem/issues/59
https://github.com/EmbarkStudios/rust-ecosystem/blob/main/lints.toml

## Solution

- move Zebra's standard lints to `zebra/.cargo/config.toml`
- fix up some minor issues detected by the new lints
- add some future incompatibility lints related to Rust 2021
- ignore a lint that was just added in nightly and beta Rust

## Review

@dconnolly or anyone else can review this PR.

It should be merged before #3377 by @gustavovalverde, because it changes the paths that are used for lint CI.

### Reviewer Checklist

  - [ ] CI passes
  - [ ] Lint changes make sense

## Follow Up Work

Add more lints over time.
