### PR TITLE
fix(ci): change pd-extreme to pd-ssd to avoid quotas

### DIFF
--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -152,7 +152,7 @@ jobs:
         run: |
           gcloud compute instances create-with-container "full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 100GB \
-          --boot-disk-type pd-extreme \
+          --boot-disk-type pd-ssd \
           --container-image ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
           --container-restart-policy=never \
           --container-stdin \


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

We are hitting gcloud quota limits for use of `pd-extreme` disks per region/zone in `us-central1`.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Switch `test-full-sync.yml` to use `pd-ssd` instead, which has more amenable limits.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

@gustavovalverde 

### Reviewer Checklist

  - [ ] Full sync test doesn't slow down too much