### PR TITLE
docs(transaction encoding): sapling fields

### DIFF
--- a/zebra-chain/src/sapling/shielded_data.rs
+++ b/zebra-chain/src/sapling/shielded_data.rs
@@ -90,6 +90,7 @@ where
     AnchorV: AnchorVariant + Clone,
 {
     /// The net value of Sapling spend transfers minus output transfers.
+    /// Denoted as `valueBalanceSapling` in the spec.
     pub value_balance: Amount,
 
     /// A bundle of spends and outputs, containing at least one spend or
@@ -100,6 +101,7 @@ where
     pub transfers: TransferData<AnchorV>,
 
     /// A signature on the transaction hash.
+    /// Denoted as `bindingSigSapling` in the spec.
     pub binding_sig: Signature<Binding>,
 }
 


### PR DESCRIPTION
## Motivation

We want to make sure all the fields in the [transaction tables of the protocol](https://zips.z.cash/protocol/protocol.pdf#txnencoding) are documented in Zebra at serialization and deserialization.

This pull request deals with the sapling fields of transactions.

Closes #3422

## Solution

Document sapling transaction fields.

## Review

Anyone can review.

### Reviewer Checklist

  - [ ]  All fields considered "sapling" are documented.


## Follow Up Work

Orchard fields: https://github.com/ZcashFoundation/zebra/issues/3424
