### PR TITLE
fix(clippy): Ignore clippy drop warnings in tests

### DIFF
--- a/zebra-network/src/peer/client/tests/vectors.rs
+++ b/zebra-network/src/peer/client/tests/vectors.rs
@@ -47,6 +47,8 @@ async fn client_service_ready_drop_ok() {
 
     let (mut client, mut harness) = ClientTestHarness::build().finish();
 
+    // If the readiness future gains a `Drop` impl, we want it to be called here.
+    #[allow(clippy::drop_non_drop)]
     std::mem::drop(client.ready());
 
     assert!(client.is_ready().await);

--- a/zebra-network/src/peer/client/tests/vectors.rs
+++ b/zebra-network/src/peer/client/tests/vectors.rs
@@ -48,6 +48,7 @@ async fn client_service_ready_drop_ok() {
     let (mut client, mut harness) = ClientTestHarness::build().finish();
 
     // If the readiness future gains a `Drop` impl, we want it to be called here.
+    #[allow(unknown_lints)]
     #[allow(clippy::drop_non_drop)]
     std::mem::drop(client.ready());
 

--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -57,6 +57,7 @@ fn peer_set_ready_single_connection() {
         let peer_ready_future = peer_set.ready();
 
         // If the readiness future gains a `Drop` impl, we want it to be called here.
+        #[allow(unknown_lints)]
         #[allow(clippy::drop_non_drop)]
         std::mem::drop(peer_ready_future);
 

--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -56,7 +56,8 @@ fn peer_set_ready_single_connection() {
         // Get a ready future
         let peer_ready_future = peer_set.ready();
 
-        // Drop the future
+        // If the readiness future gains a `Drop` impl, we want it to be called here.
+        #[allow(clippy::drop_non_drop)]
         std::mem::drop(peer_ready_future);
 
         // Peer set will remain ready for requests


### PR DESCRIPTION
## Motivation

Nightly clippy warns that we're dropping some types with no `Drop` impl.

But we want to drop in the tests, in case we implement `Drop` for those types in future refactors.

## Solution

- Ignore `clippy::drop_non_drop` warnings in tests

## Review

Anyone can review this low-priority PR.

### Reviewer Checklist

  - [ ] Tests pass with no warnings
