### PR TITLE
T2. add(test): add test API that checks process logs for failures

### DIFF
--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -726,12 +726,11 @@ impl<T> AsMut<TestChild<T>> for TestChild<T> {
 
 impl<T> Drop for TestChild<T> {
     fn drop(&mut self) {
-        // Read unread child output.
+        // Clean up child processes when the test finishes,
+        // and check for failure logs.
         //
-        // This checks for failure logs,
-        // and prevents some test hangs and deadlocks.
-        self.stdout.as_mut().map(|iter| iter.last());
-        self.stderr.as_mut().map(|iter| iter.last());
+        // We don't care about the kill result here.
+        let _ = self.kill_and_consume_output();
     }
 }
 

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -232,7 +232,8 @@ pub fn check_failure_regexes(line: &std::io::Result<String>, failure_regexes: &R
             "test command output a failure message:\n\n\
              {line}\n\n\
              Matching: {failure_matches:#?}\n\
-             Match Regexes: {failure_regexes:#?}\n",
+             Match Regexes: {:#?}\n",
+            failure_regexes.patterns(),
         );
     }
 }

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -751,7 +751,9 @@ impl<T> ContextFrom<&mut TestChild<T>> for Report {
 
         // Reading test child process output could hang if the child process is still running,
         // so kill it first.
-        let _ = source.child.kill();
+        if let Some(child) = source.child.as_mut() {
+            let _ = child.kill();
+        }
 
         let mut stdout_buf = String::new();
         let mut stderr_buf = String::new();

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -38,6 +38,8 @@ pub fn test_cmd(command_path: &str, tempdir: &Path) -> Result<Command> {
     Ok(cmd)
 }
 
+// TODO: split these extensions into their own module
+
 /// Wrappers for `Command` methods to integrate with [`zebra_test`].
 pub trait CommandExt {
     /// wrapper for `status` fn on `Command` that constructs informative error
@@ -168,6 +170,7 @@ impl TestStatus {
 }
 
 /// A test command child process.
+// TODO: split this struct into its own module (or multiple modules)
 #[derive(Debug)]
 pub struct TestChild<T> {
     /// The working directory of the command.
@@ -186,6 +189,8 @@ pub struct TestChild<T> {
     pub child: Option<Child>,
 
     /// The standard output stream of the child process.
+    ///
+    /// TODO: replace with `Option<ChildOutput { stdout, stderr }>.
     pub stdout: Option<Box<dyn IteratorDebug<Item = std::io::Result<String>>>>,
 
     /// The standard error stream of the child process.
@@ -625,6 +630,9 @@ impl<T> Drop for TestChild<T> {
     }
 }
 
+/// Test command output logs.
+// TODO: split this struct into its own module
+#[derive(Debug)]
 pub struct TestOutput<T> {
     /// The test directory for this test output.
     ///
@@ -884,6 +892,7 @@ impl<T> TestOutput<T> {
 }
 
 /// Add context to an error report
+// TODO: split this trait into its own module
 pub trait ContextFrom<S> {
     type Return;
 

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -243,7 +243,7 @@ impl<T> TestChild<T> {
     ///
     /// - adds a panic to any method that reads output,
     ///   if any stdout or stderr lines match any failure regex
-    pub fn with_failure_regex_set<R>(&mut self, failure_regexes: R)
+    pub fn with_failure_regex_set<R>(self, failure_regexes: R) -> Self
     where
         R: ToRegexSet,
     {
@@ -263,7 +263,7 @@ impl<T> TestChild<T> {
     ///
     /// - adds a panic to any method that reads output,
     ///   if any stdout or stderr lines match any failure regex
-    pub fn with_failure_regex_iter<I>(&mut self, failure_regexes: I)
+    pub fn with_failure_regex_iter<I>(self, failure_regexes: I) -> Self
     where
         I: CollectRegexSet,
     {
@@ -281,10 +281,12 @@ impl<T> TestChild<T> {
     ///
     /// - adds a panic to any method that reads output,
     ///   if any stdout or stderr lines match any failure regex
-    pub fn with_failure_regexes(&mut self, failure_regexes: RegexSet) {
+    pub fn with_failure_regexes(mut self, failure_regexes: RegexSet) -> Self {
         self.failure_regexes = failure_regexes;
 
         self.apply_failure_regexes_to_outputs();
+
+        self
     }
 
     /// Applies the failure regex set to command output.

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -25,6 +25,11 @@ use to_regex::{CollectRegexSet, ToRegex};
 
 use self::to_regex::ToRegexSet;
 
+/// A super-trait for [`Iterator`] + [`Debug`].
+pub trait IteratorDebug: Iterator + Debug {}
+
+impl<T> IteratorDebug for T where T: Iterator + Debug {}
+
 /// Runs a command
 pub fn test_cmd(command_path: &str, tempdir: &Path) -> Result<Command> {
     let mut cmd = Command::new(command_path);
@@ -163,6 +168,7 @@ impl TestStatus {
 }
 
 /// A test command child process.
+#[derive(Debug)]
 pub struct TestChild<T> {
     /// The working directory of the command.
     pub dir: T,
@@ -174,10 +180,10 @@ pub struct TestChild<T> {
     pub child: Child,
 
     /// The standard output stream of the child process.
-    pub stdout: Option<Box<dyn Iterator<Item = std::io::Result<String>>>>,
+    pub stdout: Option<Box<dyn IteratorDebug<Item = std::io::Result<String>>>>,
 
     /// The standard error stream of the child process.
-    pub stderr: Option<Box<dyn Iterator<Item = std::io::Result<String>>>>,
+    pub stderr: Option<Box<dyn IteratorDebug<Item = std::io::Result<String>>>>,
 
     /// Command outputs which indicate test failure.
     ///

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -224,9 +224,10 @@ pub fn check_failure_regexes(line: &std::io::Result<String>, failure_regexes: &R
 
         assert!(
             failure_matches.is_empty(),
-            "test command output a failure log\n\
-             Matched Failures: {failure_matches:?}\n\
-             Regex Set: {failure_regexes:?}",
+            "test command output a failure message:\n\n\
+             {line}\n\n\
+             Matching: {failure_matches:#?}\n\
+             Match Regexes: {failure_regexes:#?}\n",
         );
     }
 }

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -233,6 +233,7 @@ pub fn check_failure_regexes(line: &std::io::Result<String>, failure_regexes: &R
 
 impl<T> TestChild<T> {
     /// Sets up command output so it is checked against a failure regex set.
+    /// The failure regexes are ignored by `wait_with_output`.
     ///
     /// [`TestChild::with_failure_regexes`] wrapper for strings, [`Regex`]es,
     /// and [`RegexSet`]s.
@@ -253,6 +254,7 @@ impl<T> TestChild<T> {
     }
 
     /// Sets up command output so it is checked against a failure regex set.
+    /// The failure regexes are ignored by `wait_with_output`.
     ///
     /// [`TestChild::with_failure_regexes`] wrapper for regular expression iterators.
     ///
@@ -272,6 +274,7 @@ impl<T> TestChild<T> {
     }
 
     /// Sets up command output so it is checked against a failure regex set.
+    /// The failure regexes are ignored by `wait_with_output`.
     ///
     /// # Panics
     ///
@@ -284,6 +287,7 @@ impl<T> TestChild<T> {
     }
 
     /// Applies the failure regex set to command output.
+    /// The failure regexes are ignored by `wait_with_output`.
     ///
     /// # Panics
     ///
@@ -344,7 +348,7 @@ impl<T> TestChild<T> {
 
     /// Waits for the child process to exit, then returns its output.
     ///
-    /// Ignores any configured timeouts.
+    /// Ignores any configured timeouts or failure regexes.
     #[spandoc::spandoc]
     pub fn wait_with_output(mut self) -> Result<TestOutput<T>> {
         let child = match self.child.take() {

--- a/zebra-test/tests/command.rs
+++ b/zebra-test/tests/command.rs
@@ -182,7 +182,7 @@ fn kill_on_timeout_no_output() -> Result<()> {
 /// Make sure failure regexes detect when a child process prints a failure message to stdout,
 /// and panic with a test failure message.
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stdout_failure_message() {
     zebra_test::init();
 
@@ -191,7 +191,7 @@ fn failure_regex_matches_stdout_failure_message() {
     if !is_command_available(TEST_CMD, &[]) {
         panic!(
             "skipping test: command not available\n\
-             fake panic message: test command output a failure message"
+             fake panic message: Logged a failure message"
         );
     }
 
@@ -212,7 +212,7 @@ fn failure_regex_matches_stdout_failure_message() {
 /// Make sure failure regexes detect when a child process prints a failure message to stderr,
 /// and panic with a test failure message.
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stderr_failure_message() {
     zebra_test::init();
 
@@ -227,7 +227,7 @@ fn failure_regex_matches_stderr_failure_message() {
     if !is_command_available(TEST_CMD, &["-c", "read -t 1 -p failure_message"]) {
         panic!(
             "skipping test: command not available\n\
-             fake panic message: test command output a failure message"
+             fake panic message: Logged a failure message"
         );
     }
 
@@ -248,7 +248,7 @@ fn failure_regex_matches_stderr_failure_message() {
 /// Make sure failure regexes detect when a child process prints a failure message to stdout,
 /// then the child process is dropped without being killed.
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stdout_failure_message_drop() {
     zebra_test::init();
 
@@ -257,7 +257,7 @@ fn failure_regex_matches_stdout_failure_message_drop() {
     if !is_command_available(TEST_CMD, &[]) {
         panic!(
             "skipping test: command not available\n\
-             fake panic message: test command output a failure message"
+             fake panic message: Logged a failure message"
         );
     }
 
@@ -277,7 +277,7 @@ fn failure_regex_matches_stdout_failure_message_drop() {
 /// Make sure failure regexes detect when a child process prints a failure message to stdout,
 /// then the child process is killed.
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stdout_failure_message_kill() {
     zebra_test::init();
 
@@ -286,7 +286,7 @@ fn failure_regex_matches_stdout_failure_message_kill() {
     if !is_command_available(TEST_CMD, &[]) {
         panic!(
             "skipping test: command not available\n\
-             fake panic message: test command output a failure message"
+             fake panic message: Logged a failure message"
         );
     }
 
@@ -308,7 +308,7 @@ fn failure_regex_matches_stdout_failure_message_kill() {
 /// Make sure failure regexes detect when a child process prints a failure message to stdout,
 /// then the child process is killed on error.
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stdout_failure_message_kill_on_error() {
     zebra_test::init();
 
@@ -317,7 +317,7 @@ fn failure_regex_matches_stdout_failure_message_kill_on_error() {
     if !is_command_available(TEST_CMD, &[]) {
         panic!(
             "skipping test: command not available\n\
-             fake panic message: test command output a failure message"
+             fake panic message: Logged a failure message"
         );
     }
 
@@ -340,7 +340,7 @@ fn failure_regex_matches_stdout_failure_message_kill_on_error() {
 /// Make sure failure regexes detect when a child process prints a failure message to stdout,
 /// then the child process is not killed because there is no error.
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stdout_failure_message_no_kill_on_error() {
     zebra_test::init();
 
@@ -349,7 +349,7 @@ fn failure_regex_matches_stdout_failure_message_no_kill_on_error() {
     if !is_command_available(TEST_CMD, &[]) {
         panic!(
             "skipping test: command not available\n\
-             fake panic message: test command output a failure message"
+             fake panic message: Logged a failure message"
         );
     }
 
@@ -374,7 +374,7 @@ fn failure_regex_matches_stdout_failure_message_no_kill_on_error() {
 ///
 /// TODO: test the failure regex on timeouts with no output (#1140)
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_timeout_continuous_output() {
     zebra_test::init();
 
@@ -384,7 +384,10 @@ fn failure_regex_timeout_continuous_output() {
     const TEST_CMD: &str = "hexdump";
     // Skip the test if the test system does not have the command
     if !is_command_available(TEST_CMD, &["/dev/null"]) {
-        return;
+        panic!(
+            "skipping test: command not available\n\
+             fake panic message: Logged a failure message"
+        );
     }
 
     // Without '-v', hexdump hides duplicate lines. But we want duplicate lines
@@ -408,7 +411,7 @@ fn failure_regex_timeout_continuous_output() {
 ///
 /// This is an error, but we still want to check failure logs.
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stdout_failure_message_wait_for_output() {
     zebra_test::init();
 
@@ -417,7 +420,7 @@ fn failure_regex_matches_stdout_failure_message_wait_for_output() {
     if !is_command_available(TEST_CMD, &[]) {
         panic!(
             "skipping test: command not available\n\
-             fake panic message: test command output a failure message"
+             fake panic message: Logged a failure message"
         );
     }
 

--- a/zebra-test/tests/command.rs
+++ b/zebra-test/tests/command.rs
@@ -217,11 +217,14 @@ fn failure_regex_matches_stderr_failure_message() {
     zebra_test::init();
 
     // The read command prints its prompt to stderr.
-    // Some read versions only accept integer timeouts.
-    // Some installs only have read as a shell builtin.
-    const TEST_CMD: &str = "sh";
+    //
+    // This is tricky to get right, because:
+    // - some read command versions only accept integer timeouts
+    // - some installs only have read as a shell builtin
+    // - some `sh` shells don't allow the `-t` option for read
+    const TEST_CMD: &str = "bash";
     // Skip the test if the test system does not have the command
-    if !is_command_available(TEST_CMD, &["-c", "echo"]) {
+    if !is_command_available(TEST_CMD, &["-c", "read -t 1 -p failure_message"]) {
         panic!(
             "skipping test: command not available\n\
              fake panic message: test command output a failure message"

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -223,7 +223,7 @@ pub fn sync_until(
         // if it has already exited, ignore that error
         let _ = child.kill();
 
-        Ok(child.dir)
+        Ok(child.dir.take().expect("dir was not already taken"))
     } else {
         // Require that the mempool didn't activate,
         // checking the entire `zebrad` output after it exits.


### PR DESCRIPTION
## Motivation

We want to check lightwalletd logs and Zebra logs for failures like:
- missing RPCs
- RPC argument parse errors
- RPC argument data errors
- RPC response parse errors
- RPC response data errors
- other specific errors logged by lightwalletd

But our testing framework makes it very hard to do that.

This PR adds an API to check test logs for failures, but it doesn't actually do those checks yet.

This is related to:
- #3500 
- #3856 
- #3511

### Designs

Add a set of failure regexes to each child process, and check each log line for those regexes. Panic if any failures are logged.

Make sure test processes are cleaned up correctly, so their logs are read and checked for failures.

## Solution

Failure logs:
- Add a set of failure regexes to test child processes, and use them to check process output
- When the child is dropped, check any remaining output
- Add internal tests for failure regex panics

Reading process output:
- Add test APIs for consuming child output lines, without checking them for a success regex

Also document some edge cases, and some things we might want to fix later.

## Review

This PR is not urgent.

It is based on PR #3892.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- Check lightwalletd logs for failures