### PR TITLE
Include listing not-mentioned PRs and not-bumped crates in the release checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -15,6 +15,7 @@ To check if any of the top-level crates need version increments, go to the zebra
 
 - [ ] Increment the crates that have new commits since the last version update
 - [ ] Increment any crates that depend on crates that have changed
+- [ ] Keep a list of the crates that haven't been incremented, to include in the PR
 - [ ] Use the `zebrad` crate version in the `zebra-network` user agent string
       (currently the constant `USER_AGENT` in `zebra-network/src/constants.rs`)
 - [ ] Use the latest git tag in `README.md`
@@ -110,7 +111,7 @@ We use [the Release Drafter workflow](https://github.com/marketplace/actions/rel
 
 To create the final change log:
 - [ ] Copy the draft changelog into `CHANGELOG.md`
-- [ ] Delete any trivial changes
+- [ ] Delete any trivial changes. Keep the list of those, to include in the PR
 - [ ] Combine duplicate changes
 - [ ] Edit change descriptions so they are consistent, and make sense to non-developers
 - [ ] Check the category for each change
@@ -134,6 +135,8 @@ After you have the version increments and the updated changelog,
       (name suggestion, example: `v1.0.0-alpha.0-release`)
 - [ ] Create a release PR by adding `&template=release-checklist.md` to the
       comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/v1.0.0-alpha.0-release?expand=1&template=release-checklist.md)).
+      - [ ] Add the list of deleted changelog entries as a comment to make reviewing easier.
+      - [ ] Also add the list of not-bumped crates as a comment (can use the same comment as the previous one).
 - [ ] While the PR is being reviewed, keep track of any PRs that have been merged
       since you created the PR to update `CHANGELOG.md` and push any updates if necessary
 - [ ] Once the release PR has been approved and merged, create a new release


### PR DESCRIPTION

## Motivation

In https://github.com/ZcashFoundation/zebra/pull/3586#issuecomment-1047720780 @upbqdn had a great idea of listing the PRs that were removed from the changelog and the crates that haven't been incremented, which makes reviewing easier. So I thought we could include this in the checklist.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

## Review

Not urgent. Anyone can review. This was unprompted, so feel free to give feedback on whether we should do this or to suggest something different.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
