### PR TITLE
Chain Tip Estimate Test: Log chain progress while Zebra is syncing

### DIFF
--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -316,11 +316,11 @@ impl StartCmd {
         const MIN_SYNC_WARNING_BLOCKS: i32 = 60;
 
         loop {
-            let _now = Utc::now();
+            let now = Utc::now();
             let is_close_to_tip = sync_status.is_close_to_tip();
 
             if let Some(estimated_height) =
-                latest_chain_tip.estimate_network_chain_tip_height(network /*, now*/)
+                latest_chain_tip.estimate_network_chain_tip_height(network, now)
             {
                 // The estimate/actual race doesn't matter here,
                 // because we're only using it for metrics and logging.


### PR DESCRIPTION
## Motivation

1. This PR helps test if the chain tip estimate is accurate when it's used in `zebrad`. It will help diagnose problems during full sync tests.

2. On PR #3492, Janito asked:
> I'd especially like to know if the solution I've implemented is too generic and complicated, and if I should change it to a simpler one.

## Solution

I added a very simple chain tip progress log to Zebra.

This helped me answer the questions above:
1. I ran Zebra, the chain tip estimate seems to be accurate enough for both the full sync tests and `lightwalletd`.
2. The external `ChainTip` API is very easy to use. (The internals are much less important, because we don't have any plans to use them directly, or change them.)

This PR contains diagnostics for:
- #1592

It implements part of the `zebrad` side of:
- #3493

## Review

@jvff can review this PR.

It depends on PR #3492.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- #970 
- log progress, remaining blocks, and remaining time to the next network upgrade