### PR TITLE
change(db): Use larger database blocks for block header and transaction data

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db/tests.rs
+++ b/zebra-state/src/service/finalized_state/disk_db/tests.rs
@@ -18,7 +18,7 @@ impl Deref for DiskDb {
 impl DiskDb {
     /// Returns a list of column family names in this database.
     pub fn list_cf(&self) -> Result<Vec<String>, rocksdb::Error> {
-        let opts = DiskDb::options();
+        let opts = DiskDb::options(false);
         let path = self.path();
 
         rocksdb::DB::list_cf(&opts, path)


### PR DESCRIPTION
## Motivation

We need Zebra to sync faster for the cached state lightwalletd tests.
Using larger database blocks for Zcash block and transaction data might make it faster.

Increasing the file block size is a recommended optimisation, so we might want to do it even if the initial sync is the same speed.

### Recommendations

See "General Options" in:
https://zhangyuchi.gitbooks.io/rocksdbbook/content/RocksDB-Tuning-Guide.html

## Solution

- Use 128 kB file blocks for Zcash block and transaction data (this fits 30-1000 transactions)

I ran a full sync test to check performance:
- https://github.com/ZcashFoundation/zebra/actions/runs/2094246246

## Review

Anyone can review this PR.

This PR is based on PR #3999.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Existing Tests Pass
  - [ ] Sync is faster

