### PR TITLE
9. feat(state): add a query function for transparent UTXOs

### DIFF
--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -103,7 +103,6 @@ impl ZebraDb {
 
     /// Returns the unspent transparent outputs for a [`transparent::Address`],
     /// if they are in the finalized state.
-    #[allow(dead_code)]
     pub fn address_utxos(
         &self,
         address: &transparent::Address,
@@ -269,6 +268,29 @@ impl ZebraDb {
         balance.expect(
             "unexpected amount overflow: value balances are valid, so partial sum should be valid",
         )
+    }
+
+    /// Returns the UTXOs for `addresses` in the finalized chain.
+    ///
+    /// If none of the addresses has finalized UTXOs, returns an empty list.
+    ///
+    /// # Correctness
+    ///
+    /// Callers should apply the non-finalized UTXO changes for `addresses` to the returned UTXOs.
+    ///
+    /// The UTXOs will only be correct if the non-finalized chain matches or overlaps with
+    /// the finalized state.
+    ///
+    /// Specifically, a block in the partial chain must be a child block of the finalized tip.
+    /// (But the child block does not have to be the partial chain root.)
+    pub fn partial_finalized_transparent_utxos(
+        &self,
+        addresses: &HashSet<transparent::Address>,
+    ) -> BTreeMap<OutputLocation, transparent::Output> {
+        addresses
+            .iter()
+            .flat_map(|address| self.address_utxos(address))
+            .collect()
     }
 }
 

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -3,7 +3,7 @@
 
 use std::{
     cmp::Ordering,
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ops::Deref,
     sync::Arc,
 };
@@ -27,7 +27,8 @@ use zebra_chain::{
 };
 
 use crate::{
-    service::check, ContextuallyValidBlock, HashOrHeight, TransactionLocation, ValidateContextError,
+    service::check, ContextuallyValidBlock, HashOrHeight, OutputLocation, TransactionLocation,
+    ValidateContextError,
 };
 
 use self::index::TransparentTransfers;
@@ -536,6 +537,43 @@ impl Chain {
             "unexpected amount overflow: value balances are valid, so partial sum should be valid",
         )
     }
+
+    /// Returns the transparent UTXO changes for `addresses` in this non-finalized chain.
+    ///
+    /// If the UTXOs don't change for any of the addresses, returns empty lists.
+    ///
+    /// # Correctness
+    ///
+    /// Callers should apply these non-finalized UTXO changes to the finalized state UTXOs.
+    ///
+    /// The UTXOs will only be correct if the non-finalized chain matches or overlaps with
+    /// the finalized state.
+    ///
+    /// Specifically, a block in the partial chain must be a child block of the finalized tip.
+    /// (But the child block does not have to be the partial chain root.)
+    pub fn partial_transparent_utxo_changes(
+        &self,
+        addresses: &HashSet<transparent::Address>,
+    ) -> (
+        BTreeMap<OutputLocation, transparent::Output>,
+        BTreeSet<OutputLocation>,
+    ) {
+        let created_utxos = self
+            .partial_transparent_indexes(addresses)
+            .flat_map(|transfers| transfers.created_utxos())
+            .map(|(out_loc, output)| (*out_loc, output.clone()))
+            .collect();
+
+        let spent_utxos = self
+            .partial_transparent_indexes(addresses)
+            .flat_map(|transfers| transfers.spent_utxos())
+            .cloned()
+            .collect();
+
+        (created_utxos, spent_utxos)
+    }
+
+    // Cloning
 
     /// Clone the Chain but not the history and note commitment trees, using
     /// the specified trees instead.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -579,13 +579,18 @@ impl Chain {
     ///
     /// # Correctness
     ///
-    /// Callers should combine these non-finalized UTXO changes to the finalized state UTXOs.
+    /// Callers should combine these non-finalized transactions with the finalized state transactions.
     ///
-    /// The UTXOs will only be correct if the non-finalized chain matches or overlaps with
+    /// The transaction IDs will only be correct if the non-finalized chain matches or overlaps with
     /// the finalized state.
     ///
     /// Specifically, a block in the partial chain must be a child block of the finalized tip.
     /// (But the child block does not have to be the partial chain root.)
+    ///
+    /// This condition does not apply if there is only one address.
+    /// Since address transactions are only appended by blocks,
+    /// and the finalized state query reads them in order,
+    /// it is impossible to get inconsistent transactions for a single address.
     pub fn partial_transparent_transaction_ids(
         &self,
         addresses: &HashSet<transparent::Address>,

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -573,6 +573,28 @@ impl Chain {
         (created_utxos, spent_utxos)
     }
 
+    /// Returns the [`transaction::Hash`]es used by `addresses` to receive or spend funds.
+    ///
+    /// If none of the addresses receive or spend funds in this partial chain, returns an empty list.
+    ///
+    /// # Correctness
+    ///
+    /// Callers should combine these non-finalized UTXO changes to the finalized state UTXOs.
+    ///
+    /// The UTXOs will only be correct if the non-finalized chain matches or overlaps with
+    /// the finalized state.
+    ///
+    /// Specifically, a block in the partial chain must be a child block of the finalized tip.
+    /// (But the child block does not have to be the partial chain root.)
+    pub fn partial_transparent_transaction_ids(
+        &self,
+        addresses: &HashSet<transparent::Address>,
+    ) -> BTreeMap<TransactionLocation, transaction::Hash> {
+        self.partial_transparent_indexes(addresses)
+            .flat_map(|transfers| transfers.tx_ids(&self.tx_by_hash))
+            .collect()
+    }
+
     // Cloning
 
     /// Clone the Chain but not the history and note commitment trees, using

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -591,7 +591,7 @@ impl Chain {
     /// Since address transactions are only appended by blocks,
     /// and the finalized state query reads them in order,
     /// it is impossible to get inconsistent transactions for a single address.
-    pub fn partial_transparent_transaction_ids(
+    pub fn partial_transparent_tx_ids(
         &self,
         addresses: &HashSet<transparent::Address>,
     ) -> BTreeMap<TransactionLocation, transaction::Hash> {

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -4,7 +4,11 @@
 //! to read from the best [`Chain`] in the [`NonFinalizedState`],
 //! and the database in the [`FinalizedState`].
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashSet},
+    ops::RangeInclusive,
+    sync::Arc,
+};
 
 use zebra_chain::{
     amount::{self, Amount, NegativeAllowed, NonNegative},
@@ -15,7 +19,7 @@ use zebra_chain::{
 
 use crate::{
     service::{finalized_state::ZebraDb, non_finalized_state::Chain},
-    BoxError, HashOrHeight,
+    BoxError, HashOrHeight, OutputLocation, TransactionLocation,
 };
 
 #[cfg(test)]
@@ -202,4 +206,199 @@ fn apply_balance_change(
     let balance = finalized_balance.constrain()? + chain_balance_change;
 
     balance?.constrain()
+}
+
+/// Returns the unspent transparent outputs (UTXOs) for the supplied [`transparent::Address`]es,
+/// in chain order; and the transaction IDs for the transactions containing those UTXOs.
+///
+/// The transaction IDs can be looked up using [`OutputLocation::transaction_location()`].
+///
+/// If the addresses do not exist in the non-finalized `chain` or finalized `db`,
+/// returns an empty list.
+//
+// TODO: turn the return type into a struct, and add convenience methods
+#[allow(dead_code)]
+pub(crate) fn transparent_utxos<C>(
+    chain: Option<C>,
+    db: &ZebraDb,
+    addresses: HashSet<transparent::Address>,
+) -> Result<
+    (
+        BTreeMap<OutputLocation, transparent::Output>,
+        BTreeMap<TransactionLocation, transaction::Hash>,
+    ),
+    BoxError,
+>
+where
+    C: AsRef<Chain>,
+{
+    let mut utxo_error = None;
+
+    // Retry the finalized UTXO query if it was interruped by a finalizing block,
+    // and the non-finalized chain doesn't overlap the changed heights.
+    for _ in 0..=FINALIZED_ADDRESS_INDEX_RETRIES {
+        let (finalized_utxos, finalized_tip_range) = finalized_transparent_utxos(db, &addresses);
+
+        // Apply the non-finalized UTXO changes.
+        let chain_utxo_changes =
+            chain_transparent_utxo_changes(chain.as_ref(), &addresses, finalized_tip_range);
+
+        // If the UTXOs are valid, return them, otherwise, retry or return an error.
+        //
+        // TODO:
+        // - lookup transaction IDs
+        match chain_utxo_changes {
+            Ok(chain_utxo_changes) => {
+                let utxos = apply_utxo_changes(finalized_utxos, chain_utxo_changes);
+
+                return Ok((utxos, todo!()));
+            }
+            Err(error) => utxo_error = Some(Err(error)),
+        }
+    }
+
+    utxo_error.expect("unexpected missing error: attempts should set error or return")
+}
+
+/// Returns the unspent transparent outputs (UTXOs) for `addresses` in the finalized chain,
+/// and the finalized tip heights the UTXOs were queried at.
+///
+/// If the addresses do not exist in the finalized `db`, returns an empty list.
+//
+// TODO: turn the return type into a struct?
+fn finalized_transparent_utxos(
+    db: &ZebraDb,
+    addresses: &HashSet<transparent::Address>,
+) -> (
+    BTreeMap<OutputLocation, transparent::Output>,
+    Option<RangeInclusive<Height>>,
+) {
+    // # Correctness
+    //
+    // The StateService can commit additional blocks while we are querying address UTXOs.
+
+    // Check if the finalized state changed while we were querying it
+    let start_finalized_tip = db.finalized_tip_height();
+
+    let finalized_utxos = db.partial_finalized_transparent_utxos(addresses);
+
+    let end_finalized_tip = db.finalized_tip_height();
+
+    let finalized_tip_range = if let (Some(start_finalized_tip), Some(end_finalized_tip)) =
+        (start_finalized_tip, end_finalized_tip)
+    {
+        Some(start_finalized_tip..=end_finalized_tip)
+    } else {
+        // State is empty
+        None
+    };
+
+    (finalized_utxos, finalized_tip_range)
+}
+
+/// Returns the UTXO changes for `addresses` in the non-finalized chain,
+/// matching or overlapping the UTXOs for the `finalized_tip_range`.
+///
+/// If the addresses do not exist in the non-finalized `chain`, returns an empty list.
+//
+// TODO: turn the return type into a struct?
+fn chain_transparent_utxo_changes<C>(
+    chain: Option<C>,
+    addresses: &HashSet<transparent::Address>,
+    finalized_tip_range: Option<RangeInclusive<Height>>,
+) -> Result<
+    (
+        BTreeMap<OutputLocation, transparent::Output>,
+        BTreeSet<OutputLocation>,
+    ),
+    BoxError,
+>
+where
+    C: AsRef<Chain>,
+{
+    let finalized_tip_range = match finalized_tip_range {
+        Some(finalized_tip_range) => finalized_tip_range,
+        None => {
+            assert!(
+                chain.is_none(),
+                "unexpected non-finalized chain when finalized state is empty"
+            );
+
+            // Empty chains don't contain any changes.
+            return Ok(Default::default());
+        }
+    };
+
+    // # Correctness
+    //
+    // The StateService commits blocks to the finalized state before updating the latest chain,
+    // and it can commit additional blocks after we've cloned this `chain` variable.
+    //
+    // But we can compensate for deleted UTXOs by applying the overlapping non-finalized UTXO changes.
+
+    // Check if the finalized and non-finalized states match or overlap
+    let required_min_chain_root = finalized_tip_range.start().0 + 1;
+    let mut required_chain_overlap = required_min_chain_root..=finalized_tip_range.end().0;
+
+    if chain.is_none() {
+        if required_chain_overlap.is_empty() {
+            // The non-finalized chain is empty, and we don't need it.
+            return Ok(Default::default());
+        } else {
+            // We can't compensate for inconsistent database queries,
+            // because the non-finalized chain is empty.
+            return Err("unable to get UTXOs: state was committing a block, and non-finalized chain is empty".into());
+        }
+    }
+
+    let chain = chain.unwrap();
+    let chain = chain.as_ref();
+
+    let chain_root = chain.non_finalized_root_height().0;
+    let chain_tip = chain.non_finalized_tip_height().0;
+
+    assert!(
+        chain_root <= required_min_chain_root,
+        "unexpected chain gap: the best chain is updated after its previous root is finalized"
+    );
+
+    // If we've already committed this entire chain, ignore its UTXO changes.
+    // This is more likely if the non-finalized state is just getting started.
+    if chain_tip > *required_chain_overlap.end() {
+        if required_chain_overlap.is_empty() {
+            // The non-finalized chain has been committed, and we don't need it.
+            return Ok(Default::default());
+        } else {
+            // We can't compensate for inconsistent database queries,
+            // because the non-finalized chain is below the inconsistent query range.
+            return Err("unable to get UTXOs: state was committing a block, and non-finalized chain has been committed".into());
+        }
+    }
+
+    // Correctness: some finalized UTXOs might have duplicate creates or spends,
+    // but we've just checked they can be corrected by applying the non-finalized UTXO changes.
+    assert!(
+        required_chain_overlap.all(|height| chain.blocks.contains_key(&Height(height))),
+        "UTXO query inconsistency: chain must contain required overlap blocks",
+    );
+
+    Ok(chain.partial_transparent_utxo_changes(addresses))
+}
+
+/// Combines the supplied finalized and non-finalized UTXOs,
+/// removes the spent UTXOs, and returns the result.
+fn apply_utxo_changes(
+    finalized_utxos: BTreeMap<OutputLocation, transparent::Output>,
+    (created_chain_utxos, spent_chain_utxos): (
+        BTreeMap<OutputLocation, transparent::Output>,
+        BTreeSet<OutputLocation>,
+    ),
+) -> BTreeMap<OutputLocation, transparent::Output> {
+    // Correctness: combine the created UTXOs, then remove spent UTXOs,
+    // to compensate for overlapping finalized and non-finalized blocks.
+    finalized_utxos
+        .into_iter()
+        .chain(created_chain_utxos.into_iter())
+        .filter(|(utxo_location, _output)| !spent_chain_utxos.contains(utxo_location))
+        .collect()
 }

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -421,11 +421,7 @@ where
 
     let chain_tx_ids = chain
         .as_ref()
-        .map(|chain| {
-            chain
-                .as_ref()
-                .partial_transparent_transaction_ids(addresses)
-        })
+        .map(|chain| chain.as_ref().partial_transparent_tx_ids(addresses))
         .unwrap_or_default();
 
     // First try the in-memory chain, then the disk database

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -13,6 +13,7 @@ use std::{
 use zebra_chain::{
     amount::{self, Amount, NegativeAllowed, NonNegative},
     block::{self, Block, Height},
+    parameters::Network,
     transaction::{self, Transaction},
     transparent,
 };
@@ -219,6 +220,7 @@ fn apply_balance_change(
 /// returns an empty list.
 #[allow(dead_code)]
 pub(crate) fn transparent_utxos<C>(
+    network: Network,
     chain: Option<C>,
     db: &ZebraDb,
     addresses: HashSet<transparent::Address>,
@@ -243,8 +245,9 @@ where
                 let utxos = apply_utxo_changes(finalized_utxos, chain_utxo_changes);
                 let tx_ids = lookup_tx_ids_for_utxos(chain, db, &addresses, &utxos);
 
-                return Ok(AddressUtxos::new(utxos, tx_ids));
+                return Ok(AddressUtxos::new(network, utxos, tx_ids));
             }
+
             Err(error) => utxo_error = Some(Err(error)),
         }
     }

--- a/zebra-state/src/service/read/utxo.rs
+++ b/zebra-state/src/service/read/utxo.rs
@@ -1,0 +1,47 @@
+//! Convenience wrappers for transparent address index UTXO queries.
+
+use std::collections::BTreeMap;
+
+use zebra_chain::{transaction, transparent};
+
+use crate::{OutputLocation, TransactionLocation};
+
+/// A convenience wrapper that efficiently stores unspent transparent outputs,
+/// and the corresponding transaction IDs.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
+pub struct AddressUtxos {
+    /// A set of unspent transparent outputs.
+    utxos: BTreeMap<OutputLocation, transparent::Output>,
+
+    /// The transaction IDs for each [`OutputLocation`] in `utxos`.
+    tx_ids: BTreeMap<TransactionLocation, transaction::Hash>,
+}
+
+impl AddressUtxos {
+    /// Creates a new set of address UTXOs.
+    pub fn new(
+        utxos: BTreeMap<OutputLocation, transparent::Output>,
+        tx_ids: BTreeMap<TransactionLocation, transaction::Hash>,
+    ) -> Self {
+        Self { utxos, tx_ids }
+    }
+
+    /// Returns an iterator that provides the unspent output, its location in the chain,
+    /// the transaction hash, and...
+    ///
+    /// The UTXOs are returned in chain order, across all addresses.
+    #[allow(dead_code)]
+    pub fn utxos(
+        &self,
+    ) -> impl Iterator<Item = (&transaction::Hash, &OutputLocation, &transparent::Output)> {
+        self.utxos.iter().map(|(out_loc, output)| {
+            (
+                self.tx_ids
+                    .get(&out_loc.transaction_location())
+                    .expect("address indexes are consistent"),
+                out_loc,
+                output,
+            )
+        })
+    }
+}


### PR DESCRIPTION
## Motivation

This PR adds a state query function for the `get_address_utxos` RPC in ticket #3158.

We still need to add a state request and a RPC method.

### Specifications

RPC:
- https://zcash.github.io/rpc/getaddressutxos.html

But only the arguments and fields in ticket #3158.

### Designs

There are a few tricky parts of this PR:
- making sure the UTXOs from the finalized state are consistent with each other
- combining the finalized and non-finalized UTXOs

We could try to hold a database read snapshot, but that could cause locking issues. Instead, I just retry a few times if the UTXOs might have changed. (If the query fails for this reason, Zebra is still syncing, and the results would probably be wrong anyway.)

But this is easier than the previous PR, because we can just combine the created UTXOs, then remove the spent UTXOs.

## Solution

- Add a query function for address UTXOs
  - Add a query method for non-finalized UTXO changes
  - Add a query method for finalized state UTXOs
  - Combine UTXOs in a way that makes sure they are consistent
  - Return transaction IDs along with address UTXOs
  - Add a convenience type for address UTXOs

- Retry interrupted finalized UTXO queries

## Review

I think @oxarbitrage  is writing the RPC side of this query.



### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Do the state query for the transaction IDs RPC.