### PR TITLE
fix(network): Add a send timeout to outbound peer messages

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -43,7 +43,8 @@ pub const OUTBOUND_PEER_BIAS_DENOMINATOR: usize = 2;
 /// buffer adds up to 6 seconds worth of blocks to the queue.
 pub const PEERSET_BUFFER_SIZE: usize = 3;
 
-/// The timeout for requests made to a remote peer.
+/// The timeout for sending a message to a remote peer,
+/// and receiving a response from a remote peer.
 pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// The timeout for handshakes when connecting to new peers.

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -728,7 +728,7 @@ where
                         }
                         Either::Left((Either::Right(_), _peer_fut)) => {
                             trace!(parent: &span, "client request timed out");
-                            let e = PeerError::ClientReceiveTimeout;
+                            let e = PeerError::ConnectionReceiveTimeout;
 
                             // Replace the state with a temporary value,
                             // so we can take ownership of the response sender.

--- a/zebra-network/src/peer/connection/peer_tx.rs
+++ b/zebra-network/src/peer/connection/peer_tx.rs
@@ -25,7 +25,7 @@ where
     pub async fn send(&mut self, msg: Message) -> Result<(), PeerError> {
         tokio::time::timeout(REQUEST_TIMEOUT, self.inner.send(msg))
             .await
-            .map_err(|_| PeerError::ClientSendTimeout)?
+            .map_err(|_| PeerError::ConnectionSendTimeout)?
             .map_err(Into::into)
     }
 }

--- a/zebra-network/src/peer/connection/peer_tx.rs
+++ b/zebra-network/src/peer/connection/peer_tx.rs
@@ -1,0 +1,37 @@
+//! The peer message sender channel.
+
+use futures::{Sink, SinkExt};
+
+use zebra_chain::serialization::SerializationError;
+
+use crate::{constants::REQUEST_TIMEOUT, protocol::external::Message, PeerError};
+
+/// A wrapper type for a peer connection message sender.
+///
+/// Used to apply a timeout to send messages.
+#[derive(Clone, Debug)]
+pub struct PeerTx<Tx> {
+    /// A channel for sending Zcash messages to the connected peer.
+    ///
+    /// This channel accepts [`Message`]s.
+    inner: Tx,
+}
+
+impl<Tx> PeerTx<Tx>
+where
+    Tx: Sink<Message, Error = SerializationError> + Unpin,
+{
+    /// Sends `msg` on `self.inner`, returning a timeout error if it takes too long.
+    pub async fn send(&mut self, msg: Message) -> Result<(), PeerError> {
+        tokio::time::timeout(REQUEST_TIMEOUT, self.inner.send(msg))
+            .await
+            .map_err(|_| PeerError::ClientSendTimeout)?
+            .map_err(Into::into)
+    }
+}
+
+impl<Tx> From<Tx> for PeerTx<Tx> {
+    fn from(tx: Tx) -> Self {
+        PeerTx { inner: tx }
+    }
+}

--- a/zebra-network/src/peer/connection/tests.rs
+++ b/zebra-network/src/peer/connection/tests.rs
@@ -8,9 +8,7 @@ use zebra_chain::serialization::SerializationError;
 use zebra_test::mock_service::MockService;
 
 use crate::{
-    peer::{
-        client::ClientRequestReceiver, connection::State, ClientRequest, Connection, ErrorSlot,
-    },
+    peer::{ClientRequest, ConnectedAddr, Connection, ErrorSlot},
     peer_set::ActiveConnectionCounter,
     protocol::external::Message,
     Request, Response,
@@ -44,18 +42,14 @@ fn new_test_connection<A>() -> (
     };
     let peer_tx = peer_outbound_tx.sink_map_err(error_converter);
 
-    let connection = Connection {
-        state: State::AwaitingRequest,
-        request_timer: None,
-        cached_addrs: Vec::new(),
-        svc: mock_inbound_service.clone(),
-        client_rx: ClientRequestReceiver::from(client_rx),
-        error_slot: shared_error_slot.clone(),
+    let connection = Connection::new(
+        mock_inbound_service.clone(),
+        client_rx,
+        shared_error_slot.clone(),
         peer_tx,
-        connection_tracker: ActiveConnectionCounter::new_counter().track_connection(),
-        metrics_label: "test".to_string(),
-        last_metrics_state: None,
-    };
+        ActiveConnectionCounter::new_counter().track_connection(),
+        ConnectedAddr::Isolated,
+    );
 
     (
         connection,

--- a/zebra-network/src/peer/connection/tests/prop.rs
+++ b/zebra-network/src/peer/connection/tests/prop.rs
@@ -114,11 +114,11 @@ proptest! {
 fn new_test_connection() -> (
     Connection<
         MockService<Request, Response, PropTestAssertion>,
-        SinkMapErr<mpsc::UnboundedSender<Message>, fn(mpsc::SendError) -> SerializationError>,
+        SinkMapErr<mpsc::Sender<Message>, fn(mpsc::SendError) -> SerializationError>,
     >,
     mpsc::Sender<ClientRequest>,
     MockService<Request, Response, PropTestAssertion>,
-    mpsc::UnboundedReceiver<Message>,
+    mpsc::Receiver<Message>,
     ErrorSlot,
 ) {
     super::new_test_connection()
@@ -127,7 +127,7 @@ fn new_test_connection() -> (
 async fn send_block_request(
     block: block::Hash,
     client_requests: &mut mpsc::Sender<ClientRequest>,
-    outbound_messages: &mut mpsc::UnboundedReceiver<Message>,
+    outbound_messages: &mut mpsc::Receiver<Message>,
 ) -> oneshot::Receiver<Result<Response, SharedPeerError>> {
     let (response_sender, response_receiver) = oneshot::channel();
 

--- a/zebra-network/src/peer/connection/tests/vectors.rs
+++ b/zebra-network/src/peer/connection/tests/vectors.rs
@@ -247,7 +247,7 @@ async fn connection_run_loop_failed() {
     // Simulate an internal connection error.
     connection.state = State::Failed;
     shared_error_slot
-        .try_update_error(PeerError::ClientRequestTimeout.into())
+        .try_update_error(PeerError::ClientReceiveTimeout.into())
         .expect("unexpected previous error in tests");
 
     let connection = connection.run(peer_inbound_rx);

--- a/zebra-network/src/peer/connection/tests/vectors.rs
+++ b/zebra-network/src/peer/connection/tests/vectors.rs
@@ -26,6 +26,7 @@ use crate::{
     PeerError, Request, Response,
 };
 
+/// Test that the connection run loop works as a future
 #[tokio::test]
 async fn connection_run_loop_ok() {
     zebra_test::init();
@@ -62,6 +63,7 @@ async fn connection_run_loop_ok() {
     assert_eq!(outbound_message, None);
 }
 
+/// Test that the connection run loop works as a spawned task
 #[tokio::test]
 async fn connection_run_loop_spawn_ok() {
     zebra_test::init();
@@ -103,6 +105,7 @@ async fn connection_run_loop_spawn_ok() {
     assert_eq!(outbound_message, None);
 }
 
+/// Test that the connection run loop works as a spawned task with messages in and out
 #[tokio::test]
 async fn connection_run_loop_message_ok() {
     zebra_test::init();
@@ -180,6 +183,7 @@ async fn connection_run_loop_message_ok() {
     assert_eq!(outbound_message, None);
 }
 
+/// Test that the connection run loop fails correctly when dropped
 #[tokio::test]
 async fn connection_run_loop_future_drop() {
     zebra_test::init();
@@ -212,6 +216,7 @@ async fn connection_run_loop_future_drop() {
     assert_eq!(outbound_message, None);
 }
 
+/// Test that the connection run loop fails correctly when the internal client closes the connection channel
 #[tokio::test]
 async fn connection_run_loop_client_close() {
     zebra_test::init();
@@ -256,6 +261,7 @@ async fn connection_run_loop_client_close() {
     assert_eq!(outbound_message, None);
 }
 
+/// Test that the connection run loop fails correctly when the internal client drops the connection channel
 #[tokio::test]
 async fn connection_run_loop_client_drop() {
     zebra_test::init();
@@ -294,6 +300,8 @@ async fn connection_run_loop_client_drop() {
     assert_eq!(outbound_message, None);
 }
 
+/// Test that the connection run loop fails correctly when the peer channel is closed.
+/// (We're not sure if tokio closes or drops the TcpStream when the TCP connection closes.)
 #[tokio::test]
 async fn connection_run_loop_inbound_close() {
     zebra_test::init();
@@ -333,6 +341,8 @@ async fn connection_run_loop_inbound_close() {
     assert_eq!(outbound_message, None);
 }
 
+/// Test that the connection run loop fails correctly when the peer channel is dropped
+/// (We're not sure if tokio closes or drops the TcpStream when the TCP connection closes.)
 #[tokio::test]
 async fn connection_run_loop_inbound_drop() {
     zebra_test::init();
@@ -371,6 +381,7 @@ async fn connection_run_loop_inbound_drop() {
     assert_eq!(outbound_message, None);
 }
 
+/// Test that the connection run loop fails correctly on internal connection errors.
 #[tokio::test]
 async fn connection_run_loop_failed() {
     zebra_test::init();
@@ -420,6 +431,8 @@ async fn connection_run_loop_failed() {
     assert_eq!(outbound_message, None);
 }
 
+/// Test that the connection run loop fails correctly when sending a message to a peer times out,
+/// but we are not expecting a response message from the peer.
 #[tokio::test]
 async fn connection_run_loop_send_timeout_nil_response() {
     zebra_test::init();
@@ -491,6 +504,8 @@ async fn connection_run_loop_send_timeout_nil_response() {
     assert_eq!(outbound_message, None);
 }
 
+/// Test that the connection run loop fails correctly when sending a message to a peer times out,
+/// and we are expecting a response message from the peer.
 #[tokio::test]
 async fn connection_run_loop_send_timeout_expect_response() {
     zebra_test::init();
@@ -562,6 +577,8 @@ async fn connection_run_loop_send_timeout_expect_response() {
     assert_eq!(outbound_message, None);
 }
 
+/// Test that the connection run loop continues but returns an error to the client,
+/// when a peer accepts a message, but does not send an expected response.
 #[tokio::test]
 async fn connection_run_loop_receive_timeout() {
     zebra_test::init();

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -60,11 +60,11 @@ pub enum PeerError {
 
     /// Sending a message to a remote peer took too long.
     #[error("Sending Client request timed out")]
-    ClientSendTimeout,
+    ConnectionSendTimeout,
 
     /// Receiving a response to a [`peer::Client`] request took too long.
     #[error("Receiving client response timed out")]
-    ClientReceiveTimeout,
+    ConnectionReceiveTimeout,
 
     /// A serialization error occurred while reading or writing a message.
     #[error("Serialization error: {0}")]
@@ -95,8 +95,8 @@ impl PeerError {
             PeerError::ClientCancelledHeartbeatTask => "ClientCancelledHeartbeatTask".into(),
             PeerError::HeartbeatTaskExited => "HeartbeatTaskExited".into(),
             PeerError::ConnectionTaskExited => "ConnectionTaskExited".into(),
-            PeerError::ClientSendTimeout => "ClientSendTimeout".into(),
-            PeerError::ClientReceiveTimeout => "ClientReceiveTimeout".into(),
+            PeerError::ConnectionSendTimeout => "ConnectionSendTimeout".into(),
+            PeerError::ConnectionReceiveTimeout => "ConnectionReceiveTimeout".into(),
             // TODO: add error kinds or summaries to `SerializationError`
             PeerError::Serialization(inner) => format!("Serialization({})", inner).into(),
             PeerError::DuplicateHandshake => "DuplicateHandshake".into(),

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -21,6 +21,15 @@ where
     }
 }
 
+impl SharedPeerError {
+    /// Returns a debug-formatted string describing the inner [`PeerError`].
+    ///
+    /// Unfortunately, [`TracedError`] makes it impossible to get a reference to the original error.
+    pub fn inner_debug(&self) -> String {
+        format!("{:?}", self.0.as_ref())
+    }
+}
+
 /// An error related to peer connection handling.
 #[derive(Error, Debug)]
 #[allow(dead_code)]

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -49,9 +49,13 @@ pub enum PeerError {
     #[error("Internal heartbeat task exited")]
     HeartbeatTaskExited,
 
-    /// The remote peer did not respond to a [`peer::Client`] request in time.
-    #[error("Client request timed out")]
-    ClientRequestTimeout,
+    /// Sending a message to a remote peer took too long.
+    #[error("Sending Client request timed out")]
+    ClientSendTimeout,
+
+    /// Receiving a response to a [`peer::Client`] request took too long.
+    #[error("Receiving client response timed out")]
+    ClientReceiveTimeout,
 
     /// A serialization error occurred while reading or writing a message.
     #[error("Serialization error: {0}")]
@@ -82,7 +86,8 @@ impl PeerError {
             PeerError::ClientCancelledHeartbeatTask => "ClientCancelledHeartbeatTask".into(),
             PeerError::HeartbeatTaskExited => "HeartbeatTaskExited".into(),
             PeerError::ConnectionTaskExited => "ConnectionTaskExited".into(),
-            PeerError::ClientRequestTimeout => "ClientRequestTimeout".into(),
+            PeerError::ClientSendTimeout => "ClientSendTimeout".into(),
+            PeerError::ClientReceiveTimeout => "ClientReceiveTimeout".into(),
             // TODO: add error kinds or summaries to `SerializationError`
             PeerError::Serialization(inner) => format!("Serialization({})", inner).into(),
             PeerError::DuplicateHandshake => "DuplicateHandshake".into(),

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -958,19 +958,14 @@ where
                 })
                 .boxed();
 
-            use super::connection;
-            let server = Connection {
-                state: connection::State::AwaitingRequest,
-                request_timer: None,
-                cached_addrs: Vec::new(),
-                svc: inbound_service,
-                client_rx: server_rx.into(),
-                error_slot: error_slot.clone(),
+            let server = Connection::new(
+                inbound_service,
+                server_rx,
+                error_slot.clone(),
                 peer_tx,
                 connection_tracker,
-                metrics_label: connected_addr.get_transient_addr_label(),
-                last_metrics_state: None,
-            };
+                connected_addr,
+            );
 
             let connection_task = tokio::spawn(
                 server


### PR DESCRIPTION
## Motivation

Zebra doesn't impose a timeout when sending messages to the remote peer. (It only has one when receiving them.)

So at the moment, we're relying on the 2 minute disconnection timeout from the OS TCP stack, and Zebra's internal 2 minute peer service disconnection timeout. (If they actually work, which we haven't tested.)

## Solution

Production Code:
- wrap the peer message sender in a type that adds a timeout
- add a `Connection::new` method

Tests:
- use bounded fake peer connection channels in the connection tests, so we can actually trigger send timeouts 
- test peer send and receive timeouts 
- check for specific error types in all the connection test vectors
- add docs to all the connection test vectors

Closes #3234
Closes #3233 
Closes #3232

## Review

@oxarbitrage can review this PR, he is familiar with ticket #3234.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
