### PR TITLE
fix(build): arm64 needs extra time when building from scratch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   build:
     name: Build images
-    timeout-minutes: 60
+    timeout-minutes: 90
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Motivation

Continuous deployment is failing as the image needs more time to build arm64 from scratch

## Solution

Bump timeout

## Review
@dconnolly and @teor2345 can review this
