### PR TITLE
feat(rpc): implement the get_address_tx_ids RPC method query

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -647,7 +647,6 @@ where
         end: u32,
     ) -> BoxFuture<Result<Vec<String>>> {
         let mut state = self.state.clone();
-        let mut response_transactions = vec![];
         let start = Height(start);
         let end = Height(end);
 
@@ -661,7 +660,7 @@ where
             // height range checks
             check_height_range(start, end, chain_height?)?;
 
-            let valid_addresses: Result<Vec<Address>> = addresses
+            let valid_addresses: Result<HashSet<Address>> = addresses
                 .iter()
                 .map(|address| {
                     address.parse().map_err(|_| {
@@ -670,8 +669,10 @@ where
                 })
                 .collect();
 
-            let request =
-                zebra_state::ReadRequest::TransactionsByAddresses(valid_addresses?, start, end);
+            let request = zebra_state::ReadRequest::TransactionIdsByAddresses {
+                addresses: valid_addresses?,
+                height_range: start..=end,
+            };
             let response = state
                 .ready()
                 .and_then(|service| service.call(request))
@@ -682,13 +683,14 @@ where
                     data: None,
                 })?;
 
-            match response {
-                zebra_state::ReadResponse::TransactionIds(hashes) => response_transactions
-                    .append(&mut hashes.iter().map(|h| h.to_string()).collect()),
+            let hashes = match response {
+                zebra_state::ReadResponse::AddressesTransactionIds(hashes) => {
+                    hashes.values().map(|tx_id| tx_id.to_string()).collect()
+                }
                 _ => unreachable!("unmatched response to a TransactionsByAddresses request"),
-            }
+            };
 
-            Ok(response_transactions)
+            Ok(hashes)
         }
         .boxed()
     }

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -431,7 +431,7 @@ async fn rpc_getaddresstxids_response() {
 
     // TODO: The length of the response should be 1
     // Fix in the context of #3147
-    assert_eq!(response.len(), 0);
+    assert_eq!(response.len(), 10);
 
     mempool.expect_no_requests().await;
 

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    ops::RangeInclusive,
     sync::Arc,
 };
 
@@ -438,19 +439,27 @@ pub enum ReadRequest {
     /// * [`Response::Transaction(None)`](Response::Transaction) otherwise.
     Transaction(transaction::Hash),
 
-    /// Looks up transactions hashes that were made by provided addresses in a blockchain height range.
-    ///
-    /// Returns
-    ///
-    /// * A vector of transaction hashes.
-    /// * An empty vector if no transactions were found for the given arguments.
-    ///
-    /// Returned txids are in the order they appear in blocks, which ensures that they are topologically sorted
-    /// (i.e. parent txids will appear before child txids).
-    TransactionsByAddresses(Vec<transparent::Address>, block::Height, block::Height),
-
     /// Looks up the balance of a set of transparent addresses.
     ///
     /// Returns an [`Amount`] with the total balance of the set of addresses.
     AddressBalance(HashSet<transparent::Address>),
+
+    /// Looks up transaction hashes that sent or received from addresses,
+    /// in an inclusive blockchain height range.
+    ///
+    /// Returns
+    ///
+    /// * A set of transaction hashes.
+    /// * An empty vector if no transactions were found for the given arguments.
+    ///
+    /// Returned txids are in the order they appear in blocks,
+    /// which ensures that they are topologically sorted
+    /// (i.e. parent txids will appear before child txids).
+    TransactionIdsByAddresses {
+        /// The requested addresses.
+        addresses: HashSet<transparent::Address>,
+
+        /// The blocks to be queried for transactions.
+        height_range: RangeInclusive<block::Height>,
+    },
 }

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -1,11 +1,11 @@
 //! State [`tower::Service`] response types.
 
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use zebra_chain::{
     amount::{Amount, NonNegative},
     block::{self, Block},
-    transaction::{Hash, Transaction},
+    transaction::{self, Transaction},
     transparent,
 };
 
@@ -13,6 +13,7 @@ use zebra_chain::{
 // will work with inline links.
 #[allow(unused_imports)]
 use crate::Request;
+use crate::TransactionLocation;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// A response to a [`StateService`] [`Request`].
@@ -55,10 +56,10 @@ pub enum ReadResponse {
     /// Response to [`ReadRequest::Transaction`] with the specified transaction.
     Transaction(Option<(Arc<Transaction>, block::Height)>),
 
-    /// Response to [`ReadRequest::TransactionsByAddresses`] with the obtained transaction ids,
-    /// in the order they appear in blocks.
-    TransactionIds(Vec<Hash>),
-
     /// Response to [`ReadRequest::AddressBalance`] with the total balance of the addresses.
     AddressBalance(Amount<NonNegative>),
+
+    /// Response to [`ReadRequest::TransactionIdsByAddresses`] with the obtained transaction ids,
+    /// in the order they appear in blocks.
+    AddressesTransactionIds(BTreeMap<TransactionLocation, transaction::Hash>),
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -995,8 +995,7 @@ impl Service<ReadRequest> for ReadStateService {
             // For the get_address_tx_ids RPC.
             ReadRequest::TransactionIdsByAddresses {
                 addresses,
-                // TODO: filter by height range
-                height_range: _,
+                height_range,
             } => {
                 metrics::counter!(
                     "state.requests",
@@ -1009,7 +1008,7 @@ impl Service<ReadRequest> for ReadStateService {
 
                 async move {
                     let tx_ids = state.best_chain_receiver.with_watch_data(|best_chain| {
-                        read::transparent_tx_ids(best_chain, &state.db, addresses)
+                        read::transparent_tx_ids(best_chain, &state.db, addresses, height_range)
                     });
 
                     tx_ids.map(ReadResponse::AddressesTransactionIds)

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -403,11 +403,14 @@ impl AddressTransaction {
     /// since [`ReadDisk::zs_next_key_value_from`] will fetch the next existing (valid) value.
     pub fn address_iterator_start(address_location: AddressLocation) -> AddressTransaction {
         // Iterating from the lowest possible transaction location gets us the first transaction.
-        let zero_transaction_location = TransactionLocation::from_usize(Height(0), 0);
+        //
+        // The address location is the output location of the first UTXO sent to the address,
+        // and addresses can not spend funds until they receive their first UTXO.
+        let first_utxo_location = address_location.transaction_location();
 
         AddressTransaction {
             address_location,
-            transaction_location: zero_transaction_location,
+            transaction_location: first_utxo_location,
         }
     }
 

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -5,7 +5,7 @@
 //! The [`crate::constants::DATABASE_FORMAT_VERSION`] constant must
 //! be incremented each time the database format (column, serialization, etc) changes.
 
-use std::fmt::Debug;
+use std::{cmp::max, fmt::Debug};
 
 use zebra_chain::{
     amount::{self, Amount, NonNegative},
@@ -396,21 +396,29 @@ impl AddressTransaction {
     }
 
     /// Create an [`AddressTransaction`] which starts iteration for the supplied address.
+    /// Starts at the first UTXO, or at the `query_start` height, whichever is greater.
+    ///
     /// Used to look up the first transaction with [`ReadDisk::zs_next_key_value_from`].
     ///
-    /// The transaction location is before all unspent output locations in the index.
-    /// It is always invalid, due to the genesis consensus rules. But this is not an issue
-    /// since [`ReadDisk::zs_next_key_value_from`] will fetch the next existing (valid) value.
-    pub fn address_iterator_start(address_location: AddressLocation) -> AddressTransaction {
+    /// The transaction location might be invalid, if it is based on the `query_start` height.
+    /// But this is not an issue, since [`ReadDisk::zs_next_key_value_from`]
+    /// will fetch the next existing (valid) value.
+    pub fn address_iterator_start(
+        address_location: AddressLocation,
+        query_start: Height,
+    ) -> AddressTransaction {
         // Iterating from the lowest possible transaction location gets us the first transaction.
         //
         // The address location is the output location of the first UTXO sent to the address,
         // and addresses can not spend funds until they receive their first UTXO.
         let first_utxo_location = address_location.transaction_location();
 
+        // Iterating from the start height filters out transactions that aren't needed.
+        let query_start_location = TransactionLocation::from_usize(query_start, 0);
+
         AddressTransaction {
             address_location,
-            transaction_location: first_utxo_location,
+            transaction_location: max(first_utxo_location, query_start_location),
         }
     }
 

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
@@ -45,11 +45,14 @@ use zebra_chain::{
 };
 
 use crate::{
-    service::finalized_state::{
-        disk_format::{
-            block::TransactionIndex, transparent::OutputLocation, FromDisk, TransactionLocation,
+    service::{
+        finalized_state::{
+            disk_format::{
+                block::TransactionIndex, transparent::OutputLocation, FromDisk, TransactionLocation,
+            },
+            FinalizedState,
         },
-        FinalizedState,
+        read::ADDRESS_HEIGHTS_FULL_RANGE,
     },
     Config,
 };
@@ -495,7 +498,9 @@ fn snapshot_transparent_address_data(state: &FinalizedState, height: u32) {
         }
 
         let mut stored_transaction_locations = Vec::new();
-        for transaction_location in state.address_transaction_locations(stored_address_location) {
+        for transaction_location in
+            state.address_transaction_locations(stored_address_location, ADDRESS_HEIGHTS_FULL_RANGE)
+        {
             assert_eq!(
                 transaction_location.address_location(),
                 stored_address_location

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -146,7 +146,7 @@ impl ZebraDb {
         let mut unspent_output = AddressUnspentOutput::address_iterator_start(address_location);
 
         loop {
-            // A valid key representing an entry for this address or the next
+            // Seek to a valid entry for this address, or the first entry for the next address
             unspent_output = match self
                 .db
                 .zs_next_key_value_from(&utxo_loc_by_transparent_addr_loc, &unspent_output)
@@ -216,16 +216,16 @@ impl ZebraDb {
         // Manually fetch the entire addresses' transaction locations
         let mut addr_transactions = BTreeSet::new();
 
-        // An invalid key representing the minimum possible transaction
+        // A valid key representing the first UTXO send to the address
         let mut transaction_location = AddressTransaction::address_iterator_start(address_location);
 
         loop {
-            // A valid key representing an entry for this address or the next
+            // Seek to a valid entry for this address, or the first entry for the next address
             transaction_location = match self
                 .db
                 .zs_next_key_value_from(&tx_loc_by_transparent_addr_loc, &transaction_location)
             {
-                Some((unspent_output, ())) => unspent_output,
+                Some((transaction_location, ())) => transaction_location,
                 // We're finished with the final address in the column family
                 None => break,
             };

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -292,6 +292,34 @@ impl ZebraDb {
             .flat_map(|address| self.address_utxos(address))
             .collect()
     }
+
+    /// Returns the transaction IDs that sent or received funds to `addresses` in the finalized chain.
+    ///
+    /// If none of the addresses has finalized sends or receives, returns an empty list.
+    ///
+    /// # Correctness
+    ///
+    /// Callers should combine the non-finalized transactions for `addresses`
+    /// with the returned transactions.
+    ///
+    /// The transaction IDs will only be correct if the non-finalized chain matches or overlaps with
+    /// the finalized state.
+    ///
+    /// Specifically, a block in the partial chain must be a child block of the finalized tip.
+    /// (But the child block does not have to be the partial chain root.)
+    ///
+    /// This condition does not apply if there is only one address.
+    /// Since address transactions are only appended by blocks, and this query reads them in order,
+    /// it is impossible to get inconsistent transactions for a single address.
+    pub fn partial_finalized_transparent_tx_ids(
+        &self,
+        addresses: &HashSet<transparent::Address>,
+    ) -> BTreeMap<TransactionLocation, transaction::Hash> {
+        addresses
+            .iter()
+            .flat_map(|address| self.address_tx_ids(address))
+            .collect()
+    }
 }
 
 impl DiskWriteBatch {

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -4,7 +4,7 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    ops::Deref,
+    ops::{Deref, RangeInclusive},
     sync::Arc,
 };
 
@@ -13,7 +13,7 @@ use tracing::instrument;
 
 use zebra_chain::{
     amount::{Amount, NegativeAllowed, NonNegative},
-    block,
+    block::{self, Height},
     history_tree::HistoryTree,
     orchard,
     parameters::Network,
@@ -573,7 +573,8 @@ impl Chain {
         (created_utxos, spent_utxos)
     }
 
-    /// Returns the [`transaction::Hash`]es used by `addresses` to receive or spend funds.
+    /// Returns the [`transaction::Hash`]es used by `addresses` to receive or spend funds,
+    /// in the non-finalized chain, filtered using the `query_height_range`.
     ///
     /// If none of the addresses receive or spend funds in this partial chain, returns an empty list.
     ///
@@ -594,9 +595,10 @@ impl Chain {
     pub fn partial_transparent_tx_ids(
         &self,
         addresses: &HashSet<transparent::Address>,
+        query_height_range: RangeInclusive<Height>,
     ) -> BTreeMap<TransactionLocation, transaction::Hash> {
         self.partial_transparent_indexes(addresses)
-            .flat_map(|transfers| transfers.tx_ids(&self.tx_by_hash))
+            .flat_map(|transfers| transfers.tx_ids(&self.tx_by_hash, query_height_range.clone()))
             .collect()
     }
 

--- a/zebra-state/src/service/non_finalized_state/chain/index.rs
+++ b/zebra-state/src/service/non_finalized_state/chain/index.rs
@@ -1,11 +1,15 @@
 //! Transparent address indexes for non-finalized chains.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    ops::RangeInclusive,
+};
 
 use mset::MultiSet;
 
 use zebra_chain::{
     amount::{Amount, NegativeAllowed},
+    block::Height,
     transaction, transparent,
 };
 
@@ -205,29 +209,33 @@ impl TransparentTransfers {
         self.balance
     }
 
-    /// Returns the [`transaction::Hash`]es of the transactions that
-    /// sent or received transparent transfers to this address,
-    /// in this partial chain, in chain order.
+    /// Returns the [`transaction::Hash`]es of the transactions that sent or received
+    /// transparent transfers to this address, in this partial chain, filtered by `query_height_range`.
+    ///
+    /// The transactions are returned in chain order.
     ///
     /// `chain_tx_by_hash` should be the `tx_by_hash` field from the [`Chain`] containing this index.
     ///
     /// # Panics
     ///
     /// If `chain_tx_by_hash` is missing some transaction hashes from this index.
-    #[allow(dead_code)]
     pub fn tx_ids(
         &self,
         chain_tx_by_hash: &HashMap<transaction::Hash, TransactionLocation>,
+        query_height_range: RangeInclusive<Height>,
     ) -> BTreeMap<TransactionLocation, transaction::Hash> {
         self.tx_ids
             .distinct_elements()
-            .map(|tx_hash| {
-                (
-                    *chain_tx_by_hash
-                        .get(tx_hash)
-                        .expect("all hashes are indexed"),
-                    *tx_hash,
-                )
+            .filter_map(|tx_hash| {
+                let tx_loc = *chain_tx_by_hash
+                    .get(tx_hash)
+                    .expect("all hashes are indexed");
+
+                if query_height_range.contains(&tx_loc.height) {
+                    Some((tx_loc, *tx_hash))
+                } else {
+                    None
+                }
             })
             .collect()
     }

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -438,3 +438,180 @@ where
         })
         .collect()
 }
+
+/// Returns the transaction IDs that sent or received funds,
+/// from the supplied [`transparent::Address`]es, in chain order.
+///
+/// If the addresses do not exist in the non-finalized `chain` or finalized `db`,
+/// returns an empty list.
+#[allow(dead_code)]
+pub(crate) fn transparent_tx_ids<C>(
+    chain: Option<C>,
+    db: &ZebraDb,
+    addresses: HashSet<transparent::Address>,
+) -> Result<BTreeMap<TransactionLocation, transaction::Hash>, BoxError>
+where
+    C: AsRef<Chain>,
+{
+    let mut tx_id_error = None;
+
+    // Retry the finalized tx ID query if it was interruped by a finalizing block,
+    // and the non-finalized chain doesn't overlap the changed heights.
+    for _ in 0..=FINALIZED_ADDRESS_INDEX_RETRIES {
+        let (finalized_tx_ids, finalized_tip_range) = finalized_transparent_tx_ids(db, &addresses);
+
+        // Apply the non-finalized tx ID changes.
+        let chain_tx_id_changes =
+            chain_transparent_tx_id_changes(chain.as_ref(), &addresses, finalized_tip_range);
+
+        // If the tx IDs are valid, return them, otherwise, retry or return an error.
+        match chain_tx_id_changes {
+            Ok(chain_tx_id_changes) => {
+                let tx_ids = apply_tx_id_changes(finalized_tx_ids, chain_tx_id_changes);
+
+                return Ok(tx_ids);
+            }
+
+            Err(error) => tx_id_error = Some(Err(error)),
+        }
+    }
+
+    tx_id_error.expect("unexpected missing error: attempts should set error or return")
+}
+
+/// Returns the [`transaction::Hash`]es for `addresses` in the finalized chain,
+/// and the finalized tip heights the transaction IDs were queried at.
+///
+/// If the addresses do not exist in the finalized `db`, returns an empty list.
+//
+// TODO: turn the return type into a struct?
+fn finalized_transparent_tx_ids(
+    db: &ZebraDb,
+    addresses: &HashSet<transparent::Address>,
+) -> (
+    BTreeMap<TransactionLocation, transaction::Hash>,
+    Option<RangeInclusive<Height>>,
+) {
+    // # Correctness
+    //
+    // The StateService can commit additional blocks while we are querying transaction IDs.
+
+    // Check if the finalized state changed while we were querying it
+    let start_finalized_tip = db.finalized_tip_height();
+
+    let finalized_tx_ids = db.partial_finalized_transparent_tx_ids(addresses);
+
+    let end_finalized_tip = db.finalized_tip_height();
+
+    let finalized_tip_range = if let (Some(start_finalized_tip), Some(end_finalized_tip)) =
+        (start_finalized_tip, end_finalized_tip)
+    {
+        Some(start_finalized_tip..=end_finalized_tip)
+    } else {
+        // State is empty
+        None
+    };
+
+    (finalized_tx_ids, finalized_tip_range)
+}
+
+/// Returns the extra transaction IDs for `addresses` in the non-finalized chain,
+/// matching or overlapping the transaction IDs for the `finalized_tip_range`.
+///
+/// If the addresses do not exist in the non-finalized `chain`, returns an empty list.
+//
+// TODO: turn the return type into a struct?
+fn chain_transparent_tx_id_changes<C>(
+    chain: Option<C>,
+    addresses: &HashSet<transparent::Address>,
+    finalized_tip_range: Option<RangeInclusive<Height>>,
+) -> Result<BTreeMap<TransactionLocation, transaction::Hash>, BoxError>
+where
+    C: AsRef<Chain>,
+{
+    let finalized_tip_range = match finalized_tip_range {
+        Some(finalized_tip_range) => finalized_tip_range,
+        None => {
+            assert!(
+                chain.is_none(),
+                "unexpected non-finalized chain when finalized state is empty"
+            );
+
+            // Empty chains don't contain any tx IDs.
+            return Ok(Default::default());
+        }
+    };
+
+    // # Correctness
+    //
+    // The StateService commits blocks to the finalized state before updating the latest chain,
+    // and it can commit additional blocks after we've cloned this `chain` variable.
+    //
+    // But we can compensate for addresses with mismatching blocks,
+    // by adding the overlapping non-finalized transaction IDs.
+    //
+    // If there is only one address, mismatches aren't possible,
+    // because tx IDs are added to the finalized state in chain order (and never removed),
+    // and they are queried in chain order.
+
+    // Check if the finalized and non-finalized states match or overlap
+    let required_min_chain_root = finalized_tip_range.start().0 + 1;
+    let mut required_chain_overlap = required_min_chain_root..=finalized_tip_range.end().0;
+
+    if chain.is_none() {
+        if required_chain_overlap.is_empty() || addresses.len() <= 1 {
+            // The non-finalized chain is empty, and we don't need it.
+            return Ok(Default::default());
+        } else {
+            // We can't compensate for inconsistent database queries,
+            // because the non-finalized chain is empty.
+            return Err("unable to get tx IDs: state was committing a block, and non-finalized chain is empty".into());
+        }
+    }
+
+    let chain = chain.unwrap();
+    let chain = chain.as_ref();
+
+    let chain_root = chain.non_finalized_root_height().0;
+    let chain_tip = chain.non_finalized_tip_height().0;
+
+    assert!(
+        chain_root <= required_min_chain_root,
+        "unexpected chain gap: the best chain is updated after its previous root is finalized"
+    );
+
+    // If we've already committed this entire chain, ignore its UTXO changes.
+    // This is more likely if the non-finalized state is just getting started.
+    if chain_tip > *required_chain_overlap.end() {
+        if required_chain_overlap.is_empty() || addresses.len() <= 1 {
+            // The non-finalized chain has been committed, and we don't need it.
+            return Ok(Default::default());
+        } else {
+            // We can't compensate for inconsistent database queries,
+            // because the non-finalized chain is below the inconsistent query range.
+            return Err("unable to get tx IDs: state was committing a block, and non-finalized chain has been committed".into());
+        }
+    }
+
+    // Correctness: some finalized tx IDs might have come from different blocks for different addresses,
+    // but we've just checked they can be corrected by applying the non-finalized UTXO changes.
+    assert!(
+        required_chain_overlap.all(|height| chain.blocks.contains_key(&Height(height))) || addresses.len() <= 1,
+        "tx ID query inconsistency: chain must contain required overlap blocks if there are multiple addresses",
+    );
+
+    Ok(chain.partial_transparent_tx_ids(addresses))
+}
+
+/// Returns the combined the supplied finalized and non-finalized transaction IDs.
+fn apply_tx_id_changes(
+    finalized_tx_ids: BTreeMap<TransactionLocation, transaction::Hash>,
+    chain_tx_ids: BTreeMap<TransactionLocation, transaction::Hash>,
+) -> BTreeMap<TransactionLocation, transaction::Hash> {
+    // Correctness: compensate for inconsistent tx IDs finalized blocks across multiple addresses,
+    // by combining them with overalapping non-finalized block tx IDs.
+    finalized_tx_ids
+        .into_iter()
+        .chain(chain_tx_ids.into_iter())
+        .collect()
+}


### PR DESCRIPTION
## Motivation

This PR adds a state query function and RPC method for the `get_address_tx_ids` RPC in ticket #3147.

### Specifications

RPC:
- https://zcash.github.io/rpc/getaddresstxids.html

But only the arguments and fields in ticket #3147.

### Designs

There are a few tricky parts of this PR:
- filtering the tx IDs by height range efficiently
- making sure the tx IDs from the finalized state are consistent with each other
- combining the finalized and non-finalized tx IDs

We could try to hold a database read snapshot, but that could cause locking issues. Instead, I just retry a few times if the tx IDs might have changed. (If the query fails for this reason, Zebra is still syncing, and the results would probably be wrong anyway.)

But this is easier than the previous PR, because we can just combine the tx IDs, as long as there is chain overlap, or as long as we are querying a single address.

## Solution

- Add the get_address_tx_ids RPC method
  - Add a query function for address tx IDs
  - Add a query method for finalized tx IDs
  - Combine tx IDs in a way that makes sure they are consistent
  - Add a state request that calls the query function

- Filter the tx IDs by the query height range
  - Optimise database queries, so we don't look up filtered transaction IDs from the disk
  - Test all block range combinations for mainnet

- Retry interrupted finalized tx ID queries

Closes #3147.

## Review

Anyone can review this PR, it's not urgent.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Do a bunch of RPC testing:
- #4131 
- #4130 