### PR TITLE
fix(ci): only run the full sync test on mergify queue PRs

### DIFF
--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -38,78 +38,79 @@ env:
 
 jobs:
   build:
-    run_if:
-      if:  startsWith(github.head_ref, 'mergify/merge-queue/')
-      name: Build images
-      timeout-minutes: 210
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v2.4.0
-          with:
-            persist-credentials: false
+    # only run on Mergify head branches:
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1
+    if:  startsWith(github.head_ref, 'mergify/merge-queue/')
+    name: Build images
+    timeout-minutes: 210
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+        with:
+          persist-credentials: false
 
-        - name: Inject slug/short variables
-          uses: rlespinasse/github-slug-action@v4
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
 
-        # Automatic tag management and OCI Image Format Specification for labels
-        - name: Docker meta
-          id: meta
-          uses: docker/metadata-action@v3.6.2
-          with:
-            # list of Docker images to use as base name for tags
-            images: |
-              ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}
-              ${{ env.GCR_BASE }}/${{ env.GITHUB_REPOSITORY_SLUG_URL }}/${{ env.IMAGE_NAME }}
-            # generate Docker tags based on the following events/attributes
-            tags: |
-              type=schedule
-              type=ref,event=branch
-              type=ref,event=pr
-              type=semver,pattern={{version}}
-              type=semver,pattern={{major}}.{{minor}}
-              type=semver,pattern={{major}}
-              type=sha
+      # Automatic tag management and OCI Image Format Specification for labels
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3.6.2
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}
+            ${{ env.GCR_BASE }}/${{ env.GITHUB_REPOSITORY_SLUG_URL }}/${{ env.IMAGE_NAME }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
 
-        # Setup Docker Buildx to allow use of docker cache layers from GH
-        - name: Set up Docker Buildx
-          id: buildx
-          uses: docker/setup-buildx-action@v1
+      # Setup Docker Buildx to allow use of docker cache layers from GH
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
 
-        - name: Login to Google Artifact Registry
-          uses: docker/login-action@v1.12.0
-          with:
-            registry: us-docker.pkg.dev
-            username: _json_key
-            password: ${{ secrets.GOOGLE_CREDENTIALS }}
+      - name: Login to Google Artifact Registry
+        uses: docker/login-action@v1.12.0
+        with:
+          registry: us-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GOOGLE_CREDENTIALS }}
 
-        - name: Login to Google Container Registry
-          uses: docker/login-action@v1.12.0
-          with:
-            registry: gcr.io
-            username: _json_key
-            password: ${{ secrets.GOOGLE_CREDENTIALS }}
+      - name: Login to Google Container Registry
+        uses: docker/login-action@v1.12.0
+        with:
+          registry: gcr.io
+          username: _json_key
+          password: ${{ secrets.GOOGLE_CREDENTIALS }}
 
-        # Build and push image to Google Artifact Registry
-        - name: Build & push
-          id: docker_build
-          uses: docker/build-push-action@v2.8.0
-          with:
-            target: tester
-            context: .
-            file: ./docker/Dockerfile
-            tags: ${{ steps.meta.outputs.tags }}
-            labels: ${{ steps.meta.outputs.labels }}
-            build-args: |
-              NETWORK=${{ github.event.inputs.network || env.NETWORK }}
-              SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}
-              RUST_BACKTRACE=full
-              ZEBRA_SKIP_NETWORK_TESTS="1"
-              CHECKPOINT_SYNC=${{ github.event.inputs.checkpoint_sync || true }}
-              RUST_LOG=debug
-              SENTRY_DSN=${{ secrets.SENTRY_ENDPOINT }}
-            push: true
-            cache-from: type=gha
-            cache-to: type=gha,mode=max
+      # Build and push image to Google Artifact Registry
+      - name: Build & push
+        id: docker_build
+        uses: docker/build-push-action@v2.8.0
+        with:
+          target: tester
+          context: .
+          file: ./docker/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NETWORK=${{ github.event.inputs.network || env.NETWORK }}
+            SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}
+            RUST_BACKTRACE=full
+            ZEBRA_SKIP_NETWORK_TESTS="1"
+            CHECKPOINT_SYNC=${{ github.event.inputs.checkpoint_sync || true }}
+            RUST_LOG=debug
+            SENTRY_DSN=${{ secrets.SENTRY_ENDPOINT }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   # Test that Zebra can run a full mainnet sync after a PR is approved
   test-full-sync:

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -5,8 +5,6 @@ on:
     inputs:
       network:
         default: 'Mainnet'
-  # only run on Mergify head branches:
-  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -5,7 +5,9 @@ on:
     inputs:
       network:
         default: 'Mainnet'
-  pull_request_review:
+  # only run on Mergify head branches:
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1
+  pull_request:
     branches:
       - main
     paths:
@@ -21,7 +23,6 @@ on:
       # workflow definitions
       - 'docker/**'
       - '.github/workflows/test-full-sync.yml'
-    types: [submitted]
 
 env:
   CARGO_INCREMENTAL: '1'
@@ -37,76 +38,78 @@ env:
 
 jobs:
   build:
-    name: Build images
-    timeout-minutes: 210
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.4.0
-        with:
-          persist-credentials: false
+    run_if:
+      if:  startsWith(github.head_ref, 'mergify/merge-queue/')
+      name: Build images
+      timeout-minutes: 210
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2.4.0
+          with:
+            persist-credentials: false
 
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        - name: Inject slug/short variables
+          uses: rlespinasse/github-slug-action@v4
 
         # Automatic tag management and OCI Image Format Specification for labels
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3.6.2
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}
-            ${{ env.GCR_BASE }}/${{ env.GITHUB_REPOSITORY_SLUG_URL }}/${{ env.IMAGE_NAME }}
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
+        - name: Docker meta
+          id: meta
+          uses: docker/metadata-action@v3.6.2
+          with:
+            # list of Docker images to use as base name for tags
+            images: |
+              ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}
+              ${{ env.GCR_BASE }}/${{ env.GITHUB_REPOSITORY_SLUG_URL }}/${{ env.IMAGE_NAME }}
+            # generate Docker tags based on the following events/attributes
+            tags: |
+              type=schedule
+              type=ref,event=branch
+              type=ref,event=pr
+              type=semver,pattern={{version}}
+              type=semver,pattern={{major}}.{{minor}}
+              type=semver,pattern={{major}}
+              type=sha
 
-      # Setup Docker Buildx to allow use of docker cache layers from GH
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
+        # Setup Docker Buildx to allow use of docker cache layers from GH
+        - name: Set up Docker Buildx
+          id: buildx
+          uses: docker/setup-buildx-action@v1
 
-      - name: Login to Google Artifact Registry
-        uses: docker/login-action@v1.12.0
-        with:
-          registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GOOGLE_CREDENTIALS }}
+        - name: Login to Google Artifact Registry
+          uses: docker/login-action@v1.12.0
+          with:
+            registry: us-docker.pkg.dev
+            username: _json_key
+            password: ${{ secrets.GOOGLE_CREDENTIALS }}
 
-      - name: Login to Google Container Registry
-        uses: docker/login-action@v1.12.0
-        with:
-          registry: gcr.io
-          username: _json_key
-          password: ${{ secrets.GOOGLE_CREDENTIALS }}
+        - name: Login to Google Container Registry
+          uses: docker/login-action@v1.12.0
+          with:
+            registry: gcr.io
+            username: _json_key
+            password: ${{ secrets.GOOGLE_CREDENTIALS }}
 
-      # Build and push image to Google Artifact Registry
-      - name: Build & push
-        id: docker_build
-        uses: docker/build-push-action@v2.8.0
-        with:
-          target: tester
-          context: .
-          file: ./docker/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            NETWORK=${{ github.event.inputs.network || env.NETWORK }}
-            SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}
-            RUST_BACKTRACE=full
-            ZEBRA_SKIP_NETWORK_TESTS="1"
-            CHECKPOINT_SYNC=${{ github.event.inputs.checkpoint_sync || true }}
-            RUST_LOG=debug
-            SENTRY_DSN=${{ secrets.SENTRY_ENDPOINT }}
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        # Build and push image to Google Artifact Registry
+        - name: Build & push
+          id: docker_build
+          uses: docker/build-push-action@v2.8.0
+          with:
+            target: tester
+            context: .
+            file: ./docker/Dockerfile
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+            build-args: |
+              NETWORK=${{ github.event.inputs.network || env.NETWORK }}
+              SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}
+              RUST_BACKTRACE=full
+              ZEBRA_SKIP_NETWORK_TESTS="1"
+              CHECKPOINT_SYNC=${{ github.event.inputs.checkpoint_sync || true }}
+              RUST_LOG=debug
+              SENTRY_DSN=${{ secrets.SENTRY_ENDPOINT }}
+            push: true
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
 
   # Test that Zebra can run a full mainnet sync after a PR is approved
   test-full-sync:


### PR DESCRIPTION
## Motivation

We want to run the full sync test exactly once before merging each PR.

### GitHub API Reference

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1

## Solution

- only run the full sync test on `mergify/merge-queue/` branches

## Review

@gustavovalverde or @dconnolly can review this PR.

### Reviewer Checklist

  - [x] The full sync test doesn't run in this PR
  - [x] The full sync test runs in the Mergify queue PR for this branch

## Follow Up Work

- make the full sync test faster
- require the full sync test before merging Mergify queue PRs