### PR TITLE
7. feat(db): Add a transparent address transaction index

### DIFF
--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -18,7 +18,7 @@ pub use zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
 pub const MAX_BLOCK_REORG_HEIGHT: u32 = MIN_TRANSPARENT_COINBASE_MATURITY - 1;
 
 /// The database format version, incremented each time the database format changes.
-pub const DATABASE_FORMAT_VERSION: u32 = 21;
+pub const DATABASE_FORMAT_VERSION: u32 = 22;
 
 /// The maximum number of blocks to check for NU5 transactions,
 /// before we assume we are on a pre-NU5 legacy chain.

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -386,6 +386,10 @@ impl DiskDb {
                 "utxo_loc_by_transparent_addr_loc",
                 db_options.clone(),
             ),
+            rocksdb::ColumnFamilyDescriptor::new(
+                "tx_loc_by_transparent_addr_loc",
+                db_options.clone(),
+            ),
             // Sprout
             rocksdb::ColumnFamilyDescriptor::new("sprout_nullifiers", db_options.clone()),
             rocksdb::ColumnFamilyDescriptor::new("sprout_anchors", db_options.clone()),

--- a/zebra-state/src/service/finalized_state/disk_format/block.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/block.rs
@@ -67,7 +67,7 @@ pub const TRANSACTION_LOCATION_DISK_BYTES: usize = HEIGHT_DISK_BYTES + TX_INDEX_
     any(test, feature = "proptest-impl"),
     derive(Arbitrary, Serialize, Deserialize)
 )]
-pub struct TransactionIndex(u16);
+pub struct TransactionIndex(pub(super) u16);
 
 impl TransactionIndex {
     /// Creates a transaction index from the inner type.

--- a/zebra-state/src/service/finalized_state/disk_format/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/prop.rs
@@ -16,7 +16,8 @@ use crate::service::finalized_state::{
     disk_format::{
         block::MAX_ON_DISK_HEIGHT,
         transparent::{
-            AddressBalanceLocation, AddressLocation, AddressUnspentOutput, OutputLocation,
+            AddressBalanceLocation, AddressLocation, AddressTransaction, AddressUnspentOutput,
+            OutputLocation,
         },
         IntoDisk, TransactionLocation,
     },
@@ -185,6 +186,20 @@ fn roundtrip_address_unspent_output() {
         |(mut val in any::<AddressUnspentOutput>())| {
             *val.address_location_mut().height_mut() = val.address_location().height().clamp(Height(0), MAX_ON_DISK_HEIGHT);
             *val.unspent_output_location_mut().height_mut() = val.unspent_output_location().height().clamp(Height(0), MAX_ON_DISK_HEIGHT);
+
+            assert_value_properties(val)
+        }
+    );
+}
+
+#[test]
+fn roundtrip_address_transaction() {
+    zebra_test::init();
+
+    proptest!(
+        |(mut val in any::<AddressTransaction>())| {
+            *val.address_location_mut().height_mut() = val.address_location().height().clamp(Height(0), MAX_ON_DISK_HEIGHT);
+            val.transaction_location_mut().height = val.transaction_location().height.clamp(Height(0), MAX_ON_DISK_HEIGHT);
 
             assert_value_properties(val)
         }

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/column_family_names.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/column_family_names.snap
@@ -22,6 +22,7 @@ expression: cf_names
   "tip_chain_value_pool",
   "tx_by_hash",
   "tx_by_loc",
+  "tx_loc_by_transparent_addr_loc",
   "utxo_by_outpoint",
   "utxo_loc_by_transparent_addr_loc",
 ]

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@mainnet_0.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@mainnet_0.snap
@@ -12,6 +12,7 @@ expression: empty_column_families
   "sprout_anchors: no entries",
   "sprout_nullifiers: no entries",
   "tip_chain_value_pool: no entries",
+  "tx_loc_by_transparent_addr_loc: no entries",
   "utxo_by_outpoint: no entries",
   "utxo_loc_by_transparent_addr_loc: no entries",
 ]

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@no_blocks.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@no_blocks.snap
@@ -21,6 +21,7 @@ expression: empty_column_families
   "tip_chain_value_pool: no entries",
   "tx_by_hash: no entries",
   "tx_by_loc: no entries",
+  "tx_loc_by_transparent_addr_loc: no entries",
   "utxo_by_outpoint: no entries",
   "utxo_loc_by_transparent_addr_loc: no entries",
 ]

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@testnet_0.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@testnet_0.snap
@@ -12,6 +12,7 @@ expression: empty_column_families
   "sprout_anchors: no entries",
   "sprout_nullifiers: no entries",
   "tip_chain_value_pool: no entries",
+  "tx_loc_by_transparent_addr_loc: no entries",
   "utxo_by_outpoint: no entries",
   "utxo_loc_by_transparent_addr_loc: no entries",
 ]

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/tx_loc_by_transparent_addr_loc_raw_data@mainnet_1.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/tx_loc_by_transparent_addr_loc_raw_data@mainnet_1.snap
@@ -1,0 +1,10 @@
+---
+source: zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
+expression: cf_data
+---
+[
+  KV(
+    k: "00000100000000010000010000",
+    v: "",
+  ),
+]

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/tx_loc_by_transparent_addr_loc_raw_data@mainnet_2.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/tx_loc_by_transparent_addr_loc_raw_data@mainnet_2.snap
@@ -1,0 +1,14 @@
+---
+source: zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
+expression: cf_data
+---
+[
+  KV(
+    k: "00000100000000010000010000",
+    v: "",
+  ),
+  KV(
+    k: "00000100000000010000020000",
+    v: "",
+  ),
+]

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/tx_loc_by_transparent_addr_loc_raw_data@testnet_1.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/tx_loc_by_transparent_addr_loc_raw_data@testnet_1.snap
@@ -1,0 +1,10 @@
+---
+source: zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
+expression: cf_data
+---
+[
+  KV(
+    k: "00000100000000010000010000",
+    v: "",
+  ),
+]

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/tx_loc_by_transparent_addr_loc_raw_data@testnet_2.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/tx_loc_by_transparent_addr_loc_raw_data@testnet_2.snap
@@ -1,0 +1,14 @@
+---
+source: zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
+expression: cf_data
+---
+[
+  KV(
+    k: "00000100000000010000010000",
+    v: "",
+  ),
+  KV(
+    k: "00000100000000010000020000",
+    v: "",
+  ),
+]

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
@@ -432,15 +432,15 @@ fn snapshot_block_and_transaction_data(state: &FinalizedState) {
 
 /// Snapshot transparent address data, using `cargo insta` and RON serialization.
 fn snapshot_transparent_address_data(state: &FinalizedState, height: u32) {
-    // TODO: transactions for each address (#3951)
-
     let balance_by_transparent_addr = state.cf_handle("balance_by_transparent_addr").unwrap();
     let utxo_loc_by_transparent_addr_loc =
         state.cf_handle("utxo_loc_by_transparent_addr_loc").unwrap();
+    let tx_loc_by_transparent_addr_loc = state.cf_handle("tx_loc_by_transparent_addr_loc").unwrap();
 
     let mut stored_address_balances = Vec::new();
     let mut stored_address_utxo_locations = Vec::new();
     let mut stored_address_utxos = Vec::new();
+    let mut stored_address_transaction_locations = Vec::new();
 
     // Correctness: Multi-key iteration causes hangs in concurrent code, but seems ok in tests.
     let addresses =
@@ -448,6 +448,12 @@ fn snapshot_transparent_address_data(state: &FinalizedState, height: u32) {
     let utxo_address_location_count = state
         .full_iterator_cf(
             &utxo_loc_by_transparent_addr_loc,
+            rocksdb::IteratorMode::Start,
+        )
+        .count();
+    let transaction_address_location_count = state
+        .full_iterator_cf(
+            &tx_loc_by_transparent_addr_loc,
             rocksdb::IteratorMode::Start,
         )
         .count();
@@ -463,6 +469,7 @@ fn snapshot_transparent_address_data(state: &FinalizedState, height: u32) {
     if height == 0 {
         assert_eq!(addresses.len(), 0);
         assert_eq!(utxo_address_location_count, 0);
+        assert_eq!(transaction_address_location_count, 0);
         return;
     }
 
@@ -487,9 +494,17 @@ fn snapshot_transparent_address_data(state: &FinalizedState, height: u32) {
             stored_utxos.push(utxo);
         }
 
+        let mut stored_transaction_locations = Vec::new();
+        for transaction_location in state.address_transaction_locations(stored_address_location) {
+            assert_eq!(
+                transaction_location.address_location(),
+                stored_address_location
+            );
+
+            stored_transaction_locations.push(transaction_location.transaction_location());
+        }
+
         // Check that the lists are in chain order
-        //
-        // TODO: check that the transaction list is in chain order (#3951)
         assert!(
             is_sorted(&stored_utxo_locations),
             "unsorted: {:?}\n\
@@ -497,11 +512,19 @@ fn snapshot_transparent_address_data(state: &FinalizedState, height: u32) {
             stored_utxo_locations,
             address,
         );
+        assert!(
+            is_sorted(&stored_transaction_locations),
+            "unsorted: {:?}\n\
+             for address: {:?}",
+            stored_transaction_locations,
+            address,
+        );
 
         // The default raw data serialization is very verbose, so we hex-encode the bytes.
         stored_address_balances.push((address.to_string(), stored_address_balance_location));
         stored_address_utxo_locations.push((stored_address_location, stored_utxo_locations));
         stored_address_utxos.push((address, stored_utxos));
+        stored_address_transaction_locations.push((address, stored_transaction_locations));
     }
 
     // We want to snapshot the order in the database,
@@ -511,6 +534,10 @@ fn snapshot_transparent_address_data(state: &FinalizedState, height: u32) {
     // TODO: change these names to address_utxo_locations and address_utxos
     insta::assert_ron_snapshot!("address_utxos", stored_address_utxo_locations);
     insta::assert_ron_snapshot!("address_utxo_data", stored_address_utxos);
+    insta::assert_ron_snapshot!(
+        "address_transaction_locations",
+        stored_address_transaction_locations
+    );
 }
 
 /// Return true if `list` is sorted in ascending order.

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_transaction_locations@mainnet_1.snap
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_transaction_locations@mainnet_1.snap
@@ -1,0 +1,12 @@
+---
+source: zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+expression: stored_address_transaction_locations
+---
+[
+  ("t3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd", [
+    TransactionLocation(
+      height: Height(1),
+      index: TransactionIndex(0),
+    ),
+  ]),
+]

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_transaction_locations@mainnet_2.snap
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_transaction_locations@mainnet_2.snap
@@ -1,0 +1,16 @@
+---
+source: zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+expression: stored_address_transaction_locations
+---
+[
+  ("t3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd", [
+    TransactionLocation(
+      height: Height(1),
+      index: TransactionIndex(0),
+    ),
+    TransactionLocation(
+      height: Height(2),
+      index: TransactionIndex(0),
+    ),
+  ]),
+]

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_transaction_locations@testnet_1.snap
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_transaction_locations@testnet_1.snap
@@ -1,0 +1,12 @@
+---
+source: zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+expression: stored_address_transaction_locations
+---
+[
+  ("t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi", [
+    TransactionLocation(
+      height: Height(1),
+      index: TransactionIndex(0),
+    ),
+  ]),
+]

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_transaction_locations@testnet_2.snap
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_transaction_locations@testnet_2.snap
@@ -1,0 +1,16 @@
+---
+source: zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+expression: stored_address_transaction_locations
+---
+[
+  ("t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi", [
+    TransactionLocation(
+      height: Height(1),
+      index: TransactionIndex(0),
+    ),
+    TransactionLocation(
+      height: Height(2),
+      index: TransactionIndex(0),
+    ),
+  ]),
+]

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -22,7 +22,8 @@ use crate::{
     service::finalized_state::{
         disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
         disk_format::transparent::{
-            AddressBalanceLocation, AddressLocation, AddressUnspentOutput, OutputLocation,
+            AddressBalanceLocation, AddressLocation, AddressTransaction, AddressUnspentOutput,
+            OutputLocation,
         },
         zebra_db::ZebraDb,
     },
@@ -166,6 +167,47 @@ impl ZebraDb {
 
         addr_unspent_outputs
     }
+
+    /// Returns the locations of any transactions sent to a [`transparent::Address`],
+    /// if they are in the finalized state.
+    #[allow(dead_code)]
+    pub fn address_transaction_locations(
+        &self,
+        address_location: AddressLocation,
+    ) -> BTreeSet<AddressTransaction> {
+        let tx_loc_by_transparent_addr_loc =
+            self.db.cf_handle("tx_loc_by_transparent_addr_loc").unwrap();
+
+        // Manually fetch the entire addresses' transaction locations
+        let mut addr_transactions = BTreeSet::new();
+
+        // An invalid key representing the minimum possible transaction
+        let mut transaction_location = AddressTransaction::address_iterator_start(address_location);
+
+        loop {
+            // A valid key representing an entry for this address or the next
+            transaction_location = match self
+                .db
+                .zs_next_key_value_from(&tx_loc_by_transparent_addr_loc, &transaction_location)
+            {
+                Some((unspent_output, ())) => unspent_output,
+                // We're finished with the final address in the column family
+                None => break,
+            };
+
+            // We found the next address, so we're finished with this address
+            if transaction_location.address_location() != address_location {
+                break;
+            }
+
+            addr_transactions.insert(transaction_location);
+
+            // A potentially invalid key representing the next possible output
+            transaction_location.address_iterator_next();
+        }
+
+        addr_transactions
+    }
 }
 
 impl DiskWriteBatch {
@@ -174,8 +216,6 @@ impl DiskWriteBatch {
     /// - UTXO changes, and
     /// - transparent address index changes,
     /// and return it (without actually writing anything).
-    ///
-    /// TODO: transparent address transaction index (#3951)
     ///
     /// # Errors
     ///
@@ -190,6 +230,8 @@ impl DiskWriteBatch {
         let utxo_by_out_loc = db.cf_handle("utxo_by_outpoint").unwrap();
         let utxo_loc_by_transparent_addr_loc =
             db.cf_handle("utxo_loc_by_transparent_addr_loc").unwrap();
+        let tx_loc_by_transparent_addr_loc =
+            db.cf_handle("tx_loc_by_transparent_addr_loc").unwrap();
 
         // Index all new transparent outputs, before deleting any we've spent
         for (new_output_location, utxo) in new_outputs_by_out_loc {
@@ -223,6 +265,14 @@ impl DiskWriteBatch {
                     address_unspent_output,
                     (),
                 );
+
+                // Create a link from the AddressLocation to the new TransactionLocation in the database.
+                // Unlike the OutputLocation link, this will never be deleted.
+                let address_transaction = AddressTransaction::new(
+                    receiving_address_location,
+                    new_output_location.transaction_location(),
+                );
+                self.zs_insert(&tx_loc_by_transparent_addr_loc, address_transaction, ());
             }
 
             // Use the OutputLocation to store a copy of the new Output in the database.

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -168,7 +168,7 @@ impl ZebraDb {
         addr_unspent_outputs
     }
 
-    /// Returns the locations of any transactions sent to a [`transparent::Address`],
+    /// Returns the locations of any transactions that sent or received from a [`transparent::Address`],
     /// if they are in the finalized state.
     #[allow(dead_code)]
     pub fn address_transaction_locations(


### PR DESCRIPTION
## Motivation

Per #3951 we need to index transactions by their destination addresses.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

Create a new column family to map `AddressLocation` (how we represent `Address`es) to `TransactionLocation`s, using RocksDB keys. (It's how we do 1-to-many mappings, for efficiency)

Closes #3951

## Review

Based on #3999

I still want to test this more, but I think it's OK for review.

@teor2345 will probably be able to review this quickly, but anyone could do it.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
