### PR TITLE
test(rpc): Add Rust tests for lightwalletd sync from Zebra

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1191,13 +1191,13 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
 
     // Write a configuration that has RPC listen_addr set
     // [Note on port conflict](#Note on port conflict)
-    let mut config = if let Some(config) = test_type.zebrad_config() {
+    let config = if let Some(config) = test_type.zebrad_config() {
         config?
     } else {
         return Ok(());
     };
 
-    let zdir = testdir()?.with_config(&mut config)?;
+    let zdir = testdir()?.with_exact_config(&config)?;
     let mut zebrad = zdir
         .spawn_child(args!["start"])?
         .with_timeout(LAUNCH_DELAY)

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1390,8 +1390,8 @@ fn lightwalletd_integration_test(
         zebrad.expect_stdout_line_matches(regex::escape("sync_percent=100"))?;
 
         // Wait for lightwalletd to sync to Zebra's tip
-        lightwalletd.expect_stdout_line_matches(regex::escape("Ingestor adding block to cache"))?;
         lightwalletd.expect_stdout_line_matches(regex::escape("Ingestor waiting for block"))?;
+
         // Check Zebra is still at the tip (also clears and prints Zebra's logs)
         zebrad.expect_stdout_line_matches(regex::escape("sync_percent=100"))?;
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1307,8 +1307,7 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
         );
 
     // Wait until `lightwalletd` has launched
-    let result = lightwalletd.expect_stdout_line_matches("Starting gRPC server");
-    let (_, zebrad) = zebrad.kill_on_error(result)?;
+    lightwalletd.expect_stdout_line_matches("Starting gRPC server")?;
 
     // Check that `lightwalletd` is calling the expected Zebra RPCs
 
@@ -1316,13 +1315,10 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
     //
     // TODO: update branchID when we're using cached state (#3511)
     //       add "Waiting for zcashd height to reach Sapling activation height"
-    let result = lightwalletd.expect_stdout_line_matches(
+    lightwalletd.expect_stdout_line_matches(
         "Got sapling height 419200 block height [0-9]+ chain main branchID 00000000",
-    );
-    let (_, zebrad) = zebrad.kill_on_error(result)?;
-
-    let result = lightwalletd.expect_stdout_line_matches("Found 0 blocks in cache");
-    let (_, zebrad) = zebrad.kill_on_error(result)?;
+    )?;
+    lightwalletd.expect_stdout_line_matches("Found 0 blocks in cache")?;
 
     // getblock with the first Sapling block in Zebra's state
     //
@@ -1347,18 +1343,12 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
     //
     // TODO: expect Ingestor log when we're using cached state (#3511)
     //       "Ingestor adding block to cache"
-    let result = lightwalletd.expect_stdout_line_matches(regex::escape(
+    lightwalletd.expect_stdout_line_matches(regex::escape(
         "Waiting for zcashd height to reach Sapling activation height (419200)",
-    ));
-    let (_, zebrad) = zebrad.kill_on_error(result)?;
-
-    // (next RPC)
-    //
-    // TODO: add extra checks when we add new Zebra RPCs
+    ))?;
 
     // Cleanup both processes
-    let result = lightwalletd.kill();
-    let (_, mut zebrad) = zebrad.kill_on_error(result)?;
+    lightwalletd.kill()?;
     zebrad.kill()?;
 
     let lightwalletd_output = lightwalletd.wait_with_output()?.assert_failure()?;

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1132,7 +1132,7 @@ fn lightwalletd_integration() -> Result<()> {
 /// If `LIGHTWALLETD_DATA_DIR` is not set, just runs a full sync.
 ///
 /// This test only runs when the `ZEBRA_TEST_LIGHTWALLETD`,
-/// `CACHED_STATE_PATH`, and `LIGHTWALLETD_DATA_DIR` env vars are set.
+/// `ZEBRA_CACHED_STATE_PATH`, and `LIGHTWALLETD_DATA_DIR` env vars are set.
 ///
 /// This test doesn't work on Windows, so it is always skipped on that platform.
 #[test]
@@ -1144,7 +1144,7 @@ fn lightwalletd_update_sync() -> Result<()> {
 /// Make sure `lightwalletd` can fully sync from genesis using Zebra.
 ///
 /// This test only runs when the `ZEBRA_TEST_LIGHTWALLETD` and
-/// `CACHED_STATE_PATH` env vars are set.
+/// `ZEBRA_CACHED_STATE_PATH` env vars are set.
 ///
 /// This test doesn't work on Windows, so it is always skipped on that platform.
 #[test]
@@ -1154,22 +1154,24 @@ fn lightwalletd_full_sync() -> Result<()> {
     lightwalletd_integration_test(FullSyncFromGenesis)
 }
 
-/// Make sure `lightwalletd` can sync from Zebra, in both update and full sync modes.
+/// Make sure `lightwalletd` can sync from Zebra, in all available modes.
 ///
-/// If `LIGHTWALLETD_DATA_DIR` is set, runs a quick sync, then a full sync.
-/// If `LIGHTWALLETD_DATA_DIR` is not set, just runs a full sync.
-///
-/// These tests only run when the `ZEBRA_TEST_LIGHTWALLETD` and
-/// `CACHED_STATE_PATH` env vars are set.
+/// Runs the tests in this order:
+/// - launch lightwalletd with empty states,
+/// - if `ZEBRA_CACHED_STATE_PATH` and `LIGHTWALLETD_DATA_DIR` are set: run a quick update sync,
+/// - if `ZEBRA_CACHED_STATE_PATH` is set: run a full sync.
 ///
 /// These tests don't work on Windows, so they are always skipped on that platform.
 #[test]
 #[ignore]
 #[cfg(not(target_os = "windows"))]
-fn lightwalletd_update_then_full_sync() -> Result<()> {
-    // Only runs when LIGHTWALLETD_DATA_DIR is set
+fn lightwalletd_test_suite() -> Result<()> {
+    lightwalletd_integration_test(LaunchWithEmptyState)?;
+
+    // Only runs when LIGHTWALLETD_DATA_DIR and ZEBRA_CACHED_STATE_PATH are set
     lightwalletd_integration_test(UpdateCachedState)?;
 
+    // Only runs when ZEBRA_CACHED_STATE_PATH is set
     lightwalletd_integration_test(FullSyncFromGenesis)?;
 
     Ok(())

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1121,7 +1121,7 @@ const LIGHTWALLETD_EMPTY_ZEBRA_STATE_IGNORE_MESSAGES: &[&str] = &[
 #[test]
 #[cfg(not(target_os = "windows"))]
 fn lightwalletd_integration() -> Result<()> {
-    lightwalletd_integration_test(LaunchWithEmptyState)
+    lightwalletd_integration_test(LaunchWithEmptyState, false)
 }
 
 /// Make sure `lightwalletd` can sync from Zebra, in update sync mode.
@@ -1136,7 +1136,7 @@ fn lightwalletd_integration() -> Result<()> {
 #[test]
 #[cfg(not(target_os = "windows"))]
 fn lightwalletd_update_sync() -> Result<()> {
-    lightwalletd_integration_test(UpdateCachedState)
+    lightwalletd_integration_test(UpdateCachedState, false)
 }
 
 /// Make sure `lightwalletd` can fully sync from genesis using Zebra.
@@ -1149,7 +1149,7 @@ fn lightwalletd_update_sync() -> Result<()> {
 #[ignore]
 #[cfg(not(target_os = "windows"))]
 fn lightwalletd_full_sync() -> Result<()> {
-    lightwalletd_integration_test(FullSyncFromGenesis)
+    lightwalletd_integration_test(FullSyncFromGenesis, false)
 }
 
 /// Make sure `lightwalletd` can sync from Zebra, in all available modes.
@@ -1164,22 +1164,28 @@ fn lightwalletd_full_sync() -> Result<()> {
 #[ignore]
 #[cfg(not(target_os = "windows"))]
 fn lightwalletd_test_suite() -> Result<()> {
-    lightwalletd_integration_test(LaunchWithEmptyState)?;
+    lightwalletd_integration_test(LaunchWithEmptyState, false)?;
+
+    // Only runs when ZEBRA_CACHED_STATE_PATH is set.
+    // When manually running the test suite, allow cached state in the full sync test.
+    lightwalletd_integration_test(FullSyncFromGenesis, true)?;
 
     // Only runs when LIGHTWALLETD_DATA_DIR and ZEBRA_CACHED_STATE_PATH are set
-    lightwalletd_integration_test(UpdateCachedState)?;
-
-    // Only runs when ZEBRA_CACHED_STATE_PATH is set
-    lightwalletd_integration_test(FullSyncFromGenesis)?;
+    lightwalletd_integration_test(UpdateCachedState, false)?;
 
     Ok(())
 }
 
 /// Run a lightwalletd integration test with a configuration for `test_type`.
 ///
+/// Set `allow_cached_state_for_full_sync` to speed up manual full sync tests.
+///
 /// The random ports in this test can cause [rare port conflicts.](#Note on port conflict)
 #[cfg(not(target_os = "windows"))]
-fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> {
+fn lightwalletd_integration_test(
+    test_type: LightwalletdTestType,
+    allow_cached_state_for_full_sync: bool,
+) -> Result<()> {
     zebra_test::init();
 
     // Skip the test unless the user specifically asked for it
@@ -1217,7 +1223,7 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
         return Ok(());
     }
 
-    info!(?test_type, "running lightwalletd & zebrad integration test");
+    tracing::info!(?test_type, "running lightwalletd & zebrad integration test");
 
     // Get the process log checking timeouts
     let zebrad_timeout = if test_type == FullSyncFromGenesis || test_type == UpdateCachedState {
@@ -1349,7 +1355,7 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
     if test_type.needs_lightwalletd_cached_state() {
         // TODO: expect `[0-9]{7}` when we're using the tip cached state (#4155)
         lightwalletd.expect_stdout_line_matches("Found [0-9]{6,7} blocks in cache")?;
-    } else {
+    } else if !allow_cached_state_for_full_sync {
         // Timeout the test if we're somehow accidentally using a cached state in our temp dir
         lightwalletd.expect_stdout_line_matches("Found 0 blocks in cache")?;
     }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1105,13 +1105,11 @@ const LIGHTWALLETD_FAILURE_MESSAGES: &[&str] = &[
 ///
 /// These `lightwalletd` messages look like failure messages, but they are actually ok.
 /// So when we see them in the logs, we make the test continue.
-const LIGHTWALLETD_IGNORE_MESSAGES: &[&str] = &[
+const LIGHTWALLETD_EMPTY_ZEBRA_STATE_IGNORE_MESSAGES: &[&str] = &[
     // Exceptions to lightwalletd custom RPC error messages:
     //
     // This log matches the "error with" RPC error message,
     // but we expect Zebra to start with an empty state.
-    //
-    // TODO: this exception should not be used for the cached state tests (#3511)
     r#"No Chain tip available yet","level":"warning","msg":"error with getblockchaininfo rpc, retrying"#,
 ];
 
@@ -1212,16 +1210,29 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
         LAUNCH_DELAY
     };
 
+    let mut zebrad_failure_messages: Vec<String> = ZEBRA_FAILURE_MESSAGES
+        .iter()
+        .chain(PROCESS_FAILURE_MESSAGES)
+        .map(ToString::to_string)
+        .collect();
+
+    if test_type.needs_zebra_cached_state() {
+        // Fail if we need a cached Zebra state, but it's empty
+        zebrad_failure_messages.push("loaded Zebra state cache tip=None".to_string());
+    }
+    if test_type == LaunchWithEmptyState {
+        // Fail if we need an empty Zebra state, but it has blocks
+        zebrad_failure_messages
+            .push(r"loaded Zebra state cache tip=.*Height\([1-9][0-9]*\)".to_string());
+    }
+
     let zdir = testdir()?.with_exact_config(&config)?;
     let mut zebrad = zdir
         .spawn_child(args!["start"])?
         .with_timeout(zebrad_timeout)
         .with_failure_regex_iter(
             // TODO: replace with a function that returns the full list and correct return type
-            ZEBRA_FAILURE_MESSAGES
-                .iter()
-                .chain(PROCESS_FAILURE_MESSAGES)
-                .cloned(),
+            zebrad_failure_messages,
             NO_MATCHES_REGEX_ITER.iter().cloned(),
         );
 
@@ -1273,7 +1284,18 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
         .collect();
 
     if test_type.needs_zebra_cached_state() {
+        // Fail if we need a cached Zebra state, but it's empty
         lightwalletd_failure_messages.push("No Chain tip available yet".to_string());
+    }
+    if test_type.needs_lightwalletd_cached_state() {
+        // Fail if we need a cached lightwalletd state, but it isn't near the tip
+        lightwalletd_failure_messages
+            .push("Got sapling height 419200 block height [0-9]{1,6} chain main".to_string());
+    }
+    if test_type == FullSyncFromGenesis {
+        // Fail if we need an empty lightwalletd state, but it has blocks
+        lightwalletd_failure_messages
+            .push("Got sapling height 419200 block height [1-9][0-9]* chain main".to_string());
     }
 
     let lightwalletd_timeout = if test_type == FullSyncFromGenesis {
@@ -1287,13 +1309,20 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
         LIGHTWALLETD_DELAY
     };
 
+    let lightwalletd_ignore_messages = if test_type == LaunchWithEmptyState {
+        LIGHTWALLETD_EMPTY_ZEBRA_STATE_IGNORE_MESSAGES
+            .iter()
+            .cloned()
+    } else {
+        NO_MATCHES_REGEX_ITER.iter().cloned()
+    };
+
     let mut lightwalletd = lightwalletd
         .with_timeout(lightwalletd_timeout)
         .with_failure_regex_iter(
             // TODO: replace with a function that returns the full list and correct return type
             lightwalletd_failure_messages,
-            // TODO: some exceptions do not apply to the cached state tests (#3511)
-            LIGHTWALLETD_IGNORE_MESSAGES.iter().cloned(),
+            lightwalletd_ignore_messages,
         );
 
     // Wait until `lightwalletd` has launched
@@ -1314,7 +1343,8 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
     }
 
     if test_type.needs_lightwalletd_cached_state() {
-        lightwalletd.expect_stdout_line_matches("Found [0-9]{7} blocks in cache")?;
+        // TODO: expect `[0-9]{7}` when we're using the tip cached state (#4155)
+        lightwalletd.expect_stdout_line_matches("Found [0-9]{6,7} blocks in cache")?;
     } else {
         // Timeout the test if we're somehow accidentally using a cached state in our temp dir
         lightwalletd.expect_stdout_line_matches("Found 0 blocks in cache")?;
@@ -1351,11 +1381,12 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
 
         // Wait for lightwalletd to sync to Zebra's tip
         lightwalletd.expect_stdout_line_matches(regex::escape("Ingestor adding block to cache"))?;
+        lightwalletd.expect_stdout_line_matches(regex::escape("Ingestor waiting for block"))?;
+        // Check Zebra is still at the tip (also clears and prints Zebra's logs)
+        zebrad.expect_stdout_line_matches(regex::escape("sync_percent=100"))?;
 
         // lightwalletd doesn't log anything when we've reached the tip.
         // But when it gets near the tip, it starts using the mempool.
-        //
-        // TODO: check that lightwalletd has ingested Zebra's tip block (or higher)
         lightwalletd.expect_stdout_line_matches(regex::escape(
             "Block hash changed, clearing mempool clients",
         ))?;

--- a/zebrad/tests/common/config.rs
+++ b/zebrad/tests/common/config.rs
@@ -15,6 +15,11 @@ use zebrad::{
     config::{SyncSection, TracingSection, ZebradConfig},
 };
 
+/// The environmental variable that contains the cached state path.
+///
+/// TODO: use this in the checkpoint cached state tests as well.
+pub const CACHED_STATE_PATH_VAR: &str = "ZEBRA_CACHED_STATE_PATH";
+
 /// Returns a config with:
 /// - a Zcash listener on an unused port on IPv4 localhost, and
 /// - an ephemeral state,

--- a/zebrad/tests/common/config.rs
+++ b/zebrad/tests/common/config.rs
@@ -15,11 +15,6 @@ use zebrad::{
     config::{SyncSection, TracingSection, ZebradConfig},
 };
 
-/// The environmental variable that contains the cached state path.
-///
-/// TODO: use this in the checkpoint cached state tests as well.
-pub const CACHED_STATE_PATH_VAR: &str = "ZEBRA_CACHED_STATE_PATH";
-
 /// Returns a config with:
 /// - a Zcash listener on an unused port on IPv4 localhost, and
 /// - an ephemeral state,

--- a/zebrad/tests/common/failure_messages.rs
+++ b/zebrad/tests/common/failure_messages.rs
@@ -1,0 +1,121 @@
+//! Failure messages logged by test child processes.
+//!
+//! # Warning
+//!
+//! Test functions in this file will not be run.
+//! This file is only for test library code.
+
+/// Failure log messages for any process, from the OS or shell.
+///
+/// These messages show that the child process has failed.
+/// So when we see them in the logs, we make the test fail.
+pub const PROCESS_FAILURE_MESSAGES: &[&str] = &[
+    // Linux
+    "Aborted",
+    // macOS / BSDs
+    "Abort trap",
+    // TODO: add other OS or C library errors?
+];
+
+/// Failure log messages from Zebra.
+///
+/// These `zebrad` messages show that the `lightwalletd` integration test has failed.
+/// So when we see them in the logs, we make the test fail.
+pub const ZEBRA_FAILURE_MESSAGES: &[&str] = &[
+    // Rust-specific panics
+    "The application panicked",
+    // RPC port errors
+    "Unable to start RPC server",
+    // TODO: disable if this actually happens during test zebrad shutdown
+    "Stopping RPC endpoint",
+    // Missing RPCs in zebrad logs (this log is from PR #3860)
+    //
+    // TODO: temporarily disable until enough RPCs are implemented, if needed
+    "Received unrecognized RPC request",
+    // RPC argument errors: parsing and data
+    //
+    // These logs are produced by jsonrpc_core inside Zebra,
+    // but it doesn't log them yet.
+    //
+    // TODO: log these errors in Zebra, and check for them in the Zebra logs?
+    "Invalid params",
+    "Method not found",
+];
+
+/// Failure log messages from lightwalletd.
+///
+/// These `lightwalletd` messages show that the `lightwalletd` integration test has failed.
+/// So when we see them in the logs, we make the test fail.
+pub const LIGHTWALLETD_FAILURE_MESSAGES: &[&str] = &[
+    // Go-specific panics
+    "panic:",
+    // Missing RPCs in lightwalletd logs
+    // TODO: temporarily disable until enough RPCs are implemented, if needed
+    "unable to issue RPC call",
+    // RPC response errors: parsing and data
+    //
+    // jsonrpc_core error messages from Zebra,
+    // received by lightwalletd and written to its logs
+    "Invalid params",
+    "Method not found",
+    // Early termination
+    //
+    // TODO: temporarily disable until enough RPCs are implemented, if needed
+    "Lightwalletd died with a Fatal error",
+    // Go json package error messages:
+    "json: cannot unmarshal",
+    "into Go value of type",
+    // lightwalletd custom RPC error messages from:
+    // https://github.com/adityapk00/lightwalletd/blob/master/common/common.go
+    "block requested is newer than latest block",
+    "Cache add failed",
+    "error decoding",
+    "error marshaling",
+    "error parsing JSON",
+    "error reading JSON response",
+    "error with",
+    // We expect these errors when lightwalletd reaches the end of the zebrad cached state
+    // "error requesting block: 0: Block not found",
+    // "error zcashd getblock rpc",
+    "received overlong message",
+    "received unexpected height block",
+    "Reorg exceeded max",
+    "unable to issue RPC call",
+    // Missing fields for each specific RPC
+    //
+    // get_block_chain_info
+    //
+    // invalid sapling height
+    "Got sapling height 0",
+    // missing BIP70 chain name, should be "main" or "test"
+    " chain  ",
+    // missing branchID, should be 8 hex digits
+    " branchID \"",
+    // get_block
+    //
+    // a block error other than "-8: Block not found"
+    "error requesting block",
+    // a missing block with an incorrect error code
+    "Block not found",
+    //
+    // TODO: complete this list for each RPC with fields, if that RPC generates logs
+    // get_info - doesn't generate logs
+    // get_raw_transaction - might not generate logs
+    // z_get_tree_state
+    // get_address_txids
+    // get_address_balance
+    // get_address_utxos
+];
+
+/// Ignored failure logs for lightwalletd.
+/// These regexes override the [`LIGHTWALLETD_FAILURE_MESSAGES`].
+///
+/// These `lightwalletd` messages look like failure messages, but they are actually ok.
+/// So when we see them in the logs, we make the test continue.
+pub const LIGHTWALLETD_EMPTY_ZEBRA_STATE_IGNORE_MESSAGES: &[&str] = &[
+    // Exceptions to lightwalletd custom RPC error messages:
+    //
+    // This log matches the "error with" RPC error message,
+    // but we expect Zebra to start with an empty state.
+    r#"No Chain tip available yet","level":"warning","msg":"error with getblockchaininfo rpc, retrying"#,
+];

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -23,9 +23,9 @@ use zebra_test::{
 };
 use zebrad::config::ZebradConfig;
 
-use crate::{
-    common::lightwalletd::random_known_rpc_port_config, PROCESS_FAILURE_MESSAGES,
-    ZEBRA_FAILURE_MESSAGES,
+use crate::common::{
+    failure_messages::{PROCESS_FAILURE_MESSAGES, ZEBRA_FAILURE_MESSAGES},
+    lightwalletd::random_known_rpc_port_config,
 };
 
 /// After we launch `zebrad`, wait this long for the command to start up,

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -42,9 +42,19 @@ pub const LAUNCH_DELAY: Duration = Duration::from_secs(15);
 /// it is using for its RPCs.
 pub const LIGHTWALLETD_DELAY: Duration = Duration::from_secs(60);
 
-/// The amount of time we wait between launching two
-/// conflicting nodes.
+/// The amount of time we wait between launching two conflicting nodes.
 pub const BETWEEN_NODES_DELAY: Duration = Duration::from_secs(2);
+
+/// The amount of time we wait for lightwalletd to update to the tip.
+///
+/// The cached tip can be a few days old, and Zebra needs time to activate its mempool.
+pub const LIGHTWALLETD_UPDATE_TIP_DELAY: Duration = Duration::from_secs(10 * 60);
+
+/// The amount of time we wait for lightwalletd to do a full sync to the tip.
+///
+/// `lightwalletd` takes about half an hour to fully sync,
+/// and Zebra needs time to activate its mempool.
+pub const LIGHTWALLETD_FULL_SYNC_TIP_DELAY: Duration = Duration::from_secs(60 * 60);
 
 /// Extension trait for methods on `tempfile::TempDir` for using it as a test
 /// directory for `zebrad`.

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -21,7 +21,10 @@ use zebrad::config::ZebradConfig;
 
 use super::{
     config::{default_test_config, CACHED_STATE_PATH_VAR},
-    launch::ZebradTestDirExt,
+    launch::{
+        ZebradTestDirExt, LIGHTWALLETD_DELAY, LIGHTWALLETD_FULL_SYNC_TIP_DELAY,
+        LIGHTWALLETD_UPDATE_TIP_DELAY,
+    },
 };
 
 use LightwalletdTestType::*;
@@ -228,16 +231,14 @@ impl LightwalletdTestType {
     pub fn needs_zebra_cached_state(&self) -> bool {
         match self {
             LaunchWithEmptyState => false,
-            FullSyncFromGenesis => true,
-            UpdateCachedState => true,
+            FullSyncFromGenesis | UpdateCachedState => true,
         }
     }
 
     /// Does this test need a lightwalletd cached state?
     pub fn needs_lightwalletd_cached_state(&self) -> bool {
         match self {
-            LaunchWithEmptyState => false,
-            FullSyncFromGenesis => false,
+            LaunchWithEmptyState | FullSyncFromGenesis => false,
             UpdateCachedState => true,
         }
     }
@@ -284,5 +285,22 @@ impl LightwalletdTestType {
     /// Returns the lightwalletd state path for this test, if set.
     pub fn lightwalletd_state_path(&self) -> Option<PathBuf> {
         env::var_os(LIGHTWALLETD_DATA_DIR_VAR).map(Into::into)
+    }
+
+    /// Returns the `zebrad` timeout for this test type.
+    pub fn zebrad_timeout(&self) -> Duration {
+        match self {
+            LaunchWithEmptyState => LIGHTWALLETD_DELAY,
+            FullSyncFromGenesis | UpdateCachedState => LIGHTWALLETD_UPDATE_TIP_DELAY,
+        }
+    }
+
+    /// Returns the `lightwalletd` timeout for this test type.
+    pub fn lightwalletd_timeout(&self) -> Duration {
+        match self {
+            LaunchWithEmptyState => LIGHTWALLETD_DELAY,
+            UpdateCachedState => LIGHTWALLETD_UPDATE_TIP_DELAY,
+            FullSyncFromGenesis => LIGHTWALLETD_FULL_SYNC_TIP_DELAY,
+        }
     }
 }

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -357,19 +357,22 @@ impl LightwalletdTestType {
             .map(ToString::to_string)
             .collect();
 
+        // Zebra state failures
         if self.needs_zebra_cached_state() {
             // Fail if we need a cached Zebra state, but it's empty
             lightwalletd_failure_messages.push("No Chain tip available yet".to_string());
         }
+
+        // lightwalletd state failures
         if self.needs_lightwalletd_cached_state() {
             // Fail if we need a cached lightwalletd state, but it isn't near the tip
-            lightwalletd_failure_messages
-                .push("Got sapling height 419200 block height [0-9]{1,6} chain main".to_string());
+            //
+            // TODO: fail on `[0-9]{1,6}` when we're using the tip cached state (#4155)
+            lightwalletd_failure_messages.push("Found [0-9]{1,5} blocks in cache".to_string());
         }
         if !self.allow_lightwalletd_cached_state() {
             // Fail if we need an empty lightwalletd state, but it has blocks
-            lightwalletd_failure_messages
-                .push("Got sapling height 419200 block height [1-9][0-9]* chain main".to_string());
+            lightwalletd_failure_messages.push("Found [1-9][0-9]* blocks in cache".to_string());
         }
 
         let lightwalletd_ignore_messages = if *self == LaunchWithEmptyState {

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -283,16 +283,6 @@ impl LightwalletdTestType {
 
     /// Returns the lightwalletd state path for this test, if set.
     pub fn lightwalletd_state_path(&self) -> Option<PathBuf> {
-        match env::var_os(LIGHTWALLETD_DATA_DIR_VAR) {
-            Some(path) => Some(path.into()),
-            None => {
-                tracing::info!(
-                    "skipped {self:?} lightwalletd test, \
-                     set the {LIGHTWALLETD_DATA_DIR_VAR:?} environment variable to run the test",
-                );
-
-                None
-            }
-        }
+        env::var_os(LIGHTWALLETD_DATA_DIR_VAR).map(Into::into)
     }
 }

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -221,12 +221,17 @@ pub enum LightwalletdTestType {
 
     /// Do a full sync from an empty lightwalletd state.
     ///
-    /// This test is much faster if it has a cached Zebra state.
-    FullSyncFromGenesis,
+    /// This test requires a cached Zebra state.
+    FullSyncFromGenesis {
+        /// Should the test allow a cached lightwalletd state?
+        ///
+        /// If `false`, the test fails if the lightwalletd state is populated.
+        allow_lightwalletd_cached_state: bool,
+    },
 
     /// Sync to tip from a lightwalletd cached state.
     ///
-    /// This test is much faster if it has a cached Zebra state.
+    /// This test requires a cached Zebra and lightwalletd state.
     UpdateCachedState,
 }
 
@@ -235,14 +240,25 @@ impl LightwalletdTestType {
     pub fn needs_zebra_cached_state(&self) -> bool {
         match self {
             LaunchWithEmptyState => false,
-            FullSyncFromGenesis | UpdateCachedState => true,
+            FullSyncFromGenesis { .. } | UpdateCachedState => true,
         }
     }
 
     /// Does this test need a lightwalletd cached state?
     pub fn needs_lightwalletd_cached_state(&self) -> bool {
         match self {
-            LaunchWithEmptyState | FullSyncFromGenesis => false,
+            LaunchWithEmptyState | FullSyncFromGenesis { .. } => false,
+            UpdateCachedState => true,
+        }
+    }
+
+    /// Does this test allow a lightwalletd cached state, even if it is not required?
+    pub fn allow_lightwalletd_cached_state(&self) -> bool {
+        match self {
+            LaunchWithEmptyState => false,
+            FullSyncFromGenesis {
+                allow_lightwalletd_cached_state,
+            } => *allow_lightwalletd_cached_state,
             UpdateCachedState => true,
         }
     }
@@ -295,7 +311,7 @@ impl LightwalletdTestType {
     pub fn zebrad_timeout(&self) -> Duration {
         match self {
             LaunchWithEmptyState => LIGHTWALLETD_DELAY,
-            FullSyncFromGenesis | UpdateCachedState => LIGHTWALLETD_UPDATE_TIP_DELAY,
+            FullSyncFromGenesis { .. } | UpdateCachedState => LIGHTWALLETD_UPDATE_TIP_DELAY,
         }
     }
 
@@ -304,7 +320,7 @@ impl LightwalletdTestType {
         match self {
             LaunchWithEmptyState => LIGHTWALLETD_DELAY,
             UpdateCachedState => LIGHTWALLETD_UPDATE_TIP_DELAY,
-            FullSyncFromGenesis => LIGHTWALLETD_FULL_SYNC_TIP_DELAY,
+            FullSyncFromGenesis { .. } => LIGHTWALLETD_FULL_SYNC_TIP_DELAY,
         }
     }
 
@@ -334,10 +350,7 @@ impl LightwalletdTestType {
 
     /// Returns `lightwalletd` log regexes that indicate the tests have failed,
     /// and regexes of any failures that should be ignored.
-    pub fn lightwalletd_failure_messages(
-        &self,
-        allow_cached_state_for_full_sync: bool,
-    ) -> (Vec<String>, Vec<String>) {
+    pub fn lightwalletd_failure_messages(&self) -> (Vec<String>, Vec<String>) {
         let mut lightwalletd_failure_messages: Vec<String> = LIGHTWALLETD_FAILURE_MESSAGES
             .iter()
             .chain(PROCESS_FAILURE_MESSAGES)
@@ -353,7 +366,7 @@ impl LightwalletdTestType {
             lightwalletd_failure_messages
                 .push("Got sapling height 419200 block height [0-9]{1,6} chain main".to_string());
         }
-        if *self == FullSyncFromGenesis && !allow_cached_state_for_full_sync {
+        if !self.allow_lightwalletd_cached_state() {
             // Fail if we need an empty lightwalletd state, but it has blocks
             lightwalletd_failure_messages
                 .push("Got sapling height 419200 block height [1-9][0-9]* chain main".to_string());

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -20,7 +20,8 @@ use zebra_test::{
 use zebrad::config::ZebradConfig;
 
 use super::{
-    config::{default_test_config, CACHED_STATE_PATH_VAR},
+    cached_state::ZEBRA_CACHED_STATE_DIR_VAR,
+    config::default_test_config,
     failure_messages::{
         LIGHTWALLETD_EMPTY_ZEBRA_STATE_IGNORE_MESSAGES, LIGHTWALLETD_FAILURE_MESSAGES,
         PROCESS_FAILURE_MESSAGES, ZEBRA_FAILURE_MESSAGES,
@@ -265,12 +266,12 @@ impl LightwalletdTestType {
 
     /// Returns the Zebra state path for this test, if set.
     pub fn zebrad_state_path(&self) -> Option<PathBuf> {
-        match env::var_os(CACHED_STATE_PATH_VAR) {
+        match env::var_os(ZEBRA_CACHED_STATE_DIR_VAR) {
             Some(path) => Some(path.into()),
             None => {
                 tracing::info!(
                     "skipped {self:?} lightwalletd test, \
-                     set the {CACHED_STATE_PATH_VAR:?} environment variable to run the test",
+                     set the {ZEBRA_CACHED_STATE_DIR_VAR:?} environment variable to run the test",
                 );
 
                 None

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -5,7 +5,12 @@
 //! Test functions in this file will not be run.
 //! This file is only for test library code.
 
-use std::{env, net::SocketAddr, path::Path, time::Duration};
+use std::{
+    env,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use zebra_test::{
     command::{Arguments, TestChild, TestDirExt},
@@ -28,7 +33,16 @@ pub mod wallet_grpc;
 ///
 /// This environmental variable is used to enable the lightwalletd tests.
 /// But the network tests are *disabled* by their environmental variables.
-const ZEBRA_TEST_LIGHTWALLETD: &str = "ZEBRA_TEST_LIGHTWALLETD";
+pub const ZEBRA_TEST_LIGHTWALLETD: &str = "ZEBRA_TEST_LIGHTWALLETD";
+
+/// Optional environment variable with the cached state for lightwalletd.
+///
+/// Required for [`LightwalletdTestType::UpdateCachedState`],
+/// so we can test lightwalletd RPC integration with a populated state.
+///
+/// Can also be used to speed up the [`sending_transactions_using_lightwalletd`] test,
+/// by skipping the lightwalletd initial sync.
+pub const LIGHTWALLETD_DATA_DIR_VAR: &str = "LIGHTWALLETD_DATA_DIR";
 
 /// The maximum time that a `lightwalletd` integration test is expected to run.
 pub const LIGHTWALLETD_TEST_TIMEOUT: Duration = Duration::from_secs(60 * 60);
@@ -75,16 +89,20 @@ pub trait LightWalletdTestDirExt: ZebradTestDirExt
 where
     Self: AsRef<Path> + Sized,
 {
-    /// Spawn `lightwalletd` with `args` as a child process in this test directory,
-    /// potentially taking ownership of the tempdir for the duration of the
-    /// child process.
+    /// Spawn `lightwalletd` with `lightwalletd_state_path`, and `extra_args`,
+    /// as a child process in this test directory,
+    /// potentially taking ownership of the tempdir for the duration of the child process.
     ///
     /// By default, launch a working test instance with logging, and avoid port conflicts.
     ///
     /// # Panics
     ///
     /// If there is no lightwalletd config in the test directory.
-    fn spawn_lightwalletd_child(self, extra_args: Arguments) -> Result<TestChild<Self>>;
+    fn spawn_lightwalletd_child(
+        self,
+        lightwalletd_state_path: impl Into<Option<PathBuf>>,
+        extra_args: Arguments,
+    ) -> Result<TestChild<Self>>;
 
     /// Create a config file and use it for all subsequently spawned `lightwalletd` processes.
     /// Returns an error if the config already exists.
@@ -98,9 +116,13 @@ impl<T> LightWalletdTestDirExt for T
 where
     Self: TestDirExt + AsRef<Path> + Sized,
 {
-    fn spawn_lightwalletd_child(self, extra_args: Arguments) -> Result<TestChild<Self>> {
-        let dir = self.as_ref().to_owned();
-        let default_config_path = dir.join("lightwalletd-zcash.conf");
+    fn spawn_lightwalletd_child(
+        self,
+        lightwalletd_state_path: impl Into<Option<PathBuf>>,
+        extra_args: Arguments,
+    ) -> Result<TestChild<Self>> {
+        let test_dir = self.as_ref().to_owned();
+        let default_config_path = test_dir.join("lightwalletd-zcash.conf");
 
         assert!(
             default_config_path.exists(),
@@ -119,9 +141,24 @@ where
         args.set_parameter("--zcash-conf-path", zcash_conf_path);
 
         // the lightwalletd cache directory
-        //
-        // TODO: create a sub-directory for lightwalletd
-        args.set_parameter("--data-dir", dir.to_str().expect("Path is valid Unicode"));
+        if let Some(lightwalletd_state_path) = lightwalletd_state_path.into() {
+            args.set_parameter(
+                "--data-dir",
+                lightwalletd_state_path
+                    .to_str()
+                    .expect("path is valid Unicode"),
+            );
+        } else {
+            let empty_state_path = test_dir.join("lightwalletd_state");
+
+            std::fs::create_dir(&empty_state_path)
+                .expect("unexpected failure creating lightwalletd state sub-directory");
+
+            args.set_parameter(
+                "--data-dir",
+                empty_state_path.to_str().expect("path is valid Unicode"),
+            );
+        }
 
         // log to standard output
         //

--- a/zebrad/tests/common/lightwalletd/wallet_grpc.rs
+++ b/zebrad/tests/common/lightwalletd/wallet_grpc.rs
@@ -1,6 +1,6 @@
 //! Lightwalletd gRPC interface and utility functions.
 
-use std::{env, net::SocketAddr};
+use std::{env, net::SocketAddr, path::PathBuf};
 
 use tempfile::TempDir;
 
@@ -37,14 +37,11 @@ pub fn spawn_lightwalletd_with_rpc_server(
     let lightwalletd_rpc_port = random_known_port();
     let lightwalletd_rpc_address = format!("127.0.0.1:{lightwalletd_rpc_port}");
 
-    let mut arguments = args!["--grpc-bind-addr": lightwalletd_rpc_address];
-
-    if let Ok(data_dir) = env::var(LIGHTWALLETD_DATA_DIR_VAR) {
-        arguments.set_parameter("--data-dir", data_dir);
-    }
+    let lightwalletd_state_path = env::var(LIGHTWALLETD_DATA_DIR_VAR).ok().map(PathBuf::from);
+    let arguments = args!["--grpc-bind-addr": lightwalletd_rpc_address];
 
     let mut lightwalletd = lightwalletd_dir
-        .spawn_lightwalletd_child(arguments)?
+        .spawn_lightwalletd_child(lightwalletd_state_path, arguments)?
         .with_timeout(LIGHTWALLETD_TEST_TIMEOUT)
         .with_failure_regex_iter(
             // TODO: replace with a function that returns the full list and correct return type

--- a/zebrad/tests/common/lightwalletd/wallet_grpc.rs
+++ b/zebrad/tests/common/lightwalletd/wallet_grpc.rs
@@ -33,7 +33,7 @@ pub fn spawn_lightwalletd_with_rpc_server(
     let arguments = args!["--grpc-bind-addr": lightwalletd_rpc_address];
 
     let (lightwalletd_failure_messages, lightwalletd_ignore_messages) =
-        test_type.lightwalletd_failure_messages(true);
+        test_type.lightwalletd_failure_messages();
 
     let mut lightwalletd = lightwalletd_dir
         .spawn_lightwalletd_child(test_type.lightwalletd_state_path(), arguments)?

--- a/zebrad/tests/common/mod.rs
+++ b/zebrad/tests/common/mod.rs
@@ -12,6 +12,7 @@
 pub mod cached_state;
 pub mod check;
 pub mod config;
+pub mod failure_messages;
 pub mod launch;
 pub mod lightwalletd;
 pub mod sync;


### PR DESCRIPTION
## Motivation

We want to run full sync and quick sync integration tests for lightwalletd.

We want to merge PR #4068 first, to unblock some other work.

Depends-On: #4068

### CI Commands

You'll need to update the cache paths to match the CI paths.

To test full sync:
```sh
export ZEBRA_CACHED_STATE_PATH="$HOME/.cache/zebra"
export RUST_LOG="info"

cargo test -- --ignored --nocapture  lightwalletd_full_sync
```

To test quick update sync:
```sh
export ZEBRA_CACHED_STATE_PATH="$HOME/.cache/zebra"
export LIGHTWALLETD_DATA_DIR="$HOME/.cache/lightwalletd"
export RUST_LOG="info"

cargo test -- --ignored --nocapture  lightwalletd_update_sync
```

### Manual Testing

To manually test all the lightwalletd integration tests in series (which avoids state conflicts), use:

```sh
export ZEBRA_CACHED_STATE_PATH="$HOME/.cache/zebra"
export LIGHTWALLETD_DATA_DIR="$HOME/.cache/lightwalletd"
export RUST_LOG="info"

cargo test -- --ignored --nocapture  lightwalletd_test_suite
```

## Solution

- Create a lightwalletd full sync test
- Create a lightwalletd cached state update test

Details:
- Create a LightwalletdTestType enum
- Make the lightwalletd integration test take a test type
- Configure lightwalletd tests based on the test type
- Add checks for each LightwalletdTestType
- Create test functions that run each lightwalletd test type
- Fail if the state doesn't match the test type

Related Cleanups:
- Remove obsolete kill_on_error() in the lightwalletd test
- Add a sub-directory for lightwalletd test state
- Move failure messages into their own module

Closes #3511 
Closes #4166

## Review

@jvff is probably be the best person to review this PR.

@gustavovalverde this PR should work in CI if you use the commands above.
(It's draft because I haven't finished testing it yet.)

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- #3926 
- #4165
- #4167
