### PR TITLE
fix(ci): use correct machine names for exit codes

### DIFF
--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -223,7 +223,7 @@ jobs:
 
           EXIT_CODE=$(\
           gcloud compute ssh \
-          sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ env.ZONE }} \
           --quiet \
           --ssh-flag="-o ServerAliveInterval=5" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -324,7 +324,7 @@ jobs:
 
           EXIT_CODE=$(\
           gcloud compute ssh \
-          sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ env.ZONE }} \
           --quiet \
           --ssh-flag="-o ServerAliveInterval=5" \


### PR DESCRIPTION
## Motivation

When implementing exit codes validation https://github.com/ZcashFoundation/zebra/commit/44cb35c320f753853fdc0d24d7fa40a9196cf45b, a wrong copy paste was done for a few implementations, which didn't consider the machine name was changing.

## Solution

Use the name of the machine being deployed on each case

## Review

@conradoplg can review this
