### PR TITLE
fix(clippy): allow unprivileged runs of clippy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,13 +28,32 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run clippy
+      - name: Check workflow permissions
+        id: check_permissions
+        uses: scherermichael-oss/action-has-permission@1.0.6
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run clippy action to produce annotations
         uses: actions-rs/clippy-check@v1.0.7
+        if: ${{ steps.check_permissions.outputs.has-permission }}
         with:
           # GitHub displays the clippy job and its results as separate entries
           name: Clippy (stable) Results
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
+
+      - uses: actions-rs/toolchain@v1.0.1
+        if: ${{ !steps.check_permissions.outputs.has-permission }}
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run clippy manually without annotations
+        if: ${{ !steps.check_permissions.outputs.has-permission }}
+        run: cargo clippy --all-features --all-targets -- -D warnings
 
   fmt:
     name: Rustfmt
@@ -46,7 +65,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1.0.1
         with:
           toolchain: stable
           components: rustfmt


### PR DESCRIPTION
## Motivation

When a dependabot PR is opened, the Clippy job always fails with Resource not accessible by integration. Re-running the job manually makes it pass.

Fix: https://github.com/ZcashFoundation/zebra/issues/3477


## Solution
- Allow to run Clippy without privileges when write access is not allowed
- Use workaround stated in https://github.com/actions-rs/clippy-check/issues/2#issuecomment-807878478

### Reviewer Checklist

  - [ ] Tests for Expected Behaviour
