### PR TITLE
fix(log): Log CommitmentErrors as hex

### DIFF
--- a/zebra-chain/src/block/commitment.rs
+++ b/zebra-chain/src/block/commitment.rs
@@ -2,13 +2,11 @@
 
 use thiserror::Error;
 
-use std::convert::TryInto;
-
-use crate::parameters::{Network, NetworkUpgrade, NetworkUpgrade::*};
-use crate::sapling;
-
-use super::super::block;
-use super::merkle::AuthDataRoot;
+use crate::{
+    block::{self, merkle::AuthDataRoot},
+    parameters::{Network, NetworkUpgrade, NetworkUpgrade::*},
+    sapling,
+};
 
 /// Zcash blocks contain different kinds of commitments to their contents,
 /// depending on the network and height.
@@ -225,7 +223,11 @@ impl ChainHistoryBlockTxAuthCommitmentHash {
 #[allow(dead_code, missing_docs)]
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum CommitmentError {
-    #[error("invalid final sapling root: expected {expected:?}, actual: {actual:?}")]
+    #[error(
+        "invalid final sapling root: expected {:?}, actual: {:?}",
+        hex::encode(expected),
+        hex::encode(actual)
+    )]
     InvalidFinalSaplingRoot {
         // TODO: are these fields a security risk? If so, open a ticket to remove
         // similar fields across Zebra
@@ -233,16 +235,24 @@ pub enum CommitmentError {
         actual: [u8; 32],
     },
 
-    #[error("invalid chain history activation reserved block commitment: expected all zeroes, actual: {actual:?}")]
+    #[error("invalid chain history activation reserved block commitment: expected all zeroes, actual: {:?}",  hex::encode(actual))]
     InvalidChainHistoryActivationReserved { actual: [u8; 32] },
 
-    #[error("invalid chain history root: expected {expected:?}, actual: {actual:?}")]
+    #[error(
+        "invalid chain history root: expected {:?}, actual: {:?}",
+        hex::encode(expected),
+        hex::encode(actual)
+    )]
     InvalidChainHistoryRoot {
         expected: [u8; 32],
         actual: [u8; 32],
     },
 
-    #[error("invalid chain history + block transaction auth commitment: expected {expected:?}, actual: {actual:?}")]
+    #[error(
+        "invalid block commitment root: expected {:?}, actual: {:?}",
+        hex::encode(expected),
+        hex::encode(actual)
+    )]
     InvalidChainHistoryBlockTxAuthCommitment {
         expected: [u8; 32],
         actual: [u8; 32],


### PR DESCRIPTION
## Motivation

Zebra logs commitment errors as `u8` arrays. But they should be logged as hex strings for consistency with other 32-byte hash fields.

I discovered this bug on a Zebra instance that synced 97% of the broken testnet chain, then started rejecting blocks with commitment errors like:
> Apr 01 12:06:09.538  WARN {zebrad="7d034be" net="Test"}:sync:try_to_sync: zebrad::components::sync: error downloading and verifying block e=Invalid(Block(Commit(CloneError { source: CommitBlockError(InvalidBlockCommitment(InvalidChainHistoryBlockTxAuthCommitment { expected: [233, 158, 136, 217, 67, 36, 70, 97, 150, 52, 254, 113, 24, 70, 251, 148, 244, 43, 4, 134, 12, 47, 73, 140, 44, 247, 28, 65, 249, 197, 158, 230], actual: [133, 140, 120, 213, 234, 207, 213, 56, 28, 22, 150, 125, 243, 61, 37, 137, 118, 42, 152, 13, 227, 189, 176, 20, 77, 122, 160, 234, 70, 229, 199, 13] })) })))
> Apr 01 12:06:09.538  INFO {zebrad="7d034be" net="Test"}:sync: zebrad::components::sync: waiting to restart sync timeout=67s state_tip=Some(Height(1779302))
> Apr 01 12:06:33.780  INFO {zebrad="7d034be" net="Test"}: zebrad::commands::start: estimated progress to chain tip sync_percent=97.785 % current_height=Height(1779302) remaining_sync_blocks=40304 time_since_last_state_block=-PT7680.163426275S

## Solution

- Log commitment errors as hex, in protocol order

## Review

Anyone can review this low-priority logging fix.

### Reviewer Checklist

  - [x] Code makes sense

