### PR TITLE
Use string literal to format unreachable message

### DIFF
--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -68,7 +68,7 @@ impl<'a> SigHasher<'a> {
         use NetworkUpgrade::*;
 
         match self.network_upgrade {
-            Genesis | BeforeOverwinter => unreachable!(ZIP143_EXPLANATION),
+            Genesis | BeforeOverwinter => unreachable!("{}", ZIP143_EXPLANATION),
             Overwinter | Sapling | Blossom | Heartwood | Canopy | Nu5 => {
                 self.hash_sighash_librustzcash()
             }


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

On nightly this is being enforced, causing our nightly-dependent coverage job to fail.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Do what rustc says, and supply a string literal to format the item passed to `unreachable!`.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

Anyone can review

### Reviewer Checklist

  - [ ] Fixes Coverage job

