### PR TITLE
fix(actions): run coverage collection when pushing to main

### DIFF
--- a/.github/workflows/coverage.patch.yml
+++ b/.github/workflows/coverage.patch.yml
@@ -1,6 +1,9 @@
 name: Coverage
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     paths-ignore:
       - '**/*.rs'

--- a/.github/workflows/coverage.patch.yml
+++ b/.github/workflows/coverage.patch.yml
@@ -1,9 +1,6 @@
 name: Coverage
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths-ignore:
       - '**/*.rs'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**/*.rs'
+      - '**/*.txt'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'codecov.yml'
+      - '.github/workflows/coverage.yml'
   pull_request:
     paths:
       - '**/*.rs'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,9 @@ name: Coverage
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
   pull_request:
     paths:
       - '**/*.rs'


### PR DESCRIPTION


## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

During refactoring, we accidentally disabled Coverage collection on #main meaning we compare coverage diffs on PRs in an inconsistent manner.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Trigger on push to main as well.

Resolves #3533

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

@gustavovalverde 

