### PR TITLE
change(db): Use universal compaction for the database

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -467,6 +467,9 @@ impl DiskDb {
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
 
+        // Use the recommended Universal compaction style.
+        opts.set_compaction_style(rocksdb::DBCompactionStyle::Universal);
+
         let open_file_limit = DiskDb::increase_open_file_limit();
         let db_file_limit = DiskDb::get_db_open_file_limit(open_file_limit);
 


### PR DESCRIPTION
## TODO

This change probably requires a state version increment.

## Motivation

We need Zebra to sync faster for the cached state lightwalletd tests.
Using a different database compaction style might make it faster.

### Specifications

RocksDB has an alternative "universal" compaction style, which can improve write performance:
https://github.com/facebook/rocksdb/wiki/Universal-Compaction

## Solution

- Use universal compaction style for the database

I ran a full sync test to check performance:
- https://github.com/ZcashFoundation/zebra/actions/runs/2088373861

## Review

Anyone can review this PR.

This PR is based on PR #3999.


### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Existing Tests Pass
  - [ ] Sync is faster

