### PR TITLE
fix(ci): also check for duplicate dependencies with optional features off

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
     strategy:
       matrix:
         checks:
-          - bans 
+          - bans
           - sources
 
     # Prevent sudden announcement of a new advisory from failing ci:
@@ -244,3 +244,10 @@ jobs:
       with:
         command: check ${{ matrix.checks }}
         args: --all-features --workspace
+
+    # this check runs with optional features off
+    # so we expect some warnings about "skip tree root was not found"
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check ${{ matrix.checks }}
+        args: --workspace

--- a/deny.toml
+++ b/deny.toml
@@ -46,9 +46,6 @@ skip-tree = [
     # ticket #2984: owo-colors dependencies
     { name = "color-eyre", version = "=0.5.11" },
 
-    # ticket #2998: hdrhistogram dependencies
-    { name = "hdrhistogram", version = "=6.3.4" },
-
     # ticket #3061: reqwest and minreq dependencies
     { name = "webpki-roots", version = "=0.18.0" },
 
@@ -58,6 +55,12 @@ skip-tree = [
     # upgrade orchard from deprecated `bigint` to `uint`: https://github.com/zcash/orchard/issues/219
     # alternative: downgrade Zebra to `bigint`
     { name = "bigint", version = "=4.4.3" },
+
+    # upgrade sentry, metrics-exporter-prometheus, reqwest, hyper,
+    # which needs #2953: upgrade tracing to the latest major version
+    #
+    # also wait for tower-test and tokio-test to upgrade
+    { name = "tokio-util", version = "=0.6.9" },
 
     # recent major version bumps
     # we should re-check these dependencies in February 2022


### PR DESCRIPTION
## Motivation

We are only checking for duplicate dependencies with all our optional features on.

But we might get different dependencies when all features are off. So we should check that case too.

## Solution

- add an extra dependency check with all features off

## Review

@gustavovalverde can review this PR.

This PR blocks all open PRs that change dependencies:
- #3402
- #3585 
- #3589

Merged PRs:
- #3539 - I checked this PR, it passes the extra dependency checks

### Reviewer Checklist

  - [ ] New CI test passes

