### PR TITLE
fix(build): Stop using a test-only method in production code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5757,6 +5757,7 @@ dependencies = [
  "jsonrpc-derive",
  "jsonrpc-http-server",
  "proptest",
+ "proptest-derive",
  "serde",
  "serde_json",
  "thiserror",

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [features]
 default = []
-proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl"]
+proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl", "zebra-state/proptest-impl"]
 
 [dependencies]
 blake2b_simd = "1.0.0"

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -495,7 +495,7 @@ where
         crate::block::check::equihash_solution_is_valid(&block.header)?;
 
         // don't do precalculation until the block passes basic difficulty checks
-        let block = FinalizedBlock::with_hash_and_height(block, hash, height);
+        let block = FinalizedBlock::with_hash(block, hash);
 
         crate::block::check::merkle_root_validity(
             self.network,

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+proptest-impl = ["zebra-chain/proptest-impl", "zebra-state/proptest-impl"]
+
 [dependencies]
 zebra-chain = { path = "../zebra-chain" }
 zebra-network = { path = "../zebra-network" }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [features]
 default = []
-proptest-impl = ["zebra-chain/proptest-impl", "zebra-state/proptest-impl"]
+proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl", "zebra-state/proptest-impl"]
 
 [dependencies]
 zebra-chain = { path = "../zebra-chain" }
@@ -39,8 +39,12 @@ tracing-futures = "0.2.5"
 hex = { version = "0.4.3", features = ["serde"] }
 serde = { version = "1.0.136", features = ["serde_derive"] }
 
+proptest = { version = "0.10.1", optional = true }
+proptest-derive = { version = "0.3.0", optional = true }
+
 [dev-dependencies]
 proptest = "0.10.1"
+proptest-derive = "0.3.0"
 serde_json = "1.0.79"
 thiserror = "1.0.30"
 tokio = { version = "1.16.1", features = ["full", "test-util"] }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [features]
-proptest-impl = ["proptest", "proptest-derive", "zebra-test"]
+proptest-impl = ["proptest", "proptest-derive", "zebra-test", "zebra-chain/proptest-impl"]
 
 [dependencies]
 bincode = "1.3.3"

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -11,7 +11,7 @@ default-run = "zebrad"
 
 [features]
 default = []
-proptest-impl = ["zebra-chain/proptest-impl", "zebra-state/proptest-impl", "zebra-consensus/proptest-impl", "zebra-network/proptest-impl"]
+proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl", "zebra-state/proptest-impl", "zebra-consensus/proptest-impl", "zebra-network/proptest-impl"]
 
 enable-sentry = []
 test_sync_to_mandatory_checkpoint_mainnet = []
@@ -62,6 +62,9 @@ sentry = { version = "0.23.0", default-features = false, features = ["backtrace"
 
 num-integer = "0.1.44"
 rand = { version = "0.8.5", package = "rand" }
+
+proptest = { version = "0.10.1", optional = true }
+proptest-derive = { version = "0.3.0", optional = true }
 
 [build-dependencies]
 vergen = { version = "7.0.0", default-features = false, features = ["cargo", "git"] }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -9,6 +9,16 @@ repository = "https://github.com/ZcashFoundation/zebra"
 # when run in the workspace directory
 default-run = "zebrad"
 
+[features]
+default = []
+proptest-impl = ["zebra-chain/proptest-impl", "zebra-state/proptest-impl", "zebra-consensus/proptest-impl", "zebra-network/proptest-impl"]
+
+enable-sentry = []
+test_sync_to_mandatory_checkpoint_mainnet = []
+test_sync_to_mandatory_checkpoint_testnet = []
+test_sync_past_mandatory_checkpoint_mainnet = []
+test_sync_past_mandatory_checkpoint_testnet = []
+
 [dependencies]
 zebra-chain = { path = "../zebra-chain" }
 zebra-consensus = { path = "../zebra-consensus/" }
@@ -74,10 +84,3 @@ zebra-consensus = { path = "../zebra-consensus/", features = ["proptest-impl"] }
 zebra-network = { path = "../zebra-network", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test" }
-
-[features]
-enable-sentry = []
-test_sync_to_mandatory_checkpoint_mainnet = []
-test_sync_to_mandatory_checkpoint_testnet = []
-test_sync_past_mandatory_checkpoint_mainnet = []
-test_sync_past_mandatory_checkpoint_testnet = []


### PR DESCRIPTION
## Motivation

Zebra fails to build from the README instructions, because it calls some test-only code.

`cargo` allows this to happen because:
1. CI always builds tests
2. Some Zebra crates have missing feature dependencies

## Solution

- Fix feature dependencies within Zebra crates - this makes test and non-test builds fail
- Use the production method - this makes all builds work

## Review

@dconnolly can review this PR.

### Reviewer Checklist

  - [ ] Build succeeds using `--locked`

## Follow Up Work

- #3998
