### PR TITLE
feat(log): log the state tip height as part of sync progress logs

### DIFF
--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -24,7 +24,7 @@ use futures::{FutureExt, TryFutureExt};
 use thiserror::Error;
 use tokio::task::{spawn_blocking, JoinHandle};
 use tower::{buffer::Buffer, util::BoxService, Service, ServiceExt};
-use tracing::instrument;
+use tracing::{instrument, Span};
 
 use zebra_chain::{
     block::{self, Block},
@@ -215,13 +215,16 @@ where
 
     // The parameter download thread must be launched before initializing any verifiers.
     // Otherwise, the download might happen on the startup thread.
+    let span = Span::current();
     let groth16_download_handle = spawn_blocking(move || {
-        if !debug_skip_parameter_preload {
-            // The lazy static initializer does the download, if needed,
-            // and the file hash checks.
-            lazy_static::initialize(&crate::groth16::GROTH16_PARAMETERS);
-            tracing::info!("Groth16 pre-download and check task finished");
-        }
+        span.in_scope(|| {
+            if !debug_skip_parameter_preload {
+                // The lazy static initializer does the download, if needed,
+                // and the file hash checks.
+                lazy_static::initialize(&crate::groth16::GROTH16_PARAMETERS);
+                tracing::info!("Groth16 pre-download and check task finished");
+            }
+        })
     });
 
     // transaction verification

--- a/zebra-network/src/address_book_updater.rs
+++ b/zebra-network/src/address_book_updater.rs
@@ -7,6 +7,7 @@ use tokio::{
     sync::{mpsc, watch},
     task::JoinHandle,
 };
+use tracing::Span;
 
 use crate::{
     address_book::AddressMetrics, meta_addr::MetaAddrChange, AddressBook, BoxError, Config,
@@ -54,25 +55,28 @@ impl AddressBookUpdater {
         let address_book = Arc::new(std::sync::Mutex::new(address_book));
 
         let worker_address_book = address_book.clone();
+        let span = Span::current();
         let worker = move || {
-            info!("starting the address book updater");
+            span.in_scope(|| {
+                info!("starting the address book updater");
 
-            while let Some(event) = worker_rx.blocking_recv() {
-                trace!(?event, "got address book change");
+                while let Some(event) = worker_rx.blocking_recv() {
+                    trace!(?event, "got address book change");
 
-                // # Correctness
-                //
-                // Briefly hold the address book threaded mutex, to update the
-                // state for a single address.
-                worker_address_book
-                    .lock()
-                    .expect("mutex should be unpoisoned")
-                    .update(event);
-            }
+                    // # Correctness
+                    //
+                    // Briefly hold the address book threaded mutex, to update the
+                    // state for a single address.
+                    worker_address_book
+                        .lock()
+                        .expect("mutex should be unpoisoned")
+                        .update(event);
+                }
 
-            let error = Err(AllAddressBookUpdaterSendersClosed.into());
-            info!(?error, "stopping address book updater");
-            error
+                let error = Err(AllAddressBookUpdaterSendersClosed.into());
+                info!(?error, "stopping address book updater");
+                error
+            })
         };
 
         // Correctness: spawn address book accesses on a blocking thread,

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -682,7 +682,7 @@ impl Service<Request> for StateService {
                 .checked_sub(new_len)
                 .expect("prune does not add any utxo requests");
             if prune_count > 0 {
-                tracing::info!(
+                tracing::debug!(
                     ?old_len,
                     ?new_len,
                     ?prune_count,

--- a/zebra-state/src/util.rs
+++ b/zebra-state/src/util.rs
@@ -18,7 +18,7 @@ pub fn block_locator_heights(tip_height: block::Height) -> Vec<block::Height> {
         .map(block::Height);
 
     let locators = locators.collect();
-    tracing::info!(
+    tracing::debug!(
         ?tip_height,
         ?min_locator_height,
         ?locators,

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -275,45 +275,49 @@ where
                 })
                 .unwrap_or(block::Height(0));
 
-            if let Some(block_height) = block.coinbase_height() {
-                if block_height > max_lookahead_height {
-                    debug!(
-                        ?hash,
-                        ?block_height,
-                        ?tip_height,
-                        ?max_lookahead_height,
-                        lookahead_limit = ?MAX_INBOUND_CONCURRENCY,
-                        "gossiped block height too far ahead of the tip: dropped downloaded block"
-                    );
-                    metrics::counter!("gossip.max.height.limit.dropped.block.count", 1);
-
-                    Err("gossiped block height too far ahead")?;
-                } else if block_height < min_accepted_height {
-                    debug!(
-                        ?hash,
-                        ?block_height,
-                        ?tip_height,
-                        ?min_accepted_height,
-                        behind_tip_limit = ?zs::MAX_BLOCK_REORG_HEIGHT,
-                        "gossiped block height behind the finalized tip: dropped downloaded block"
-                    );
-                    metrics::counter!("gossip.min.height.limit.dropped.block.count", 1);
-
-                    Err("gossiped block height behind the finalized tip")?;
-                }
-            } else {
+            let block_height = block.coinbase_height().ok_or_else(|| {
                 debug!(
                     ?hash,
                     "gossiped block with no height: dropped downloaded block"
                 );
                 metrics::counter!("gossip.no.height.dropped.block.count", 1);
 
-                Err("gossiped block with no height")?;
+                BoxError::from("gossiped block with no height")
+            })?;
+
+            if block_height > max_lookahead_height {
+                debug!(
+                    ?hash,
+                    ?block_height,
+                    ?tip_height,
+                    ?max_lookahead_height,
+                    lookahead_limit = ?MAX_INBOUND_CONCURRENCY,
+                    "gossiped block height too far ahead of the tip: dropped downloaded block"
+                );
+                metrics::counter!("gossip.max.height.limit.dropped.block.count", 1);
+
+                Err("gossiped block height too far ahead")?;
+            } else if block_height < min_accepted_height {
+                debug!(
+                    ?hash,
+                    ?block_height,
+                    ?tip_height,
+                    ?min_accepted_height,
+                    behind_tip_limit = ?zs::MAX_BLOCK_REORG_HEIGHT,
+                    "gossiped block height behind the finalized tip: dropped downloaded block"
+                );
+                metrics::counter!("gossip.min.height.limit.dropped.block.count", 1);
+
+                Err("gossiped block height behind the finalized tip")?;
             }
 
-            verifier.oneshot(block).await
+            verifier
+                .oneshot(block)
+                .await
+                .map(|hash| (hash, block_height))
         }
-        .map_ok(|hash| {
+        .map_ok(|(hash, height)| {
+            info!(?height, "downloaded and verified gossiped block");
             metrics::counter!("gossip.verified.block.count", 1);
             hash
         })

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -52,6 +52,7 @@ use std::{collections::HashSet, time::Duration};
 use futures::{future, pin_mut, stream::FuturesUnordered, StreamExt};
 use tokio::{sync::watch, task::JoinHandle, time::sleep};
 use tower::{timeout::Timeout, BoxError, Service, ServiceExt};
+use tracing_futures::Instrument;
 
 use zebra_chain::{block::Height, transaction::UnminedTxId};
 use zebra_network as zn;
@@ -129,7 +130,7 @@ where
             debug_enable_at_height: config.debug_enable_at_height.map(Height),
         };
 
-        tokio::spawn(crawler.run())
+        tokio::spawn(crawler.run().in_current_span())
     }
 
     /// Waits until the mempool crawler is enabled by a debug config option.

--- a/zebrad/src/components/mempool/queue_checker.rs
+++ b/zebrad/src/components/mempool/queue_checker.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use tokio::{task::JoinHandle, time::sleep};
 use tower::{BoxError, Service, ServiceExt};
+use tracing_futures::Instrument;
 
 use crate::components::mempool;
 
@@ -45,7 +46,7 @@ where
     pub fn spawn(mempool: Mempool) -> JoinHandle<Result<(), BoxError>> {
         let queue_checker = QueueChecker { mempool };
 
-        tokio::spawn(queue_checker.run())
+        tokio::spawn(queue_checker.run().in_current_span())
     }
 
     /// Periodically check if the mempool has newly verified transactions.


### PR DESCRIPTION
## Motivation

In PR https://github.com/ZcashFoundation/zebra/pull/3418 we remove some info-level logs that show the block height during syncing.

Cherry picked from https://github.com/oxarbitrage/zebra/pull/169

## Solution

Downgrade logs:
- downgrade some verbose state logs to debug level

Improve logs:
- add the block height to the syncer info-level logs
- spawn top-level tasks within the global Zebra tracing span
- log successful gossiped block verification at info level

The gossiped block logs will help us diagnose slow syncs near the tip.
(There won't be very many of them, because they should only happen within a few hundred blocks of the tip.)

## Review

@oxarbitrage can review this PR.

### Reviewer Checklist

  - [x] Logging changes work as expected

