### PR TITLE
Refactor to create a new `zebra-node-services` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5692,6 +5692,7 @@ dependencies = [
 name = "zebra-node-services"
 version = "1.0.0-beta.5"
 dependencies = [
+ "tower",
  "zebra-chain",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5717,6 +5717,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "zebra-services"
+version = "1.0.0-beta.5"
+
+[[package]]
 name = "zebra-state"
 version = "1.0.0-beta.5"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5692,7 +5692,6 @@ dependencies = [
 name = "zebra-node-services"
 version = "1.0.0-beta.5"
 dependencies = [
- "tower",
  "zebra-chain",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5689,6 +5689,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "zebra-node-services"
+version = "1.0.0-beta.5"
+dependencies = [
+ "zebra-chain",
+]
+
+[[package]]
 name = "zebra-rpc"
 version = "1.0.0-beta.0"
 dependencies = [
@@ -5715,10 +5722,6 @@ dependencies = [
  "zebra-chain",
  "zebra-test",
 ]
-
-[[package]]
-name = "zebra-services"
-version = "1.0.0-beta.5"
 
 [[package]]
 name = "zebra-state"
@@ -5835,6 +5838,7 @@ dependencies = [
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
+ "zebra-node-services",
  "zebra-rpc",
  "zebra-state",
  "zebra-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
         "zebra-consensus",
         "zebra-rpc",
         "zebra-client",
+        "zebra-node-services",
         "zebra-test",
         "zebra-utils",
         "tower-batch",

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -8,3 +8,5 @@ repository = "https://github.com/ZcashFoundation/zebra"
 
 [dependencies]
 zebra-chain = { path = "../zebra-chain" }
+
+tower = "0.4.12"

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -8,5 +8,3 @@ repository = "https://github.com/ZcashFoundation/zebra"
 
 [dependencies]
 zebra-chain = { path = "../zebra-chain" }
-
-tower = "0.4.12"

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 repository = "https://github.com/ZcashFoundation/zebra"
 
 [dependencies]
+zebra-chain = { path = "../zebra-chain" }

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "zebra-node-services"
+authors = ["Zcash Foundation <zebra@zfnd.org>"]
+license = "MIT OR Apache-2.0"
+version = "1.0.0-beta.5"
+edition = "2021"
+repository = "https://github.com/ZcashFoundation/zebra"
+
+[dependencies]

--- a/zebra-node-services/src/lib.rs
+++ b/zebra-node-services/src/lib.rs
@@ -1,3 +1,10 @@
 //! The interfaces of some Zebra node services.
 
 pub mod mempool;
+
+/// Error type alias to make working with tower traits easier.
+///
+/// Note: the 'static lifetime bound means that the *type* cannot have any
+/// non-'static lifetimes, (e.g., when a type contains a borrow and is
+/// parameterized by 'a), *not* that the object itself has 'static lifetime.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/zebra-node-services/src/lib.rs
+++ b/zebra-node-services/src/lib.rs
@@ -1,1 +1,3 @@
 //! The interfaces of some Zebra node services.
+
+pub mod mempool;

--- a/zebra-node-services/src/lib.rs
+++ b/zebra-node-services/src/lib.rs
@@ -1,0 +1,1 @@
+//! The interfaces of some Zebra node services.

--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -4,9 +4,9 @@
 
 use std::collections::HashSet;
 
-use tower::BoxError;
-
 use zebra_chain::transaction::{UnminedTx, UnminedTxId};
+
+use crate::BoxError;
 
 /// A mempool service request.
 ///

--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -8,6 +8,9 @@ use zebra_chain::transaction::{UnminedTx, UnminedTxId};
 
 use crate::BoxError;
 
+mod gossip;
+pub use self::gossip::Gossip;
+
 /// A mempool service request.
 ///
 /// Requests can query the current set of mempool transactions,
@@ -56,38 +59,6 @@ pub enum Request {
     /// too many slots are reserved but unused:
     /// <https://docs.rs/tower/0.4.10/tower/buffer/struct.Buffer.html#a-note-on-choosing-a-bound>
     CheckForVerifiedTransactions,
-}
-
-/// A gossiped transaction, which can be the transaction itself or just its ID.
-#[derive(Debug, Eq, PartialEq)]
-pub enum Gossip {
-    /// Just the ID of an unmined transaction.
-    Id(UnminedTxId),
-
-    /// The full contents of an unmined transaction.
-    Tx(UnminedTx),
-}
-
-impl Gossip {
-    /// Return the [`UnminedTxId`] of a gossiped transaction.
-    pub fn id(&self) -> UnminedTxId {
-        match self {
-            Gossip::Id(txid) => *txid,
-            Gossip::Tx(tx) => tx.id,
-        }
-    }
-}
-
-impl From<UnminedTxId> for Gossip {
-    fn from(txid: UnminedTxId) -> Self {
-        Gossip::Id(txid)
-    }
-}
-
-impl From<UnminedTx> for Gossip {
-    fn from(tx: UnminedTx) -> Self {
-        Gossip::Tx(tx)
-    }
 }
 
 /// A response to a mempool service request.

--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -7,7 +7,10 @@ use zebra_chain::transaction::{UnminedTx, UnminedTxId};
 /// A gossiped transaction, which can be the transaction itself or just its ID.
 #[derive(Debug, Eq, PartialEq)]
 pub enum Gossip {
+    /// Just the ID of an unmined transaction.
     Id(UnminedTxId),
+
+    /// The full contents of an unmined transaction.
     Tx(UnminedTx),
 }
 

--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -2,7 +2,59 @@
 //!
 //! A service that manages known unmined Zcash transactions.
 
+use std::collections::HashSet;
+
 use zebra_chain::transaction::{UnminedTx, UnminedTxId};
+
+/// A mempool service request.
+///
+/// Requests can query the current set of mempool transactions,
+/// queue transactions to be downloaded and verified, or
+/// run the mempool to check for newly verified transactions.
+///
+/// Requests can't modify the mempool directly,
+/// because all mempool transactions must be verified.
+#[derive(Debug, Eq, PartialEq)]
+#[allow(dead_code)]
+pub enum Request {
+    /// Query all transaction IDs in the mempool.
+    TransactionIds,
+
+    /// Query matching  transactions in the mempool,
+    /// using a unique set of [`UnminedTxId`]s.
+    TransactionsById(HashSet<UnminedTxId>),
+
+    /// Query matching cached rejected transaction IDs in the mempool,
+    /// using a unique set of [`UnminedTxId`]s.
+    RejectedTransactionIds(HashSet<UnminedTxId>),
+
+    /// Queue a list of gossiped transactions or transaction IDs, or
+    /// crawled transaction IDs.
+    ///
+    /// The transaction downloader checks for duplicates across IDs and transactions.
+    Queue(Vec<Gossip>),
+
+    /// Check for newly verified transactions.
+    ///
+    /// The transaction downloader does not push transactions into the mempool.
+    /// So a task should send this request regularly (every 5-10 seconds).
+    ///
+    /// These checks also happen for other request variants,
+    /// but we can't rely on peers to send queries regularly,
+    /// and crawler queue requests depend on peer responses.
+    /// Also, crawler requests aren't frequent enough for transaction propagation.
+    ///
+    /// # Correctness
+    ///
+    /// This request is required to avoid hangs in the mempool.
+    ///
+    /// The queue checker task can't call `poll_ready` directly on the [`Mempool`] service,
+    /// because the mempool service is wrapped in a `Buffer`.
+    /// Calling [`Buffer::poll_ready`] reserves a buffer slot, which can cause hangs when
+    /// too many slots are reserved but unused:
+    /// <https://docs.rs/tower/0.4.10/tower/buffer/struct.Buffer.html#a-note-on-choosing-a-bound>
+    CheckForVerifiedTransactions,
+}
 
 /// A gossiped transaction, which can be the transaction itself or just its ID.
 #[derive(Debug, Eq, PartialEq)]

--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -4,6 +4,8 @@
 
 use std::collections::HashSet;
 
+use tower::BoxError;
+
 use zebra_chain::transaction::{UnminedTx, UnminedTxId};
 
 /// A mempool service request.
@@ -86,4 +88,35 @@ impl From<UnminedTx> for Gossip {
     fn from(tx: UnminedTx) -> Self {
         Gossip::Tx(tx)
     }
+}
+
+/// A response to a mempool service request.
+///
+/// Responses can read the current set of mempool transactions,
+/// check the queued status of transactions to be downloaded and verified, or
+/// confirm that the mempool has been checked for newly verified transactions.
+#[derive(Debug)]
+pub enum Response {
+    /// Returns all transaction IDs from the mempool.
+    TransactionIds(HashSet<UnminedTxId>),
+
+    /// Returns matching transactions from the mempool.
+    ///
+    /// Since the [`TransactionsById`] request is unique,
+    /// the response transactions are also unique.
+    Transactions(Vec<UnminedTx>),
+
+    /// Returns matching cached rejected transaction IDs from the mempool,
+    RejectedTransactionIds(HashSet<UnminedTxId>),
+
+    /// Returns a list of queue results.
+    ///
+    /// These are the results of the initial queue checks.
+    /// The transaction may also fail download or verification later.
+    ///
+    /// Each result matches the request at the corresponding vector index.
+    Queued(Vec<Result<(), BoxError>>),
+
+    /// Confirms that the mempool has checked for recently verified transactions.
+    CheckedForVerifiedTransactions,
 }

--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -1,0 +1,34 @@
+//! The Zebra mempool.
+//!
+//! A service that manages known unmined Zcash transactions.
+
+use zebra_chain::transaction::{UnminedTx, UnminedTxId};
+
+/// A gossiped transaction, which can be the transaction itself or just its ID.
+#[derive(Debug, Eq, PartialEq)]
+pub enum Gossip {
+    Id(UnminedTxId),
+    Tx(UnminedTx),
+}
+
+impl Gossip {
+    /// Return the [`UnminedTxId`] of a gossiped transaction.
+    pub fn id(&self) -> UnminedTxId {
+        match self {
+            Gossip::Id(txid) => *txid,
+            Gossip::Tx(tx) => tx.id,
+        }
+    }
+}
+
+impl From<UnminedTxId> for Gossip {
+    fn from(txid: UnminedTxId) -> Self {
+        Gossip::Id(txid)
+    }
+}
+
+impl From<UnminedTx> for Gossip {
+    fn from(tx: UnminedTx) -> Self {
+        Gossip::Tx(tx)
+    }
+}

--- a/zebra-node-services/src/mempool/gossip.rs
+++ b/zebra-node-services/src/mempool/gossip.rs
@@ -1,0 +1,35 @@
+//! Representation of a gossiped transaction to send to the mempool.
+
+use zebra_chain::transaction::{UnminedTx, UnminedTxId};
+
+/// A gossiped transaction, which can be the transaction itself or just its ID.
+#[derive(Debug, Eq, PartialEq)]
+pub enum Gossip {
+    /// Just the ID of an unmined transaction.
+    Id(UnminedTxId),
+
+    /// The full contents of an unmined transaction.
+    Tx(UnminedTx),
+}
+
+impl Gossip {
+    /// Return the [`UnminedTxId`] of a gossiped transaction.
+    pub fn id(&self) -> UnminedTxId {
+        match self {
+            Gossip::Id(txid) => *txid,
+            Gossip::Tx(tx) => tx.id,
+        }
+    }
+}
+
+impl From<UnminedTxId> for Gossip {
+    fn from(txid: UnminedTxId) -> Self {
+        Gossip::Id(txid)
+    }
+}
+
+impl From<UnminedTx> for Gossip {
+    fn from(tx: UnminedTx) -> Self {
+        Gossip::Tx(tx)
+    }
+}

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -13,6 +13,7 @@ default-run = "zebrad"
 zebra-chain = { path = "../zebra-chain" }
 zebra-consensus = { path = "../zebra-consensus/" }
 zebra-network = { path = "../zebra-network" }
+zebra-node-services = { path = "../zebra-node-services" }
 zebra-rpc = { path = "../zebra-rpc" }
 zebra-state = { path = "../zebra-state" }
 

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -19,7 +19,7 @@ use futures::{
     stream::Stream,
 };
 use tokio::sync::oneshot::{self, error::TryRecvError};
-use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, Service, ServiceExt};
+use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, BoxError, Service, ServiceExt};
 
 use zebra_network as zn;
 use zebra_state as zs;
@@ -36,10 +36,7 @@ use zebra_network::{
 use zebra_node_services::mempool;
 
 // Re-use the syncer timeouts for consistency.
-use super::{
-    mempool as mp,
-    sync::{BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT},
-};
+use super::sync::{BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT};
 
 use InventoryResponse::*;
 
@@ -53,8 +50,7 @@ use downloads::Downloads as BlockDownloads;
 type BlockDownloadPeerSet =
     Buffer<BoxService<zn::Request, zn::Response, zn::BoxError>, zn::Request>;
 type State = Buffer<BoxService<zs::Request, zs::Response, zs::BoxError>, zs::Request>;
-type Mempool =
-    Buffer<BoxService<mempool::Request, mempool::Response, mp::BoxError>, mempool::Request>;
+type Mempool = Buffer<BoxService<mempool::Request, mempool::Response, BoxError>, mempool::Request>;
 type BlockVerifier = Buffer<BoxService<Arc<Block>, block::Hash, VerifyChainError>, Arc<Block>>;
 type GossipedBlockDownloads =
     BlockDownloads<Timeout<BlockDownloadPeerSet>, Timeout<BlockVerifier>, State>;

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -19,7 +19,7 @@ use futures::{
     stream::Stream,
 };
 use tokio::sync::oneshot::{self, error::TryRecvError};
-use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, BoxError, Service, ServiceExt};
+use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, Service, ServiceExt};
 
 use zebra_network as zn;
 use zebra_state as zs;
@@ -37,6 +37,7 @@ use zebra_node_services::mempool;
 
 // Re-use the syncer timeouts for consistency.
 use super::sync::{BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT};
+use crate::BoxError;
 
 use InventoryResponse::*;
 

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -33,10 +33,11 @@ use zebra_network::{
     constants::{ADDR_RESPONSE_LIMIT_DENOMINATOR, MAX_ADDRS_IN_MESSAGE},
     AddressBook, InventoryResponse,
 };
+use zebra_node_services::mempool;
 
 // Re-use the syncer timeouts for consistency.
 use super::{
-    mempool, mempool as mp,
+    mempool as mp,
     sync::{BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT},
 };
 
@@ -52,7 +53,7 @@ use downloads::Downloads as BlockDownloads;
 type BlockDownloadPeerSet =
     Buffer<BoxService<zn::Request, zn::Response, zn::BoxError>, zn::Request>;
 type State = Buffer<BoxService<zs::Request, zs::Response, zs::BoxError>, zs::Request>;
-type Mempool = Buffer<BoxService<mp::Request, mp::Response, mp::BoxError>, mp::Request>;
+type Mempool = Buffer<BoxService<mempool::Request, mp::Response, mp::BoxError>, mempool::Request>;
 type BlockVerifier = Buffer<BoxService<Arc<Block>, block::Hash, VerifyChainError>, Arc<Block>>;
 type GossipedBlockDownloads =
     BlockDownloads<Timeout<BlockDownloadPeerSet>, Timeout<BlockVerifier>, State>;
@@ -394,7 +395,7 @@ impl Service<zn::Request> for Inbound {
                 let request = mempool::Request::TransactionsById(req_tx_ids.clone());
                 mempool.clone().oneshot(request).map_ok(move |resp| {
                     let transactions = match resp {
-                        mempool::Response::Transactions(transactions) => transactions,
+                        mp::Response::Transactions(transactions) => transactions,
                         _ => unreachable!("Mempool component should always respond to a `TransactionsById` request with a `Transactions` response"),
                     };
 
@@ -447,8 +448,8 @@ impl Service<zn::Request> for Inbound {
             }
             zn::Request::MempoolTransactionIds => {
                 mempool.clone().oneshot(mempool::Request::TransactionIds).map_ok(|resp| match resp {
-                    mempool::Response::TransactionIds(transaction_ids) if transaction_ids.is_empty() => zn::Response::Nil,
-                    mempool::Response::TransactionIds(transaction_ids) => zn::Response::TransactionIds(transaction_ids.into_iter().collect()),
+                    mp::Response::TransactionIds(transaction_ids) if transaction_ids.is_empty() => zn::Response::Nil,
+                    mp::Response::TransactionIds(transaction_ids) => zn::Response::TransactionIds(transaction_ids.into_iter().collect()),
                     _ => unreachable!("Mempool component should always respond to a `TransactionIds` request with a `TransactionIds` response"),
                 })
                     .boxed()

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -53,7 +53,8 @@ use downloads::Downloads as BlockDownloads;
 type BlockDownloadPeerSet =
     Buffer<BoxService<zn::Request, zn::Response, zn::BoxError>, zn::Request>;
 type State = Buffer<BoxService<zs::Request, zs::Response, zs::BoxError>, zs::Request>;
-type Mempool = Buffer<BoxService<mempool::Request, mp::Response, mp::BoxError>, mempool::Request>;
+type Mempool =
+    Buffer<BoxService<mempool::Request, mempool::Response, mp::BoxError>, mempool::Request>;
 type BlockVerifier = Buffer<BoxService<Arc<Block>, block::Hash, VerifyChainError>, Arc<Block>>;
 type GossipedBlockDownloads =
     BlockDownloads<Timeout<BlockDownloadPeerSet>, Timeout<BlockVerifier>, State>;
@@ -395,7 +396,7 @@ impl Service<zn::Request> for Inbound {
                 let request = mempool::Request::TransactionsById(req_tx_ids.clone());
                 mempool.clone().oneshot(request).map_ok(move |resp| {
                     let transactions = match resp {
-                        mp::Response::Transactions(transactions) => transactions,
+                        mempool::Response::Transactions(transactions) => transactions,
                         _ => unreachable!("Mempool component should always respond to a `TransactionsById` request with a `Transactions` response"),
                     };
 
@@ -448,8 +449,8 @@ impl Service<zn::Request> for Inbound {
             }
             zn::Request::MempoolTransactionIds => {
                 mempool.clone().oneshot(mempool::Request::TransactionIds).map_ok(|resp| match resp {
-                    mp::Response::TransactionIds(transaction_ids) if transaction_ids.is_empty() => zn::Response::Nil,
-                    mp::Response::TransactionIds(transaction_ids) => zn::Response::TransactionIds(transaction_ids.into_iter().collect()),
+                    mempool::Response::TransactionIds(transaction_ids) if transaction_ids.is_empty() => zn::Response::Nil,
+                    mempool::Response::TransactionIds(transaction_ids) => zn::Response::TransactionIds(transaction_ids.into_iter().collect()),
                     _ => unreachable!("Mempool component should always respond to a `TransactionIds` request with a `TransactionIds` response"),
                 })
                     .boxed()

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -32,6 +32,7 @@ use crate::{
         inbound::{Inbound, InboundSetupData},
         mempool::{
             self as mp, gossip_mempool_transaction_id, unmined_transactions_in_blocks, Mempool,
+            UnboxMempoolError,
         },
         sync::{self, BlockGossipError, SyncStatus},
     },
@@ -490,10 +491,12 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
 
     assert_eq!(queued_responses.len(), 1);
     assert_eq!(
-        queued_responses[0],
-        Err(mp::MempoolError::StorageEffectsChain(
-            mp::SameEffectsChainRejectionError::Expired
-        ))
+        queued_responses
+            .into_iter()
+            .next()
+            .unwrap()
+            .unbox_mempool_error(),
+        mp::MempoolError::StorageEffectsChain(mp::SameEffectsChainRejectionError::Expired)
     );
 
     // Test transaction 2 is gossiped

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -485,7 +485,7 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
         .unwrap();
 
     let queued_responses = match response {
-        mp::Response::Queued(queue_responses) => queue_responses,
+        mempool::Response::Queued(queue_responses) => queue_responses,
         _ => unreachable!("will never happen in this test"),
     };
 
@@ -681,7 +681,7 @@ async fn setup(
         BoxService<zebra_network::Request, zebra_network::Response, BoxError>,
         zebra_network::Request,
     >,
-    Buffer<BoxService<mempool::Request, mp::Response, BoxError>, mempool::Request>,
+    Buffer<BoxService<mempool::Request, mempool::Response, BoxError>, mempool::Request>,
     Vec<Arc<Block>>,
     Vec<VerifiedUnminedTx>,
     MockService<transaction::Request, transaction::Response, PanicAssertion, TransactionError>,

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -31,8 +31,8 @@ use crate::{
     components::{
         inbound::{Inbound, InboundSetupData},
         mempool::{
-            self as mp, gossip_mempool_transaction_id, unmined_transactions_in_blocks, Mempool,
-            UnboxMempoolError,
+            gossip_mempool_transaction_id, unmined_transactions_in_blocks, Config as MempoolConfig,
+            Mempool, MempoolError, SameEffectsChainRejectionError, UnboxMempoolError,
         },
         sync::{self, BlockGossipError, SyncStatus},
     },
@@ -496,7 +496,7 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
             .next()
             .unwrap()
             .unbox_mempool_error(),
-        mp::MempoolError::StorageEffectsChain(mp::SameEffectsChainRejectionError::Expired)
+        MempoolError::StorageEffectsChain(SameEffectsChainRejectionError::Expired)
     );
 
     // Test transaction 2 is gossiped
@@ -756,7 +756,7 @@ async fn setup(
     committed_blocks.push(block_one);
 
     let (mut mempool_service, transaction_receiver) = Mempool::new(
-        &mp::Config::default(),
+        &MempoolConfig::default(),
         buffered_peer_set.clone(),
         state_service.clone(),
         buffered_tx_verifier.clone(),

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -29,7 +29,7 @@ use zebra_test::mock_service::{MockService, PanicAssertion};
 use crate::{
     components::{
         inbound::{Inbound, InboundSetupData},
-        mempool::{self as mp, gossip_mempool_transaction_id, Mempool},
+        mempool::{gossip_mempool_transaction_id, Config as MempoolConfig, Mempool},
         sync::{self, BlockGossipError, SyncStatus},
     },
     BoxError,
@@ -698,7 +698,7 @@ async fn setup(
         .service(BoxService::new(mock_tx_verifier.clone()));
 
     // Mempool
-    let mempool_config = mp::Config::default();
+    let mempool_config = MempoolConfig::default();
     let (mut mempool_service, transaction_receiver) = Mempool::new(
         &mempool_config,
         peer_set.clone(),

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -617,7 +617,7 @@ async fn setup(
         BoxService<zebra_network::Request, zebra_network::Response, BoxError>,
         zebra_network::Request,
     >,
-    Buffer<BoxService<mempool::Request, mp::Response, BoxError>, mempool::Request>,
+    Buffer<BoxService<mempool::Request, mempool::Response, BoxError>, mempool::Request>,
     Buffer<BoxService<zebra_state::Request, zebra_state::Response, BoxError>, zebra_state::Request>,
     // mocked services
     MockService<Arc<Block>, block::Hash, PanicAssertion, VerifyChainError>,

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -37,7 +37,7 @@ use zebra_chain::{
 };
 use zebra_consensus::{error::TransactionError, transaction};
 use zebra_network as zn;
-use zebra_node_services::mempool::Gossip;
+use zebra_node_services::mempool::Request;
 use zebra_state as zs;
 use zebra_state::{ChainTipChange, TipAction};
 
@@ -79,56 +79,6 @@ type TxVerifier = Buffer<
     transaction::Request,
 >;
 type InboundTxDownloads = TxDownloads<Timeout<Outbound>, Timeout<TxVerifier>, State>;
-
-/// A mempool service request.
-///
-/// Requests can query the current set of mempool transactions,
-/// queue transactions to be downloaded and verified, or
-/// run the mempool to check for newly verified transactions.
-///
-/// Requests can't modify the mempool directly,
-/// because all mempool transactions must be verified.
-#[derive(Debug, Eq, PartialEq)]
-#[allow(dead_code)]
-pub enum Request {
-    /// Query all transaction IDs in the mempool.
-    TransactionIds,
-
-    /// Query matching  transactions in the mempool,
-    /// using a unique set of [`UnminedTxId`]s.
-    TransactionsById(HashSet<UnminedTxId>),
-
-    /// Query matching cached rejected transaction IDs in the mempool,
-    /// using a unique set of [`UnminedTxId`]s.
-    RejectedTransactionIds(HashSet<UnminedTxId>),
-
-    /// Queue a list of gossiped transactions or transaction IDs, or
-    /// crawled transaction IDs.
-    ///
-    /// The transaction downloader checks for duplicates across IDs and transactions.
-    Queue(Vec<Gossip>),
-
-    /// Check for newly verified transactions.
-    ///
-    /// The transaction downloader does not push transactions into the mempool.
-    /// So a task should send this request regularly (every 5-10 seconds).
-    ///
-    /// These checks also happen for other request variants,
-    /// but we can't rely on peers to send queries regularly,
-    /// and crawler queue requests depend on peer responses.
-    /// Also, crawler requests aren't frequent enough for transaction propagation.
-    ///
-    /// # Correctness
-    ///
-    /// This request is required to avoid hangs in the mempool.
-    ///
-    /// The queue checker task can't call `poll_ready` directly on the [`Mempool`] service,
-    /// because the mempool service is wrapped in a `Buffer`.
-    /// Calling [`Buffer::poll_ready`] reserves a buffer slot, which can cause hangs when
-    /// too many slots are reserved but unused:
-    /// <https://docs.rs/tower/0.4.10/tower/buffer/struct.Buffer.html#a-note-on-choosing-a-bound>
-    CheckForVerifiedTransactions,
-}
 
 /// A response to a mempool service request.
 ///

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -37,6 +37,7 @@ use zebra_chain::{
 };
 use zebra_consensus::{error::TransactionError, transaction};
 use zebra_network as zn;
+use zebra_node_services::mempool::Gossip;
 use zebra_state as zs;
 use zebra_state::{ChainTipChange, TipAction};
 
@@ -68,7 +69,7 @@ pub use storage::{
 pub use storage::tests::unmined_transactions_in_blocks;
 
 use downloads::{
-    Downloads as TxDownloads, Gossip, TRANSACTION_DOWNLOAD_TIMEOUT, TRANSACTION_VERIFY_TIMEOUT,
+    Downloads as TxDownloads, TRANSACTION_DOWNLOAD_TIMEOUT, TRANSACTION_VERIFY_TIMEOUT,
 };
 
 type Outbound = Buffer<BoxService<zn::Request, zn::Response, zn::BoxError>, zn::Request>;

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -56,10 +56,11 @@ use tracing_futures::Instrument;
 
 use zebra_chain::{block::Height, transaction::UnminedTxId};
 use zebra_network as zn;
+use zebra_node_services::mempool::Gossip;
 use zebra_state::ChainTipChange;
 
 use crate::components::{
-    mempool::{self, downloads::Gossip, Config},
+    mempool::{self, Config},
     sync::SyncStatus,
 };
 

--- a/zebrad/src/components/mempool/crawler/tests/prop.rs
+++ b/zebrad/src/components/mempool/crawler/tests/prop.rs
@@ -7,7 +7,6 @@ use proptest::{
     prelude::*,
 };
 use tokio::time;
-use tower::BoxError;
 
 use zebra_chain::{parameters::Network, transaction::UnminedTxId};
 use zebra_network as zn;
@@ -15,14 +14,17 @@ use zebra_node_services::mempool::Gossip;
 use zebra_state::ChainTipSender;
 use zebra_test::mock_service::{MockService, PropTestAssertion};
 
-use crate::components::{
-    mempool::{
-        self,
-        crawler::{Crawler, SyncStatus, FANOUT, RATE_LIMIT_DELAY},
-        error::MempoolError,
-        Config,
+use crate::{
+    components::{
+        mempool::{
+            self,
+            crawler::{Crawler, SyncStatus, FANOUT, RATE_LIMIT_DELAY},
+            error::MempoolError,
+            Config,
+        },
+        sync::RecentSyncLengths,
     },
-    sync::RecentSyncLengths,
+    BoxError,
 };
 
 /// The number of iterations to crawl while testing.

--- a/zebrad/src/components/mempool/crawler/tests/prop.rs
+++ b/zebrad/src/components/mempool/crawler/tests/prop.rs
@@ -10,6 +10,7 @@ use tokio::time;
 
 use zebra_chain::{parameters::Network, transaction::UnminedTxId};
 use zebra_network as zn;
+use zebra_node_services::mempool::Gossip;
 use zebra_state::ChainTipSender;
 use zebra_test::mock_service::{MockService, PropTestAssertion};
 
@@ -17,7 +18,6 @@ use crate::components::{
     mempool::{
         self,
         crawler::{Crawler, SyncStatus, FANOUT, RATE_LIMIT_DELAY},
-        downloads::Gossip,
         error::MempoolError,
         Config,
     },

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -39,9 +39,10 @@ use tokio::{sync::oneshot, task::JoinHandle};
 use tower::{Service, ServiceExt};
 use tracing_futures::Instrument;
 
-use zebra_chain::transaction::{self, UnminedTx, UnminedTxId, VerifiedUnminedTx};
+use zebra_chain::transaction::{self, UnminedTxId, VerifiedUnminedTx};
 use zebra_consensus::transaction as tx;
 use zebra_network as zn;
+use zebra_node_services::mempool::Gossip;
 use zebra_state as zs;
 
 use crate::components::sync::{BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT};
@@ -109,35 +110,6 @@ pub enum TransactionDownloadVerifyError {
 
     #[error("transaction did not pass consensus validation")]
     Invalid(#[from] zebra_consensus::error::TransactionError),
-}
-
-/// A gossiped transaction, which can be the transaction itself or just its ID.
-#[derive(Debug, Eq, PartialEq)]
-pub enum Gossip {
-    Id(UnminedTxId),
-    Tx(UnminedTx),
-}
-
-impl Gossip {
-    /// Return the [`UnminedTxId`] of a gossiped transaction.
-    pub fn id(&self) -> UnminedTxId {
-        match self {
-            Gossip::Id(txid) => *txid,
-            Gossip::Tx(tx) => tx.id,
-        }
-    }
-}
-
-impl From<UnminedTxId> for Gossip {
-    fn from(txid: UnminedTxId) -> Self {
-        Gossip::Id(txid)
-    }
-}
-
-impl From<UnminedTx> for Gossip {
-    fn from(tx: UnminedTx) -> Self {
-        Gossip::Tx(tx)
-    }
 }
 
 /// Represents a [`Stream`] of download and verification tasks.

--- a/zebrad/src/components/mempool/tests.rs
+++ b/zebrad/src/components/mempool/tests.rs
@@ -1,11 +1,14 @@
 use std::pin::Pin;
 
-use tower::{BoxError, ServiceExt};
+use tower::ServiceExt;
 
 use super::{
     error::MempoolError, storage::Storage, ActiveState, InboundTxDownloads, Mempool, Request,
 };
-use crate::components::sync::{RecentSyncLengths, SyncStatus};
+use crate::{
+    components::sync::{RecentSyncLengths, SyncStatus},
+    BoxError,
+};
 
 mod prop;
 mod vector;

--- a/zebrad/src/components/mempool/tests.rs
+++ b/zebrad/src/components/mempool/tests.rs
@@ -1,8 +1,10 @@
 use std::pin::Pin;
 
-use tower::ServiceExt;
+use tower::{BoxError, ServiceExt};
 
-use super::{storage::Storage, ActiveState, InboundTxDownloads, Mempool, Request};
+use super::{
+    error::MempoolError, storage::Storage, ActiveState, InboundTxDownloads, Mempool, Request,
+};
 use crate::components::sync::{RecentSyncLengths, SyncStatus};
 
 mod prop;
@@ -46,5 +48,43 @@ impl Mempool {
         self.oneshot(Request::CheckForVerifiedTransactions)
             .await
             .expect("unexpected failure when checking for verified transactions");
+    }
+}
+
+/// Helper trait to extract the [`MempoolError`] from a [`BoxError`].
+pub trait UnboxMempoolError {
+    /// Extract and unbox the [`MempoolError`] stored inside `self`.
+    ///
+    /// # Panics
+    ///
+    /// If the `boxed_error` is not a boxed [`MempoolError`].
+    fn unbox_mempool_error(self) -> MempoolError;
+}
+
+impl UnboxMempoolError for MempoolError {
+    fn unbox_mempool_error(self) -> MempoolError {
+        self
+    }
+}
+
+impl UnboxMempoolError for BoxError {
+    fn unbox_mempool_error(self) -> MempoolError {
+        self.downcast::<MempoolError>()
+            .expect("error is not an expected `MempoolError`")
+            // TODO: use `Box::into_inner` when it becomes stabilized.
+            .as_ref()
+            .clone()
+    }
+}
+
+impl<T, E> UnboxMempoolError for Result<T, E>
+where
+    E: UnboxMempoolError,
+{
+    fn unbox_mempool_error(self) -> MempoolError {
+        match self {
+            Ok(_) => panic!("expected a mempool error, but got a success instead"),
+            Err(error) => error.unbox_mempool_error(),
+        }
     }
 }


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
As part of the work for the `sendrawtransaction` RPC implementation (#3146), the `RpcImpl` type needed to send transactions to the mempool service. However, the mempool service is defined in the `zebrad` crate, and making the `zebra-rpc` crate depend on it would create a cyclic dependency.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
As per the discussion #3598, a new `zebra-node-services` crate was created. This is currently a minimal crate that only contains the `mempool::{Request, Response}` types so that other crates (`zebra-rpc` specifically) could have access to the mempool service interface definition. This is enough to unblock #3146.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@teor2345 can review this.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
It's still unclear how this new crate will evolve in the future. It can either:

- contain the mempool, inbound and synchronizer services
- contain only interfaces for Zebra services
- something else...

The name may also change in the future. These decisions do not have to be made in the forseable short term future.