### PR TITLE
feat(codeowners): add code reviewers to the repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,10 @@
 /docker/                                @ZcashFoundation/devops-reviewers
 cloudbuild.yaml                         @ZcashFoundation/devops-reviewers
 codecov.yml                             @ZcashFoundation/devops-reviewers
+.dockerignore                           @ZcashFoundation/devops-reviewers
+codecov.yml                             @ZcashFoundation/devops-reviewers
+firebase.json                           @ZcashFoundation/devops-reviewers
+katex-header.html                       @ZcashFoundation/devops-reviewers
 
 # Unsafe Code
 # To be reviewed by Teor, Janito, Conrado, or Marek.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,41 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @ZcashFoundation/network-owners @ZcashFoundation/cryptographic-owners
+
+# Network and Async Code
+# To be reviewed by Teor, Janito, or Alfredo.
+/tower-batch/                           @ZcashFoundation/network-owners
+/tower-fallback/                        @ZcashFoundation/network-owners
+/zebra-consensus/                       @ZcashFoundation/network-owners
+/zebra-network/                         @ZcashFoundation/network-owners
+/zebra-state/                           @ZcashFoundation/network-owners
+/zebra-tests/src/mock_service.rs        @ZcashFoundation/network-owners
+/zebra-tests/src/service_extensions.rs  @ZcashFoundation/network-owners
+/zebra-tests/src/transcript.rs          @ZcashFoundation/network-owners
+/zebra-utils/                           @ZcashFoundation/network-owners
+/zebrad/src/commands/                   @ZcashFoundation/network-owners
+/zebrad/src/components/                 @ZcashFoundation/network-owners
+
+# Cryptographic Code
+# To be reviewed by Deirdre, Conrado, or Marek.
+/zebra-consensus/src/primitives/        @ZcashFoundation/cryptographic-owners
+/zebra-chain/src/primitives/            @ZcashFoundation/cryptographic-owners
+/zebra-chain/src/orchard/               @ZcashFoundation/cryptographic-owners
+/zebra-chain/src/sapling/               @ZcashFoundation/cryptographic-owners
+/zebra-chain/src/sprout/                @ZcashFoundation/cryptographic-owners
+/zebra-chain/src/transparent/           @ZcashFoundation/cryptographic-owners
+/zebra-chain/src/history_tree.rs        @ZcashFoundation/cryptographic-owners
+/zebra-chain/src/history_tree/          @ZcashFoundation/cryptographic-owners
+
+# Devops Code
+# To be reviewed by Gustavo, Deirdre, Teor, or Conrado.
+/.github/                               @ZcashFoundation/devops-owners
+/docker/                                @ZcashFoundation/devops-owners
+cloudbuild.yaml                         @ZcashFoundation/devops-owners
+codecov.yml                             @ZcashFoundation/devops-owners
+
+# Unsafe Code
+# To be reviewed by Teor, Janito, Conrado, or Marek.
+/zebra-script/                          @ZcashFoundation/unsafe-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,41 +2,41 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @ZcashFoundation/network-owners @ZcashFoundation/cryptographic-owners
+*       @ZcashFoundation/network-reviewers @ZcashFoundation/cryptographic-reviewers
 
 # Network and Async Code
 # To be reviewed by Teor, Janito, or Alfredo.
-/tower-batch/                           @ZcashFoundation/network-owners
-/tower-fallback/                        @ZcashFoundation/network-owners
-/zebra-consensus/                       @ZcashFoundation/network-owners
-/zebra-network/                         @ZcashFoundation/network-owners
-/zebra-node-services/                   @ZcashFoundation/network-owners
-/zebra-state/                           @ZcashFoundation/network-owners
-/zebra-tests/src/mock_service.rs        @ZcashFoundation/network-owners
-/zebra-tests/src/service_extensions.rs  @ZcashFoundation/network-owners
-/zebra-tests/src/transcript.rs          @ZcashFoundation/network-owners
-/zebra-utils/                           @ZcashFoundation/network-owners
-/zebrad/src/commands/                   @ZcashFoundation/network-owners
-/zebrad/src/components/                 @ZcashFoundation/network-owners
+/tower-batch/                           @ZcashFoundation/network-reviewers
+/tower-fallback/                        @ZcashFoundation/network-reviewers
+/zebra-consensus/                       @ZcashFoundation/network-reviewers
+/zebra-network/                         @ZcashFoundation/network-reviewers
+/zebra-node-services/                   @ZcashFoundation/network-reviewers
+/zebra-state/                           @ZcashFoundation/network-reviewers
+/zebra-tests/src/mock_service.rs        @ZcashFoundation/network-reviewers
+/zebra-tests/src/service_extensions.rs  @ZcashFoundation/network-reviewers
+/zebra-tests/src/transcript.rs          @ZcashFoundation/network-reviewers
+/zebra-utils/                           @ZcashFoundation/network-reviewers
+/zebrad/src/commands/                   @ZcashFoundation/network-reviewers
+/zebrad/src/components/                 @ZcashFoundation/network-reviewers
 
 # Cryptographic Code
 # To be reviewed by Deirdre, Conrado, or Marek.
-/zebra-consensus/src/primitives/        @ZcashFoundation/cryptographic-owners
-/zebra-chain/src/primitives/            @ZcashFoundation/cryptographic-owners
-/zebra-chain/src/orchard/               @ZcashFoundation/cryptographic-owners
-/zebra-chain/src/sapling/               @ZcashFoundation/cryptographic-owners
-/zebra-chain/src/sprout/                @ZcashFoundation/cryptographic-owners
-/zebra-chain/src/transparent/           @ZcashFoundation/cryptographic-owners
-/zebra-chain/src/history_tree.rs        @ZcashFoundation/cryptographic-owners
-/zebra-chain/src/history_tree/          @ZcashFoundation/cryptographic-owners
+/zebra-consensus/src/primitives/        @ZcashFoundation/cryptographic-reviewers
+/zebra-chain/src/primitives/            @ZcashFoundation/cryptographic-reviewers
+/zebra-chain/src/orchard/               @ZcashFoundation/cryptographic-reviewers
+/zebra-chain/src/sapling/               @ZcashFoundation/cryptographic-reviewers
+/zebra-chain/src/sprout/                @ZcashFoundation/cryptographic-reviewers
+/zebra-chain/src/transparent/           @ZcashFoundation/cryptographic-reviewers
+/zebra-chain/src/history_tree.rs        @ZcashFoundation/cryptographic-reviewers
+/zebra-chain/src/history_tree/          @ZcashFoundation/cryptographic-reviewers
 
 # Devops Code
 # To be reviewed by Gustavo, Deirdre, Teor, or Conrado.
-/.github/                               @ZcashFoundation/devops-owners
-/docker/                                @ZcashFoundation/devops-owners
-cloudbuild.yaml                         @ZcashFoundation/devops-owners
-codecov.yml                             @ZcashFoundation/devops-owners
+/.github/                               @ZcashFoundation/devops-reviewers
+/docker/                                @ZcashFoundation/devops-reviewers
+cloudbuild.yaml                         @ZcashFoundation/devops-reviewers
+codecov.yml                             @ZcashFoundation/devops-reviewers
 
 # Unsafe Code
 # To be reviewed by Teor, Janito, Conrado, or Marek.
-/zebra-script/                          @ZcashFoundation/unsafe-owners
+/zebra-script/                          @ZcashFoundation/unsafe-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 /tower-fallback/                        @ZcashFoundation/network-owners
 /zebra-consensus/                       @ZcashFoundation/network-owners
 /zebra-network/                         @ZcashFoundation/network-owners
+/zebra-node-services/                   @ZcashFoundation/network-owners
 /zebra-state/                           @ZcashFoundation/network-owners
 /zebra-tests/src/mock_service.rs        @ZcashFoundation/network-owners
 /zebra-tests/src/service_extensions.rs  @ZcashFoundation/network-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,4 +39,4 @@ codecov.yml                             @ZcashFoundation/devops-reviewers
 
 # Unsafe Code
 # To be reviewed by Teor, Janito, Conrado, or Marek.
-/zebra-script/                          @ZcashFoundation/unsafe-reviewers
+/zebra-script/                          @ZcashFoundation/unsafe-rust-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
+# this teams will be requested for review when someone opens a pull request.
 *       @ZcashFoundation/network-reviewers @ZcashFoundation/cryptographic-reviewers
 
 # Network and Async Code


### PR DESCRIPTION
## Motivation

Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.

## Solution
- Create teams with distribution based on modules/responsibility they have on the code.
- Create a CODEOWNERS file with the owners definition

Closes #3391 

## Review

@teor2345 can review this

## Follow Up Work
The teams I created need write permission, and should preferably be under the ZFND team. But I don't have enough permissions to edit the teams with this information.