### PR TITLE
fix(mergify): put PRs with no priority label in the low priority queue

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -64,25 +64,13 @@ pull_request_rules:
       - "#review-threads-unresolved=0"
       - -draft
       - base=main
-      - or:
-          - "label~=^P-Low"
-          - "label~=^P-Optional"
       - label!=do-not-merge
+      # This queue handles Low, Optional, and PRs with no priority label,
+      # including automated dependabot PRs.
+      #
+      # We don't need to check priority labels here, because the rules are evaluated in order:
+      # https://docs.mergify.com/configuration/#pull-request-rules
     actions:
       queue:
         name: low
-        method: squash
-
-  - name: automatic merge for Dependabot pull requests
-    conditions:
-      - "#approved-reviews-by>=1"
-      - "#review-threads-unresolved=0"
-      - author~=^dependabot(|-preview)\[bot\]$
-      - check-success=Test (+stable) on ubuntu-latest
-      - check-success=Test (+stable) on macOS-latest
-      - check-success=Test (+stable) on windows-latest
-      - check-success=pull-request (zealous-zebra)
-      - check-success=Coverage (+nightly)
-    actions:
-      merge:
         method: squash

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -33,6 +33,7 @@ pull_request_rules:
   - name: move to urgent queue when CI passes with 1 review and not WIP targeting main
     conditions:
       - "#approved-reviews-by>=1"
+      - "#review-threads-unresolved=0"
       - -draft
       - base=main
       - or:
@@ -47,6 +48,7 @@ pull_request_rules:
   - name: move to medium queue when CI passes with 1 review and not WIP targeting main
     conditions:
       - "#approved-reviews-by>=1"
+      - "#review-threads-unresolved=0"
       - -draft
       - base=main
       - "label~=^P-Medium"
@@ -59,6 +61,7 @@ pull_request_rules:
   - name: move to low queue when CI passes with 1 review and not WIP targeting main
     conditions:
       - "#approved-reviews-by>=1"
+      - "#review-threads-unresolved=0"
       - -draft
       - base=main
       - or:
@@ -73,6 +76,7 @@ pull_request_rules:
   - name: automatic merge for Dependabot pull requests
     conditions:
       - "#approved-reviews-by>=1"
+      - "#review-threads-unresolved=0"
       - author~=^dependabot(|-preview)\[bot\]$
       - check-success=Test (+stable) on ubuntu-latest
       - check-success=Test (+stable) on macOS-latest


### PR DESCRIPTION
## Motivation

If a PRs doesn't have a priority label, it isn't getting merged by mergify.

Depends-On: #3453 

### Specifications

> The rules are evaluated in the order they are defined in `pull_request_rules`

https://docs.mergify.com/configuration/#pull-request-rules

## Solution

- make the low priority queue rule into a catch-all rule
- delete the dependabot rule, because it is very similar to the new catch-all rule

## Review

@gustavovalverde should review this PR.

This PR is based on PR #3453, so it might need a rebase when that PR merges.

### Reviewer Checklist

  - [ ] Rules work as expected

