### PR TITLE
build(docker): revert supporting arm64

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -96,9 +96,10 @@ jobs:
         target: runtime
         context: .
         file: ./docker/Dockerfile
-        platforms: |
-          linux/amd64
-          linux/arm64
+        # TODO: building crates is taking too long with arm64 and it's timing out on GHA
+        # platforms: |
+        #   linux/amd64
+        #   linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |

--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -88,9 +88,11 @@ jobs:
         target: builder
         context: .
         file: ./docker/zcash-params/Dockerfile
-        platforms: |
-          linux/amd64
-          linux/arm64
+        # TODO: building crates is taking too long with arm64 and it's timing out on GHA
+        # platforms: |
+        #   linux/amd64
+        #   linux/arm64
+
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |


### PR DESCRIPTION
## Motivation

Building crates it's taking too much time and timing out on GitHub's Action.

## Solution

- Temporarily remove ARM64 support for Zebra until we can improve build times or have ARM64 self hosted runners.

## Review

Anyone on the DevOps team can review this as this was the previous state.
