### PR TITLE
doc(db): update database design for read-only state service

### DIFF
--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -89,9 +89,11 @@ impl DiskWriteBatch {
             self.zs_delete(history_tree_cf, h);
         }
 
-        // TODO: just store a single history tree, using `()` as the key,
-        //       and remove the delete (like the chain value pool balances).
-        //       This requires a database version update.
+        // TODO: if we ever need concurrent read-only access to the history tree,
+        // store it by `()`, not height.
+        // Otherwise, the ReadStateService could access a height
+        // that was just deleted by a concurrent StateService write.
+        // This requires a database version update.
         if let Some(history_tree) = history_tree.as_ref() {
             self.zs_insert(history_tree_cf, height, history_tree);
         }


### PR DESCRIPTION
## Motivation

The read-only `ReadStateService` needs to correctly handle concurrent writes by the read-write `StateService`.

This needs a few tweaks to the database design.

Most of these changes are optional, because they are not part of the `lightwalletd` MVP.

## Solution

Design Changes:
- add the `AddressLocation` to the UTXO index, so we can delete UTXOs from both the UTXO and address indexes
- remove height keys from sprout tree and history tree column families, to avoid reading deleted heights
- do some minor design updates from PR #3818

Additional Documentation:
- document the issue and the possible resolutions

## Review

@jvff mentioned this issue in the engineering review meeting.

### Reviewer Checklist

  - [x] Design handles issue

