### PR TITLE
Ignore non-verack and non-version messages in handshake

### DIFF
--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -605,7 +605,7 @@ where
                     .next()
                     .await
                     .ok_or(HandshakeError::ConnectionClosed)??;
-                debug!("ignoring non-version message from remote peer");
+                debug!(?remote_msg, "ignoring non-version message from remote peer");
             }
         }
     }
@@ -733,7 +733,7 @@ where
                     .next()
                     .await
                     .ok_or(HandshakeError::ConnectionClosed)??;
-                debug!("ignoring non-verack message from remote peer");
+                debug!(?remote_msg, "ignoring non-verack message from remote peer");
             }
         }
     }

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -592,17 +592,21 @@ where
         .next()
         .await
         .ok_or(HandshakeError::ConnectionClosed)??;
-    debug!(?remote_msg, "got message from remote peer");
 
-    // Wait for next message if the one we have is not Version
-    match remote_msg {
-        Message::Version { .. } => (),
-        _ => {
-            remote_msg = peer_conn
-                .next()
-                .await
-                .ok_or(HandshakeError::ConnectionClosed)??;
-            debug!(?remote_msg, "got message from remote peer");
+    // Wait for next message if the one we got is not Version
+    loop {
+        match remote_msg {
+            Message::Version { .. } => {
+                debug!(?remote_msg, "got version message from remote peer");
+                break;
+            }
+            _ => {
+                remote_msg = peer_conn
+                    .next()
+                    .await
+                    .ok_or(HandshakeError::ConnectionClosed)??;
+                debug!("ignoring non-version message from remote peer");
+            }
         }
     }
 
@@ -712,14 +716,26 @@ where
 
     peer_conn.send(Message::Verack).await?;
 
-    let remote_msg = peer_conn
+    let mut remote_msg = peer_conn
         .next()
         .await
         .ok_or(HandshakeError::ConnectionClosed)??;
-    if let Message::Verack = remote_msg {
-        debug!("got verack message from remote peer");
-    } else {
-        debug!("ignoring non-verack message from remote peer");
+
+    // Wait for next message if the one we got is not Verack
+    loop {
+        match remote_msg {
+            Message::Verack => {
+                debug!(?remote_msg, "got verack message from remote peer");
+                break;
+            }
+            _ => {
+                remote_msg = peer_conn
+                    .next()
+                    .await
+                    .ok_or(HandshakeError::ConnectionClosed)??;
+                debug!("ignoring non-verack message from remote peer");
+            }
+        }
     }
 
     Ok((remote_version, remote_services, remote_canonical_addr))

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -705,9 +705,9 @@ where
         .await
         .ok_or(HandshakeError::ConnectionClosed)??;
     if let Message::Verack = remote_msg {
-        debug!("got verack from remote peer");
+        debug!("got verack message from remote peer");
     } else {
-        Err(HandshakeError::UnexpectedMessage(Box::new(remote_msg)))?;
+        debug!("ignoring non-verack message from remote peer");
     }
 
     Ok((remote_version, remote_services, remote_canonical_addr))


### PR DESCRIPTION
## Motivation

We want to ignore some messages during handshake to make the conformance tests of ziggurat pass: https://github.com/eqlabs/ziggurat/blob/master/SPEC.md#zg-conformance-003

Close https://github.com/ZcashFoundation/zebra/issues/3429

## Solution

Ignore the verack can be done just by not closing the connection when receiving other messages at the end of the handshake. This is done in https://github.com/ZcashFoundation/zebra/commit/cce709ab8509fa94ebf8950b477cf6ecba4aa91c

The version is a bit trickier, we need to wait for another message when we receive a non version one at the beginning of the handshake.

I made a proof of concept of this at https://github.com/ZcashFoundation/zebra/commit/cce709ab8509fa94ebf8950b477cf6ecba4aa91c however the code can be improved as it is doing some duplicated work. I am looking for some suggestions there but before that i want to make sure that we will want to really do that as it is in this pull request.

## Review

I will like @teor2345 and/or @jvff to take a look.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors