### PR TITLE
feat(build): add arm64 support with cross-compilation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,8 +42,16 @@ jobs:
       with:
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+
     # Setup Docker Buildx to allow use of docker cache layers from GH
     - name: Set up Docker Buildx
+      id: buildx
       uses: docker/setup-buildx-action@v1
 
     - name: Login to Google Artifact Registry
@@ -68,6 +76,9 @@ jobs:
         target: runtime
         context: .
         file: ./docker/Dockerfile
+        platforms: |
+          linux/amd64
+          linux/arm64
         tags: |
           ${{ env.GAR_BASE }}/${{ env.GITHUB_HEAD_REF_SLUG_URL || env.GITHUB_REF_SLUG_URL }}:latest
           ${{ env.GAR_BASE }}/${{ env.GITHUB_HEAD_REF_SLUG_URL || env.GITHUB_REF_SLUG_URL }}:${{ env.GITHUB_SHA_SHORT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,13 +45,6 @@ jobs:
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
 
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v1
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: all
-
       # Setup Docker Buildx to allow use of docker cache layers from GH
       - name: Set up Docker Buildx
         id: buildx
@@ -79,9 +72,6 @@ jobs:
           target: tester
           context: .
           file: ./docker/Dockerfile
-          platforms: |
-            linux/amd64
-            linux/arm64
           tags: |
             ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT || env.GITHUB_SHA_SHORT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,11 +45,17 @@ jobs:
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
 
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+
       # Setup Docker Buildx to allow use of docker cache layers from GH
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          driver-opts: network=host
 
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v1.12.0
@@ -73,6 +79,9 @@ jobs:
           target: tester
           context: .
           file: ./docker/Dockerfile
+          platforms: |
+            linux/amd64
+            linux/arm64
           tags: |
             ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_EVENT_PULL_REQUEST_HEAD_SHA_SHORT || env.GITHUB_SHA_SHORT }}

--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -45,8 +45,16 @@ jobs:
       with:
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+
     # Setup Docker Buildx to allow use of docker cache layers from GH
     - name: Set up Docker Buildx
+      id: buildx
       uses: docker/setup-buildx-action@v1
 
     - name: Login to Google Artifact Registry
@@ -64,6 +72,9 @@ jobs:
         target: builder
         context: .
         file: ./zebra/docker/zcash-lightwalletd/Dockerfile
+        platforms: |
+          linux/amd64
+          linux/arm64
         tags: |
           ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:latest
           ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_SHA_SHORT }}

--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -39,8 +39,16 @@ jobs:
       with:
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+
     # Setup Docker Buildx to allow use of docker cache layers from GH
     - name: Set up Docker Buildx
+      id: buildx
       uses: docker/setup-buildx-action@v1
 
     - name: Login to Google Artifact Registry
@@ -58,6 +66,9 @@ jobs:
         target: builder
         context: .
         file: ./docker/zcash-params/Dockerfile
+        platforms: |
+          linux/amd64
+          linux/arm64
         tags: |
           ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:latest
           ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_SHA_SHORT }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,8 @@ RUN apt-get -qq update && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Install google OS Config agent
-RUN apt-get -qq update && \
+RUN if [ "$(uname -m)" != "aarch64" ]; then \
+    apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \
     curl \
     lsb-release \
@@ -36,6 +37,7 @@ RUN apt-get -qq update && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     apt-get -qq update  && \
     apt-get -qq install -y --no-install-recommends google-osconfig-agent && \
+    ; fi && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Optimize builds. In particular, regenerate-stateful-test-disks.yml was reaching the


### PR DESCRIPTION
## Motivation

To run dockerized containers in M1 and other arm64 processors, we need to cross-compile the Docker image for this platforms. This makes it very hard to test locally, as all builds must be done remotely, or pushing to confirm on GHA.

## Solution

- Add QEMU for arm64 platform support
- Build the docker image with arm64

## Review

@dconnolly  can review this
