### PR TITLE
refactor(test): cleanup GCP instances on a single PR

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -37,4 +37,4 @@ jobs:
         continue-on-error: true
         run: |
           TEST_INSTANCES=$(gcloud compute instances list --filter="${{ env.GITHUB_REF_SLUG_URL }}" --format='value(NAME)')
-          for instance in ${TEST_INSTANCES}; do gcloud compute instances delete $instance; done
+          for instance in ${TEST_INSTANCES}; do gcloud compute instances delete $instance --zone "${{ env.ZONE }}" --delete-disks all --quiet; done

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -1,0 +1,40 @@
+name: Clean
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types: [ closed ]
+
+env:
+  NETWORK: Mainnet
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  REGION: us-central1
+  ZONE: us-central1-a
+
+jobs:
+  delete:
+    name: Delete test deployments
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    steps:
+      - uses: actions/checkout@v2.4.0
+        with:
+          persist-credentials: false
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+
+      # Setup gcloud CLI
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.5.0
+        with:
+          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+
+      - name: Delete test instance
+        continue-on-error: true
+        run: |
+          TEST_INSTANCES=$(gcloud compute instances list --filter="${{ env.GITHUB_REF_SLUG_URL }}" --format='value(NAME)')
+          for instance in ${TEST_INSTANCES}; do gcloud compute instances delete $instance; done

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -141,7 +141,7 @@ jobs:
         run: |
           gcloud compute instances update-container "full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
           --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
-          --zone "${{ env.ZONE }}
+          --zone "${{ env.ZONE }}"
 
       # Creates Compute Engine virtual machine instance w/ disks
       - name: Create GCP compute instance

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -144,6 +144,7 @@ jobs:
             echo "No instance to delete"
           else
             gcloud compute instances delete "${INSTANCE}" --zone "${{ env.ZONE }}" --delete-disks all --quiet
+          fi
 
       # Creates Compute Engine virtual machine instance w/ disks
       - name: Create GCP compute instance

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -128,11 +128,25 @@ jobs:
         with:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
+      # Check if our destination compute instance exists already
+      - name: Check if compute instance exists
+        id: instance-exists
+        continue-on-error: true
+        run: |
+          gcloud compute instances list --filter="full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}" --format='value(NAME)' | grep "regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}"
+
+      - name: Update GCP compute instance
+        id: update-instance
+        if: ${{ steps.instance-exists.outcome == 'failure' }}
+        run: |
+          gcloud compute instances update-container "full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
+          --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
+
       # Creates Compute Engine virtual machine instance w/ disks
       - name: Create GCP compute instance
         id: create-instance
         run: |
-          gcloud compute instances create-with-container "full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
+          gcloud compute instances create-with-container "full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
           --boot-disk-size 100GB \
           --boot-disk-type pd-extreme \
           --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
@@ -152,33 +166,26 @@ jobs:
       # https://www.googlecloudcommunity.com/gc/Infrastructure-Compute-Storage/SSH-into-Compute-Container-not-easily-possible/td-p/170915
       - name: Get container name from logs
         id: get-container-name
-        if: steps.create-instance.outcome == 'success'
+        if: ${{ steps.create-instance.outcome == 'success' || steps.update-instance.outcome == 'success' }}
         run: |
-          INSTANCE_ID=$(gcloud compute instances describe full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} --zone ${{ env.ZONE }} --format='value(id)')
+          INSTANCE_ID=$(gcloud compute instances describe full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }} --zone ${{ env.ZONE }} --format='value(id)')
           echo "Using instance: $INSTANCE_ID"
-          while [[ ${CONTAINER_NAME} != *"full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"* ]]; do
-              CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
+          while [[ ${CONTAINER_NAME} != *"full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}"* ]]; do
+              CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}-....' | tr -d "'.")
               echo "Using container: ${CONTAINER_NAME} from instance: ${INSTANCE_ID}"
               sleep 10
           done
-          CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
+          CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}-....' | tr -d "'.")
           echo "::set-output name=zebra_container::$CONTAINER_NAME"
 
       - name: Full sync mainnet
         id: full-sync-mainnet
         run: |
           gcloud compute ssh \
-          full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }} \
           --zone ${{ env.ZONE }} \
           --quiet \
           --ssh-flag="-o ServerAliveInterval=5" \
           --command="docker logs --follow ${{ env.ZEBRA_CONTAINER }}"
         env:
           ZEBRA_CONTAINER: ${{ steps.get-container-name.outputs.zebra_container }}
-
-      - name: Delete test instance
-        # Do not delete the instance if the sync timeouts in GitHub
-        if: ${{ steps.full-sync-mainnet.outcome == 'success' || steps.full-sync-mainnet.outcome == 'failure' }}
-        continue-on-error: true
-        run: |
-          gcloud compute instances delete "full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --delete-disks all --zone "${{ env.ZONE }}"

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -140,7 +140,8 @@ jobs:
         if: ${{ steps.instance-exists.outcome == 'failure' }}
         run: |
           gcloud compute instances update-container "full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
-          --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
+          --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
+          --zone "${{ env.ZONE }}
 
       # Creates Compute Engine virtual machine instance w/ disks
       - name: Create GCP compute instance

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -137,7 +137,7 @@ jobs:
 
       # Check if our destination compute instance exists and delete it
       - name: Delete existing instance with same SHA
-        id: instance-exists
+        id: delete-old-instance
         continue-on-error: true
         run: |
           gcloud compute instances delete $(gcloud compute instances list --filter="full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)') --zone "${{ env.ZONE }}" --delete-disks all --quiet

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -135,27 +135,19 @@ jobs:
         with:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
-      # Check if our destination compute instance exists already
-      - name: Check if compute instance exists
+      # Check if our destination compute instance exists and delete it
+      - name: Delete existing instance with same SHA
         id: instance-exists
         continue-on-error: true
         run: |
-          gcloud compute instances list --filter="full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}" --format='value(NAME)' | grep "regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}"
-
-      - name: Update GCP compute instance
-        id: update-instance
-        if: ${{ steps.instance-exists.outcome == 'success' }}
-        run: |
-          gcloud compute instances update-container "full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
-          --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
-          --zone "${{ env.ZONE }}"
+          gcloud compute instances delete $(gcloud compute instances list --filter="full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)')
 
       # Creates Compute Engine virtual machine instance w/ disks
       - name: Create GCP compute instance
         id: create-instance
         if: ${{ steps.instance-exists.outcome == 'failure' }}
         run: |
-          gcloud compute instances create-with-container "full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
+          gcloud compute instances create-with-container "full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 100GB \
           --boot-disk-type pd-extreme \
           --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
@@ -175,23 +167,24 @@ jobs:
       # https://www.googlecloudcommunity.com/gc/Infrastructure-Compute-Storage/SSH-into-Compute-Container-not-easily-possible/td-p/170915
       - name: Get container name from logs
         id: get-container-name
-        if: ${{ steps.create-instance.outcome == 'success' || steps.update-instance.outcome == 'success' }}
+        if: ${{ steps.create-instance.outcome == 'success' }}
         run: |
-          INSTANCE_ID=$(gcloud compute instances describe full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }} --zone ${{ env.ZONE }} --format='value(id)')
+          INSTANCE_ID=$(gcloud compute instances describe full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} --zone ${{ env.ZONE }} --format='value(id)')
           echo "Using instance: $INSTANCE_ID"
-          while [[ ${CONTAINER_NAME} != *"full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}"* ]]; do
-              CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}-....' | tr -d "'.")
+          while [[ ${CONTAINER_NAME} != *"full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"* ]]; do
+              CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
               echo "Using container: ${CONTAINER_NAME} from instance: ${INSTANCE_ID}"
               sleep 10
           done
-          CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}-....' | tr -d "'.")
+          CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
           echo "::set-output name=zebra_container::$CONTAINER_NAME"
 
       - name: Full sync mainnet
         id: full-sync-mainnet
+        if: ${{ steps.create-instance.outcome == 'success' }}
         run: |
           gcloud compute ssh \
-          full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }} \
+          full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ env.ZONE }} \
           --quiet \
           --ssh-flag="-o ServerAliveInterval=5" \

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -145,7 +145,6 @@ jobs:
       # Creates Compute Engine virtual machine instance w/ disks
       - name: Create GCP compute instance
         id: create-instance
-        if: ${{ steps.instance-exists.outcome == 'failure' }}
         run: |
           gcloud compute instances create-with-container "full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 100GB \

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -138,9 +138,12 @@ jobs:
       # Check if our destination compute instance exists and delete it
       - name: Delete existing instance with same SHA
         id: delete-old-instance
-        continue-on-error: true
         run: |
-          gcloud compute instances delete $(gcloud compute instances list --filter="full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)') --zone "${{ env.ZONE }}" --delete-disks all --quiet
+          INSTANCE=$(gcloud compute instances list --filter=full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} --format='value(NAME)')
+          if [ -z "${INSTANCE}" ]; then
+            echo "No instance to delete"
+          else
+            gcloud compute instances delete "${INSTANCE}" --zone "${{ env.ZONE }}" --delete-disks all --quiet
 
       # Creates Compute Engine virtual machine instance w/ disks
       - name: Create GCP compute instance

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Update GCP compute instance
         id: update-instance
-        if: ${{ steps.instance-exists.outcome == 'failure' }}
+        if: ${{ steps.instance-exists.outcome == 'success' }}
         run: |
           gcloud compute instances update-container "full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
           --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
@@ -148,6 +148,7 @@ jobs:
       # Creates Compute Engine virtual machine instance w/ disks
       - name: Create GCP compute instance
         id: create-instance
+        if: ${{ steps.instance-exists.outcome == 'failure' }}
         run: |
           gcloud compute instances create-with-container "full-sync-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
           --boot-disk-size 100GB \

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -140,7 +140,7 @@ jobs:
         id: instance-exists
         continue-on-error: true
         run: |
-          gcloud compute instances delete $(gcloud compute instances list --filter="full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)') --delete-disks all --zone "${{ env.ZONE }}
+          gcloud compute instances delete $(gcloud compute instances list --filter="full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)') --zone "${{ env.ZONE }}" --delete-disks all --quiet
 
       # Creates Compute Engine virtual machine instance w/ disks
       - name: Create GCP compute instance
@@ -196,4 +196,4 @@ jobs:
         if: ${{ steps.full-sync-mainnet.outcome == 'success' || steps.full-sync-mainnet.outcome == 'failure' }}
         continue-on-error: true
         run: |
-          gcloud compute instances delete "full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --delete-disks all --zone "${{ env.ZONE }}"
+          gcloud compute instances delete "full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --zone "${{ env.ZONE }}" --delete-disks all --quiet

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -140,7 +140,7 @@ jobs:
         id: instance-exists
         continue-on-error: true
         run: |
-          gcloud compute instances delete $(gcloud compute instances list --filter="full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)')
+          gcloud compute instances delete $(gcloud compute instances list --filter="full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)') --delete-disks all --zone "${{ env.ZONE }}
 
       # Creates Compute Engine virtual machine instance w/ disks
       - name: Create GCP compute instance
@@ -191,3 +191,10 @@ jobs:
           --command="docker logs --follow ${{ env.ZEBRA_CONTAINER }}"
         env:
           ZEBRA_CONTAINER: ${{ steps.get-container-name.outputs.zebra_container }}
+
+      - name: Delete test instance
+        # Do not delete the instance if the sync timeouts in GitHub
+        if: ${{ steps.full-sync-mainnet.outcome == 'success' || steps.full-sync-mainnet.outcome == 'failure' }}
+        continue-on-error: true
+        run: |
+          gcloud compute instances delete "full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --delete-disks all --zone "${{ env.ZONE }}"

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -181,6 +181,7 @@ jobs:
           done
           CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
           echo "::set-output name=zebra_container::$CONTAINER_NAME"
+          sleep 60
 
       - name: Full sync mainnet
         id: full-sync-mainnet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,9 +250,12 @@ jobs:
       - name: Delete existing instance with same SHA
         id: delete-old-instance
         if: ${{ steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true' }}
-        continue-on-error: true
         run: |
-          gcloud compute instances delete $(gcloud compute instances list --filter="regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)') --zone "${{ env.ZONE }}" --delete-disks all --quiet
+          INSTANCE=$(gcloud compute instances list --filter=regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} --format='value(NAME)')
+          if [ -z "${INSTANCE}" ]; then
+            echo "No instance to delete"
+          else
+            gcloud compute instances delete "${INSTANCE}" --zone "${{ env.ZONE }}" --delete-disks all --quiet
 
       - name: Create GCP compute instance
         id: create-instance
@@ -364,7 +367,11 @@ jobs:
         if: ${{ needs.regenerate-stateful-disks.outputs.any_changed != 'true' || github.event.inputs.regenerate-disks != 'true'}}
         continue-on-error: true
         run: |
-          gcloud compute instances delete $(gcloud compute instances list --filter="regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)') --zone "${{ env.ZONE }}" --delete-disks all --quiet
+          INSTANCE=$(gcloud compute instances list --filter=sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} --format='value(NAME)')
+          if [ -z "${INSTANCE}" ]; then
+            echo "No instance to delete"
+          else
+            gcloud compute instances delete "${INSTANCE}" --zone "${{ env.ZONE }}" --delete-disks all --quiet
 
       - name: Get disk state name from gcloud
         id: get-disk-name

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,7 +252,7 @@ jobs:
         if: ${{ steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true' }}
         continue-on-error: true
         run: |
-          gcloud compute instances delete $(gcloud compute instances list --filter="regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)') --delete-disks all --zone "${{ env.ZONE }}
+          gcloud compute instances delete $(gcloud compute instances list --filter="regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)') --zone "${{ env.ZONE }}" --delete-disks all --quiet
 
       - name: Create GCP compute instance
         id: create-instance
@@ -332,7 +332,7 @@ jobs:
         if: ${{ steps.sync-to-checkpoint.outcome == 'success' || steps.sync-to-checkpoint.outcome == 'failure' }}
         continue-on-error: true
         run: |
-          gcloud compute instances delete "regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --delete-disks all --zone "${{ env.ZONE }}"
+          gcloud compute instances delete "regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --zone "${{ env.ZONE }}" --delete-disks all --quiet
 
   # Test that Zebra syncs and fully validates a few thousand blocks from a cached post-checkpoint state
   test-stateful-sync:
@@ -364,7 +364,7 @@ jobs:
         if: ${{ needs.regenerate-stateful-disks.outputs.any_changed != 'true' || github.event.inputs.regenerate-disks != 'true'}}
         continue-on-error: true
         run: |
-          gcloud compute instances delete $(gcloud compute instances list --filter="regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)') --delete-disks all --zone "${{ env.ZONE }}
+          gcloud compute instances delete $(gcloud compute instances list --filter="regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)') --zone "${{ env.ZONE }}" --delete-disks all --quiet
 
       - name: Get disk state name from gcloud
         id: get-disk-name
@@ -441,4 +441,4 @@ jobs:
         if: ${{ steps.sync-past-checkpoint.outcome == 'success' || steps.sync-past-checkpoint.outcome == 'failure' }}
         continue-on-error: true
         run: |
-          gcloud compute instances delete "sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --delete-disks all --zone "${{ env.ZONE }}"
+          gcloud compute instances delete "sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --zone "${{ env.ZONE }}" --delete-disks all --quiet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ on:
 
 env:
   CARGO_INCREMENTAL: '1'
-  ZEBRA_SKIP_IPV6_TESTS: "1"
+  ZEBRA_SKIP_IPV6_TESTS: '1'
   NETWORK: Mainnet
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   GAR_BASE: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/zebra
@@ -130,6 +130,11 @@ jobs:
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
           docker run -e ZEBRA_SKIP_IPV6_TESTS --name zebrad-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features enable-sentry --workspace -- --include-ignored
 
+  # This test changes zebra-chain's activation heights,
+  # which can recompile all the Zebra crates,
+  # so we want its build products to be cached separately.
+  #
+  # Also, we don't want to accidentally use the fake heights in other tests.
   test-fake-activation-heights:
     name: Test with fake activation heights
     runs-on: ubuntu-latest
@@ -233,11 +238,25 @@ jobs:
         with:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
+      # Check if our destination compute instance exists already
+      - name: Check if compute instance exists
+        id: instance-exists
+        continue-on-error: true
+        run: |
+          gcloud compute instances list --filter="regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}" --format='value(NAME)' | grep "regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}"
+
+      - name: Update GCP compute instance
+        id: update-instance
+        if: ${{ steps.instance-exists.outcome == 'failure' }}
+        run: |
+          gcloud compute instances update-container "regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
+          --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
+
       - name: Create GCP compute instance
         id: create-instance
         if: ${{ steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true' }}
         run: |
-          gcloud compute instances create-with-container "regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
+          gcloud compute instances create-with-container "regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
           --boot-disk-size 100GB \
           --boot-disk-type pd-ssd \
           --create-disk name="zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${{ env.lower_net_name }}-canopy",size=100GB,type=pd-ssd \
@@ -268,24 +287,24 @@ jobs:
       # https://www.googlecloudcommunity.com/gc/Infrastructure-Compute-Storage/SSH-into-Compute-Container-not-easily-possible/td-p/170915
       - name: Get container name from logs
         id: get-container-name
-        if: steps.create-instance.outcome == 'success'
+        if: ${{ steps.create-instance.outcome == 'success' || steps.update-instance.outcome == 'success' }}
         run: |
-          INSTANCE_ID=$(gcloud compute instances describe regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} --zone ${{ env.ZONE }} --format='value(id)')
+          INSTANCE_ID=$(gcloud compute instances describe regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }} --zone ${{ env.ZONE }} --format='value(id)')
           echo "Using instance: $INSTANCE_ID"
-          while [[ ${CONTAINER_NAME} != *"regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"* ]]; do
-              CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
+          while [[ ${CONTAINER_NAME} != *"regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}"* ]]; do
+              CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}-....' | tr -d "'.")
               echo "Using container: ${CONTAINER_NAME} from instance: ${INSTANCE_ID}"
               sleep 10
           done
-          CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
+          CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}-....' | tr -d "'.")
           echo "::set-output name=zebra_container::$CONTAINER_NAME"
 
       - name: Regenerate stateful disks logs
         id: sync-to-checkpoint
-        if: steps.create-instance.outcome == 'success'
+        if: ${{ steps.create-instance.outcome == 'success' || steps.update-instance.outcome == 'success' }}
         run: |
           gcloud compute ssh \
-          regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }} \
           --zone ${{ env.ZONE }} \
           --quiet \
           --ssh-flag="-o ServerAliveInterval=5" \
@@ -321,13 +340,6 @@ jobs:
           name: latest-disk-state-sha
           path: latest-disk-state-sha.txt
           retention-days: 1095
-
-      - name: Delete test instance
-        # Do not delete the instance if the sync timeouts in GitHub
-        if: ${{ steps.sync-to-checkpoint.outcome == 'success' || steps.sync-to-checkpoint.outcome == 'failure' }}
-        continue-on-error: true
-        run: |
-          gcloud compute instances delete "regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --delete-disks all --zone "${{ env.ZONE }}"
 
   # Test that Zebra syncs and fully validates a few thousand blocks from a cached post-checkpoint state
   test-stateful-sync:
@@ -373,11 +385,25 @@ jobs:
         with:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
+      # Check if our destination compute instance exists already
+      - name: Check if compute instance exists
+        id: instance-exists
+        continue-on-error: true
+        run: |
+          gcloud compute instances list --filter="sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }}" --format='value(NAME)' | grep "regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}"
+
+      - name: Update GCP compute instance
+        id: update-instance
+        if: ${{ steps.instance-exists.outcome == 'failure' }}
+        run: |
+          gcloud compute instances update-container "sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
+          --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
+
       # Creates Compute Engine virtual machine instance w/ disks
       - name: Create GCP compute instance
         id: create-instance
         run: |
-          gcloud compute instances create-with-container "sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
+          gcloud compute instances create-with-container "sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
           --boot-disk-size 100GB \
           --boot-disk-type pd-ssd \
           --create-disk=image=zebrad-cache-${{ env.DISK_SHORT_SHA }}-${{ env.lower_net_name }}-canopy,name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${{ env.lower_net_name }}-canopy,size=100GB,type=pd-ssd \
@@ -410,33 +436,26 @@ jobs:
       # https://www.googlecloudcommunity.com/gc/Infrastructure-Compute-Storage/SSH-into-Compute-Container-not-easily-possible/td-p/170915
       - name: Get container name from logs
         id: get-container-name
-        if: steps.create-instance.outcome == 'success'
+        if: ${{ steps.create-instance.outcome == 'success' || steps.update-instance.outcome == 'success' }}
         run: |
-          INSTANCE_ID=$(gcloud compute instances describe sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} --zone ${{ env.ZONE }} --format='value(id)')
+          INSTANCE_ID=$(gcloud compute instances describe sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }} --zone ${{ env.ZONE }} --format='value(id)')
           echo "Using instance: $INSTANCE_ID"
-          while [[ ${CONTAINER_NAME} != *"sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"* ]]; do
-              CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
+          while [[ ${CONTAINER_NAME} != *"sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }}"* ]]; do
+              CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }}-....' | tr -d "'.")
               echo "Using container: ${CONTAINER_NAME} from instance: ${INSTANCE_ID}"
               sleep 10
           done
-          CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
+          CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }}-....' | tr -d "'.")
           echo "::set-output name=zebra_container::$CONTAINER_NAME"
 
       - name: Sync past mandatory checkpoint logs
         id: sync-past-checkpoint
         run: |
           gcloud compute ssh \
-          sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }} \
           --zone ${{ env.ZONE }} \
           --quiet \
           --ssh-flag="-o ServerAliveInterval=5" \
           --command="docker logs --follow ${{ env.ZEBRA_CONTAINER }}"
         env:
           ZEBRA_CONTAINER: ${{ steps.get-container-name.outputs.zebra_container }}
-
-      - name: Delete test instance
-        # Do not delete the instance if the sync timeouts in GitHub
-        if: ${{ steps.sync-past-checkpoint.outcome == 'success' || steps.sync-past-checkpoint.outcome == 'failure' }}
-        continue-on-error: true
-        run: |
-          gcloud compute instances delete "sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --delete-disks all --zone "${{ env.ZONE }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,6 +256,7 @@ jobs:
             echo "No instance to delete"
           else
             gcloud compute instances delete "${INSTANCE}" --zone "${{ env.ZONE }}" --delete-disks all --quiet
+          fi
 
       - name: Create GCP compute instance
         id: create-instance
@@ -365,13 +366,13 @@ jobs:
       - name: Delete existing instance with same SHA
         id: delete-old-instance
         if: ${{ needs.regenerate-stateful-disks.outputs.any_changed != 'true' || github.event.inputs.regenerate-disks != 'true'}}
-        continue-on-error: true
         run: |
           INSTANCE=$(gcloud compute instances list --filter=sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} --format='value(NAME)')
           if [ -z "${INSTANCE}" ]; then
             echo "No instance to delete"
           else
             gcloud compute instances delete "${INSTANCE}" --zone "${{ env.ZONE }}" --delete-disks all --quiet
+          fi
 
       - name: Get disk state name from gcloud
         id: get-disk-name

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,13 +244,14 @@ jobs:
       # Check if our destination compute instance exists already
       - name: Check if compute instance exists
         id: instance-exists
+        if: ${{ steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true' }}
         continue-on-error: true
         run: |
           gcloud compute instances list --filter="regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}" --format='value(NAME)' | grep "regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}"
 
       - name: Update GCP compute instance
         id: update-instance
-        if: ${{ steps.instance-exists.outcome == 'failure' }}
+        if: ${{ (steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true') && (steps.instance-exists.outcome == 'success') }}
         run: |
           gcloud compute instances update-container "regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
           --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
@@ -258,7 +259,7 @@ jobs:
 
       - name: Create GCP compute instance
         id: create-instance
-        if: ${{ steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true' }}
+        if: ${{ (steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true') && (steps.instance-exists.outcome == 'failure') }}
         run: |
           gcloud compute instances create-with-container "regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
           --boot-disk-size 100GB \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,7 +252,7 @@ jobs:
         if: ${{ steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true' }}
         continue-on-error: true
         run: |
-          gcloud compute instances delete $(gcloud compute instances list --filter="regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)')
+          gcloud compute instances delete $(gcloud compute instances list --filter="regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)') --delete-disks all --zone "${{ env.ZONE }}
 
       - name: Create GCP compute instance
         id: create-instance
@@ -327,6 +327,13 @@ jobs:
           --storage-location=us \
           --description="Created from head branch ${{ env.GITHUB_HEAD_REF_SLUG_URL }} targeting ${{ env.GITHUB_BASE_REF_SLUG }} from PR ${{ env.GITHUB_REF_SLUG_URL }} with commit ${{ env.GITHUB_EVENT_PULL_REQUEST_HEAD_SHA }}"
 
+      - name: Delete test instance
+        # Do not delete the instance if the sync timeouts in GitHub
+        if: ${{ steps.sync-to-checkpoint.outcome == 'success' || steps.sync-to-checkpoint.outcome == 'failure' }}
+        continue-on-error: true
+        run: |
+          gcloud compute instances delete "regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --delete-disks all --zone "${{ env.ZONE }}"
+
   # Test that Zebra syncs and fully validates a few thousand blocks from a cached post-checkpoint state
   test-stateful-sync:
     name: Test full validation sync from cached state
@@ -357,7 +364,7 @@ jobs:
         if: ${{ needs.regenerate-stateful-disks.outputs.any_changed != 'true' || github.event.inputs.regenerate-disks != 'true'}}
         continue-on-error: true
         run: |
-          gcloud compute instances delete $(gcloud compute instances list --filter="regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)')
+          gcloud compute instances delete $(gcloud compute instances list --filter="regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)') --delete-disks all --zone "${{ env.ZONE }}
 
       - name: Get disk state name from gcloud
         id: get-disk-name
@@ -428,3 +435,10 @@ jobs:
           --command="docker logs --follow ${{ env.ZEBRA_CONTAINER }}"
         env:
           ZEBRA_CONTAINER: ${{ steps.get-container-name.outputs.zebra_container }}
+
+      - name: Delete test instance
+        # Do not delete the instance if the sync timeouts in GitHub
+        if: ${{ steps.sync-past-checkpoint.outcome == 'success' || steps.sync-past-checkpoint.outcome == 'failure' }}
+        continue-on-error: true
+        run: |
+          gcloud compute instances delete "sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --delete-disks all --zone "${{ env.ZONE }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -248,7 +248,7 @@ jobs:
 
       # Check if our destination compute instance exists and delete it
       - name: Delete existing instance with same SHA
-        id: instance-exists
+        id: delete-old-instance
         if: ${{ steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true' }}
         continue-on-error: true
         run: |
@@ -360,7 +360,7 @@ jobs:
 
       # Check if our destination compute instance exists and delete it
       - name: Delete existing instance with same SHA
-        id: instance-exists
+        id: delete-old-instance
         if: ${{ needs.regenerate-stateful-disks.outputs.any_changed != 'true' || github.event.inputs.regenerate-disks != 'true'}}
         continue-on-error: true
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -251,7 +251,7 @@ jobs:
         run: |
           gcloud compute instances update-container "regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
           --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
-          --zone "${{ env.ZONE }}
+          --zone "${{ env.ZONE }}"
 
       - name: Create GCP compute instance
         id: create-instance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,7 +250,8 @@ jobs:
         if: ${{ steps.instance-exists.outcome == 'failure' }}
         run: |
           gcloud compute instances update-container "regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
-          --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
+          --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
+          --zone "${{ env.ZONE }}
 
       - name: Create GCP compute instance
         id: create-instance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,27 +246,19 @@ jobs:
         with:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
-      # Check if our destination compute instance exists already
-      - name: Check if compute instance exists
+      # Check if our destination compute instance exists and delete it
+      - name: Delete existing instance with same SHA
         id: instance-exists
         if: ${{ steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true' }}
         continue-on-error: true
         run: |
-          gcloud compute instances list --filter="regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}" --format='value(NAME)' | grep "regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}"
-
-      - name: Update GCP compute instance
-        id: update-instance
-        if: ${{ (steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true') && (steps.instance-exists.outcome == 'success') }}
-        run: |
-          gcloud compute instances update-container "regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
-          --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
-          --zone "${{ env.ZONE }}"
+          gcloud compute instances delete $(gcloud compute instances list --filter="regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)')
 
       - name: Create GCP compute instance
         id: create-instance
-        if: ${{ (steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true') && (steps.instance-exists.outcome == 'failure') }}
+        if: ${{ steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true' }}
         run: |
-          gcloud compute instances create-with-container "regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
+          gcloud compute instances create-with-container "regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 100GB \
           --boot-disk-type pd-ssd \
           --create-disk name="zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${{ env.lower_net_name }}-canopy",size=100GB,type=pd-ssd \
@@ -297,24 +289,24 @@ jobs:
       # https://www.googlecloudcommunity.com/gc/Infrastructure-Compute-Storage/SSH-into-Compute-Container-not-easily-possible/td-p/170915
       - name: Get container name from logs
         id: get-container-name
-        if: ${{ steps.create-instance.outcome == 'success' || steps.update-instance.outcome == 'success' }}
+        if: ${{ steps.create-instance.outcome == 'success' }}
         run: |
-          INSTANCE_ID=$(gcloud compute instances describe regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }} --zone ${{ env.ZONE }} --format='value(id)')
+          INSTANCE_ID=$(gcloud compute instances describe regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} --zone ${{ env.ZONE }} --format='value(id)')
           echo "Using instance: $INSTANCE_ID"
-          while [[ ${CONTAINER_NAME} != *"regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}"* ]]; do
-              CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}-....' | tr -d "'.")
+          while [[ ${CONTAINER_NAME} != *"regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"* ]]; do
+              CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
               echo "Using container: ${CONTAINER_NAME} from instance: ${INSTANCE_ID}"
               sleep 10
           done
-          CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }}-....' | tr -d "'.")
+          CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
           echo "::set-output name=zebra_container::$CONTAINER_NAME"
 
       - name: Regenerate stateful disks logs
         id: sync-to-checkpoint
-        if: ${{ steps.create-instance.outcome == 'success' || steps.update-instance.outcome == 'success' }}
+        if: ${{ steps.create-instance.outcome == 'success' }}
         run: |
           gcloud compute ssh \
-          regenerate-disk-pr-${{ env.GITHUB_REF_SLUG_URL }} \
+          regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ env.ZONE }} \
           --quiet \
           --ssh-flag="-o ServerAliveInterval=5" \
@@ -359,6 +351,14 @@ jobs:
         with:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
+      # Check if our destination compute instance exists and delete it
+      - name: Delete existing instance with same SHA
+        id: instance-exists
+        if: ${{ needs.regenerate-stateful-disks.outputs.any_changed != 'true' || github.event.inputs.regenerate-disks != 'true'}}
+        continue-on-error: true
+        run: |
+          gcloud compute instances delete $(gcloud compute instances list --filter="regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" --format='value(NAME)')
+
       - name: Get disk state name from gcloud
         id: get-disk-name
         if: ${{ needs.regenerate-stateful-disks.outputs.any_changed != 'true' || github.event.inputs.regenerate-disks != 'true'}}
@@ -372,7 +372,7 @@ jobs:
       - name: Create GCP compute instance
         id: create-instance
         run: |
-          gcloud compute instances create-with-container "sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }}" \
+          gcloud compute instances create-with-container "sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 100GB \
           --boot-disk-type pd-ssd \
           --create-disk=image=${{ env.CACHED_DISK_NAME }},name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${{ env.lower_net_name }}-canopy,size=100GB,type=pd-ssd \
@@ -407,21 +407,21 @@ jobs:
         id: get-container-name
         if: ${{ steps.create-instance.outcome == 'success' || steps.update-instance.outcome == 'success' }}
         run: |
-          INSTANCE_ID=$(gcloud compute instances describe sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }} --zone ${{ env.ZONE }} --format='value(id)')
+          INSTANCE_ID=$(gcloud compute instances describe sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} --zone ${{ env.ZONE }} --format='value(id)')
           echo "Using instance: $INSTANCE_ID"
-          while [[ ${CONTAINER_NAME} != *"sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }}"* ]]; do
-              CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }}-....' | tr -d "'.")
+          while [[ ${CONTAINER_NAME} != *"sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"* ]]; do
+              CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
               echo "Using container: ${CONTAINER_NAME} from instance: ${INSTANCE_ID}"
               sleep 10
           done
-          CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }}-....' | tr -d "'.")
+          CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
           echo "::set-output name=zebra_container::$CONTAINER_NAME"
 
       - name: Sync past mandatory checkpoint logs
         id: sync-past-checkpoint
         run: |
           gcloud compute ssh \
-          sync-checkpoint-pr-${{ env.GITHUB_REF_SLUG_URL }} \
+          sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ env.ZONE }} \
           --quiet \
           --ssh-flag="-o ServerAliveInterval=5" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -412,7 +412,7 @@ jobs:
       # https://www.googlecloudcommunity.com/gc/Infrastructure-Compute-Storage/SSH-into-Compute-Container-not-easily-possible/td-p/170915
       - name: Get container name from logs
         id: get-container-name
-        if: ${{ steps.create-instance.outcome == 'success' || steps.update-instance.outcome == 'success' }}
+        if: ${{ steps.create-instance.outcome == 'success' }}
         run: |
           INSTANCE_ID=$(gcloud compute instances describe sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} --zone ${{ env.ZONE }} --format='value(id)')
           echo "Using instance: $INSTANCE_ID"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,6 +304,7 @@ jobs:
           done
           CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
           echo "::set-output name=zebra_container::$CONTAINER_NAME"
+          sleep 60
 
       - name: Regenerate stateful disks logs
         id: sync-to-checkpoint
@@ -431,6 +432,7 @@ jobs:
           done
           CONTAINER_NAME=$(gcloud logging read 'log_name=projects/${{ env.PROJECT_ID }}/logs/cos_system AND jsonPayload.MESSAGE:sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}' --format='value(jsonPayload.MESSAGE)' --limit=1 | grep -o '...-sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-....' | tr -d "'.")
           echo "::set-output name=zebra_container::$CONTAINER_NAME"
+          sleep 60
 
       - name: Sync past mandatory checkpoint logs
         id: sync-past-checkpoint


### PR DESCRIPTION
## Motivation
On each push to a PR we're recreating a new instance, with the previous one still running. When the team is on a high-demand sprint, a bunch of instances are created and it's hard to track which one of those is actually needed and it makes deployment slower as it needs to create an instance each time.

Also, when an action is executed twice on the same SHA, if the previous instance was not deleted, it crashes. This ensure that if an instance exists, it updates the instance.

## Solution
- Always keep a single VM for a single PR, and update it on each successful image build
- Delete instances from a branch when a PR is closed or merged

## Review
@dconnolly or @teor2345 can review this PR
