### PR TITLE
Increase cloud build timeout to 60 mins

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,4 +22,4 @@ options:
     machineType: 'N1_HIGHCPU_32'
     substitution_option: 'ALLOW_LOOSE'
 
-timeout: 1800s # 30 mins
+timeout: 3600s # 60 mins


### PR DESCRIPTION
## Motivation

We're having multiple timeouts in the cloud build while downloading the Zcash parameters. Ideally we should cache them but meanwhile we can try increasing the timeout.

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
