### PR TITLE
change(ci): remove Windows support

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,7 +11,7 @@ queue_rules:
       - check-success=Test stable zebra-state with fake activation heights on ubuntu-latest
       - check-success=Test stable on ubuntu-latest
       - check-success=Test stable on macOS-latest
-      # Windows was removed for now, see https://github.com/ZcashFoundation/zebra/discussions/3704
+      # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
       # - check-success=Test stable on windows-latest
       - check-success=Coverage nightly
       - check-success=Clippy

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,7 +11,8 @@ queue_rules:
       - check-success=Test stable zebra-state with fake activation heights on ubuntu-latest
       - check-success=Test stable on ubuntu-latest
       - check-success=Test stable on macOS-latest
-      - check-success=Test stable on windows-latest
+      # Windows was removed for now, see https://github.com/ZcashFoundation/zebra/discussions/3704
+      # - check-success=Test stable on windows-latest
       - check-success=Coverage nightly
       - check-success=Clippy
       - check-success=Rustfmt
@@ -28,7 +29,7 @@ queue_rules:
       - check-success=Test stable zebra-state with fake activation heights on ubuntu-latest
       - check-success=Test stable on ubuntu-latest
       - check-success=Test stable on macOS-latest
-      - check-success=Test stable on windows-latest
+      # - check-success=Test stable on windows-latest
       - check-success=Coverage nightly
       - check-success=Clippy
       - check-success=Rustfmt
@@ -45,7 +46,7 @@ queue_rules:
       - check-success=Test stable zebra-state with fake activation heights on ubuntu-latest
       - check-success=Test stable on ubuntu-latest
       - check-success=Test stable on macOS-latest
-      - check-success=Test stable on windows-latest
+      # - check-success=Test stable on windows-latest
       - check-success=Coverage nightly
       - check-success=Clippy
       - check-success=Rustfmt

--- a/.github/workflows/ci.patch.yml
+++ b/.github/workflows/ci.patch.yml
@@ -22,7 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        # Windows was removed for now, see https://github.com/ZcashFoundation/zebra/discussions/3704
+        os: [ubuntu-latest, macOS-latest]
         rust: [stable]
 
     steps:
@@ -64,7 +65,7 @@ jobs:
     strategy:
       matrix:
         checks:
-          - bans 
+          - bans
           - sources
 
     # Prevent sudden announcement of a new advisory from failing ci:

--- a/.github/workflows/ci.patch.yml
+++ b/.github/workflows/ci.patch.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Windows was removed for now, see https://github.com/ZcashFoundation/zebra/discussions/3704
+        # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
         os: [ubuntu-latest, macOS-latest]
         rust: [stable]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Windows was removed for now, see https://github.com/ZcashFoundation/zebra/discussions/3704
+        # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
         os: [ubuntu-latest, macOS-latest]
         rust: [stable]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        # Windows was removed for now, see https://github.com/ZcashFoundation/zebra/discussions/3704
+        os: [ubuntu-latest, macOS-latest]
         rust: [stable]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ The recommended requirements for compiling and running `zebrad` are:
 We continuously test that our builds and tests pass on:
 
 The *latest* [GitHub Runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) for:
-- Windows Server
 - macOS
 - Ubuntu
 
@@ -206,6 +205,8 @@ There are a few bugs in Zebra that we're still working on fixing:
   - These panics can be ignored, unless they happen frequently.
 - [Interrupt handler does not work when a blocking task is running #1351](https://github.com/ZcashFoundation/zebra/issues/1351)
   - Zebra should eventually exit once the task finishes. Or you can forcibly terminate the process.
+- [No Windows support #3801](https://github.com/ZcashFoundation/zebra/issues/3801)
+  - We used to test with Windows Server 2019, but not anymore; see issue for details
 
 ## Future Work
 

--- a/book/src/user/requirements.md
+++ b/book/src/user/requirements.md
@@ -9,7 +9,6 @@ On many-core machines (like, 32-core) the build is very fast; on 2-core machines
 it's less fast.
 
 We continuously test that our builds and tests pass on:
-- Windows Server 2019
 - macOS Big Sur 11.0
 - Ubuntu 18.04 / the latest LTS
 - Debian Buster


### PR DESCRIPTION
## Motivation

We can no longer support Windows, see https://github.com/ZcashFoundation/zebra/discussions/3704

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

Remove Windows testing from CI

## Review

Not super urgent, but this blocks https://github.com/ZcashFoundation/zebra/pull/3799

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
