### PR TITLE
lint(clippy): warn on manual printing to stdout or stderr

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -38,6 +38,12 @@ rustflags = [
     "-Wclippy::dbg_macro",
     "-Wclippy::todo",
 
+    # Manual debugging output.
+    # Use tracing::trace!() or tracing::debug!() instead.
+    "-Wclippy::print_stdout",
+    "-Wclippy::print_stderr",
+    "-Wclippy::dbg_macro",
+
     # Code styles we want to accept
     "-Aclippy::try_err",
 
@@ -58,10 +64,6 @@ rustflags = [
     #"-Wclippy::cast_possible_wrap", # 13 test warnings (fixed outside tests)
     #"-Wclippy::cast_precision_loss", # 25 non-test warnings, 10 test warnings
     #"-Wclippy::cast_sign_loss", # 6 non-test warnings, 15 test warnings
-
-    # disable these lints using a zebra-test config.toml, but warn for other crates
-    #"-Wclippy::print_stdout",
-    #"-Wclippy::print_stderr",
 
     # fix hidden lifetime parameters
     #"-Wrust_2018_idioms",

--- a/zebra-chain/src/parameters/tests.rs
+++ b/zebra-chain/src/parameters/tests.rs
@@ -14,11 +14,6 @@ use NetworkUpgrade::*;
 fn activation_bijective() {
     zebra_test::init();
 
-    if std::env::var_os("TEST_FAKE_ACTIVATION_HEIGHTS").is_some() {
-        eprintln!("Skipping activation_bijective() since $TEST_FAKE_ACTIVATION_HEIGHTS is set");
-        return;
-    }
-
     let mainnet_activations = NetworkUpgrade::activation_list(Mainnet);
     let mainnet_heights: HashSet<&block::Height> = mainnet_activations.keys().collect();
     assert_eq!(MAINNET_ACTIVATION_HEIGHTS.len(), mainnet_heights.len());

--- a/zebra-consensus/examples/get-params-path.rs
+++ b/zebra-consensus/examples/get-params-path.rs
@@ -3,6 +3,7 @@
 // Modified from:
 // https://github.com/zcash/librustzcash/blob/c48bb4def2e122289843ddb3cb2984c325c03ca0/zcash_proofs/examples/get-params-path.rs
 
+#[allow(clippy::print_stdout)]
 fn main() {
     let path = zebra_consensus::groth16::Groth16Parameters::directory();
     if let Some(path) = path.to_str() {

--- a/zebra-consensus/src/primitives/halo2/tests.rs
+++ b/zebra-consensus/src/primitives/halo2/tests.rs
@@ -23,7 +23,7 @@ use zebra_chain::{
 
 use crate::primitives::halo2::*;
 
-#[allow(dead_code)]
+#[allow(dead_code, clippy::print_stdout)]
 fn generate_test_vectors() {
     let proving_key = ProvingKey::build();
 

--- a/zebra-state/src/service/finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/tests/prop.rs
@@ -48,6 +48,7 @@ fn blocks_with_v5_transactions() -> Result<()> {
 ///
 /// This test requires setting the TEST_FAKE_ACTIVATION_HEIGHTS.
 #[test]
+#[allow(clippy::print_stderr)]
 fn all_upgrades_and_wrong_commitments_with_fake_activation_heights() -> Result<()> {
     zebra_test::init();
 

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -276,6 +276,7 @@ impl<T> TestChild<T> {
     /// Note: the timeout is only checked after each full line is received from
     /// the child.
     #[instrument(skip(self, lines))]
+    #[allow(clippy::print_stdout)]
     pub fn expect_line_matching<L>(
         &mut self,
         lines: &mut L,

--- a/zebra-test/src/net.rs
+++ b/zebra-test/src/net.rs
@@ -18,6 +18,7 @@ const ZEBRA_SKIP_IPV6_TESTS: &str = "ZEBRA_SKIP_IPV6_TESTS";
 /// Should we skip Zebra tests which need reliable, fast network connectivity?
 //
 // TODO: separate "good and reliable" from "any network"?
+#[allow(clippy::print_stderr)]
 pub fn zebra_skip_network_tests() -> bool {
     if env::var_os(ZEBRA_SKIP_NETWORK_TESTS).is_some() {
         // This message is captured by the test runner, use
@@ -34,6 +35,7 @@ pub fn zebra_skip_network_tests() -> bool {
 ///
 /// Since `zebra_skip_network_tests` only disables tests which need reliable network connectivity,
 /// we allow IPv6 tests even when `ZEBRA_SKIP_NETWORK_TESTS` is set.
+#[allow(clippy::print_stderr)]
 pub fn zebra_skip_ipv6_tests() -> bool {
     if env::var_os(ZEBRA_SKIP_IPV6_TESTS).is_some() {
         eprintln!("Skipping IPv6 network test because '$ZEBRA_SKIP_IPV6_TESTS' is set.");

--- a/zebra-test/tests/command.rs
+++ b/zebra-test/tests/command.rs
@@ -11,6 +11,7 @@ use zebra_test::{command::TestDirExt, prelude::Stdio};
 /// (This message is captured by the test runner, use `cargo test -- --nocapture` to see it.)
 ///
 /// The command's stdout and stderr are ignored.
+#[allow(clippy::print_stderr)]
 fn is_command_available(cmd: &str, args: &[&str]) -> bool {
     let status = Command::new(cmd)
         .args(args)

--- a/zebra-utils/src/bin/zebra-checkpoints/main.rs
+++ b/zebra-utils/src/bin/zebra-checkpoints/main.rs
@@ -65,6 +65,7 @@ fn cmd_output(cmd: &mut std::process::Command) -> Result<String> {
     Ok(s)
 }
 
+#[allow(clippy::print_stdout)]
 fn main() -> Result<()> {
     init_tracing();
 

--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -28,6 +28,7 @@ fn disable_non_reproducible(_config: &mut Config) {
      */
 }
 
+#[allow(clippy::print_stderr)]
 fn main() {
     let mut config = Config::default();
     disable_non_reproducible(&mut config);
@@ -48,7 +49,7 @@ fn main() {
         Err(e) => {
             eprintln!(
                 "git error in vergen build script: skipping git env vars: {:?}",
-                e
+                e,
             );
             *config.git_mut().enabled_mut() = false;
             vergen(config).expect("non-git vergen should succeed");

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -192,6 +192,7 @@ impl Application for ZebradApp {
     /// If you would like to add additional components to your application
     /// beyond the default ones provided by the framework, this is the place
     /// to do so.
+    #[allow(clippy::print_stderr)]
     fn register_components(&mut self, command: &Self::Cmd) -> Result<(), FrameworkError> {
         use crate::components::{
             metrics::MetricsEndpoint, tokio::TokioComponent, tracing::TracingEndpoint,

--- a/zebrad/src/commands/generate.rs
+++ b/zebrad/src/commands/generate.rs
@@ -13,6 +13,7 @@ pub struct GenerateCmd {
 
 impl Runnable for GenerateCmd {
     /// Start the application.
+    #[allow(clippy::print_stdout)]
     fn run(&self) {
         let default_config = ZebradConfig::default();
         let mut output = r"# Default configuration for zebrad.

--- a/zebrad/src/commands/version.rs
+++ b/zebrad/src/commands/version.rs
@@ -11,6 +11,7 @@ pub struct VersionCmd {}
 
 impl Runnable for VersionCmd {
     /// Print version message
+    #[allow(clippy::print_stdout)]
     fn run(&self) {
         println!("{} {}", ZebradCmd::name(), ZebradCmd::version());
     }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1261,6 +1261,7 @@ fn cached_mandatory_checkpoint_test_config() -> Result<ZebradConfig> {
 ///
 /// Returns an error if the child exits or the fixed timeout elapses
 /// before `STOP_AT_HEIGHT_REGEX` is found.
+#[allow(clippy::print_stderr)]
 fn create_cached_database_height(
     network: Network,
     height: Height,
@@ -1268,7 +1269,8 @@ fn create_cached_database_height(
     checkpoint_sync: bool,
     stop_regex: &str,
 ) -> Result<()> {
-    println!("Creating cached database");
+    eprintln!("creating cached database");
+
     // 16 hours
     let timeout = Duration::from_secs(60 * 60 * 16);
 


### PR DESCRIPTION
## Motivation

In PR #3749 we accidentally merged some debug print statements, which caused CI failures for about a day. We fixed the specific bug in PR #3755.

This PR prevents similar bugs in future PRs using clippy lints.

### Clippy Reference

https://rust-lang.github.io/rust-clippy/master/#print_stdout
https://rust-lang.github.io/rust-clippy/master/#print_stderr
https://rust-lang.github.io/rust-clippy/master/#dbg_macro

## Solution

- warn about printing to stdout and stderr, using `println!()`, `eprintln!()` and `dbg!()`
- allow some writes, such as `zebrad` commands, and skipping tests
- fix or delete some unnecessary writes

These lints don't catch `write!(stdout, ...)` or `writeln!(stdout, ...)`, but other lints that are on by default do.

## Review

This PR is a low-priority bug prevention PR.

### Reviewer Checklist

  - [ ] Code changes are valid
  - [ ] New lints pass
  - [ ] Existing tests pass

