### PR TITLE
fix(ci): Retry after docker log follow ssh failures

### DIFF
--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -236,12 +236,15 @@ jobs:
       - name: Full sync
         id: full-sync
         run: |
-          gcloud compute ssh \
-          full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
-          --zone ${{ env.ZONE }} \
-          --quiet \
-          --ssh-flag="-o ServerAliveInterval=5" \
-          --command="docker logs --follow ${{ env.CONTAINER_NAME }}"
+          for RETRY in 1 2 3 4; do
+              gcloud compute ssh \
+              full-sync-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+              --zone ${{ env.ZONE }} \
+              --quiet \
+              --ssh-flag="-o ServerAliveInterval=15" \
+              --command="docker logs --follow ${{ env.CONTAINER_NAME }}" \
+              || echo "ssh disconnected $RETRY times"
+          done
 
           EXIT_CODE=$(\
           gcloud compute ssh \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -347,12 +347,15 @@ jobs:
         id: sync-to-checkpoint
         if: ${{ steps.create-instance.outcome == 'success' }}
         run: |
-          gcloud compute ssh \
-          regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
-          --zone ${{ env.ZONE }} \
-          --quiet \
-          --ssh-flag="-o ServerAliveInterval=5" \
-          --command="docker logs --follow ${{ env.CONTAINER_NAME }}"
+          for RETRY in 1 2 3 4; do
+              gcloud compute ssh \
+              regenerate-disk-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+              --zone ${{ env.ZONE }} \
+              --quiet \
+              --ssh-flag="-o ServerAliveInterval=15" \
+              --command="docker logs --follow ${{ env.CONTAINER_NAME }}" \
+              || echo "ssh disconnected $RETRY times"
+          done
 
           EXIT_CODE=$(\
           gcloud compute ssh \
@@ -512,12 +515,15 @@ jobs:
       - name: Sync past mandatory checkpoint
         id: sync-past-checkpoint
         run: |
-          gcloud compute ssh \
-          sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
-          --zone ${{ env.ZONE }} \
-          --quiet \
-          --ssh-flag="-o ServerAliveInterval=5" \
-          --command="docker logs --follow ${{ env.CONTAINER_NAME }}"
+          for RETRY in 1 2 3 4; do
+              gcloud compute ssh \
+              sync-checkpoint-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+              --zone ${{ env.ZONE }} \
+              --quiet \
+              --ssh-flag="-o ServerAliveInterval=15" \
+              --command="docker logs --follow ${{ env.CONTAINER_NAME }}" \
+              || echo "ssh disconnected $RETRY times"
+          done
 
           EXIT_CODE=$(\
           gcloud compute ssh \


### PR DESCRIPTION
## Motivation

The CI failures in #3991 are blocking fixes to #4155, which is blocking the rest of the lightwalletd tests.

## Solution

- retry the ssh log command on failure
- increase the ssh timeout to 15 seconds (it tries 3 times, for a total of 45 seconds before disconnecting)

Closes #3991.

## Review

@gustavovalverde can review this PR.

### Reviewer Checklist

  - [ ] Full sync test doesn't fail

