### PR TITLE
3a. refactor(rpc): use ChainTip for get_best_block_hash

### DIFF
--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -5,9 +5,7 @@ use std::sync::Arc;
 use tower::buffer::Buffer;
 
 use zebra_chain::{
-    block::Block,
-    chain_tip::NoChainTip,
-    parameters::Network::{self, *},
+    block::Block, chain_tip::NoChainTip, parameters::Network::*,
     serialization::ZcashDeserializeInto,
 };
 use zebra_network::constants::USER_AGENT;
@@ -61,14 +59,15 @@ async fn rpc_getblock() {
 
     let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
     // Create a populated state service
-    let state = zebra_state::populated_state(blocks.clone(), Network::Mainnet).await;
+    let (_state, read_state, latest_chain_tip, _chain_tip_change) =
+        zebra_state::populated_state(blocks.clone(), Mainnet).await;
 
     // Init RPC
     let rpc = RpcImpl::new(
         "RPC test",
         Buffer::new(mempool.clone(), 1),
-        state,
-        NoChainTip,
+        read_state,
+        latest_chain_tip,
         Mainnet,
     );
 
@@ -131,21 +130,21 @@ async fn rpc_getbestblockhash() {
     // Get a mempool handle
     let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
     // Create a populated state service, the tip will be in `NUMBER_OF_BLOCKS`.
-    let state = zebra_state::populated_state(blocks.clone(), Network::Mainnet).await;
+    let (_state, read_state, latest_chain_tip, _chain_tip_change) =
+        zebra_state::populated_state(blocks.clone(), Mainnet).await;
 
     // Init RPC
     let rpc = RpcImpl::new(
         "RPC test",
         Buffer::new(mempool.clone(), 1),
-        state,
-        NoChainTip,
+        read_state,
+        latest_chain_tip,
         Mainnet,
     );
 
     // Get the tip hash using RPC method `get_best_block_hash`
     let get_best_block_hash = rpc
         .get_best_block_hash()
-        .await
         .expect("We should have a GetBestBlockHash struct");
     let response_hash = get_best_block_hash.0;
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -859,12 +859,6 @@ impl Service<Request> for ReadStateService {
                 .boxed()
             }
 
-            // Used by get_best_block_hash & get_blockchain_info (#3143) RPCs.
-            //
-            // These RPC methods could use the ChainTip struct instead,
-            // if that's easier or more consistent.
-            Request::Tip => unimplemented!("ReadStateService doesn't Tip yet"),
-
             // TODO: implement for lightwalletd as part of these tickets
 
             // get_raw_transaction (#3145)
@@ -884,6 +878,9 @@ impl Service<Request> for ReadStateService {
 
             // Out of Scope
             // TODO: delete when splitting the Request enum
+
+            // Use ChainTip instead.
+            Request::Tip => unreachable!("ReadStateService doesn't need to Tip"),
 
             // These requests don't need better performance at the moment.
             Request::FindBlockHashes {

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -196,7 +196,7 @@ async fn test_populated_state_responds_correctly(
 
 #[tokio::main]
 async fn populate_and_check(blocks: Vec<Arc<Block>>) -> Result<()> {
-    let state = populated_state(blocks, Network::Mainnet).await;
+    let (state, _, _, _) = populated_state(blocks, Network::Mainnet).await;
     test_populated_state_responds_correctly(state).await?;
     Ok(())
 }


### PR DESCRIPTION
## Motivation

This makes the results of get_best_block_hash and get_blockchain_info consistent.

It also simplifies the code, and improves performance.

## Solution

- Use ChainTip for get_best_block_hash RPC
- Use ReadStateService and LatestChainTip in tests

## Review

This PR changes how the RPC tests work, so it could cause merge conflicts or test failures. So I've marked it as a high priority.

It is based on PR #3863.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Implement the related RPC:
- #3143
