### PR TITLE
fix(zebrad/test): stop excessive logging which causes test hangs

### DIFF
--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -192,11 +192,18 @@ impl NetworkUpgrade {
             {
                 (MAINNET_ACTIVATION_HEIGHTS, TESTNET_ACTIVATION_HEIGHTS)
             }
+
             // To prevent accidentally setting this somehow, only check the env var
             // when being compiled for tests. We can't use cfg(test) since the
             // test that uses this is in zebra-state, and cfg(test) is not
             // set for dependencies. However, zebra-state does set the
             // zebra-test feature of zebra-chain if it's a dev dependency.
+            //
+            // Cargo features are additive, so all test binaries built along with
+            // zebra-state will have this feature enabled. But we are using
+            // Rust Edition 2021 and Cargo resolver version 2, so the "zebra-test"
+            // feature should only be enabled for tests:
+            // https://doc.rust-lang.org/cargo/reference/features.html#resolver-version-2-command-line-flags
             #[cfg(feature = "zebra-test")]
             if std::env::var_os("TEST_FAKE_ACTIVATION_HEIGHTS").is_some() {
                 (

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -187,10 +187,6 @@ impl NetworkUpgrade {
     /// and it's a test build, this returns a list of fake activation heights
     /// used by some tests.
     pub(crate) fn activation_list(network: Network) -> BTreeMap<block::Height, NetworkUpgrade> {
-        println!(
-            "activation_list called {:?}",
-            std::env::var_os("TEST_FAKE_ACTIVATION_HEIGHTS")
-        );
         let (mainnet_heights, testnet_heights) = {
             #[cfg(not(feature = "zebra-test"))]
             {


### PR DESCRIPTION
## Motivation

This PR fixes required test failures in the `main` branch. We can't automatically merge PRs until it is fixed.

If we print a line every time the network upgrade heights are accessed, some tests hang.  This could happen because they are expecting different log output, or because the standard output pipes fill up, blocking the `zebrad` subprocess.

After PR #3749, the coverage, macOS, and Linux builds hang on:
```sh
cargo test --test acceptance
```

But they succeed on:
```sh
cargo test --test acceptance -- --nocapture
```

This PR fixes the hangs on my machine.

## Solution

- stop excessive logging in `activation_list`

Unrelated documentation:
- explain how feature unification interacts with test environmental variables

## Review

@conradoplg wrote PR #3749.

### Reviewer Checklist

  - [ ] CI passes
