### PR TITLE
4. Avoid repeated requests to peers after partial responses or errors

### DIFF
--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -55,7 +55,7 @@ zcash_note_encryption = { git = "https://github.com/ZcashFoundation/librustzcash
 zcash_primitives = { git = "https://github.com/ZcashFoundation/librustzcash.git", tag = "0.5.1-zebra-v1.0.0-beta.4" }
 zcash_history = { git = "https://github.com/ZcashFoundation/librustzcash.git", tag = "0.5.1-zebra-v1.0.0-beta.4" }
 
-proptest = { version = "0.10", optional = true }
+proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 
 rand = { version = "0.8", optional = true }
@@ -76,8 +76,8 @@ itertools = "0.10.3"
 spandoc = "0.2"
 tracing = "0.1.29"
 
-proptest = "0.10"
-proptest-derive = "0.3"
+proptest = "0.10.1"
+proptest-derive = "0.3.0"
 rand = "0.8"
 rand_chacha = "0.3"
 

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -47,13 +47,13 @@ zebra-chain = { path = "../zebra-chain" }
 zebra-state = { path = "../zebra-state" }
 zebra-script = { path = "../zebra-script" }
 
-proptest = { version = "0.10", optional = true }
+proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 color-eyre = "0.5.11"
 hex = "0.4.3"
-proptest = "0.10"
+proptest = "0.10.1"
 proptest-derive = "0.3.0"
 rand07 = { package = "rand", version = "0.7" }
 spandoc = "0.2"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 [features]
 default = []
 tor = ["arti-client", "tor-rtcompat"]
+proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl"]
 
 [dependencies]
 bitflags = "1.2"
@@ -40,11 +41,16 @@ tracing-error = { version = "0.1.2", features = ["traced-error"] }
 arti-client = { version = "0.0.2", optional = true }
 tor-rtcompat  = { version = "0.0.2", optional = true }
 
+# proptest dependencies
+proptest = { version = "0.10.1", optional = true }
+proptest-derive = { version = "0.3.0", optional = true }
+
 zebra-chain = { path = "../zebra-chain" }
 
 [dev-dependencies]
-proptest = "0.10"
-proptest-derive = "0.3"
+proptest = "0.10.1"
+proptest-derive = "0.3.0"
+
 static_assertions = "1.1.0"
 tokio = { version = "1.16.1", features = ["test-util"] }
 toml = "0.5"

--- a/zebra-network/src/isolated/tor.rs
+++ b/zebra-network/src/isolated/tor.rs
@@ -55,13 +55,13 @@ pub async fn connect_isolated_tor(
 }
 
 /// Creates an isolated Zcash peer connection to `hostname` via Tor.
-/// This method is for testing purposes only.
+/// This function is for testing purposes only.
 ///
 /// See [`connect_isolated_with_inbound`] and [`connect_isolated_tor`] for details.
 ///
 /// # Privacy
 ///
-/// This method can make the isolated connection send different responses to peers,
+/// This function can make the isolated connection send different responses to peers,
 /// which makes it stand out from other isolated connections from other peers.
 pub async fn connect_isolated_tor_with_inbound<InboundService>(
     network: Network,

--- a/zebra-network/src/isolated/tor.rs
+++ b/zebra-network/src/isolated/tor.rs
@@ -2,13 +2,13 @@
 
 use std::sync::{Arc, Mutex};
 
-use arti_client::{TorAddr, TorClient, TorClientConfig};
+use arti_client::{TorAddr, TorClient, TorClientConfig, DataStream};
 use tor_rtcompat::tokio::TokioRuntimeHandle;
-use tower::util::BoxService;
+use tower::{util::BoxService, Service};
 
 use zebra_chain::parameters::Network;
 
-use crate::{connect_isolated, BoxError, Request, Response};
+use crate::{connect_isolated_with_inbound, connect_isolated, BoxError, Request, Response};
 
 #[cfg(test)]
 mod tests;
@@ -45,6 +45,42 @@ pub async fn connect_isolated_tor(
     hostname: String,
     user_agent: String,
 ) -> Result<BoxService<Request, Response, BoxError>, BoxError> {
+    let tor_stream = new_tor_stream(hostname).await?;
+
+    // Calling connect_isolated_tor_with_inbound causes lifetime issues
+    connect_isolated(network, tor_stream, user_agent).await
+}
+
+/// Creates an isolated Zcash peer connection to `hostname` via Tor.
+/// This method is for testing purposes only.
+///
+/// See [`connect_isolated_with_inbound`] and [`connect_isolated_tor`] for details.
+///
+/// # Privacy
+///
+/// This method can make the isolated connection send different responses to peers,
+/// which makes it stand out from other isolated connections from other peers.
+pub async fn connect_isolated_tor_with_inbound<InboundService>(
+    network: Network,
+    hostname: String,
+    user_agent: String,
+    inbound_service: InboundService,
+) -> Result<BoxService<Request, Response, BoxError>, BoxError>
+where
+    InboundService:
+        Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    InboundService::Future: Send,
+{
+    let tor_stream = new_tor_stream(hostname).await?;
+
+    connect_isolated_with_inbound(network, tor_stream, user_agent, inbound_service).await
+}
+
+/// Creates a Zcash peer connection to `hostname` via Tor, and returns a tor stream.
+///
+/// See [`connect_isolated`] for details.
+async fn new_tor_stream(    hostname: String,
+) -> Result<DataStream, BoxError> {
     let addr = TorAddr::from(hostname)?;
 
     // Initialize or clone the shared tor client instance
@@ -55,7 +91,7 @@ pub async fn connect_isolated_tor(
 
     let tor_stream = tor_client.connect(addr, None).await?;
 
-    connect_isolated(network, tor_stream, user_agent).await
+    Ok(tor_stream)
 }
 
 /// Returns a new tor client instance, and updates [`SHARED_TOR_CLIENT`].

--- a/zebra-network/src/isolated/tor.rs
+++ b/zebra-network/src/isolated/tor.rs
@@ -2,13 +2,13 @@
 
 use std::sync::{Arc, Mutex};
 
-use arti_client::{TorAddr, TorClient, TorClientConfig, DataStream};
+use arti_client::{DataStream, TorAddr, TorClient, TorClientConfig};
 use tor_rtcompat::tokio::TokioRuntimeHandle;
 use tower::{util::BoxService, Service};
 
 use zebra_chain::parameters::Network;
 
-use crate::{connect_isolated_with_inbound, connect_isolated, BoxError, Request, Response};
+use crate::{connect_isolated, connect_isolated_with_inbound, BoxError, Request, Response};
 
 #[cfg(test)]
 mod tests;
@@ -79,8 +79,7 @@ where
 /// Creates a Zcash peer connection to `hostname` via Tor, and returns a tor stream.
 ///
 /// See [`connect_isolated`] for details.
-async fn new_tor_stream(    hostname: String,
-) -> Result<DataStream, BoxError> {
+async fn new_tor_stream(hostname: String) -> Result<DataStream, BoxError> {
     let addr = TorAddr::from(hostname)?;
 
     // Initialize or clone the shared tor client instance

--- a/zebra-network/src/isolated/tor.rs
+++ b/zebra-network/src/isolated/tor.rs
@@ -47,7 +47,10 @@ pub async fn connect_isolated_tor(
 ) -> Result<BoxService<Request, Response, BoxError>, BoxError> {
     let tor_stream = new_tor_stream(hostname).await?;
 
-    // Calling connect_isolated_tor_with_inbound causes lifetime issues
+    // Calling connect_isolated_tor_with_inbound causes lifetime issues.
+    //
+    // TODO: fix the lifetime issues, and call connect_isolated_tor_with_inbound
+    //       so the behaviour of both functions is consistent.
     connect_isolated(network, tor_stream, user_agent).await
 }
 

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -150,6 +150,14 @@ mod protocol;
 #[cfg(feature = "tor")]
 pub use crate::isolated::tor::connect_isolated_tor;
 
+#[cfg(all(feature = "tor", any(test, feature = "proptest-impl")))]
+pub use crate::isolated::tor::connect_isolated_tor_with_inbound;
+
+#[cfg(any(test, feature = "proptest-impl"))]
+pub use crate::isolated::{
+    connect_isolated_tcp_direct_with_inbound, connect_isolated_with_inbound,
+};
+
 pub use crate::{
     address_book::AddressBook,
     config::Config,

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -172,4 +172,7 @@ pub use crate::{
 /// Types used in the definition of [`Request`] and [`Response`] messages.
 pub mod types {
     pub use crate::{meta_addr::MetaAddr, protocol::types::PeerServices};
+
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub use crate::protocol::external::InventoryHash;
 }

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -158,7 +158,7 @@ pub use crate::{
     peer::{HandshakeError, PeerError, SharedPeerError},
     peer_set::init,
     policies::RetryLimit,
-    protocol::internal::{Request, Response, InventoryResponse},
+    protocol::internal::{InventoryResponse, Request, Response},
 };
 
 /// Types used in the definition of [`Request`] and [`Response`] messages.

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -158,7 +158,7 @@ pub use crate::{
     peer::{HandshakeError, PeerError, SharedPeerError},
     peer_set::init,
     policies::RetryLimit,
-    protocol::internal::{Request, Response, ResponseStatus},
+    protocol::internal::{Request, Response, InventoryResponse},
 };
 
 /// Types used in the definition of [`Request`] and [`Response`] messages.

--- a/zebra-network/src/meta_addr/arbitrary.rs
+++ b/zebra-network/src/meta_addr/arbitrary.rs
@@ -12,12 +12,14 @@ use super::{MetaAddr, MetaAddrChange, PeerServices};
 ///
 /// This should be at least twice the number of [`PeerAddrState`]s, so the tests
 /// can cover multiple transitions through every state.
+#[allow(dead_code)]
 pub const MAX_ADDR_CHANGE: usize = 15;
 
 /// The largest number of random addresses we want to add to an [`AddressBook`].
 ///
 /// This should be at least the number of [`PeerAddrState`]s, so the tests can
 /// cover interactions between addresses in different states.
+#[allow(dead_code)]
 pub const MAX_META_ADDR: usize = 8;
 
 impl MetaAddr {

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -16,7 +16,7 @@ pub(crate) use client::tests::ReceiveRequestAttempt;
 #[cfg(test)]
 pub(crate) use handshake::register_inventory_status;
 
-use client::{ClientRequestReceiver, InProgressClientRequest, MustUseOneshotSender};
+use client::{ClientRequestReceiver, InProgressClientRequest, MustUseClientResponseSender};
 
 pub(crate) use client::{CancelHeartbeatTask, ClientRequest};
 

--- a/zebra-network/src/peer/client/tests.rs
+++ b/zebra-network/src/peer/client/tests.rs
@@ -1,7 +1,7 @@
 //! Tests for the [`Client`] part of peer connections, and some test utilities for mocking
 //! [`Client`] instances.
 
-mod vectors;
+#![cfg_attr(feature = "proptest-impl", allow(dead_code))]
 
 use std::time::Duration;
 
@@ -19,6 +19,9 @@ use crate::{
     peer_set::InventoryChange,
     protocol::external::types::Version,
 };
+
+#[cfg(test)]
+mod vectors;
 
 /// The maximum time a mocked peer connection should be alive during a test.
 const MAX_PEER_CONNECTION_TIME: Duration = Duration::from_secs(10);

--- a/zebra-network/src/peer/client/tests/vectors.rs
+++ b/zebra-network/src/peer/client/tests/vectors.rs
@@ -246,8 +246,11 @@ fn missing_inv_collector_ignores_local_registry_errors() {
     let (inv_collector, mut inv_receiver) = broadcast::channel(1);
     let transient_addr = "0.0.0.0:0".parse().unwrap();
 
+    // Keep the channel open, so we don't get a `Closed` error.
+    let _inv_channel_guard = inv_collector.clone();
+
     let missing_inv =
-        MissingInventoryCollector::new(&request, Some(inv_collector.clone()), Some(transient_addr))
+        MissingInventoryCollector::new(&request, Some(inv_collector), Some(transient_addr))
             .expect("unexpected invalid collector: arguments should be valid");
 
     missing_inv.send(&response);

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -387,7 +387,7 @@ pub(super) enum State {
     /// Awaiting a peer message we can interpret as a client request.
     AwaitingResponse {
         handler: Handler,
-        tx: MustUseClientResponseSender<Result<Response, SharedPeerError>>,
+        tx: MustUseClientResponseSender,
         span: tracing::Span,
     },
     /// A failure has occurred and we are shutting down the connection.

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -1243,7 +1243,7 @@ where
             }
             Response::Blocks(blocks) => {
                 // Generate one tx message per block,
-                // then a notfound% message with all the missing block hashes.
+                // then a notfound message with all the missing block hashes.
                 let mut missing_hashes = Vec::new();
 
                 for block in blocks.into_iter() {

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -286,10 +286,14 @@ impl Handler {
                     // when the response for the second request arrives.
                     //
                     // Ignoring the message gives us a chance to synchronize back to the correct
-                    // request.
+                    // request. If that doesn't happen, this request times out.
                     //
-                    // Peers can avoid these cascading errors by sending an explicit `notfound`.
-                    // Zebra sends `notfound`, but `zcashd` doesn't.
+                    // In case 2, if peers respond with a `notfound` message,
+                    // the cascading errors don't happen. The `notfound` message cancels our request,
+                    // and we know we are in sync with the peer.
+                    //
+                    // Zebra sends `notfound` in response to block requests, but `zcashd` doesn't.
+                    // So we need this message workaround, and the related inventory workarounds.
                     ignored_msg = Some(Message::Block(block));
                 }
 

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -470,7 +470,7 @@ pub struct Connection<S, Tx> {
     pub(super) client_rx: ClientRequestReceiver,
 
     /// A slot for an error shared between the Connection and the Client that uses it.
-    //
+    ///
     /// `None` unless the connection or client have errored.
     pub(super) error_slot: ErrorSlot,
 

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -35,12 +35,12 @@ use crate::{
     peer_set::ConnectionTracker,
     protocol::{
         external::{types::Nonce, InventoryHash, Message},
-        internal::{Request, Response, ResponseStatus},
+        internal::{Request, Response, InventoryResponse},
     },
     BoxError,
 };
 
-use ResponseStatus::*;
+use InventoryResponse::*;
 
 mod peer_tx;
 
@@ -191,8 +191,8 @@ impl Handler {
                     Handler::Finished(Err(PeerError::NotFoundResponse(missing_transaction_ids)))
                 } else if pending_ids.is_empty() || ignored_msg.is_some() {
                     // If we got some of what we wanted, let the internal client know.
-                    let available = transactions.into_iter().map(ResponseStatus::Available);
-                    let missing = pending_ids.into_iter().map(ResponseStatus::Missing);
+                    let available = transactions.into_iter().map(InventoryResponse::Available);
+                    let missing = pending_ids.into_iter().map(InventoryResponse::Missing);
 
                     Handler::Finished(Ok(Response::Transactions(
                         available.chain(missing).collect(),
@@ -239,8 +239,8 @@ impl Handler {
                     Handler::Finished(Err(PeerError::NotFoundResponse(missing_transaction_ids)))
                 } else {
                     // If we got some of what we wanted, let the internal client know.
-                    let available = transactions.into_iter().map(ResponseStatus::Available);
-                    let missing = pending_ids.into_iter().map(ResponseStatus::Missing);
+                    let available = transactions.into_iter().map(InventoryResponse::Available);
+                    let missing = pending_ids.into_iter().map(InventoryResponse::Missing);
 
                     Handler::Finished(Ok(Response::Transactions(
                         available.chain(missing).collect(),
@@ -295,7 +295,7 @@ impl Handler {
 
                 if pending_hashes.is_empty() {
                     // If we got everything we wanted, let the internal client know.
-                    let available = blocks.into_iter().map(ResponseStatus::Available);
+                    let available = blocks.into_iter().map(InventoryResponse::Available);
                     Handler::Finished(Ok(Response::Blocks(available.collect())))
                 } else {
                     // Keep on waiting for all the blocks we wanted, until we get them or time out.
@@ -339,8 +339,8 @@ impl Handler {
                     Handler::Finished(Err(PeerError::NotFoundResponse(missing_block_hashes)))
                 } else {
                     // If we got some of what we wanted, let the internal client know.
-                    let available = blocks.into_iter().map(ResponseStatus::Available);
-                    let missing = pending_hashes.into_iter().map(ResponseStatus::Missing);
+                    let available = blocks.into_iter().map(InventoryResponse::Available);
+                    let missing = pending_hashes.into_iter().map(InventoryResponse::Missing);
 
                     Handler::Finished(Ok(Response::Blocks(available.chain(missing).collect())))
                 }

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -29,7 +29,7 @@ use crate::{
     meta_addr::MetaAddr,
     peer::{
         connection::peer_tx::PeerTx, error::AlreadyErrored, ClientRequest, ClientRequestReceiver,
-        ConnectedAddr, ErrorSlot, InProgressClientRequest, MustUseOneshotSender, PeerError,
+        ConnectedAddr, ErrorSlot, InProgressClientRequest, MustUseClientResponseSender, PeerError,
         SharedPeerError,
     },
     peer_set::ConnectionTracker,
@@ -387,7 +387,7 @@ pub(super) enum State {
     /// Awaiting a peer message we can interpret as a client request.
     AwaitingResponse {
         handler: Handler,
-        tx: MustUseOneshotSender<Result<Response, SharedPeerError>>,
+        tx: MustUseClientResponseSender<Result<Response, SharedPeerError>>,
         span: tracing::Span,
     },
     /// A failure has occurred and we are shutting down the connection.

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -35,7 +35,7 @@ use crate::{
     peer_set::ConnectionTracker,
     protocol::{
         external::{types::Nonce, InventoryHash, Message},
-        internal::{Request, Response, InventoryResponse},
+        internal::{InventoryResponse, Request, Response},
     },
     BoxError,
 };

--- a/zebra-network/src/peer/connection/tests/prop.rs
+++ b/zebra-network/src/peer/connection/tests/prop.rs
@@ -156,6 +156,9 @@ async fn send_block_request(
     let client_request = ClientRequest {
         request,
         tx: response_sender,
+        // we skip inventory collection in these tests
+        inv_collector: None,
+        transient_addr: None,
         span: Span::none(),
     };
 

--- a/zebra-network/src/peer/connection/tests/prop.rs
+++ b/zebra-network/src/peer/connection/tests/prop.rs
@@ -20,11 +20,11 @@ use zebra_test::mock_service::{MockService, PropTestAssertion};
 use crate::{
     peer::{connection::Connection, ClientRequest, ErrorSlot},
     protocol::external::Message,
-    protocol::internal::ResponseStatus,
+    protocol::internal::InventoryResponse,
     Request, Response, SharedPeerError,
 };
 
-use ResponseStatus::*;
+use InventoryResponse::*;
 
 proptest! {
     // The default value of proptest cases (256) causes this test to take more than ten seconds on

--- a/zebra-network/src/peer/connection/tests/vectors.rs
+++ b/zebra-network/src/peer/connection/tests/vectors.rs
@@ -132,6 +132,8 @@ async fn connection_run_loop_message_ok() {
     let request = ClientRequest {
         request: Request::Peers,
         tx: request_tx,
+        inv_collector: None,
+        transient_addr: None,
         span: Span::current(),
     };
 
@@ -459,6 +461,8 @@ async fn connection_run_loop_send_timeout_nil_response() {
     let request = ClientRequest {
         request: Request::AdvertiseTransactionIds(HashSet::new()),
         tx: request_tx,
+        inv_collector: None,
+        transient_addr: None,
         span: Span::current(),
     };
 
@@ -532,6 +536,8 @@ async fn connection_run_loop_send_timeout_expect_response() {
     let request = ClientRequest {
         request: Request::Peers,
         tx: request_tx,
+        inv_collector: None,
+        transient_addr: None,
         span: Span::current(),
     };
 
@@ -605,6 +611,8 @@ async fn connection_run_loop_receive_timeout() {
     let request = ClientRequest {
         request: Request::Peers,
         tx: request_tx,
+        inv_collector: None,
+        transient_addr: None,
         span: Span::current(),
     };
 

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -94,12 +94,12 @@ pub enum PeerError {
     /// or peers can download and verify the missing data.
     ///
     /// If the peer has some of the data, the request returns an [`Ok`] response,
-    /// with any `notfound` data is marked as [`Missing`](ResponseStatus::Missing).
+    /// with any `notfound` data is marked as [`Missing`](InventoryResponse::Missing).
     #[error("Remote peer could not find any of the items: {0:?}")]
     NotFoundResponse(Vec<InventoryHash>),
 
     /// We requested data, but all our ready peers are marked as recently
-    /// [`Missing`](ResponseStatus::Missing) that data in our local inventory registry.
+    /// [`Missing`](InventoryResponse::Missing) that data in our local inventory registry.
     ///
     /// This is a temporary error.
     ///

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -82,9 +82,40 @@ pub enum PeerError {
     #[error("Internal services over capacity")]
     Overloaded,
 
-    /// We requested data that the peer couldn't find.
-    #[error("Remote peer could not find items: {0:?}")]
-    NotFound(Vec<InventoryHash>),
+    /// We requested data, but the peer replied with a `notfound` message.
+    /// (Or it didn't respond before the request finished.)
+    ///
+    /// This error happens when the peer doesn't have any of the requested data,
+    /// so that the original request can be retried.
+    ///
+    /// This is a temporary error.
+    ///
+    /// Zebra can try different peers if the request is retried,
+    /// or peers can download and verify the missing data.
+    ///
+    /// If the peer has some of the data, the request returns an [`Ok`] response,
+    /// with any `notfound` data is marked as [`Missing`](ResponseStatus::Missing).
+    #[error("Remote peer could not find any of the items: {0:?}")]
+    NotFoundResponse(Vec<InventoryHash>),
+
+    /// We requested data, but all our ready peers are marked as recently
+    /// [`Missing`](ResponseStatus::Missing) that data in our local inventory registry.
+    ///
+    /// This is a temporary error.
+    ///
+    /// Peers with the inventory can finish their requests and become ready,
+    /// or other peers can download and verify the missing data.
+    ///
+    /// # Correctness
+    ///
+    /// This error is produced using Zebra's local inventory registry,
+    /// without contacting any peers.
+    ///
+    /// Client responses containing this error must not be used to update the inventory registry.
+    /// This makes sure that we eventually expire our local cache of missing inventory,
+    /// and send requests to peers again.
+    #[error("All ready peers are registered as recently missing these items: {0:?}")]
+    NotFoundRegistry(Vec<InventoryHash>),
 }
 
 impl PeerError {
@@ -103,7 +134,8 @@ impl PeerError {
             PeerError::Serialization(inner) => format!("Serialization({})", inner).into(),
             PeerError::DuplicateHandshake => "DuplicateHandshake".into(),
             PeerError::Overloaded => "Overloaded".into(),
-            PeerError::NotFound(_) => "NotFound".into(),
+            PeerError::NotFoundResponse(_) => "NotFoundResponse".into(),
+            PeerError::NotFoundRegistry(_) => "NotFoundRegistry".into(),
         }
     }
 }

--- a/zebra-network/src/peer/minimum_peer_version/tests.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests.rs
@@ -1,5 +1,7 @@
 //! Test utilities and tests for minimum network peer version requirements.
 
+#![cfg_attr(feature = "proptest-impl", allow(dead_code))]
+
 use zebra_chain::{
     chain_tip::mock::{MockChainTip, MockChainTipSender},
     parameters::Network,

--- a/zebra-network/src/peer_set/inventory_registry.rs
+++ b/zebra-network/src/peer_set/inventory_registry.rs
@@ -21,14 +21,14 @@ use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream, 
 use zebra_chain::{parameters::POST_BLOSSOM_POW_TARGET_SPACING, serialization::AtLeastOne};
 
 use crate::{
-    protocol::{external::InventoryHash, internal::ResponseStatus},
+    protocol::{external::InventoryHash, internal::InventoryResponse},
     BoxError,
 };
 
 use self::update::Update;
 
 /// Underlying type for the alias InventoryStatus::*
-use ResponseStatus::*;
+use InventoryResponse::*;
 
 pub mod update;
 
@@ -36,7 +36,7 @@ pub mod update;
 mod tests;
 
 /// A peer inventory status, which tracks a hash for both available and missing inventory.
-pub type InventoryStatus<T> = ResponseStatus<T, T>;
+pub type InventoryStatus<T> = InventoryResponse<T, T>;
 
 /// A peer inventory status change, used in the inventory status channel.
 ///

--- a/zebra-network/src/peer_set/inventory_registry.rs
+++ b/zebra-network/src/peer_set/inventory_registry.rs
@@ -8,7 +8,6 @@ use std::{
     net::SocketAddr,
     pin::Pin,
     task::{Context, Poll},
-    time::Duration,
 };
 
 use futures::{FutureExt, Stream, StreamExt};
@@ -18,9 +17,10 @@ use tokio::{
 };
 use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream, IntervalStream};
 
-use zebra_chain::{parameters::POST_BLOSSOM_POW_TARGET_SPACING, serialization::AtLeastOne};
+use zebra_chain::serialization::AtLeastOne;
 
 use crate::{
+    constants::INVENTORY_ROTATION_INTERVAL,
     protocol::{external::InventoryHash, internal::InventoryResponse},
     BoxError,
 };
@@ -145,11 +145,7 @@ impl<T: Clone> InventoryStatus<T> {
 impl InventoryRegistry {
     /// Returns a new Inventory Registry for `inv_stream`.
     pub fn new(inv_stream: broadcast::Receiver<InventoryChange>) -> Self {
-        let interval = Duration::from_secs(
-            POST_BLOSSOM_POW_TARGET_SPACING
-                .try_into()
-                .expect("non-negative"),
-        );
+        let interval = INVENTORY_ROTATION_INTERVAL;
 
         // Don't do an immediate rotation, current and prev are already empty.
         let mut interval = tokio::time::interval_at(Instant::now() + interval, interval);

--- a/zebra-network/src/peer_set/inventory_registry.rs
+++ b/zebra-network/src/peer_set/inventory_registry.rs
@@ -106,7 +106,6 @@ impl InventoryChange {
     }
 
     /// Returns a new missing multiple inventory change, if `hashes` contains at least one change.
-    #[allow(dead_code)]
     pub fn new_missing_multi<'a>(
         hashes: impl IntoIterator<Item = &'a InventoryHash>,
         peer: SocketAddr,

--- a/zebra-network/src/peer_set/inventory_registry.rs
+++ b/zebra-network/src/peer_set/inventory_registry.rs
@@ -134,8 +134,8 @@ impl<T> InventoryStatus<T> {
 }
 
 impl<T: Clone> InventoryStatus<T> {
-    /// Get the inner item, regardless of status.
-    pub fn inner(&self) -> T {
+    /// Returns a clone of the inner item, regardless of status.
+    pub fn to_inner(&self) -> T {
         match self {
             Available(item) | Missing(item) => item.clone(),
         }
@@ -269,7 +269,7 @@ impl InventoryRegistry {
     /// `Missing` markers are not updated until the registry rotates, for security reasons.
     fn register(&mut self, change: InventoryChange) {
         let new_status = change.marker();
-        let (invs, addr) = change.inner();
+        let (invs, addr) = change.to_inner();
 
         for inv in invs {
             use InventoryHash::*;

--- a/zebra-network/src/peer_set/inventory_registry/tests/prop.rs
+++ b/zebra-network/src/peer_set/inventory_registry/tests/prop.rs
@@ -29,7 +29,6 @@ proptest! {
 
         // Start the runtime
         let runtime = zebra_test::init_async();
-        let _guard = runtime.enter();
 
         runtime.block_on(async move {
             // Check all combinations of:

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -654,7 +654,7 @@ where
     /// falling back to a ready peer that isn't missing the inventory.
     ///
     /// If all ready peers are missing the inventory,
-    /// returns a [`NotFound`](PeerError::NotFound) error.
+    /// returns a synthetic [`NotFoundRegistry`](PeerError::NotFoundRegistry) error.
     ///
     /// Uses P2C to route requests to the least loaded peer in each list.
     fn route_inv(
@@ -724,7 +724,9 @@ where
             // Avoid routing requests to peers that are missing inventory.
             // If we kept trying doomed requests, peers that are missing our requested inventory
             // could take up a large amount of our bandwidth and retry limits.
-            Err(SharedPeerError::from(PeerError::NotFound(vec![hash])))
+            Err(SharedPeerError::from(PeerError::NotFoundRegistry(vec![
+                hash,
+            ])))
         }
         .map_err(Into::into)
         .boxed()

--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -542,7 +542,7 @@ fn peer_set_route_inv_all_missing_fail() {
                 .downcast_ref::<SharedPeerError>()
                 .expect("peer set should return a boxed SharedPeerError")
                 .inner_debug(),
-            "NotFound([Block(block::Hash(\"0000000000000000000000000000000000000000000000000000000000000000\"))])"
+            "NotFoundRegistry([Block(block::Hash(\"0000000000000000000000000000000000000000000000000000000000000000\"))])"
         );
     });
 }

--- a/zebra-network/src/protocol/external/addr.rs
+++ b/zebra-network/src/protocol/external/addr.rs
@@ -20,6 +20,7 @@ pub use in_version::AddrInVersion;
 pub(super) use v1::AddrV1;
 pub(super) use v2::AddrV2;
 
+#[allow(unused_imports)]
 #[cfg(any(test, feature = "proptest-impl"))]
 pub(super) use v1::{ipv6_mapped_socket_addr, ADDR_V1_SIZE};
 

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -230,7 +230,7 @@ pub enum Message {
     ///
     /// `zcashd` returns requested items in a single batch of messages.
     /// Missing blocks are silently skipped. Missing transaction hashes are
-    /// included in a single `NotFound` message following the transactions.
+    /// included in a single `notfound` message following the transactions.
     /// Other item or non-item messages can come before or after the batch.
     ///
     /// The list contains zero or more inventory hashes.
@@ -254,13 +254,15 @@ pub enum Message {
 
     /// A `notfound` message.
     ///
+    /// Zebra responds with this message when it doesn't have the requested blocks or transactions.
+    ///
     /// When a peer requests a list of transaction hashes, `zcashd` returns:
     ///   - a batch of messages containing found transactions, then
-    ///   - a `NotFound` message containing a list of transaction hashes that
+    ///   - a `notfound` message containing a list of transaction hashes that
     ///      aren't available in its mempool or state.
     ///
     /// But when a peer requests blocks or headers, any missing items are
-    /// silently skipped, without any `NotFound` messages.
+    /// silently skipped, without any `notfound` messages.
     ///
     /// The list contains zero or more inventory hashes.
     ///

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -1,7 +1,3 @@
-#![allow(clippy::unit_arg)]
-
-use crate::constants::{self, magics};
-
 use std::{cmp::max, fmt};
 
 use zebra_chain::{
@@ -12,7 +8,9 @@ use zebra_chain::{
     },
 };
 
-#[cfg(test)]
+use crate::constants::{self, magics};
+
+#[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
 
 /// A magic number identifying the network.

--- a/zebra-network/src/protocol/internal.rs
+++ b/zebra-network/src/protocol/internal.rs
@@ -4,4 +4,4 @@ mod response_status;
 
 pub use request::Request;
 pub use response::Response;
-pub use response_status::ResponseStatus;
+pub use response_status::InventoryResponse;

--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -249,4 +249,30 @@ impl Request {
             Request::MempoolTransactionIds => "MempoolTransactionIds",
         }
     }
+
+    /// Returns true if the request is for block or transaction inventory downloads.
+    pub fn is_inventory_download(&self) -> bool {
+        matches!(
+            self,
+            Request::BlocksByHash(_) | Request::TransactionsById(_)
+        )
+    }
+
+    /// Returns the block hash inventory downloads from the request, if any.
+    pub fn block_hash_inventory(&self) -> HashSet<block::Hash> {
+        if let Request::BlocksByHash(block_hashes) = self {
+            block_hashes.clone()
+        } else {
+            HashSet::new()
+        }
+    }
+
+    /// Returns the transaction ID inventory downloads from the request, if any.
+    pub fn transaction_id_inventory(&self) -> HashSet<UnminedTxId> {
+        if let Request::TransactionsById(transaction_ids) = self {
+            transaction_ids.clone()
+        } else {
+            HashSet::new()
+        }
+    }
 }

--- a/zebra-network/src/protocol/internal/response.rs
+++ b/zebra-network/src/protocol/internal/response.rs
@@ -136,4 +136,9 @@ impl Response {
             Response::Transactions(_) => "Transactions",
         }
     }
+
+    /// Returns true if the response is a block or transaction inventory download.
+    pub fn is_inventory_download(&self) -> bool {
+        matches!(self, Response::Blocks(_) | Response::Transactions(_))
+    }
 }

--- a/zebra-network/src/protocol/internal/response.rs
+++ b/zebra-network/src/protocol/internal/response.rs
@@ -7,12 +7,12 @@ use zebra_chain::{
     transaction::{UnminedTx, UnminedTxId},
 };
 
-use crate::{meta_addr::MetaAddr, protocol::internal::ResponseStatus};
+use crate::{meta_addr::MetaAddr, protocol::internal::InventoryResponse};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
 
-use ResponseStatus::*;
+use InventoryResponse::*;
 
 /// A response to a network request, represented in internal format.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -66,15 +66,15 @@ pub enum Response {
     /// When Zebra doesn't have a block or transaction, it always sends `notfound`.
     /// `zcashd` sometimes sends no response, and sometimes sends `notfound`.
     //
-    // TODO: make this into a HashMap<block::Hash, ResponseStatus<Arc<Block>, ()>> - a unique list (#2244)
-    Blocks(Vec<ResponseStatus<Arc<Block>, block::Hash>>),
+    // TODO: make this into a HashMap<block::Hash, InventoryResponse<Arc<Block>, ()>> - a unique list (#2244)
+    Blocks(Vec<InventoryResponse<Arc<Block>, block::Hash>>),
 
     /// A list of found unmined transactions, and missing unmined transaction IDs.
     ///
     /// Each list contains zero or more entries.
     //
-    // TODO: make this into a HashMap<UnminedTxId, ResponseStatus<UnminedTx, ()>> - a unique list (#2244)
-    Transactions(Vec<ResponseStatus<UnminedTx, UnminedTxId>>),
+    // TODO: make this into a HashMap<UnminedTxId, InventoryResponse<UnminedTx, ()>> - a unique list (#2244)
+    Transactions(Vec<InventoryResponse<UnminedTx, UnminedTxId>>),
 }
 
 impl fmt::Display for Response {

--- a/zebra-network/src/protocol/internal/response_status.rs
+++ b/zebra-network/src/protocol/internal/response_status.rs
@@ -5,7 +5,7 @@ use std::fmt;
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
 
-use ResponseStatus::*;
+use InventoryResponse::*;
 
 /// A generic peer inventory response status.
 ///
@@ -13,7 +13,7 @@ use ResponseStatus::*;
 /// and `Missing` is used for inventory that is missing from the response.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
-pub enum ResponseStatus<A, M> {
+pub enum InventoryResponse<A, M> {
     /// An available inventory item.
     Available(A),
 
@@ -21,18 +21,18 @@ pub enum ResponseStatus<A, M> {
     Missing(M),
 }
 
-impl<A, M> fmt::Display for ResponseStatus<A, M> {
+impl<A, M> fmt::Display for InventoryResponse<A, M> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(self.command())
     }
 }
 
-impl<A, M> ResponseStatus<A, M> {
+impl<A, M> InventoryResponse<A, M> {
     /// Returns the response status type as a string.
     pub fn command(&self) -> &'static str {
         match self {
-            ResponseStatus::Available(_) => "Available",
-            ResponseStatus::Missing(_) => "Missing",
+            InventoryResponse::Available(_) => "Available",
+            InventoryResponse::Missing(_) => "Missing",
         }
     }
 
@@ -48,10 +48,10 @@ impl<A, M> ResponseStatus<A, M> {
         matches!(self, Missing(_))
     }
 
-    /// Maps a `ResponseStatus<A, M>` to `ResponseStatus<B, M>` by applying a function to a
+    /// Maps a `InventoryResponse<A, M>` to `InventoryResponse<B, M>` by applying a function to a
     /// contained [`Available`] value, leaving the [`Missing`] value untouched.
     #[allow(dead_code)]
-    pub fn map_available<B, F: FnOnce(A) -> B>(self, f: F) -> ResponseStatus<B, M> {
+    pub fn map_available<B, F: FnOnce(A) -> B>(self, f: F) -> InventoryResponse<B, M> {
         // Based on Result::map from https://doc.rust-lang.org/src/core/result.rs.html#765
         match self {
             Available(a) => Available(f(a)),
@@ -59,10 +59,10 @@ impl<A, M> ResponseStatus<A, M> {
         }
     }
 
-    /// Maps a `ResponseStatus<A, M>` to `ResponseStatus<A, N>` by applying a function to a
+    /// Maps a `InventoryResponse<A, M>` to `InventoryResponse<A, N>` by applying a function to a
     /// contained [`Missing`] value, leaving the [`Available`] value untouched.
     #[allow(dead_code)]
-    pub fn map_missing<N, F: FnOnce(M) -> N>(self, f: F) -> ResponseStatus<A, N> {
+    pub fn map_missing<N, F: FnOnce(M) -> N>(self, f: F) -> InventoryResponse<A, N> {
         // Based on Result::map_err from https://doc.rust-lang.org/src/core/result.rs.html#850
         match self {
             Available(a) => Available(a),
@@ -70,8 +70,8 @@ impl<A, M> ResponseStatus<A, M> {
         }
     }
 
-    /// Converts from `&ResponseStatus<A, M>` to `ResponseStatus<&A, &M>`.
-    pub fn as_ref(&self) -> ResponseStatus<&A, &M> {
+    /// Converts from `&InventoryResponse<A, M>` to `InventoryResponse<&A, &M>`.
+    pub fn as_ref(&self) -> InventoryResponse<&A, &M> {
         match self {
             Available(item) => Available(item),
             Missing(item) => Missing(item),
@@ -79,7 +79,7 @@ impl<A, M> ResponseStatus<A, M> {
     }
 }
 
-impl<A: Clone, M: Clone> ResponseStatus<A, M> {
+impl<A: Clone, M: Clone> InventoryResponse<A, M> {
     /// Get the available inventory item, if present.
     pub fn available(&self) -> Option<A> {
         if let Available(item) = self {

--- a/zebra-network/src/protocol/internal/response_status.rs
+++ b/zebra-network/src/protocol/internal/response_status.rs
@@ -37,20 +37,17 @@ impl<A, M> InventoryResponse<A, M> {
     }
 
     /// Returns true if the inventory item was available.
-    #[allow(dead_code)]
     pub fn is_available(&self) -> bool {
         matches!(self, Available(_))
     }
 
     /// Returns true if the inventory item was missing.
-    #[allow(dead_code)]
     pub fn is_missing(&self) -> bool {
         matches!(self, Missing(_))
     }
 
     /// Maps a `InventoryResponse<A, M>` to `InventoryResponse<B, M>` by applying a function to a
     /// contained [`Available`] value, leaving the [`Missing`] value untouched.
-    #[allow(dead_code)]
     pub fn map_available<B, F: FnOnce(A) -> B>(self, f: F) -> InventoryResponse<B, M> {
         // Based on Result::map from https://doc.rust-lang.org/src/core/result.rs.html#765
         match self {
@@ -61,7 +58,6 @@ impl<A, M> InventoryResponse<A, M> {
 
     /// Maps a `InventoryResponse<A, M>` to `InventoryResponse<A, N>` by applying a function to a
     /// contained [`Missing`] value, leaving the [`Available`] value untouched.
-    #[allow(dead_code)]
     pub fn map_missing<N, F: FnOnce(M) -> N>(self, f: F) -> InventoryResponse<A, N> {
         // Based on Result::map_err from https://doc.rust-lang.org/src/core/result.rs.html#850
         match self {
@@ -90,7 +86,6 @@ impl<A: Clone, M: Clone> InventoryResponse<A, M> {
     }
 
     /// Get the missing inventory item, if present.
-    #[allow(dead_code)]
     pub fn missing(&self) -> Option<M> {
         if let Missing(item) = self {
             Some(item.clone())

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -24,7 +24,7 @@ metrics = "0.17.1"
 # The fix should be included in multiset 0.0.6.
 multiset = { git = "https://github.com/jmitchell/multiset", rev = "91ef8550b518f75ae87ae0d8771150f259fd34d5" }
 proptest = { version = "0.10.1", optional = true }
-proptest-derive = { version = "0.3", optional = true }
+proptest-derive = { version = "0.3.0", optional = true }
 regex = "1"
 rlimit = "0.5.4"
 rocksdb = "0.17.0"
@@ -47,7 +47,7 @@ halo2 = "=0.1.0-beta.1"
 itertools = "0.10.3"
 jubjub = "0.8.0"
 proptest = "0.10.1"
-proptest-derive = "0.3"
+proptest-derive = "0.3.0"
 spandoc = "0.2"
 tokio = { version = "1.16.1", features = ["full"] }
 

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -61,11 +61,12 @@ semver = "1.0.5"
 tempfile = "3.3.0"
 tokio = { version = "1.16.1", features = ["full", "test-util"] }
 
-proptest = "0.10"
-proptest-derive = "0.3"
+proptest = "0.10.1"
+proptest-derive = "0.3.0"
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
 zebra-consensus = { path = "../zebra-consensus/", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test" }
 

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -366,9 +366,6 @@ impl Service<zn::Request> for Inbound {
                     .try_filter_map(|response| async move {
                         Ok(match response {
                             zs::Response::Block(Some(block)) => Some(block),
-                            // `zcashd` ignores missing blocks in GetData responses,
-                            // rather than including them in a trailing `NotFound`
-                            // message
                             zs::Response::Block(None) => None,
                             _ => unreachable!("wrong response from state"),
                         })

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -319,6 +319,9 @@ impl Service<zn::Request> for Inbound {
 
                 async move {
                     // Correctness: get the current time after acquiring the address book lock.
+                    //
+                    // This time is used to filter outdated peers, so it doesn't really matter
+                    // if we get it when the future is created, or when it starts running.
                     let now = Utc::now();
 
                     // Send a sanitized response

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -31,7 +31,7 @@ use zebra_chain::{
 use zebra_consensus::chain::VerifyChainError;
 use zebra_network::{
     constants::{ADDR_RESPONSE_LIMIT_DENOMINATOR, MAX_ADDRS_IN_MESSAGE},
-    AddressBook, ResponseStatus,
+    AddressBook, InventoryResponse,
 };
 
 // Re-use the syncer timeouts for consistency.
@@ -40,7 +40,7 @@ use super::{
     sync::{BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT},
 };
 
-use ResponseStatus::*;
+use InventoryResponse::*;
 
 pub(crate) mod downloads;
 

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -361,8 +361,8 @@ impl Service<zn::Request> for Inbound {
                 // https://github.com/tower-rs/tower/blob/master/tower/src/util/call_all/common.rs#L112
                 use futures::stream::TryStreamExt;
                 hashes
-                    .clone()
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .map(|hash| zs::Request::Block(hash.into()))
                     .map(|request| state.clone().oneshot(request))
                     .collect::<futures::stream::FuturesOrdered<_>>()

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -22,7 +22,7 @@ use zebra_chain::{
     transaction::{UnminedTx, UnminedTxId, VerifiedUnminedTx},
 };
 use zebra_consensus::{error::TransactionError, transaction, Config as ConsensusConfig};
-use zebra_network::{AddressBook, Request, Response, InventoryResponse};
+use zebra_network::{AddressBook, InventoryResponse, Request, Response};
 use zebra_state::Config as StateConfig;
 use zebra_test::mock_service::{MockService, PanicAssertion};
 

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -22,7 +22,7 @@ use zebra_chain::{
     transaction::{UnminedTx, UnminedTxId, VerifiedUnminedTx},
 };
 use zebra_consensus::{error::TransactionError, transaction, Config as ConsensusConfig};
-use zebra_network::{AddressBook, Request, Response, ResponseStatus};
+use zebra_network::{AddressBook, Request, Response, InventoryResponse};
 use zebra_state::Config as StateConfig;
 use zebra_test::mock_service::{MockService, PanicAssertion};
 
@@ -35,7 +35,7 @@ use crate::{
     BoxError,
 };
 
-use ResponseStatus::*;
+use InventoryResponse::*;
 
 /// Maximum time to wait for a network service request.
 ///

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -18,7 +18,7 @@ use zebra_chain::{
 };
 use zebra_consensus::{chain::VerifyChainError, error::TransactionError, transaction};
 use zebra_network::{
-    connect_isolated_tcp_direct, Config as NetworkConfig, Request, Response, InventoryResponse,
+    connect_isolated_tcp_direct, Config as NetworkConfig, InventoryResponse, Request, Response,
     SharedPeerError,
 };
 use zebra_state::Config as StateConfig;

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -171,11 +171,11 @@ async fn inbound_block_empty_state_notfound() -> Result<(), crate::BoxError> {
                 .expect("unexpected inner error type, expected SharedPeerError");
             assert_eq!(
                 missing_error.inner_debug(),
-                "NotFound([Block(block::Hash(\"1111111111111111111111111111111111111111111111111111111111111111\"))])"
+                "NotFoundResponse([Block(block::Hash(\"1111111111111111111111111111111111111111111111111111111111111111\"))])"
             );
         }
         _ => unreachable!(
-            "peer::Connection should map missing `BlocksByHash` responses as `Err(SharedPeerError(NotFound(_)))`, \
+            "peer::Connection should map missing `BlocksByHash` responses as `Err(SharedPeerError(NotFoundResponse(_)))`, \
              actual result: {:?}",
             response
         ),
@@ -272,22 +272,22 @@ async fn inbound_tx_empty_state_notfound() -> Result<(), crate::BoxError> {
                 if txs == vec![test_tx] {
                     assert_eq!(
                         missing_error.inner_debug(),
-                        "NotFound([Tx(transaction::Hash(\"2222222222222222222222222222222222222222222222222222222222222222\"))])",
+                        "NotFoundResponse([Tx(transaction::Hash(\"2222222222222222222222222222222222222222222222222222222222222222\"))])",
                     );
                 } else if txs == vec![test_wtx] {
                     assert_eq!(
                         missing_error.inner_debug(),
-                        "NotFound([Wtx(WtxId { id: transaction::Hash(\"3333333333333333333333333333333333333333333333333333333333333333\"), auth_digest: AuthDigest(\"4444444444444444444444444444444444444444444444444444444444444444\") })])",
+                        "NotFoundResponse([Wtx(WtxId { id: transaction::Hash(\"3333333333333333333333333333333333333333333333333333333333333333\"), auth_digest: AuthDigest(\"4444444444444444444444444444444444444444444444444444444444444444\") })])",
                     );
                 } else if txs == vec![test_tx, test_wtx] {
                     // The response order is unstable, because it depends on concurrent inbound futures.
                     // In #2244 we will fix this by replacing response Vecs with HashSets.
                     assert!(
                         missing_error.inner_debug() ==
-                        "NotFound([Tx(transaction::Hash(\"2222222222222222222222222222222222222222222222222222222222222222\")), Wtx(WtxId { id: transaction::Hash(\"3333333333333333333333333333333333333333333333333333333333333333\"), auth_digest: AuthDigest(\"4444444444444444444444444444444444444444444444444444444444444444\") })])"
+                        "NotFoundResponse([Tx(transaction::Hash(\"2222222222222222222222222222222222222222222222222222222222222222\")), Wtx(WtxId { id: transaction::Hash(\"3333333333333333333333333333333333333333333333333333333333333333\"), auth_digest: AuthDigest(\"4444444444444444444444444444444444444444444444444444444444444444\") })])"
                         ||
                         missing_error.inner_debug() ==
-                        "NotFound([Wtx(WtxId { id: transaction::Hash(\"3333333333333333333333333333333333333333333333333333333333333333\"), auth_digest: AuthDigest(\"4444444444444444444444444444444444444444444444444444444444444444\") }), Tx(transaction::Hash(\"2222222222222222222222222222222222222222222222222222222222222222\"))])",
+                        "NotFoundResponse([Wtx(WtxId { id: transaction::Hash(\"3333333333333333333333333333333333333333333333333333333333333333\"), auth_digest: AuthDigest(\"4444444444444444444444444444444444444444444444444444444444444444\") }), Tx(transaction::Hash(\"2222222222222222222222222222222222222222222222222222222222222222\"))])",
                         "unexpected response: {:?}",
                         missing_error.inner_debug(),
                     );
@@ -296,7 +296,7 @@ async fn inbound_tx_empty_state_notfound() -> Result<(), crate::BoxError> {
                 }
             }
             _ => unreachable!(
-                "peer::Connection should map missing `TransactionsById` responses as `Err(SharedPeerError(NotFound(_)))`, \
+                "peer::Connection should map missing `TransactionsById` responses as `Err(SharedPeerError(NotFoundResponse(_)))`, \
                  actual result: {:?}",
                 response
             ),

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -18,7 +18,7 @@ use zebra_chain::{
 };
 use zebra_consensus::{chain::VerifyChainError, error::TransactionError, transaction};
 use zebra_network::{
-    connect_isolated_tcp_direct, Config as NetworkConfig, Request, Response, ResponseStatus,
+    connect_isolated_tcp_direct, Config as NetworkConfig, Request, Response, InventoryResponse,
     SharedPeerError,
 };
 use zebra_state::Config as StateConfig;
@@ -33,7 +33,7 @@ use crate::{
     BoxError,
 };
 
-use ResponseStatus::*;
+use InventoryResponse::*;
 
 /// Check that a network stack with an empty address book only contains the local listener port,
 /// by querying the inbound service via a local TCP connection.

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -542,7 +542,7 @@ async fn outbound_tx_partial_response_notfound() -> Result<(), crate::BoxError> 
         )
     };
 
-    // Now send the same request to the  peer set,
+    // Now send another request to the peer set with only the missing transaction,
     // but expect a local failure from the inventory registry.
     //
     // The peer set only does routing for single-transaction requests.

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -59,7 +59,7 @@ async fn inbound_peers_empty_address_book() -> Result<(), crate::BoxError> {
         listen_addr,
     ) = setup().await;
 
-    // Use inbound directly
+    // Send a request to inbound directly
     let request = inbound_service.clone().oneshot(Request::Peers);
     let response = request.await;
     match response.as_ref() {
@@ -78,7 +78,7 @@ async fn inbound_peers_empty_address_book() -> Result<(), crate::BoxError> {
         ),
     };
 
-    // Use the connected peer via a local TCP connection
+    // Send a request via the connected peer, via a local TCP connection, to the inbound service
     let request = connected_peer_service.clone().oneshot(Request::Peers);
     let response = request.await;
     match response.as_ref() {
@@ -138,7 +138,7 @@ async fn inbound_block_empty_state_notfound() -> Result<(), crate::BoxError> {
 
     let test_block = block::Hash([0x11; 32]);
 
-    // Use inbound directly
+    // Send a request to inbound directly
     let request = inbound_service
         .clone()
         .oneshot(Request::BlocksByHash(iter::once(test_block).collect()));
@@ -159,7 +159,7 @@ async fn inbound_block_empty_state_notfound() -> Result<(), crate::BoxError> {
         ),
     };
 
-    // Use the connected peer via a local TCP connection
+    // Send a request via the connected peer, via a local TCP connection, to the inbound service
     let request = connected_peer_service
         .clone()
         .oneshot(Request::BlocksByHash(iter::once(test_block).collect()));
@@ -231,7 +231,7 @@ async fn inbound_tx_empty_state_notfound() -> Result<(), crate::BoxError> {
 
     // Test both transaction ID variants, separately and together
     for txs in [vec![test_tx], vec![test_wtx], vec![test_tx, test_wtx]] {
-        // Use inbound directly
+        // Send a request to inbound directly
         let request = inbound_service
             .clone()
             .oneshot(Request::TransactionsById(txs.iter().copied().collect()));
@@ -256,7 +256,7 @@ async fn inbound_tx_empty_state_notfound() -> Result<(), crate::BoxError> {
             ),
         };
 
-        // Use the connected peer via a local TCP connection
+        // Send a request via the connected peer, via a local TCP connection, to the inbound service
         let request = connected_peer_service
             .clone()
             .oneshot(Request::TransactionsById(txs.iter().copied().collect()));

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -288,8 +288,10 @@ async fn inbound_tx_empty_state_notfound() -> Result<(), crate::BoxError> {
                         ||
                         missing_error.inner_debug() ==
                         "NotFoundResponse([Wtx(WtxId { id: transaction::Hash(\"3333333333333333333333333333333333333333333333333333333333333333\"), auth_digest: AuthDigest(\"4444444444444444444444444444444444444444444444444444444444444444\") }), Tx(transaction::Hash(\"2222222222222222222222222222222222222222222222222222222222222222\"))])",
-                        "unexpected response: {:?}",
+                        "unexpected response: {:?} \
+                         expected response to: {:?}",
                         missing_error.inner_debug(),
+                        txs,
                     );
                 } else {
                     unreachable!("unexpected test case");

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -853,6 +853,8 @@ where
             BlockDownloadVerifyError::DownloadFailed(ref source)
                 if format!("{:?}", source).contains("NotFound") =>
             {
+                // Covers both NotFoundResponse and NotFoundRegistry errors.
+                //
                 // TODO: improve this by checking the type (#2908)
                 //       restart after a certain number of NotFound errors?
                 debug!(error = ?e, "block was not found, possibly from a peer that doesn't have the block yet, continuing");

--- a/zebrad/src/components/sync/tests/timing.rs
+++ b/zebrad/src/components/sync/tests/timing.rs
@@ -95,8 +95,9 @@ fn ensure_timeouts_consistent() {
         "we should expire some inventory every time the syncer resets"
     );
     assert!(
-        2 * INVENTORY_ROTATION_INTERVAL > SYNC_RESTART_DELAY,
-        "we should expire all inventory after the syncer has reset once or twice"
+        SYNC_RESTART_DELAY < 2 * INVENTORY_ROTATION_INTERVAL,
+        "we should give the syncer at least one retry attempt, \
+         before we expire all inventory"
     );
 
     // The default peer crawler interval should be at least

--- a/zebrad/src/components/sync/tests/timing.rs
+++ b/zebrad/src/components/sync/tests/timing.rs
@@ -10,11 +10,18 @@ use futures::future;
 use tokio::time::{timeout, Duration};
 
 use zebra_chain::parameters::{Network, POST_BLOSSOM_POW_TARGET_SPACING};
-use zebra_network::constants::{DEFAULT_CRAWL_NEW_PEER_INTERVAL, HANDSHAKE_TIMEOUT};
-use zn::constants::INVENTORY_ROTATION_INTERVAL;
+use zebra_network::constants::{
+    DEFAULT_CRAWL_NEW_PEER_INTERVAL, HANDSHAKE_TIMEOUT, INVENTORY_ROTATION_INTERVAL,
+};
+use zebra_state::ChainTipSender;
 
-use super::super::*;
-use crate::config::ZebradConfig;
+use crate::{
+    components::sync::{
+        ChainSync, BLOCK_DOWNLOAD_RETRY_LIMIT, BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT,
+        GENESIS_TIMEOUT_RETRY, SYNC_RESTART_DELAY,
+    },
+    config::ZebradConfig,
+};
 
 /// Make sure the timeout values are consistent with each other.
 #[test]
@@ -147,7 +154,7 @@ fn request_genesis_is_rate_limited() {
     });
 
     // create an empty latest chain tip
-    let (_sender, latest_chain_tip, _change) = zs::ChainTipSender::new(None, Network::Mainnet);
+    let (_sender, latest_chain_tip, _change) = ChainTipSender::new(None, Network::Mainnet);
 
     // create a verifier service that will always panic as it will never be called
     let verifier_service =

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -11,7 +11,7 @@ use zebra_chain::{
     serialization::ZcashDeserializeInto,
 };
 use zebra_consensus::Config as ConsensusConfig;
-use zebra_network::ResponseStatus;
+use zebra_network::InventoryResponse;
 use zebra_state::Config as StateConfig;
 use zebra_test::mock_service::{MockService, PanicAssertion};
 
@@ -26,7 +26,7 @@ use crate::{
     config::ZebradConfig,
 };
 
-use ResponseStatus::*;
+use InventoryResponse::*;
 
 /// Maximum time to wait for a request to any test service.
 ///


### PR DESCRIPTION
## Motivation

We want to avoid repeated requests to peers that don't have a block or transaction:

1. `zcashd` doesn't respond to requests for missing blocks with `notfound` messages.
So we have to check its responses, and track missing inventory in them.

2. When Zebra cancels a request because a peer is slow, or when a peer times out, we don't want to try that peer again.

We want to retry missing blocks or transactions after a few minutes:

3. Zebra's inventory rotation interval was a bit long.

## Solution

- register peer partial responses and errors as missing inventory
    - add an inventory collector to Client
    - split synthetic NotFoundRegistry errors from NotFoundResponse errors created from peer messages
    - add tests for partial missing and error inventory registration
- make the inventory rotation interval a bit shorter, to improve performance

Related changes (needed for tests):
- add a proptest-impl feature to zebra-network
- add a test-only `connect_isolated_with_inbound` function

Related Fixes:
- minor review fixes from PR #3466

Closes #2156.

## Review

@oxarbitrage can review this PR, I'm happy to do a video review if that would help.

During reviews, I'd like to focus on any design issues or bugs in this PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

We're finally done with these network fixes!