### PR TITLE
fix(ci): only run full sync workflow on ✅ review

### DIFF
--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -40,6 +40,7 @@ jobs:
     name: Build images
     timeout-minutes: 210
     runs-on: ubuntu-latest
+    if: github.event.review.state == 'approved'
     steps:
       - uses: actions/checkout@v2.4.0
         with:


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

We're hitting GitHub rate limits often, causing tests and build to fail spuriously.


## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Instead of running the full sync test workflow every time a review is submitted, only run the build job (and its dependent test job) when the review has the 'accepted' value.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] test-full-sync.yml is skipped unless a ✅ review is submitted

