### PR TITLE
fix(ci): share GitHub runner caches between branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,23 @@ name: CI
 
 on:
   workflow_dispatch:
+  # we build Rust and Zcash parameter caches on main,
+  # so they can be shared by all branches:
+  # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+  push:
+    branches:
+      - main
+    paths:
+      # production code and test code
+      - '**/*.rs'
+      # hard-coded checkpoints
+      # TODO: skip proptest regressions
+      - '**/*.txt'
+      # dependencies
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      # workflow definitions
+      - '.github/workflows/ci.yml'
   pull_request:
     paths:
       # code and tests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,23 @@
 name: Lint Rust files
 
 on:
+  # we build Rust caches on main, so they can be shared by all branches:
+  # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+  push:
+    branches:
+      - main
+    paths:
+      # production code and test code
+      - '**/*.rs'
+      # hard-coded checkpoints
+      # TODO: skip proptest regressions
+      - '**/*.txt'
+      # dependencies
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      # workflow definitions that change the clippy cache
+      - '.cargo/config.toml'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches:
       - 'main'
@@ -41,6 +58,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: Swatinem/rust-cache@v1
+
       - name: Run clippy action to produce annotations
         uses: actions-rs/clippy-check@v1.0.7
         if: ${{ steps.check_permissions.outputs.has-permission }}
@@ -76,7 +95,7 @@ jobs:
           components: rustfmt
           override: true
 
-      - uses: Swatinem/rust-cache@v1 # TODO: No cache is being found
+      - uses: Swatinem/rust-cache@v1
 
       - uses: actions-rs/cargo@v1.0.3
         with:


### PR DESCRIPTION
## Motivation

Our Linux and macOS builds using GitHub runners are very slow the first time we open a PR on a new branch, because they aren't using any caches.

We need to build the Zcash parameter and Rust caches on the `main` branch, if we want them to be available to newly 
created branches.

This should give us a massive performance improvement the first time we open a PR for a new branch.

### Specifications

> A workflow can access and restore a cache created in the current branch, the base branch (including base branches of forked repositories), or the default branch (usually main). For example, a cache created on the default branch would be accessible from any pull request. Also, if the branch feature-b has the base branch feature-a, a workflow triggered on feature-b would have access to caches created in the default branch (main), feature-a, and feature-b.
> 
> Access restrictions provide cache isolation and security by creating a logical boundary between different branches. For example, a cache created for the branch feature-a (with the base main) would not be accessible to a pull request for the branch feature-b (with the base main).

https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache

## Solution

- Run the CI and lint jobs on the `main` branch
- Cache the clippy job Rust dependencies

This is a quick fix, we can probably do better later.

## Review

Anyone can review this PR.

I'd like @gustavovalverde to check that I got this right.

### Reviewer Checklist

  - [ ] CI passes
  - [ ] Configs match specs

