### PR TITLE
doc(ci): explain the different ways .txt files are used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     paths:
       # code and tests
       - '**/*.rs'
-      # hard-coded checkpoints
+      # hard-coded checkpoints and proptest regressions
       - '**/*.txt'
       # test data snapshots
       - '**/*.snap'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ on:
     paths:
       # code and tests
       - '**/*.rs'
-      # hard-coded checkpoints
+      # hard-coded checkpoints and proptest regressions
       - '**/*.txt'
       # test data snapshots
       - '**/*.snap'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
     paths:
       # code and tests
       - '**/*.rs'
-      # hard-coded checkpoints
+      # hard-coded checkpoints and proptest regressions
       - '**/*.txt'
       # test data snapshots
       - '**/*.snap'


### PR DESCRIPTION
## Motivation

We also use .txt files for proptest regressions, so they're not just build-time data, they're test data as well.