### PR TITLE
change(db): Use new bloom filter format for database index lookups

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -463,9 +463,16 @@ impl DiskDb {
     /// Returns the database options for the finalized state database.
     fn options() -> rocksdb::Options {
         let mut opts = rocksdb::Options::default();
+        let mut block_based_opts = rocksdb::BlockBasedOptions::default();
 
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
+
+        // Use the recommended bloom filter setting for all column families, and make them file-based,
+        // because the block header and transaction column families have large values.
+        //
+        // (They aren't needed for single-valued column families, but they don't hurt either.)
+        block_based_opts.set_bloom_filter(10.0, false);
 
         let open_file_limit = DiskDb::increase_open_file_limit();
         let db_file_limit = DiskDb::get_db_open_file_limit(open_file_limit);
@@ -477,6 +484,9 @@ impl DiskDb {
         let db_file_limit = db_file_limit.try_into().unwrap_or(ideal_limit);
 
         opts.set_max_open_files(db_file_limit);
+
+        // Set the block-based options
+        opts.set_block_based_table_factory(&block_based_opts);
 
         opts
     }

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -474,6 +474,12 @@ impl DiskDb {
         // (They aren't needed for single-valued column families, but they don't hurt either.)
         block_based_opts.set_bloom_filter(10.0, false);
 
+        // Use the new bloom filter format, which is faster and more accurate.
+        //
+        // Can be read by RocksDB 6.6.0 and later.
+        // https://github.com/facebook/rocksdb/blob/36bc3da97fcb6aa2df6e43df27552f49b762d61e/include/rocksdb/table.h#L409-L434
+        block_based_opts.set_format_version(5);
+
         let open_file_limit = DiskDb::increase_open_file_limit();
         let db_file_limit = DiskDb::get_db_open_file_limit(open_file_limit);
 


### PR DESCRIPTION
## Motivation

This PR is exactly like PR #4032, but with the new bloom filter format, which should be more efficient.

Full sync test:
- https://github.com/ZcashFoundation/zebra/actions/runs/2094304355
