### PR TITLE
change(db): Use bloom filters for database index lookups

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -463,9 +463,16 @@ impl DiskDb {
     /// Returns the database options for the finalized state database.
     fn options() -> rocksdb::Options {
         let mut opts = rocksdb::Options::default();
+        let mut block_based_opts = rocksdb::BlockBasedOptions::default();
 
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
+
+        // Use the recommended bloom filter setting for all column families, and make them file-based,
+        // because the block header and transaction column families have large values.
+        //
+        // (They aren't needed for single-valued column families, but they don't hurt either.)
+        block_based_opts.set_bloom_filter(10.0, false);
 
         let open_file_limit = DiskDb::increase_open_file_limit();
         let db_file_limit = DiskDb::get_db_open_file_limit(open_file_limit);
@@ -477,6 +484,9 @@ impl DiskDb {
         let db_file_limit = db_file_limit.try_into().unwrap_or(ideal_limit);
 
         opts.set_max_open_files(db_file_limit);
+
+        // Set the block-based options
+        opts.set_block_based_table_factory(&block_based_opts);
 
         opts
     }


### PR DESCRIPTION
## TODO

This change might need a state version increment - check the quick cached state test.

## Motivation

We need Zebra to sync faster for the cached state lightwalletd tests.
Using bloom filters for index lookups makes it about 5% faster.

Bloom filters are a recommended optimisation.

### Specifications

RocksDB can do lookups using a bloom filter, which can improve read performance:
https://docs.rs/rocksdb/latest/rocksdb/struct.BlockBasedOptions.html#method.set_bloom_filter

See also:
https://zhangyuchi.gitbooks.io/rocksdbbook/content/RocksDB-Tuning-Guide.html

## Solution

- Use a bloom filter for database queries

I ran a full sync test to check performance:
- https://github.com/ZcashFoundation/zebra/actions/runs/2088446513

It finished in 5h50m, compared with most syncs that are around 97% - 99% at 6h.

### Alternatives

We should also try ribbon filters, to see if they are even faster.

## Review

Anyone can review this PR.

This PR is based on PR #3999.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Existing Tests Pass
  - [ ] Sync is faster

