### PR TITLE
feat(ci): run cached state rebuilds in main branch

### DIFF
--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -27,6 +27,22 @@ on:
       # workflow definitions
       - 'docker/**'
       - '.github/workflows/test-full-sync.yml'
+  push:
+    branches:
+      - main
+    paths:
+      # code and tests (including full sync acceptance test changes)
+      # TODO: ignore changes in test code that isn't used in the full sync test
+      - '**/*.rs'
+      # hard-coded checkpoints
+      # TODO: ignore changes to proptest seed .txt files
+      - '**/*.txt'
+      # dependencies
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      # workflow definitions
+      - 'docker/**'
+      - '.github/workflows/test-full-sync.yml'
 
 env:
   CARGO_INCREMENTAL: '1'

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -273,12 +273,12 @@ jobs:
       # Force the image creation as the disk is still attached, even though is not being used by the container
       - name: Create image from state disk
         run: |
-          gcloud compute images create zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-v${{ env.STATE_VERSION }}-${{ env.NETWORK }}-${{ env.SYNC_HEIGHT }}-tip \
+          gcloud compute images create zebrad-cache-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-v${{ env.STATE_VERSION }}-${{ env.NETWORK }}-tip \
           --force \
           --source-disk=full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --source-disk-zone=${{ env.ZONE }} \
           --storage-location=us \
-          --description="Created from head branch ${{ env.GITHUB_HEAD_REF_SLUG_URL }} targeting ${{ env.GITHUB_BASE_REF_SLUG }} from PR ${{ env.GITHUB_REF_SLUG_URL }} with commit ${{ env.GITHUB_EVENT_PULL_REQUEST_HEAD_SHA }}"
+          --description="Created from commit ${{ env.GITHUB_SHA_SHORT }} with height ${{ env.SYNC_HEIGHT }}"
 
       - name: Delete test instance
         # Do not delete the instance if the sync timeouts in GitHub

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -61,9 +61,10 @@ env:
 
 jobs:
   build:
+    # TODO add `startsWith(github.head_ref, 'mergify/merge-queue/')` to the condition to
     # only run on Mergify head branches, and on manual dispatch:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1
-    if: startsWith(github.head_ref, 'mergify/merge-queue/') || github.event_name == 'workflow_dispatch'
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     name: Build images
     timeout-minutes: 210
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -389,12 +389,12 @@ jobs:
         # Only run if the earlier step succeeds
         if: ${{ steps.sync-to-checkpoint.outcome == 'success' }}
         run: |
-          gcloud compute images create zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-v${{ env.STATE_VERSION }}-${{ env.NETWORK }}-${{ env.SYNC_HEIGHT }}-checkpoint \
+          gcloud compute images create zebrad-cache-${{ env.GITHUB_REF_SLUG_URL }}-v${{ env.STATE_VERSION }}-${{ env.NETWORK }}-checkpoint \
           --force \
           --source-disk=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${{ env.NETWORK }}-checkpoint \
           --source-disk-zone=${{ env.ZONE }} \
           --storage-location=us \
-          --description="Created from head branch ${{ env.GITHUB_HEAD_REF_SLUG_URL }} targeting ${{ env.GITHUB_BASE_REF_SLUG }} from PR ${{ env.GITHUB_REF_SLUG_URL }} with commit ${{ env.GITHUB_EVENT_PULL_REQUEST_HEAD_SHA }}"
+          --description="Created from commit ${{ env.GITHUB_SHA_SHORT }} with height ${{ env.SYNC_HEIGHT }}"
 
       - name: Delete test instance
         # Do not delete the instance if the sync timeouts in GitHub

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,23 @@ on:
       - 'docker/**'
       - '.github/workflows/test.yml'
 
+  push:
+    branches:
+      - main
+    paths:
+      # code and tests
+      - '**/*.rs'
+      # hard-coded checkpoints and proptest regressions
+      - '**/*.txt'
+      # test data snapshots
+      - '**/*.snap'
+      # dependencies
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      # workflow definitions
+      - 'docker/**'
+      - '.github/workflows/test.yml'
+
 env:
   CARGO_INCREMENTAL: '1'
   ZEBRA_SKIP_IPV6_TESTS: '1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -280,7 +280,7 @@ jobs:
       # Check if our destination compute instance exists and delete it
       - name: Delete existing instance with same SHA
         id: delete-old-instance
-        if: ${{ steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true' }}
+        if: ${{ steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true' || github.event_name == 'push'}}
         run: |
           INSTANCE=$(gcloud compute instances list --filter=regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} --format='value(NAME)')
           if [ -z "${INSTANCE}" ]; then
@@ -291,7 +291,7 @@ jobs:
 
       - name: Create GCP compute instance
         id: create-instance
-        if: ${{ steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true' }}
+        if: ${{ steps.changed-files-specific.outputs.any_changed == 'true' || github.event.inputs.regenerate-disks == 'true' || github.event_name == 'push'}}
         run: |
           gcloud compute instances create-with-container "regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 100GB \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -389,7 +389,7 @@ jobs:
         # Only run if the earlier step succeeds
         if: ${{ steps.sync-to-checkpoint.outcome == 'success' }}
         run: |
-          gcloud compute images create zebrad-cache-${{ env.GITHUB_REF_SLUG_URL }}-v${{ env.STATE_VERSION }}-${{ env.NETWORK }}-checkpoint \
+          gcloud compute images create zebrad-cache-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-v${{ env.STATE_VERSION }}-${{ env.NETWORK }}-checkpoint \
           --force \
           --source-disk=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${{ env.NETWORK }}-checkpoint \
           --source-disk-zone=${{ env.ZONE }} \


### PR DESCRIPTION
## Motivation

This is an intermediate PR to allow cached state rebuilds in the `main` branch when merge is successful, needed for https://github.com/ZcashFoundation/zebra/pull/4074

As this workflows run other tests that doesn't add much value, as those tests are validated in the PR checks, and while merging using Mergify, these should be improved in the near future with https://github.com/ZcashFoundation/zebra/issues/4106

This is also a replacement for https://github.com/ZcashFoundation/zebra/pull/4095

## Solution
- Run the Test and Full sync test workflows when pushing to `main`, to have up to date disks using the `main` reference in their name.
- Add GitHub's ref name (branch/PR) to the disk name

## Review

@teor2345 or @dconnolly can review this


## Follow Up Work
https://github.com/ZcashFoundation/zebra/issues/4106