### PR TITLE
fix(actions): typo in paths filtering keyword

### DIFF
--- a/.github/workflows/ci.patch.yml
+++ b/.github/workflows/ci.patch.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    path-ignore:
+    paths-ignore:
       - '**/*.rs'
       - '**/*.txt'
       - '**/Cargo.toml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
-    path:
+    paths:
       - '**/*.rs'
       - '**/*.txt'
       - '**/Cargo.toml'

--- a/.github/workflows/coverage.patch.yml
+++ b/.github/workflows/coverage.patch.yml
@@ -3,7 +3,7 @@ name: Coverage
 on:
   workflow_dispatch:
   pull_request:
-    path-ignore:
+    paths-ignore:
       - '**/*.rs'
       - '**/*.txt'
       - '**/Cargo.toml'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,7 @@ name: Coverage
 on:
   workflow_dispatch:
   pull_request:
-    path:
+    paths:
       - '**/*.rs'
       - '**/*.txt'
       - '**/Cargo.toml'

--- a/.github/workflows/docs.patch.yml
+++ b/.github/workflows/docs.patch.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-    path-ignore:
+    paths-ignore:
       - 'book/**'
       - '**/firebase.json'
       - 'katex-header.html'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-    path:
+    paths:
       - 'book/**'
       - '**/firebase.json'
       - 'katex-header.html'

--- a/.github/workflows/lint.patch.yml
+++ b/.github/workflows/lint.patch.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "**"
       - "!main"
-    path-ignore:
+    paths-ignore:
       - '**/*.rs'
       - '**/Cargo.toml'
       - '**/Cargo.lock'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "**"
       - "!main"
-    path:
+    paths:
       - '**/*.rs'
       - '**/Cargo.toml'
       - '**/Cargo.lock'

--- a/.github/workflows/test.patch.yml
+++ b/.github/workflows/test.patch.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-    path-ignore:
+    paths-ignore:
       - '**/*.rs'
       - '**/*.txt'
       - '**/Cargo.toml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-    path:
+    paths:
       - '**/*.rs'
       - '**/*.txt'
       - '**/Cargo.toml'

--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - 'main'
-    path:
+    paths:
       - 'zebra-consensus/src/primitives/groth16/params.rs'
       - 'zebra-consensus/src/chain.rs'
       - 'zebrad/src/commands/start.rs'


### PR DESCRIPTION
## Motivation

Most actions have been running, without respecting which file is being modified, and there's been no impact in time savings because of this.


## Solution

The keyword is `paths` and the actions were using `path`

## Review

@conradoplg @dconnolly 
