### PR TITLE
ci(Mergify): Fix invalid mergify config on main branch

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,8 +4,8 @@ queue_rules:
     allow_checks_interruption: False
     speculative_checks: 1
     batch_size: 5
-    # Just wait 2 minutes to embark hotfixes together in a merge train
-    batch_max_wait_time: 120
+    # Wait a short time to embark hotfixes together in a merge train
+    batch_max_wait_time: "2 minutes"
     conditions:
       # Mergify automatically applies status check, approval, and conversation rules,
       # which are the same as the GitHub main branch protection rules
@@ -17,8 +17,8 @@ queue_rules:
     allow_checks_interruption: True
     speculative_checks: 1
     batch_size: 5
-    # Wait 10 minutes to embark high priority tickets together in a merge train
-    batch_max_wait_time: 300
+    # Wait for a few minutes to embark high priority tickets together in a merge train
+    batch_max_wait_time: "5 minutes"
     conditions:
       - base=main
 
@@ -27,8 +27,8 @@ queue_rules:
     allow_checks_interruption: True
     speculative_checks: 1
     batch_size: 5
-    # Wait 10 minutes to embark low priority tickets together in a merge train
-    batch_max_wait_time: 300
+    # Wait a bit longer to embark low priority tickets together in a merge train
+    batch_max_wait_time: "10 minutes"
     conditions:
       - base=main
 


### PR DESCRIPTION
## Motivation

PR #4094 got merged with an invalid mergify config, so I'm going to admin-merge this fix to unblock the NU5 release.

### Testing

This change has been made by @teor2345 from https://mergify.com config editor.

## Related Issues

This is another instance of #4110 