### PR TITLE
fix(deploy): use correct conditional in job to deploy Mainnet nodes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -116,7 +116,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: $${{ github.event_name == 'push' && github.ref_name == 'main' }}
+    if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
     steps:
       - uses: actions/checkout@v2.4.0

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -116,7 +116,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event_name == 'push' && github.ref == 'ref/head/main'
+    if: $${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
     steps:
       - uses: actions/checkout@v2.4.0


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

The cd.yml workflow has been skipping this job on main for at least a week.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Explicitly use expression syntax and match on `github.ref_name` just in case.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

@gustavovalverde 

