### PR TITLE
5. change(state): split ReadStateService requests into a ReadRequest enum

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -110,8 +110,8 @@ pub struct RpcImpl<Mempool, State, Tip>
 where
     Mempool: Service<mempool::Request, Response = mempool::Response, Error = BoxError>,
     State: Service<
-        zebra_state::Request,
-        Response = zebra_state::Response,
+        zebra_state::ReadRequest,
+        Response = zebra_state::ReadResponse,
         Error = zebra_state::BoxError,
     >,
     Tip: ChainTip,
@@ -137,8 +137,8 @@ impl<Mempool, State, Tip> RpcImpl<Mempool, State, Tip>
 where
     Mempool: Service<mempool::Request, Response = mempool::Response, Error = BoxError>,
     State: Service<
-        zebra_state::Request,
-        Response = zebra_state::Response,
+        zebra_state::ReadRequest,
+        Response = zebra_state::ReadResponse,
         Error = zebra_state::BoxError,
     >,
     Tip: ChainTip + Send + Sync,
@@ -170,8 +170,8 @@ where
         tower::Service<mempool::Request, Response = mempool::Response, Error = BoxError> + 'static,
     Mempool::Future: Send,
     State: Service<
-            zebra_state::Request,
-            Response = zebra_state::Response,
+            zebra_state::ReadRequest,
+            Response = zebra_state::ReadResponse,
             Error = zebra_state::BoxError,
         > + Clone
         + Send
@@ -257,7 +257,8 @@ where
                 data: None,
             })?;
 
-            let request = zebra_state::Request::Block(zebra_state::HashOrHeight::Height(height));
+            let request =
+                zebra_state::ReadRequest::Block(zebra_state::HashOrHeight::Height(height));
             let response = state
                 .ready()
                 .and_then(|service| service.call(request))
@@ -269,8 +270,8 @@ where
                 })?;
 
             match response {
-                zebra_state::Response::Block(Some(block)) => Ok(GetBlock(block.into())),
-                zebra_state::Response::Block(None) => Err(Error {
+                zebra_state::ReadResponse::Block(Some(block)) => Ok(GetBlock(block.into())),
+                zebra_state::ReadResponse::Block(None) => Err(Error {
                     code: ErrorCode::ServerError(0),
                     message: "Block not found".to_string(),
                     data: None,

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -15,9 +15,6 @@ use zebra_test::mock_service::MockService;
 
 use super::super::*;
 
-// Number of blocks to populate state with
-const NUMBER_OF_BLOCKS: u32 = 10;
-
 #[tokio::test]
 async fn rpc_getinfo() {
     zebra_test::init();
@@ -51,10 +48,10 @@ async fn rpc_getinfo() {
 async fn rpc_getblock() {
     zebra_test::init();
 
-    // Put the first `NUMBER_OF_BLOCKS` blocks in a vector
-    let blocks: Vec<Arc<Block>> = zebra_test::vectors::MAINNET_BLOCKS
-        .range(0..=NUMBER_OF_BLOCKS)
-        .map(|(_, block_bytes)| block_bytes.zcash_deserialize_into::<Arc<Block>>().unwrap())
+    // Create a continuous chain of mainnet blocks from genesis
+    let blocks: Vec<Arc<Block>> = zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS
+        .iter()
+        .map(|(_height, block_bytes)| block_bytes.zcash_deserialize_into().unwrap())
         .collect();
 
     let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
@@ -114,17 +111,15 @@ async fn rpc_getblock_error() {
 async fn rpc_getbestblockhash() {
     zebra_test::init();
 
-    // Put `NUMBER_OF_BLOCKS` blocks in a vector
-    let blocks: Vec<Arc<Block>> = zebra_test::vectors::MAINNET_BLOCKS
-        .range(0..=NUMBER_OF_BLOCKS)
-        .map(|(_, block_bytes)| block_bytes.zcash_deserialize_into::<Arc<Block>>().unwrap())
+    // Create a continuous chain of mainnet blocks from genesis
+    let blocks: Vec<Arc<Block>> = zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS
+        .iter()
+        .map(|(_height, block_bytes)| block_bytes.zcash_deserialize_into().unwrap())
         .collect();
 
     // Get the hash of the block at the tip using hardcoded block tip bytes.
     // We want to test the RPC response is equal to this hash
-    let tip_block: Block = zebra_test::vectors::BLOCK_MAINNET_10_BYTES
-        .zcash_deserialize_into()
-        .unwrap();
+    let tip_block = blocks.last().unwrap();
     let tip_block_hash = tip_block.hash();
 
     // Get a mempool handle

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -44,8 +44,8 @@ impl RpcServer {
             + 'static,
         Mempool::Future: Send,
         State: Service<
-                zebra_state::Request,
-                Response = zebra_state::Response,
+                zebra_state::ReadRequest,
+                Response = zebra_state::ReadResponse,
                 Error = zebra_state::BoxError,
             > + Clone
             + Send

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -31,8 +31,8 @@ mod tests;
 pub use config::Config;
 pub use constants::MAX_BLOCK_REORG_HEIGHT;
 pub use error::{BoxError, CloneError, CommitBlockError, ValidateContextError};
-pub use request::{FinalizedBlock, HashOrHeight, PreparedBlock, Request};
-pub use response::Response;
+pub use request::{FinalizedBlock, HashOrHeight, PreparedBlock, ReadRequest, Request};
+pub use response::{ReadResponse, Response};
 pub use service::{
     chain_tip::{ChainTipChange, LatestChainTip, TipAction},
     init,

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -42,7 +42,7 @@ pub use service::{
 pub use service::{
     arbitrary::populated_state,
     chain_tip::{ChainTipBlock, ChainTipSender},
-    init_test,
+    init_test, init_test_services,
 };
 
 pub(crate) use request::ContextuallyValidBlock;

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1,3 +1,5 @@
+//! State [`tower::Service`] request types.
+
 use std::{collections::HashMap, sync::Arc};
 
 use zebra_chain::{
@@ -229,7 +231,7 @@ impl From<ContextuallyValidBlock> for FinalizedBlock {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-/// A query about or modification to the chain state.
+/// A query about or modification to the chain state, via the [`StateService`].
 pub enum Request {
     /// Performs contextual validation of the given block, committing it to the
     /// state if successful.
@@ -376,4 +378,27 @@ pub enum Request {
         /// Optionally, the hash of the last header to request.
         stop: Option<block::Hash>,
     },
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+/// A read-only query about the chain state, via the [`ReadStateService`].
+pub enum ReadRequest {
+    /// Looks up a block by hash or height in the current best chain.
+    ///
+    /// Returns
+    ///
+    /// * [`Response::Block(Some(Arc<Block>))`](Response::Block) if the block is in the best chain;
+    /// * [`Response::Block(None)`](Response::Block) otherwise.
+    ///
+    /// Note: the [`HashOrHeight`] can be constructed from a [`block::Hash`] or
+    /// [`block::Height`] using `.into()`.
+    Block(HashOrHeight),
+
+    /// Looks up a transaction by hash in the current best chain.
+    ///
+    /// Returns
+    ///
+    /// * [`Response::Transaction(Some(Arc<Transaction>))`](Response::Transaction) if the transaction is in the best chain;
+    /// * [`Response::Transaction(None)`](Response::Transaction) otherwise.
+    Transaction(transaction::Hash),
 }

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -1,4 +1,7 @@
+//! State [`tower::Service`] response types.
+
 use std::sync::Arc;
+
 use zebra_chain::{
     block::{self, Block},
     transaction::Transaction,
@@ -11,7 +14,7 @@ use zebra_chain::{
 use crate::Request;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-/// A response to a state [`Request`].
+/// A response to a [`StateService`] [`Request`].
 pub enum Response {
     /// Response to [`Request::CommitBlock`] indicating that a block was
     /// successfully committed to the state.
@@ -40,4 +43,14 @@ pub enum Response {
 
     /// The response to a `FindBlockHeaders` request.
     BlockHeaders(Vec<block::CountedHeader>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// A response to a read-only [`ReadStateService`] [`ReadRequest`].
+pub enum ReadResponse {
+    /// Response to [`ReadRequest::Block`] with the specified block.
+    Block(Option<Arc<Block>>),
+
+    /// Response to [`ReadRequest::Transaction`] with the specified transaction.
+    Transaction(Option<Arc<Transaction>>),
 }

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -16,6 +16,9 @@ use crate::{
     HashOrHeight,
 };
 
+#[cfg(test)]
+mod tests;
+
 /// Returns the [`Block`] with [`block::Hash`](zebra_chain::block::Hash) or
 /// [`Height`](zebra_chain::block::Height),
 /// if it exists in the non-finalized `chain` or finalized `db`.

--- a/zebra-state/src/service/read/tests.rs
+++ b/zebra-state/src/service/read/tests.rs
@@ -1,0 +1,3 @@
+//! Tests for the ReadStateService.
+
+mod vectors;

--- a/zebra-state/src/service/read/tests/vectors.rs
+++ b/zebra-state/src/service/read/tests/vectors.rs
@@ -1,0 +1,102 @@
+//! Fixed test vectors for the ReadStateService.
+
+use std::sync::Arc;
+
+use zebra_chain::{
+    block::Block, parameters::Network::*, serialization::ZcashDeserializeInto, transaction,
+};
+
+use zebra_test::{
+    prelude::Result,
+    transcript::{ExpectedTranscriptError, Transcript},
+};
+
+use crate::{init_test_services, populated_state, ReadRequest, ReadResponse};
+
+/// Test that ReadStateService responds correctly when empty.
+#[tokio::test]
+async fn empty_read_state_still_responds_to_requests() -> Result<()> {
+    zebra_test::init();
+
+    let transcript = Transcript::from(empty_state_test_cases());
+
+    let network = Mainnet;
+    let (_state, read_state, _latest_chain_tip, _chain_tip_change) = init_test_services(network);
+
+    transcript.check(read_state).await?;
+
+    Ok(())
+}
+
+/// Test that ReadStateService responds correctly when the state contains blocks.
+#[tokio::test]
+async fn populated_read_state_responds_correctly() -> Result<()> {
+    zebra_test::init();
+
+    // Create a continuous chain of mainnet blocks from genesis
+    let blocks: Vec<Arc<Block>> = zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS
+        .iter()
+        .map(|(_height, block_bytes)| block_bytes.zcash_deserialize_into().unwrap())
+        .collect();
+
+    let (_state, read_state, _latest_chain_tip, _chain_tip_change) =
+        populated_state(blocks.clone(), Mainnet).await;
+
+    let empty_cases = Transcript::from(empty_state_test_cases());
+    empty_cases.check(read_state.clone()).await?;
+
+    for block in blocks {
+        let block_cases = vec![
+            (
+                ReadRequest::Block(block.hash().into()),
+                Ok(ReadResponse::Block(Some(block.clone()))),
+            ),
+            (
+                ReadRequest::Block(block.coinbase_height().unwrap().into()),
+                Ok(ReadResponse::Block(Some(block.clone()))),
+            ),
+        ];
+
+        let block_cases = Transcript::from(block_cases);
+        block_cases.check(read_state.clone()).await?;
+
+        // Spec: transactions in the genesis block are ignored.
+        if block.coinbase_height().unwrap().0 == 0 {
+            continue;
+        }
+
+        for transaction in &block.transactions {
+            let transaction_cases = vec![(
+                ReadRequest::Transaction(transaction.hash()),
+                Ok(ReadResponse::Transaction(Some(transaction.clone()))),
+            )];
+
+            let transaction_cases = Transcript::from(transaction_cases);
+            transaction_cases.check(read_state.clone()).await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns test cases for the empty state and missing blocks.
+fn empty_state_test_cases() -> Vec<(ReadRequest, Result<ReadResponse, ExpectedTranscriptError>)> {
+    let block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_419200_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+
+    vec![
+        (
+            ReadRequest::Transaction(transaction::Hash([0; 32])),
+            Ok(ReadResponse::Transaction(None)),
+        ),
+        (
+            ReadRequest::Block(block.hash().into()),
+            Ok(ReadResponse::Block(None)),
+        ),
+        (
+            ReadRequest::Block(block.coinbase_height().unwrap().into()),
+            Ok(ReadResponse::Block(None)),
+        ),
+    ]
+}

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -1,3 +1,7 @@
+//! StateService test vectors.
+//!
+//! TODO: move these tests into tests::vectors and tests::prop modules.
+
 use std::{convert::TryInto, env, sync::Arc};
 
 use tower::{buffer::Buffer, util::BoxService};
@@ -11,6 +15,7 @@ use zebra_chain::{
     transaction, transparent,
     value_balance::ValueBalance,
 };
+
 use zebra_test::{prelude::*, transcript::Transcript};
 
 use crate::{

--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -1,6 +1,10 @@
+//! Basic integration tests for zebra-state
+
+use std::sync::Arc;
+
 use color_eyre::eyre::Report;
 use once_cell::sync::Lazy;
-use std::sync::Arc;
+
 use zebra_chain::{block::Block, parameters::Network, serialization::ZcashDeserialize};
 use zebra_test::transcript::{ExpectedTranscriptError, Transcript};
 

--- a/zebra-test/src/transcript.rs
+++ b/zebra-test/src/transcript.rs
@@ -37,6 +37,7 @@ impl ExpectedTranscriptError {
     }
 
     /// Check the actual error `e` against this expected error.
+    #[track_caller]
     fn check(&self, e: BoxError) -> Result<(), Report> {
         match self {
             ExpectedTranscriptError::Any => Ok(()),
@@ -89,6 +90,7 @@ where
     S: Debug + Eq,
 {
     /// Check this transcript against the responses from the `to_check` service
+    #[track_caller]
     pub async fn check<C>(mut self, mut to_check: C) -> Result<(), Report>
     where
         C: Service<R, Response = S>,
@@ -169,6 +171,7 @@ where
         Poll::Ready(Ok(()))
     }
 
+    #[track_caller]
     fn call(&mut self, request: R) -> Self::Future {
         if let Some((expected_request, response)) = self.messages.next() {
             match response {


### PR DESCRIPTION
## Motivation

This splits out a state service read request, in preparation for:
- #3156 
- #3147 
- #3157 
- #3158

Splitting the request type allows us to just implement these methods once in the state.

## Solution

- Split out ReadRequest and ReadResponse state service enums
- Make zebra-rpc use the new state ReadRequest 

Related cleanups:
- Simplify RPC test vectors

## Review

This PR blocks a bunch of tickets, so I've marked it as high priority.

It is based on PR #3865.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

The tickets listed at the top of this PR.