### PR TITLE
fix(actions): use a specific shortening length for SHAs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
         persist-credentials: false
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4.2
+      uses: rlespinasse/github-slug-action@v4
       with:
         short-length: 7
 
@@ -132,7 +132,7 @@ jobs:
 
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2
+        uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 
@@ -196,7 +196,7 @@ jobs:
 
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2
+        uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,9 @@ jobs:
         persist-credentials: false
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4
+      uses: rlespinasse/github-slug-action@v4.0.2
+      with:
+        short-length: 7
 
       # Automatic tag management and OCI Image Format Specification for labels
     - name: Docker meta
@@ -129,12 +131,10 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
     steps:
-      - uses: actions/checkout@v3.0.0
-        with:
-          persist-credentials: false
-
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
@@ -195,12 +195,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
 
     steps:
-      - uses: actions/checkout@v3.0.0
-        with:
-          persist-credentials: false
-
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
         persist-credentials: false
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4.2.0
+      uses: rlespinasse/github-slug-action@v4.2
       with:
         short-length: 7
 
@@ -132,7 +132,7 @@ jobs:
 
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2.0
+        uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 
@@ -196,7 +196,7 @@ jobs:
 
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2.0
+        uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
         persist-credentials: false
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4.0.2
+      uses: rlespinasse/github-slug-action@v4.2.0
       with:
         short-length: 7
 
@@ -132,7 +132,7 @@ jobs:
 
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.0.2
+        uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 
@@ -196,7 +196,7 @@ jobs:
 
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.0.2
+        uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: 'write'
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2
+        uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -21,12 +21,10 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v2.4.0
-        with:
-          persist-credentials: false
-
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: 'write'
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2.0
+        uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: 'write'
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.0.2
+        uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -54,7 +54,7 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2
+        uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 
@@ -138,7 +138,7 @@ jobs:
       id-token: 'write'
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2
+        uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -54,7 +54,7 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.0.2
+        uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 
@@ -138,7 +138,7 @@ jobs:
       id-token: 'write'
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.0.2
+        uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -54,7 +54,9 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
       # Automatic tag management and OCI Image Format Specification for labels
       - name: Docker meta
@@ -135,12 +137,10 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v3.0.0
-        with:
-          persist-credentials: false
-
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -54,7 +54,7 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2.0
+        uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 
@@ -138,7 +138,7 @@ jobs:
       id-token: 'write'
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2.0
+        uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2
+        uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 
@@ -137,7 +137,7 @@ jobs:
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2
+        uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 
@@ -158,7 +158,7 @@ jobs:
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2
+        uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 
@@ -177,7 +177,7 @@ jobs:
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2
+        uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 
@@ -193,7 +193,7 @@ jobs:
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2
+        uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 
@@ -241,7 +241,7 @@ jobs:
             zebra-state/**/zebra_db/transparent.rs
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2
+        uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 
@@ -361,7 +361,7 @@ jobs:
       id-token: 'write'
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2
+        uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.0.2
+        uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 
@@ -137,7 +137,7 @@ jobs:
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.0.2
+        uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 
@@ -158,7 +158,7 @@ jobs:
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.0.2
+        uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 
@@ -177,7 +177,7 @@ jobs:
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.0.2
+        uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 
@@ -193,7 +193,7 @@ jobs:
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.0.2
+        uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 
@@ -241,7 +241,7 @@ jobs:
             zebra-state/**/zebra_db/transparent.rs
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.0.2
+        uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 
@@ -361,7 +361,7 @@ jobs:
       id-token: 'write'
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.0.2
+        uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,9 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
         # Automatic tag management and OCI Image Format Specification for labels
       - name: Docker meta
@@ -134,12 +136,10 @@ jobs:
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
-      - uses: actions/checkout@v3.0.0
-        with:
-          persist-credentials: false
-
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
       - name: Run all zebrad tests
         run: |
@@ -157,12 +157,10 @@ jobs:
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
-      - uses: actions/checkout@v3.0.0
-        with:
-          persist-credentials: false
-
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
       - name: Run tests with fake activation heights
         run: |
@@ -178,12 +176,10 @@ jobs:
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
-      - uses: actions/checkout@v3.0.0
-        with:
-          persist-credentials: false
-
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
       - name: Run zebrad large sync tests
         run: |
@@ -196,12 +192,10 @@ jobs:
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
-      - uses: actions/checkout@v3.0.0
-        with:
-          persist-credentials: false
-
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
       - name: Run tests with included lightwalletd binary
         run: |
@@ -247,7 +241,9 @@ jobs:
             zebra-state/**/zebra_db/transparent.rs
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
       - name: Downcase network name for disks
         run: |
@@ -364,12 +360,10 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v3.0.0
-        with:
-          persist-credentials: false
-
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
       - name: Downcase network name for disks
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2.0
+        uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 
@@ -137,7 +137,7 @@ jobs:
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2.0
+        uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 
@@ -158,7 +158,7 @@ jobs:
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2.0
+        uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 
@@ -177,7 +177,7 @@ jobs:
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2.0
+        uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 
@@ -193,7 +193,7 @@ jobs:
     if: ${{ github.event.inputs.regenerate-disks != 'true' }}
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2.0
+        uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 
@@ -241,7 +241,7 @@ jobs:
             zebra-state/**/zebra_db/transparent.rs
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2.0
+        uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 
@@ -361,7 +361,7 @@ jobs:
       id-token: 'write'
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2.0
+        uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 

--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -47,7 +47,9 @@ jobs:
         persist-credentials: false
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4
+      uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
       # Automatic tag management and OCI Image Format Specification for labels
     - name: Docker meta

--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -47,7 +47,7 @@ jobs:
         persist-credentials: false
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4.0.2
+      uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 

--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -47,7 +47,7 @@ jobs:
         persist-credentials: false
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4.2.0
+      uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 

--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -47,7 +47,7 @@ jobs:
         persist-credentials: false
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4.2
+      uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 

--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -37,7 +37,7 @@ jobs:
         persist-credentials: false
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4.2
+      uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 

--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -37,7 +37,9 @@ jobs:
         persist-credentials: false
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4
+      uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
       # Automatic tag management and OCI Image Format Specification for labels
     - name: Docker meta

--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -37,7 +37,7 @@ jobs:
         persist-credentials: false
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4.0.2
+      uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 

--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -37,7 +37,7 @@ jobs:
         persist-credentials: false
 
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4.2.0
+      uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2.0
+        uses: rlespinasse/github-slug-action@v4.2
         with:
           short-length: 7
 

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.0.2
+        uses: rlespinasse/github-slug-action@v4.2.0
         with:
           short-length: 7
 

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.2
+        uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
 

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -29,7 +29,9 @@ jobs:
           persist-credentials: false
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@v4.0.2
+        with:
+          short-length: 7
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud


### PR DESCRIPTION
## Motivation

The action used to get a shortened SHA in most workflows has been recently changed as it's not using a fixed version, and the action is sometimes returning a SHA with a length of 7 and sometimes with a length of 8, which crashes some actions.

Fixes: #3921 

### Designs

The rlespinasse/github-slug-action now works without checking out the code, reduce time and improving security with following actions.

This requires to specify the GITHUB_SHA_SHORT variable length, as git uses 8 by default, but docker uses 7 by default

## Solution

- Use the latest version of `rlespinasse/github-slug-action` (4.2.0) which introduced a feature to allow defining the length of the GITHUB_SHA_SHORT

- Set the same length as the one use by docker actions `length = 7`

## Review

@dconnolly and @teor2345 can review this
