### PR TITLE
feat: get addresses from transparent outputs

### DIFF
--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -30,7 +30,10 @@ mod tests;
 
 use crate::{
     amount::{Amount, NonNegative},
-    block, transaction,
+    block,
+    parameters::Network,
+    primitives::zcash_primitives,
+    transaction,
 };
 
 use std::{collections::HashMap, fmt, iter};
@@ -302,5 +305,12 @@ impl Output {
     /// This amount is subtracted from the transaction value pool by this output.
     pub fn value(&self) -> Amount<NonNegative> {
         self.value
+    }
+
+    /// Return the destination address from a transparent output.
+    ///
+    /// Returns None if the address type is not valid or unrecognized.
+    pub fn address(&self, network: Network) -> Option<Address> {
+        zcash_primitives::transparent_output_address(self, network)
     }
 }

--- a/zebra-chain/src/transparent/address.rs
+++ b/zebra-chain/src/transparent/address.rs
@@ -192,6 +192,22 @@ impl ToAddressWithNetwork for PublicKey {
 }
 
 impl Address {
+    /// Create an address for the given public key hash and network.
+    pub fn from_pub_key_hash(network: Network, pub_key_hash: [u8; 20]) -> Self {
+        Self::PayToPublicKeyHash {
+            network,
+            pub_key_hash,
+        }
+    }
+
+    /// Create an address for the given script hash and network.
+    pub fn from_script_hash(network: Network, script_hash: [u8; 20]) -> Self {
+        Self::PayToScriptHash {
+            network,
+            script_hash,
+        }
+    }
+
     /// A hash of a transparent address payload, as used in
     /// transparent pay-to-script-hash and pay-to-publickey-hash
     /// addresses.

--- a/zebra-chain/src/transparent/tests/vectors.rs
+++ b/zebra-chain/src/transparent/tests/vectors.rs
@@ -1,4 +1,13 @@
+use std::sync::Arc;
+
 use super::super::serialize::parse_coinbase_height;
+use crate::{
+    parameters::Network, primitives::zcash_primitives::transparent_output_address,
+    serialization::ZcashDeserializeInto, transaction,
+};
+use hex::FromHex;
+
+use zebra_test::prelude::*;
 
 #[test]
 fn parse_coinbase_height_mins() {
@@ -36,4 +45,38 @@ fn parse_coinbase_height_mins() {
 
     let case4 = vec![0x04, 0x11, 0x00, 0x00, 0x00];
     assert!(parse_coinbase_height(case4).is_err());
+}
+
+#[test]
+fn get_transparent_output_address() -> Result<()> {
+    zebra_test::init();
+
+    let script_tx: Vec<u8> = <Vec<u8>>::from_hex("0400008085202f8901fcaf44919d4a17f6181a02a7ebe0420be6f7dad1ef86755b81d5a9567456653c010000006a473044022035224ed7276e61affd53315eca059c92876bc2df61d84277cafd7af61d4dbf4002203ed72ea497a9f6b38eb29df08e830d99e32377edb8a574b8a289024f0241d7c40121031f54b095eae066d96b2557c1f99e40e967978a5fd117465dbec0986ca74201a6feffffff020050d6dc0100000017a9141b8a9bda4b62cd0d0582b55455d0778c86f8628f870d03c812030000001976a914e4ff5512ffafe9287992a1cd177ca6e408e0300388ac62070d0095070d000000000000000000000000")
+    .expect("Block bytes are in valid hex representation");
+
+    let transaction = script_tx.zcash_deserialize_into::<Arc<transaction::Transaction>>()?;
+
+    // Hashes were extracted from the transaction (parsed with zebra-chain,
+    // then manually extracted from lock_script).
+    // Final expected values were generated with https://secretscan.org/PrivateKeyHex,
+    // by filling field 4 with the prefix followed by the address hash.
+    // Refer to <https://zips.z.cash/protocol/protocol.pdf#transparentaddrencoding>
+    // for the prefixes.
+
+    // Script hash 1b8a9bda4b62cd0d0582b55455d0778c86f8628f
+    let addr = transparent_output_address(&transaction.outputs()[0], Network::Mainnet)
+        .expect("should return address");
+    assert_eq!(addr.to_string(), "t3M5FDmPfWNRG3HRLddbicsuSCvKuk9hxzZ");
+    let addr = transparent_output_address(&transaction.outputs()[0], Network::Testnet)
+        .expect("should return address");
+    assert_eq!(addr.to_string(), "t294SGSVoNq2daz15ZNbmAW65KQZ5e3nN5G");
+    // Public key hash e4ff5512ffafe9287992a1cd177ca6e408e03003
+    let addr = transparent_output_address(&transaction.outputs()[1], Network::Mainnet)
+        .expect("should return address");
+    assert_eq!(addr.to_string(), "t1ekRwsd4LaSsd6NXgsx66q2HxQWTLCF44y");
+    let addr = transparent_output_address(&transaction.outputs()[1], Network::Testnet)
+        .expect("should return address");
+    assert_eq!(addr.to_string(), "tmWbBGi7TjExNmLZyMcFpxVh3ZPbGrpbX3H");
+
+    Ok(())
 }


### PR DESCRIPTION
## Motivation

For `lightwalletd` support we need to be able to get the destination address from a transparent output.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

- Add a `Output::address()` method that calls `zcash_primitives` from `librustzcash`

Closes https://github.com/ZcashFoundation/zebra/issues/3149 

## Review

Not urgent right now but it blocks other six lightwalletd tickets

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
