### PR TITLE
5. refactor(state): split database writes into separate functions

### DIFF
--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -336,10 +336,10 @@ impl FinalizedState {
             .flat_map(|outpoint| self.utxo(&outpoint).map(|utxo| (outpoint, utxo)))
             .collect();
 
-        let batch = disk_db::DiskWriteBatch::new();
+        let mut batch = disk_db::DiskWriteBatch::new();
 
         // In case of errors, propagate and do not write the batch.
-        let batch = batch.prepare_block_batch(
+        batch.prepare_block_batch(
             &self.db,
             finalized,
             self.network,

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -343,7 +343,6 @@ impl FinalizedState {
             &self.db,
             finalized,
             self.network,
-            self.finalized_tip_height(),
             all_utxos_spent_by_block,
             self.note_commitment_trees(),
             history_tree,

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -345,9 +345,7 @@ impl FinalizedState {
             self.network,
             self.finalized_tip_height(),
             all_utxos_spent_by_block,
-            self.sprout_note_commitment_tree(),
-            self.sapling_note_commitment_tree(),
-            self.orchard_note_commitment_tree(),
+            self.note_commitment_trees(),
             history_tree,
             self.finalized_value_pool(),
         )?;

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -32,6 +32,10 @@ pub struct DiskDb {
 }
 
 /// Wrapper struct to ensure low-level database writes go through the correct API.
+///
+/// [`rocksdb::WriteBatch`] is a batched set of database updates,
+/// which must be written to the database using `DiskDb::write(batch)`.
+#[must_use = "batches must be written to the database"]
 pub struct DiskWriteBatch {
     /// The inner RocksDB write batch.
     batch: rocksdb::WriteBatch,

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -103,6 +103,8 @@ impl ReadDisk for DiskDb {
         // We use `get_pinned_cf` to avoid taking ownership of the serialized
         // value, because we're going to deserialize it anyways, which avoids an
         // extra copy
+        //
+        // TODO: move disk reads to a blocking thread (#2188)
         let value_bytes = self
             .db
             .get_pinned_cf(cf, key_bytes)
@@ -119,6 +121,8 @@ impl ReadDisk for DiskDb {
 
         // We use `get_pinned_cf` to avoid taking ownership of the serialized
         // value, because we don't use the value at all. This avoids an extra copy.
+        //
+        // TODO: move disk reads to a blocking thread (#2188)
         self.db
             .get_pinned_cf(cf, key_bytes)
             .expect("expected that disk errors would not occur")
@@ -217,11 +221,15 @@ impl DiskDb {
     }
 
     /// Returns an iterator over the keys in `cf_name`, starting from the first key.
+    ///
+    /// TODO: add an iterator wrapper struct that does disk reads in a blocking thread (#2188)
     pub fn forward_iterator(&self, cf_handle: &rocksdb::ColumnFamily) -> rocksdb::DBIterator {
         self.db.iterator_cf(cf_handle, rocksdb::IteratorMode::Start)
     }
 
     /// Returns a reverse iterator over the keys in `cf_name`, starting from the last key.
+    ///
+    /// TODO: add an iterator wrapper struct that does disk reads in a blocking thread (#2188)
     pub fn reverse_iterator(&self, cf_handle: &rocksdb::ColumnFamily) -> rocksdb::DBIterator {
         self.db.iterator_cf(cf_handle, rocksdb::IteratorMode::End)
     }

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -142,6 +142,8 @@ impl FinalizedState {
         self.db.zs_contains(orchard_anchors, &orchard_anchor)
     }
 
+    // Read chain history methods
+
     /// Returns the Sprout note commitment tree of the finalized tip
     /// or the empty tree if the state is empty.
     pub fn sprout_note_commitment_tree(&self) -> sprout::tree::NoteCommitmentTree {
@@ -201,8 +203,6 @@ impl FinalizedState {
             .expect("Orchard note commitment tree must exist if there is a finalized tip")
     }
 
-    // Read chain methods
-
     /// Returns the ZIP-221 history tree of the finalized tip or `None`
     /// if it does not exist yet in the state (pre-Heartwood).
     pub fn history_tree(&self) -> HistoryTree {
@@ -229,7 +229,7 @@ impl FinalizedState {
             .unwrap_or_else(ValueBalance::zero)
     }
 
-    // Metrics methods
+    // Update metrics methods - used when writing
 
     /// Update metrics before committing a block.
     fn block_precommit_metrics(block: &Block, hash: block::Hash, height: block::Height) {
@@ -307,14 +307,12 @@ impl FinalizedState {
     }
 }
 
-// Write methods
-
 impl DiskWriteBatch {
     /// Prepare a database batch containing a `finalized` block,
     /// and return it (without actually writing anything).
     ///
     /// If this method returns an error, it will be propagated,
-    /// and the batch will not be written to the database.
+    /// and the batch should not be written to the database.
     ///
     /// # Errors
     ///

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -361,13 +361,7 @@ impl DiskWriteBatch {
         // but it ignores the genesis UTXO and value pool updates.
         //
         // TODO: commit transaction data but not UTXOs in the next PR.
-        if self.prepare_genesis_batch(
-            db,
-            &finalized,
-            &sprout_note_commitment_tree,
-            &sapling_note_commitment_tree,
-            &orchard_note_commitment_tree,
-        ) {
+        if self.prepare_genesis_batch(db, &finalized) {
             return Ok(self);
         }
 
@@ -402,15 +396,7 @@ impl DiskWriteBatch {
     /// If `finalized.block` is not a genesis block, does nothing.
     ///
     /// This method never returns an error.
-    #[allow(clippy::too_many_arguments)]
-    pub fn prepare_genesis_batch(
-        &mut self,
-        db: &DiskDb,
-        finalized: &FinalizedBlock,
-        sprout_note_commitment_tree: &sprout::tree::NoteCommitmentTree,
-        sapling_note_commitment_tree: &sapling::tree::NoteCommitmentTree,
-        orchard_note_commitment_tree: &orchard::tree::NoteCommitmentTree,
-    ) -> bool {
+    pub fn prepare_genesis_batch(&mut self, db: &DiskDb, finalized: &FinalizedBlock) -> bool {
         let sprout_note_commitment_tree_cf = db.cf_handle("sprout_note_commitment_tree").unwrap();
         let sapling_note_commitment_tree_cf = db.cf_handle("sapling_note_commitment_tree").unwrap();
         let orchard_note_commitment_tree_cf = db.cf_handle("orchard_note_commitment_tree").unwrap();
@@ -425,17 +411,17 @@ impl DiskWriteBatch {
             self.zs_insert(
                 sprout_note_commitment_tree_cf,
                 height,
-                sprout_note_commitment_tree,
+                sprout::tree::NoteCommitmentTree::default(),
             );
             self.zs_insert(
                 sapling_note_commitment_tree_cf,
                 height,
-                sapling_note_commitment_tree,
+                sapling::tree::NoteCommitmentTree::default(),
             );
             self.zs_insert(
                 orchard_note_commitment_tree_cf,
                 height,
-                orchard_note_commitment_tree,
+                orchard::tree::NoteCommitmentTree::default(),
             );
 
             return true;


### PR DESCRIPTION
## Motivation

As part of changing the database, we'll need to make sure all database accesses go through a well-defined API.

As the next step, we need to make sure database writes are well-defined.
(This makes sure all access to the database respects any consistency rules.)

## Solution

Code Movement:
- split write batch into block, transactions, transparent, nullifiers, note commitment tree, history, and chain value pool updates
- split out a genesis block write method

Related Cleanups:
- calculate current tip height, and remove that argument
- mark DiskWriteBatch as must_use
- combine note commitment trees into an argument struct
- update some comments and variable names
- make the batch methods take `&mut self`

Part of ticket #3151.

Based on PR #3590, feel free to move this PR out of draft after it merges.

## Review

@oxarbitrage can review this PR.

`git diff --color-moved` could make the review a lot easier.

### Reviewer Checklist

  - [x] Code moves are correct
  - [x] Existing tests pass

## Follow Up Work

I don't know if I want to split up writes any further. I'll probably want reads and writes of the same data in their own modules, so it's easy to compare them. But I can do this before the test PR.