### PR TITLE
fix(ci): Increase test coverage of state rebuild

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,26 +219,19 @@ jobs:
           persist-credentials: false
           fetch-depth: '2'
 
-      # only run this job if the database format might have changed
+      # Only run this job if the database format version has (likely) changed.
+      #
+      # If we have accidentally changed the format, but not changed the version,
+      # we want to run with the old cached state, so this job fails.
+      #
+      # If we change the state path without changing the version,
+      # this job will take a few hours, because it will do a full rebuild.
       - name: Get specific changed files
         id: changed-files-specific
         uses: tj-actions/changed-files@v18.4
         with:
           files: |
-            zebra-state/**/config.rs
             zebra-state/**/constants.rs
-            zebra-state/**/finalized_state.rs
-            zebra-state/**/disk_format.rs
-            zebra-state/**/disk_format/block.rs
-            zebra-state/**/disk_format/chain.rs
-            zebra-state/**/disk_format/shielded.rs
-            zebra-state/**/disk_format/transparent.rs
-            zebra-state/**/disk_db.rs
-            zebra-state/**/zebra_db.rs
-            zebra-state/**/zebra_db/block.rs
-            zebra-state/**/zebra_db/chain.rs
-            zebra-state/**/zebra_db/shielded.rs
-            zebra-state/**/zebra_db/transparent.rs
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4


### PR DESCRIPTION
## Motivation

We only want to run the state rebuild job if the database format version has changed.

If we have accidentally changed the format, but not changed the version, we want to run with the old cached state, so the job fails.

(If we change the state path without changing the version, the job will take a few hours, because it will do a full rebuild. So it won't fail on any format changes if the path also changes. This is a rare case.)

## Solution

- Only do a rebuild when `state::constants` changes, because it contains the database format version

This should also speed up a whole bunch of PRs.

I'd like to get this merged before we merge any more database changes, I'll set ZenHub blockers.

## Review

This is a high priority PR, because it increases coverage. (And increases CI speed.)
It is low risk, because it just stops running state rebuilds, and we're not changing the state for NU5.

I'd like @dconnolly or @conradoplg to double-check I got the coverage logic right here.

### Reviewer Checklist

  - [x] CI works

