### PR TITLE
5. refactor(state): split the state service into modules

### DIFF
--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -40,8 +40,9 @@ pub use service::{
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use service::{
+    arbitrary::populated_state,
     chain_tip::{ChainTipBlock, ChainTipSender},
-    init_test, populated_state,
+    init_test,
 };
 
 pub(crate) use request::ContextuallyValidBlock;

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -7,9 +7,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use futures::{future::FutureExt, stream::FuturesUnordered};
+use futures::future::FutureExt;
 use tokio::sync::oneshot;
-use tower::{util::BoxService, Service, ServiceExt};
+use tower::{util::BoxService, Service};
 use tracing::instrument;
 
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -57,6 +57,15 @@ pub type QueuedFinalized = (
     oneshot::Sender<Result<block::Hash, BoxError>>,
 );
 
+/// A read-write service for Zebra's cached blockchain state.
+///
+/// This service modifies and provides access to:
+/// - the non-finalized state: the ~100 most recent blocks.
+///                            Zebra allows chain forks in the non-finalized state,
+///                            stores it in memory, and re-downloads it when restarted.
+/// - the finalized state: older blocks that have many confirmations.
+///                        Zebra stores the single best chain in the finalized state,
+///                        and re-loads it from disk when restarted.
 pub(crate) struct StateService {
     /// Holds data relating to finalized chain state.
     pub(crate) disk: FinalizedState,

--- a/zebra-state/src/service/block_iter.rs
+++ b/zebra-state/src/service/block_iter.rs
@@ -1,0 +1,103 @@
+//! Iterators for blocks in the non-finalized and finalized state.
+
+use std::sync::Arc;
+
+use zebra_chain::block::{self, Block};
+
+use crate::{service::StateService, HashOrHeight};
+
+/// Iterator for state blocks.
+///
+/// Starts at any block in any non-finalized or finalized chain,
+/// and iterates in reverse height order. (Towards the genesis block.)
+pub(crate) struct Iter<'a> {
+    pub(super) service: &'a StateService,
+    pub(super) state: IterState,
+}
+
+pub(super) enum IterState {
+    NonFinalized(block::Hash),
+    Finalized(block::Height),
+    Finished,
+}
+
+impl Iter<'_> {
+    fn next_non_finalized_block(&mut self) -> Option<Arc<Block>> {
+        let Iter { service, state } = self;
+
+        let hash = match state {
+            IterState::NonFinalized(hash) => *hash,
+            IterState::Finalized(_) | IterState::Finished => unreachable!(),
+        };
+
+        if let Some(block) = service.mem.any_block_by_hash(hash) {
+            let hash = block.header.previous_block_hash;
+            self.state = IterState::NonFinalized(hash);
+            Some(block)
+        } else {
+            None
+        }
+    }
+
+    fn next_finalized_block(&mut self) -> Option<Arc<Block>> {
+        let Iter { service, state } = self;
+
+        let hash_or_height: HashOrHeight = match *state {
+            IterState::Finalized(height) => height.into(),
+            IterState::NonFinalized(hash) => hash.into(),
+            IterState::Finished => unreachable!(),
+        };
+
+        if let Some(block) = service.disk.block(hash_or_height) {
+            let height = block
+                .coinbase_height()
+                .expect("valid blocks have a coinbase height");
+
+            if let Some(next_height) = height - 1 {
+                self.state = IterState::Finalized(next_height);
+            } else {
+                self.state = IterState::Finished;
+            }
+
+            Some(block)
+        } else {
+            self.state = IterState::Finished;
+            None
+        }
+    }
+}
+
+impl Iterator for Iter<'_> {
+    type Item = Arc<Block>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.state {
+            IterState::NonFinalized(_) => self
+                .next_non_finalized_block()
+                .or_else(|| self.next_finalized_block()),
+            IterState::Finalized(_) => self.next_finalized_block(),
+            IterState::Finished => None,
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl std::iter::FusedIterator for Iter<'_> {}
+
+impl ExactSizeIterator for Iter<'_> {
+    fn len(&self) -> usize {
+        match self.state {
+            IterState::NonFinalized(hash) => self
+                .service
+                .any_height_by_hash(hash)
+                .map(|height| (height.0 + 1) as _)
+                .unwrap_or(0),
+            IterState::Finalized(height) => (height.0 + 1) as _,
+            IterState::Finished => 0,
+        }
+    }
+}

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -16,7 +16,7 @@ use zebra_test::{prelude::*, transcript::Transcript};
 use crate::{
     arbitrary::Prepare,
     constants, init_test,
-    service::{chain_tip::TipAction, populated_state, StateService},
+    service::{arbitrary::populated_state, chain_tip::TipAction, StateService},
     tests::setup::{partial_nu5_chain_strategy, transaction_v4_from_coinbase},
     BoxError, Config, FinalizedBlock, PreparedBlock, Request, Response,
 };
@@ -305,7 +305,7 @@ proptest! {
     fn some_block_less_than_network_upgrade(
         (network, nu_activation_height, chain) in partial_nu5_chain_strategy(4, true, UNDER_LEGACY_CHAIN_LIMIT, NetworkUpgrade::Canopy)
     ) {
-        let response = crate::service::legacy_chain_check(nu_activation_height, chain.into_iter().rev(), network)
+        let response = crate::service::check::legacy_chain(nu_activation_height, chain.into_iter().rev(), network)
             .map_err(|error| error.to_string());
 
         prop_assert_eq!(response, Ok(()));
@@ -316,7 +316,7 @@ proptest! {
     fn no_transaction_with_network_upgrade(
         (network, nu_activation_height, chain) in partial_nu5_chain_strategy(4, true, OVER_LEGACY_CHAIN_LIMIT, NetworkUpgrade::Canopy)
     ) {
-        let response = crate::service::legacy_chain_check(nu_activation_height, chain.into_iter().rev(), network)
+        let response = crate::service::check::legacy_chain(nu_activation_height, chain.into_iter().rev(), network)
             .map_err(|error| error.to_string());
 
         prop_assert_eq!(
@@ -350,7 +350,7 @@ proptest! {
                 .is_err()
         );
 
-        let response = crate::service::legacy_chain_check(
+        let response = crate::service::check::legacy_chain(
             nu_activation_height,
             chain.clone().into_iter().rev(),
             network
@@ -370,7 +370,7 @@ proptest! {
     fn at_least_one_transaction_with_valid_network_upgrade(
         (network, nu_activation_height, chain) in partial_nu5_chain_strategy(5, true, UNDER_LEGACY_CHAIN_LIMIT, NetworkUpgrade::Canopy)
     ) {
-        let response = crate::service::legacy_chain_check(nu_activation_height, chain.into_iter().rev(), network)
+        let response = crate::service::check::legacy_chain(nu_activation_height, chain.into_iter().rev(), network)
             .map_err(|error| error.to_string());
 
         prop_assert_eq!(response, Ok(()));


### PR DESCRIPTION
## Motivation

This is preparation for ticket #3745, where we split the state service itself.

## Solution

- move everything except the state service implementation into modules

## Review

This is mostly code movement, I recommend `git diff --color-moved`.

This PR is somewhat urgent, because #3745 could block integration testing for RPC methods.

### Reviewer Checklist

  - [x] Code is moved
  - [x] Existing tests pass

## Follow Up Work

- #3745