### PR TITLE
A. change(db): Use LZ4 compression for RocksDB

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -291,11 +291,18 @@ impl DiskDb {
         opts.create_missing_column_families(true);
 
         // Use the recommended Ribbon filter setting for all column families.
-        // (Ribbon filters are faster than Bloom filters in Zebra, as of April 2022.)
         //
+        // Ribbon filters are faster than Bloom filters in Zebra, as of April 2022.
         // (They aren't needed for single-valued column families, but they don't hurt either.)
         block_based_opts.set_ribbon_filter(9.9);
 
+        // Use the recommended LZ4 compression type.
+        //
+        // https://github.com/facebook/rocksdb/wiki/Compression#configuration
+        opts.set_compression_type(rocksdb::DBCompressionType::Lz4);
+
+        // Increase the process open file limit if needed,
+        // then use it to set RocksDB's limit.
         let open_file_limit = DiskDb::increase_open_file_limit();
         let db_file_limit = DiskDb::get_db_open_file_limit(open_file_limit);
 


### PR DESCRIPTION
## Motivation

We need Zebra to sync faster for the cached state lightwalletd tests.

The recommended LZ4 compression method seems slightly faster.

### Specifications

The RocksDB wiki recommends using LZ4 compression, but the default is Snappy:
https://github.com/facebook/rocksdb/wiki/Compression#configuration

## Solution

- Change from Snappy to LZ4 compression for RocksDB

This does not need a state version increment, RocksDB should handle it transparently.

I ran a full sync test for performance, and a local sync test for database size.
(The Snappy size was 35 GB after the initial sync, and 29 GB after the first relaunch.)

- https://github.com/ZcashFoundation/zebra/actions/runs/2086988121

There is no size change, but the sync speed seems slightly faster (1-2%).

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Existing Tests Pass
  - [ ] Sync is faster or database is smaller

## Follow Up Work

- Disable all other compression algorithms except LZ4, to improve compilation speed (this needs to happen after the next state version increment)