### PR TITLE
change(doc): Simplify the database design using prefix iterators

### DIFF
--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -604,7 +604,7 @@ We use the following rocksdb column families:
 | ------------------------------ | ---------------------- | ----------------------------------- | ------- |
 | *Blocks*                       |                        |                                     |         |
 | `hash_by_height`               | `block::Height`        | `block::Hash`                       | Never   |
-| `height_tx_count_by_hash`      | `block::Hash`          | `block::Height`                     | Never   |
+| `height_by_hash`               | `block::Hash`          | `block::Height`                     | Never   |
 | `block_header_by_height`       | `block::Height`        | `block::Header`                     | Never   |
 | *Transactions*                 |                        |                                     |         |
 | `tx_by_loc`                    | `TransactionLocation`  | `Transaction`                       | Never   |
@@ -747,7 +747,7 @@ So they should not be used for consensus-critical checks.
   - Look up `height` in `height_by_hash`
   - Get the block header for `height` from `block_header_by_height`
   - Use a [`prefix_iterator`](https://docs.rs/rocksdb/0.17.0/rocksdb/struct.DBWithThreadMode.html#method.prefix_iterator)
-    to get each transaction with `height` from `tx_by_location`
+    to get each transaction with `height` from `tx_by_loc`
 
 - Block headers are stored by height, not by hash.  This has the downside that looking
   up a block by hash requires an extra level of indirection.  The upside is
@@ -822,7 +822,7 @@ So they should not be used for consensus-critical checks.
   the anchor to the matching note commitment tree. This is required to support interstitial
   treestates, which are unique to Sprout.
   **TODO:** store the `Root` hash in `sprout_note_commitment_tree`, and use it to look up the
-  note commitment tree. This de-duplicates tree state data.
+  note commitment tree. This de-duplicates tree state data. But we currently only store one sprout tree by height.
 
 - The value pools are only stored for the finalized tip.
 


### PR DESCRIPTION
## Motivation

To avoid storing the transaction count for each block, we can use RocksDB prefix iterators.

### API Reference

API Function:
https://docs.rs/rocksdb/latest/rocksdb/struct.DBWithThreadMode.html#method.prefix_iterator_cf

API Docs:
https://github.com/facebook/rocksdb/wiki/Prefix-Seek#why-prefix-seek

### Designs

Iterate through every transaction for a height, rather than storing a transaction count.

## Solution

- Update the design to use a prefix iterator

Related changes:
- Make column family names consistent
- Fix some minor design details

## Review

This is a low-priority design fix.

It would be good to have it merged by the database design review meeting later this week. (Wednesday evening UTC.)

### Reviewer Checklist

  - [ ] Design changes make sense

## Follow Up Work

Implement the design in:
- #3511