### PR TITLE
fix(test): don't create another 'state' directory when implementing ZebradTestDirExt

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1379,7 +1379,6 @@ fn zebra_state_conflict() -> Result<()> {
         let mut dir_conflict_full = PathBuf::new();
         dir_conflict_full.push(dir_conflict.path());
         dir_conflict_full.push("state");
-        dir_conflict_full.push("state");
         dir_conflict_full.push(format!(
             "v{}",
             zebra_state::constants::DATABASE_FORMAT_VERSION

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -5,7 +5,11 @@
 //! Test functions in this file will not be run.
 //! This file is only for test library code.
 
-use std::{env, path::Path, time::Duration};
+use std::{
+    env,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use color_eyre::eyre::Result;
 
@@ -142,7 +146,7 @@ where
     fn cache_config_update_helper(self, config: &mut ZebradConfig) -> Result<Self> {
         if !config.state.ephemeral {
             let dir = self.as_ref();
-            let cache_dir = dir.join("state");
+            let cache_dir = PathBuf::from(dir);
             config.state.cache_dir = cache_dir;
         }
 


### PR DESCRIPTION
## Motivation

The `ZebradTestDirExt` trait implementation, which is used by acceptance test to crate temporary Zebra configs, would append a "state" to the cached folder but Zebra already adds it, which would make it look like `~/.cache/zebra/state/state`. This would prevent cached states from being picked up.

I think it's not causing any problems currently, but I found this while working on https://github.com/ZcashFoundation/zebra/pull/4157


### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

Don't add a `state` subfolder when computing the path.

## Review

Not urgent but can cause problem for lightwalletd tests that expect a fully synced Zebra from a cached state. Anyone can review.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
