### PR TITLE
3. fix(state): prevent watch channel deadlocks in the state

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -850,7 +850,7 @@ impl Service<Request> for ReadStateService {
 
                 async move {
                     Ok(read::block(
-                        state.best_chain_receiver.borrow().clone().as_ref(),
+                        state.best_chain_receiver.borrow().as_ref(),
                         &state.db,
                         hash_or_height,
                     ))

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -458,8 +458,8 @@ impl StateService {
         Some(tip.0 - height.0)
     }
 
-    /// Return the block identified by either its `height` or `hash`,
-    /// if it exists in the current best chain.
+    /// Returns the [`Block`] with [`Hash`](zebra_chain::block::Hash) or
+    /// [`Height`](zebra_chain::block::Height), if it exists in the current best chain.
     pub fn best_block(&self, hash_or_height: HashOrHeight) -> Option<Arc<Block>> {
         read::block(self.mem.best_chain(), self.disk.db(), hash_or_height)
     }

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -69,7 +69,8 @@ impl ZebraDb {
         self.db.zs_get(height_by_hash, &hash)
     }
 
-    /// Returns the given block if it exists.
+    /// Returns the [`Block`] with [`Hash`](zebra_chain::block::Hash) or
+    /// [`Height`](zebra_chain::block::Height), if it exists in the finalized chain.
     pub fn block(&self, hash_or_height: HashOrHeight) -> Option<Arc<Block>> {
         let height_by_hash = self.db.cf_handle("height_by_hash").unwrap();
         let block_by_height = self.db.cf_handle("block_by_height").unwrap();

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -318,7 +318,8 @@ impl Chain {
         Ok(Some(forked))
     }
 
-    /// Returns the [`ContextuallyValidBlock`] at a given height or hash in this chain.
+    /// Returns the [`ContextuallyValidBlock`] with [`Hash`](zebra_chain::block::Hash) or
+    /// [`Height`](zebra_chain::block::Height), if it exists in this chain.
     pub fn block(&self, hash_or_height: HashOrHeight) -> Option<&ContextuallyValidBlock> {
         let height =
             hash_or_height.height_or_else(|hash| self.height_by_hash.get(&hash).cloned())?;

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -13,15 +13,28 @@ use crate::{
     HashOrHeight,
 };
 
-/// Return the block identified by either its `height` or `hash` if it exists
-/// in the non-finalized `chain` or finalized `db`.
-pub(crate) fn block(
-    chain: Option<&Arc<Chain>>,
+/// Returns the [`Block`] with [`Hash`](zebra_chain::block::Hash) or
+/// [`Height`](zebra_chain::block::Height),
+/// if it exists in the non-finalized `chain` or finalized `db`.
+pub(crate) fn block<C>(
+    chain: Option<C>,
     db: &ZebraDb,
     hash_or_height: HashOrHeight,
-) -> Option<Arc<Block>> {
+) -> Option<Arc<Block>>
+where
+    C: AsRef<Chain>,
+{
+    // # Correctness
+    //
+    // The StateService commits blocks to the finalized state before updating the latest chain,
+    // and it can commit additional blocks after we've cloned this `chain` variable.
+    //
+    // Since blocks are the same in the finalized and non-finalized state,
+    // we check the most efficient alternative first.
+    // (`chain` is always in memory, but `db` stores blocks on disk, with a memory cache.)
     chain
-        .and_then(|chain| chain.block(hash_or_height))
+        .as_ref()
+        .and_then(|chain| chain.as_ref().block(hash_or_height))
         .map(|contextual| contextual.block.clone())
         .or_else(|| db.block(hash_or_height))
 }

--- a/zebra-state/src/service/watch_receiver.rs
+++ b/zebra-state/src/service/watch_receiver.rs
@@ -1,0 +1,87 @@
+//! Shared [`tokio::sync::watch`] channel wrappers.
+//!
+//! These wrappers help use watch channels correctly.
+
+use tokio::sync::watch;
+
+/// Efficient access to state data via a [`tokio`] [`watch::Receiver`] channel,
+/// while avoiding deadlocks.
+///
+/// Returns data from the most recent state,
+/// regardless of how many times you call its methods.
+///
+/// Cloned instances provide identical state data.
+///
+/// # Correctness
+///
+/// To avoid deadlocks, see the correctness note on [`WatchReceiver::with_watch_data`].
+///
+/// # Note
+///
+/// If a lot of blocks are committed at the same time,
+/// the watch chanel will skip some block updates,
+/// even though those updates were committed to the state.
+#[derive(Clone, Debug)]
+pub struct WatchReceiver<T> {
+    /// The receiver for the current state data.
+    receiver: watch::Receiver<T>,
+}
+
+impl<T> WatchReceiver<T> {
+    /// Create a new [`WatchReceiver`] from a watch channel receiver.
+    pub fn new(receiver: watch::Receiver<T>) -> Self {
+        Self { receiver }
+    }
+}
+
+impl<T> WatchReceiver<T>
+where
+    T: Clone,
+{
+    /// Maps the current data `T` to `U` by applying a function to the watched value,
+    /// while holding the receiver lock as briefly as possible.
+    ///
+    /// This helper method is a shorter way to borrow the value from the [`watch::Receiver`] and
+    /// extract some information from it.
+    ///
+    /// # Performance
+    ///
+    /// A single read lock is acquired to clone `T`, and then released after the clone.
+    /// To make this clone efficient, large or expensive `T` can be wrapped in an [`Arc`].
+    /// (Or individual fields can be wrapped in an `Arc`.)
+    ///
+    /// # Correctness
+    ///
+    /// To prevent deadlocks:
+    ///
+    /// - `receiver.borrow()` should not be called before this method while in the same scope.
+    ///
+    /// It is important to avoid calling `borrow` more than once in the same scope, which
+    /// effectively tries to acquire two read locks to the shared data in the watch channel. If
+    /// that is done, there's a chance that the [`watch::Sender`] tries to send a value, which
+    /// starts acquiring a write-lock, and prevents further read-locks from being acquired until
+    /// the update is finished.
+    ///
+    /// What can happen in that scenario is:
+    ///
+    /// 1. The receiver manages to acquire a read-lock for the first `borrow`
+    /// 2. The sender starts acquiring the write-lock
+    /// 3. The receiver fails to acquire a read-lock for the second `borrow`
+    ///
+    /// Now both the sender and the receivers hang, because the sender won't release the lock until
+    /// it can update the value, and the receiver won't release its first read-lock until it
+    /// acquires the second read-lock and finishes what it's doing.
+    pub fn with_watch_data<U, F>(&self, f: F) -> U
+    where
+        F: FnOnce(T) -> U,
+    {
+        let cloned_data = self.receiver.borrow().clone();
+
+        f(cloned_data)
+    }
+
+    /// Calls [`watch::Receiver::changed`] and returns the result.
+    pub async fn changed(&mut self) -> Result<(), watch::error::RecvError> {
+        self.receiver.changed().await
+    }
+}


### PR DESCRIPTION
## Motivation

This PR makes watch channel deadlocks in the state impossible, which avoids deadlocks. (And time-consuming investigations into deadlock causes.)

It also avoids some livelocks, and some performance issues. (Clones are cheap, lock contention is expensive.)

### Specifications

If the watch receiver holds a read lock, then the sender tries to get the write lock, then another receiver tries to get another read lock, the watch channel can deadlock.

See the "potential deadlock example" in:
https://docs.rs/tokio/latest/tokio/sync/watch/struct.Receiver.html#method.borrow

### Designs

The `WatchReceiver` wrapper clones the watched data before allowing access to it, then explicitly drops the read lock as soon as possible. This prevents:
- read-write-read deadlocks, and
- read-write livelocks under heavy use,

because the read lock is dropped immediately after the clone.

For more details, see the conversation at https://github.com/ZcashFoundation/zebra/pull/3847#issuecomment-1067352847

## Solution

Deadlock prevention:
- Add a WatchReceiver wrapper that always clones the borrowed watch data
- Explicitly drop the read lock as quickly as possible

Memory optimisations:
- Drop the shared Arc<Chain>s as quickly as possible

Ergonomics:
- Make read::block more flexible, by accepting any AsRef<Chain>
- Make the block method docs consistent 

### Testing

When testing syncing lightwalletd from a zebrad that is also syncing from peers, I saw pauses of up to 3 minutes. These pauses finished when lightwalletd gave up and exited. The pauses seem to be fixed by commit 3240332.

## Review

This is part of an high-priority series of state refactor PRs, because they will cause merge conflicts with other PRs.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- Testing syncing lightwalletd from zebrad syncing from peers (maybe #3511?) 