### PR TITLE
feature(rpc): add real data to `getinfo` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5709,6 +5709,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "zebra-network",
+ "zebra-test",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5701,6 +5701,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
+ "zebra-network",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5704,6 +5704,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-derive",
  "jsonrpc-http-server",
+ "lazy_static",
  "serde",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5704,7 +5704,6 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-derive",
  "jsonrpc-http-server",
- "lazy_static",
  "serde",
  "tokio",
  "tracing",

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -26,3 +26,7 @@ tracing = "0.1"
 tracing-futures = "0.2"
 
 serde = { version = "1", features = ["serde_derive"] }
+
+[dev-dependencies]
+
+zebra-test = { path = "../zebra-test/" }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 
 [dependencies]
 
+zebra-network = { path = "../zebra-network" }
+
 futures = "0.3"
 
 # lightwalletd sends JSON-RPC requests over HTTP 1.1

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -20,8 +20,6 @@ jsonrpc-core = "18.0.0"
 jsonrpc-derive = "18.0.0"
 jsonrpc-http-server = "18.0.0"
 
-lazy_static = "1.4.0"
-
 tokio = { version = "1.16.1", features = ["time", "rt-multi-thread", "macros", "tracing"] }
 
 tracing = "0.1"

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -20,6 +20,8 @@ jsonrpc-core = "18.0.0"
 jsonrpc-derive = "18.0.0"
 jsonrpc-http-server = "18.0.0"
 
+lazy_static = "1.4.0"
+
 tokio = { version = "1.16.1", features = ["time", "rt-multi-thread", "macros", "tracing"] }
 
 tracing = "0.1"

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -18,7 +18,7 @@ pub trait Rpc {
     ///
     /// Returns software information from the RPC server running Zebra.
     ///
-    /// zcadhd reference: <https://zcash.github.io/rpc/getinfo.html>
+    /// zcashd reference: <https://zcash.github.io/rpc/getinfo.html>
     ///
     /// Result:
     /// {
@@ -33,6 +33,7 @@ pub trait Rpc {
     /// show the fields we are exposing. However, this fields are part of the output
     /// as shown in the following zcashd code:
     /// <https://github.com/zcash/zcash/blob/v4.6.0-1/src/rpc/misc.cpp#L86-L87>
+    /// Zcash open ticket to add this fields to the docs: <https://github.com/zcash/zcash/issues/5606>
     #[rpc(name = "getinfo")]
     fn get_info(&self) -> Result<GetInfo>;
 

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -9,6 +9,7 @@
 use jsonrpc_core::{self, Result};
 use jsonrpc_derive::rpc;
 
+use crate::server::APP_VERSION;
 use zebra_network::constants::USER_AGENT;
 
 #[rpc(server)]
@@ -50,9 +51,14 @@ pub trait Rpc {
 pub struct RpcImpl;
 impl Rpc for RpcImpl {
     fn get_info(&self) -> Result<GetInfo> {
-        // TODO: dummy output data, fix in the context of #3142
         let response = GetInfo {
-            build: "TODO: Zebra v1.0.0 ...".into(),
+            build: String::from_utf8(
+                APP_VERSION
+                    .lock()
+                    .expect("mutex should be unpoisoned")
+                    .to_vec(),
+            )
+            .expect("app version should be valid utf8"),
             subversion: USER_AGENT.into(),
         };
 

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -11,6 +11,9 @@ use jsonrpc_derive::rpc;
 
 use zebra_network::constants::USER_AGENT;
 
+#[cfg(test)]
+mod tests;
+
 #[rpc(server)]
 /// RPC method signatures.
 pub trait Rpc {

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -9,15 +9,30 @@
 use jsonrpc_core::{self, Result};
 use jsonrpc_derive::rpc;
 
+use zebra_network::constants::USER_AGENT;
+
 #[rpc(server)]
 /// RPC method signatures.
 pub trait Rpc {
     /// getinfo
     ///
-    /// TODO: explain what the method does
-    ///       link to the zcashd RPC reference
-    ///       list the arguments and fields that lightwalletd uses
-    ///       note any other lightwalletd changes
+    /// Returns software information from the RPC server running Zebra.
+    ///
+    /// zcadhd reference: <https://zcash.github.io/rpc/getinfo.html>
+    ///
+    /// Result:
+    /// {
+    ///      "build": String, // Full application version
+    ///      "subversion", String, // Zebra user agent
+    /// }
+    ///
+    /// Note 1: We only expose 2 fields as they are the only ones needed for
+    /// lightwalletd: <https://github.com/zcash/lightwalletd/blob/v0.4.9/common/common.go#L91-L95>
+    ///
+    /// Note 2: <https://zcash.github.io/rpc/getinfo.html> is outdated so it does not
+    /// show the fields we are exposing. However, this fields are part of the output
+    /// as shown in the following zcashd code:
+    /// <https://github.com/zcash/zcash/blob/v4.6.0-1/src/rpc/misc.cpp#L86-L87>
     #[rpc(name = "getinfo")]
     fn get_info(&self) -> Result<GetInfo>;
 
@@ -38,7 +53,7 @@ impl Rpc for RpcImpl {
         // TODO: dummy output data, fix in the context of #3142
         let response = GetInfo {
             build: "TODO: Zebra v1.0.0 ...".into(),
-            subversion: "TODO: /Zebra:1.0.0-beta.../".into(),
+            subversion: USER_AGENT.into(),
         };
 
         Ok(response)

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -9,7 +9,6 @@
 use jsonrpc_core::{self, Result};
 use jsonrpc_derive::rpc;
 
-use crate::server::APP_VERSION;
 use zebra_network::constants::USER_AGENT;
 
 #[rpc(server)]
@@ -48,17 +47,15 @@ pub trait Rpc {
 }
 
 /// RPC method implementations.
-pub struct RpcImpl;
+
+pub struct RpcImpl {
+    /// Zebra's application version.
+    pub app_version: String,
+}
 impl Rpc for RpcImpl {
     fn get_info(&self) -> Result<GetInfo> {
         let response = GetInfo {
-            build: String::from_utf8(
-                APP_VERSION
-                    .lock()
-                    .expect("mutex should be unpoisoned")
-                    .to_vec(),
-            )
-            .expect("app version should be valid utf8"),
+            build: self.app_version.clone(),
             subversion: USER_AGENT.into(),
         };
 

--- a/zebra-rpc/src/methods/tests.rs
+++ b/zebra-rpc/src/methods/tests.rs
@@ -1,0 +1,2 @@
+//! Test code for RPC methods
+mod vectors;

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -14,7 +14,7 @@ fn rpc_getinfo() {
     let get_info = rpc.get_info().expect("We should have a GetInfo struct");
 
     // make sure there is a `build` field in the response,
-    // and that is equal to the provided
+    // and that is equal to the provided string.
     assert_eq!(get_info.build, "Zebra version test");
 
     // make sure there is a `subversion` field,

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1,0 +1,23 @@
+//! Fixed test vectors for RPC methods.
+
+use super::super::*;
+use zebra_network::constants::USER_AGENT;
+
+#[test]
+fn rpc_getinfo() {
+    zebra_test::init();
+
+    let rpc = RpcImpl {
+        app_version: "Zebra version test".to_string(),
+    };
+
+    let get_info = rpc.get_info().expect("We should have a GetInfo struct");
+
+    // make sure there is a `build` field in the response,
+    // and that is equal to the provided
+    assert_eq!(get_info.build, "Zebra version test");
+
+    // make sure there is a `subversion` field,
+    // and that is equal to the Zebra user agent.
+    assert_eq!(get_info.subversion, USER_AGENT);
+}

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -4,7 +4,6 @@
 //! `"jsonrpc" = 1.0` fields in JSON-RPC 1.0 requests,
 //! such as `lightwalletd`.
 
-use std::sync::Mutex;
 use tracing::*;
 use tracing_futures::Instrument;
 
@@ -23,21 +22,19 @@ pub mod compatibility;
 #[derive(Clone, Debug)]
 pub struct RpcServer;
 
-lazy_static::lazy_static! {
-    /// Storage for the application version string coming from zebrad.
-    pub static ref APP_VERSION: Mutex<Vec<u8>> = Mutex::new(vec![]);
-}
-
 impl RpcServer {
     /// Start a new RPC server endpoint
     pub fn spawn(config: Config, app_version: String) -> tokio::task::JoinHandle<()> {
         if let Some(listen_addr) = config.listen_addr {
             info!("Trying to open RPC endpoint at {}...", listen_addr,);
 
+            // Initialize the rpc methods with the zebra version
+            let rpc_impl = RpcImpl { app_version };
+
             // Create handler compatible with V1 and V2 RPC protocols
             let mut io =
                 jsonrpc_core::IoHandler::with_compatibility(jsonrpc_core::Compatibility::Both);
-            io.extend_with(RpcImpl.to_delegate());
+            io.extend_with(rpc_impl.to_delegate());
 
             let server = ServerBuilder::new(io)
                 // use the same tokio executor as the rest of Zebra
@@ -60,11 +57,6 @@ impl RpcServer {
                     info!("Stopping RPC endpoint");
                 })
             };
-
-            APP_VERSION
-                .lock()
-                .expect("mutex should be unpoisoned")
-                .append(&mut app_version.as_bytes().to_vec());
 
             tokio::task::spawn_blocking(server)
         } else {

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -75,6 +75,7 @@ use zebra_consensus::CheckpointList;
 use zebra_rpc::server::RpcServer;
 
 use crate::{
+    application::app_version,
     components::{
         inbound::{self, InboundSetupData},
         mempool::{self, Mempool},
@@ -196,7 +197,7 @@ impl StartCmd {
                 .in_current_span(),
         );
 
-        let rpc_task_handle = RpcServer::spawn(config.rpc);
+        let rpc_task_handle = RpcServer::spawn(config.rpc, app_version().to_string());
 
         info!("spawned initial Zebra tasks");
 


### PR DESCRIPTION
## Motivation

Implement the `getinfo` RPC method with the fields used by lightwalletd. Close https://github.com/ZcashFoundation/zebra/issues/3142 if merged.

## Solution

I had a hard time trying to pass the app version into the method. This approach is with `lazy_static`. I am open to change this if i find something that works and it is better.

This PR does not have a specific test, i am unsure if the tests we will use will be acceptance or something else for each method. If they are acceptance then the test for this call should be added after https://github.com/ZcashFoundation/zebra/pull/3641 as it is very similar to what we have now.

The code in this pull was tested manually:

```
$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "method": "getinfo", "params": [], "id":123 }' 127.0.0.1:8832 | jq
{
  "jsonrpc": "2.0",
  "result": {
    "build": "1.0.0-beta.5+22.g45caa63",
    "subversion": "/Zebra:1.0.0-beta.5/"
  },
  "id": 123
}
$ 
```

The docs for the method are in a discussion at https://github.com/ZcashFoundation/zebra/discussions/3638. Open to change the format.

## Review

Probably @teor2345 will be the best option if they have time so i can have some feedback for my morning.

### Reviewer Checklist

  - [ ] Lazy static implementation is acceptable.
  - [ ] If so, check the code as a whole.
