### PR TITLE
fix (zebra-chain): make test and bench targets build using 2021 edition

### DIFF
--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -81,11 +81,14 @@ proptest-derive = "0.3"
 rand = "0.8"
 rand_chacha = "0.3"
 
+tokio = "1.15.0"
+
 zebra-test = { path = "../zebra-test/" }
 
 [[bench]]
 name = "block"
 harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "redpallas"


### PR DESCRIPTION
## Motivation

The 2021 edition activates the v2 cargo resolver.

This broke implicit feature resolution, but only when `zebra-chain`'s dev or bench targets were compiled by themselves.

## Solution

- add the correct dependencies for these targets

## Review

@dconnolly did the 2021 edition upgrade, but anyone can review this PR.

### Reviewer Checklist

  - [ ] `cargo build --package zebra-chain --all-targets` works

## Follow Up Work

Add CI to stop this happening again:
- #1364
