### PR TITLE
change(db): Pipeline database write requests

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -467,6 +467,9 @@ impl DiskDb {
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
 
+        // Split threads for write-ahead-log and memtable writes into two queues.
+        opts.set_enable_pipelined_write(true);
+
         let open_file_limit = DiskDb::increase_open_file_limit();
         let db_file_limit = DiskDb::get_db_open_file_limit(open_file_limit);
 


### PR DESCRIPTION
## Motivation

We need Zebra to sync faster for the cached state lightwalletd tests.
Pipelining writes might make it faster.

### Specifications

RocksDB allows splitting write threads into two queues:
https://docs.rs/rocksdb/latest/rocksdb/struct.Options.html#method.set_enable_pipelined_write

## Solution

- Split write threads into a write-ahead-log queue, and a memtable queue

This does not need a state version increment, it is a runtime-only option.

I ran a full sync test to check performance:
- https://github.com/ZcashFoundation/zebra/actions/runs/2086843717

This change does not make Zebra faster, so we should only apply it if it fixes a bug.


## Review

Anyone can review this PR.

This PR is based on PR #3999.


### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Existing Tests Pass
  - [ ] Sync is faster

