### PR TITLE
2a. refactor(rpc): Add the ChainTip and Network to RpcImpl

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -126,9 +126,11 @@ where
     state: State,
 
     /// Allows efficient access to the best tip of the blockchain.
+    #[allow(dead_code)]
     latest_chain_tip: Tip,
 
     /// The configured network for this RPC service.
+    #[allow(dead_code)]
     network: Network,
 }
 

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -143,15 +143,18 @@ where
     Tip: ChainTip + Send + Sync,
 {
     /// Create a new instance of the RPC handler.
-    pub fn new(
-        app_version: String,
+    pub fn new<Version>(
+        app_version: Version,
         mempool: Buffer<Mempool, mempool::Request>,
         state: State,
         latest_chain_tip: Tip,
         network: Network,
-    ) -> Self {
+    ) -> Self
+    where
+        Version: ToString,
+    {
         RpcImpl {
-            app_version,
+            app_version: app_version.to_string(),
             mempool,
             state,
             latest_chain_tip,

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -14,6 +14,8 @@ use tower::{buffer::Buffer, Service, ServiceExt};
 
 use zebra_chain::{
     block::{self, SerializedBlock},
+    chain_tip::ChainTip,
+    parameters::Network,
     serialization::{SerializationError, ZcashDeserialize},
     transaction::{self, Transaction},
 };
@@ -104,7 +106,7 @@ pub trait Rpc {
 }
 
 /// RPC method implementations.
-pub struct RpcImpl<Mempool, State>
+pub struct RpcImpl<Mempool, State, Tip>
 where
     Mempool: Service<mempool::Request, Response = mempool::Response, Error = BoxError>,
     State: Service<
@@ -112,16 +114,25 @@ where
         Response = zebra_state::Response,
         Error = zebra_state::BoxError,
     >,
+    Tip: ChainTip,
 {
     /// Zebra's application version.
     app_version: String,
+
     /// A handle to the mempool service.
     mempool: Buffer<Mempool, mempool::Request>,
+
     /// A handle to the state service.
     state: State,
+
+    /// Allows efficient access to the best tip of the blockchain.
+    latest_chain_tip: Tip,
+
+    /// The configured network for this RPC service.
+    network: Network,
 }
 
-impl<Mempool, State> RpcImpl<Mempool, State>
+impl<Mempool, State, Tip> RpcImpl<Mempool, State, Tip>
 where
     Mempool: Service<mempool::Request, Response = mempool::Response, Error = BoxError>,
     State: Service<
@@ -129,22 +140,27 @@ where
         Response = zebra_state::Response,
         Error = zebra_state::BoxError,
     >,
+    Tip: ChainTip + Send + Sync,
 {
     /// Create a new instance of the RPC handler.
     pub fn new(
         app_version: String,
         mempool: Buffer<Mempool, mempool::Request>,
         state: State,
+        latest_chain_tip: Tip,
+        network: Network,
     ) -> Self {
         RpcImpl {
             app_version,
             mempool,
             state,
+            latest_chain_tip,
+            network,
         }
     }
 }
 
-impl<Mempool, State> Rpc for RpcImpl<Mempool, State>
+impl<Mempool, State, Tip> Rpc for RpcImpl<Mempool, State, Tip>
 where
     Mempool:
         tower::Service<mempool::Request, Response = mempool::Response, Error = BoxError> + 'static,
@@ -158,6 +174,7 @@ where
         + Sync
         + 'static,
     State::Future: Send,
+    Tip: ChainTip + Send + Sync + 'static,
 {
     fn get_info(&self) -> Result<GetInfo> {
         let response = GetInfo {
@@ -170,6 +187,8 @@ where
 
     fn get_blockchain_info(&self) -> Result<GetBlockChainInfo> {
         // TODO: dummy output data, fix in the context of #3143
+        //       use self.latest_chain_tip.estimate_network_chain_tip_height()
+        //       to estimate the current block height on the network
         let response = GetBlockChainInfo {
             chain: "TODO: main".to_string(),
         };

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -1,3 +1,5 @@
+//! Randomised property tests for RPC methods.
+
 use std::collections::HashSet;
 
 use hex::ToHex;
@@ -7,6 +9,8 @@ use thiserror::Error;
 use tower::buffer::Buffer;
 
 use zebra_chain::{
+    chain_tip::NoChainTip,
+    parameters::Network::*,
     serialization::{ZcashDeserialize, ZcashSerialize},
     transaction::{Transaction, UnminedTx, UnminedTxId},
 };
@@ -30,6 +34,8 @@ proptest! {
                 "RPC test".to_owned(),
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
+                NoChainTip,
+                Mainnet,
             );
             let hash = SentTransactionHash(transaction.hash());
 
@@ -76,6 +82,8 @@ proptest! {
                 "RPC test".to_owned(),
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
+                NoChainTip,
+                Mainnet,
             );
 
             let transaction_bytes = transaction
@@ -127,6 +135,8 @@ proptest! {
                 "RPC test".to_owned(),
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
+                NoChainTip,
+                Mainnet,
             );
 
             let transaction_bytes = transaction
@@ -186,6 +196,8 @@ proptest! {
                 "RPC test".to_owned(),
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
+                NoChainTip,
+                Mainnet,
             );
 
             let send_task = tokio::spawn(rpc.send_raw_transaction(non_hex_string));
@@ -234,6 +246,8 @@ proptest! {
                 "RPC test".to_owned(),
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
+                NoChainTip,
+                Mainnet,
             );
 
             let send_task = tokio::spawn(rpc.send_raw_transaction(hex::encode(random_bytes)));
@@ -281,6 +295,8 @@ proptest! {
                 "RPC test".to_owned(),
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
+                NoChainTip,
+                Mainnet,
             );
 
             let call_task = tokio::spawn(rpc.get_raw_mempool());

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -31,7 +31,7 @@ proptest! {
             let mut mempool = MockService::build().for_prop_tests();
             let mut state: MockService<_, _, _, BoxError> = MockService::build().for_prop_tests();
             let rpc = RpcImpl::new(
-                "RPC test".to_owned(),
+                "RPC test",
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
@@ -79,7 +79,7 @@ proptest! {
             let mut state: MockService<_, _, _, BoxError> = MockService::build().for_prop_tests();
 
             let rpc = RpcImpl::new(
-                "RPC test".to_owned(),
+                "RPC test",
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
@@ -132,7 +132,7 @@ proptest! {
             let mut state: MockService<_, _, _, BoxError> = MockService::build().for_prop_tests();
 
             let rpc = RpcImpl::new(
-                "RPC test".to_owned(),
+                "RPC test",
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
@@ -193,7 +193,7 @@ proptest! {
             let mut state: MockService<_, _, _, BoxError> = MockService::build().for_prop_tests();
 
             let rpc = RpcImpl::new(
-                "RPC test".to_owned(),
+                "RPC test",
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
@@ -243,7 +243,7 @@ proptest! {
             let mut state: MockService<_, _, _, BoxError> = MockService::build().for_prop_tests();
 
             let rpc = RpcImpl::new(
-                "RPC test".to_owned(),
+                "RPC test",
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
@@ -292,7 +292,7 @@ proptest! {
             let mut state: MockService<_, _, _, BoxError> = MockService::build().for_prop_tests();
 
             let rpc = RpcImpl::new(
-                "RPC test".to_owned(),
+                "RPC test",
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -4,7 +4,12 @@ use std::sync::Arc;
 
 use tower::buffer::Buffer;
 
-use zebra_chain::{block::Block, parameters::Network, serialization::ZcashDeserializeInto};
+use zebra_chain::{
+    block::Block,
+    chain_tip::NoChainTip,
+    parameters::Network::{self, *},
+    serialization::ZcashDeserializeInto,
+};
 use zebra_network::constants::USER_AGENT;
 use zebra_node_services::BoxError;
 
@@ -23,16 +28,18 @@ async fn rpc_getinfo() {
     let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
     let rpc = RpcImpl::new(
-        "Zebra version test".to_string(),
+        "RPC test".to_string(),
         Buffer::new(mempool.clone(), 1),
         Buffer::new(state.clone(), 1),
+        NoChainTip,
+        Mainnet,
     );
 
     let get_info = rpc.get_info().expect("We should have a GetInfo struct");
 
     // make sure there is a `build` field in the response,
     // and that is equal to the provided string.
-    assert_eq!(get_info.build, "Zebra version test");
+    assert_eq!(get_info.build, "RPC test");
 
     // make sure there is a `subversion` field,
     // and that is equal to the Zebra user agent.
@@ -57,11 +64,13 @@ async fn rpc_getblock() {
     let state = zebra_state::populated_state(blocks.clone(), Network::Mainnet).await;
 
     // Init RPC
-    let rpc = RpcImpl {
-        app_version: "Zebra version test".to_string(),
-        mempool: Buffer::new(mempool.clone(), 1),
+    let rpc = RpcImpl::new(
+        "RPC test".to_string(),
+        Buffer::new(mempool.clone(), 1),
         state,
-    };
+        NoChainTip,
+        Mainnet,
+    );
 
     // Make calls and check response
     for (i, block) in blocks.into_iter().enumerate() {
@@ -84,11 +93,13 @@ async fn rpc_getblock_error() {
     let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
     // Init RPC
-    let rpc = RpcImpl {
-        app_version: "Zebra version test".to_string(),
-        mempool: Buffer::new(mempool.clone(), 1),
-        state: Buffer::new(state.clone(), 1),
-    };
+    let rpc = RpcImpl::new(
+        "RPC test".to_string(),
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        NoChainTip,
+        Mainnet,
+    );
 
     // Make sure we get an error if Zebra can't parse the block height.
     assert!(rpc
@@ -123,11 +134,13 @@ async fn rpc_getbestblockhash() {
     let state = zebra_state::populated_state(blocks.clone(), Network::Mainnet).await;
 
     // Init RPC
-    let rpc = RpcImpl {
-        app_version: "Zebra version test".to_string(),
-        mempool: Buffer::new(mempool.clone(), 1),
+    let rpc = RpcImpl::new(
+        "RPC test".to_string(),
+        Buffer::new(mempool.clone(), 1),
         state,
-    };
+        NoChainTip,
+        Mainnet,
+    );
 
     // Get the tip hash using RPC method `get_best_block_hash`
     let get_best_block_hash = rpc

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -28,7 +28,7 @@ async fn rpc_getinfo() {
     let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
     let rpc = RpcImpl::new(
-        "RPC test".to_string(),
+        "RPC test",
         Buffer::new(mempool.clone(), 1),
         Buffer::new(state.clone(), 1),
         NoChainTip,
@@ -65,7 +65,7 @@ async fn rpc_getblock() {
 
     // Init RPC
     let rpc = RpcImpl::new(
-        "RPC test".to_string(),
+        "RPC test",
         Buffer::new(mempool.clone(), 1),
         state,
         NoChainTip,
@@ -94,7 +94,7 @@ async fn rpc_getblock_error() {
 
     // Init RPC
     let rpc = RpcImpl::new(
-        "RPC test".to_string(),
+        "RPC test",
         Buffer::new(mempool.clone(), 1),
         Buffer::new(state.clone(), 1),
         NoChainTip,
@@ -135,7 +135,7 @@ async fn rpc_getbestblockhash() {
 
     // Init RPC
     let rpc = RpcImpl::new(
-        "RPC test".to_string(),
+        "RPC test",
         Buffer::new(mempool.clone(), 1),
         state,
         NoChainTip,

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -30,15 +30,16 @@ pub struct RpcServer;
 
 impl RpcServer {
     /// Start a new RPC server endpoint
-    pub fn spawn<Mempool, State, Tip>(
+    pub fn spawn<Version, Mempool, State, Tip>(
         config: Config,
-        app_version: String,
+        app_version: Version,
         mempool: Buffer<Mempool, mempool::Request>,
         state: State,
         latest_chain_tip: Tip,
         network: Network,
     ) -> tokio::task::JoinHandle<()>
     where
+        Version: ToString,
         Mempool: tower::Service<mempool::Request, Response = mempool::Response, Error = BoxError>
             + 'static,
         Mempool::Future: Send,

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -162,7 +162,7 @@ impl StartCmd {
         // Launch RPC server
         let rpc_task_handle = RpcServer::spawn(
             config.rpc,
-            app_version().to_string(),
+            app_version(),
             mempool.clone(),
             read_only_state_service,
             latest_chain_tip.clone(),

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -165,6 +165,8 @@ impl StartCmd {
             app_version().to_string(),
             mempool.clone(),
             read_only_state_service,
+            latest_chain_tip.clone(),
+            config.network.network,
         );
 
         let setup_data = InboundSetupData {


### PR DESCRIPTION
## Motivation

We need to estimate the chain height for these RPCs:
- #3143

This PR adds the fields, but doesn't implement the RPC.

## Solution

- Add the ChainTip and Network to RpcImpl
- Simplify RPC version field using generics

## Review

This PR could cause merge conflicts, so I'm marking it as a high priority.

It is based on PR #3847.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Implement #3143.
