### PR TITLE
fix(ci): re-enable manual dispatch for test full sync

### DIFF
--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -39,9 +39,9 @@ env:
 
 jobs:
   build:
-    # only run on Mergify head branches:
+    # only run on Mergify head branches, and on manual dispatch:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1
-    if:  startsWith(github.head_ref, 'mergify/merge-queue/')
+    if:  startsWith(github.head_ref, 'mergify/merge-queue/') || github.event_name == "workflow_dispatch"
     name: Build images
     timeout-minutes: 210
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

The mergify branch filters stop us doing manual dispatch for full sync tests.