### PR TITLE
fix(network): increase state concurrency and syncer lookahead

### DIFF
--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -36,7 +36,8 @@ use super::{
     sync::{BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT},
 };
 
-mod downloads;
+pub(crate) mod downloads;
+
 #[cfg(test)]
 mod tests;
 

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -1,3 +1,5 @@
+//! A download stream that handles gossiped blocks from peers.
+
 use std::{
     collections::HashMap,
     convert::TryFrom,
@@ -47,7 +49,7 @@ type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// Since Zebra keeps an `inv` index, inbound downloads for malicious blocks
 /// will be directed to the malicious node that originally gossiped the hash.
 /// Therefore, this attack can be carried out by a single malicious node.
-const MAX_INBOUND_CONCURRENCY: usize = 20;
+pub const MAX_INBOUND_CONCURRENCY: usize = 20;
 
 /// The action taken in response to a peer's gossiped block hash.
 pub enum DownloadAction {

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -25,18 +25,13 @@ use zebra_chain::{
 use zebra_network as zn;
 use zebra_state as zs;
 
-use super::{DEFAULT_LOOKAHEAD_LIMIT, MAX_TIPS_RESPONSE_HASH_COUNT};
-
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-/// A divisor used to calculate the extra number of blocks we allow in the
+/// A multiplier used to calculate the extra number of blocks we allow in the
 /// verifier and state pipelines, on top of the lookahead limit.
 ///
 /// The extra number of blocks is calculated using
-/// `lookahead_limit / VERIFICATION_PIPELINE_SCALING_DIVISOR`.
-///
-/// For the default lookahead limit, the extra number of blocks is
-/// `4 * MAX_TIPS_RESPONSE_HASH_COUNT`.
+/// `lookahead_limit * VERIFICATION_PIPELINE_SCALING_MULTIPLIER`.
 ///
 /// This allows the verifier and state queues to hold a few extra tips responses worth of blocks,
 /// even if the syncer queue is full. Any unused capacity is shared between both queues.
@@ -48,8 +43,7 @@ type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// the rest of the capacity is reserved for the other queues.
 /// There is no reserved capacity for the syncer queue:
 /// if the other queues stay full, the syncer will eventually time out and reset.
-const VERIFICATION_PIPELINE_SCALING_DIVISOR: usize =
-    DEFAULT_LOOKAHEAD_LIMIT / (4 * MAX_TIPS_RESPONSE_HASH_COUNT);
+const VERIFICATION_PIPELINE_SCALING_MULTIPLIER: usize = 2;
 
 #[derive(Copy, Clone, Debug)]
 pub(super) struct AlwaysHedge;
@@ -282,7 +276,7 @@ where
                     // Scale the height limit with the lookahead limit,
                     // so users with low capacity or under DoS can reduce them both.
                     let lookahead = i32::try_from(
-                        lookahead_limit + lookahead_limit / VERIFICATION_PIPELINE_SCALING_DIVISOR,
+                        lookahead_limit + lookahead_limit * VERIFICATION_PIPELINE_SCALING_MULTIPLIER,
                     )
                     .expect("fits in i32");
                     (tip_height + lookahead).expect("tip is much lower than Height::MAX")


### PR DESCRIPTION
## Motivation

On my machine, the syncer can get 4000-6000 blocks ahead of the state. This causes the sync downloader to hit its lookahead limit, and return an error.

This bug happens a lot on testnet, and occasionally on mainnet.

These logs and stalls make it hard to test the other code I'm working on. (And they are a usability issue.)

## Solution

- increase the state buffer bound to the maximum of the sync, inbound, and mempool buffers
- increase the sync downloader lookahead limit to 6000 blocks by default

This is a temporary quick fix to #3438, but it doesn't close that ticket.

With these changes, my testnet instance syncs in 1 hour, and my mainnet instance syncs in 6 hours. This fix significantly reduces the number of syncer stalls on both networks.

## Review

@jvff can review this PR.

I am looking for a quick review to make sure these temporary changes don't break anything.
I expect we will make more changes when we actually schedule #3438 in a sprint.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
