### PR TITLE
fix (actions): add duplicated workflows with path-ignore

### DIFF
--- a/.github/workflows/ci.patch.yml
+++ b/.github/workflows/ci.patch.yml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  pull_request:
+    path-ignore:
+      - '**/*.rs'
+      - '**/*.txt'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '**/deny.toml'
+      - 'docker/**'
+      - '.github/workflows/ci.yml'
+
+jobs:
+  test:
+    name: Test (+${{ matrix.rust }}) on ${{ matrix.os }}
+    # The large timeout is to accommodate:
+    # - Windows builds (75 minutes, typically 30-50 minutes)
+    # - parameter downloads (40 minutes, but only when the cache expires)
+    timeout-minutes: 115
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        rust: [stable]
+
+    steps:
+      - run: 'echo "No build required"'
+
+  test-fake-activation-heights:
+    name: Build (+${{ matrix.rust }}) zebra-state with fake activation heights on ubuntu-latest
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable]
+
+    steps:
+      - run: 'echo "No build required"'
+
+  build-chain-no-features:
+    name: Build (+${{ matrix.rust }}) zebra-chain w/o features on ubuntu-latest
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, beta]
+
+    steps:
+      - run: 'echo "No build required"'
+
+  build:
+    name: Build (+stable) on ubuntu-latest
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: 'echo "No build required"'
+
+  cargo-deny:
+    name: Check deny.toml crate dependencies and validate licenses
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - bans 
+          - sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/coverage.patch.yml
+++ b/.github/workflows/coverage.patch.yml
@@ -1,0 +1,24 @@
+name: Coverage
+
+on:
+  workflow_dispatch:
+  pull_request:
+    path-ignore:
+      - '**/*.rs'
+      - '**/*.txt'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'codecov.yml'
+      - '.github/workflows/coverage.yml'
+
+jobs:
+  coverage:
+    name: Coverage (+nightly)
+    # The large timeout is to accommodate:
+    # - nightly builds (75 minutes, typically 30-50 minutes)
+    # - parameter downloads (40 minutes, but only when the cache expires)
+    timeout-minutes: 115
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/docs.patch.yml
+++ b/.github/workflows/docs.patch.yml
@@ -1,0 +1,21 @@
+name: Docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    path-ignore:
+      - 'book/**'
+      - '**/firebase.json'
+      - 'katex-header.html'
+      - '.github/workflows/docs.yml'
+
+jobs:
+  build:
+    name: Build and Deploy Docs (+beta)
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/lint.patch.yml
+++ b/.github/workflows/lint.patch.yml
@@ -1,0 +1,27 @@
+name: Lint Rust files
+
+on:
+  push:
+    branches:
+      - "**"
+      - "!main"
+    path-ignore:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'clippy.toml'
+      - '.cargo/config.toml'
+      - '.github/workflows/lint.yml'
+
+jobs:
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/test.patch.yml
+++ b/.github/workflows/test.patch.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    path-ignore:
+      - '**/*.rs'
+      - '**/*.txt'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'docker/**'
+      - '.github/workflows/test.yml'
+
+jobs:
+  test:
+    name: Run all tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: 'echo "No build required"'


### PR DESCRIPTION
## Motivation

GitHub does not support skipped but required checks by default, this is an official workaround to allow this feature; which requires duplicating the same workflow using path-ignore and just executing a step that will always pass, for each job.

Reference: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks

## Review
@teor2345 

### Reviewer Checklist

  - [ ] New checks should pass

## Follow Up Work

Find a better way to do this.