### PR TITLE
Remove test.yml pull_request_review trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,17 +25,6 @@ on:
       # workflow definitions
       - 'docker/**'
       - '.github/workflows/test.yml'
-  pull_request_review:
-    branches:
-      - main
-    paths:
-      - '**/*.rs'
-      - '**/*.txt'
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - 'docker/**'
-      - '.github/workflows/test.yml'
-    types: [submitted]
 
 env:
   CARGO_INCREMENTAL: '1'


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

We've been hitting some GitHub API rate limits with the `test.yml` workflow.


## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Matching on the `pull_request_review` trigger means we re-run the `test.yml` workflow even if no changes have been pushed, so to bring down our rate of API calls, we can remove this trigger.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

@gustavovalverde @teor2345 

