### PR TITLE
Full chain synchronization acceptance tests

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1481,3 +1481,27 @@ where
 
     Ok(())
 }
+
+/// What the expected behavior of the mempool is for a test that uses [`sync_until`].
+enum MempoolBehavior {
+    /// The mempool should be forced to activate at a certain height, for debug purposes.
+    ForceActivationAt(Height),
+
+    /// The mempool should not become active during the test.
+    ShouldNotActivate,
+}
+
+impl MempoolBehavior {
+    /// Return the height value that the mempool should be enabled at, if available.
+    pub fn enable_at_height(&self) -> Option<u32> {
+        match self {
+            MempoolBehavior::ForceActivationAt(height) => Some(height.0),
+            MempoolBehavior::ShouldNotActivate => None,
+        }
+    }
+
+    /// Returns `true` if the mempool should be forcefully activated at a specified height.
+    pub fn is_forced_activation(&self) -> bool {
+        matches!(self, MempoolBehavior::ForceActivationAt(_))
+    }
+}


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
As we approach our first stable release, it's important for Zebra to work well and not have any regressions. We've had a few issues with chain synchronization before (#3322, #3375, #3352), and we didn't have a good way to catch these issues early one. Running an acceptance test that synchronizes the full chain should help us detect if there are any hangs or performance regressions in the future.

This closes #3493, and serves as a base for #1592.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Two acceptance tests were added, one for mainnet and one for testnet. Both synchronize the chain and check that it completes within an externally specified timeout and that the mempool becomes active when synchronization finishes.

The tests only run if `--ignored` is specified to the test command and if an environment value with the specific test timeout value is specified. This is because these tests may take a long time, and can exceed GitHub Action's time limit. Having the timeout value specified externally makes it easier to tweak it in the CI jobs.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@oxarbitrage can review this.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
#1592 will add this test to the CI pipeline.