### PR TITLE
Replace unmantained multiset with mset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,9 +2378,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "multiset"
-version = "0.0.5"
-source = "git+https://github.com/jmitchell/multiset?rev=91ef8550b518f75ae87ae0d8771150f259fd34d5#91ef8550b518f75ae87ae0d8771150f259fd34d5"
+name = "mset"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d1cf737c48148e9956a9ea00710258dcf2a7afdedc34a2c672a44866f618dc"
 
 [[package]]
 name = "native-tls"
@@ -5617,7 +5618,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "metrics",
- "multiset",
+ "mset",
  "once_cell",
  "proptest",
  "proptest-derive",

--- a/deny.toml
+++ b/deny.toml
@@ -90,9 +90,6 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     # ticket #2982: librustzcash and orchard git versions
     "https://github.com/str4d/redjubjub",
-
-    # ticket #2523: replace unmaintained multiset
-    "https://github.com/jmitchell/multiset",
 ]
 
 [sources.allow-org]

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -17,12 +17,7 @@ futures = "0.3.21"
 hex = "0.4.3"
 lazy_static = "1.4.0"
 metrics = "0.17.1"
-# TODO: this crate is not maintained anymore. Replace it?
-# https://github.com/ZcashFoundation/zebra/issues/2523
-#
-# Pinned to a commit which includes bug fix https://github.com/jmitchell/multiset/pull/21
-# The fix should be included in multiset 0.0.6.
-multiset = { git = "https://github.com/jmitchell/multiset", rev = "91ef8550b518f75ae87ae0d8771150f259fd34d5" }
+mset = "0.1.0"
 proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 regex = "1"

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -6,7 +6,7 @@ use std::{
     ops::Deref,
 };
 
-use multiset::HashMultiSet;
+use mset::MultiSet;
 use tracing::instrument;
 
 use zebra_chain::{
@@ -60,7 +60,7 @@ pub struct Chain {
     pub(crate) history_tree: HistoryTree,
 
     /// The Sprout anchors created by `blocks`.
-    pub(crate) sprout_anchors: HashMultiSet<sprout::tree::Root>,
+    pub(crate) sprout_anchors: MultiSet<sprout::tree::Root>,
     /// The Sprout anchors created by each block in `blocks`.
     pub(crate) sprout_anchors_by_height: BTreeMap<block::Height, sprout::tree::Root>,
     /// The Sprout note commitment tree for each anchor.
@@ -68,11 +68,11 @@ pub struct Chain {
     pub(crate) sprout_trees_by_anchor:
         HashMap<sprout::tree::Root, sprout::tree::NoteCommitmentTree>,
     /// The Sapling anchors created by `blocks`.
-    pub(crate) sapling_anchors: HashMultiSet<sapling::tree::Root>,
+    pub(crate) sapling_anchors: MultiSet<sapling::tree::Root>,
     /// The Sapling anchors created by each block in `blocks`.
     pub(crate) sapling_anchors_by_height: BTreeMap<block::Height, sapling::tree::Root>,
     /// The Orchard anchors created by `blocks`.
-    pub(crate) orchard_anchors: HashMultiSet<orchard::tree::Root>,
+    pub(crate) orchard_anchors: MultiSet<orchard::tree::Root>,
     /// The Orchard anchors created by each block in `blocks`.
     pub(crate) orchard_anchors_by_height: BTreeMap<block::Height, orchard::tree::Root>,
 
@@ -119,12 +119,12 @@ impl Chain {
             sapling_note_commitment_tree,
             orchard_note_commitment_tree,
             spent_utxos: Default::default(),
-            sprout_anchors: HashMultiSet::new(),
+            sprout_anchors: MultiSet::new(),
             sprout_anchors_by_height: Default::default(),
             sprout_trees_by_anchor: Default::default(),
-            sapling_anchors: HashMultiSet::new(),
+            sapling_anchors: MultiSet::new(),
             sapling_anchors_by_height: Default::default(),
-            orchard_anchors: HashMultiSet::new(),
+            orchard_anchors: MultiSet::new(),
             orchard_anchors_by_height: Default::default(),
             sprout_nullifiers: Default::default(),
             sapling_nullifiers: Default::default(),


### PR DESCRIPTION
## Motivation

We use the `multiset` crate which is not maintained anymore and contains bugs in the last released version which were fixed in the main branch, requiring pinning to a git version.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

Replace with a more well-maintained crate. I picked `mset` because it has a similar API in contrast to `hashbag`.

Closes https://github.com/ZcashFoundation/zebra/issues/2523

## Review

Anyone can review, not urgent.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
