### PR TITLE
T3. add(test): check for failure messages in lightwalletd and Zebra logs

### DIFF
--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -726,12 +726,11 @@ impl<T> AsMut<TestChild<T>> for TestChild<T> {
 
 impl<T> Drop for TestChild<T> {
     fn drop(&mut self) {
-        // Read unread child output.
+        // Clean up child processes when the test finishes,
+        // and check for failure logs.
         //
-        // This checks for failure logs,
-        // and prevents some test hangs and deadlocks.
-        self.stdout.as_mut().map(|iter| iter.last());
-        self.stderr.as_mut().map(|iter| iter.last());
+        // We don't care about the kill result here.
+        let _ = self.kill_and_consume_output();
     }
 }
 

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -232,7 +232,8 @@ pub fn check_failure_regexes(line: &std::io::Result<String>, failure_regexes: &R
             "test command output a failure message:\n\n\
              {line}\n\n\
              Matching: {failure_matches:#?}\n\
-             Match Regexes: {failure_regexes:#?}\n",
+             Match Regexes: {:#?}\n",
+            failure_regexes.patterns(),
         );
     }
 }

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -751,7 +751,9 @@ impl<T> ContextFrom<&mut TestChild<T>> for Report {
 
         // Reading test child process output could hang if the child process is still running,
         // so kill it first.
-        let _ = source.child.kill();
+        if let Some(child) = source.child.as_mut() {
+            let _ = child.kill();
+        }
 
         let mut stdout_buf = String::new();
         let mut stderr_buf = String::new();

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -130,9 +130,13 @@ where
     }
 }
 
+/// Test command exit status information.
 #[derive(Debug)]
 pub struct TestStatus {
+    /// The original command string.
     pub cmd: String,
+
+    /// The exit status of the command.
     pub status: ExitStatus,
 }
 
@@ -154,14 +158,31 @@ impl TestStatus {
     }
 }
 
+/// A test command child process.
 #[derive(Debug)]
 pub struct TestChild<T> {
+    /// The working directory of the command.
     pub dir: T,
+
+    /// The original command string.
     pub cmd: String,
+
+    /// The child process itself.
     pub child: Child,
+
+    /// The standard output stream of the child process.
     pub stdout: Option<Lines<BufReader<ChildStdout>>>,
+
+    /// The standard error stream of the child process.
     pub stderr: Option<Lines<BufReader<ChildStderr>>>,
+
+    /// The deadline for this command to finish.
+    ///
+    /// Only checked when the command outputs each new line (#1140).
     pub deadline: Option<Instant>,
+
+    /// If true, write child output directly to standard output,
+    /// bypassing the Rust test harness output capture.
     bypass_test_capture: bool,
 }
 

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -38,6 +38,8 @@ pub fn test_cmd(command_path: &str, tempdir: &Path) -> Result<Command> {
     Ok(cmd)
 }
 
+// TODO: split these extensions into their own module
+
 /// Wrappers for `Command` methods to integrate with [`zebra_test`].
 pub trait CommandExt {
     /// wrapper for `status` fn on `Command` that constructs informative error
@@ -168,6 +170,7 @@ impl TestStatus {
 }
 
 /// A test command child process.
+// TODO: split this struct into its own module (or multiple modules)
 #[derive(Debug)]
 pub struct TestChild<T> {
     /// The working directory of the command.
@@ -186,6 +189,8 @@ pub struct TestChild<T> {
     pub child: Option<Child>,
 
     /// The standard output stream of the child process.
+    ///
+    /// TODO: replace with `Option<ChildOutput { stdout, stderr }>.
     pub stdout: Option<Box<dyn IteratorDebug<Item = std::io::Result<String>>>>,
 
     /// The standard error stream of the child process.
@@ -625,6 +630,9 @@ impl<T> Drop for TestChild<T> {
     }
 }
 
+/// Test command output logs.
+// TODO: split this struct into its own module
+#[derive(Debug)]
 pub struct TestOutput<T> {
     /// The test directory for this test output.
     ///
@@ -884,6 +892,7 @@ impl<T> TestOutput<T> {
 }
 
 /// Add context to an error report
+// TODO: split this trait into its own module
 pub trait ContextFrom<S> {
     type Return;
 

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -243,7 +243,7 @@ impl<T> TestChild<T> {
     ///
     /// - adds a panic to any method that reads output,
     ///   if any stdout or stderr lines match any failure regex
-    pub fn with_failure_regex_set<R>(&mut self, failure_regexes: R)
+    pub fn with_failure_regex_set<R>(self, failure_regexes: R) -> Self
     where
         R: ToRegexSet,
     {
@@ -263,7 +263,7 @@ impl<T> TestChild<T> {
     ///
     /// - adds a panic to any method that reads output,
     ///   if any stdout or stderr lines match any failure regex
-    pub fn with_failure_regex_iter<I>(&mut self, failure_regexes: I)
+    pub fn with_failure_regex_iter<I>(self, failure_regexes: I) -> Self
     where
         I: CollectRegexSet,
     {
@@ -281,10 +281,12 @@ impl<T> TestChild<T> {
     ///
     /// - adds a panic to any method that reads output,
     ///   if any stdout or stderr lines match any failure regex
-    pub fn with_failure_regexes(&mut self, failure_regexes: RegexSet) {
+    pub fn with_failure_regexes(mut self, failure_regexes: RegexSet) -> Self {
         self.failure_regexes = failure_regexes;
 
         self.apply_failure_regexes_to_outputs();
+
+        self
     }
 
     /// Applies the failure regex set to command output.

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -25,6 +25,11 @@ use to_regex::{CollectRegexSet, ToRegex};
 
 use self::to_regex::ToRegexSet;
 
+/// A super-trait for [`Iterator`] + [`Debug`].
+pub trait IteratorDebug: Iterator + Debug {}
+
+impl<T> IteratorDebug for T where T: Iterator + Debug {}
+
 /// Runs a command
 pub fn test_cmd(command_path: &str, tempdir: &Path) -> Result<Command> {
     let mut cmd = Command::new(command_path);
@@ -163,6 +168,7 @@ impl TestStatus {
 }
 
 /// A test command child process.
+#[derive(Debug)]
 pub struct TestChild<T> {
     /// The working directory of the command.
     pub dir: T,
@@ -174,10 +180,10 @@ pub struct TestChild<T> {
     pub child: Child,
 
     /// The standard output stream of the child process.
-    pub stdout: Option<Box<dyn Iterator<Item = std::io::Result<String>>>>,
+    pub stdout: Option<Box<dyn IteratorDebug<Item = std::io::Result<String>>>>,
 
     /// The standard error stream of the child process.
-    pub stderr: Option<Box<dyn Iterator<Item = std::io::Result<String>>>>,
+    pub stderr: Option<Box<dyn IteratorDebug<Item = std::io::Result<String>>>>,
 
     /// Command outputs which indicate test failure.
     ///

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -751,9 +751,7 @@ impl<T> ContextFrom<&mut TestChild<T>> for Report {
 
         // Reading test child process output could hang if the child process is still running,
         // so kill it first.
-        if let Some(child) = source.child.as_mut() {
-            let _ = child.kill();
-        }
+        let _ = source.child.kill();
 
         let mut stdout_buf = String::new();
         let mut stderr_buf = String::new();

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -224,9 +224,10 @@ pub fn check_failure_regexes(line: &std::io::Result<String>, failure_regexes: &R
 
         assert!(
             failure_matches.is_empty(),
-            "test command output a failure log\n\
-             Matched Failures: {failure_matches:?}\n\
-             Regex Set: {failure_regexes:?}",
+            "test command output a failure message:\n\n\
+             {line}\n\n\
+             Matching: {failure_matches:#?}\n\
+             Match Regexes: {failure_regexes:#?}\n",
         );
     }
 }

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -233,6 +233,7 @@ pub fn check_failure_regexes(line: &std::io::Result<String>, failure_regexes: &R
 
 impl<T> TestChild<T> {
     /// Sets up command output so it is checked against a failure regex set.
+    /// The failure regexes are ignored by `wait_with_output`.
     ///
     /// [`TestChild::with_failure_regexes`] wrapper for strings, [`Regex`]es,
     /// and [`RegexSet`]s.
@@ -253,6 +254,7 @@ impl<T> TestChild<T> {
     }
 
     /// Sets up command output so it is checked against a failure regex set.
+    /// The failure regexes are ignored by `wait_with_output`.
     ///
     /// [`TestChild::with_failure_regexes`] wrapper for regular expression iterators.
     ///
@@ -272,6 +274,7 @@ impl<T> TestChild<T> {
     }
 
     /// Sets up command output so it is checked against a failure regex set.
+    /// The failure regexes are ignored by `wait_with_output`.
     ///
     /// # Panics
     ///
@@ -284,6 +287,7 @@ impl<T> TestChild<T> {
     }
 
     /// Applies the failure regex set to command output.
+    /// The failure regexes are ignored by `wait_with_output`.
     ///
     /// # Panics
     ///
@@ -344,7 +348,7 @@ impl<T> TestChild<T> {
 
     /// Waits for the child process to exit, then returns its output.
     ///
-    /// Ignores any configured timeouts.
+    /// Ignores any configured timeouts or failure regexes.
     #[spandoc::spandoc]
     pub fn wait_with_output(mut self) -> Result<TestOutput<T>> {
         let child = match self.child.take() {

--- a/zebra-test/src/command/to_regex.rs
+++ b/zebra-test/src/command/to_regex.rs
@@ -120,6 +120,12 @@ where
 pub trait CollectRegexSet {
     /// Collects the iterator values to a [`RegexSet`].
     ///
+    /// When converting from a [`Regex`] or [`RegexBuilder`],
+    /// resets match flags and limits to the defaults.
+    ///
+    /// Use a [`RegexSet`] or [`RegexSetBuilder`] to preserve these settings,
+    /// via the `*_regex_set` methods.
+    ///
     /// Returns an [`Error`] if any conversion fails.
     fn collect_regex_set(self) -> Result<RegexSet, Error>;
 }

--- a/zebra-test/src/command/to_regex.rs
+++ b/zebra-test/src/command/to_regex.rs
@@ -1,0 +1,144 @@
+//! Convenience traits for converting to [`Regex`] and [`RegexSet`].
+
+use std::iter;
+
+use regex::{Error, Regex, RegexBuilder, RegexSet, RegexSetBuilder};
+
+/// A trait for converting a value to a [`Regex`].
+pub trait ToRegex {
+    /// Converts the given value to a [`Regex`].
+    ///
+    /// Returns an [`Error`] if conversion fails.
+    fn to_regex(&self) -> Result<Regex, Error>;
+}
+
+// Identity conversions
+
+impl ToRegex for Regex {
+    fn to_regex(&self) -> Result<Regex, Error> {
+        Ok(self.clone())
+    }
+}
+
+impl ToRegex for &Regex {
+    fn to_regex(&self) -> Result<Regex, Error> {
+        Ok((*self).clone())
+    }
+}
+
+// Builder Conversions
+
+impl ToRegex for RegexBuilder {
+    fn to_regex(&self) -> Result<Regex, Error> {
+        self.build()
+    }
+}
+
+impl ToRegex for &RegexBuilder {
+    fn to_regex(&self) -> Result<Regex, Error> {
+        self.build()
+    }
+}
+
+// String conversions
+
+impl ToRegex for String {
+    fn to_regex(&self) -> Result<Regex, Error> {
+        Regex::new(self)
+    }
+}
+
+impl ToRegex for &String {
+    fn to_regex(&self) -> Result<Regex, Error> {
+        Regex::new(self)
+    }
+}
+
+impl ToRegex for &str {
+    fn to_regex(&self) -> Result<Regex, Error> {
+        Regex::new(self)
+    }
+}
+
+/// A trait for converting a value to a [`RegexSet`].
+pub trait ToRegexSet {
+    /// Converts the given values to a [`RegexSet`].
+    ///
+    /// When converting from a [`Regex`] or [`RegexBuilder`],
+    /// resets match flags and limits to the defaults.
+    /// Use a [`RegexSet`] or [`RegexSetBuilder`] to preserve these settings.
+    ///
+    /// Returns an [`Error`] if any conversion fails.
+    fn to_regex_set(&self) -> Result<RegexSet, Error>;
+}
+
+// Identity conversions
+
+impl ToRegexSet for RegexSet {
+    fn to_regex_set(&self) -> Result<RegexSet, Error> {
+        Ok(self.clone())
+    }
+}
+
+impl ToRegexSet for &RegexSet {
+    fn to_regex_set(&self) -> Result<RegexSet, Error> {
+        Ok((*self).clone())
+    }
+}
+
+// Builder Conversions
+
+impl ToRegexSet for RegexSetBuilder {
+    fn to_regex_set(&self) -> Result<RegexSet, Error> {
+        self.build()
+    }
+}
+
+impl ToRegexSet for &RegexSetBuilder {
+    fn to_regex_set(&self) -> Result<RegexSet, Error> {
+        self.build()
+    }
+}
+
+// Single item conversion
+
+impl<T> ToRegexSet for T
+where
+    T: ToRegex,
+{
+    fn to_regex_set(&self) -> Result<RegexSet, Error> {
+        let regex = self.to_regex()?;
+
+        // This conversion discards flags and limits from Regex and RegexBuilder.
+        let regex = regex.as_str();
+
+        RegexSet::new(iter::once(regex))
+    }
+}
+
+/// A trait for collecting an iterator into a [`RegexSet`].
+pub trait CollectRegexSet {
+    /// Collects the iterator values to a [`RegexSet`].
+    ///
+    /// Returns an [`Error`] if any conversion fails.
+    fn collect_regex_set(self) -> Result<RegexSet, Error>;
+}
+
+// Multi item conversion
+
+impl<I> CollectRegexSet for I
+where
+    I: IntoIterator,
+    I::Item: ToRegex,
+{
+    fn collect_regex_set(self) -> Result<RegexSet, Error> {
+        let regexes: Result<Vec<Regex>, Error> =
+            self.into_iter().map(|item| item.to_regex()).collect();
+        let regexes = regexes?;
+
+        // This conversion discards flags and limits from Regex and RegexBuilder.
+        let regexes = regexes.iter().map(|regex| regex.as_str());
+
+        RegexSet::new(regexes)
+    }
+}

--- a/zebra-test/tests/command.rs
+++ b/zebra-test/tests/command.rs
@@ -182,7 +182,7 @@ fn kill_on_timeout_no_output() -> Result<()> {
 /// Make sure failure regexes detect when a child process prints a failure message to stdout,
 /// and panic with a test failure message.
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stdout_failure_message() {
     zebra_test::init();
 
@@ -191,7 +191,7 @@ fn failure_regex_matches_stdout_failure_message() {
     if !is_command_available(TEST_CMD, &[]) {
         panic!(
             "skipping test: command not available\n\
-             fake panic message: test command output a failure message"
+             fake panic message: Logged a failure message"
         );
     }
 
@@ -212,7 +212,7 @@ fn failure_regex_matches_stdout_failure_message() {
 /// Make sure failure regexes detect when a child process prints a failure message to stderr,
 /// and panic with a test failure message.
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stderr_failure_message() {
     zebra_test::init();
 
@@ -227,7 +227,7 @@ fn failure_regex_matches_stderr_failure_message() {
     if !is_command_available(TEST_CMD, &["-c", "read -t 1 -p failure_message"]) {
         panic!(
             "skipping test: command not available\n\
-             fake panic message: test command output a failure message"
+             fake panic message: Logged a failure message"
         );
     }
 
@@ -248,7 +248,7 @@ fn failure_regex_matches_stderr_failure_message() {
 /// Make sure failure regexes detect when a child process prints a failure message to stdout,
 /// then the child process is dropped without being killed.
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stdout_failure_message_drop() {
     zebra_test::init();
 
@@ -257,7 +257,7 @@ fn failure_regex_matches_stdout_failure_message_drop() {
     if !is_command_available(TEST_CMD, &[]) {
         panic!(
             "skipping test: command not available\n\
-             fake panic message: test command output a failure message"
+             fake panic message: Logged a failure message"
         );
     }
 
@@ -277,7 +277,7 @@ fn failure_regex_matches_stdout_failure_message_drop() {
 /// Make sure failure regexes detect when a child process prints a failure message to stdout,
 /// then the child process is killed.
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stdout_failure_message_kill() {
     zebra_test::init();
 
@@ -286,7 +286,7 @@ fn failure_regex_matches_stdout_failure_message_kill() {
     if !is_command_available(TEST_CMD, &[]) {
         panic!(
             "skipping test: command not available\n\
-             fake panic message: test command output a failure message"
+             fake panic message: Logged a failure message"
         );
     }
 
@@ -308,7 +308,7 @@ fn failure_regex_matches_stdout_failure_message_kill() {
 /// Make sure failure regexes detect when a child process prints a failure message to stdout,
 /// then the child process is killed on error.
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stdout_failure_message_kill_on_error() {
     zebra_test::init();
 
@@ -317,7 +317,7 @@ fn failure_regex_matches_stdout_failure_message_kill_on_error() {
     if !is_command_available(TEST_CMD, &[]) {
         panic!(
             "skipping test: command not available\n\
-             fake panic message: test command output a failure message"
+             fake panic message: Logged a failure message"
         );
     }
 
@@ -340,7 +340,7 @@ fn failure_regex_matches_stdout_failure_message_kill_on_error() {
 /// Make sure failure regexes detect when a child process prints a failure message to stdout,
 /// then the child process is not killed because there is no error.
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stdout_failure_message_no_kill_on_error() {
     zebra_test::init();
 
@@ -349,7 +349,7 @@ fn failure_regex_matches_stdout_failure_message_no_kill_on_error() {
     if !is_command_available(TEST_CMD, &[]) {
         panic!(
             "skipping test: command not available\n\
-             fake panic message: test command output a failure message"
+             fake panic message: Logged a failure message"
         );
     }
 
@@ -374,7 +374,7 @@ fn failure_regex_matches_stdout_failure_message_no_kill_on_error() {
 ///
 /// TODO: test the failure regex on timeouts with no output (#1140)
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_timeout_continuous_output() {
     zebra_test::init();
 
@@ -384,7 +384,10 @@ fn failure_regex_timeout_continuous_output() {
     const TEST_CMD: &str = "hexdump";
     // Skip the test if the test system does not have the command
     if !is_command_available(TEST_CMD, &["/dev/null"]) {
-        return;
+        panic!(
+            "skipping test: command not available\n\
+             fake panic message: Logged a failure message"
+        );
     }
 
     // Without '-v', hexdump hides duplicate lines. But we want duplicate lines
@@ -408,7 +411,7 @@ fn failure_regex_timeout_continuous_output() {
 ///
 /// This is an error, but we still want to check failure logs.
 #[test]
-#[should_panic(expected = "test command output a failure message")]
+#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stdout_failure_message_wait_for_output() {
     zebra_test::init();
 
@@ -417,7 +420,7 @@ fn failure_regex_matches_stdout_failure_message_wait_for_output() {
     if !is_command_available(TEST_CMD, &[]) {
         panic!(
             "skipping test: command not available\n\
-             fake panic message: test command output a failure message"
+             fake panic message: Logged a failure message"
         );
     }
 

--- a/zebra-test/tests/command.rs
+++ b/zebra-test/tests/command.rs
@@ -217,11 +217,14 @@ fn failure_regex_matches_stderr_failure_message() {
     zebra_test::init();
 
     // The read command prints its prompt to stderr.
-    // Some read versions only accept integer timeouts.
-    // Some installs only have read as a shell builtin.
-    const TEST_CMD: &str = "sh";
+    //
+    // This is tricky to get right, because:
+    // - some read command versions only accept integer timeouts
+    // - some installs only have read as a shell builtin
+    // - some `sh` shells don't allow the `-t` option for read
+    const TEST_CMD: &str = "bash";
     // Skip the test if the test system does not have the command
-    if !is_command_available(TEST_CMD, &["-c", "echo"]) {
+    if !is_command_available(TEST_CMD, &["-c", "read -t 1 -p failure_message"]) {
         panic!(
             "skipping test: command not available\n\
              fake panic message: test command output a failure message"

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -994,11 +994,12 @@ const PROCESS_FAILURE_MESSAGES: &[&str] = &[
     "Aborted",
     // macOS / BSDs
     "Abort trap",
+    // TODO: add other OS or C library errors?
 ];
 
 /// Failure log messages from Zebra.
 const ZEBRA_FAILURE_MESSAGES: &[&str] = &[
-    // Rust-specific
+    // Rust-specific panics
     "The application panicked",
     // RPC port errors
     "Unable to start RPC server",
@@ -1029,18 +1030,16 @@ const LIGHTWALLETD_FAILURE_MESSAGES: &[&str] = &[
     //
     // jsonrpc_core error messages from Zebra,
     // received by lightwalletd and written to its logs
-    //
-    // TODO: log these errors in Zebra, and check for them in the Zebra logs?
     "Invalid params",
     "Method not found",
     // Early termination
     //
     // TODO: temporarily disable until enough RPCs are implemented, if needed
     "Lightwalletd died with a Fatal error",
-    // JSON error messages:
+    // Go json package error messages:
     "json: cannot unmarshal",
     "into Go value of type",
-    // RPC error messages from:
+    // lightwalletd RPC error messages from:
     // https://github.com/adityapk00/lightwalletd/blob/master/common/common.go
     "block requested is newer than latest block",
     "Cache add failed",
@@ -1058,8 +1057,6 @@ const LIGHTWALLETD_FAILURE_MESSAGES: &[&str] = &[
     "unable to issue RPC call",
     // Missing fields for each specific RPC
     //
-    // TODO: complete this list for each RPC field?
-    //
     // get_block_chain_info
     //
     // missing branchID, should be the 8 hex digits "76b809bb"
@@ -1072,6 +1069,14 @@ const LIGHTWALLETD_FAILURE_MESSAGES: &[&str] = &[
     //" chain  ",
     // missing branchID, should be the 8 hex digits "76b809bb"
     //" branchID \"",
+    //
+    // TODO: complete this list for each RPC with fields?
+    // get_info
+    // get_raw_transaction
+    // z_get_tree_state
+    // get_address_txids
+    // get_address_balance
+    // get_address_utxos
 ];
 
 /// Launch `zebrad` with an RPC port, and make sure `lightwalletd` works with Zebra.

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -659,7 +659,7 @@ fn full_sync_testnet() {
 /// The timeout is specified using an environment variable, with the name configured by the
 /// `timeout_argument_name` parameter. The value of the environment variable must the number of
 /// minutes specified as an integer.
-fn full_sync_test(network: Network, timeout_argument_name: &'static str) -> Result<()> {
+fn full_sync_test(network: Network, timeout_argument_name: &str) -> Result<()> {
     let timeout_argument: Option<u64> = env::var(timeout_argument_name)
         .ok()
         .and_then(|timeout_string| timeout_string.parse().ok());
@@ -678,8 +678,7 @@ fn full_sync_test(network: Network, timeout_argument_name: &'static str) -> Resu
             // TODO: if full validation performance improves, do another test with checkpoint_sync off
             true,
             true,
-        )
-        .map(|_| ())
+        )?;
     } else {
         tracing::info!(
             ?network,
@@ -687,9 +686,9 @@ fn full_sync_test(network: Network, timeout_argument_name: &'static str) -> Resu
              set the {:?} environmental variable to run the test",
             timeout_argument_name,
         );
-
-        Ok(())
     }
+
+    Ok(())
 }
 
 fn create_cached_database(network: Network) -> Result<()> {

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1059,15 +1059,13 @@ const LIGHTWALLETD_FAILURE_MESSAGES: &[&str] = &[
     //
     // get_block_chain_info
     //
-    // missing branchID, should be the 8 hex digits "76b809bb"
-    " branchID 0",
     // TODO: enable these checks after PR #3891 merges
     //
     // invalid sapling height
     //"Got sapling height 0",
     // missing BIP70 chain name, should be "main" or "test"
     //" chain  ",
-    // missing branchID, should be the 8 hex digits "76b809bb"
+    // missing branchID, should be 8 hex digits
     //" branchID \"",
     //
     // TODO: complete this list for each RPC with fields?

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -988,6 +988,92 @@ async fn rpc_endpoint() -> Result<()> {
     Ok(())
 }
 
+/// Failure log messages for any process, from the OS or shell.
+const PROCESS_FAILURE_MESSAGES: &[&str] = &[
+    // Linux
+    "Aborted",
+    // macOS / BSDs
+    "Abort trap",
+];
+
+/// Failure log messages from Zebra.
+const ZEBRA_FAILURE_MESSAGES: &[&str] = &[
+    // Rust-specific
+    "The application panicked",
+    // RPC port errors
+    "Unable to start RPC server",
+    // TODO: disable if this actually happens during test zebrad shutdown
+    "Stopping RPC endpoint",
+    // Missing RPCs in zebrad logs (this log is from PR #3860)
+    //
+    // TODO: temporarily disable until enough RPCs are implemented, if needed
+    "Received unrecognized RPC request",
+    // RPC argument errors: parsing and data
+    //
+    // These logs are produced by jsonrpc_core inside Zebra,
+    // but it doesn't log them yet.
+    //
+    // TODO: log these errors in Zebra, and check for them in the Zebra logs?
+    "Invalid params",
+    "Method not found",
+];
+
+/// Failure log messages from lightwalletd.
+const LIGHTWALLETD_FAILURE_MESSAGES: &[&str] = &[
+    // Go-specific panics
+    "panic:",
+    // Missing RPCs in lightwalletd logs
+    // TODO: temporarily disable until enough RPCs are implemented, if needed
+    "unable to issue RPC call",
+    // RPC response errors: parsing and data
+    //
+    // jsonrpc_core error messages from Zebra,
+    // received by lightwalletd and written to its logs
+    //
+    // TODO: log these errors in Zebra, and check for them in the Zebra logs?
+    "Invalid params",
+    "Method not found",
+    // Early termination
+    //
+    // TODO: temporarily disable until enough RPCs are implemented, if needed
+    "Lightwalletd died with a Fatal error",
+    // JSON error messages:
+    "json: cannot unmarshal",
+    "into Go value of type",
+    // RPC error messages from:
+    // https://github.com/adityapk00/lightwalletd/blob/master/common/common.go
+    "block requested is newer than latest block",
+    "Cache add failed",
+    "error decoding",
+    "error marshaling",
+    "error parsing JSON",
+    "error reading JSON response",
+    "error with",
+    // We expect these errors when lightwalletd reaches the end of the zebrad cached state
+    // "error requesting block: 0: Block not found",
+    // "error zcashd getblock rpc",
+    "received overlong message",
+    "received unexpected height block",
+    "Reorg exceeded max",
+    "unable to issue RPC call",
+    // Missing fields for each specific RPC
+    //
+    // TODO: complete this list for each RPC field?
+    //
+    // get_block_chain_info
+    //
+    // missing branchID, should be the 8 hex digits "76b809bb"
+    " branchID 0",
+    // TODO: enable these checks after PR #3891 merges
+    //
+    // invalid sapling height
+    //"Got sapling height 0",
+    // missing BIP70 chain name, should be "main" or "test"
+    //" chain  ",
+    // missing branchID, should be the 8 hex digits "76b809bb"
+    //" branchID \"",
+];
+
 /// Launch `zebrad` with an RPC port, and make sure `lightwalletd` works with Zebra.
 ///
 /// This test only runs when the `ZEBRA_TEST_LIGHTWALLETD` env var is set.
@@ -1010,7 +1096,16 @@ fn lightwalletd_integration() -> Result<()> {
     let mut config = random_known_rpc_port_config()?;
 
     let zdir = testdir()?.with_config(&mut config)?;
-    let mut zebrad = zdir.spawn_child(&["start"])?.with_timeout(LAUNCH_DELAY);
+    let mut zebrad = zdir
+        .spawn_child(&["start"])?
+        .with_timeout(LAUNCH_DELAY)
+        .with_failure_regex_iter(
+            // TODO: replace with a function that returns the full list and correct return type
+            ZEBRA_FAILURE_MESSAGES
+                .iter()
+                .chain(PROCESS_FAILURE_MESSAGES)
+                .cloned(),
+        );
 
     // Wait until `zebrad` has opened the RPC endpoint
     zebrad.expect_stdout_line_matches(
@@ -1026,7 +1121,15 @@ fn lightwalletd_integration() -> Result<()> {
     // Launch the lightwalletd process
     let result = ldir.spawn_lightwalletd_child(&[]);
     let (lightwalletd, zebrad) = zebrad.kill_on_error(result)?;
-    let mut lightwalletd = lightwalletd.with_timeout(LIGHTWALLETD_DELAY);
+    let mut lightwalletd = lightwalletd
+        .with_timeout(LIGHTWALLETD_DELAY)
+        .with_failure_regex_iter(
+            // TODO: replace with a function that returns the full list and correct return type
+            LIGHTWALLETD_FAILURE_MESSAGES
+                .iter()
+                .chain(PROCESS_FAILURE_MESSAGES)
+                .cloned(),
+        );
 
     // Wait until `lightwalletd` has launched
     let result = lightwalletd.expect_stdout_line_matches("Starting gRPC server");
@@ -1035,6 +1138,9 @@ fn lightwalletd_integration() -> Result<()> {
     // Check that `lightwalletd` is calling the expected Zebra RPCs
 
     // getblockchaininfo
+    //
+    // TODO: add correct sapling height, chain, branchID (PR #3891)
+    //       add "Waiting for zcashd height to reach Sapling activation height"
     let result = lightwalletd.expect_stdout_line_matches("Got sapling height");
     let (_, zebrad) = zebrad.kill_on_error(result)?;
 

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -223,7 +223,7 @@ pub fn sync_until(
         // if it has already exited, ignore that error
         let _ = child.kill();
 
-        Ok(child.dir)
+        Ok(child.dir.take().expect("dir was not already taken"))
     } else {
         // Require that the mempool didn't activate,
         // checking the entire `zebrad` output after it exits.


### PR DESCRIPTION
## Motivation

We want to check lightwalletd logs and Zebra logs for failures like:
- missing RPCs
- RPC argument parse errors
- RPC argument data errors
- RPC response parse errors
- RPC response data errors
- other specific errors logged by lightwalletd

This PR checks `lightwalletd` and `zebrad` test logs for failure messages.

This is related to:
- #3500 
- #3856 
- #3511

## Solution

- Add a list of failure messages for `lightwalletd`, `zebrad`, and any process
- Check for them in the integration test logs

## Review

This PR isn't urgent, but it might need changes when we add new RPCs.
(Or it might find bugs in new RPCs.)

This PR is based on PR #3899.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Keep the failure lists up-to-date as we add new RPCs.