### PR TITLE
2. refactor(state): move all RocksDB API calls to the disk_db module

### DIFF
--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -1,8 +1,6 @@
-use std::{convert::TryInto, path::PathBuf};
+use std::path::PathBuf;
 
-use rlimit::increase_nofile_limit;
 use serde::{Deserialize, Serialize};
-use tracing::{info, warn};
 
 use zebra_chain::parameters::Network;
 
@@ -57,34 +55,14 @@ fn gen_temp_path(prefix: &str) -> PathBuf {
 }
 
 impl Config {
-    /// The ideal open file limit for Zebra
-    const IDEAL_OPEN_FILE_LIMIT: u64 = 1024;
-
-    /// The minimum number of open files for Zebra to operate normally. Also used
-    /// as the default open file limit, when the OS doesn't tell us how many
-    /// files we can use.
-    ///
-    /// We want 100+ file descriptors for peers, and 100+ for the database.
-    ///
-    /// On Windows, the default limit is 512 high-level I/O files, and 8192
-    /// low-level I/O files:
-    /// https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setmaxstdio?view=msvc-160#remarks
-    const MIN_OPEN_FILE_LIMIT: u64 = 512;
-
-    /// The number of files used internally by Zebra.
-    ///
-    /// Zebra uses file descriptors for OS libraries (10+), polling APIs (10+),
-    /// stdio (3), and other OS facilities (2+).
-    const RESERVED_FILE_COUNT: u64 = 48;
-
-    /// Returns the path and database options for the finalized state database
-    pub(crate) fn db_config(&self, network: Network) -> (PathBuf, rocksdb::Options) {
+    /// Returns the path for the finalized state database
+    pub(crate) fn db_path(&self, network: Network) -> PathBuf {
         let net_dir = match network {
             Network::Mainnet => "mainnet",
             Network::Testnet => "testnet",
         };
 
-        let path = if self.ephemeral {
+        if self.ephemeral {
             gen_temp_path(&format!(
                 "zebra-state-v{}-{}",
                 crate::constants::DATABASE_FORMAT_VERSION,
@@ -95,25 +73,7 @@ impl Config {
                 .join("state")
                 .join(format!("v{}", crate::constants::DATABASE_FORMAT_VERSION))
                 .join(net_dir)
-        };
-
-        let mut opts = rocksdb::Options::default();
-
-        opts.create_if_missing(true);
-        opts.create_missing_column_families(true);
-
-        let open_file_limit = Config::increase_open_file_limit();
-        let db_file_limit = Config::get_db_open_file_limit(open_file_limit);
-
-        // If the current limit is very large, set the DB limit using the ideal limit
-        let ideal_limit = Config::get_db_open_file_limit(Config::IDEAL_OPEN_FILE_LIMIT)
-            .try_into()
-            .expect("ideal open file limit fits in a c_int");
-        let db_file_limit = db_file_limit.try_into().unwrap_or(ideal_limit);
-
-        opts.set_max_open_files(db_file_limit);
-
-        (path, opts)
+        }
     }
 
     /// Construct a config for an ephemeral database
@@ -122,92 +82,6 @@ impl Config {
             ephemeral: true,
             ..Config::default()
         }
-    }
-
-    /// Calculate the database's share of `open_file_limit`
-    fn get_db_open_file_limit(open_file_limit: u64) -> u64 {
-        // Give the DB half the files, and reserve half the files for peers
-        (open_file_limit - Config::RESERVED_FILE_COUNT) / 2
-    }
-
-    /// Increase the open file limit for this process to `IDEAL_OPEN_FILE_LIMIT`.
-    /// If that fails, try `MIN_OPEN_FILE_LIMIT`.
-    ///
-    /// If the current limit is above `IDEAL_OPEN_FILE_LIMIT`, leaves it
-    /// unchanged.
-    ///
-    /// Returns the current limit, after any successful increases.
-    ///
-    /// # Panics
-    ///
-    /// If the open file limit can not be increased to `MIN_OPEN_FILE_LIMIT`.
-    fn increase_open_file_limit() -> u64 {
-        // `increase_nofile_limit` doesn't do anything on Windows in rlimit 0.7.0.
-        //
-        // On Windows, the default limit is:
-        // - 512 high-level stream I/O files (via the C standard functions), and
-        // - 8192 low-level I/O files (via the Unix C functions).
-        // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setmaxstdio?view=msvc-160#remarks
-        //
-        // If we need more high-level I/O files on Windows,
-        // use `setmaxstdio` and `getmaxstdio` from the `rlimit` crate:
-        // https://docs.rs/rlimit/latest/rlimit/#windows
-        //
-        // Then panic if `setmaxstdio` fails to set the minimum value,
-        // and `getmaxstdio` is below the minimum value.
-
-        // We try setting the ideal limit, then the minimum limit.
-        let current_limit = match increase_nofile_limit(Config::IDEAL_OPEN_FILE_LIMIT) {
-            Ok(current_limit) => current_limit,
-            Err(limit_error) => {
-                info!(
-                ?limit_error,
-                min_limit = ?Config::MIN_OPEN_FILE_LIMIT,
-                ideal_limit = ?Config::IDEAL_OPEN_FILE_LIMIT,
-                "unable to increase the open file limit, \
-                 assuming Zebra can open a minimum number of files"
-                );
-
-                return Config::MIN_OPEN_FILE_LIMIT;
-            }
-        };
-
-        if current_limit < Config::MIN_OPEN_FILE_LIMIT {
-            panic!(
-                "open file limit too low: \
-                 unable to set the number of open files to {}, \
-                 the minimum number of files required by Zebra. \
-                 Current limit is {:?}. \
-                 Hint: Increase the open file limit to {} before launching Zebra",
-                Config::MIN_OPEN_FILE_LIMIT,
-                current_limit,
-                Config::IDEAL_OPEN_FILE_LIMIT
-            );
-        } else if current_limit < Config::IDEAL_OPEN_FILE_LIMIT {
-            warn!(
-                ?current_limit,
-                min_limit = ?Config::MIN_OPEN_FILE_LIMIT,
-                ideal_limit = ?Config::IDEAL_OPEN_FILE_LIMIT,
-                "the maximum number of open files is below Zebra's ideal limit. \
-                 Hint: Increase the open file limit to {} before launching Zebra",
-                Config::IDEAL_OPEN_FILE_LIMIT
-            );
-        } else if cfg!(windows) {
-            info!(
-                min_limit = ?Config::MIN_OPEN_FILE_LIMIT,
-                ideal_limit = ?Config::IDEAL_OPEN_FILE_LIMIT,
-                "assuming the open file limit is high enough for Zebra",
-            );
-        } else {
-            info!(
-                ?current_limit,
-                min_limit = ?Config::MIN_OPEN_FILE_LIMIT,
-                ideal_limit = ?Config::IDEAL_OPEN_FILE_LIMIT,
-                "the open file limit is high enough for Zebra",
-            );
-        }
-
-        current_limit
     }
 }
 

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -12,6 +12,9 @@
 #![doc(html_logo_url = "https://www.zfnd.org/images/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_state")]
 
+#[macro_use]
+extern crate tracing;
+
 #[cfg(any(test, feature = "proptest-impl"))]
 mod arbitrary;
 mod config;

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -721,51 +721,6 @@ impl FinalizedState {
             .zs_get(value_pool_cf, &())
             .unwrap_or_else(ValueBalance::zero)
     }
-
-    /// Allow to set up a fake value pool in the database for testing purposes.
-    #[cfg(any(test, feature = "proptest-impl"))]
-    #[allow(dead_code)]
-    pub fn set_current_value_pool(&self, fake_value_pool: ValueBalance<NonNegative>) {
-        let mut batch = DiskWriteBatch::new();
-        let value_pool_cf = self.db.cf_handle("tip_chain_value_pool").unwrap();
-
-        batch.zs_insert(value_pool_cf, (), fake_value_pool);
-        self.db.write(batch).unwrap();
-    }
-
-    /// Artificially prime the note commitment tree anchor sets with anchors
-    /// referenced in a block, for testing purposes _only_.
-    #[cfg(test)]
-    pub fn populate_with_anchors(&self, block: &Block) {
-        let mut batch = DiskWriteBatch::new();
-
-        let sprout_anchors = self.db.cf_handle("sprout_anchors").unwrap();
-        let sapling_anchors = self.db.cf_handle("sapling_anchors").unwrap();
-        let orchard_anchors = self.db.cf_handle("orchard_anchors").unwrap();
-
-        for transaction in block.transactions.iter() {
-            // Sprout
-            for joinsplit in transaction.sprout_groth16_joinsplits() {
-                batch.zs_insert(
-                    sprout_anchors,
-                    joinsplit.anchor,
-                    sprout::tree::NoteCommitmentTree::default(),
-                );
-            }
-
-            // Sapling
-            for anchor in transaction.sapling_anchors() {
-                batch.zs_insert(sapling_anchors, anchor, ());
-            }
-
-            // Orchard
-            if let Some(orchard_shielded_data) = transaction.orchard_shielded_data() {
-                batch.zs_insert(orchard_anchors, orchard_shielded_data.shared_anchor, ());
-            }
-        }
-
-        self.db.write(batch).unwrap();
-    }
 }
 
 fn block_precommit_metrics(block: &Block, hash: block::Hash, height: block::Height) {

--- a/zebra-state/src/service/finalized_state/arbitrary.rs
+++ b/zebra-state/src/service/finalized_state/arbitrary.rs
@@ -6,9 +6,18 @@ use std::sync::Arc;
 
 use proptest::prelude::*;
 
-use zebra_chain::block;
+use zebra_chain::{
+    amount::NonNegative,
+    block::{self, Block},
+    sprout,
+    value_balance::ValueBalance,
+};
 
-use crate::service::finalized_state::disk_format::{FromDisk, IntoDisk, TransactionLocation};
+use crate::service::finalized_state::{
+    disk_db::{DiskWriteBatch, WriteDisk},
+    disk_format::{FromDisk, IntoDisk, TransactionLocation},
+    FinalizedState,
+};
 
 impl Arbitrary for TransactionLocation {
     type Parameters = ();
@@ -83,4 +92,48 @@ where
     assert_round_trip_ref(&input);
     assert_round_trip_arc(Arc::new(input.clone()));
     assert_round_trip(input);
+}
+
+impl FinalizedState {
+    /// Allow to set up a fake value pool in the database for testing purposes.
+    pub fn set_current_value_pool(&self, fake_value_pool: ValueBalance<NonNegative>) {
+        let mut batch = DiskWriteBatch::new();
+        let value_pool_cf = self.db.cf_handle("tip_chain_value_pool").unwrap();
+
+        batch.zs_insert(value_pool_cf, (), fake_value_pool);
+        self.db.write(batch).unwrap();
+    }
+
+    /// Artificially prime the note commitment tree anchor sets with anchors
+    /// referenced in a block, for testing purposes _only_.
+    pub fn populate_with_anchors(&self, block: &Block) {
+        let mut batch = DiskWriteBatch::new();
+
+        let sprout_anchors = self.db.cf_handle("sprout_anchors").unwrap();
+        let sapling_anchors = self.db.cf_handle("sapling_anchors").unwrap();
+        let orchard_anchors = self.db.cf_handle("orchard_anchors").unwrap();
+
+        for transaction in block.transactions.iter() {
+            // Sprout
+            for joinsplit in transaction.sprout_groth16_joinsplits() {
+                batch.zs_insert(
+                    sprout_anchors,
+                    joinsplit.anchor,
+                    sprout::tree::NoteCommitmentTree::default(),
+                );
+            }
+
+            // Sapling
+            for anchor in transaction.sapling_anchors() {
+                batch.zs_insert(sapling_anchors, anchor, ());
+            }
+
+            // Orchard
+            if let Some(orchard_shielded_data) = transaction.orchard_shielded_data() {
+                batch.zs_insert(orchard_anchors, orchard_shielded_data.shared_anchor, ());
+            }
+        }
+
+        self.db.write(batch).unwrap();
+    }
 }

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -3,10 +3,26 @@
 //! This module makes sure that:
 //! - all disk writes happen inside a RocksDB transaction, and
 //! - format-specific invariants are maintained.
+//!
+//! # Correctness
+//!
+//! The [`crate::constants::DATABASE_FORMAT_VERSION`] constant must
+//! be incremented each time the database format (column, serialization, etc) changes.
 
 use std::fmt::Debug;
 
-use crate::service::finalized_state::disk_format::{FromDisk, IntoDisk};
+use rlimit::increase_nofile_limit;
+
+use zebra_chain::parameters::Network;
+
+use crate::{
+    service::finalized_state::disk_format::{FromDisk, IntoDisk},
+    Config,
+};
+
+/// Wrapper struct to ensure low-level disk reads go through
+/// the correct API.
+pub struct DiskDb(rocksdb::DB);
 
 /// Helper trait for inserting (Key, Value) pairs into rocksdb with a consistently
 /// defined format
@@ -59,7 +75,7 @@ pub trait ReadDisk {
         K: IntoDisk;
 }
 
-impl ReadDisk for rocksdb::DB {
+impl ReadDisk for DiskDb {
     fn zs_get<K, V>(&self, cf: &rocksdb::ColumnFamily, key: &K) -> Option<V>
     where
         K: IntoDisk,
@@ -71,6 +87,7 @@ impl ReadDisk for rocksdb::DB {
         // value, because we're going to deserialize it anyways, which avoids an
         // extra copy
         let value_bytes = self
+            .0
             .get_pinned_cf(cf, key_bytes)
             .expect("expected that disk errors would not occur");
 
@@ -85,8 +102,184 @@ impl ReadDisk for rocksdb::DB {
 
         // We use `get_pinned_cf` to avoid taking ownership of the serialized
         // value, because we don't use the value at all. This avoids an extra copy.
-        self.get_pinned_cf(cf, key_bytes)
+        self.0
+            .get_pinned_cf(cf, key_bytes)
             .expect("expected that disk errors would not occur")
             .is_some()
+    }
+}
+
+impl DiskDb {
+    /// The ideal open file limit for Zebra
+    const IDEAL_OPEN_FILE_LIMIT: u64 = 1024;
+
+    /// The minimum number of open files for Zebra to operate normally. Also used
+    /// as the default open file limit, when the OS doesn't tell us how many
+    /// files we can use.
+    ///
+    /// We want 100+ file descriptors for peers, and 100+ for the database.
+    ///
+    /// On Windows, the default limit is 512 high-level I/O files, and 8192
+    /// low-level I/O files:
+    /// https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setmaxstdio?view=msvc-160#remarks
+    const MIN_OPEN_FILE_LIMIT: u64 = 512;
+
+    /// The number of files used internally by Zebra.
+    ///
+    /// Zebra uses file descriptors for OS libraries (10+), polling APIs (10+),
+    /// stdio (3), and other OS facilities (2+).
+    const RESERVED_FILE_COUNT: u64 = 48;
+
+    pub fn new(config: &Config, network: Network) -> DiskDb {
+        let path = config.db_path(network);
+        let db_options = DiskDb::options();
+
+        let column_families = vec![
+            rocksdb::ColumnFamilyDescriptor::new("hash_by_height", db_options.clone()),
+            rocksdb::ColumnFamilyDescriptor::new("height_by_hash", db_options.clone()),
+            rocksdb::ColumnFamilyDescriptor::new("block_by_height", db_options.clone()),
+            rocksdb::ColumnFamilyDescriptor::new("tx_by_hash", db_options.clone()),
+            rocksdb::ColumnFamilyDescriptor::new("utxo_by_outpoint", db_options.clone()),
+            rocksdb::ColumnFamilyDescriptor::new("sprout_nullifiers", db_options.clone()),
+            rocksdb::ColumnFamilyDescriptor::new("sapling_nullifiers", db_options.clone()),
+            rocksdb::ColumnFamilyDescriptor::new("orchard_nullifiers", db_options.clone()),
+            rocksdb::ColumnFamilyDescriptor::new("sprout_anchors", db_options.clone()),
+            rocksdb::ColumnFamilyDescriptor::new("sapling_anchors", db_options.clone()),
+            rocksdb::ColumnFamilyDescriptor::new("orchard_anchors", db_options.clone()),
+            rocksdb::ColumnFamilyDescriptor::new("sprout_note_commitment_tree", db_options.clone()),
+            rocksdb::ColumnFamilyDescriptor::new(
+                "sapling_note_commitment_tree",
+                db_options.clone(),
+            ),
+            rocksdb::ColumnFamilyDescriptor::new(
+                "orchard_note_commitment_tree",
+                db_options.clone(),
+            ),
+            rocksdb::ColumnFamilyDescriptor::new("history_tree", db_options.clone()),
+            rocksdb::ColumnFamilyDescriptor::new("tip_chain_value_pool", db_options.clone()),
+        ];
+
+        let db_result = rocksdb::DB::open_cf_descriptors(&db_options, &path, column_families);
+
+        match db_result {
+            Ok(d) => {
+                tracing::info!("Opened Zebra state cache at {}", path.display());
+                DiskDb(d)
+            }
+            // TODO: provide a different hint if the disk is full, see #1623
+            Err(e) => panic!(
+                "Opening database {:?} failed: {:?}. \
+                 Hint: Check if another zebrad process is running. \
+                 Try changing the state cache_dir in the Zebra config.",
+                path, e,
+            ),
+        }
+    }
+
+    /// Returns the database options for the finalized state database
+    fn options() -> rocksdb::Options {
+        let mut opts = rocksdb::Options::default();
+
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+
+        let open_file_limit = DiskDb::increase_open_file_limit();
+        let db_file_limit = DiskDb::get_db_open_file_limit(open_file_limit);
+
+        // If the current limit is very large, set the DB limit using the ideal limit
+        let ideal_limit = DiskDb::get_db_open_file_limit(DiskDb::IDEAL_OPEN_FILE_LIMIT)
+            .try_into()
+            .expect("ideal open file limit fits in a c_int");
+        let db_file_limit = db_file_limit.try_into().unwrap_or(ideal_limit);
+
+        opts.set_max_open_files(db_file_limit);
+
+        opts
+    }
+
+    /// Calculate the database's share of `open_file_limit`
+    fn get_db_open_file_limit(open_file_limit: u64) -> u64 {
+        // Give the DB half the files, and reserve half the files for peers
+        (open_file_limit - DiskDb::RESERVED_FILE_COUNT) / 2
+    }
+
+    /// Increase the open file limit for this process to `IDEAL_OPEN_FILE_LIMIT`.
+    /// If that fails, try `MIN_OPEN_FILE_LIMIT`.
+    ///
+    /// If the current limit is above `IDEAL_OPEN_FILE_LIMIT`, leaves it
+    /// unchanged.
+    ///
+    /// Returns the current limit, after any successful increases.
+    ///
+    /// # Panics
+    ///
+    /// If the open file limit can not be increased to `MIN_OPEN_FILE_LIMIT`.
+    fn increase_open_file_limit() -> u64 {
+        // `increase_nofile_limit` doesn't do anything on Windows in rlimit 0.7.0.
+        //
+        // On Windows, the default limit is:
+        // - 512 high-level stream I/O files (via the C standard functions), and
+        // - 8192 low-level I/O files (via the Unix C functions).
+        // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setmaxstdio?view=msvc-160#remarks
+        //
+        // If we need more high-level I/O files on Windows,
+        // use `setmaxstdio` and `getmaxstdio` from the `rlimit` crate:
+        // https://docs.rs/rlimit/latest/rlimit/#windows
+        //
+        // Then panic if `setmaxstdio` fails to set the minimum value,
+        // and `getmaxstdio` is below the minimum value.
+
+        // We try setting the ideal limit, then the minimum limit.
+        let current_limit = match increase_nofile_limit(DiskDb::IDEAL_OPEN_FILE_LIMIT) {
+            Ok(current_limit) => current_limit,
+            Err(limit_error) => {
+                info!(
+                ?limit_error,
+                min_limit = ?DiskDb::MIN_OPEN_FILE_LIMIT,
+                ideal_limit = ?DiskDb::IDEAL_OPEN_FILE_LIMIT,
+                "unable to increase the open file limit, \
+                 assuming Zebra can open a minimum number of files"
+                );
+
+                return DiskDb::MIN_OPEN_FILE_LIMIT;
+            }
+        };
+
+        if current_limit < DiskDb::MIN_OPEN_FILE_LIMIT {
+            panic!(
+                "open file limit too low: \
+                 unable to set the number of open files to {}, \
+                 the minimum number of files required by Zebra. \
+                 Current limit is {:?}. \
+                 Hint: Increase the open file limit to {} before launching Zebra",
+                DiskDb::MIN_OPEN_FILE_LIMIT,
+                current_limit,
+                DiskDb::IDEAL_OPEN_FILE_LIMIT
+            );
+        } else if current_limit < DiskDb::IDEAL_OPEN_FILE_LIMIT {
+            warn!(
+                ?current_limit,
+                min_limit = ?DiskDb::MIN_OPEN_FILE_LIMIT,
+                ideal_limit = ?DiskDb::IDEAL_OPEN_FILE_LIMIT,
+                "the maximum number of open files is below Zebra's ideal limit. \
+                 Hint: Increase the open file limit to {} before launching Zebra",
+                DiskDb::IDEAL_OPEN_FILE_LIMIT
+            );
+        } else if cfg!(windows) {
+            info!(
+                min_limit = ?DiskDb::MIN_OPEN_FILE_LIMIT,
+                ideal_limit = ?DiskDb::IDEAL_OPEN_FILE_LIMIT,
+                "assuming the open file limit is high enough for Zebra",
+            );
+        } else {
+            info!(
+                ?current_limit,
+                min_limit = ?DiskDb::MIN_OPEN_FILE_LIMIT,
+                ideal_limit = ?DiskDb::IDEAL_OPEN_FILE_LIMIT,
+                "the open file limit is high enough for Zebra",
+            );
+        }
+
+        current_limit
     }
 }

--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -1,4 +1,9 @@
 //! Module defining the serialization format for finalized data.
+//!
+//! # Correctness
+//!
+//! The [`crate::constants::DATABASE_FORMAT_VERSION`] constant must
+//! be incremented each time the database format (column, serialization, etc) changes.
 
 use std::{collections::BTreeMap, convert::TryInto, fmt::Debug, sync::Arc};
 


### PR DESCRIPTION
## Motivation

As part of changing the database, we'll need to make sure all database accesses go through a well-defined API.

As the second step, we need to make sure all RocksDB API calls go through the same module.
(This makes sure all access to the database respects any consistency rules.)

## Solution

Code Movement:
- move RocksDB initialization to the disk_db module
- move RocksDB reads and writes to the disk_db module
    - and fix a write that didn't go through the `DiskWrite` interface
- move RocksDB shutdown to the disk_db module
- add a DiskWriteBatch wrapper for RocksDB writes

Related cleanups:
- improve module documentation
- clean up module imports

Part of ticket #3151.

Based on PR #3539, feel free to move this PR out of draft after it merges.

## Review

@oxarbitrage can review this PR.

`git diff --color-moved` could make the review a lot easier.

### Reviewer Checklist

  - [ ] Code moves are correct
  - [ ] Existing tests pass

## Follow Up Work

- split out another module that only provides complete Zcash types, no raw bytes or database-specific types