### PR TITLE
Enable `checkpoint_sync` by default

### DIFF
--- a/zebra-consensus/src/config.rs
+++ b/zebra-consensus/src/config.rs
@@ -4,13 +4,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
-    /// Should Zebra sync using checkpoints?
+    /// Should Zebra sync using post-Canopy checkpoints?
     ///
-    /// Setting this option to true enables post-Canopy checkpoints.
-    /// (Zebra always checkpoints up to and including Canopy activation.)
+    /// This option is `true` by default, and allows for faster chain synchronization.
     ///
-    /// Future versions of Zebra may change the mandatory checkpoint
-    /// height.
+    /// Disabling this option forces Zebra to only use checkpoints until Canopy activation, which
+    /// helps with debugging by forcing Zebra to validate more blocks.
     pub checkpoint_sync: bool,
 
     /// Skip the pre-download of Groth16 parameters if this option is true.

--- a/zebra-consensus/src/config.rs
+++ b/zebra-consensus/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     /// Future versions of Zebra may change the mandatory checkpoint
     /// height.
     pub checkpoint_sync: bool,
+
     /// Skip the pre-download of Groth16 parameters if this option is true.
     pub debug_skip_parameter_preload: bool,
 }

--- a/zebra-consensus/src/config.rs
+++ b/zebra-consensus/src/config.rs
@@ -4,12 +4,17 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
-    /// Should Zebra sync using post-Canopy checkpoints?
+    /// Should Zebra use its optional checkpoints to sync?
     ///
     /// This option is `true` by default, and allows for faster chain synchronization.
     ///
-    /// Disabling this option forces Zebra to only use checkpoints until Canopy activation, which
-    /// helps with debugging by forcing Zebra to validate more blocks.
+    /// Zebra requires some checkpoints to validate legacy network upgrades.
+    /// But it also ships with optional checkpoints, which can be used instead of full block validation.
+    ///
+    /// Disabling this option makes Zebra start full validation as soon as possible.
+    /// This helps developers debug Zebra, by running full validation on more blocks.
+    ///
+    /// Future versions of Zebra may change the required and optional checkpoints.
     pub checkpoint_sync: bool,
 
     /// Skip the pre-download of Groth16 parameters if this option is true.

--- a/zebra-consensus/src/config.rs
+++ b/zebra-consensus/src/config.rs
@@ -22,7 +22,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            checkpoint_sync: false,
+            checkpoint_sync: true,
             debug_skip_parameter_preload: false,
         }
     }


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
Before a Zebra stable release, we should enable post-Canopy checkpoints so that Zebra synchronizes the chain more quickly.

This is part of #2368.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
- Make `checkpoint_sync` `true` by default
- Update the documentation to say that setting it to false is useful for debugging

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
Finish the rest of #2368 by increasing the checkpoint height.