### PR TITLE
fix(ci): deploy full sync tests to europe-west1

### DIFF
--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -30,8 +30,8 @@ env:
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   GAR_BASE: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/zebra
   GCR_BASE: gcr.io/${{ secrets.GCP_PROJECT_ID }}
-  REGION: us-central1
-  ZONE: us-central1-a
+  REGION: europe-west1
+  ZONE: europe-west1-a
   MACHINE_TYPE: c2d-standard-16
   IMAGE_NAME: zebrad-test
 


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

We want to spread out our test deployments to avoid gcloud resource limits.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Deploy the long, full sync tests to a different gcloud region/zone, europe-west1 (Belgium). No other workflows are currently using this region.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

@gustavovalverde 

### Reviewer Checklist

  - [ ] `test-full-sync.yml` successfully deploys and completes to new region
