### PR TITLE
fix(test/lightwalletd): add an alternative log to the final integration test check

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1694,10 +1694,11 @@ fn lightwalletd_integration() -> Result<()> {
         lightwalletd.expect_stdout_line_matches("Method not found.*error zcashd getblock rpc");
     let (_, zebrad) = zebrad.kill_on_error(result)?;
 
-    // zcash/lightwalletd exits with a fatal error here, but
-    // adityapk00/lightwalletd keeps trying the mempool
+    // zcash/lightwalletd exits with a fatal error here.
+    // adityapk00/lightwalletd keeps trying the mempool,
+    // but it sometimes skips the "Method not found" log line.
     let result =
-        lightwalletd.expect_stdout_line_matches("Mempool refresh error: -32601: Method not found");
+        lightwalletd.expect_stdout_line_matches("(Mempool refresh error: -32601: Method not found)|(Another refresh in progress, returning)");
     let (_, zebrad) = zebrad.kill_on_error(result)?;
 
     // Cleanup both processes


### PR DESCRIPTION
## Motivation

Sometimes lightwalletd goes straight to logging "Another refresh in progress", without logging "Mempool refresh error" first.

## Review

This is a high-priority fix, but the test sometimes succeeds.

### Reviewer Checklist

  - [ ] Integration test passes
