### PR TITLE
fix(ci): increase the Zcash parameter fetch timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
   test:
     name: Test ${{ matrix.rust }} on ${{ matrix.os }}
     # The large timeout is to accommodate:
-    # - Windows builds (75 minutes, typically 30-50 minutes)
-    # - parameter downloads (40 minutes, but only when the cache expires)
-    timeout-minutes: 115
+    # - Windows builds (75 minutes, typically 30-50 minutes), and
+    # - parameter downloads (an extra 90 minutes, but only when the cache expires)
+    timeout-minutes: 165
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,9 +38,9 @@ jobs:
   coverage:
     name: Coverage nightly
     # The large timeout is to accommodate:
-    # - nightly builds (75 minutes, typically 30-50 minutes)
-    # - parameter downloads (40 minutes, but only when the cache expires)
-    timeout-minutes: 115
+    # - nightly builds (75 minutes, typically 30-50 minutes), and
+    # - parameter downloads (an extra 90 minutes, but only when the cache expires)
+    timeout-minutes: 165
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Motivation

The macOS tests are failing because downloading the Zcash parameters takes longer than the timeout:
https://github.com/ZcashFoundation/zebra/runs/6085103982?check_suite_focus=true

## Solution

Increase the OS test and coverage timeouts to match the observed download time.

This is a temporary fix, until we fix the caching (PR #4149).

## Review

@gustavovalverde can review this PR. Merges will probably fail until this is fixed.

### Reviewer Checklist

  - [ ] Changes make sense

## Follow Up Work

Fix the underlying caching issue:
> a cache created for the branch feature-a (with the base main) would not be accessible to a pull request for the branch feature-b (with the base main).

https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache

See PR #4149.

This is also related to ticket #3448.