### PR TITLE
T1. add(test): add test API that checks logs for multiple regexes

### DIFF
--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -130,9 +130,13 @@ where
     }
 }
 
+/// Test command exit status information.
 #[derive(Debug)]
 pub struct TestStatus {
+    /// The original command string.
     pub cmd: String,
+
+    /// The exit status of the command.
     pub status: ExitStatus,
 }
 
@@ -154,14 +158,31 @@ impl TestStatus {
     }
 }
 
+/// A test command child process.
 #[derive(Debug)]
 pub struct TestChild<T> {
+    /// The working directory of the command.
     pub dir: T,
+
+    /// The original command string.
     pub cmd: String,
+
+    /// The child process itself.
     pub child: Child,
+
+    /// The standard output stream of the child process.
     pub stdout: Option<Lines<BufReader<ChildStdout>>>,
+
+    /// The standard error stream of the child process.
     pub stderr: Option<Lines<BufReader<ChildStderr>>>,
+
+    /// The deadline for this command to finish.
+    ///
+    /// Only checked when the command outputs each new line (#1140).
     pub deadline: Option<Instant>,
+
+    /// If true, write child output directly to standard output,
+    /// bypassing the Rust test harness output capture.
     bypass_test_capture: bool,
 }
 

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -751,9 +751,7 @@ impl<T> ContextFrom<&mut TestChild<T>> for Report {
 
         // Reading test child process output could hang if the child process is still running,
         // so kill it first.
-        if let Some(child) = source.child.as_mut() {
-            let _ = child.kill();
-        }
+        let _ = source.child.kill();
 
         let mut stdout_buf = String::new();
         let mut stderr_buf = String::new();

--- a/zebra-test/src/command/to_regex.rs
+++ b/zebra-test/src/command/to_regex.rs
@@ -120,6 +120,12 @@ where
 pub trait CollectRegexSet {
     /// Collects the iterator values to a [`RegexSet`].
     ///
+    /// When converting from a [`Regex`] or [`RegexBuilder`],
+    /// resets match flags and limits to the defaults.
+    ///
+    /// Use a [`RegexSet`] or [`RegexSetBuilder`] to preserve these settings,
+    /// via the `*_regex_set` methods.
+    ///
     /// Returns an [`Error`] if any conversion fails.
     fn collect_regex_set(self) -> Result<RegexSet, Error>;
 }

--- a/zebra-test/src/command/to_regex.rs
+++ b/zebra-test/src/command/to_regex.rs
@@ -1,0 +1,144 @@
+//! Convenience traits for converting to [`Regex`] and [`RegexSet`].
+
+use std::iter;
+
+use regex::{Error, Regex, RegexBuilder, RegexSet, RegexSetBuilder};
+
+/// A trait for converting a value to a [`Regex`].
+pub trait ToRegex {
+    /// Converts the given value to a [`Regex`].
+    ///
+    /// Returns an [`Error`] if conversion fails.
+    fn to_regex(&self) -> Result<Regex, Error>;
+}
+
+// Identity conversions
+
+impl ToRegex for Regex {
+    fn to_regex(&self) -> Result<Regex, Error> {
+        Ok(self.clone())
+    }
+}
+
+impl ToRegex for &Regex {
+    fn to_regex(&self) -> Result<Regex, Error> {
+        Ok((*self).clone())
+    }
+}
+
+// Builder Conversions
+
+impl ToRegex for RegexBuilder {
+    fn to_regex(&self) -> Result<Regex, Error> {
+        self.build()
+    }
+}
+
+impl ToRegex for &RegexBuilder {
+    fn to_regex(&self) -> Result<Regex, Error> {
+        self.build()
+    }
+}
+
+// String conversions
+
+impl ToRegex for String {
+    fn to_regex(&self) -> Result<Regex, Error> {
+        Regex::new(self)
+    }
+}
+
+impl ToRegex for &String {
+    fn to_regex(&self) -> Result<Regex, Error> {
+        Regex::new(self)
+    }
+}
+
+impl ToRegex for &str {
+    fn to_regex(&self) -> Result<Regex, Error> {
+        Regex::new(self)
+    }
+}
+
+/// A trait for converting a value to a [`RegexSet`].
+pub trait ToRegexSet {
+    /// Converts the given values to a [`RegexSet`].
+    ///
+    /// When converting from a [`Regex`] or [`RegexBuilder`],
+    /// resets match flags and limits to the defaults.
+    /// Use a [`RegexSet`] or [`RegexSetBuilder`] to preserve these settings.
+    ///
+    /// Returns an [`Error`] if any conversion fails.
+    fn to_regex_set(&self) -> Result<RegexSet, Error>;
+}
+
+// Identity conversions
+
+impl ToRegexSet for RegexSet {
+    fn to_regex_set(&self) -> Result<RegexSet, Error> {
+        Ok(self.clone())
+    }
+}
+
+impl ToRegexSet for &RegexSet {
+    fn to_regex_set(&self) -> Result<RegexSet, Error> {
+        Ok((*self).clone())
+    }
+}
+
+// Builder Conversions
+
+impl ToRegexSet for RegexSetBuilder {
+    fn to_regex_set(&self) -> Result<RegexSet, Error> {
+        self.build()
+    }
+}
+
+impl ToRegexSet for &RegexSetBuilder {
+    fn to_regex_set(&self) -> Result<RegexSet, Error> {
+        self.build()
+    }
+}
+
+// Single item conversion
+
+impl<T> ToRegexSet for T
+where
+    T: ToRegex,
+{
+    fn to_regex_set(&self) -> Result<RegexSet, Error> {
+        let regex = self.to_regex()?;
+
+        // This conversion discards flags and limits from Regex and RegexBuilder.
+        let regex = regex.as_str();
+
+        RegexSet::new(iter::once(regex))
+    }
+}
+
+/// A trait for collecting an iterator into a [`RegexSet`].
+pub trait CollectRegexSet {
+    /// Collects the iterator values to a [`RegexSet`].
+    ///
+    /// Returns an [`Error`] if any conversion fails.
+    fn collect_regex_set(self) -> Result<RegexSet, Error>;
+}
+
+// Multi item conversion
+
+impl<I> CollectRegexSet for I
+where
+    I: IntoIterator,
+    I::Item: ToRegex,
+{
+    fn collect_regex_set(self) -> Result<RegexSet, Error> {
+        let regexes: Result<Vec<Regex>, Error> =
+            self.into_iter().map(|item| item.to_regex()).collect();
+        let regexes = regexes?;
+
+        // This conversion discards flags and limits from Regex and RegexBuilder.
+        let regexes = regexes.iter().map(|regex| regex.as_str());
+
+        RegexSet::new(regexes)
+    }
+}


### PR DESCRIPTION
## Motivation

We want to check lightwalletd logs and Zebra logs for failures like:
- missing RPCs
- RPC argument parse errors
- RPC argument data errors
- RPC response parse errors
- RPC response data errors
- other specific errors logged by lightwalletd

But our testing framework makes it very hard to do that.

This PR makes it easier to check `lightwalletd` logs for multiple regexes.

This is related to:
- #3500 
- #3856 
- #3511

### Regex API Reference

https://docs.rs/regex/latest/regex/struct.RegexSet.html#

### Designs

Add convenience traits for converting and collecting regular expression sets.

## Solution

- Make test log checks accept generic regexes, and convert them automatically
- Support matching multiple regexes internally in the test command

Related Bug Fixes:
- Fix a potential hang in test child error reports 

Documentation:
- Document test command structs

## Review

This PR is not urgent.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- Use regexes to check all log output for failures