### PR TITLE
fix(build): use the correct lightwalletd multistage target

### DIFF
--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -62,7 +62,7 @@ jobs:
       id: docker_build
       uses: docker/build-push-action@v2.9.0
       with:
-        target: builder
+        target: build
         context: .
         file: ./zebra/docker/zcash-lightwalletd/Dockerfile
         tags: |


### PR DESCRIPTION
## Motivation

lightwallted build was failing, this was not captured in the PR

## Solution

- Change the workflow build target, to use the one available in the Dockerfile

## Review
@conradoplg or @dconnolly can review this
