### PR TITLE
change(state): Remove `active_value` field from `ChainTipSender`

### DIFF
--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -236,12 +236,15 @@ jobs:
       - name: Full sync
         id: full-sync
         run: |
-          gcloud compute ssh \
-          full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
-          --zone ${{ env.ZONE }} \
-          --quiet \
-          --ssh-flag="-o ServerAliveInterval=5" \
-          --command="docker logs --follow ${{ env.CONTAINER_NAME }}"
+          for RETRY in 1 2 3 4; do
+              gcloud compute ssh \
+              full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+              --zone ${{ env.ZONE }} \
+              --quiet \
+              --ssh-flag="-o ServerAliveInterval=15" \
+              --command="docker logs --follow ${{ env.CONTAINER_NAME }}" \
+              || echo "ssh disconnected $RETRY times"
+          done
 
           EXIT_CODE=$(\
           gcloud compute ssh \

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -151,9 +151,6 @@ impl ChainTipSender {
     /// Update the latest finalized tip.
     ///
     /// May trigger an update to the best tip.
-    //
-    // TODO: when we replace active_value with  `watch::Sender::borrow`,
-    //       refactor instrument to avoid multiple borrows, to prevent deadlocks
     #[instrument(
         skip(self, new_tip),
         fields(old_use_non_finalized_tip, old_height, old_hash, new_height, new_hash)
@@ -170,9 +167,6 @@ impl ChainTipSender {
     /// Update the latest non-finalized tip.
     ///
     /// May trigger an update to the best tip.
-    //
-    // TODO: when we replace active_value with  `watch::Sender::borrow`,
-    //       refactor instrument to avoid multiple borrows, to prevent deadlocks
     #[instrument(
         skip(self, new_tip),
         fields(old_use_non_finalized_tip, old_height, old_hash, new_height, new_hash)

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -191,6 +191,10 @@ impl ChainTipSender {
     /// An update is only sent if the current best tip is different from the last best tip
     /// that was sent.
     fn update(&mut self, new_tip: Option<ChainTipBlock>) {
+        // Correctness: the `self.sender.borrow()` must not be placed in a `let` binding to prevent
+        // a read-lock being created and living beyond the `self.sender.send(..)` call. If that
+        // happens, the `send` method will attempt to obtain a write-lock and will dead-lock.
+        // Without the binding, the guard is dropped at the end of the expression.
         let needs_update = match (new_tip.as_ref(), self.sender.borrow().as_ref()) {
             // since the blocks have been contextually validated,
             // we know their hashes cover all the block data


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
The `ChainTipSender` type had an extra field as a workaround to when Zebra was using an older version of Tokio that didn't have the `watch::Sender::borrow()` method. Zebra now depends on a newer version of Tokio, so that field can be removed.

This was a cleanup I did some time ago, and I was afraid I'd forget to push this.

Depends-On: #4198

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
Remove the field, replacing the usages with `watcher::Sender::borrow()`.

As part of the changes, I also simplified the instrumentation attribute a bit.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
