### PR TITLE
fix(ci): revert a test job name change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -331,7 +331,7 @@ jobs:
 
   # Test that Zebra syncs and fully validates a few thousand blocks from a cached post-checkpoint state
   test-stateful-sync:
-    name: Test validation sync from cached state
+    name: Test full validation sync from cached state
     runs-on: ubuntu-latest
     needs: [ build, regenerate-stateful-disks]
     steps:


### PR DESCRIPTION
## Motivation

Mergify can't merge most PRs.

A job was renamed in PR #3735, and mergify is searching for the old name.

## Solution

Revert the job name change.

This is the simplest change that unblocks the PR queues.

## Review

Anyone can review this urgent PR.

### Reviewer Checklist

  - [ ] CI passes