### PR TITLE
fix(log): Make sync error logs more user-friendly

### DIFF
--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -389,7 +389,7 @@ where
             "starting sync, obtaining new tips"
         );
         if let Err(e) = self.obtain_tips().await {
-            warn!(?e, "error obtaining tips");
+            info!("temporary error obtaining tips: {:#}", e);
             return Err(());
         }
         self.update_metrics();
@@ -438,7 +438,7 @@ where
             );
 
             if let Err(e) = self.extend_tips().await {
-                warn!(?e, "error extending tips");
+                info!("temporary error extending tips: {:#}", e);
                 return Err(());
             }
             self.update_metrics();


### PR DESCRIPTION
## Motivation

The sync fix changed some of the syncer logs. Some of those logs could be alarming to users.

(And they are annoying during testing, because they contain long backtraces.)

### eyre::Report API Reference

This PR uses the one-line mode with more info, but no backtrace or multi-line error:
https://docs.rs/eyre/0.6.7/eyre/struct.Report.html#display-representations

## Solution

- use info level, there is nothing the user needs to do, particularly for a single error
- explain that the errors are temporary
- hide backtraces, because they look like crashes

## Review

Anyone can review this PR, it's a low priority log/usability/dev fix.

### Reviewer Checklist

  - [x] Syncer logs are smaller and less alarming

