### PR TITLE
change(rpc): Return getblockchaininfo network upgrades in height order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,6 +1942,7 @@ checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -3870,6 +3871,7 @@ version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
+ "indexmap",
  "itoa 1.0.1",
  "ryu",
  "serde",
@@ -5750,11 +5752,13 @@ dependencies = [
  "futures",
  "hex",
  "hyper",
+ "indexmap",
  "jsonrpc-core",
  "jsonrpc-derive",
  "jsonrpc-http-server",
  "proptest",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tower",

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -120,20 +120,7 @@ const FAKE_TESTNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] = &[
 
 /// The Consensus Branch Id, used to bind transactions and blocks to a
 /// particular network upgrade.
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Default,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    serde::Serialize,
-    serde::Deserialize,
-)]
-
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ConsensusBranchId(u32);
 
 impl ConsensusBranchId {
@@ -153,6 +140,16 @@ impl From<ConsensusBranchId> for u32 {
 }
 
 impl ToHex for &ConsensusBranchId {
+    fn encode_hex<T: FromIterator<char>>(&self) -> T {
+        self.bytes_in_display_order().encode_hex()
+    }
+
+    fn encode_hex_upper<T: FromIterator<char>>(&self) -> T {
+        self.bytes_in_display_order().encode_hex_upper()
+    }
+}
+
+impl ToHex for ConsensusBranchId {
     fn encode_hex<T: FromIterator<char>>(&self) -> T {
         self.bytes_in_display_order().encode_hex()
     }
@@ -460,6 +457,16 @@ impl NetworkUpgrade {
 }
 
 impl ConsensusBranchId {
+    /// The value used by `zcashd` RPCs for missing consensus branch IDs.
+    ///
+    /// # Consensus
+    ///
+    /// This value must only be used in RPCs.
+    ///
+    /// The consensus rules handle missing branch IDs by rejecting blocks and transactions,
+    /// so this substitute value must not be used in consensus-critical code.
+    pub const RPC_MISSING_ID: ConsensusBranchId = ConsensusBranchId(0);
+
     /// Returns the current consensus branch id for `network` and `height`.
     ///
     /// Returns None if the network has no branch id at this height.

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -139,8 +139,8 @@ pub struct ConsensusBranchId(u32);
 impl ConsensusBranchId {
     /// Return the hash bytes in big-endian byte-order suitable for printing out byte by byte.
     ///
-    /// Zebra displays transaction and block hashes in big-endian byte-order,
-    /// following the u256 convention set by Bitcoin and zcashd.
+    /// Zebra displays consensus branch IDs in big-endian byte-order,
+    /// following the convention set by zcashd.
     fn bytes_in_display_order(&self) -> [u8; 4] {
         self.0.to_be_bytes()
     }
@@ -225,8 +225,8 @@ const TESTNET_MINIMUM_DIFFICULTY_START_HEIGHT: block::Height = block::Height(299
 pub const TESTNET_MAX_TIME_START_HEIGHT: block::Height = block::Height(653_606);
 
 impl NetworkUpgrade {
-    /// Returns a BTreeMap of activation heights and network upgrades for
-    /// `network`.
+    /// Returns a map between activation heights and network upgrades for `network`,
+    /// in ascending height order.
     ///
     /// If the activation height of a future upgrade is not known, that
     /// network upgrade does not appear in the list.
@@ -313,7 +313,7 @@ impl NetworkUpgrade {
         NetworkUpgrade::activation_list(network).contains_key(&height)
     }
 
-    /// Returns a BTreeMap of NetworkUpgrades and their ConsensusBranchIds.
+    /// Returns an unordered mapping between NetworkUpgrades and their ConsensusBranchIds.
     ///
     /// Branch ids are the same for mainnet and testnet.
     ///

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -22,6 +22,9 @@ hyper = { version = "0.14.17", features = ["http1", "server"] }
 jsonrpc-core = "18.0.0"
 jsonrpc-derive = "18.0.0"
 jsonrpc-http-server = "18.0.0"
+# zebra-rpc needs the preserve_order feature in serde_json, which is a dependency of jsonrpc-core
+serde_json = { version = "1.0.79", features = ["preserve_order"] }
+indexmap = { version = "1.8.0", features = ["serde"] }
 
 tokio = { version = "1.17.0", features = ["time", "rt-multi-thread", "macros", "tracing"] }
 tower = "0.4.12"

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -4,13 +4,12 @@
 //! as used by `lightwalletd.`
 //!
 //! Some parts of the `zcashd` RPC documentation are outdated.
-//! So this implementation follows the `lightwalletd` client implementation.
-
-use std::collections::BTreeMap;
+//! So this implementation follows the `zcashd` server and `lightwalletd` client implementations.
 
 use chrono::Utc;
 use futures::{FutureExt, TryFutureExt};
 use hex::{FromHex, ToHex};
+use indexmap::IndexMap;
 use jsonrpc_core::{self, BoxFuture, Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use tower::{buffer::Buffer, Service, ServiceExt};
@@ -227,10 +226,16 @@ where
             })?;
 
         // `upgrades` object
-        let mut upgrades = BTreeMap::new();
+        //
+        // Get the network upgrades in height order, like `zcashd`.
+        let mut upgrades = IndexMap::new();
         for (activation_height, network_upgrade) in NetworkUpgrade::activation_list(network) {
-            // zcashd output network upgrades greater than height 1.
-            if activation_height > Height(1) {
+            // Zebra defines network upgrades based on incompatible consensus rule changes,
+            // but zcashd defines them based on ZIPs.
+            //
+            // All the network upgrades with a consensus branch ID are the same in Zebra and zcashd.
+            if let Some(branch_id) = network_upgrade.branch_id() {
+                // zcashd's RPC seems to ignore Disabled network upgrages, so Zebra does too.
                 let status = if tip_height >= activation_height {
                     NetworkUpgradeStatus::Active
                 } else {
@@ -242,24 +247,23 @@ where
                     activation_height,
                     status,
                 };
-                let branch = ConsensusBranchIdHex(network_upgrade.branch_id().unwrap_or_default());
-                upgrades.insert(branch, upgrade);
+                upgrades.insert(ConsensusBranchIdHex(branch_id), upgrade);
             }
         }
 
         // `consensus` object
         let next_block_height =
             (tip_height + 1).expect("valid chain tips are a lot less than Height::MAX");
-        let consensus = Consensus {
+        let consensus = TipConsensusBranch {
             chain_tip: ConsensusBranchIdHex(
                 NetworkUpgrade::current(network, tip_height)
                     .branch_id()
-                    .unwrap_or_default(),
+                    .unwrap_or(ConsensusBranchId::RPC_MISSING_ID),
             ),
             next_block: ConsensusBranchIdHex(
                 NetworkUpgrade::current(network, next_block_height)
                     .branch_id()
-                    .unwrap_or_default(),
+                    .unwrap_or(ConsensusBranchId::RPC_MISSING_ID),
             ),
         };
 
@@ -406,10 +410,10 @@ pub struct GetInfo {
     subversion: String,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// Response to a `getblockchaininfo` RPC request.
 ///
 /// See the notes for the [`Rpc::get_blockchain_info` method].
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct GetBlockChainInfo {
     chain: String,
     blocks: u32,
@@ -417,14 +421,16 @@ pub struct GetBlockChainInfo {
     best_block_hash: GetBestBlockHash,
     #[serde(rename = "estimatedheight")]
     estimated_height: u32,
-    upgrades: BTreeMap<ConsensusBranchIdHex, NetworkUpgradeInfo>,
-    consensus: Consensus,
+    upgrades: IndexMap<ConsensusBranchIdHex, NetworkUpgradeInfo>,
+    consensus: TipConsensusBranch,
 }
 
-#[derive(Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+/// A hex-encoded [`ConsensusBranchId`] string.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 struct ConsensusBranchIdHex(#[serde(with = "hex")] ConsensusBranchId);
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+/// Information about [`NetworkUpgrade`] activation.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 struct NetworkUpgradeInfo {
     name: NetworkUpgrade,
     #[serde(rename = "activationheight")]
@@ -432,7 +438,8 @@ struct NetworkUpgradeInfo {
     status: NetworkUpgradeStatus,
 }
 
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+/// The activation status of a [`NetworkUpgrade`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 enum NetworkUpgradeStatus {
     #[serde(rename = "active")]
     Active,
@@ -442,8 +449,11 @@ enum NetworkUpgradeStatus {
     Pending,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-struct Consensus {
+/// The [`ConsensusBranchId`]s for the tip and the next block.
+///
+/// These branch IDs are different when the next block is a network upgrade activation block.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+struct TipConsensusBranch {
     #[serde(rename = "chaintip")]
     chain_tip: ConsensusBranchIdHex,
     #[serde(rename = "nextblock")]

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -401,10 +401,10 @@ where
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
 /// Response to a `getinfo` RPC request.
 ///
 /// See the notes for the [`Rpc::get_info` method].
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct GetInfo {
     build: String,
     subversion: String,
@@ -460,24 +460,24 @@ struct TipConsensusBranch {
     next_block: ConsensusBranchIdHex,
 }
 
-#[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 /// Response to a `sendrawtransaction` RPC request.
 ///
 /// Contains the hex-encoded hash of the sent transaction.
 ///
 /// See the notes for the [`Rpc::send_raw_transaction` method].
+#[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SentTransactionHash(#[serde(with = "hex")] transaction::Hash);
 
-#[derive(serde::Serialize)]
 /// Response to a `getblock` RPC request.
 ///
 /// See the notes for the [`Rpc::get_block` method].
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
 pub struct GetBlock(#[serde(with = "hex")] SerializedBlock);
 
-#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 /// Response to a `getbestblockhash` RPC request.
 ///
 /// Contains the hex-encoded hash of the tip block.
 ///
 /// Also see the notes for the [`Rpc::get_best_block_hash` method].
+#[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GetBestBlockHash(#[serde(with = "hex")] block::Hash);

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -396,7 +396,7 @@ proptest! {
             },
         };
 
-        // check no futures were called in this test
+        // check no requests were made during this test
         runtime.block_on(async move {
             mempool.expect_no_requests().await?;
             state.expect_no_requests().await?;

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -61,7 +61,8 @@ abscissa_core = { version = "0.5", features = ["testing"] }
 once_cell = "1.10.0"
 regex = "1.5.5"
 semver = "1.0.6"
-serde_json = "1.0"
+# zebra-rpc needs the preserve_order feature, it also makes test results more stable
+serde_json = { version = "1.0.79", features = ["preserve_order"] }
 tempfile = "3.3.0"
 tokio = { version = "1.17.0", features = ["full", "test-util"] }
 


### PR DESCRIPTION
## Motivation

1. In PR #3891, we return network upgrades in numeric consensus branch ID order. But `zcashd` returns them in height order. I don't know if this matters to any `lightwalletd` implementation. But it does make them easier to read & debug.

2. PR #3891 adds a default value for ConsensusBranchId, but this doesn't match the consensus rules. (The default is only used for RPCs.)

### Specifications

RPC:
* https://zcash.github.io/rpc/getblockchaininfo.html

serde_json `preserve_order` feature:
https://docs.serde.rs/serde_json/map/index.html

### Designs

Use `IndexMap` to preserve map order. (This is a serde_json feature.)

Use a constant for a RPC-specific default value.

## Solution

- List network upgrades in order in the getblockchaininfo RPC

- Use a constant for the "missing consensus branch ID" RPC value, because there is no default value for consensus rule validation
- Simplify fetching consensus branch IDs

Related cleanups:
- Make RPC trait derives consistent

Related documentation:
- Update some doc comments for network upgrades
- Update RPC type documentation

## Review

This PR can merge separately to PR #3891, it doesn't change the test results.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Example Test

When I run:
```sh
$ curl --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "getblockchaininfo", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:28232/ | jq .
```
I get this output:

<details>

```json
{
  "result": {
    "chain": "main",
    "blocks": 10800,
    "bestblockhash": "000000013207dd76d0d7031fa78e67b38e37c99f4c33489b4d39119a1172dbd0",
    "estimatedheight": 1616108,
    "upgrades": {
      "5ba81b19": {
        "name": "Overwinter",
        "activationheight": 347500,
        "status": "pending"
      },
      "76b809bb": {
        "name": "Sapling",
        "activationheight": 419200,
        "status": "pending"
      },
      "2bb40e60": {
        "name": "Blossom",
        "activationheight": 653600,
        "status": "pending"
      },
      "f5b9230b": {
        "name": "Heartwood",
        "activationheight": 903000,
        "status": "pending"
      },
      "e9ff75a6": {
        "name": "Canopy",
        "activationheight": 1046400,
        "status": "pending"
      }
    },
    "consensus": {
      "chaintip": "00000000",
      "nextblock": "00000000"
    }
  },
  "id": "curltest"
}
```

</details>

(Click the triangle for details.)
