### PR TITLE
Document consensus rules from 7.3 Spend Description Encoding and Consensus

### DIFF
--- a/zebra-chain/src/sapling/spend.rs
+++ b/zebra-chain/src/sapling/spend.rs
@@ -193,12 +193,20 @@ impl ZcashDeserialize for Spend<PerSpendAnchor> {
         // https://zips.z.cash/protocol/protocol.pdf#spenddesc
         //
         // See comments below for each specific type.
+        //
+        // > LEOS2IP_{256}(anchorSapling), if present, MUST be less than 𝑞_𝕁.
+        //
+        // https://zips.z.cash/protocol/protocol.pdf#spendencodingandconsensus
+        //
+        // Applies to `per_spend_anchor` below; validated in
+        // [`crate::sapling::tree::Root::zcash_deserialize`].
         Ok(Spend {
             // Type is `ValueCommit^{Sapling}.Output`, i.e. J
             // https://zips.z.cash/protocol/protocol.pdf#abstractcommit
             // See [`commitment::NotSmallOrderValueCommitment::zcash_deserialize`].
             cv: commitment::NotSmallOrderValueCommitment::zcash_deserialize(&mut reader)?,
-            // Type is `B^{[ℓ_{Sapling}_{Merkle}]}`, i.e. 32 bytes
+            // Type is `B^{[ℓ_{Sapling}_{Merkle}]}`, i.e. 32 bytes.
+            // But as mentioned above, we validate it further as an integer.
             per_spend_anchor: (&mut reader).zcash_deserialize_into()?,
             // Type is `B^Y^{[ℓ_{PRFnfSapling}/8]}`, i.e. 32 bytes
             nullifier: note::Nullifier::from(reader.read_32_bytes()?),

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -207,13 +207,11 @@ impl ZcashDeserialize for Option<sapling::ShieldedData<SharedAnchor>> {
         //
         // Type is `B^{[ℓ_{Sapling}_{Merkle}]}`, i.e. 32 bytes
         //
-        // # Consensus
+        // > LEOS2IP_{256}(anchorSapling), if present, MUST be less than 𝑞_𝕁.
         //
-        // > Elements of a Spend description MUST be valid encodings of the types given above.
+        // https://zips.z.cash/protocol/protocol.pdf#spendencodingandconsensus
         //
-        // https://zips.z.cash/protocol/protocol.pdf#spenddesc
-        //
-        // Type is `B^{[ℓ_{Sapling}_{Merkle}]}`, i.e. 32 bytes
+        // Validated in [`crate::sapling::tree::Root::zcash_deserialize`].
         let shared_anchor = if spends_count > 0 {
             Some((&mut reader).zcash_deserialize_into()?)
         } else {
@@ -221,18 +219,6 @@ impl ZcashDeserialize for Option<sapling::ShieldedData<SharedAnchor>> {
         };
 
         // Denoted as `vSpendProofsSapling` in the spec.
-        //
-        // # Consensus
-        //
-        // > Elements of a Spend description MUST be valid encodings of the types given above.
-        //
-        // https://zips.z.cash/protocol/protocol.pdf#spenddesc
-        //
-        // Type is `ZKSpend.Proof`, described in
-        // https://zips.z.cash/protocol/protocol.pdf#grothencoding
-        // It is not enforced here; this just reads 192 bytes.
-        // The type is validated when validating the proof, see
-        // [`groth16::Item::try_from`]. In #3179 we plan to validate here instead.
         //
         // # Consensus
         //


### PR DESCRIPTION
## Motivation

We must document and double-check all consensus rules

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

This also removes some duplicated comments that somehow ended up appearing (I think by some automatic merge)

Closes https://github.com/ZcashFoundation/zebra/issues/3224

## Review

@dconnolly and/or @upbqdn might want to review

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
