### PR TITLE
doc(network): explain optional zebra-network/tor dependencies

### DIFF
--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -18,13 +18,26 @@ that there is a lot of key functionality still missing.
 #### Build Troubleshooting
 
 If you're having trouble with:
-- **dependencies:**
-  - install both `libclang` and `clang` - they are usually different packages
-  - use `cargo install` without `--locked` to build with the latest versions of each dependency
+
+Dependencies:
+- use `cargo install` without `--locked` to build with the latest versions of each dependency
+- **sqlite linker errors:** libsqlite3 is an optional dependency of the `zebra-network/tor` feature.
+  If you don't have it installed, you might see errors like `note: /usr/bin/ld: cannot find -lsqlite3`.
+  [Follow the arti instructions](https://gitlab.torproject.org/tpo/core/arti/-/blob/main/CONTRIBUTING.md#setting-up-your-development-environment)
+  to install libsqlite3, or use one of these commands instead:
+```sh
+cargo build
+cargo build -p zebrad --all-features
+```
+
+Compilers:
+- **clang:** install both `libclang` and `clang` - they are usually different packages
 - **libclang:** check out the [clang-sys documentation](https://github.com/KyleMayes/clang-sys#dependencies)
 - **g++ or MSVC++:** try using clang or Xcode instead
-- **rustc:** use rustc 1.48 or later
+- **rustc:** use rustc 1.58 or later
   - Zebra does not have a minimum supported Rust version (MSRV) policy yet
+
+
 
 ### Dependencies
 

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -38,7 +38,6 @@ Compilers:
   - Zebra does not have a minimum supported Rust version (MSRV) policy yet
 
 
-
 ### Dependencies
 
 Zebra primarily depends on pure Rust crates, and some Rust/C++ crates:


### PR DESCRIPTION
## Motivation

Add a build troubleshooting note for the optional `zebra-network/tor` feature.

Also update the suggested Rust version, as we're using newer Rust features now.