### PR TITLE
docs: document consensus rules from 4.4 Spend Descriptions

### DIFF
--- a/zebra-chain/src/sapling/commitment.rs
+++ b/zebra-chain/src/sapling/commitment.rs
@@ -314,6 +314,8 @@ impl TryFrom<ValueCommitment> for NotSmallOrderValueCommitment {
     ///
     /// Returns an error if the point is of small order.
     ///
+    /// # Consensus
+    ///
     /// > cv and rk [MUST NOT be of small order][1], i.e. [h_J]cv MUST NOT be 𝒪_J
     /// > and [h_J]rk MUST NOT be 𝒪_J.
     ///

--- a/zebra-chain/src/sapling/keys.rs
+++ b/zebra-chain/src/sapling/keys.rs
@@ -1101,6 +1101,8 @@ impl TryFrom<redjubjub::VerificationKey<SpendAuth>> for ValidatingKey {
     ///
     /// Returns an error if the key is malformed or [is of small order][1].
     ///
+    /// # Consensus
+    ///
     /// > Check that a Spend description's cv and rk are not of small order,
     /// > i.e. [h_J]cv MUST NOT be 𝒪_J and [h_J]rk MUST NOT be 𝒪_J.
     ///

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -750,9 +750,13 @@ where
 
         if let Some(sapling_shielded_data) = sapling_shielded_data {
             for spend in sapling_shielded_data.spends_per_anchor() {
-                // Consensus rule: The proof π_ZKSpend MUST be valid
-                // given a primary input formed from the other
-                // fields except spendAuthSig.
+                // # Consensus
+                //
+                // > The proof π_ZKSpend MUST be valid
+                // > given a primary input formed from the other
+                // > fields except spendAuthSig.
+                //
+                // https://zips.z.cash/protocol/protocol.pdf#spenddesc
                 //
                 // Queue the verification of the Groth16 spend proof
                 // for each Spend description while adding the
@@ -765,9 +769,23 @@ where
                         .oneshot(DescriptionWrapper(&spend).try_into()?),
                 );
 
-                // Consensus rule: The spend authorization signature
-                // MUST be a valid SpendAuthSig signature over
-                // SigHash using rk as the validating key.
+                // # Consensus
+                //
+                // > The spend authorization signature
+                // > MUST be a valid SpendAuthSig signature over
+                // > SigHash using rk as the validating key.
+                //
+                // This is validated by the verifier.
+                //
+                // > [NU5 onward] As specified in § 5.4.7 ‘RedDSA, RedJubjub,
+                // > and RedPallas’ on p. 88, the validation of the 𝑅
+                // > component of the signature changes to prohibit non-canonical encodings.
+                //
+                // This is validated by the verifier, inside the `redjubjub` crate.
+                // It calls [`jubjub::AffinePoint::from_bytes`] to parse R and
+                // that enforces the canonical encoding.
+                //
+                // https://zips.z.cash/protocol/protocol.pdf#spenddesc
                 //
                 // Queue the validation of the RedJubjub spend
                 // authorization signature for each Spend


### PR DESCRIPTION
## Motivation

We need to document all consensus rules.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

Closes https://github.com/ZcashFoundation/zebra/issues/3216

## Review

Not urgent. Anyone can review but I think it's best for @dconnolly to take a look

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
