### PR TITLE
Use a `SerializedBlock` type to help serializing blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,6 +1813,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hkdf"

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -22,7 +22,7 @@ pub use commitment::{
 pub use hash::Hash;
 pub use header::{BlockTimeError, CountedHeader, Header};
 pub use height::Height;
-pub use serialize::MAX_BLOCK_BYTES;
+pub use serialize::{SerializedBlock, MAX_BLOCK_BYTES};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use arbitrary::LedgerState;

--- a/zebra-chain/src/block/serialize.rs
+++ b/zebra-chain/src/block/serialize.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, io};
+use std::{borrow::Borrow, convert::TryInto, io};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use chrono::{TimeZone, Utc};
@@ -133,5 +133,32 @@ impl ZcashDeserialize for Block {
             header: limited_reader.zcash_deserialize_into()?,
             transactions: limited_reader.zcash_deserialize_into()?,
         })
+    }
+}
+
+/// A serialized block.
+///
+/// Stores bytes that are guaranteed to be deserializable into a [`Block`].
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct SerializedBlock {
+    bytes: Vec<u8>,
+}
+
+/// Build a [`SerializedBlock`] by serializing a block.
+impl<B: Borrow<Block>> From<B> for SerializedBlock {
+    fn from(block: B) -> Self {
+        SerializedBlock {
+            bytes: block
+                .borrow()
+                .zcash_serialize_to_vec()
+                .expect("Writing to a `Vec` should never fail"),
+        }
+    }
+}
+
+/// Access the serialized bytes of a [`SerializedBlock`].
+impl AsRef<[u8]> for SerializedBlock {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
     }
 }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -14,7 +14,7 @@ zebra-network = { path = "../zebra-network" }
 zebra-state = { path = "../zebra-state" }
 
 futures = "0.3"
-hex = "0.4.3"
+hex = { version = "0.4.3", features = ["serde"] }
 
 # lightwalletd sends JSON-RPC requests over HTTP 1.1
 hyper = { version = "0.14.17", features = ["http1", "server"] }

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -57,7 +57,7 @@ async fn rpc_getblock() {
     };
 
     // Make calls and check response
-    for (i, block) in blocks.iter().enumerate() {
+    for (i, block) in blocks.into_iter().enumerate() {
         let get_block = rpc
             .get_block(Height(i as u32), 0u8)
             .await

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -63,13 +63,6 @@ async fn rpc_getblock() {
             .await
             .expect("We should have a GetBlock struct");
 
-        assert_eq!(
-            get_block.data,
-            hex::encode(
-                block
-                    .zcash_serialize_to_vec()
-                    .expect("vec serialization is infallible")
-            )
-        );
+        assert_eq!(get_block.data, block.into());
     }
 }


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
As part of #3707, the `GetBlock` response type must contain a `data` field with a hexadecimal string with the block's serialized bytes. In order to use the type system to make sure that the `data` field contains a valid block, it needs to use a type that:

1. Represents the bytes of a serialized block
2. Can be serialized as a hexadecimal string

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
A new `SerializedBlock` type is added to the `zebra_chain::block::serialize` module. It meets the requirements above by:

1. It can only be constructed from a borrowed `Block` type, so it is guaranteed to only contain the bytes of a serialized block.
2. It implements `AsRef<[u8]>`, which allows it to be used as a direct parameter for `hex::encode` and `hex::serde::serialize`.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->
@oxarbitrage is working on the original issue and @teor2345 is reviewing it.

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [x] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
