### PR TITLE
fix(sync): prevent synchronizer loop when very close to tip

### DIFF
--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -346,110 +346,123 @@ where
         (new_syncer, sync_status)
     }
 
+    /// Runs the syncer to synchronize the chain and keep it synchronized.
     #[instrument(skip(self))]
     pub async fn sync(mut self) -> Result<(), Report> {
         // We can't download the genesis block using our normal algorithm,
         // due to protocol limitations
         self.request_genesis().await?;
 
-        // Distinguishes a restart from a start, so we don't sleep when starting
-        // the sync process, but we can keep restart logic in one place.
-        let mut started_once = false;
+        loop {
+            let _ = self.try_to_sync().await;
 
-        'sync: loop {
-            if started_once {
-                info!(
-                    timeout = ?SYNC_RESTART_DELAY,
-                    state_tip = ?self.latest_chain_tip.best_tip_height(),
-                    "waiting to restart sync"
-                );
-                self.prospective_tips = HashSet::new();
-                self.downloads.cancel_all();
-                self.update_metrics();
-                sleep(SYNC_RESTART_DELAY).await;
-            } else {
-                started_once = true;
-            }
+            self.downloads.cancel_all();
+            self.update_metrics();
 
             info!(
+                timeout = ?SYNC_RESTART_DELAY,
                 state_tip = ?self.latest_chain_tip.best_tip_height(),
-                "starting sync, obtaining new tips"
+                "waiting to restart sync"
             );
-            if let Err(e) = self.obtain_tips().await {
-                warn!(?e, "error obtaining tips");
-                continue 'sync;
+            sleep(SYNC_RESTART_DELAY).await;
+        }
+    }
+
+    /// Tries to synchronize the chain as far as it can.
+    ///
+    /// Obtains some prospective tips and iteratively tries to extend them and download the missing
+    /// blocks.
+    ///
+    /// Returns `Ok` if it was able to synchronize as much of the chain as it could, and then ran
+    /// out of prospective tips. This happens when synchronization finishes or if Zebra ended up
+    /// following a fork. Either way, Zebra should attempt to obtain some more tips.
+    ///
+    /// Returns `Err` if there was an unrecoverable error and restarting the synchronization is
+    /// necessary.
+    #[instrument(skip(self))]
+    async fn try_to_sync(&mut self) -> Result<(), ()> {
+        self.prospective_tips = HashSet::new();
+
+        info!(
+            state_tip = ?self.latest_chain_tip.best_tip_height(),
+            "starting sync, obtaining new tips"
+        );
+        if let Err(e) = self.obtain_tips().await {
+            warn!(?e, "error obtaining tips");
+            return Err(());
+        }
+        self.update_metrics();
+
+        while !self.prospective_tips.is_empty() {
+            // Check whether any block tasks are currently ready:
+            while let Poll::Ready(Some(rsp)) = futures::poll!(self.downloads.next()) {
+                match rsp {
+                    Ok(hash) => {
+                        trace!(?hash, "verified and committed block to state");
+                    }
+                    Err(e) => {
+                        if Self::should_restart_sync(e) {
+                            return Err(());
+                        }
+                    }
+                }
             }
             self.update_metrics();
 
-            while !self.prospective_tips.is_empty() {
-                // Check whether any block tasks are currently ready:
-                while let Poll::Ready(Some(rsp)) = futures::poll!(self.downloads.next()) {
-                    match rsp {
-                        Ok(hash) => {
-                            trace!(?hash, "verified and committed block to state");
-                        }
-                        Err(e) => {
-                            if Self::should_restart_sync(e) {
-                                continue 'sync;
-                            }
-                        }
-                    }
-                }
-                self.update_metrics();
-
-                // If we have too many pending tasks, wait for some to finish.
-                //
-                // Starting to wait is interesting, but logging each wait can be
-                // very verbose.
-                if self.downloads.in_flight() > self.lookahead_limit {
-                    tracing::info!(
-                        tips.len = self.prospective_tips.len(),
-                        in_flight = self.downloads.in_flight(),
-                        lookahead_limit = self.lookahead_limit,
-                        "waiting for pending blocks",
-                    );
-                }
-                while self.downloads.in_flight() > self.lookahead_limit {
-                    trace!(
-                        tips.len = self.prospective_tips.len(),
-                        in_flight = self.downloads.in_flight(),
-                        lookahead_limit = self.lookahead_limit,
-                        state_tip = ?self.latest_chain_tip.best_tip_height(),
-                        "waiting for pending blocks",
-                    );
-
-                    match self.downloads.next().await.expect("downloads is nonempty") {
-                        Ok(hash) => {
-                            trace!(?hash, "verified and committed block to state");
-                        }
-
-                        Err(e) => {
-                            if Self::should_restart_sync(e) {
-                                continue 'sync;
-                            }
-                        }
-                    }
-                    self.update_metrics();
-                }
-
-                // Once we're below the lookahead limit, we can keep extending the tips.
-                info!(
+            // If we have too many pending tasks, wait for some to finish.
+            //
+            // Starting to wait is interesting, but logging each wait can be
+            // very verbose.
+            if self.downloads.in_flight() > self.lookahead_limit {
+                tracing::info!(
+                    tips.len = self.prospective_tips.len(),
+                    in_flight = self.downloads.in_flight(),
+                    lookahead_limit = self.lookahead_limit,
+                    "waiting for pending blocks",
+                );
+            }
+            while self.downloads.in_flight() > self.lookahead_limit {
+                trace!(
                     tips.len = self.prospective_tips.len(),
                     in_flight = self.downloads.in_flight(),
                     lookahead_limit = self.lookahead_limit,
                     state_tip = ?self.latest_chain_tip.best_tip_height(),
-                    "extending tips",
+                    "waiting for pending blocks",
                 );
 
-                if let Err(e) = self.extend_tips().await {
-                    warn!(?e, "error extending tips");
-                    continue 'sync;
+                match self.downloads.next().await.expect("downloads is nonempty") {
+                    Ok(hash) => {
+                        trace!(?hash, "verified and committed block to state");
+                    }
+
+                    Err(e) => {
+                        if Self::should_restart_sync(e) {
+                            return Err(());
+                        }
+                    }
                 }
                 self.update_metrics();
             }
 
-            info!("exhausted prospective tip set");
+            // Once we're below the lookahead limit, we can keep extending the tips.
+            info!(
+                tips.len = self.prospective_tips.len(),
+                in_flight = self.downloads.in_flight(),
+                lookahead_limit = self.lookahead_limit,
+                state_tip = ?self.latest_chain_tip.best_tip_height(),
+                "extending tips",
+            );
+
+            if let Err(e) = self.extend_tips().await {
+                warn!(?e, "error extending tips");
+                return Err(());
+            }
+            self.update_metrics();
         }
+
+        info!("exhausted prospective tip set");
+
+        Ok(())
     }
 
     /// Given a block_locator list fan out request for subsequent hashes to

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -354,9 +354,10 @@ where
         self.request_genesis().await?;
 
         loop {
-            let _ = self.try_to_sync().await;
+            if self.try_to_sync().await.is_err() {
+                self.downloads.cancel_all();
+            }
 
-            self.downloads.cancel_all();
             self.update_metrics();
 
             info!(


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
Zebra currently has some performance issues when block synchronization is close to the chain tip. During the investigation of the issue, I ran into two causes:

1. The synchronizer cancels all active block downloads when it exhausts its prospective tips set. This results in the final few block downloads being constantly started and cancelled.
2. Timeouts when waiting for inputs from the state service during the validation of transactions.

This PR fixes the first cause, and the second cause will very likely be fixed by the refactor to split the state service to increase throughput of read only requests (#3866).

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Only cancel active block download tasks in case there's an error, preventing them from being cancelled when the prospective tips set is exhausted.

Closes #3375

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
I'd like to have a regression test for this, but I'll try to open a separate optional PR for it.