### PR TITLE
change(db): Use more background flush and compression threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5861,6 +5861,7 @@ dependencies = [
  "lazy_static",
  "metrics",
  "mset",
+ "num_cpus",
  "once_cell",
  "proptest",
  "proptest-derive",

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -19,8 +19,7 @@ itertools = "0.10.3"
 lazy_static = "1.4.0"
 metrics = "0.17.1"
 mset = "0.1.0"
-proptest = { version = "0.10.1", optional = true }
-proptest-derive = { version = "0.3.0", optional = true }
+num_cpus = "1.13.1"
 regex = "1.5.5"
 rlimit = "0.7.0"
 rocksdb = "0.18.0"
@@ -30,6 +29,9 @@ thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["sync"] }
 tower = { version = "0.4.12", features = ["buffer", "util"] }
 tracing = "0.1.31"
+
+proptest = { version = "0.10.1", optional = true }
+proptest-derive = { version = "0.3.0", optional = true }
 
 zebra-chain = { path = "../zebra-chain" }
 zebra-test = { path = "../zebra-test/", optional = true }


### PR DESCRIPTION
## Motivation

We need Zebra to sync faster for the cached state lightwalletd tests.
Using more threads might make it faster.

### Specifications

The RocksDB docs recommend using one background thread per code:
https://docs.rs/rocksdb/latest/rocksdb/struct.Options.html#method.increase_parallelism 

## Solution

- Use one background thread per logical CPU core, up to 8 threads

This does not need a state version increment, it is a runtime-only option.

I ran a full sync test to check performance:
- https://github.com/ZcashFoundation/zebra/actions/runs/2086799294

This change does not make Zebra faster, so we should only apply it if it fixes a bug.

## Review

Anyone can review this PR.

This PR is based on PR #3999.


### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Existing Tests Pass
  - [ ] Sync is faster

