### PR TITLE
fix(chain): make FromHex consistent with ToHex for tx/block hashes

### DIFF
--- a/zebra-chain/src/block/hash.rs
+++ b/zebra-chain/src/block/hash.rs
@@ -74,7 +74,8 @@ impl FromHex for Hash {
     type Error = <[u8; 32] as FromHex>::Error;
 
     fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
-        let hash = <[u8; 32]>::from_hex(hex)?;
+        let mut hash = <[u8; 32]>::from_hex(hex)?;
+        hash.reverse();
 
         Ok(hash.into())
     }

--- a/zebra-chain/src/block/tests/prop.rs
+++ b/zebra-chain/src/block/tests/prop.rs
@@ -2,6 +2,8 @@ use std::{env, io::ErrorKind};
 
 use proptest::{arbitrary::any, prelude::*, test_runner::Config};
 
+use hex::{FromHex, ToHex};
+
 use zebra_test::prelude::*;
 
 use crate::{
@@ -41,6 +43,15 @@ proptest! {
         let display = format!("{}", hash);
         let parsed = display.parse::<Hash>().expect("hash should parse");
         prop_assert_eq!(hash, parsed);
+    }
+
+    #[test]
+    fn block_hash_hex_roundtrip(hash in any::<Hash>()) {
+        zebra_test::init();
+
+        let hex_hash: String = hash.encode_hex();
+        let new_hash = Hash::from_hex(hex_hash).expect("hex hash should parse");
+        prop_assert_eq!(hash, new_hash);
     }
 
     #[test]

--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -137,7 +137,8 @@ impl FromHex for Hash {
     type Error = <[u8; 32] as FromHex>::Error;
 
     fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
-        let hash = <[u8; 32]>::from_hex(hex)?;
+        let mut hash = <[u8; 32]>::from_hex(hex)?;
+        hash.reverse();
 
         Ok(hash.into())
     }

--- a/zebra-chain/src/transaction/tests/prop.rs
+++ b/zebra-chain/src/transaction/tests/prop.rs
@@ -6,6 +6,8 @@ use std::io::Cursor;
 
 use zebra_test::prelude::*;
 
+use hex::{FromHex, ToHex};
+
 use super::super::*;
 
 use crate::{
@@ -49,6 +51,15 @@ proptest! {
             let display = format!("{}", parsed);
             prop_assert_eq!(hash, display);
         }
+    }
+
+    #[test]
+    fn transaction_hash_hex_roundtrip(hash in any::<Hash>()) {
+        zebra_test::init();
+
+        let hex_hash: String = hash.encode_hex();
+        let new_hash = Hash::from_hex(hex_hash).expect("hex hash should parse");
+        prop_assert_eq!(hash, new_hash);
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`FromHex` wasn't reversing the bytes like `ToHex` does for transaction and block hashes. (See [here](https://bitcointalk.org/index.php?topic=5201170.0) for some background on this terrible decision of reversing in the first place :rofl: )

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

Fix it, add tests

## Review

Detected while working on https://github.com/ZcashFoundation/zebra/issues/3145, also discovered in https://github.com/ZcashFoundation/zebra/pull/3891/. It's not currently blocking those, but will soon.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
