### PR TITLE
docs(transaction encoding): header fields

### DIFF
--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -448,7 +448,7 @@ impl ZcashSerialize for Transaction {
 
                 // Denoted as `lock_time` in the spec.
                 lock_time.zcash_serialize(&mut writer)?;
-                
+
                 match joinsplit_data {
                     // Write 0 for nJoinSplits to signal no JoinSplitData.
                     None => zcash_serialize_empty_list(writer)?,
@@ -498,6 +498,7 @@ impl ZcashSerialize for Transaction {
                 // Denoted as `lock_time` in the spec.
                 lock_time.zcash_serialize(&mut writer)?;
 
+                // Denoted as `nExpiryHeight` in the spec.
                 writer.write_u32::<LittleEndian>(expiry_height.0)?;
 
                 // The previous match arms serialize in one go, because the
@@ -569,6 +570,7 @@ impl ZcashSerialize for Transaction {
                 // Denoted as `lock_time` in the spec.
                 lock_time.zcash_serialize(&mut writer)?;
 
+                // Denoted as `nExpiryHeight` in the spec.
                 writer.write_u32::<LittleEndian>(expiry_height.0)?;
 
                 // transparent
@@ -636,6 +638,7 @@ impl ZcashDeserialize for Transaction {
             (1, false) => Ok(Transaction::V1 {
                 inputs: Vec::zcash_deserialize(&mut limited_reader)?,
                 outputs: Vec::zcash_deserialize(&mut limited_reader)?,
+                // Denoted as `lock_time` in the spec.
                 lock_time: LockTime::zcash_deserialize(&mut limited_reader)?,
             }),
             (2, false) => {
@@ -644,6 +647,7 @@ impl ZcashDeserialize for Transaction {
                 Ok(Transaction::V2 {
                     inputs: Vec::zcash_deserialize(&mut limited_reader)?,
                     outputs: Vec::zcash_deserialize(&mut limited_reader)?,
+                    // Denoted as `lock_time` in the spec.
                     lock_time: LockTime::zcash_deserialize(&mut limited_reader)?,
                     joinsplit_data: OptV2Jsd::zcash_deserialize(&mut limited_reader)?,
                 })
@@ -661,7 +665,9 @@ impl ZcashDeserialize for Transaction {
                 Ok(Transaction::V3 {
                     inputs: Vec::zcash_deserialize(&mut limited_reader)?,
                     outputs: Vec::zcash_deserialize(&mut limited_reader)?,
+                    // Denoted as `lock_time` in the spec.
                     lock_time: LockTime::zcash_deserialize(&mut limited_reader)?,
+                    // Denoted as `nExpiryHeight` in the spec.
                     expiry_height: block::Height(limited_reader.read_u32::<LittleEndian>()?),
                     joinsplit_data: OptV3Jsd::zcash_deserialize(&mut limited_reader)?,
                 })
@@ -694,6 +700,7 @@ impl ZcashDeserialize for Transaction {
                 // Denoted as `lock_time` in the spec.
                 let lock_time = LockTime::zcash_deserialize(&mut limited_reader)?;
 
+                // Denoted as `nExpiryHeight` in the spec.
                 let expiry_height = block::Height(limited_reader.read_u32::<LittleEndian>()?);
 
                 let value_balance = (&mut limited_reader).zcash_deserialize_into()?;
@@ -764,6 +771,7 @@ impl ZcashDeserialize for Transaction {
                 // Denoted as `lock_time` in the spec.
                 let lock_time = LockTime::zcash_deserialize(&mut limited_reader)?;
 
+                // Denoted as `nExpiryHeight` in the spec.
                 let expiry_height = block::Height(limited_reader.read_u32::<LittleEndian>()?);
 
                 // transparent

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -418,7 +418,7 @@ impl ZcashSerialize for Transaction {
         // Since we checkpoint on Canopy activation, we won't ever need
         // to check the smaller pre-Sapling transaction size limit.
 
-        // Denoted as `header` in the spec.
+        // Denoted as `header` in the spec, contains the `fOverwintered` flag and the `version` field.
         // Write `version` and set the `fOverwintered` bit if necessary
         let overwintered_flag = if self.is_overwintered() { 1 << 31 } else { 0 };
         let version = overwintered_flag | self.version();

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -457,7 +457,9 @@ impl ZcashSerialize for Transaction {
                 expiry_height,
                 joinsplit_data,
             } => {
+                // Denoted as `nVersionGroupId` in the spec.
                 writer.write_u32::<LittleEndian>(OVERWINTER_VERSION_GROUP_ID)?;
+
                 inputs.zcash_serialize(&mut writer)?;
                 outputs.zcash_serialize(&mut writer)?;
                 lock_time.zcash_serialize(&mut writer)?;
@@ -476,7 +478,12 @@ impl ZcashSerialize for Transaction {
                 sapling_shielded_data,
                 joinsplit_data,
             } => {
+                // Transaction V4 spec:
+                // https://zips.z.cash/protocol/protocol.pdf#txnencoding
+
+                // Denoted as `nVersionGroupId` in the spec.
                 writer.write_u32::<LittleEndian>(SAPLING_VERSION_GROUP_ID)?;
+
                 inputs.zcash_serialize(&mut writer)?;
                 outputs.zcash_serialize(&mut writer)?;
                 lock_time.zcash_serialize(&mut writer)?;
@@ -536,8 +543,9 @@ impl ZcashSerialize for Transaction {
                 orchard_shielded_data,
             } => {
                 // Transaction V5 spec:
-                // https://zips.z.cash/protocol/nu5.pdf#txnencodingandconsensus
+                // https://zips.z.cash/protocol/protocol.pdf#txnencoding
 
+                // Denoted as `nVersionGroupId` in the spec.
                 writer.write_u32::<LittleEndian>(TX_V5_VERSION_GROUP_ID)?;
 
                 // header: Write the nConsensusBranchId
@@ -629,6 +637,7 @@ impl ZcashDeserialize for Transaction {
                 })
             }
             (3, true) => {
+                // Denoted as `nVersionGroupId` in the spec.
                 let id = limited_reader.read_u32::<LittleEndian>()?;
                 if id != OVERWINTER_VERSION_GROUP_ID {
                     return Err(SerializationError::Parse(
@@ -646,6 +655,10 @@ impl ZcashDeserialize for Transaction {
                 })
             }
             (4, true) => {
+                // Transaction V4 spec:
+                // https://zips.z.cash/protocol/protocol.pdf#txnencoding
+
+                // Denoted as `nVersionGroupId` in the spec.
                 let id = limited_reader.read_u32::<LittleEndian>()?;
                 if id != SAPLING_VERSION_GROUP_ID {
                     return Err(SerializationError::Parse(
@@ -717,6 +730,10 @@ impl ZcashDeserialize for Transaction {
                 })
             }
             (5, true) => {
+                // Transaction V5 spec:
+                // https://zips.z.cash/protocol/protocol.pdf#txnencoding
+
+                // Denoted as `nVersionGroupId` in the spec.
                 let id = limited_reader.read_u32::<LittleEndian>()?;
                 if id != TX_V5_VERSION_GROUP_ID {
                     return Err(SerializationError::Parse("expected TX_V5_VERSION_GROUP_ID"));

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -418,7 +418,8 @@ impl ZcashSerialize for Transaction {
         // Since we checkpoint on Canopy activation, we won't ever need
         // to check the smaller pre-Sapling transaction size limit.
 
-        // header: Write version and set the fOverwintered bit if necessary
+        // Denoted as `header` in the spec.
+        // Write `version` and set the `fOverwintered` bit if necessary
         let overwintered_flag = if self.is_overwintered() { 1 << 31 } else { 0 };
         let version = overwintered_flag | self.version();
 
@@ -572,6 +573,7 @@ impl ZcashDeserialize for Transaction {
 
         let (version, overwintered) = {
             const LOW_31_BITS: u32 = (1 << 31) - 1;
+            // Denoted as `header` in the spec, contains the `fOverwintered` flag and the `version` field.
             let header = limited_reader.read_u32::<LittleEndian>()?;
             (header & LOW_31_BITS, header >> 31 != 0)
         };

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -433,6 +433,8 @@ impl ZcashSerialize for Transaction {
             } => {
                 inputs.zcash_serialize(&mut writer)?;
                 outputs.zcash_serialize(&mut writer)?;
+
+                // Denoted as `lock_time` in the spec.
                 lock_time.zcash_serialize(&mut writer)?;
             }
             Transaction::V2 {
@@ -443,7 +445,10 @@ impl ZcashSerialize for Transaction {
             } => {
                 inputs.zcash_serialize(&mut writer)?;
                 outputs.zcash_serialize(&mut writer)?;
+
+                // Denoted as `lock_time` in the spec.
                 lock_time.zcash_serialize(&mut writer)?;
+                
                 match joinsplit_data {
                     // Write 0 for nJoinSplits to signal no JoinSplitData.
                     None => zcash_serialize_empty_list(writer)?,
@@ -462,7 +467,10 @@ impl ZcashSerialize for Transaction {
 
                 inputs.zcash_serialize(&mut writer)?;
                 outputs.zcash_serialize(&mut writer)?;
+
+                // Denoted as `lock_time` in the spec.
                 lock_time.zcash_serialize(&mut writer)?;
+
                 writer.write_u32::<LittleEndian>(expiry_height.0)?;
                 match joinsplit_data {
                     // Write 0 for nJoinSplits to signal no JoinSplitData.
@@ -486,7 +494,10 @@ impl ZcashSerialize for Transaction {
 
                 inputs.zcash_serialize(&mut writer)?;
                 outputs.zcash_serialize(&mut writer)?;
+
+                // Denoted as `lock_time` in the spec.
                 lock_time.zcash_serialize(&mut writer)?;
+
                 writer.write_u32::<LittleEndian>(expiry_height.0)?;
 
                 // The previous match arms serialize in one go, because the
@@ -555,8 +566,9 @@ impl ZcashSerialize for Transaction {
                         .expect("valid transactions must have a network upgrade with a branch id"),
                 ))?;
 
-                // transaction validity time and height limits
+                // Denoted as `lock_time` in the spec.
                 lock_time.zcash_serialize(&mut writer)?;
+
                 writer.write_u32::<LittleEndian>(expiry_height.0)?;
 
                 // transparent
@@ -678,7 +690,10 @@ impl ZcashDeserialize for Transaction {
 
                 let inputs = Vec::zcash_deserialize(&mut limited_reader)?;
                 let outputs = Vec::zcash_deserialize(&mut limited_reader)?;
+
+                // Denoted as `lock_time` in the spec.
                 let lock_time = LockTime::zcash_deserialize(&mut limited_reader)?;
+
                 let expiry_height = block::Height(limited_reader.read_u32::<LittleEndian>()?);
 
                 let value_balance = (&mut limited_reader).zcash_deserialize_into()?;
@@ -746,8 +761,9 @@ impl ZcashDeserialize for Transaction {
                             "expected a valid network upgrade from the consensus branch id",
                         ))?;
 
-                // transaction validity time and height limits
+                // Denoted as `lock_time` in the spec.
                 let lock_time = LockTime::zcash_deserialize(&mut limited_reader)?;
+
                 let expiry_height = block::Height(limited_reader.read_u32::<LittleEndian>()?);
 
                 // transparent

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -548,7 +548,7 @@ impl ZcashSerialize for Transaction {
                 // Denoted as `nVersionGroupId` in the spec.
                 writer.write_u32::<LittleEndian>(TX_V5_VERSION_GROUP_ID)?;
 
-                // header: Write the nConsensusBranchId
+                // Denoted as `nConsensusBranchId` in the spec.
                 writer.write_u32::<LittleEndian>(u32::from(
                     network_upgrade
                         .branch_id()
@@ -738,7 +738,8 @@ impl ZcashDeserialize for Transaction {
                 if id != TX_V5_VERSION_GROUP_ID {
                     return Err(SerializationError::Parse("expected TX_V5_VERSION_GROUP_ID"));
                 }
-                // convert the nConsensusBranchId to a NetworkUpgrade
+                // Denoted as `nConsensusBranchId` in the spec.
+                // Convert it to a NetworkUpgrade
                 let network_upgrade =
                     NetworkUpgrade::from_branch_id(limited_reader.read_u32::<LittleEndian>()?)
                         .ok_or(SerializationError::Parse(


### PR DESCRIPTION
## Motivation

We want to make sure all the fields in the [transaction tables of the protocol ](https://zips.z.cash/protocol/protocol.pdf#txnencoding ) are documented in Zebra at serialization and deserialization. 

This pull request deals with the header fields of transactions. 

Closes https://github.com/ZcashFoundation/zebra/issues/3420

## Solution

Document header fields of transactions.

## Review

Anyone that has some time can review.

### Reviewer Checklist

  - [ ] All fields considered "header" are documented (We know the header fields by the double separation lines in the V5 table of the spec)

## Follow Up Work

There are a few tickets related to this that will be coming next, they are listed in https://github.com/ZcashFoundation/zebra/issues/3222


