### PR TITLE
feat(rpc): Implement `getaddressbalance` RPC

### DIFF
--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -15,6 +15,7 @@ use std::{
 
 use crate::serialization::{ZcashDeserialize, ZcashSerialize};
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};
+use serde::Serializer;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod arbitrary;
@@ -81,6 +82,16 @@ impl<C> Amount<C> {
         C: Constraint,
     {
         0.try_into().expect("an amount of 0 is always valid")
+    }
+
+    /// Serialize this [`Amount`] as a string instead of an integer.
+    ///
+    /// The string contains the amount of Zatoshis in the amount.
+    pub fn serialize_as_string<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
     }
 }
 

--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -15,7 +15,6 @@ use std::{
 
 use crate::serialization::{ZcashDeserialize, ZcashSerialize};
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};
-use serde::Serializer;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod arbitrary;
@@ -82,16 +81,6 @@ impl<C> Amount<C> {
         C: Constraint,
     {
         0.try_into().expect("an amount of 0 is always valid")
-    }
-
-    /// Serialize this [`Amount`] as a string instead of an integer.
-    ///
-    /// The string contains the amount of Zatoshis in the amount.
-    pub fn serialize_as_string<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&self.0.to_string())
     }
 }
 

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -710,6 +710,14 @@ pub struct GetBlockChainInfo {
     consensus: TipConsensusBranch,
 }
 
+/// A wrapper type with a list of strings of addresses.
+///
+/// This is used for the input parameter of [`Rpc::get_account_balance`].
+#[derive(Clone, Debug, Eq, PartialEq, Hash, serde::Deserialize)]
+pub struct AddressStrings {
+    addresses: Vec<String>,
+}
+
 /// The transparent balance of a set of addresses.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, serde::Serialize)]
 pub struct AddressBalance {

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -19,6 +19,7 @@ use tower::{buffer::Buffer, Service, ServiceExt};
 use tracing::Instrument;
 
 use zebra_chain::{
+    amount::{Amount, NonNegative},
     block::{self, Height, SerializedBlock},
     chain_tip::ChainTip,
     parameters::{ConsensusBranchId, Network, NetworkUpgrade},
@@ -655,6 +656,13 @@ pub struct GetBlockChainInfo {
     estimated_height: u32,
     upgrades: IndexMap<ConsensusBranchIdHex, NetworkUpgradeInfo>,
     consensus: TipConsensusBranch,
+}
+
+/// The transparent balance of a set of addresses.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, serde::Serialize)]
+pub struct AddressBalance {
+    #[serde(serialize_with = "Amount::serialize_as_string")]
+    balance: Amount<NonNegative>,
 }
 
 /// A hex-encoded [`ConsensusBranchId`] string.

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -83,6 +83,10 @@ pub trait Rpc {
     ///
     /// zcashd also returns the total amount of Zatoshis received by the addresses, but Zebra
     /// doesn't because lightwalletd doesn't use that information.
+    ///
+    /// The RPC documentation says that the returned object has a string `balance` field, but
+    /// zcashd actually [returns an
+    /// integer](https://github.com/zcash/lightwalletd/blob/bdaac63f3ee0dbef62bde04f6817a9f90d483b00/common/common.go#L128-L130).
     #[rpc(name = "getaddressbalance")]
     fn get_address_balance(&self, addresses: Vec<String>) -> BoxFuture<Result<AddressBalance>>;
 
@@ -707,7 +711,6 @@ pub struct GetBlockChainInfo {
 /// The transparent balance of a set of addresses.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, serde::Serialize)]
 pub struct AddressBalance {
-    #[serde(serialize_with = "Amount::serialize_as_string")]
     balance: Amount<NonNegative>,
 }
 

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -72,6 +72,8 @@ pub trait Rpc {
 
     /// Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
     ///
+    /// zcashd reference: [`getaddressbalance`](https://zcash.github.io/rpc/getaddressbalance.html)
+    ///
     /// # Parameters
     ///
     /// - `addresses`: (array of strings) A list of base-58 encoded addresses.

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -304,8 +304,7 @@ proptest! {
     /// Make the mock mempool service return a list of transaction IDs, and check that the RPC call
     /// returns those IDs as hexadecimal strings.
     #[test]
-    fn mempool_transactions_are_sent_to_caller(transaction_ids in any::<HashSet<UnminedTxId>>())
-    {
+    fn mempool_transactions_are_sent_to_caller(transaction_ids in any::<HashSet<UnminedTxId>>()) {
         let runtime = zebra_test::init_async();
         let _guard = runtime.enter();
 
@@ -357,7 +356,9 @@ proptest! {
     /// Try to call `get_raw_transaction` using a string parameter that has at least one
     /// non-hexadecimal character, and check that it fails with an expected error.
     #[test]
-    fn get_raw_transaction_non_hexadecimal_string_results_in_an_error(non_hex_string in ".*[^0-9A-Fa-f].*") {
+    fn get_raw_transaction_non_hexadecimal_string_results_in_an_error(
+        non_hex_string in ".*[^0-9A-Fa-f].*",
+    ) {
         let runtime = zebra_test::init_async();
         let _guard = runtime.enter();
 
@@ -409,7 +410,9 @@ proptest! {
     /// Try to call `get_raw_transaction` using random bytes that fail to deserialize as a
     /// transaction, and check that it fails with an expected error.
     #[test]
-    fn get_raw_transaction_invalid_transaction_results_in_an_error(random_bytes in any::<Vec<u8>>()) {
+    fn get_raw_transaction_invalid_transaction_results_in_an_error(
+        random_bytes in any::<Vec<u8>>(),
+    ) {
         let runtime = zebra_test::init_async();
         let _guard = runtime.enter();
 
@@ -476,7 +479,10 @@ proptest! {
         );
 
         let response = rpc.get_blockchain_info();
-        prop_assert_eq!(&response.err().unwrap().message, "No Chain tip available yet");
+        prop_assert_eq!(
+            &response.err().unwrap().message,
+            "No Chain tip available yet"
+        );
 
         // The queue task should continue without errors or panics
         let rpc_tx_queue_task_result = rpc_tx_queue_task_handle.now_or_never();
@@ -529,8 +535,18 @@ proptest! {
                 prop_assert_eq!(info.best_block_hash.0, block_hash);
                 prop_assert!(info.estimated_height < Height::MAX.0);
 
-                prop_assert_eq!(info.consensus.chain_tip.0, NetworkUpgrade::current(network, block_height).branch_id().unwrap());
-                prop_assert_eq!(info.consensus.next_block.0, NetworkUpgrade::current(network, (block_height + 1).unwrap()).branch_id().unwrap());
+                prop_assert_eq!(
+                    info.consensus.chain_tip.0,
+                    NetworkUpgrade::current(network, block_height)
+                        .branch_id()
+                        .unwrap()
+                );
+                prop_assert_eq!(
+                    info.consensus.next_block.0,
+                    NetworkUpgrade::current(network, (block_height + 1).unwrap())
+                        .branch_id()
+                        .unwrap()
+                );
 
                 for u in info.upgrades {
                     let mut status = NetworkUpgradeStatus::Active;
@@ -539,10 +555,10 @@ proptest! {
                     }
                     prop_assert_eq!(u.1.status, status);
                 }
-            },
+            }
             Err(_) => {
                 unreachable!("Test should never error with the data we are feeding it")
-            },
+            }
         };
 
         // The queue task should continue without errors or panics
@@ -560,8 +576,7 @@ proptest! {
 
     /// Test the queue functionality using `send_raw_transaction`
     #[test]
-    fn rpc_queue_main_loop(tx in any::<Transaction>())
-    {
+    fn rpc_queue_main_loop(tx in any::<Transaction>()) {
         let runtime = zebra_test::init_async();
         let _guard = runtime.enter();
 
@@ -627,7 +642,8 @@ proptest! {
                 .respond(response);
 
             // now a retry will be sent to the mempool
-            let expected_request = mempool::Request::Queue(vec![mempool::Gossip::Tx(tx_unmined.clone())]);
+            let expected_request =
+                mempool::Request::Queue(vec![mempool::Gossip::Tx(tx_unmined.clone())]);
             let response = mempool::Response::Queued(vec![Ok(())]);
 
             mempool
@@ -649,8 +665,7 @@ proptest! {
 
     /// Test we receive all transactions that are sent in a channel
     #[test]
-    fn rpc_queue_receives_all_transactions_from_channel(txs in any::<[Transaction; 2]>())
-    {
+    fn rpc_queue_receives_all_transactions_from_channel(txs in any::<[Transaction; 2]>()) {
         let runtime = zebra_test::init_async();
         let _guard = runtime.enter();
 
@@ -715,14 +730,17 @@ proptest! {
 
                 // we use `expect_request_that` because we can't guarantee the state request order
                 state
-                    .expect_request_that(|request| matches!(request, zebra_state::ReadRequest::Transaction(_)))
+                    .expect_request_that(|request| {
+                        matches!(request, zebra_state::ReadRequest::Transaction(_))
+                    })
                     .await?
                     .respond(response);
             }
 
             // each transaction will be retried
             for tx in txs.clone() {
-                let expected_request = mempool::Request::Queue(vec![mempool::Gossip::Tx(UnminedTx::from(tx))]);
+                let expected_request =
+                    mempool::Request::Queue(vec![mempool::Gossip::Tx(UnminedTx::from(tx))]);
                 let response = mempool::Response::Queued(vec![Ok(())]);
 
                 mempool

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1,6 +1,9 @@
 //! State [`tower::Service`] request types.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use zebra_chain::{
     amount::NegativeAllowed,
@@ -445,4 +448,9 @@ pub enum ReadRequest {
     /// Returned txids are in the order they appear in blocks, which ensures that they are topologically sorted
     /// (i.e. parent txids will appear before child txids).
     TransactionsByAddresses(Vec<transparent::Address>, block::Height, block::Height),
+
+    /// Looks up the balance of a set of transparent addresses.
+    ///
+    /// Returns an [`Amount`] with the total balance of the set of addresses.
+    AddressBalance(HashSet<transparent::Address>),
 }

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use zebra_chain::{
+    amount::{Amount, NonNegative},
     block::{self, Block},
     transaction::{Hash, Transaction},
     transparent,
@@ -57,4 +58,7 @@ pub enum ReadResponse {
     /// Response to [`ReadRequest::TransactionsByAddresses`] with the obtained transaction ids,
     /// in the order they appear in blocks.
     TransactionIds(Vec<Hash>),
+
+    /// Response to [`ReadRequest::AddressBalance`] with the total balance of the addresses.
+    AddressBalance(Amount<NonNegative>),
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1014,6 +1014,27 @@ impl Service<ReadRequest> for ReadStateService {
                 }
                 .boxed()
             }
+
+            // For the get_address_balance RPC.
+            ReadRequest::AddressBalance(addresses) => {
+                metrics::counter!(
+                    "state.requests",
+                    1,
+                    "service" => "read_state",
+                    "type" => "balance",
+                );
+
+                let state = self.clone();
+
+                async move {
+                    let balance = state.best_chain_receiver.with_watch_data(|best_chain| {
+                        read::transparent_balance(best_chain, &state.db, addresses)
+                    })?;
+
+                    Ok(ReadResponse::AddressBalance(balance))
+                }
+                .boxed()
+            }
         }
     }
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1021,7 +1021,7 @@ impl Service<ReadRequest> for ReadStateService {
                     "state.requests",
                     1,
                     "service" => "read_state",
-                    "type" => "balance",
+                    "type" => "address_balance",
                 );
 
                 let state = self.clone();


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
Lightwalletd requires the `getaddressbalance` RPC in order to check a wallet's balance.

Closes #3157.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->
Zcash RPC documentation: https://zcash.github.io/rpc/getaddressbalance.html

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Implement the RPC, connecting it to the read-only state service using a new `AddressBalance` request/response pair, which uses the `read::transparent_balance` query function.

Two property tests were added. The first one tests using valid addresses and checks if the RPC leads to the expected address balance query to the state service. The second one uses at least one invalid address to check if the RPC returns an error.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
