### PR TITLE
feat(rpc): Log unrecognized RPC requests

### DIFF
--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 
 pub mod compatibility;
+mod tracing_middleware;
 
 /// Zebra RPC Server
 #[derive(Clone, Debug)]

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -7,7 +7,7 @@
 //! See the full list of
 //! [Differences between JSON-RPC 1.0 and 2.0.](https://www.simple-is-better.org/rpc/#differences-between-1-0-and-2-0)
 
-use jsonrpc_core;
+use jsonrpc_core::{Compatibility, MetaIoHandler};
 use jsonrpc_http_server::ServerBuilder;
 use tower::{buffer::Buffer, Service};
 use tracing::*;
@@ -18,7 +18,7 @@ use zebra_node_services::{mempool, BoxError};
 use crate::{
     config::Config,
     methods::{Rpc, RpcImpl},
-    server::compatibility::FixHttpRequestMiddleware,
+    server::{compatibility::FixHttpRequestMiddleware, tracing_middleware::TracingMiddleware},
 };
 
 pub mod compatibility;
@@ -57,8 +57,8 @@ impl RpcServer {
             let rpc_impl = RpcImpl::new(app_version, mempool, state);
 
             // Create handler compatible with V1 and V2 RPC protocols
-            let mut io =
-                jsonrpc_core::IoHandler::with_compatibility(jsonrpc_core::Compatibility::Both);
+            let mut io: MetaIoHandler<(), _> =
+                MetaIoHandler::new(Compatibility::Both, TracingMiddleware);
             io.extend_with(rpc_impl.to_delegate());
 
             let server = ServerBuilder::new(io)

--- a/zebra-rpc/src/server/tracing_middleware.rs
+++ b/zebra-rpc/src/server/tracing_middleware.rs
@@ -66,7 +66,7 @@ impl TracingMiddleware {
             ..
         })) = output
         {
-            tracing::error!("Received unrecognized RPC request: {call_description}");
+            tracing::warn!("Received unrecognized RPC request: {call_description}");
         }
 
         output

--- a/zebra-rpc/src/server/tracing_middleware.rs
+++ b/zebra-rpc/src/server/tracing_middleware.rs
@@ -1,0 +1,74 @@
+//! A custom middleware to trace unrecognized RPC requests.
+
+use std::future::Future;
+
+use futures::future::{Either, FutureExt};
+use jsonrpc_core::{
+    middleware::Middleware,
+    types::{Call, Failure, Output, Response},
+    BoxFuture, Error, ErrorCode, Metadata, MethodCall, Notification,
+};
+
+/// A custom RPC middleware that logs unrecognized RPC requests.
+pub struct TracingMiddleware;
+
+impl<M: Metadata> Middleware<M> for TracingMiddleware {
+    type Future = BoxFuture<Option<Response>>;
+    type CallFuture = BoxFuture<Option<Output>>;
+
+    fn on_call<Next, NextFuture>(
+        &self,
+        call: Call,
+        meta: M,
+        next: Next,
+    ) -> Either<Self::CallFuture, NextFuture>
+    where
+        Next: Fn(Call, M) -> NextFuture + Send + Sync,
+        NextFuture: Future<Output = Option<Output>> + Send + 'static,
+    {
+        let call_description = self.call_description(&call);
+
+        Either::Left(
+            next(call, meta)
+                .then(move |output| Self::log_error_if_method_not_found(output, call_description))
+                .boxed(),
+        )
+    }
+}
+
+impl TracingMiddleware {
+    /// Obtain a description string for a received request.
+    ///
+    /// Prints out only the method name and the received parameters.
+    fn call_description(&self, call: &Call) -> String {
+        match call {
+            Call::MethodCall(MethodCall { method, params, .. }) => {
+                format!(r#"method = {method:?}, params = {params:?}"#)
+            }
+            Call::Notification(Notification { method, params, .. }) => {
+                format!(r#"notification = {method:?}, params = {params:?}"#)
+            }
+            Call::Invalid { .. } => "invalid request".to_owned(),
+        }
+    }
+
+    /// Check an RPC output and log an error if it indicates the method was not found.
+    async fn log_error_if_method_not_found(
+        output: Option<Output>,
+        call_description: String,
+    ) -> Option<Output> {
+        if let Some(Output::Failure(Failure {
+            error:
+                Error {
+                    code: ErrorCode::MethodNotFound,
+                    ..
+                },
+            ..
+        })) = output
+        {
+            tracing::error!("Received unrecognized RPC request: {call_description}");
+        }
+
+        output
+    }
+}

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -342,7 +342,11 @@ impl Application for ZebradApp {
             .as_ref()
             .expect("config is loaded before register_components");
 
-        let default_filter = if command.verbose { "debug" } else { "info" };
+        let default_filter = if command.verbose {
+            "debug,rpc=trace"
+        } else {
+            "info,rpc=trace"
+        };
         let is_server = command
             .command
             .as_ref()

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -342,11 +342,7 @@ impl Application for ZebradApp {
             .as_ref()
             .expect("config is loaded before register_components");
 
-        let default_filter = if command.verbose {
-            "debug,rpc=trace"
-        } else {
-            "info,rpc=trace"
-        };
+        let default_filter = if command.verbose { "debug" } else { "info" };
         let is_server = command
             .command
             .as_ref()


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
While preparing Zebra to support being a backend for lightwalletd, we should ensure we're not missing any RPCs sent by lightwalletd. One thing that can help is to trace the received RPCs and log errors if unrecognized RPC requests are received.

Closes #3855.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
- Enable tracing of received RPC requests by default, by making the default `tracing` filter allow `trace` level output from `jsonrpc-core`
- Create a custom middleware for the RPC server that prints error messages if an unrecognized RPC request is received

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
