### PR TITLE
fix(ci): give enough time to zebra before reading logs

### DIFF
--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -214,6 +214,9 @@ jobs:
       # This TODO relates to the following issues:
       # https://github.com/actions/runner/issues/241
       # https://www.googlecloudcommunity.com/gc/Infrastructure-Compute-Storage/SSH-into-Compute-Container-not-easily-possible/td-p/170915
+      #
+      # Deploying a zebra container might take more than 30 seconds to completely start, so we're adding a timer at the end
+      # of this step before starting the following ones
       - name: Get container name from logs
         run: |
           INSTANCE_ID=$(gcloud compute instances describe full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} --zone ${{ env.ZONE }} --format='value(id)')

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -228,6 +228,7 @@ jobs:
 
           echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
           echo "CONTAINER_NAME=$CONTAINER_NAME" >> $GITHUB_ENV
+          sleep 90
 
       - name: Full sync
         id: full-sync

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -322,6 +322,9 @@ jobs:
       # This TODO relates to the following issues:
       # https://github.com/actions/runner/issues/241
       # https://www.googlecloudcommunity.com/gc/Infrastructure-Compute-Storage/SSH-into-Compute-Container-not-easily-possible/td-p/170915
+      #
+      # Deploying a zebra container might take more than 30 seconds to completely start, so we're adding a timer at the end
+      # of this step before starting the following ones
       - name: Get container name from logs
         id: get-container-name
         if: ${{ steps.create-instance.outcome == 'success' }}
@@ -485,6 +488,9 @@ jobs:
       # This TODO relates to the following issues:
       # https://github.com/actions/runner/issues/241
       # https://www.googlecloudcommunity.com/gc/Infrastructure-Compute-Storage/SSH-into-Compute-Container-not-easily-possible/td-p/170915
+      #
+      # Deploying a zebra container might take more than 30 seconds to completely start, so we're adding a timer at the end
+      # of this step before starting the following ones
       - name: Get container name from logs
         id: get-container-name
         if: ${{ steps.create-instance.outcome == 'success' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -338,6 +338,7 @@ jobs:
 
           echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
           echo "CONTAINER_NAME=$CONTAINER_NAME" >> $GITHUB_ENV
+          sleep 90
 
       - name: Regenerate stateful disks
         id: sync-to-checkpoint
@@ -500,6 +501,7 @@ jobs:
 
           echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
           echo "CONTAINER_NAME=$CONTAINER_NAME" >> $GITHUB_ENV
+          sleep 90
 
       - name: Sync past mandatory checkpoint
         id: sync-past-checkpoint


### PR DESCRIPTION
## Motivation

Deploying a zebra container might take more than 30 seconds to completely start, depending on the machine resources it might take a bit more.

Fixes #4114

## Solution

- To ensure we're on the safe side, we're adding 90 seconds before start reading the logs and getting the exit code.

## Review

Anyone can review this

## Follow Up Work

We have to look for a better deploying approach to a container native one.