### PR TITLE
2. Route peer requests based on missing inventory

### DIFF
--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -214,7 +214,7 @@ fn v5_coinbase_transaction_without_enable_spends_flag_passes_validation() {
 
     insert_fake_orchard_shielded_data(&mut transaction);
 
-    assert!(check::coinbase_tx_no_prevout_joinsplit_spend(&transaction).is_ok(),);
+    assert!(check::coinbase_tx_no_prevout_joinsplit_spend(&transaction).is_ok());
 }
 
 #[test]

--- a/zebra-network/src/isolated/tor/tests/vectors.rs
+++ b/zebra-network/src/isolated/tor/tests/vectors.rs
@@ -86,7 +86,7 @@ async fn connect_isolated_run_tor_once_with(network: Network, hostname: String) 
     // We make the test pass if there are network errors, if we get a valid running service,
     // or if we are still waiting for Tor or the handshake.
     let outbound_result = outbound_join_handle_timeout.await;
-    assert!(matches!(outbound_result, Ok(Ok(_)) | Err(_),));
+    assert!(matches!(outbound_result, Ok(Ok(_)) | Err(_)));
 
     outbound_join_handle.abort();
 }

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -1018,6 +1018,7 @@ async fn register_inventory_status(
                     if let Some(change) =
                         InventoryChange::new_advertised_multi(advertised, transient_addr)
                     {
+                        // Ignore channel errors that should only happen during shutdown.
                         let _ = inv_collector.send(change);
                     }
                 }

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -1023,7 +1023,7 @@ async fn register_inventory_status(
         }
 
         (Ok(Message::NotFound(missing)), Some(transient_addr)) => {
-            debug!(?missing, "registering missing inventory for peer",);
+            debug!(?missing, "registering missing inventory for peer");
 
             if let Some(change) = InventoryChange::new_missing_multi(missing, transient_addr) {
                 let _ = inv_collector.send(change);

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -1000,6 +1000,8 @@ async fn register_inventory_status(
 
                     // The peer set and inv collector use the peer's remote
                     // address as an identifier
+                    // If all receivers have been dropped, `send` returns an error.
+                    // When that happens, Zebra is shutting down, so we want to ignore this error.
                     let _ = inv_collector
                         .send(InventoryChange::new_advertised(*advertised, transient_addr));
                 }

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -29,6 +29,7 @@ use zebra_chain::{
     block,
     chain_tip::{ChainTip, NoChainTip},
     parameters::Network,
+    serialization::SerializationError,
 };
 
 use crate::{
@@ -917,76 +918,7 @@ where
                 .then(move |msg| {
                     let inv_collector = inv_collector.clone();
                     let span = debug_span!(parent: inv_inner_conn_span.clone(), "inventory_filter");
-                    async move {
-                        match (&msg, connected_addr.get_transient_addr()) {
-                            (Ok(Message::Inv(advertised)), Some(transient_addr)) => {
-                                // We ignore inventory messages with more than one
-                                // block, because they are most likely replies to a
-                                // query, rather than a newly gossiped block.
-                                //
-                                // (We process inventory messages with any number of
-                                // transactions.)
-                                //
-                                // https://zebra.zfnd.org/dev/rfcs/0003-inventory-tracking.html#inventory-monitoring
-                                //
-                                // Note: zcashd has a bug where it merges queued inv messages of
-                                // the same or different types. Zebra compensates by sending `notfound`
-                                // responses to the inv collector. (#2156, #1768)
-                                //
-                                // (We can't split `inv`s, because that fills the inventory registry
-                                // with useless entries that the whole network has, making it large and slow.)
-                                match advertised.as_slice() {
-                                    [advertised @ InventoryHash::Block(_)] => {
-                                        debug!(?advertised, "registering gossiped advertised block inventory for peer");
-
-                                        // The peer set and inv collector use the peer's remote
-                                        // address as an identifier
-                                        let _ = inv_collector.send(InventoryChange::new_advertised(
-                                            *advertised,
-                                            transient_addr,
-                                        ));
-                                    }
-                                    [advertised @ ..] => {
-                                        let advertised =
-                                            advertised.iter().filter(|advertised| advertised.unmined_tx_id().is_some());
-
-                                        debug!(
-                                            ?advertised,
-                                            "registering advertised unmined transaction inventory for peer",
-                                        );
-
-                                        if let Some(change) = InventoryChange::new_advertised_multi(
-                                            advertised,
-                                            transient_addr,
-                                        ) {
-                                            let _ = inv_collector.send(change);
-                                        }
-                                    }
-                                }
-                            }
-
-                            (Ok(Message::NotFound(missing)), Some(transient_addr)) =>
-
-                            {
-                                debug!(
-                                    ?missing,
-                                    "registering missing inventory for peer",
-                                );
-
-                                if let Some(change) = InventoryChange::new_missing_multi(
-                                    missing,
-                                    transient_addr,
-                                ) {
-                                    let _ = inv_collector.send(change);
-                                }
-
-                            }
-                            _ => {}
-                        }
-
-                        msg
-                    }
-                    .instrument(span)
+                    register_inventory_status(msg, connected_addr, inv_collector).instrument(span)
                 })
                 .boxed();
 
@@ -1034,6 +966,73 @@ where
             .map(|x: Result<Result<Client, HandshakeError>, JoinError>| Ok(x??))
             .boxed()
     }
+}
+
+/// Register any advertised or missing inventory in `msg` for `connected_addr`.
+async fn register_inventory_status(
+    msg: Result<Message, SerializationError>,
+    connected_addr: ConnectedAddr,
+    inv_collector: broadcast::Sender<InventoryChange>,
+) -> Result<Message, SerializationError> {
+    match (&msg, connected_addr.get_transient_addr()) {
+        (Ok(Message::Inv(advertised)), Some(transient_addr)) => {
+            // We ignore inventory messages with more than one
+            // block, because they are most likely replies to a
+            // query, rather than a newly gossiped block.
+            //
+            // (We process inventory messages with any number of
+            // transactions.)
+            //
+            // https://zebra.zfnd.org/dev/rfcs/0003-inventory-tracking.html#inventory-monitoring
+            //
+            // Note: zcashd has a bug where it merges queued inv messages of
+            // the same or different types. Zebra compensates by sending `notfound`
+            // responses to the inv collector. (#2156, #1768)
+            //
+            // (We can't split `inv`s, because that fills the inventory registry
+            // with useless entries that the whole network has, making it large and slow.)
+            match advertised.as_slice() {
+                [advertised @ InventoryHash::Block(_)] => {
+                    debug!(
+                        ?advertised,
+                        "registering gossiped advertised block inventory for peer"
+                    );
+
+                    // The peer set and inv collector use the peer's remote
+                    // address as an identifier
+                    let _ = inv_collector
+                        .send(InventoryChange::new_advertised(*advertised, transient_addr));
+                }
+                [advertised @ ..] => {
+                    let advertised = advertised
+                        .iter()
+                        .filter(|advertised| advertised.unmined_tx_id().is_some());
+
+                    debug!(
+                        ?advertised,
+                        "registering advertised unmined transaction inventory for peer",
+                    );
+
+                    if let Some(change) =
+                        InventoryChange::new_advertised_multi(advertised, transient_addr)
+                    {
+                        let _ = inv_collector.send(change);
+                    }
+                }
+            }
+        }
+
+        (Ok(Message::NotFound(missing)), Some(transient_addr)) => {
+            debug!(?missing, "registering missing inventory for peer",);
+
+            if let Some(change) = InventoryChange::new_missing_multi(missing, transient_addr) {
+                let _ = inv_collector.send(change);
+            }
+        }
+        _ => {}
+    }
+
+    msg
 }
 
 /// Send periodical heartbeats to `server_tx`, and update the peer status through

--- a/zebra-network/src/peer_set/inventory_registry/tests/vectors.rs
+++ b/zebra-network/src/peer_set/inventory_registry/tests/vectors.rs
@@ -58,6 +58,7 @@ async fn inv_registry_one_advertised_ok() {
         inv_registry.advertising_peers(test_hash).next(),
         Some(&test_peer),
     );
+    assert_eq!(inv_registry.advertising_peers(test_hash).count(), 1);
     assert_eq!(inv_registry.missing_peers(test_hash).count(), 0);
 }
 
@@ -87,6 +88,7 @@ async fn inv_registry_one_missing_ok() {
         inv_registry.missing_peers(test_hash).next(),
         Some(&test_peer),
     );
+    assert_eq!(inv_registry.missing_peers(test_hash).count(), 1);
 }
 
 /// Check inventory registration for one hash/peer prefers missing over advertised.
@@ -131,6 +133,7 @@ async fn inv_registry_prefer_missing_order(missing_first: bool) {
         inv_registry.missing_peers(test_hash).next(),
         Some(&test_peer),
     );
+    assert_eq!(inv_registry.missing_peers(test_hash).count(), 1);
 }
 
 /// Check inventory registration for one hash/peer prefers current over previous.
@@ -179,11 +182,13 @@ async fn inv_registry_prefer_current_order(missing_current: bool) {
             inv_registry.missing_peers(test_hash).next(),
             Some(&test_peer),
         );
+        assert_eq!(inv_registry.missing_peers(test_hash).count(), 1);
     } else {
         assert_eq!(
             inv_registry.advertising_peers(test_hash).next(),
             Some(&test_peer),
         );
+        assert_eq!(inv_registry.advertising_peers(test_hash).count(), 1);
         assert_eq!(inv_registry.missing_peers(test_hash).count(), 0);
     }
 }

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -695,7 +695,7 @@ where
         let maybe_peer_list = self
             .ready_services
             .keys()
-            .filter(|&addr| !missing_peer_list.contains(&addr))
+            .filter(|addr| !missing_peer_list.contains(addr))
             .copied()
             .collect();
 

--- a/zebra-state/src/service/non_finalized_state/queued_blocks.rs
+++ b/zebra-state/src/service/non_finalized_state/queued_blocks.rs
@@ -144,7 +144,7 @@ impl QueuedBlocks {
             }
         }
 
-        tracing::trace!(num_blocks = %self.blocks.len(), "Finished pruning blocks at or beneath the finalized tip height",);
+        tracing::trace!(num_blocks = %self.blocks.len(), "Finished pruning blocks at or beneath the finalized tip height");
         self.update_metrics();
     }
 


### PR DESCRIPTION
## Motivation

Zebra needs to stop asking the same peer for the same block multiple times.

## Solution

- send inbound notfound messages to the inv collector
- use notfound inventory to route inventory requests in the peer set
- test that it all works

Part of #2156.

## Review

@oxarbitrage is reviewing this PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- #2156 
    - [ ] if a block or transaction request fails, times out, or is dropped, send a synthetic `notfound` message to the inv collector
- #2726
    - [x] send `notfound` to peers when Zebra doesn't have a block or transaction
    - [x] use received `notfound` to finish pending block or transaction requests
