### PR TITLE
feat(consensus): Validate ZIP-212 grace period blocks using checkpoints

### DIFF
--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -90,10 +90,16 @@ impl Network {
     /// If a Zcash consensus rule only applies before the mandatory checkpoint,
     /// Zebra can skip validation of that rule.
     pub fn mandatory_checkpoint_height(&self) -> Height {
-        // Currently this is the Canopy activation height for both networks.
-        Canopy
+        // Currently this is after the ZIP-212 grace period.
+        //
+        // See the `ZIP_212_GRACE_PERIOD_DOCUMENTATION` for more information.
+
+        let canopy_activation = Canopy
             .activation_height(*self)
-            .expect("Canopy activation height must be present for both networks")
+            .expect("Canopy activation height must be present for both networks");
+
+        (canopy_activation + ZIP_212_GRACE_PERIOD_DURATION)
+            .expect("ZIP-212 grace period ends at a valid block height")
     }
 }
 

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -5,6 +5,45 @@ use crate::{block::Height, parameters::NetworkUpgrade::Canopy};
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
 
+#[cfg(test)]
+mod tests;
+
+/// The ZIP-212 grace period length after the Canopy activation height.
+///
+/// # Consensus
+///
+/// ZIP-212 requires Zcash nodes to validate that Sapling spends and Orchard actions follows a
+/// specific plaintext format after Canopy's activation.
+///
+/// > [Heartwood onward] All Sapling and Orchard outputs in coinbase transactions MUST decrypt to a
+/// > note plaintext , i.e. the procedure in § 4.19.3 ‘Decryption using a Full Viewing Key (Sapling
+/// > and Orchard)’ on p. 67 does not return ⊥, using a sequence of 32 zero bytes as the outgoing
+/// > viewing key . (This implies that before Canopy activation, Sapling outputs of a coinbase
+/// > transaction MUST have note plaintext lead byte equal to 0x01.)
+///
+/// > [Canopy onward] Any Sapling or Orchard output of a coinbase transaction decrypted to a note
+/// > plaintext according to the preceding rule MUST have note plaintext lead byte equal to 0x02.
+/// > (This applies even during the “grace period” specified in [ZIP-212].)
+///
+/// https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
+///
+/// Wallets have a grace period of 32,256 blocks after Canopy's activation to validate those blocks,
+/// but nodes do not.
+///
+/// > There is a "grace period" of 32256 blocks starting from the block at which this ZIP activates,
+/// > during which note plaintexts with lead byte 0x01 MUST still be accepted [by wallets].
+/// >
+/// > Let ActivationHeight be the activation height of this ZIP, and let GracePeriodEndHeight be
+/// > ActivationHeight + 32256.
+///
+/// https://zips.z.cash/zip-0212#changes-to-the-process-of-receiving-sapling-or-orchard-notes
+///
+/// Zebra uses `librustzcash` to validate that rule, but it won't validate it during the grace
+/// period. Therefore Zebra must validate those blocks during the grace period using checkpoints.
+/// Therefore the mandatory checkpoint height ([`Network::mandatory_checkpoint_height`]) must be
+/// after the grace period.
+const ZIP_212_GRACE_PERIOD_DURATION: i32 = 32_256;
+
 /// An enum describing the possible network choices.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]

--- a/zebra-chain/src/parameters/network/tests.rs
+++ b/zebra-chain/src/parameters/network/tests.rs
@@ -1,0 +1,1 @@
+mod prop;

--- a/zebra-chain/src/parameters/network/tests/prop.rs
+++ b/zebra-chain/src/parameters/network/tests/prop.rs
@@ -1,0 +1,26 @@
+use proptest::prelude::*;
+
+use super::super::{Network, ZIP_212_GRACE_PERIOD_DURATION};
+use crate::parameters::NetworkUpgrade;
+
+proptest! {
+    /// Check that the mandatory checkpoint is after the ZIP-212 grace period.
+    ///
+    /// This is necessary because Zebra can't fully validate the blocks during the grace period due
+    /// to a limitation of `librustzcash`.
+    ///
+    /// See [`ZIP_212_GRACE_PERIOD_DURATION`] for more information.
+    #[test]
+    fn mandatory_checkpoint_is_after_zip212_grace_period(network in any::<Network>()) {
+        zebra_test::init();
+
+        let canopy_activation = NetworkUpgrade::Canopy
+            .activation_height(network)
+            .expect("Canopy activation height is set");
+
+        let grace_period_end_height = (canopy_activation + ZIP_212_GRACE_PERIOD_DURATION)
+            .expect("ZIP-212 grace period ends in a valid block height");
+
+        assert!(network.mandatory_checkpoint_height() >= grace_period_end_height);
+    }
+}


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
[ZIP-212](https://zips.z.cash/zip-0212) changes the plaintext format for Sapling spends and Orchard actions. Zebra validates that consensus rule using `librustzcash` (#3029). However, `librustzcash` doesn't fully validate the consensus rule during a wallet grace period of 32,256 blocks after the Canopy activation height. Therefore, we should validate those blocks during the grace period using checkpoints.

Closes #2368.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

> [Heartwood onward] All Sapling and Orchard outputs in coinbase transactions MUST decrypt to a note
> plaintext , i.e. the procedure in § 4.19.3 ‘Decryption using a Full Viewing Key ( Sapling and Orchard )’ on p. 67
> does not return ⊥, using a sequence of 32 zero bytes as the outgoing viewing key . (This implies that before
> Canopy activation, Sapling outputs of a coinbase transaction MUST have note plaintext lead byte equal to
> 0x01 .)

> [Canopy onward] Any Sapling or Orchard output of a coinbase transaction decrypted to a note plaintext
> according to the preceding rule MUST have note plaintext lead byte equal to 0x02 . (This applies even during
> the “grace period” specified in [ZIP-212].)

https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus

> There is a "grace period" of 32256 blocks starting from the block at which this ZIP activates, during which note plaintexts with lead byte 0x01 MUST still be accepted [by wallets].
> Let ActivationHeight be the activation height of this ZIP, and let GracePeriodEndHeight be ActivationHeight + 32256.

https://zips.z.cash/zip-0212#changes-to-the-process-of-receiving-sapling-or-orchard-notes

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Increase the mandatory height to be after the end of the ZIP-212 grace period.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
- Update the cached state in CI to the new mandatory checkpoint height: will be done in the next state update in #3874.