### PR TITLE
refactor(ci): use improved OIDC for gcloud authentication

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ on:
 env:
   CARGO_INCREMENTAL: '1'
   NETWORK: Mainnet
-  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  PROJECT_ID: zealous-zebra
   GAR_BASE: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/zebra
   GCR_BASE: gcr.io/${{ secrets.GCP_PROJECT_ID }}
   REGION: us-central1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,8 +15,8 @@ env:
   CARGO_INCREMENTAL: '1'
   NETWORK: Mainnet
   PROJECT_ID: zealous-zebra
-  GAR_BASE: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/zebra
-  GCR_BASE: gcr.io/${{ secrets.GCP_PROJECT_ID }}
+  GAR_BASE: us-docker.pkg.dev/zealous-zebra/zebra
+  GCR_BASE: gcr.io/zealous-zebra
   REGION: us-central1
   ZONE: us-central1-a
   MACHINE_TYPE: c2-standard-4
@@ -27,6 +27,9 @@ jobs:
     # TODO: remove timeout until we have an average build time
     # timeout-minutes: 180
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
 
     steps:
     - uses: actions/checkout@v3.0.0
@@ -60,7 +63,9 @@ jobs:
       id: auth
       uses: google-github-actions/auth@v0.6.0
       with:
-        credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+        workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+        service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+        token_format: 'access_token'
 
     - name: Set up QEMU
       id: qemu
@@ -78,15 +83,15 @@ jobs:
       uses: docker/login-action@v1.14.1
       with:
         registry: us-docker.pkg.dev
-        username: _json_key
-        password: ${{ secrets.GOOGLE_CREDENTIALS }}
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
 
     - name: Login to Google Container Registry
       uses: docker/login-action@v1.14.1
       with:
         registry: gcr.io
-        username: _json_key
-        password: ${{ secrets.GOOGLE_CREDENTIALS }}
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
 
     # Build and push image to Google Artifact Registry
     - name: Build & push
@@ -118,6 +123,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
     steps:
@@ -133,12 +141,9 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v0.6.0
         with:
-          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
-
-      - name: Set up gcloud SDK environment
-        uses: google-github-actions/setup-gcloud@v0.6.0
-        with:
-          project_id: ${{ env.PROJECT_ID }}
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
 
       - name: Create instance template
         run: |
@@ -184,6 +189,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     if: github.event_name == 'workflow_dispatch'
 
     steps:
@@ -199,12 +207,9 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v0.6.0
         with:
-          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
-
-      - name: Set up gcloud SDK environment
-        uses: google-github-actions/setup-gcloud@v0.6.0
-        with:
-          project_id: ${{ env.PROJECT_ID }}
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
 
       # Create instance template from container image
       - name: Manual deploy of a single instance running zebrad

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   NETWORK: Mainnet
-  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  PROJECT_ID: zealous-zebra
   REGION: us-central1
   ZONE: us-central1-a
 
@@ -31,7 +31,8 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v0.5.0
         with:
-          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
 
       - name: Delete test instance
         continue-on-error: true

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -18,6 +18,9 @@ jobs:
     name: Delete test deployments
     runs-on: ubuntu-latest
     needs: [ build ]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v2.4.0
         with:
@@ -29,10 +32,11 @@ jobs:
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v0.5.0
+        uses: google-github-actions/auth@v0.6.0
         with:
           workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
 
       - name: Delete test instance
         continue-on-error: true

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -17,7 +17,6 @@ jobs:
   delete:
     name: Delete test deployments
     runs-on: ubuntu-latest
-    needs: [ build ]
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -29,9 +29,9 @@ env:
   RUST_LIB_BACKTRACE: full
   COLORBT_SHOW_HIDDEN: '1'
   NETWORK: Mainnet
-  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-  GAR_BASE: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/zebra
-  GCR_BASE: gcr.io/${{ secrets.GCP_PROJECT_ID }}
+  PROJECT_ID: zealous-zebra
+  GAR_BASE: us-docker.pkg.dev/zealous-zebra/zebra
+  GCR_BASE: gcr.io/zealous-zebra
   REGION: us-central1
   ZONE: us-central1-a
   MACHINE_TYPE: c2d-standard-16
@@ -133,7 +133,8 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v0.5.0
         with:
-          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
 
       # Check if our destination compute instance exists and delete it
       - name: Delete existing instance with same SHA

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -45,6 +45,9 @@ jobs:
     name: Build images
     timeout-minutes: 210
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v3.0.0
         with:
@@ -77,19 +80,27 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
+    - name: Authenticate to Google Cloud
+      id: auth
+      uses: google-github-actions/auth@v0.6.0
+      with:
+        workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+        service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+        token_format: 'access_token'
+
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v1.14.1
         with:
           registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GOOGLE_CREDENTIALS }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Login to Google Container Registry
         uses: docker/login-action@v1.14.1
         with:
           registry: gcr.io
-          username: _json_key
-          password: ${{ secrets.GOOGLE_CREDENTIALS }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       # Build and push image to Google Artifact Registry
       - name: Build & push
@@ -120,6 +131,9 @@ jobs:
     name: Test full Mainnet sync
     runs-on: ubuntu-latest
     needs: [ build ]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v3.0.0
         with:
@@ -131,10 +145,11 @@ jobs:
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v0.5.0
+        uses: google-github-actions/auth@v0.6.0
         with:
           workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
 
       # Check if our destination compute instance exists and delete it
       - name: Delete existing instance with same SHA

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -80,13 +80,13 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
-    - name: Authenticate to Google Cloud
-      id: auth
-      uses: google-github-actions/auth@v0.6.0
-      with:
-        workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
-        service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
-        token_format: 'access_token'
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.6.0
+        with:
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
 
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v1.14.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
     name: Build images
     timeout-minutes: 210
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v3.0.0
         with:
@@ -78,19 +81,27 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.6.0
+        with:
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
+
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v1.14.1
         with:
           registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GOOGLE_CREDENTIALS }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Login to Google Container Registry
         uses: docker/login-action@v1.14.1
         with:
           registry: gcr.io
-          username: _json_key
-          password: ${{ secrets.GOOGLE_CREDENTIALS }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       # Build and push image to Google Artifact Registry
       - name: Build & push
@@ -245,10 +256,11 @@ jobs:
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v0.5.0
+        uses: google-github-actions/auth@v0.6.0
         with:
           workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
 
       # Check if our destination compute instance exists and delete it
       - name: Delete existing instance with same SHA
@@ -348,6 +360,9 @@ jobs:
     name: Test full validation sync from cached state
     runs-on: ubuntu-latest
     needs: [ build, regenerate-stateful-disks]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v3.0.0
         with:
@@ -363,10 +378,11 @@ jobs:
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v0.5.0
+        uses: google-github-actions/auth@v0.6.0
         with:
           workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
 
       # Check if our destination compute instance exists and delete it
       - name: Delete existing instance with same SHA

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,9 @@ env:
   RUST_LIB_BACKTRACE: full
   COLORBT_SHOW_HIDDEN: '1'
   NETWORK: Mainnet
-  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-  GAR_BASE: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/zebra
-  GCR_BASE: gcr.io/${{ secrets.GCP_PROJECT_ID }}
+  PROJECT_ID: zealous-zebra
+  GAR_BASE: us-docker.pkg.dev/zealous-zebra/zebra
+  GCR_BASE: gcr.io/zealous-zebra
   REGION: us-central1
   ZONE: us-central1-a
   MACHINE_TYPE: c2d-standard-4
@@ -205,6 +205,9 @@ jobs:
     needs: build
     outputs:
       any_changed: ${{ steps.changed-files-specific.outputs.any_changed }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v3.0.0
         with:
@@ -244,7 +247,8 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v0.5.0
         with:
-          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
 
       # Check if our destination compute instance exists and delete it
       - name: Delete existing instance with same SHA
@@ -361,7 +365,8 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v0.5.0
         with:
-          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
 
       # Check if our destination compute instance exists and delete it
       - name: Delete existing instance with same SHA

--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -21,9 +21,9 @@ on:
       - '.github/workflows/zcash-lightwalletd.yml'
 
 env:
-  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-  GAR_BASE: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/zebra
-  GCR_BASE: gcr.io/${{ secrets.GCP_PROJECT_ID }}
+  PROJECT_ID: zealous-zebra
+  GAR_BASE: us-docker.pkg.dev/zealous-zebra/zebra
+  GCR_BASE: gcr.io/zealous-zebra
   IMAGE_NAME: lightwalletd
 
 jobs:

--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -30,6 +30,9 @@ jobs:
   build:
     name: Build images
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
 
     steps:
     - uses: actions/checkout@v3.0.0
@@ -64,13 +67,6 @@ jobs:
           type=semver,pattern={{major}}
           type=sha
 
-    # Setup gcloud CLI
-    - name: Authenticate to Google Cloud
-      id: auth
-      uses: google-github-actions/auth@v0.6.0
-      with:
-        credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
-
     - name: Set up QEMU
       id: qemu
       uses: docker/setup-qemu-action@v1
@@ -83,12 +79,21 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v1
 
+    # Setup gcloud CLI
+    - name: Authenticate to Google Cloud
+      id: auth
+      uses: google-github-actions/auth@v0.6.0
+      with:
+        workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+        service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+        token_format: 'access_token'
+
     - name: Login to Google Artifact Registry
       uses: docker/login-action@v1.14.1
       with:
         registry: us-docker.pkg.dev
-        username: _json_key
-        password: ${{ secrets.GOOGLE_CREDENTIALS }}
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
 
     # Build and push image to Google Artifact Registry
     - name: Build & push

--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -27,6 +27,9 @@ jobs:
     # TODO: remove timeout until we have an average build time
     # timeout-minutes: 180
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
 
     steps:
     - uses: actions/checkout@v3.0.0
@@ -54,13 +57,6 @@ jobs:
           type=semver,pattern={{major}}
           type=sha
 
-    # Setup gcloud CLI
-    - name: Authenticate to Google Cloud
-      id: auth
-      uses: google-github-actions/auth@v0.6.0
-      with:
-        credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
-
     - name: Set up QEMU
       id: qemu
       uses: docker/setup-qemu-action@v1
@@ -73,12 +69,21 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v1
 
+    # Setup gcloud CLI
+    - name: Authenticate to Google Cloud
+      id: auth
+      uses: google-github-actions/auth@v0.6.0
+      with:
+        workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+        service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+        token_format: 'access_token'
+
     - name: Login to Google Artifact Registry
       uses: docker/login-action@v1.14.1
       with:
         registry: us-docker.pkg.dev
-        username: _json_key
-        password: ${{ secrets.GOOGLE_CREDENTIALS }}
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
 
     # Build and push image to Google Artifact Registry
     - name: Build & push

--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -16,9 +16,9 @@ on:
 
 env:
   CARGO_INCREMENTAL: '1'
-  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-  GAR_BASE: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/zebra
-  GCR_BASE: gcr.io/${{ secrets.GCP_PROJECT_ID }}
+  PROJECT_ID: zealous-zebra
+  GAR_BASE: us-docker.pkg.dev/zealous-zebra/zebra
+  GCR_BASE: gcr.io/zealous-zebra
   IMAGE_NAME: zcash-params
 
 jobs:

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -19,6 +19,9 @@ jobs:
     name: Deploy zcashd nodes
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
 
     steps:
       - uses: actions/checkout@v3.0.0
@@ -31,10 +34,11 @@ jobs:
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v0.5.0
+        uses: google-github-actions/auth@v0.6.0
         with:
           workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
 
       # Create instance template from container image
       - name: Create instance template

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -9,7 +9,7 @@ on:
         default: 10
 
 env:
-  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  PROJECT_ID: zealous-zebra
   REGION: us-central1
   ZONE: us-central1-a
   MACHINE_TYPE: c2-standard-4
@@ -29,11 +29,12 @@ jobs:
         uses: rlespinasse/github-slug-action@v4
 
       # Setup gcloud CLI
-      - name: Set up gcloud SDK environment
-        uses: google-github-actions/setup-gcloud@v0.6.0
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.5.0
         with:
-          project_id: ${{ env.PROJECT_ID }}
-          service_account_key: ${{ secrets.GCLOUD_AUTH }}
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
 
       # Create instance template from container image
       - name: Create instance template


### PR DESCRIPTION
## Motivation

Traditionally, applications running outside Google Cloud have used service account keys to access Google Cloud resources. Service account keys are powerful credentials and can represent a security risk if they are not managed correctly. And this required using **secrets** which were not accesible by external contributors, by bots (dependabot), and when using forks.

Fixes #3419

### Specifications

Configuring OpenID Connect in Google Cloud Platform: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform

### Designs

- Made an implementation using Terraform (pending repo)

## Solution
- Create an Identity Provider in GCP
- Link the provider to a service account used by GHA to deploy in GCP
- Configure CI with this OIDC Provider
- Remove all need of secrets from CI/Test which were triggered on Pull Requests

## Review

@dconnolly can review this when ready

## Follow Up Work

Create the terraform repository with this configuration