### PR TITLE
fix: temporarily allow forked repos to run PR workflows

### DIFF
--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -2,7 +2,9 @@ name: zcash-params
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  push:
+    branches:
+      - 'main'
     path:
       - 'zebra-consensus/src/primitives/groth16/params.rs'
       - 'zebra-consensus/src/chain.rs'

--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -2,7 +2,7 @@ name: zcash-params
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     path:
       - 'zebra-consensus/src/primitives/groth16/params.rs'
       - 'zebra-consensus/src/chain.rs'


### PR DESCRIPTION
## Motivation

The continuous deployment refactors included a workflow to cache Zcash parameters, which was triggered by a `pull_request` event. But when triggered from a forked repo, this event does not have the right context nor permissions to read **secrets**

### Specifications
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

## Solution
Temporarily use `pull_request_target` instead of `pull_request`


## Review
@teor2345 

## Follow Up Work
This is a temporal fix, which needs to be solved with #3419 