### PR TITLE
Bump cd workflow timeout to 60 mins

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
 
   build:
     name: Build images
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->


We bumped the cloudbuild.yml timeout to 60 mins, but the cd.yml workflow times out sooner than 60 mins.



## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Bump workflow timeout to 60 mins

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

@gustavovalverde @conradoplg 

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
