### PR TITLE
change(nu5): disconnect from testnet peers using the first NU5 testnet rules

### DIFF
--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -68,7 +68,7 @@ pub(super) const MAINNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] 
     (block::Height(653_600), Blossom),
     (block::Height(903_000), Heartwood),
     (block::Height(1_046_400), Canopy),
-    // TODO: Add Nu5 mainnet activation height
+    // TODO: Add Nu5 mainnet activation height (#4115)
 ];
 
 /// Fake mainnet network upgrade activation heights, used in tests.

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -1,4 +1,9 @@
-//! Definitions of constants.
+//! Definitions of Zebra network constants, including:
+//! - network protocol versions,
+//! - network protocol user agents,
+//! - peer address limits,
+//! - peer connection limits, and
+//! - peer connection timeouts.
 
 use std::{collections::HashMap, time::Duration};
 
@@ -9,7 +14,10 @@ use regex::Regex;
 use crate::protocol::external::types::*;
 
 use zebra_chain::{
-    parameters::{Network, NetworkUpgrade},
+    parameters::{
+        Network::{self, *},
+        NetworkUpgrade::*,
+    },
     serialization::Duration32,
 };
 
@@ -241,6 +249,8 @@ pub const USER_AGENT: &str = "/Zebra:1.0.0-beta.8/";
 ///
 /// The current protocol version typically changes before Mainnet and Testnet
 /// network upgrades.
+//
+// TODO: update to Nu5 mainnet (#4115)
 pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_050);
 
 /// The default RTT estimate for peer responses.
@@ -275,10 +285,22 @@ lazy_static! {
     ///
     /// The minimum network protocol version typically changes after Mainnet and/or
     /// Testnet network upgrades.
-    pub static ref INITIAL_MIN_NETWORK_PROTOCOL_VERSION: HashMap<Network, NetworkUpgrade> = {
+    pub static ref INITIAL_MIN_NETWORK_PROTOCOL_VERSION: HashMap<Network, Version> = {
         let mut hash_map = HashMap::new();
-        hash_map.insert(Network::Mainnet, NetworkUpgrade::Canopy);
-        hash_map.insert(Network::Testnet, NetworkUpgrade::Canopy);
+
+        // TODO: update to Nu5 when there are enough Nu5 mainnet nodes deployed (#4117)
+        hash_map.insert(Mainnet, Version::min_specified_for_upgrade(Mainnet, Canopy));
+
+        // This is the `zcashd` network protocol version:
+        // - after the first NU5 testnet activation, and
+        // - after updating to the second NU5 testnet activation consensus rules,
+        // - but before setting the second NU5 testnet activation height.
+        //
+        // TODO: update to:
+        // Version::min_specified_for_upgrade(Mainnet, Nu5)
+        // when there are enough Nu5 testnet nodes deployed (#4116)
+        hash_map.insert(Testnet, Version(170_040));
+
         hash_map
     };
 

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -77,12 +77,9 @@ impl Version {
     /// - after Zebra restarts, and
     /// - after Zebra's local network is slow or shut down.
     fn initial_min_for_network(network: Network) -> Version {
-        Version::min_specified_for_upgrade(
-            network,
-            *constants::INITIAL_MIN_NETWORK_PROTOCOL_VERSION
-                .get(&network)
-                .expect("We always have a value for testnet or mainnet"),
-        )
+        *constants::INITIAL_MIN_NETWORK_PROTOCOL_VERSION
+            .get(&network)
+            .expect("We always have a value for testnet or mainnet")
     }
 
     /// Returns the minimum specified network protocol version for `network` and


### PR DESCRIPTION
## Merging

This PR will fail the network tests until testnet has enough `zcashd` or Zebra instances on protocol version 170,040 or later:
- `zcashd` 4.6.0-2,
- `zebrad` 1.0.0-beta.8

## Motivation

`zcashd` is disconnecting from testnet nodes on network protocol versions lower than 170,040:
https://github.com/zcash/zips/pull/600/files#diff-b424a91f01c7799201470397654fcf582c045c318b0f91e1e15af4b7fdfc8f78R159-R160

So Zebra should do the same thing.

### Designs

Zebra has a minimum network protocol version constant, but it's currently using the `NetworkUpgrade` type.

## Solution

- Change the minimum network protocol version constant to use the network `Version` type
- Make the minimum testnet network protocol version 170,040

## Review

Anyone can review this PR.

This is based on PR #3799.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

We have also updated the DNS seeders, we might as well update them straight to version 170,100:
- #3458 

(There is no minimum protocol version for the DNS seeders.)