### PR TITLE
change(db): Disable unused rocksdb compression features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,7 +2173,6 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
- "zstd-sys",
 ]
 
 [[package]]

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -23,7 +23,7 @@ proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 regex = "1.5.5"
 rlimit = "0.8.3"
-rocksdb = "0.18.0"
+rocksdb = { version = "0.18.0", default_features = false, features = ["lz4"] }
 serde = { version = "1.0.136", features = ["serde_derive"] }
 tempfile = "3.3.0"
 thiserror = "1.0.30"


### PR DESCRIPTION
## Motivation

We're not using most of the compression methods supported by `rocksdb`, so there's no point compiling them into Zebra.

This should speed up compilation slightly.

### Specifications

> By default, support for the [Snappy](https://github.com/google/snappy), [LZ4](https://github.com/lz4/lz4), [Zstd](https://github.com/facebook/zstd), [Zlib](https://zlib.net/), and [Bzip2](http://www.bzip.org/) compression is enabled through crate features. If support for all of these compression algorithms is not needed, default features can be disabled and specific compression algorithms can be enabled.

https://github.com/rust-rocksdb/rust-rocksdb#compression-support

## Solution

- enable `lz4` compression, and disable all the other compression types

We've had a state version increment since we changed the compression type, so this doesn't need another one.

## Review

Anyone can review this low priority PR.

### Reviewer Checklist

  - [ ] Existing build and tests works

