### PR TITLE
imp(ci): do not invalidate cache between PRs

### DIFF
--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -125,8 +125,8 @@ jobs:
             RUST_LOG=debug
             SENTRY_DSN=${{ secrets.SENTRY_ENDPOINT }}
           push: true
-          cache-from: type=registry,ref=${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_REF_SLUG_URL }}-buildcache
+          cache-to: type=registry,ref=${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_REF_SLUG_URL }}-buildcache,mode=max
 
   # Test that Zebra can run a full mainnet sync after a PR is approved
   test-full-sync:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,8 +126,8 @@ jobs:
             RUST_LOG=debug
             SENTRY_DSN=${{ secrets.SENTRY_ENDPOINT }}
           push: true
-          cache-from: type=registry,ref=${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_REF_SLUG_URL }}-buildcache
+          cache-to: type=registry,ref=${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_REF_SLUG_URL }}-buildcache,mode=max
 
   # Run all the zebra tests, including tests that are ignored by default
   test-all:


### PR DESCRIPTION
## Motivation

When a PR is created and an image is built in a branch, the cache is also pushed to a `buildcache` tag.

As all PRs are using the same tag, sometimes the cache for a specific branch gets invalidated and makes it take longer on further pushes.

This fix might make the first commit take longer, but further ones will be faster if no changes in the code are applied.

Fixes #3995

## Solution

- Add the PR ref to the tag, making it unique for the specific branch, and keeping a separate cache for each PR.

## Review

@dconnolly can also review this
