### PR TITLE
security(rust): forbid non-ascii identifiers

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,6 +5,7 @@ rustflags = [
 
     # High-risk code
     "-Dunsafe_code",
+    "-Dnon_ascii_idents",
 
     # Potential bugs
     #


### PR DESCRIPTION
## Motivation

Rust supports non-ascii identifiers, but we don't use them in Zebra.

But similar non-ascii characters can be a security risk, particularly when using some editors or GitHub reviews.

## Solution

- check for non-ascii identifiers in CI

Closes #1143

## Review

@gustavovalverde can review this PR.

### Reviewer Checklist

  - [ ] Existing tests pass
