### PR TITLE
change(doc): Link to Conventional Commits specification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,14 @@ increase development coordination and makes PRs easier to merge.
 Check out the [help wanted][hw] or [good first issue][gfi] labels if you're
 looking for a place to get started!
 
+Zebra follows the [convential commits][conventional] standard for the commits
+merged to main. Since PRs are squashed before merging to main, the PR titles
+should follow the conventional commits standard so that the merged commits
+are conformant.
+
 [hw]: https://github.com/ZcashFoundation/zebra/labels/E-help-wanted
 [gfi]: https://github.com/ZcashFoundation/zebra/labels/good%20first%20issue
+[conventional]: https://www.conventionalcommits.org/en/v1.0.0/#specification
 
 ## Coverage Reports
 [coverage-reports]: #coverage-reports


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
The Zebra team decided to start using Conventional Commits for commits merged to main. The `CONTRIBUTING` guidelines should link to that specification and describe how to follow it for PRs.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->
Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/#specification

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
