### PR TITLE
fix(network): only send responded updates on handshake/ping/pong

### DIFF
--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -821,6 +821,15 @@ where
                 let _ = address_book_updater.send(alt_addr).await;
             }
 
+            // The handshake succeeded: update the peer status from AttemptPending to Responded
+            if let Some(book_addr) = connected_addr.get_address_book_addr() {
+                // the collector doesn't depend on network activity,
+                // so this await should not hang
+                let _ = address_book_updater
+                    .send(MetaAddr::new_responded(&book_addr, &remote_services))
+                    .await;
+            }
+
             // Set the connection's version to the minimum of the received version or our own.
             let negotiated_version =
                 std::cmp::min(remote_version, constants::CURRENT_NETWORK_PROTOCOL_VERSION);
@@ -864,8 +873,13 @@ where
 
             // CORRECTNESS
             //
-            // Every message and error must update the peer address state via
+            // Ping/Pong messages and every error must update the peer address state via
             // the inbound_ts_collector.
+            //
+            // The heartbeat task sends regular Ping/Pong messages,
+            // and it ends the connection if the heartbeat times out.
+            // So we can just track peer activity based on Ping and Pong.
+            // (This significantly improves performance, by reducing time system calls.)
             let inbound_ts_collector = address_book_updater.clone();
             let inv_collector = inv_collector.clone();
             let ts_inner_conn_span = connection_span.clone();
@@ -888,11 +902,16 @@ where
                                 );
 
                                 if let Some(book_addr) = connected_addr.get_address_book_addr() {
-                                    // the collector doesn't depend on network activity,
-                                    // so this await should not hang
-                                    let _ = inbound_ts_collector
-                                        .send(MetaAddr::new_responded(&book_addr, &remote_services))
-                                        .await;
+                                    if matches!(msg, Message::Ping(_) | Message::Pong(_)) {
+                                        // the collector doesn't depend on network activity,
+                                        // so this await should not hang
+                                        let _ = inbound_ts_collector
+                                            .send(MetaAddr::new_responded(
+                                                &book_addr,
+                                                &remote_services,
+                                            ))
+                                            .await;
+                                    }
                                 }
                             }
                             Err(err) => {


### PR DESCRIPTION
## Motivation

During the initial sync, Zebra sends a peer timestamp update to the address book for every inbound message.

This uses approximately:
* 2 million address book update channel messages
* 2 million time system calls 
* 2 million address book mutex locks

When I sync testnet from a few nodes on my local network, it takes about an hour to get to the tip.

## Solution

I changed Zebra to send a peer timestamp update to the address book after the handshake, and for every inbound Ping or Pong message. This uses approximately 1 thousand address book update channel messages, time system calls, and address book mutex locks, a 2000x decrease.

After this change, when I sync testnet from a few nodes on my local network, it takes about 30-45 minutes to get to the tip.

This change is correct because:
* Zebra's peer heartbeat task sends a ping every minute, and closes the connection if it doesn't get a pong within 20 seconds. So Zebra does at least one timestamp update in each `MIN_PEER_RECONNECTION_DELAY` interval. (Typically, there should be 1-3 per interval.)
* The other peer should also send regular inbound pings, but we don't require them for correctness.

The impact of this change is that peer timestamps update every 1-2 minutes, rather than potentially hundreds of times per second. This might change Zebra's internal reconnection order slightly for some peers.

But Zebra already truncates peer timestamps to the nearest 30 seconds before sending them externally. So this change won't have much impact on the times that we send to other peers.

Mainnet sync time doesn't change on my machine. So it probably depends on network latency, block size, or verification CPU time.

## Review

@jvff can review this PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

