### PR TITLE
fix(mergify): restrict merges with unresolved threads

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -33,6 +33,7 @@ pull_request_rules:
   - name: move to urgent queue when CI passes with 1 review and not WIP targeting main
     conditions:
       - "#approved-reviews-by>=1"
+      - "#review-threads-unresolved=0"
       - -draft
       - base=main
       - or:
@@ -47,6 +48,7 @@ pull_request_rules:
   - name: move to medium queue when CI passes with 1 review and not WIP targeting main
     conditions:
       - "#approved-reviews-by>=1"
+      - "#review-threads-unresolved=0"
       - -draft
       - base=main
       - "label~=^P-Medium"
@@ -59,6 +61,7 @@ pull_request_rules:
   - name: move to low queue when CI passes with 1 review and not WIP targeting main
     conditions:
       - "#approved-reviews-by>=1"
+      - "#review-threads-unresolved=0"
       - -draft
       - base=main
       - or:
@@ -73,6 +76,7 @@ pull_request_rules:
   - name: automatic merge for Dependabot pull requests
     conditions:
       - "#approved-reviews-by>=1"
+      - "#review-threads-unresolved=0"
       - author~=^dependabot(|-preview)\[bot\]$
       - check-success=Test (+stable) on ubuntu-latest
       - check-success=Test (+stable) on macOS-latest


### PR DESCRIPTION
## Motivation
We've had a few cases of Mergify merging reviewed PR's with unresolved comments.

## Solution
- Added `"#review-threads-unresolved=0"` to all `pull_request_rules` which will prevent merges with unresolved threads.

## Review
@dconnolly 