### PR TITLE
fix(clippy): new lints in nightly Rust

### DIFF
--- a/zebra-consensus/src/checkpoint/list/tests.rs
+++ b/zebra-consensus/src/checkpoint/list/tests.rs
@@ -174,14 +174,13 @@ fn checkpoint_list_duplicate_heights_fail() -> Result<(), BoxError> {
 
     // Parse the genesis block
     let mut checkpoint_data = Vec::new();
-    for b in &[&zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..]] {
-        let block = Arc::<Block>::zcash_deserialize(*b)?;
-        let hash = block.hash();
-        checkpoint_data.push((
-            block.coinbase_height().expect("test block has height"),
-            hash,
-        ));
-    }
+    let block =
+        Arc::<Block>::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..])?;
+    let hash = block.hash();
+    checkpoint_data.push((
+        block.coinbase_height().expect("test block has height"),
+        hash,
+    ));
 
     // Then add some fake entries with duplicate heights
     checkpoint_data.push((block::Height(1), block::Hash([0xaa; 32])));
@@ -202,14 +201,13 @@ fn checkpoint_list_duplicate_hashes_fail() -> Result<(), BoxError> {
 
     // Parse the genesis block
     let mut checkpoint_data = Vec::new();
-    for b in &[&zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..]] {
-        let block = Arc::<Block>::zcash_deserialize(*b)?;
-        let hash = block.hash();
-        checkpoint_data.push((
-            block.coinbase_height().expect("test block has height"),
-            hash,
-        ));
-    }
+    let block =
+        Arc::<Block>::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..])?;
+    let hash = block.hash();
+    checkpoint_data.push((
+        block.coinbase_height().expect("test block has height"),
+        hash,
+    ));
 
     // Then add some fake entries with duplicate hashes
     checkpoint_data.push((block::Height(1), block::Hash([0xcc; 32])));


### PR DESCRIPTION
## Motivation

`clippy` provides automated feedback on how to write good Rust code.

Some developers use nightly Rust, which adds a few lints every few weeks.
If we don't fix or disable these warnings, we might miss important warnings or errors.

## Solution

Fix the following new clippy lints:
- manual Range::contains
    - also make the surrounding code clearer
- for loop with only one item

## Review

Anyone can review this optional PR.

### Reviewer Checklist

  - [ ] New Code Makes Sense
  - [ ] Existing Tests Pass

