### PR TITLE
fix(ci): remove coverage from mergify because nightly builds fail

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,7 +13,6 @@ queue_rules:
       - check-success=Test stable on macOS-latest
       # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
       # - check-success=Test stable on windows-latest
-      - check-success=Coverage nightly
       - check-success=Clippy
       - check-success=Rustfmt
 
@@ -30,7 +29,6 @@ queue_rules:
       - check-success=Test stable on ubuntu-latest
       - check-success=Test stable on macOS-latest
       # - check-success=Test stable on windows-latest
-      - check-success=Coverage nightly
       - check-success=Clippy
       - check-success=Rustfmt
 
@@ -47,7 +45,6 @@ queue_rules:
       - check-success=Test stable on ubuntu-latest
       - check-success=Test stable on macOS-latest
       # - check-success=Test stable on windows-latest
-      - check-success=Coverage nightly
       - check-success=Clippy
       - check-success=Rustfmt
 


### PR DESCRIPTION
## Motivation

Rust nightly Zebra builds are failing with:
> thread 'rustc' panicked at 'assertion failed: !value.has_escaping_bound_vars()', /rustc/52b34550aca5f7dd7e152f773e3ab786acb86f6f/compiler/rustc_middle/src/ty/sty.rs:1089:9

https://github.com/ZcashFoundation/zebra/runs/5563957159?check_suite_focus=true#step:9:19

All automatic mergify merges will fail until this is fixed.

## Solution

- Remove coverage as a required mergify step
- Manually disable the coverage job

## Review

The first person who sees this should review this critical-priority PR.

Mergify changes require a manual merge.

### Reviewer Checklist

  - [x] Mergify config is valid

## Follow Up Work

- Re-enable the coverage job
- Decide if coverage should be a required build step
- If it is required, add it to the GitHub `main` branch protection rules, because they are easier to change