### PR TITLE
fix(codeowners): avoid multiple reviewer assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,20 +2,25 @@
 # this team will be requested for review when someone opens a pull request.
 #
 # We use a single team here, because if we use two teams, GitHub assigns two reviewers.
-*       @ZcashFoundation/general-rust-reviewers
+*                                       @ZcashFoundation/general-rust-reviewers
+
+# Frequently Modified Code
+#
+# This code is currently being modified in most PRs,
+# so we assign reviews to the largest group of reviewers,
+# to stop GitHub assigning multiple reviewers
+#
+# lightwalletd epic
+/zebrad/src/commands/start.rs           @ZcashFoundation/general-rust-reviewers
 
 # Network and Async Code
 /tower-batch/                           @ZcashFoundation/network-reviewers
 /tower-fallback/                        @ZcashFoundation/network-reviewers
-/zebra-consensus/                       @ZcashFoundation/network-reviewers
 /zebra-network/                         @ZcashFoundation/network-reviewers
 /zebra-node-services/                   @ZcashFoundation/network-reviewers
-/zebra-state/                           @ZcashFoundation/network-reviewers
 /zebra-tests/src/mock_service.rs        @ZcashFoundation/network-reviewers
 /zebra-tests/src/service_extensions.rs  @ZcashFoundation/network-reviewers
 /zebra-tests/src/transcript.rs          @ZcashFoundation/network-reviewers
-/zebra-utils/                           @ZcashFoundation/network-reviewers
-/zebrad/src/commands/                   @ZcashFoundation/network-reviewers
 /zebrad/src/components/                 @ZcashFoundation/network-reviewers
 
 # Cryptographic Code
@@ -29,12 +34,12 @@
 /zebra-chain/src/history_tree/          @ZcashFoundation/cryptographic-reviewers
 
 # Devops Code
-/.github/                               @ZcashFoundation/devops-reviewers
+/.github/workflows/                     @ZcashFoundation/devops-reviewers
+/.github/mergify.yml                    @ZcashFoundation/devops-reviewers
 /docker/                                @ZcashFoundation/devops-reviewers
 cloudbuild.yaml                         @ZcashFoundation/devops-reviewers
 codecov.yml                             @ZcashFoundation/devops-reviewers
 .dockerignore                           @ZcashFoundation/devops-reviewers
-codecov.yml                             @ZcashFoundation/devops-reviewers
 firebase.json                           @ZcashFoundation/devops-reviewers
 katex-header.html                       @ZcashFoundation/devops-reviewers
 


### PR DESCRIPTION
## Motivation

When a PR includes code assigned to multiple review teams, GitHub requires multiple reviewers, one from each team.

For example:
- #3717

## Solution

Assign more code to the largest review team, to avoid multiple reviewer assignments. I focused on code we're changing a lot right now - it should be assigned to the largest team.

(This doesn't actually fix the problem in PR #3717, because the refactor changes the file paths in devops configs. But it avoids most similar problems.)

## Follow Up Tasks

We can tweak CODEOWNERS as any other issues come up.
