### PR TITLE
tests(rpc): Add some RPC acceptance tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5816,6 +5816,7 @@ dependencies = [
  "sentry",
  "sentry-tracing",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "tokio",

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -60,6 +60,7 @@ abscissa_core = { version = "0.5", features = ["testing"] }
 once_cell = "1.9"
 regex = "1.5.4"
 semver = "1.0.6"
+serde_json = "1.0"
 tempfile = "3.3.0"
 tokio = { version = "1.16.1", features = ["full", "test-util"] }
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1487,7 +1487,7 @@ async fn rpc_endpoint() -> Result<()> {
         .uri(url)
         .header("content-type", "application/json")
         .body(Body::from(
-            r#"{"jsonrpc": "1.0", "method": "getinfo", "id":123}"#,
+            r#"{"jsonrpc":"1.0","method":"getinfo","params":[],"id":123}"#,
         ))?;
 
     // Make the call to the RPC endpoint

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1457,7 +1457,7 @@ async fn tracing_endpoint() -> Result<()> {
 
 #[tokio::test]
 async fn rpc_endpoint() -> Result<()> {
-    use hyper::Client;
+    use hyper::{body::to_bytes, Body, Client, Method, Request};
 
     zebra_test::init();
 
@@ -1481,11 +1481,11 @@ async fn rpc_endpoint() -> Result<()> {
     let client = Client::new();
 
     // Create a request to call `getinfo` RPC method
-    let req = hyper::Request::builder()
-        .method(hyper::Method::POST)
+    let req = Request::builder()
+        .method(Method::POST)
         .uri(url)
         .header("content-type", "application/json")
-        .body(hyper::Body::from(
+        .body(Body::from(
             r#"{"jsonrpc": "2.0", "method": "getinfo", "id":123}"#,
         ))?;
 
@@ -1494,7 +1494,7 @@ async fn rpc_endpoint() -> Result<()> {
 
     // Test rpc endpoint response
     assert!(res.status().is_success());
-    let body = hyper::body::to_bytes(res).await;
+    let body = to_bytes(res).await;
     let response_bytes = body.expect("a response as bytes");
     let response_string = format!("{:?}", response_bytes);
 


### PR DESCRIPTION
## Motivation

We need to add some RPC port and config tests. Close https://github.com/ZcashFoundation/zebra/issues/3165


## Solution

Add two tests: 

- `rpc_endpoint` to test configuration and make sure everything is up and running.
- `zebra_rpc_conflict` to test RPC port conflicts.

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] New tests logic and code
  - [ ] New tests pass 

## Follow Up Work

Should we add a port hint for already in use RPC port as we did for other endpoints ? If so, we can open a ticket to do it.