### PR TITLE
fix(ci): path format for cached state rebuild

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,20 +217,20 @@ jobs:
         uses: tj-actions/changed-files@v17.3
         with:
           files: |
-            /zebra-state/**/config.rs
-            /zebra-state/**/constants.rs
-            /zebra-state/**/finalized_state.rs
-            /zebra-state/**/disk_format.rs
-            /zebra-state/**/disk_format/block.rs
-            /zebra-state/**/disk_format/chain.rs
-            /zebra-state/**/disk_format/shielded.rs
-            /zebra-state/**/disk_format/transparent.rs
-            /zebra-state/**/disk_db.rs
-            /zebra-state/**/zebra_db.rs
-            /zebra-state/**/zebra_db/block.rs
-            /zebra-state/**/zebra_db/chain.rs
-            /zebra-state/**/zebra_db/shielded.rs
-            /zebra-state/**/zebra_db/transparent.rs
+            zebra-state/**/config.rs
+            zebra-state/**/constants.rs
+            zebra-state/**/finalized_state.rs
+            zebra-state/**/disk_format.rs
+            zebra-state/**/disk_format/block.rs
+            zebra-state/**/disk_format/chain.rs
+            zebra-state/**/disk_format/shielded.rs
+            zebra-state/**/disk_format/transparent.rs
+            zebra-state/**/disk_db.rs
+            zebra-state/**/zebra_db.rs
+            zebra-state/**/zebra_db/block.rs
+            zebra-state/**/zebra_db/chain.rs
+            zebra-state/**/zebra_db/shielded.rs
+            zebra-state/**/zebra_db/transparent.rs
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4


### PR DESCRIPTION
## Motivation

The cached state workflow is using the wrong path format for changed files.

I marked this PR as low priority.

We can do a manual state rebuild after PR #3818 merges, and test these changes on the next database format change PR.

### Reference Docs

https://github.com/marketplace/actions/changed-files#example

## Solution

- remove leading slashes from changed paths files

## Review

This fix is not urgent, but it should happen before the next database format change merges.

### Reviewer Checklist

  - [x] Follows reference docs

## Follow Up Work

Test the fix.