### PR TITLE
7. feat(state): add a read-only state service stub

### DIFF
--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -37,4 +37,5 @@ thiserror = "1.0.30"
 tokio = { version = "1.16.1", features = ["full", "test-util"] }
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/" }

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -119,24 +119,23 @@ where
     /// A handle to the mempool service.
     mempool: Buffer<Mempool, mempool::Request>,
     /// A handle to the state service.
-    state: Buffer<State, zebra_state::Request>,
+    state: State,
 }
 
 impl<Mempool, State> RpcImpl<Mempool, State>
 where
     Mempool: Service<mempool::Request, Response = mempool::Response, Error = BoxError>,
     State: Service<
-            zebra_state::Request,
-            Response = zebra_state::Response,
-            Error = zebra_state::BoxError,
-        > + 'static,
-    State::Future: Send,
+        zebra_state::Request,
+        Response = zebra_state::Response,
+        Error = zebra_state::BoxError,
+    >,
 {
     /// Create a new instance of the RPC handler.
     pub fn new(
         app_version: String,
         mempool: Buffer<Mempool, mempool::Request>,
-        state: Buffer<State, zebra_state::Request>,
+        state: State,
     ) -> Self {
         RpcImpl {
             app_version,
@@ -155,7 +154,10 @@ where
             zebra_state::Request,
             Response = zebra_state::Response,
             Error = zebra_state::BoxError,
-        > + 'static,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
     State::Future: Send,
 {
     fn get_info(&self) -> Result<GetInfo> {

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -8,6 +8,8 @@ use zebra_chain::{
     transaction::{Transaction, UnminedTx},
 };
 use zebra_node_services::mempool;
+use zebra_state::BoxError;
+
 use zebra_test::mock_service::MockService;
 
 use super::super::{Rpc, RpcImpl, SentTransactionHash};
@@ -20,7 +22,7 @@ proptest! {
 
         runtime.block_on(async move {
             let mut mempool = MockService::build().for_prop_tests();
-            let mut state = MockService::build().for_prop_tests();
+            let mut state: MockService<_, _, _, BoxError> = MockService::build().for_prop_tests();
             let rpc = RpcImpl::new("RPC test".to_owned(), Buffer::new(mempool.clone(), 1), Buffer::new(state.clone(), 1));
             let hash = SentTransactionHash(transaction.hash());
 
@@ -61,7 +63,7 @@ proptest! {
 
         runtime.block_on(async move {
             let mut mempool = MockService::build().for_prop_tests();
-            let mut state = MockService::build().for_prop_tests();
+            let mut state: MockService<_, _, _, BoxError> = MockService::build().for_prop_tests();
 
             let rpc = RpcImpl::new("RPC test".to_owned(), Buffer::new(mempool.clone(), 1), Buffer::new(state.clone(), 1));
 
@@ -109,7 +111,7 @@ proptest! {
 
         runtime.block_on(async move {
             let mut mempool = MockService::build().for_prop_tests();
-            let mut state = MockService::build().for_prop_tests();
+            let mut state: MockService<_, _, _, BoxError> = MockService::build().for_prop_tests();
 
             let rpc = RpcImpl::new("RPC test".to_owned(), Buffer::new(mempool.clone(), 1), Buffer::new(state.clone(), 1));
 
@@ -164,7 +166,7 @@ proptest! {
 
         runtime.block_on(async move {
             let mut mempool = MockService::build().for_prop_tests();
-            let mut state = MockService::build().for_prop_tests();
+            let mut state: MockService<_, _, _, BoxError> = MockService::build().for_prop_tests();
 
             let rpc = RpcImpl::new("RPC test".to_owned(), Buffer::new(mempool.clone(), 1), Buffer::new(state.clone(), 1));
 
@@ -208,7 +210,7 @@ proptest! {
 
         runtime.block_on(async move {
             let mut mempool = MockService::build().for_prop_tests();
-            let mut state = MockService::build().for_prop_tests();
+            let mut state: MockService<_, _, _, BoxError> = MockService::build().for_prop_tests();
 
             let rpc = RpcImpl::new("RPC test".to_owned(), Buffer::new(mempool.clone(), 1), Buffer::new(state.clone(), 1));
 

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -7,6 +7,7 @@ use tower::buffer::Buffer;
 use zebra_chain::{block::Block, parameters::Network, serialization::ZcashDeserializeInto};
 use zebra_network::constants::USER_AGENT;
 use zebra_node_services::BoxError;
+
 use zebra_test::mock_service::MockService;
 
 use super::super::*;
@@ -19,7 +20,7 @@ async fn rpc_getinfo() {
     zebra_test::init();
 
     let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
-    let mut state = MockService::build().for_unit_tests();
+    let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
     let rpc = RpcImpl::new(
         "Zebra version test".to_string(),
@@ -80,7 +81,7 @@ async fn rpc_getblock_error() {
     zebra_test::init();
 
     let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
-    let mut state = MockService::build().for_unit_tests();
+    let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
     // Init RPC
     let rpc = RpcImpl {

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -3,6 +3,9 @@
 //! This endpoint is compatible with clients that incorrectly send
 //! `"jsonrpc" = 1.0` fields in JSON-RPC 1.0 requests,
 //! such as `lightwalletd`.
+//!
+//! See the full list of
+//! [Differences between JSON-RPC 1.0 and 2.0.](https://www.simple-is-better.org/rpc/#differences-between-1-0-and-2-0)
 
 use jsonrpc_core;
 use jsonrpc_http_server::ServerBuilder;

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -33,7 +33,7 @@ impl RpcServer {
         config: Config,
         app_version: String,
         mempool: Buffer<Mempool, mempool::Request>,
-        state: Buffer<State, zebra_state::Request>,
+        state: State,
     ) -> tokio::task::JoinHandle<()>
     where
         Mempool: tower::Service<mempool::Request, Response = mempool::Response, Error = BoxError>
@@ -43,7 +43,10 @@ impl RpcServer {
                 zebra_state::Request,
                 Response = zebra_state::Response,
                 Error = zebra_state::BoxError,
-            > + 'static,
+            > + Clone
+            + Send
+            + Sync
+            + 'static,
         State::Future: Send,
     {
         if let Some(listen_addr) = config.listen_addr {

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -831,6 +831,65 @@ impl Service<Request> for StateService {
     }
 }
 
+impl Service<Request> for ReadStateService {
+    type Response = Response;
+    type Error = BoxError;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    #[instrument(name = "read_state", skip(self, req))]
+    fn call(&mut self, req: Request) -> Self::Future {
+        match req {
+            // TODO: implement for lightwalletd
+            Request::Block(_hash_or_height) => unimplemented!("ReadStateService doesn't Block yet"),
+            Request::Transaction(_hash) => {
+                unimplemented!("ReadStateService doesn't Transaction yet")
+            }
+
+            Request::Tip => unimplemented!("ReadStateService doesn't Tip yet"),
+
+            // We can get existing UTXOs,
+            // but that should be a different request with a different name
+            Request::AwaitUtxo(_outpoint) => unreachable!("ReadStateService can't await UTXOs"),
+
+            // Out of scope.
+            //
+            // This request might benefit from better performance,
+            // but it isn't needed for lightwalletd.
+            Request::Depth(_hash) => unimplemented!("ReadStateService doesn't Depth yet"),
+
+            // These requests probably don't need better performance.
+            Request::FindBlockHashes {
+                known_blocks: _,
+                stop: _,
+            } => {
+                unimplemented!("ReadStateService doesn't FindBlockHashes yet")
+            }
+            Request::FindBlockHeaders {
+                known_blocks: _,
+                stop: _,
+            } => {
+                unimplemented!("ReadStateService doesn't FindBlockHeaders yet")
+            }
+
+            // This request needs to wait for queued blocks.
+            Request::BlockLocator => {
+                unreachable!("ReadStateService should not be used for block locators")
+            }
+
+            // Write Requests.
+            Request::CommitBlock(_prepared) => unreachable!("ReadStateService can't commit blocks"),
+            Request::CommitFinalizedBlock(_finalized) => {
+                unreachable!("ReadStateService can't commit blocks")
+            }
+        }
+    }
+}
+
 /// Initialize a state service from the provided [`Config`].
 /// Returns a boxed state service, a read-only state service,
 /// and receivers for state chain tip updates.

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -846,11 +846,13 @@ impl Service<Request> for ReadStateService {
         match req {
             // TODO: implement for lightwalletd before using this state in RPC methods
 
-            // get_block
+            // Used by get_block RPC.
             Request::Block(_hash_or_height) => unimplemented!("ReadStateService doesn't Block yet"),
 
-            // get_best_block_hash & get_blockchain_info (#3143)
-            // these methods can use Request::Tip or the ChainTip struct
+            // Used by get_best_block_hash & get_blockchain_info (#3143) RPCs.
+            //
+            // These RPC methods could use the ChainTip struct instead,
+            // if that's easier or more consistent.
             Request::Tip => unimplemented!("ReadStateService doesn't Tip yet"),
 
             // TODO: implement for lightwalletd as part of these tickets
@@ -860,7 +862,8 @@ impl Service<Request> for ReadStateService {
                 unimplemented!("ReadStateService doesn't Transaction yet")
             }
 
-            // TODO: split the Request enum, then implement new ReadRequests for lightwalletd
+            // TODO: split the Request enum, then implement these new ReadRequests for lightwalletd
+            //       as part of these tickets
 
             // z_get_tree_state (#3156)
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -36,16 +36,15 @@ use zebra_chain::{
 };
 
 use crate::{
-    request::HashOrHeight, service::chain_tip::ChainTipBlock, BoxError, CloneError,
-    CommitBlockError, Config, FinalizedBlock, PreparedBlock, Request, Response,
-    ValidateContextError,
-};
-
-use self::{
-    chain_tip::{ChainTipChange, ChainTipSender, LatestChainTip},
-    finalized_state::FinalizedState,
-    non_finalized_state::{NonFinalizedState, QueuedBlocks},
-    pending_utxos::PendingUtxos,
+    request::HashOrHeight,
+    service::{
+        chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip},
+        finalized_state::{DiskDb, FinalizedState},
+        non_finalized_state::{Chain, NonFinalizedState, QueuedBlocks},
+        pending_utxos::PendingUtxos,
+    },
+    BoxError, CloneError, CommitBlockError, Config, FinalizedBlock, PreparedBlock, Request,
+    Response, ValidateContextError,
 };
 
 pub mod block_iter;

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -18,14 +18,9 @@ use std::{
     collections::HashMap,
     io::{stderr, stdout, Write},
     path::Path,
-    sync::Arc,
 };
 
-use zebra_chain::{
-    block::{self, Block},
-    history_tree::HistoryTree,
-    parameters::{Network, GENESIS_PREVIOUS_BLOCK_HASH},
-};
+use zebra_chain::{block, history_tree::HistoryTree, parameters::Network};
 
 use crate::{
     service::{check, QueuedFinalized},
@@ -118,29 +113,19 @@ impl FinalizedState {
         new_state
     }
 
+    /// Returns the configured network for this database.
+    pub fn network(&self) -> Network {
+        self.network
+    }
+
     /// Returns the `Path` where the files used by this database are located.
-    #[allow(dead_code)]
     pub fn path(&self) -> &Path {
         self.db.path()
     }
 
-    /// Returns the hash of the current finalized tip block.
-    pub fn finalized_tip_hash(&self) -> block::Hash {
-        self.tip()
-            .map(|(_, hash)| hash)
-            // if the state is empty, return the genesis previous block hash
-            .unwrap_or(GENESIS_PREVIOUS_BLOCK_HASH)
-    }
-
-    /// Returns the height of the current finalized tip block.
-    pub fn finalized_tip_height(&self) -> Option<block::Height> {
-        self.tip().map(|(height, _)| height)
-    }
-
-    /// Returns the tip block, if there is one.
-    pub fn tip_block(&self) -> Option<Arc<Block>> {
-        let (height, _hash) = self.tip()?;
-        self.block(height.into())
+    /// Returns a reference to the inner database instance.
+    pub(crate) fn db(&self) -> &DiskDb {
+        &self.db
     }
 
     /// Queue a finalized block to be committed to the state.

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -78,6 +78,27 @@ impl FinalizedState {
         self.db.zs_get(block_by_height, &height)
     }
 
+    // Read tip block methods
+
+    /// Returns the hash of the current finalized tip block.
+    pub fn finalized_tip_hash(&self) -> block::Hash {
+        self.tip()
+            .map(|(_, hash)| hash)
+            // if the state is empty, return the genesis previous block hash
+            .unwrap_or(GENESIS_PREVIOUS_BLOCK_HASH)
+    }
+
+    /// Returns the height of the current finalized tip block.
+    pub fn finalized_tip_height(&self) -> Option<block::Height> {
+        self.tip().map(|(height, _)| height)
+    }
+
+    /// Returns the tip block, if there is one.
+    pub fn tip_block(&self) -> Option<Arc<Block>> {
+        let (height, _hash) = self.tip()?;
+        self.block(height.into())
+    }
+
     // Read transaction methods
 
     /// Returns the given transaction if it exists.

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -10,7 +10,7 @@ mod tests;
 
 pub use queued_blocks::QueuedBlocks;
 
-use std::{collections::BTreeSet, mem, ops::Deref, sync::Arc};
+use std::{collections::BTreeSet, mem, sync::Arc};
 
 use zebra_chain::{
     block::{self, Block},
@@ -332,9 +332,11 @@ impl NonFinalizedState {
     }
 
     /// Returns the block at the tip of the best chain.
-    pub fn best_tip_block(&self) -> Option<ContextuallyValidBlock> {
-        let (height, _hash) = self.best_tip()?;
-        self.best_block(height.into())
+    #[allow(dead_code)]
+    pub fn best_tip_block(&self) -> Option<&ContextuallyValidBlock> {
+        let best_chain = self.best_chain()?;
+
+        best_chain.tip_block()
     }
 
     /// Returns the height of `hash` in the best chain.

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -388,12 +388,9 @@ impl NonFinalizedState {
             .unwrap_or(false)
     }
 
-    /// Return the non-finalized portion of the current best chain
-    pub(crate) fn best_chain(&self) -> Option<&Chain> {
-        self.chain_set
-            .iter()
-            .next_back()
-            .map(|box_chain| box_chain.deref())
+    /// Return the non-finalized portion of the current best chain.
+    pub(crate) fn best_chain(&self) -> Option<&Arc<Chain>> {
+        self.chain_set.iter().next_back()
     }
 
     /// Return the chain whose tip block hash is `parent_hash`.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -369,6 +369,12 @@ impl Chain {
         self.blocks.keys().next_back().cloned()
     }
 
+    /// Return the non-finalized tip block for this chain,
+    /// or `None` if `self.blocks` is empty.
+    pub fn tip_block(&self) -> Option<&ContextuallyValidBlock> {
+        self.blocks.values().next_back()
+    }
+
     /// Returns true if the non-finalized part of this chain is empty.
     pub fn is_empty(&self) -> bool {
         self.blocks.is_empty()

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -390,7 +390,7 @@ proptest! {
     ) {
         zebra_test::init();
 
-        let (mut state_service, latest_chain_tip, mut chain_tip_change) = StateService::new(Config::ephemeral(), network);
+        let (mut state_service, _read_only_state_service, latest_chain_tip, mut chain_tip_change) = StateService::new(Config::ephemeral(), network);
 
         prop_assert_eq!(latest_chain_tip.best_tip_height(), None);
         prop_assert_eq!(chain_tip_change.last_tip_change(), None);
@@ -443,7 +443,7 @@ proptest! {
     ) {
         zebra_test::init();
 
-        let (mut state_service, _, _) = StateService::new(Config::ephemeral(), network);
+        let (mut state_service, _, _, _) = StateService::new(Config::ephemeral(), network);
 
         prop_assert_eq!(state_service.disk.finalized_value_pool(), ValueBalance::zero());
         prop_assert_eq!(

--- a/zebra-state/src/tests/setup.rs
+++ b/zebra-state/src/tests/setup.rs
@@ -84,7 +84,7 @@ pub(crate) fn new_state_with_mainnet_genesis() -> (StateService, FinalizedBlock)
         .zcash_deserialize_into::<Arc<Block>>()
         .expect("block should deserialize");
 
-    let (mut state, _, _) = StateService::new(Config::ephemeral(), Mainnet);
+    let (mut state, _, _, _) = StateService::new(Config::ephemeral(), Mainnet);
 
     assert_eq!(None, state.best_tip());
 

--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -69,7 +69,7 @@ async fn check_transcripts(network: Network) -> Result<(), Report> {
         Network::Mainnet => mainnet_transcript,
         Network::Testnet => testnet_transcript,
     } {
-        let (service, _, _) = zebra_state::init(Config::ephemeral(), network);
+        let (service, _, _, _) = zebra_state::init(Config::ephemeral(), network);
         let transcript = Transcript::from(transcript_data.iter().cloned());
         /// SPANDOC: check the on disk service against the transcript
         transcript.check(service).await?;

--- a/zebrad/src/commands/copy_state.rs
+++ b/zebrad/src/commands/copy_state.rs
@@ -111,8 +111,13 @@ impl CopyStateCmd {
         );
 
         let source_start_time = Instant::now();
-        let (mut source_state, _source_latest_chain_tip, _source_chain_tip_change) =
-            old_zs::init(source_config.clone(), network);
+        // TODO: use ReadStateService for the source?
+        let (
+            mut source_state,
+            _source_read_only_state_service,
+            _source_latest_chain_tip,
+            _source_chain_tip_change,
+        ) = old_zs::init(source_config.clone(), network);
 
         let elapsed = source_start_time.elapsed();
         info!(?elapsed, "finished initializing source state service");
@@ -123,8 +128,12 @@ impl CopyStateCmd {
         );
 
         let target_start_time = Instant::now();
-        let (mut target_state, _target_latest_chain_tip, _target_chain_tip_change) =
-            new_zs::init(target_config.clone(), network);
+        let (
+            mut target_state,
+            _target_read_only_state_service,
+            _target_latest_chain_tip,
+            _target_chain_tip_change,
+        ) = new_zs::init(target_config.clone(), network);
 
         let elapsed = target_start_time.elapsed();
         info!(?elapsed, "finished initializing target state service");

--- a/zebrad/src/commands/copy_state.rs
+++ b/zebrad/src/commands/copy_state.rs
@@ -128,6 +128,9 @@ impl CopyStateCmd {
         );
 
         let target_start_time = Instant::now();
+        // TODO: call Options::PrepareForBulkLoad()
+        // See "What's the fastest way to load data into RocksDB?" in
+        // https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ
         let (
             mut target_state,
             _target_read_only_state_service,

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -101,7 +101,7 @@ impl StartCmd {
         info!(?config);
 
         info!("initializing node state");
-        let (state_service, latest_chain_tip, chain_tip_change) =
+        let (state_service, _read_only_state_service, latest_chain_tip, chain_tip_change) =
             zebra_state::init(config.state.clone(), config.network.network);
         let state = ServiceBuilder::new()
             .buffer(Self::state_buffer_bound())

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -53,6 +53,11 @@
 //!  * Transaction Gossip Task
 //!    * runs in the background and gossips newly added mempool transactions
 //!      to peers
+//!
+//! Remote Procedure Calls:
+//!  * JSON-RPC Service
+//!    * answers RPC client requests using the State Service and Mempool Service
+//!    * submits client transactions to the node's mempool
 
 use std::{cmp::max, ops::Add, time::Duration};
 

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -698,7 +698,7 @@ async fn setup(
     let address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Span::none());
     let address_book = Arc::new(std::sync::Mutex::new(address_book));
     let (sync_status, mut recent_syncs) = SyncStatus::new();
-    let (state, latest_chain_tip, chain_tip_change) =
+    let (state, _read_only_state_service, latest_chain_tip, chain_tip_change) =
         zebra_state::init(state_config.clone(), network);
 
     let mut state_service = ServiceBuilder::new().buffer(1).service(state);

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -645,7 +645,7 @@ async fn setup(
 
     // State
     let state_config = StateConfig::ephemeral();
-    let (state_service, latest_chain_tip, chain_tip_change) =
+    let (state_service, _read_only_state_service, latest_chain_tip, chain_tip_change) =
         zebra_state::init(state_config, network);
     let state_service = ServiceBuilder::new().buffer(10).service(state_service);
 

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -704,7 +704,8 @@ async fn setup(
     let peer_set = MockService::build().for_unit_tests();
 
     let state_config = StateConfig::ephemeral();
-    let (state, latest_chain_tip, chain_tip_change) = zebra_state::init(state_config, network);
+    let (state, _read_only_state_service, latest_chain_tip, chain_tip_change) =
+        zebra_state::init(state_config, network);
     let state_service = ServiceBuilder::new().buffer(1).service(state);
 
     let tx_verifier = MockService::build().for_unit_tests();


### PR DESCRIPTION
## Motivation

In #3745, we want to add a read-only, cloneable state service, with no buffer or queue.

### Designs

Share access to the best non-finalized chain and the finalized state.

## Solution

- Create a ReadStateService struct
    - Add a stub service implementation
    - Add support methods in the finalized and non-finalized state
- Make RPC accept a buffered state or a read-only state
- Doc comment updates

## Review

There is a lot of code changed in this PR series, it would be good to get it merged soon to avoid conflicts.

This doesn't do anything yet, the next few PRs will implement the read-only state requests, and add tests.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs

## Follow Up Work

- implement block requests
- use in the RPC implementation
- test performance
- add tests
