### PR TITLE
fix(test): check for zebrad test output in the correct order

### DIFF
--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -382,11 +382,17 @@ impl<T> TestChild<T> {
 }
 
 pub struct TestOutput<T> {
+    /// The test directory for this test output.
+    ///
+    /// Keeps the test dir around from `TestChild`,
+    /// so it doesn't get deleted during `wait_with_output`.
     #[allow(dead_code)]
-    // this just keeps the test dir around from `TestChild` so it doesn't get
-    // deleted during `wait_with_output`
-    dir: Option<T>,
+    pub dir: Option<T>,
+
+    /// The test command for this test output.
     pub cmd: String,
+
+    /// The test exit status, standard out, and standard error.
     pub output: Output,
 }
 


### PR DESCRIPTION
## Motivation

The `sync_until` function was checking for mempool activation in unreliable and slow ways:
1. The sync test was checking for mempool output after the stop log, but sometimes the mempool activates before the stop log
2. The non-mempool tests were checking each individual log line, but they need to check the entire log

## Solution

1. The mempool is only activated once, so we must check for that log first. After mempool activation, the stop regex is always logged at least once. (It might be logged before mempool activation as well, but we can't rely on that.)

2. When checking that the mempool didn't activate, wait for the `zebrad` command to exit, then check the entire log.

## Review

@jvff can review this PR, but I'm going to cherry-pick it into #3582 as well.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- #1592