### PR TITLE
8. feat(state): add a query function for transparent address balances

### DIFF
--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -22,7 +22,8 @@ pub mod arbitrary;
 #[cfg(test)]
 mod tests;
 
-type Result<T, E = Error> = std::result::Result<T, E>;
+/// The result of an amount operation.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// A runtime validated type for representing amounts of zatoshis
 #[derive(Clone, Copy, Serialize, Deserialize)]

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_utxo_data@mainnet_1.snap
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_utxo_data@mainnet_1.snap
@@ -4,13 +4,9 @@ expression: stored_address_utxos
 ---
 [
   ("t3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd", [
-    Utxo(
-      output: Output(
-        value: Amount(12500),
-        lock_script: Script("a9147d46a730d31f97b1930d3368a967c309bd4d136a87"),
-      ),
-      height: Height(1),
-      from_coinbase: true,
+    Output(
+      value: Amount(12500),
+      lock_script: Script("a9147d46a730d31f97b1930d3368a967c309bd4d136a87"),
     ),
   ]),
 ]

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_utxo_data@mainnet_2.snap
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_utxo_data@mainnet_2.snap
@@ -4,21 +4,13 @@ expression: stored_address_utxos
 ---
 [
   ("t3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd", [
-    Utxo(
-      output: Output(
-        value: Amount(12500),
-        lock_script: Script("a9147d46a730d31f97b1930d3368a967c309bd4d136a87"),
-      ),
-      height: Height(1),
-      from_coinbase: true,
+    Output(
+      value: Amount(12500),
+      lock_script: Script("a9147d46a730d31f97b1930d3368a967c309bd4d136a87"),
     ),
-    Utxo(
-      output: Output(
-        value: Amount(25000),
-        lock_script: Script("a9147d46a730d31f97b1930d3368a967c309bd4d136a87"),
-      ),
-      height: Height(2),
-      from_coinbase: true,
+    Output(
+      value: Amount(25000),
+      lock_script: Script("a9147d46a730d31f97b1930d3368a967c309bd4d136a87"),
     ),
   ]),
 ]

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_utxo_data@testnet_1.snap
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_utxo_data@testnet_1.snap
@@ -4,13 +4,9 @@ expression: stored_address_utxos
 ---
 [
   ("t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi", [
-    Utxo(
-      output: Output(
-        value: Amount(12500),
-        lock_script: Script("a914ef775f1f997f122a062fff1a2d7443abd1f9c64287"),
-      ),
-      height: Height(1),
-      from_coinbase: true,
+    Output(
+      value: Amount(12500),
+      lock_script: Script("a914ef775f1f997f122a062fff1a2d7443abd1f9c64287"),
     ),
   ]),
 ]

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_utxo_data@testnet_2.snap
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshots/address_utxo_data@testnet_2.snap
@@ -4,21 +4,13 @@ expression: stored_address_utxos
 ---
 [
   ("t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi", [
-    Utxo(
-      output: Output(
-        value: Amount(12500),
-        lock_script: Script("a914ef775f1f997f122a062fff1a2d7443abd1f9c64287"),
-      ),
-      height: Height(1),
-      from_coinbase: true,
+    Output(
+      value: Amount(12500),
+      lock_script: Script("a914ef775f1f997f122a062fff1a2d7443abd1f9c64287"),
     ),
-    Utxo(
-      output: Output(
-        value: Amount(25000),
-        lock_script: Script("a914ef775f1f997f122a062fff1a2d7443abd1f9c64287"),
-      ),
-      height: Height(2),
-      from_coinbase: true,
+    Output(
+      value: Amount(25000),
+      lock_script: Script("a914ef775f1f997f122a062fff1a2d7443abd1f9c64287"),
     ),
   ]),
 ]

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -255,8 +255,8 @@ impl ZebraDb {
     ///
     /// Callers should apply the non-finalized balance change for `addresses` to the returned balance.
     ///
-    /// The total balance will only be correct if this partial chain matches the finalized state.
-    /// Specifically, the root of this partial chain must be a child block of the finalized tip.
+    /// The total balance will only be correct if the non-finalized chain matches the finalized state.
+    /// Specifically, the root of the partial non-finalized chain must be a child block of the finalized tip.
     pub fn partial_finalized_transparent_balance(
         &self,
         addresses: &HashSet<transparent::Address>,

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -11,10 +11,10 @@
 //! The [`crate::constants::DATABASE_FORMAT_VERSION`] constant must
 //! be incremented each time the database format (column, serialization, etc) changes.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use zebra_chain::{
-    amount::{Amount, NonNegative},
+    amount::{self, Amount, NonNegative},
     transaction, transparent,
 };
 
@@ -49,7 +49,6 @@ impl ZebraDb {
 
     /// Returns the balance for a [`transparent::Address`],
     /// if it is in the finalized state.
-    #[allow(dead_code)]
     pub fn address_balance(&self, address: &transparent::Address) -> Option<Amount<NonNegative>> {
         self.address_balance_location(address)
             .map(|abl| abl.balance())
@@ -244,6 +243,32 @@ impl ZebraDb {
         }
 
         addr_transactions
+    }
+
+    // Address index queries
+
+    /// Returns the total transparent balance for `addresses` in the finalized chain.
+    ///
+    /// If none of the addresses has a balance, returns zero.
+    ///
+    /// # Correctness
+    ///
+    /// Callers should apply the non-finalized balance change for `addresses` to the returned balance.
+    ///
+    /// The total balance will only be correct if this partial chain matches the finalized state.
+    /// Specifically, the root of this partial chain must be a child block of the finalized tip.
+    pub fn partial_finalized_transparent_balance(
+        &self,
+        addresses: &HashSet<transparent::Address>,
+    ) -> Amount<NonNegative> {
+        let balance: amount::Result<Amount<NonNegative>> = addresses
+            .iter()
+            .filter_map(|address| self.address_balance(address))
+            .sum();
+
+        balance.expect(
+            "unexpected amount overflow: value balances are valid, so partial sum should be valid",
+        )
     }
 }
 

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -108,7 +108,7 @@ impl ZebraDb {
     pub fn address_utxos(
         &self,
         address: &transparent::Address,
-    ) -> BTreeMap<OutputLocation, transparent::Utxo> {
+    ) -> BTreeMap<OutputLocation, transparent::Output> {
         let address_location = match self.address_location(address) {
             Some(address_location) => address_location,
             None => return BTreeMap::new(),
@@ -123,7 +123,8 @@ impl ZebraDb {
                 Some((
                     addr_out_loc.unspent_output_location(),
                     self.utxo_by_location(addr_out_loc.unspent_output_location())?
-                        .utxo,
+                        .utxo
+                        .output,
                 ))
             })
             .collect()

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -762,10 +762,8 @@ impl UpdateWith<ContextuallyValidBlock> for Chain {
             };
 
             // remove the utxos this produced
-            // uses `tx_by_hash`
             self.revert_chain_with(&(outputs, transaction_hash, new_outputs), position);
             // remove the utxos this consumed
-            // uses `tx_by_hash`
             self.revert_chain_with(&(inputs, transaction_hash, spent_outputs), position);
 
             // remove `transaction.hash` from `tx_by_hash`
@@ -866,15 +864,7 @@ impl
                     .entry(receiving_address)
                     .or_default();
 
-                let transaction_location = self.tx_by_hash.get(&outpoint.hash).expect(
-                    "unexpected missing transaction hash: transaction must already be indexed",
-                );
-
-                address_transfers.update_chain_tip_with(&(
-                    &outpoint,
-                    created_utxo,
-                    transaction_location,
-                ))?;
+                address_transfers.update_chain_tip_with(&(&outpoint, created_utxo))?;
             }
         }
 
@@ -913,13 +903,7 @@ impl
                     .get_mut(&receiving_address)
                     .expect("block has previously been applied to the chain");
 
-                let transaction_location = self
-                    .tx_by_hash
-                    .get(&outpoint.hash)
-                    .expect("transaction is reverted after its UTXOs are reverted");
-
-                address_transfers
-                    .revert_chain_with(&(&outpoint, created_utxo, transaction_location), position);
+                address_transfers.revert_chain_with(&(&outpoint, created_utxo), position);
 
                 // Remove this transfer if it is now empty
                 if address_transfers.is_empty() {

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -236,7 +236,7 @@ impl Chain {
     /// Remove the lowest height block of the non-finalized portion of a chain.
     #[instrument(level = "debug", skip(self))]
     pub(crate) fn pop_root(&mut self) -> ContextuallyValidBlock {
-        let block_height = self.lowest_height();
+        let block_height = self.non_finalized_root_height();
 
         // remove the lowest height block from self.blocks
         let block = self
@@ -251,7 +251,8 @@ impl Chain {
         block
     }
 
-    fn lowest_height(&self) -> block::Height {
+    /// Returns the height of the chain root.
+    pub fn non_finalized_root_height(&self) -> block::Height {
         self.blocks
             .keys()
             .next()
@@ -383,6 +384,15 @@ impl Chain {
             .get(tx_loc.index.as_usize())
     }
 
+    /// Returns the non-finalized tip block hash and height.
+    #[allow(dead_code)]
+    pub fn non_finalized_tip(&self) -> (block::Hash, block::Height) {
+        (
+            self.non_finalized_tip_hash(),
+            self.non_finalized_tip_height(),
+        )
+    }
+
     /// Returns the block hash of the tip block.
     pub fn non_finalized_tip_hash(&self) -> block::Hash {
         self.blocks
@@ -390,6 +400,15 @@ impl Chain {
             .next_back()
             .expect("only called while blocks is populated")
             .hash
+    }
+
+    /// Returns the non-finalized root block hash and height.
+    #[allow(dead_code)]
+    pub fn non_finalized_root(&self) -> (block::Hash, block::Height) {
+        (
+            self.non_finalized_root_hash(),
+            self.non_finalized_root_height(),
+        )
     }
 
     /// Returns the block hash of the non-finalized root block.
@@ -403,7 +422,7 @@ impl Chain {
 
     /// Returns the block hash of the `n`th block from the non-finalized root.
     ///
-    /// This is the block at `lowest_height() + n`.
+    /// This is the block at `non_finalized_root_height() + n`.
     #[allow(dead_code)]
     pub fn non_finalized_nth_hash(&self, n: usize) -> Option<block::Hash> {
         self.blocks.values().nth(n).map(|block| block.hash)

--- a/zebra-state/src/service/non_finalized_state/chain/index.rs
+++ b/zebra-state/src/service/non_finalized_state/chain/index.rs
@@ -6,13 +6,10 @@ use mset::MultiSet;
 
 use zebra_chain::{
     amount::{Amount, NegativeAllowed},
-    block::Height,
     transaction, transparent,
 };
 
-use crate::{
-    request::ContextuallyValidBlock, OutputLocation, TransactionLocation, ValidateContextError,
-};
+use crate::{OutputLocation, TransactionLocation, ValidateContextError};
 
 use super::{RevertPosition, UpdateWith};
 
@@ -235,29 +232,14 @@ impl TransparentTransfers {
             .collect()
     }
 
-    /// Returns the unspent transparent outputs sent to this address,
+    /// Returns the new transparent outputs sent to this address,
     /// in this partial chain, in chain order.
     ///
-    /// `chain_blocks` should be the `blocks` field from the [`Chain`] containing this index.
-    ///
-    /// # Panics
-    ///
-    /// If `chain_blocks` is missing some transaction hashes from this index.
+    /// Some of these outputs might already be spent.
+    /// [`TransparentTransfers::spent_utxos`] returns spent UTXOs.
     #[allow(dead_code)]
-    pub fn created_utxos(
-        &self,
-        chain_blocks: &BTreeMap<Height, ContextuallyValidBlock>,
-    ) -> BTreeMap<OutputLocation, (transparent::Output, transaction::Hash)> {
-        self.created_utxos
-            .iter()
-            .map(|(output_location, output)| {
-                let tx_loc = output_location.transaction_location();
-                let transaction_hash =
-                    chain_blocks[&tx_loc.height].transaction_hashes[tx_loc.index.as_usize()];
-
-                (*output_location, (output.clone(), transaction_hash))
-            })
-            .collect()
+    pub fn created_utxos(&self) -> &BTreeMap<OutputLocation, transparent::Output> {
+        &self.created_utxos
     }
 
     /// Returns the [`OutputLocation`]s of the spent transparent outputs sent to this address,

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -8,7 +8,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use zebra_chain::{
     amount::{Amount, NonNegative},
-    block::{self, Block},
+    block::{self, Block, Height},
     transaction::{self, Transaction},
     transparent,
 };
@@ -82,7 +82,7 @@ where
 #[allow(dead_code)]
 pub(crate) fn transparent_balance<C>(
     chain: Option<C>,
-    _db: &ZebraDb,
+    db: &ZebraDb,
     addresses: HashSet<transparent::Address>,
 ) -> Result<Amount<NonNegative>, BoxError>
 where
@@ -92,15 +92,66 @@ where
     //
     // The StateService commits blocks to the finalized state before updating the latest chain,
     // and it can commit additional blocks after we've cloned this `chain` variable.
-    //
-    // TODO: pop root blocks from `chain` until the chain root is a child of the finalized tip
 
-    let _partial_transparent_balance_change = chain
+    // Check if the finalized state changed while we were querying it
+    let original_finalized_tip = db.tip();
+
+    let transparent_balance = query_transparent_balance(&chain, db, addresses);
+    let finalized_tip = db.tip();
+
+    if original_finalized_tip != finalized_tip {
+        // Correctness: Some balances might be from before the block, and some after
+        //
+        // TODO: retry a few times?
+        return Err("unable to get balance: state was committing a block".into());
+    }
+
+    // Check if the finalized and non-finalized states match
+    if let Some(chain) = chain {
+        let required_chain_root = finalized_tip
+            .map(|(height, _hash)| (height + 1).unwrap())
+            .unwrap_or(Height(0));
+
+        if chain.as_ref().non_finalized_root_height() != required_chain_root {
+            // Correctness: some balances might have duplicate creates or spends
+            //
+            // TODO: pop root blocks from `chain` until the chain root is a child of the finalized tip
+            return Err(
+                "unable to get balance: finalized state doesn't match partial chain".into(),
+            );
+        }
+    }
+
+    Ok(transparent_balance.expect(
+        "unexpected amount overflow: value balances are valid, so partial sum should be valid",
+    ))
+}
+
+/// Returns the total transparent balance for the supplied [`transparent::Address`]es.
+///
+/// If they do not exist in the non-finalized `chain` or finalized `db`, returns zero.
+fn query_transparent_balance<C>(
+    chain: &Option<C>,
+    db: &ZebraDb,
+    addresses: HashSet<transparent::Address>,
+) -> Result<Amount<NonNegative>, BoxError>
+where
+    C: AsRef<Chain>,
+{
+    let balance_change = chain
         .as_ref()
-        .map(|chain| chain.as_ref().partial_transparent_balance_change(addresses))
+        .map(|chain| {
+            chain
+                .as_ref()
+                .partial_transparent_balance_change(&addresses)
+        })
         .unwrap_or_else(Amount::zero);
 
-    //.or_else(|| db.finalized_transparent_balance(addresses))
+    let finalized_balance = db
+        .partial_finalized_transparent_balance(&addresses)
+        .constrain()?;
 
-    Err("unimplemented".into())
+    let balance = (finalized_balance + balance_change)?.constrain()?;
+
+    Ok(balance)
 }


### PR DESCRIPTION
## Motivation

This PR adds a state query function for the `get_address_balance` RPC in ticket #3157.

We still need to add a state request and a RPC method.

### Specifications

RPC:
- https://zcash.github.io/rpc/getaddressbalance.html

But only the arguments and fields in ticket #3157.

### Designs

There are a few tricky parts of this PR:
- making sure the balances from finalized state are consistent with each other
- combining the finalized and non-finalized balances

We could try to hold a database read snapshot, but that could cause locking issues. Instead, I just retry a few times if the balance might have changed. (If the query fails for this reason, Zebra is still syncing, and the results would probably be wrong anyway.)

## Solution

- Add a query function for address balances
  - Add a query method for non-finalized address balance changes
  - Add a query method for finalized state address balances
- Retry interrupted finalized balance queries
- Pop chain root blocks until it matches the finalized tip 

Related changes:
- Make address index types consistent
- Simplify non-finalized address index updates
  - Update snapshots for address index queries
- Simplify non-finalized UTXO query

## Review

I think @jvff is writing the RPC side of this query.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Do the state queries for the other address RPCs.