### PR TITLE
imp(build): make zcash-params build faster as it's timing out

### DIFF
--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -3,8 +3,8 @@ name: zcash-params
 on:
   workflow_dispatch:
   push:
-    branches:
-      - 'main'
+    # branches:
+    #   - 'main'
     paths:
       # parameter download code
       - 'zebra-consensus/src/primitives/groth16/params.rs'

--- a/docker/zcash-params/Dockerfile
+++ b/docker/zcash-params/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -qq update && \
 
 # Optimize builds. In particular, regenerate-stateful-test-disks.yml was reaching the
 # GitHub Actions time limit (6 hours), so we needed to make it faster.
-ENV RUSTFLAGS "-C opt-level=0 -C link-arg=-fuse-ld=lld"
+ENV RUSTFLAGS "-C opt-level=0"
 ENV CARGO_HOME /app/.cargo/
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook --release --features enable-sentry --recipe-path recipe.json

--- a/docker/zcash-params/Dockerfile
+++ b/docker/zcash-params/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -qq update && \
 
 # Optimize builds. In particular, regenerate-stateful-test-disks.yml was reaching the
 # GitHub Actions time limit (6 hours), so we needed to make it faster.
-ENV RUSTFLAGS "-C opt-level=0,link-arg=-fuse-ld=lld"
+ENV RUSTFLAGS "-C opt-level=0 -C link-arg=-fuse-ld=lld"
 ENV CARGO_HOME /app/.cargo/
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook --release --features enable-sentry --recipe-path recipe.json

--- a/docker/zcash-params/Dockerfile
+++ b/docker/zcash-params/Dockerfile
@@ -23,12 +23,12 @@ RUN apt-get -qq update && \
 
 # Optimize builds. In particular, regenerate-stateful-test-disks.yml was reaching the
 # GitHub Actions time limit (6 hours), so we needed to make it faster.
-ENV RUSTFLAGS -O
+ENV RUSTFLAGS "-C opt-level=0,link-arg=-fuse-ld=lld"
 ENV CARGO_HOME /app/.cargo/
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook --release --features enable-sentry --recipe-path recipe.json
 
-ARG RUST_BACKTRACE=1
+ARG RUST_BACKTRACE=0
 ENV RUST_BACKTRACE ${RUST_BACKTRACE}
 
 COPY . .


### PR DESCRIPTION
## Motivation
The build zcash-params has been timing out, weird enough as the main image is building successfully, but in the meanwhile we're just building this one to use the downloaded params, so stripping optimizations shouldn't affect the resulting outcome.

## Solution

- Use a faster linker
- Remove optimizations
- Remove backtraces from the build

## Review

Wait for successful build