### PR TITLE
fix(test): make full sync test more accurate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5734,6 +5734,7 @@ dependencies = [
  "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
+ "num-integer",
  "once_cell",
  "pin-project 1.0.7",
  "proptest",

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -42,7 +42,7 @@ mod types;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use list::CheckpointList;
+pub use list::CheckpointList;
 use types::{Progress, Progress::*};
 use types::{TargetHeight, TargetHeight::*};
 

--- a/zebra-consensus/src/checkpoint/list.rs
+++ b/zebra-consensus/src/checkpoint/list.rs
@@ -53,7 +53,7 @@ const TESTNET_CHECKPOINTS: &str = include_str!("test-checkpoints.txt");
 /// This is actually a bijective map, but since it is read-only, we use a
 /// BTreeMap, and do the value uniqueness check on initialisation.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct CheckpointList(BTreeMap<block::Height, block::Hash>);
+pub struct CheckpointList(BTreeMap<block::Height, block::Hash>);
 
 impl FromStr for CheckpointList {
     type Err = BoxError;

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -48,7 +48,9 @@ pub mod chain;
 pub mod error;
 
 pub use block::VerifyBlockError;
-pub use checkpoint::{VerifyCheckpointError, MAX_CHECKPOINT_BYTE_COUNT, MAX_CHECKPOINT_HEIGHT_GAP};
+pub use checkpoint::{
+    CheckpointList, VerifyCheckpointError, MAX_CHECKPOINT_BYTE_COUNT, MAX_CHECKPOINT_HEIGHT_GAP,
+};
 pub use config::Config;
 pub use error::BlockError;
 pub use primitives::groth16;

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -48,6 +48,7 @@ atty = "0.2.14"
 sentry = { version = "0.23.0", default-features = false, features = ["backtrace", "contexts", "reqwest", "rustls"] }
 sentry-tracing = "0.23.0"
 
+num-integer = "0.1.44"
 rand = "0.8.5"
 
 [build-dependencies]

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -327,6 +327,9 @@ impl StartCmd {
         // The minimum number of extra blocks mined between updating a checkpoint list,
         // and running an automated test that depends on that list.
         //
+        // Makes sure that the block finalization code always runs in sync tests,
+        // even if the miner or test node clock is wrong by a few minutes.
+        //
         // This is an estimate based on the time it takes to:
         // - get the tip height from `zcashd`,
         // - run `zebra-checkpoints` to update the checkpoint list,

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -346,6 +346,11 @@ impl StartCmd {
         // Most chain forks are 1-7 blocks long.
         let min_state_block_interval = max_block_spacing.unwrap_or(target_block_spacing * 4) * 2;
 
+        // Formatted string for logging.
+        let max_block_spacing = max_block_spacing
+            .map(|duration| duration.to_string())
+            .unwrap_or_else(|| "None".to_string());
+
         // The last time we downloaded and verified at least one block.
         //
         // Initialized to the start time to simplify the code.
@@ -400,9 +405,9 @@ impl StartCmd {
                     warn!(
                         %sync_percent,
                         ?current_height,
-                        ?time_since_last_state_block,
-                        ?target_block_spacing,
-                        ?max_block_spacing,
+                        %time_since_last_state_block,
+                        %target_block_spacing,
+                        %max_block_spacing,
                         ?is_syncer_stopped,
                         "chain updates have stalled, \
                          state height has not increased for {} minutes. \
@@ -419,7 +424,7 @@ impl StartCmd {
                         ?current_height,
                         ?remaining_sync_blocks,
                         ?after_checkpoint_height,
-                        ?time_since_last_state_block,
+                        %time_since_last_state_block,
                         "initial sync is very slow, or estimated tip is wrong. \
                          Hint: check your network connection, \
                          and your computer clock and time zone",
@@ -432,7 +437,7 @@ impl StartCmd {
                         ?current_height,
                         ?remaining_sync_blocks,
                         ?after_checkpoint_height,
-                        ?time_since_last_state_block,
+                        %time_since_last_state_block,
                         "initial sync is very slow, and state is below the highest checkpoint. \
                          Hint: check your network connection, \
                          and your computer clock and time zone",
@@ -443,7 +448,7 @@ impl StartCmd {
                         %sync_percent,
                         ?current_height,
                         ?remaining_sync_blocks,
-                        ?time_since_last_state_block,
+                        %time_since_last_state_block,
                         "finished initial sync to chain tip, and activated mempool",
                     );
                 } else if remaining_sync_blocks <= MAX_CLOSE_TO_TIP_BLOCKS {
@@ -452,7 +457,7 @@ impl StartCmd {
                         %sync_percent,
                         ?current_height,
                         ?remaining_sync_blocks,
-                        ?time_since_last_state_block,
+                        %time_since_last_state_block,
                         "finished initial sync, \
                          waiting for syncer to stabilise before activating mempool",
                     );
@@ -462,7 +467,7 @@ impl StartCmd {
                         %sync_percent,
                         ?current_height,
                         ?remaining_sync_blocks,
-                        ?time_since_last_state_block,
+                        %time_since_last_state_block,
                         "estimated progress to chain tip",
                     );
                 }

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -344,6 +344,9 @@ impl StartCmd {
         // We expect the state height to increase at least once in this interval.
         //
         // Most chain forks are 1-7 blocks long.
+        //
+        // TODO: remove the target_block_spacing multiplier,
+        //       after fixing slow syncing near tip (#3375)
         let min_state_block_interval = max_block_spacing.unwrap_or(target_block_spacing * 4) * 2;
 
         // Formatted string for logging.
@@ -492,7 +495,7 @@ impl StartCmd {
                     info!(
                         %sync_percent,
                         current_height = %"None",
-                        "initial sync is waiting to download the genesis block"
+                        "initial sync is waiting to download the genesis block",
                     );
                 }
             }

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -399,7 +399,7 @@ impl StartCmd {
                 // Work out the sync progress towards the estimated tip.
                 let sync_progress = f64::from(current_height.0) / f64::from(estimated_height.0);
                 let sync_percent = format!(
-                    "{:.frac$}",
+                    "{:.frac$} %",
                     sync_progress * 100.0,
                     frac = SYNC_PERCENT_FRAC_DIGITS,
                 );
@@ -504,7 +504,7 @@ impl StartCmd {
                     );
                 }
             } else {
-                let sync_percent = format!("{:.frac$}", 0.0f64, frac = SYNC_PERCENT_FRAC_DIGITS,);
+                let sync_percent = format!("{:.frac$} %", 0.0f64, frac = SYNC_PERCENT_FRAC_DIGITS,);
 
                 if is_syncer_stopped {
                     // We've stopped syncing blocks,

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -355,7 +355,7 @@ impl StartCmd {
                         %sync_percent,
                         ?current_height,
                         ?remaining_sync_blocks,
-                        "finished initial sync to chain tip"
+                        "finished initial sync to chain tip, and activated mempool",
                     );
                 } else if remaining_sync_blocks <= MAX_CLOSE_TO_TIP_BLOCKS {
                     // We estimate we're near the tip, but we have been syncing lots of blocks recently.
@@ -363,7 +363,8 @@ impl StartCmd {
                         %sync_percent,
                         ?current_height,
                         ?remaining_sync_blocks,
-                        "finished initial sync to chain tip"
+                        "finished initial sync, \
+                         waiting for syncer to stabilise before activating mempool",
                     );
                 } else {
                     // We estimate we're far from the tip, and we've been syncing lots of blocks.
@@ -371,7 +372,7 @@ impl StartCmd {
                         %sync_percent,
                         ?current_height,
                         ?remaining_sync_blocks,
-                        "estimated progress to chain tip"
+                        "estimated progress to chain tip",
                     );
                 }
             }

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -64,7 +64,11 @@ use tokio::{pin, select, sync::oneshot};
 use tower::{builder::ServiceBuilder, util::BoxService};
 use tracing_futures::Instrument;
 
-use zebra_chain::{chain_tip::ChainTip, parameters::Network};
+use zebra_chain::{
+    block::Height,
+    chain_tip::ChainTip,
+    parameters::{Network, NetworkUpgrade},
+};
 use zebra_consensus::CheckpointList;
 
 use crate::{
@@ -333,9 +337,28 @@ impl StartCmd {
             .add(min_after_checkpoint_blocks)
             .expect("hard-coded checkpoint height is far below Height::MAX");
 
+        let target_block_spacing = NetworkUpgrade::target_spacing_for_height(network, Height::MAX);
+        let max_block_spacing =
+            NetworkUpgrade::minimum_difficulty_spacing_for_height(network, Height::MAX);
+
+        // We expect the state height to increase at least once in this interval.
+        //
+        // Most chain forks are 1-7 blocks long.
+        let min_state_block_interval = max_block_spacing.unwrap_or(target_block_spacing * 4) * 2;
+
+        // The last time we downloaded and verified at least one block.
+        //
+        // Initialized to the start time to simplify the code.
+        let mut last_state_change_time = Utc::now();
+
+        // The state tip height, when we last downloaded and verified at least one block.
+        //
+        // Initialized to the genesis height to simplify the code.
+        let mut last_state_change_height = Height(0);
+
         loop {
             let now = Utc::now();
-            let is_close_to_tip = sync_status.is_close_to_tip();
+            let is_syncer_stopped = sync_status.is_close_to_tip();
 
             if let Some(estimated_height) =
                 latest_chain_tip.estimate_network_chain_tip_height(network, now)
@@ -346,6 +369,7 @@ impl StartCmd {
                     .best_tip_height()
                     .expect("unexpected empty state: estimate requires a block height");
 
+                // Work out the sync progress towards the estimated tip.
                 let sync_progress = f64::from(current_height.0) / f64::from(estimated_height.0);
                 let sync_percent = format!(
                     "{:.frac$}",
@@ -355,11 +379,38 @@ impl StartCmd {
 
                 let remaining_sync_blocks = estimated_height - current_height;
 
+                // Work out how long it has been since the state height has increased.
+                //
+                // Non-finalized forks can decrease the height, we only want to track increases.
+                if current_height > last_state_change_height {
+                    last_state_change_height = current_height;
+                    last_state_change_time = now;
+                }
+
+                let time_since_last_state_block = last_state_change_time.signed_duration_since(now);
+
                 // TODO:
                 // - log progress, remaining blocks, and remaining time to next network upgrade
                 // - add some of this info to the metrics
 
-                if is_close_to_tip && remaining_sync_blocks > MIN_SYNC_WARNING_BLOCKS {
+                if time_since_last_state_block > min_state_block_interval {
+                    // The state tip height hasn't increased for a long time.
+                    //
+                    // Block verification can fail if the local node's clock is wrong.
+                    warn!(
+                        %sync_percent,
+                        ?current_height,
+                        ?time_since_last_state_block,
+                        ?target_block_spacing,
+                        ?max_block_spacing,
+                        ?is_syncer_stopped,
+                        "chain updates have stalled, \
+                         state height has not increased for {} minutes. \
+                         Hint: check your network connection, \
+                         and your computer clock and time zone",
+                        time_since_last_state_block.num_minutes(),
+                    );
+                } else if is_syncer_stopped && remaining_sync_blocks > MIN_SYNC_WARNING_BLOCKS {
                     // We've stopped syncing blocks, but we estimate we're a long way from the tip.
                     //
                     // TODO: warn after fixing slow syncing near tip (#3375)
@@ -368,30 +419,31 @@ impl StartCmd {
                         ?current_height,
                         ?remaining_sync_blocks,
                         ?after_checkpoint_height,
+                        ?time_since_last_state_block,
                         "initial sync is very slow, or estimated tip is wrong. \
                          Hint: check your network connection, \
                          and your computer clock and time zone",
                     );
-                } else if is_close_to_tip && current_height <= after_checkpoint_height {
+                } else if is_syncer_stopped && current_height <= after_checkpoint_height {
                     // We've stopped syncing blocks,
                     // but we're below the height our checkpoints were generated from.
-                    //
-                    // Block verification can fail if the local node's clock is wrong.
                     warn!(
                         %sync_percent,
                         ?current_height,
                         ?remaining_sync_blocks,
                         ?after_checkpoint_height,
+                        ?time_since_last_state_block,
                         "initial sync is very slow, and state is below the highest checkpoint. \
                          Hint: check your network connection, \
                          and your computer clock and time zone",
                     );
-                } else if is_close_to_tip {
+                } else if is_syncer_stopped {
                     // We've stayed near the tip for a while, and we've stopped syncing lots of blocks.
                     info!(
                         %sync_percent,
                         ?current_height,
                         ?remaining_sync_blocks,
+                        ?time_since_last_state_block,
                         "finished initial sync to chain tip, and activated mempool",
                     );
                 } else if remaining_sync_blocks <= MAX_CLOSE_TO_TIP_BLOCKS {
@@ -400,6 +452,7 @@ impl StartCmd {
                         %sync_percent,
                         ?current_height,
                         ?remaining_sync_blocks,
+                        ?time_since_last_state_block,
                         "finished initial sync, \
                          waiting for syncer to stabilise before activating mempool",
                     );
@@ -409,13 +462,14 @@ impl StartCmd {
                         %sync_percent,
                         ?current_height,
                         ?remaining_sync_blocks,
+                        ?time_since_last_state_block,
                         "estimated progress to chain tip",
                     );
                 }
             } else {
                 let sync_percent = format!("{:.frac$}", 0.0f64, frac = SYNC_PERCENT_FRAC_DIGITS,);
 
-                if is_close_to_tip {
+                if is_syncer_stopped {
                     // We've stopped syncing blocks,
                     // but we haven't downloaded and verified the genesis block.
                     warn!(

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -444,22 +444,24 @@ impl StartCmd {
                     );
                 } else if is_syncer_stopped {
                     // We've stayed near the tip for a while, and we've stopped syncing lots of blocks.
+                    // So we're mostly using gossiped blocks now.
                     info!(
                         %sync_percent,
                         ?current_height,
                         ?remaining_sync_blocks,
                         %time_since_last_state_block,
-                        "finished initial sync to chain tip, and activated mempool",
+                        "finished initial sync to chain tip, using gossiped blocks",
                     );
                 } else if remaining_sync_blocks <= MAX_CLOSE_TO_TIP_BLOCKS {
                     // We estimate we're near the tip, but we have been syncing lots of blocks recently.
+                    // We might also be using some gossiped blocks.
                     info!(
                         %sync_percent,
                         ?current_height,
                         ?remaining_sync_blocks,
                         %time_since_last_state_block,
-                        "finished initial sync, \
-                         waiting for syncer to stabilise before activating mempool",
+                        "close to finishing initial sync, \
+                         confirming using syncer and gossiped blocks",
                     );
                 } else {
                     // We estimate we're far from the tip, and we've been syncing lots of blocks.

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -344,6 +344,7 @@ impl StartCmd {
                     // TODO: warn after fixing slow syncing near tip (#3375)
                     info!(
                         %sync_percent,
+                        ?current_height,
                         ?remaining_sync_blocks,
                         "initial sync might have stalled, or estimated tip is wrong. \
                          Hint: check that your computer's clock and time zone are correct"
@@ -355,6 +356,7 @@ impl StartCmd {
                     //       and have been stable for a while (#1592)
                     info!(
                         %sync_percent,
+                        ?current_height,
                         ?remaining_sync_blocks,
                         "finished initial sync to chain tip"
                     );
@@ -362,6 +364,7 @@ impl StartCmd {
                     // We estimate we're near the tip, but we have been syncing lots of blocks recently.
                     info!(
                         %sync_percent,
+                        ?current_height,
                         ?remaining_sync_blocks,
                         "finished initial sync to chain tip"
                     );
@@ -369,6 +372,7 @@ impl StartCmd {
                     // We estimate we're far from the tip, and we've been syncing lots of blocks.
                     info!(
                         %sync_percent,
+                        ?current_height,
                         ?remaining_sync_blocks,
                         "estimated progress to chain tip"
                     );

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -351,9 +351,6 @@ impl StartCmd {
                     );
                 } else if is_close_to_tip {
                     // We've stayed near the tip for a while, and we've stopped syncing lots of blocks.
-                    //
-                    // TODO: reduce this log level after full sync tests are merged,
-                    //       and have been stable for a while (#1592)
                     info!(
                         %sync_percent,
                         ?current_height,

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -903,7 +903,7 @@ fn sync_large_checkpoints_mempool_mainnet() -> Result<()> {
 #[test]
 #[ignore]
 fn full_sync_mainnet() {
-    assert!(full_sync_test(Mainnet, "FULL_SYNC_MAINNET_TIMEOUT_MINUTES").is_ok());
+    full_sync_test(Mainnet, "FULL_SYNC_MAINNET_TIMEOUT_MINUTES").expect("unexpected test failure");
 }
 
 /// Test if `zebrad` can fully sync the chain on testnet.
@@ -914,7 +914,7 @@ fn full_sync_mainnet() {
 #[test]
 #[ignore]
 fn full_sync_testnet() {
-    assert!(full_sync_test(Testnet, "FULL_SYNC_TESTNET_TIMEOUT_MINUTES").is_ok());
+    full_sync_test(Testnet, "FULL_SYNC_TESTNET_TIMEOUT_MINUTES").expect("unexpected test failure");
 }
 
 /// Sync `network` until the chain tip is reached, or a timeout elapses.
@@ -939,6 +939,13 @@ fn full_sync_test(network: Network, timeout_argument_name: &'static str) -> Resu
         )
         .map(|_| ())
     } else {
+        tracing::info!(
+            ?network,
+            "skipped full sync test, \
+             set the {:?} environmental variable to run the test",
+            timeout_argument_name,
+        );
+
         Ok(())
     }
 }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -739,9 +739,14 @@ const LARGE_CHECKPOINT_TEST_HEIGHT: Height =
 
 const STOP_AT_HEIGHT_REGEX: &str = "stopping at configured height";
 
-/// The text that should be logged when synchronization finishes, reaches the estimated chain tip,
-/// and activates the mempool.
-const SYNC_FINISHED_REGEX: &str = "finished initial sync to chain tip, and activated mempool";
+/// The text that should be logged when the initial sync finishes at the estimated chain tip.
+///
+/// This message is only logged if:
+/// - we have reached the estimated chain tip,
+/// - we have synced all known checkpoints,
+/// - the syncer has stopped downloading lots of blocks, and
+/// - we are regularly downloading some blocks via the syncer or block gossip.
+const SYNC_FINISHED_REGEX: &str = "finished initial sync to chain tip, using gossiped blocks";
 
 /// The maximum amount of time Zebra should take to reload after shutting down.
 ///

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -957,9 +957,8 @@ fn full_sync_test(network: Network, timeout_argument_name: &'static str) -> Resu
 /// If `check_legacy_chain` is true,
 /// make sure the logs contain the legacy chain check.
 ///
-/// If `enable_mempool_at_height` is `Some(Height(_))`,
-/// configure `zebrad` to debug-enable the mempool at that height.
-/// Then check the logs for the mempool being enabled.
+/// Configure `zebrad` to debug-enable the mempool based on `mempool_behavior`,
+/// Then check the logs for the expected `mempool_behavior`.
 ///
 /// If `stop_regex` is encountered before the process exits, kills the
 /// process, and mark the test as successful, even if `height` has not
@@ -1122,6 +1121,10 @@ fn create_cached_database(network: Network) -> Result<()> {
         true,
         |test_child: &mut TestChild<PathBuf>| {
             // make sure pre-cached databases finish before the mandatory checkpoint
+            //
+            // TODO: this check passes even if we reach the mandatory checkpoint,
+            //       because we sync finalized state, then non-finalized state.
+            //       Instead, fail if we see "best non-finalized chain root" in the logs.
             test_child.expect_stdout_line_matches("CommitFinalized request")?;
             Ok(())
         },

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -963,7 +963,7 @@ fn full_sync_test(network: Network, timeout_argument_name: &'static str) -> Resu
 /// make sure the logs contain the legacy chain check.
 ///
 /// Configure `zebrad` to debug-enable the mempool based on `mempool_behavior`,
-/// Then check the logs for the expected `mempool_behavior`.
+/// then check the logs for the expected `mempool_behavior`.
 ///
 /// If `stop_regex` is encountered before the process exits, kills the
 /// process, and mark the test as successful, even if `height` has not

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -739,9 +739,9 @@ const LARGE_CHECKPOINT_TEST_HEIGHT: Height =
 
 const STOP_AT_HEIGHT_REGEX: &str = "stopping at configured height";
 
-/// The text that should be logged when synchronization finishes and reaches the estimated chain
-/// tip.
-const SYNC_FINISHED_REGEX: &str = "finished initial sync to chain tip";
+/// The text that should be logged when synchronization finishes, reaches the estimated chain tip,
+/// and activates the mempool.
+const SYNC_FINISHED_REGEX: &str = "finished initial sync to chain tip, and activated mempool";
 
 /// The maximum amount of time Zebra should take to reload after shutting down.
 ///


### PR DESCRIPTION
## Motivation

1. There is a race condition between mempool activation and the full sync logs, which can cause the full sync tests to fail
2. I need more detail in the sync progress logs to diagnose sync failures

These are a bunch of minor changes after PR #3543.

## Solution

Make full sync test more accurate:
- wait until mempool activates in full sync tests
- warn when Zebra stalls below the maximum checkpoint height - this catches some incorrect local node clocks
- log the specific error when full sync tests fail

Improve sync diagnostics:
- log current height when logging sync progress

This PR adds a direct dependency on `num-integer`, which is already used by `chrono` and `fpe`.

## Review

@jvff can review this PR.

I'm also running these tests locally.

### Reviewer Checklist

  - [ ] Logging & test changes make sense
  - [ ] Tests still pass

