### PR TITLE
Add a job to ci.yml that does `cargo install --locked --path ./zebrad/ zebrad`

### DIFF
--- a/.github/workflows/ci.patch.yml
+++ b/.github/workflows/ci.patch.yml
@@ -52,7 +52,7 @@ jobs:
       - run: 'echo "No build required"'
 
   install-from-lockfile-no-cache:
-    name: Install --locked --path ./zebrad/ zebrad, stable on ubuntu-latest, no cache
+    name: Install --locked zebrad on ubuntu-latest, no cache
     timeout-minutes: 60
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.patch.yml
+++ b/.github/workflows/ci.patch.yml
@@ -52,7 +52,7 @@ jobs:
       - run: 'echo "No build required"'
 
   install-from-lockfile-no-cache:
-    name: Install --locked zebrad on ubuntu-latest, no cache
+    name: Install zebrad from lockfile without cache on ubuntu-latest
     timeout-minutes: 60
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.patch.yml
+++ b/.github/workflows/ci.patch.yml
@@ -51,6 +51,14 @@ jobs:
     steps:
       - run: 'echo "No build required"'
 
+  install-from-lockfile-no-cache:
+    name: Install --locked --path ./zebrad/ zebrad, stable on ubuntu-latest, no cache
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: 'echo "No build required"'
+
   build:
     name: Build stable on ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
         run: cargo build --verbose --no-default-features
 
   install-from-lockfile-no-cache:
-    name: Install --locked --path ./zebrad/ zebrad, stable on ubuntu-latest, no cache
+    name: Install --locked zebrad on ubuntu-latest, no cache
     timeout-minutes: 60
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
         run: cargo build --verbose --no-default-features
 
   install-from-lockfile-no-cache:
-    name: Install --locked zebrad on ubuntu-latest, no cache
+    name: Install zebrad from lockfile without cache on ubuntu-latest
     timeout-minutes: 60
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,28 @@ jobs:
         working-directory: ./zebra-chain
         run: cargo build --verbose --no-default-features
 
+  install-from-lockfile-no-cache:
+    name: Install --locked --path ./zebrad/ zebrad, stable on ubuntu-latest, no cache
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Install
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: install
+          args: --locked --path ./zebrad/ zebrad
+
   build:
     name: Build stable on ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

A change got into our beta.6 release where a `zebra-consensus` depended upon a test-only method in `zebra-state`, so that when a user installs zebrad via `cargo install --locked`, it fails to compile.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

We do not test this instruction as part of CI. This job addition to the `ci.yml` workflow does this, with no caching or anything, to simulate a user installing zebrad per our README instructions.

Closes #3449.
Depends-On: #4000

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

@teor2345 @gustavovalverde 

### Reviewer Checklist

  - [x] Catches the build error
  - [ ] Simulates the installation instructions we give to users in README.md

