### PR TITLE
0. change(db): Use Ribbon filters for database index lookups

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -290,8 +290,8 @@ impl DiskDb {
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
 
-        // Use the recommended ribbon filter setting for all column families, and make them file-based,
-        // because the block header and transaction column families have large values.
+        // Use the recommended Ribbon filter setting for all column families.
+        // (Ribbon filters are faster than Bloom filters in Zebra, as of April 2022.)
         //
         // (They aren't needed for single-valued column families, but they don't hurt either.)
         block_based_opts.set_ribbon_filter(9.9);

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -285,9 +285,16 @@ impl DiskDb {
     /// Returns the database options for the finalized state database.
     fn options() -> rocksdb::Options {
         let mut opts = rocksdb::Options::default();
+        let mut block_based_opts = rocksdb::BlockBasedOptions::default();
 
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
+
+        // Use the recommended ribbon filter setting for all column families, and make them file-based,
+        // because the block header and transaction column families have large values.
+        //
+        // (They aren't needed for single-valued column families, but they don't hurt either.)
+        block_based_opts.set_ribbon_filter(9.9);
 
         let open_file_limit = DiskDb::increase_open_file_limit();
         let db_file_limit = DiskDb::get_db_open_file_limit(open_file_limit);
@@ -299,6 +306,9 @@ impl DiskDb {
         let db_file_limit = db_file_limit.try_into().unwrap_or(ideal_limit);
 
         opts.set_max_open_files(db_file_limit);
+
+        // Set the block-based options
+        opts.set_block_based_table_factory(&block_based_opts);
 
         opts
     }


### PR DESCRIPTION
## Motivation

1. We need Zebra to sync faster for the cached state lightwalletd tests. 
2. We want to speed up Zebra's tests, and the slowest tests are sync tests.
3. This might help with locking bugs.

Using Ribbon filters for index lookups makes it about 7% faster. (Ribbon filters are like bloom filters.)

### Specifications

RocksDB can do lookups using a Ribbon filter, which can improve read performance:
https://docs.rs/rocksdb/latest/rocksdb/struct.BlockBasedOptions.html#method.set_ribbon_filter

See also:
https://zhangyuchi.gitbooks.io/rocksdbbook/content/RocksDB-Tuning-Guide.html

## Solution

- Use a Ribbon filter for database queries

This change doesn't require a database version increment, but it won't have the full performance impact until the database is rebuilt. (I tested locally, and the cached state test should also check this.)

### Performance

I ran a full sync test to check performance:
- https://github.com/ZcashFoundation/zebra/actions/runs/2094282197

It finished in 5h43m, compared with most syncs that are around 97% - 99% at 6h.
That's around 7% faster.

(The test was after the lightwalletd database changes, but it should also be faster before them.)

## Review

Anyone can review this PR.

I'd like to merge this PR before we merge any more database changes, to make merging them faster.

### Reviewer Checklist

  - [ ] Code makes sense
  - [ ] Existing Tests Pass
  - [ ] Sync is faster

## Follow Up Tasks

Try a database format upgrade with these changes:
- like #4041, but with Ribbon filters