### PR TITLE
A. fix(shielded): use RwLock for note commitment tree root caches

### DIFF
--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -10,16 +10,14 @@
 //!
 //! A root of a note commitment tree is associated with each treestate.
 
-#![allow(clippy::unit_arg)]
 #![allow(clippy::derive_hash_xor_eq)]
 #![allow(dead_code)]
 
 use std::{
-    cell::Cell,
-    convert::TryFrom,
     fmt,
     hash::{Hash, Hasher},
     io,
+    ops::Deref,
 };
 
 use bitvec::prelude::*;
@@ -213,7 +211,7 @@ pub enum NoteCommitmentTreeError {
 }
 
 /// Orchard Incremental Note Commitment Tree
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct NoteCommitmentTree {
     /// The tree represented as a Frontier.
     ///
@@ -244,12 +242,9 @@ pub struct NoteCommitmentTree {
     /// serialized with the tree). This is particularly important since we decided
     /// to instantiate the trees from the genesis block, for simplicity.
     ///
-    /// [`Cell`] offers interior mutability (it works even with a non-mutable
-    /// reference to the tree) but it prevents the tree (and anything that uses it)
-    /// from being shared between threads. If this ever becomes an issue we can
-    /// leave caching to the callers (which requires much more code), or replace
-    /// `Cell` with `Arc<Mutex<_>>` (and be careful of deadlocks and async code.)
-    cached_root: Cell<Option<Root>>,
+    /// We use a [`RwLock`] for this cache, because it is only written once per tree update.
+    /// Each tree has its own cached root, a new lock is created for each clone.
+    cached_root: std::sync::RwLock<Option<Root>>,
 }
 
 impl NoteCommitmentTree {
@@ -263,7 +258,13 @@ impl NoteCommitmentTree {
     pub fn append(&mut self, cm_x: pallas::Base) -> Result<(), NoteCommitmentTreeError> {
         if self.inner.append(&cm_x.into()) {
             // Invalidate cached root
-            self.cached_root.replace(None);
+            let cached_root = self
+                .cached_root
+                .get_mut()
+                .expect("a thread that previously held exclusive lock access panicked");
+
+            *cached_root = None;
+
             Ok(())
         } else {
             Err(NoteCommitmentTreeError::FullTree)
@@ -273,13 +274,28 @@ impl NoteCommitmentTree {
     /// Returns the current root of the tree, used as an anchor in Orchard
     /// shielded transactions.
     pub fn root(&self) -> Root {
-        match self.cached_root.get() {
-            // Return cached root
-            Some(root) => root,
+        if let Some(root) = self
+            .cached_root
+            .read()
+            .expect("a thread that previously held exclusive lock access panicked")
+            .deref()
+        {
+            // Return cached root.
+            return *root;
+        }
+
+        // Get exclusive access, compute the root, and cache it.
+        let mut write_root = self
+            .cached_root
+            .write()
+            .expect("a thread that previously held exclusive lock access panicked");
+        match write_root.deref() {
+            // Another thread got write access first, return cached root.
+            Some(root) => *root,
             None => {
-                // Compute root and cache it
+                // Compute root and cache it.
                 let root = Root(self.inner.root().0);
-                self.cached_root.replace(Some(root));
+                *write_root = Some(root);
                 root
             }
         }
@@ -305,6 +321,21 @@ impl NoteCommitmentTree {
     /// For Orchard, the tree is capped at 2^32.
     pub fn count(&self) -> u64 {
         self.inner.position().map_or(0, |pos| u64::from(pos) + 1)
+    }
+}
+
+impl Clone for NoteCommitmentTree {
+    /// Clones the inner tree, and creates a new `RwLock` with the cloned root data.
+    fn clone(&self) -> Self {
+        let cached_root = *self
+            .cached_root
+            .read()
+            .expect("a thread that previously held exclusive lock access panicked");
+
+        Self {
+            inner: self.inner.clone(),
+            cached_root: std::sync::RwLock::new(cached_root),
+        }
     }
 }
 


### PR DESCRIPTION
## Motivation

As part of #3745, we need to share `zebra_state::Chain`s between threads. So we need to share cached note commitment tree roots between threads.

### API Reference

https://doc.rust-lang.org/std/sync/struct.RwLock.html#method.get_mut
https://doc.rust-lang.org/std/sync/struct.RwLock.html#method.read
https://doc.rust-lang.org/std/sync/struct.RwLock.html#method.write

### Design

I used an `RwLock`, because the cache is only written once after each note commitment tree update. Caches aren't shared between trees, because the cache needs to be consistent with each tree's notes.

Modifying the tree and clearing the cache doesn't require locking, because we already have exclusive access to the tree.

When filling the cache, there is no risk of deadlocks, because each tree has exclusive access to a single `RwLock`. If multiple threads queue on the lock, one of these scenarios happens:
- if the cache is empty, the first writer fills it, the other writers read the cache (exclusively), then subsequent threads share read access to the cache
- if the cache is full, all threads share read access to the cache

## Solution

- use RwLock for note commitment tree root caches

## Review

@conradoplg is most familiar with this code.

### Reviewer Checklist

  - [ ] Existing tests pass

## Follow Up Work

The rest of:
- #3745