### PR TITLE
1. feat(state): Use ReadStateService for RPCs

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -850,7 +850,7 @@ impl Service<Request> for ReadStateService {
 
                 async move {
                     Ok(read::block(
-                        state.best_chain_receiver.borrow().as_ref(),
+                        state.best_chain_receiver.borrow().clone().as_ref(),
                         &state.db,
                         hash_or_height,
                     ))

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -55,6 +55,7 @@ pub(crate) mod check;
 mod finalized_state;
 mod non_finalized_state;
 mod pending_utxos;
+mod read;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod arbitrary;
@@ -443,13 +444,10 @@ impl StateService {
         Some(tip.0 - height.0)
     }
 
-    /// Return the block identified by either its `height` or `hash` if it exists
-    /// in the current best chain.
+    /// Return the block identified by either its `height` or `hash`,
+    /// if it exists in the current best chain.
     pub fn best_block(&self, hash_or_height: HashOrHeight) -> Option<Arc<Block>> {
-        self.mem
-            .best_block(hash_or_height)
-            .map(|contextual| contextual.block)
-            .or_else(|| self.disk.db().block(hash_or_height))
+        read::block(self.mem.best_chain(), self.disk.db(), hash_or_height)
     }
 
     /// Return the transaction identified by `hash` if it exists in the current

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -17,7 +17,7 @@ use zebra_chain::{
 use crate::{
     request::ContextuallyValidBlock,
     service::{check, finalized_state::ZebraDb},
-    FinalizedBlock, HashOrHeight, PreparedBlock, ValidateContextError,
+    FinalizedBlock, PreparedBlock, ValidateContextError,
 };
 
 mod chain;
@@ -302,15 +302,6 @@ impl NonFinalizedState {
         }
 
         None
-    }
-
-    /// Returns the [`ContextuallyValidBlock`] at a given height or hash in the best chain.
-    pub fn best_block(&self, hash_or_height: HashOrHeight) -> Option<ContextuallyValidBlock> {
-        let best_chain = self.best_chain()?;
-        let height =
-            hash_or_height.height_or_else(|hash| best_chain.height_by_hash.get(&hash).cloned())?;
-
-        best_chain.blocks.get(&height).map(Clone::clone)
     }
 
     /// Returns the hash for a given `block::Height` if it is present in the best chain.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -1,4 +1,5 @@
-//! Chain that is a part of the non-finalized state.
+//! [`Chain`] implements a single non-finalized blockchain,
+//! starting at the finalized tip.
 
 use std::{
     cmp::Ordering,
@@ -23,7 +24,7 @@ use zebra_chain::{
     work::difficulty::PartialCumulativeWork,
 };
 
-use crate::{service::check, ContextuallyValidBlock, ValidateContextError};
+use crate::{service::check, ContextuallyValidBlock, HashOrHeight, ValidateContextError};
 
 #[derive(Debug, Clone)]
 pub struct Chain {
@@ -307,6 +308,14 @@ impl Chain {
         }
 
         Ok(Some(forked))
+    }
+
+    /// Returns the [`ContextuallyValidBlock`] at a given height or hash in this chain.
+    pub fn block(&self, hash_or_height: HashOrHeight) -> Option<&ContextuallyValidBlock> {
+        let height =
+            hash_or_height.height_or_else(|hash| self.height_by_hash.get(&hash).cloned())?;
+
+        self.blocks.get(&height)
     }
 
     /// Returns the block hash of the tip block.

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -1,0 +1,27 @@
+//! Shared state reading code.
+//!
+//! Used by [`StateService`] and [`ReadStateService`]
+//! to read from the best [`Chain`] in the [`NonFinalizedState`],
+//! and the database in the [`FinalizedState`].
+
+use std::sync::Arc;
+
+use zebra_chain::block::Block;
+
+use crate::{
+    service::{finalized_state::ZebraDb, non_finalized_state::Chain},
+    HashOrHeight,
+};
+
+/// Return the block identified by either its `height` or `hash` if it exists
+/// in the non-finalized `chain` or finalized `db`.
+pub(crate) fn block(
+    chain: Option<&Arc<Chain>>,
+    db: &ZebraDb,
+    hash_or_height: HashOrHeight,
+) -> Option<Arc<Block>> {
+    chain
+        .and_then(|chain| chain.block(hash_or_height))
+        .map(|contextual| contextual.block.clone())
+        .or_else(|| db.block(hash_or_height))
+}

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -106,7 +106,7 @@ impl StartCmd {
         info!(?config);
 
         info!("initializing node state");
-        let (state_service, _read_only_state_service, latest_chain_tip, chain_tip_change) =
+        let (state_service, read_only_state_service, latest_chain_tip, chain_tip_change) =
             zebra_state::init(config.state.clone(), config.network.network);
         let state = ServiceBuilder::new()
             .buffer(Self::state_buffer_bound())
@@ -164,7 +164,7 @@ impl StartCmd {
             config.rpc,
             app_version().to_string(),
             mempool.clone(),
-            state.clone(),
+            read_only_state_service,
         );
 
         let setup_data = InboundSetupData {


### PR DESCRIPTION
## Motivation

We want to get blocks from the state without waiting for queued blocks.

### Designs

Share block lookup code between the StateService and ReadStateService.

## Solution

Functionality:
- Use ReadStateService for RPCs
- Implement Request::Block for ReadStateService
- Refactor block lookup code so it can be shared between the StateService and ReadStateService

Deadlocks:
- Add a WatchReceiver wrapper that always clones the borrowed watch data
- Drop the shared Arc<Chain>s as quickly as possible 

Ergonomics:
- Make read::block more flexible, by accepting any AsRef<Chain>

After this PR merges, the `get_best_block_hash` RPC will panic. But `lightwalletd` doesn't do that in our tests, so we have some time to fix it.

Closes #3745.

## Review

This PR is a high priority, because it could cause merge conflicts.

I tested a full lightwalletd sync manually, and it took about 28 minutes. (The same as the read-write StateService.)

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- implement Request::Tip for ReadStateService or replace the state call in `get_best_block_hash` with ChainTip