### PR TITLE
Make the zcash_script versions match in Cargo.lock and Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "zcash_script"
 version = "0.1.6-alpha.0"
-source = "git+https://github.com/ZcashFoundation/zcash_script.git?rev=70738fc9b143c2a23df7c138c87c95b398273402#70738fc9b143c2a23df7c138c87c95b398273402"
+source = "git+https://github.com/ZcashFoundation/zcash_script.git?rev=270d32d192c5880f911acf21ef100caa128e6179#270d32d192c5880f911acf21ef100caa128e6179"
 dependencies = [
  "bindgen",
  "blake2b_simd",


### PR DESCRIPTION
## Motivation

In PR #3363, we changed the `zcash_script` version in Cargo.toml, but we didn't update Cargo.lock.

This dependency bug should have been caught by the Cargo.lock CI check:
https://github.com/ZcashFoundation/zebra/blob/ebd94b2e60c01f74042db4a5899b294659d5f207/.github/workflows/ci.yml#L305-L310

## Review

@oxarbitrage can review this PR.

### Reviewer Checklist

  - [x] Versions match

## Follow Up Work

- [ ] Re-enable the up-to-date Cargo.lock CI check