### PR TITLE
2. fix(perf): When writing blocks to disk, don't block other async tasks

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -1,6 +1,6 @@
 //! Blocks and block-related structures (heights, headers, etc.)
 
-use std::{collections::HashMap, fmt, ops::Neg};
+use std::{collections::HashMap, fmt, ops::Neg, sync::Arc};
 
 use crate::{
     amount::NegativeAllowed,
@@ -46,9 +46,9 @@ pub use arbitrary::LedgerState;
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Serialize))]
 pub struct Block {
     /// The block header, containing block metadata.
-    pub header: Header,
+    pub header: Arc<Header>,
     /// The block transactions.
-    pub transactions: Vec<std::sync::Arc<Transaction>>,
+    pub transactions: Vec<Arc<Transaction>>,
 }
 
 impl fmt::Display for Block {
@@ -219,7 +219,7 @@ impl Block {
 
 impl<'a> From<&'a Block> for Hash {
     fn from(block: &'a Block) -> Hash {
-        block.header.into()
+        block.header.as_ref().into()
     }
 }
 

--- a/zebra-chain/src/block/hash.rs
+++ b/zebra-chain/src/block/hash.rs
@@ -1,4 +1,4 @@
-use std::{fmt, io};
+use std::{fmt, io, sync::Arc};
 
 use hex::{FromHex, ToHex};
 
@@ -102,6 +102,22 @@ impl From<Header> for Hash {
     #[allow(clippy::needless_borrow)]
     fn from(block_header: Header) -> Self {
         (&block_header).into()
+    }
+}
+
+impl From<&Arc<Header>> for Hash {
+    // The borrow is actually needed to use From<&Header>
+    #[allow(clippy::needless_borrow)]
+    fn from(block_header: &Arc<Header>) -> Self {
+        block_header.as_ref().into()
+    }
+}
+
+impl From<Arc<Header>> for Hash {
+    // The borrow is actually needed to use From<&Header>
+    #[allow(clippy::needless_borrow)]
+    fn from(block_header: Arc<Header>) -> Self {
+        block_header.as_ref().into()
     }
 }
 

--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -1,12 +1,12 @@
 //! The block header.
 
-use std::usize;
+use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
 use thiserror::Error;
 
 use crate::{
-    serialization::{CompactSizeMessage, TrustedPreallocate, MAX_PROTOCOL_MESSAGE_LEN},
+    serialization::{TrustedPreallocate, MAX_PROTOCOL_MESSAGE_LEN},
     work::{difficulty::CompactDifficulty, equihash::Solution},
 };
 
@@ -125,18 +125,14 @@ impl Header {
 }
 
 /// A header with a count of the number of transactions in its block.
-///
 /// This structure is used in the Bitcoin network protocol.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+///
+/// The transaction count field is always zero, so we don't store it in the struct.
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct CountedHeader {
     /// The header for a block
-    pub header: Header,
-
-    /// The number of transactions that come after the header
-    ///
-    /// TODO: should this always be zero? (#1924)
-    pub transaction_count: CompactSizeMessage,
+    pub header: Arc<Header>,
 }
 
 /// The serialized size of a Zcash block header.

--- a/zebra-chain/src/block/serialize.rs
+++ b/zebra-chain/src/block/serialize.rs
@@ -1,11 +1,14 @@
-use std::{borrow::Borrow, convert::TryInto, io};
+//! Serialization and deserialization for Zcash blocks.
+
+use std::{borrow::Borrow, io};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use chrono::{TimeZone, Utc};
 
 use crate::{
     serialization::{
-        ReadZcashExt, SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
+        CompactSizeMessage, ReadZcashExt, SerializationError, ZcashDeserialize,
+        ZcashDeserializeInto, ZcashSerialize,
     },
     work::{difficulty::CompactDifficulty, equihash},
 };
@@ -93,19 +96,30 @@ impl ZcashDeserialize for Header {
 }
 
 impl ZcashSerialize for CountedHeader {
+    #[allow(clippy::unwrap_in_result)]
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         self.header.zcash_serialize(&mut writer)?;
-        self.transaction_count.zcash_serialize(&mut writer)?;
+
+        // A header-only message has zero transactions in it.
+        let transaction_count =
+            CompactSizeMessage::try_from(0).expect("0 is below the message size limit");
+        transaction_count.zcash_serialize(&mut writer)?;
+
         Ok(())
     }
 }
 
 impl ZcashDeserialize for CountedHeader {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        Ok(CountedHeader {
+        let header = CountedHeader {
             header: (&mut reader).zcash_deserialize_into()?,
-            transaction_count: (&mut reader).zcash_deserialize_into()?,
-        })
+        };
+
+        // We ignore the number of transactions in a header-only message,
+        // it should always be zero.
+        let _transaction_count: CompactSizeMessage = (&mut reader).zcash_deserialize_into()?;
+
+        Ok(header)
     }
 }
 

--- a/zebra-chain/src/block/tests/generate.rs
+++ b/zebra-chain/src/block/tests/generate.rs
@@ -148,7 +148,7 @@ fn multi_transaction_block(oversized: bool) -> Block {
 
     // Add the transactions into a block
     let block = Block {
-        header: block_header,
+        header: block_header.into(),
         transactions,
     };
 
@@ -228,7 +228,7 @@ fn single_transaction_block_many_inputs(oversized: bool) -> Block {
     let transactions = vec![Arc::new(big_transaction)];
 
     let block = Block {
-        header: block_header,
+        header: block_header.into(),
         transactions,
     };
 
@@ -306,7 +306,7 @@ fn single_transaction_block_many_outputs(oversized: bool) -> Block {
     let transactions = vec![Arc::new(big_transaction)];
 
     let block = Block {
-        header: block_header,
+        header: block_header.into(),
         transactions,
     };
 

--- a/zebra-consensus/src/chain/tests.rs
+++ b/zebra-consensus/src/chain/tests.rs
@@ -134,7 +134,7 @@ static STATE_VERIFY_TRANSCRIPT_GENESIS: Lazy<
     )]
 });
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn verify_checkpoint_test() -> Result<(), Report> {
     verify_checkpoint(Config {
         checkpoint_sync: true,
@@ -204,7 +204,7 @@ async fn verify_fail_no_coinbase() -> Result<(), Report> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn round_trip_checkpoint_test() -> Result<(), Report> {
     round_trip_checkpoint().await
 }
@@ -229,7 +229,7 @@ async fn round_trip_checkpoint() -> Result<(), Report> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn verify_fail_add_block_checkpoint_test() -> Result<(), Report> {
     verify_fail_add_block_checkpoint().await
 }

--- a/zebra-consensus/src/chain/tests.rs
+++ b/zebra-consensus/src/chain/tests.rs
@@ -9,7 +9,7 @@ use tower::{layer::Layer, timeout::TimeoutLayer, Service};
 use zebra_chain::{
     block::{self, Block},
     parameters::Network,
-    serialization::ZcashDeserialize,
+    serialization::{ZcashDeserialize, ZcashDeserializeInto},
 };
 use zebra_state as zs;
 use zebra_test::transcript::{ExpectedTranscriptError, Transcript};
@@ -36,7 +36,9 @@ const VERIFY_TIMEOUT_SECONDS: u64 = 10;
 /// The generated block should fail validation.
 pub fn block_no_transactions() -> Block {
     Block {
-        header: block::Header::zcash_deserialize(&zebra_test::vectors::DUMMY_HEADER[..]).unwrap(),
+        header: zebra_test::vectors::DUMMY_HEADER[..]
+            .zcash_deserialize_into()
+            .unwrap(),
         transactions: Vec::new(),
     }
 }

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -29,7 +29,7 @@ use super::{
 /// high system load.
 const VERIFY_TIMEOUT_SECONDS: u64 = 10;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn single_item_checkpoint_list_test() -> Result<(), Report> {
     single_item_checkpoint_list().await
 }
@@ -100,7 +100,7 @@ async fn single_item_checkpoint_list() -> Result<(), Report> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn multi_item_checkpoint_list_test() -> Result<(), Report> {
     multi_item_checkpoint_list().await
 }
@@ -207,14 +207,14 @@ async fn multi_item_checkpoint_list() -> Result<(), Report> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn continuous_blockchain_no_restart() -> Result<(), Report> {
     continuous_blockchain(None, Mainnet).await?;
     continuous_blockchain(None, Testnet).await?;
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn continuous_blockchain_restart() -> Result<(), Report> {
     for height in 0..zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS.len() {
         continuous_blockchain(Some(block::Height(height.try_into().unwrap())), Mainnet).await?;
@@ -424,7 +424,7 @@ async fn continuous_blockchain(
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn block_higher_than_max_checkpoint_fail_test() -> Result<(), Report> {
     block_higher_than_max_checkpoint_fail().await
 }
@@ -494,7 +494,7 @@ async fn block_higher_than_max_checkpoint_fail() -> Result<(), Report> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn wrong_checkpoint_hash_fail_test() -> Result<(), Report> {
     wrong_checkpoint_hash_fail().await
 }
@@ -662,7 +662,7 @@ async fn wrong_checkpoint_hash_fail() -> Result<(), Report> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn checkpoint_drop_cancel_test() -> Result<(), Report> {
     checkpoint_drop_cancel().await
 }
@@ -762,7 +762,7 @@ async fn checkpoint_drop_cancel() -> Result<(), Report> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn hard_coded_mainnet_test() -> Result<(), Report> {
     hard_coded_mainnet().await
 }

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -16,7 +16,7 @@ use zebra_test::mock_service::MockService;
 use super::super::*;
 
 /// Snapshot test for RPC methods responses.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_rpc_response_data() {
     zebra_test::init();
 

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -20,7 +20,7 @@ use zebra_test::mock_service::MockService;
 
 use super::super::*;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn rpc_getinfo() {
     zebra_test::init();
 
@@ -53,7 +53,7 @@ async fn rpc_getinfo() {
     assert!(matches!(rpc_tx_queue_task_result, None));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn rpc_getblock() {
     zebra_test::init();
 
@@ -113,7 +113,7 @@ async fn rpc_getblock() {
     assert!(matches!(rpc_tx_queue_task_result, None));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn rpc_getblock_parse_error() {
     zebra_test::init();
 
@@ -143,7 +143,7 @@ async fn rpc_getblock_parse_error() {
     assert!(matches!(rpc_tx_queue_task_result, None));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn rpc_getblock_missing_error() {
     zebra_test::init();
 
@@ -195,7 +195,7 @@ async fn rpc_getblock_missing_error() {
     assert!(matches!(rpc_tx_queue_task_result, None));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn rpc_getbestblockhash() {
     zebra_test::init();
 
@@ -241,7 +241,7 @@ async fn rpc_getbestblockhash() {
     assert!(matches!(rpc_tx_queue_task_result, None));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn rpc_getrawtransaction() {
     zebra_test::init();
 
@@ -326,7 +326,7 @@ async fn rpc_getrawtransaction() {
     assert!(matches!(rpc_tx_queue_task_result, None));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn rpc_getaddresstxids_invalid_arguments() {
     zebra_test::init();
 
@@ -430,7 +430,7 @@ async fn rpc_getaddresstxids_invalid_arguments() {
     assert!(matches!(rpc_tx_queue_task_result, None));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn rpc_getaddresstxids_response() {
     zebra_test::init();
 
@@ -525,7 +525,7 @@ async fn rpc_getaddresstxids_response_with(
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn rpc_getaddressutxos_invalid_arguments() {
     zebra_test::init();
 
@@ -560,7 +560,7 @@ async fn rpc_getaddressutxos_invalid_arguments() {
     state.expect_no_requests().await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn rpc_getaddressutxos_response() {
     zebra_test::init();
 

--- a/zebra-state/src/service/chain_tip/tests/prop.rs
+++ b/zebra-state/src/service/chain_tip/tests/prop.rs
@@ -1,3 +1,5 @@
+//! Randomised property tests for the Zebra chain tip.
+
 use std::{collections::HashSet, env, sync::Arc};
 
 use futures::FutureExt;
@@ -50,7 +52,9 @@ proptest! {
             // prepare the update
             if connection.is_grow() {
                 if let (Some(mut block), Some(last_block_hash)) = (update.block(), last_block_hash) {
-                    Arc::make_mut(&mut block).header.previous_block_hash = last_block_hash;
+                    let block_mut = Arc::make_mut(&mut block);
+                    Arc::make_mut(&mut block_mut.header).previous_block_hash = last_block_hash;
+
                     *update.block_mut() = Some(block);
                 }
             }

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -460,7 +460,6 @@ impl DiskDb {
 
     /// Writes `batch` to the database.
     pub fn write(&self, batch: DiskWriteBatch) -> Result<(), rocksdb::Error> {
-        // TODO: move writing to the database to a blocking thread (#2188)
         self.db.write(batch.batch)
     }
 

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -511,7 +511,7 @@ fn rejection_restores_internal_state_genesis() -> Result<()> {
         prop_assert_eq!(state.best_tip(), reject_state.best_tip());
         prop_assert!(state.eq_internal_state(&reject_state));
 
-        bad_block.header.previous_block_hash = valid_tip_hash;
+        Arc::make_mut(&mut bad_block.header).previous_block_hash = valid_tip_hash;
         let bad_block = Arc::new(bad_block.0).prepare();
         let reject_result = reject_state.commit_block(bad_block, &finalized_state);
 

--- a/zebra-state/src/service/read/tests/vectors.rs
+++ b/zebra-state/src/service/read/tests/vectors.rs
@@ -29,7 +29,7 @@ async fn empty_read_state_still_responds_to_requests() -> Result<()> {
 }
 
 /// Test that ReadStateService responds correctly when the state contains blocks.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn populated_read_state_responds_correctly() -> Result<()> {
     zebra_test::init();
 

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -2,7 +2,7 @@
 //!
 //! TODO: move these tests into tests::vectors and tests::prop modules.
 
-use std::{convert::TryInto, env, sync::Arc};
+use std::{env, sync::Arc};
 
 use tower::{buffer::Buffer, util::BoxService};
 
@@ -40,12 +40,7 @@ async fn test_populated_state_responds_correctly(
     let block_headers: Vec<CountedHeader> = blocks
         .iter()
         .map(|block| CountedHeader {
-            header: block.header,
-            transaction_count: block
-                .transactions
-                .len()
-                .try_into()
-                .expect("test block transaction counts are valid"),
+            header: block.header.clone(),
         })
         .collect();
 

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -1,4 +1,6 @@
-use std::{convert::TryFrom, mem, sync::Arc};
+//! Tests for the Zebra state service.
+
+use std::{mem, sync::Arc};
 
 use zebra_chain::{
     block::{self, Block},
@@ -42,7 +44,7 @@ impl FakeChainHelper for Arc<Block> {
         }
 
         child.transactions.push(tx);
-        child.header.previous_block_hash = parent_hash;
+        Arc::make_mut(&mut child.header).previous_block_hash = parent_hash;
 
         Arc::new(child)
     }
@@ -52,13 +54,13 @@ impl FakeChainHelper for Arc<Block> {
         let expanded = work_to_expanded(work);
 
         let block = Arc::make_mut(&mut self);
-        block.header.difficulty_threshold = expanded.into();
+        Arc::make_mut(&mut block.header).difficulty_threshold = expanded.into();
         self
     }
 
     fn set_block_commitment(mut self, block_commitment: [u8; 32]) -> Arc<Block> {
         let block = Arc::make_mut(&mut self);
-        block.header.commitment_bytes = block_commitment;
+        Arc::make_mut(&mut block.header).commitment_bytes = block_commitment;
         self
     }
 }

--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -52,12 +52,12 @@ static COMMIT_FINALIZED_BLOCK_TESTNET: Lazy<
     ]
 });
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_transcripts_mainnet() -> Result<(), Report> {
     check_transcripts(Network::Mainnet).await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_transcripts_testnet() -> Result<(), Report> {
     check_transcripts(Network::Testnet).await
 }

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -49,7 +49,7 @@ use InventoryResponse::*;
 /// Increasing this value causes the tests to take longer to complete, so it can't be too large.
 const MAX_PEER_SET_REQUEST_DELAY: Duration = Duration::from_millis(500);
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn mempool_requests_for_transactions() {
     let (
         inbound_service,
@@ -124,7 +124,7 @@ async fn mempool_requests_for_transactions() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn mempool_push_transaction() -> Result<(), crate::BoxError> {
     // get a block that has at least one non coinbase transaction
     let block: Arc<Block> =
@@ -208,7 +208,7 @@ async fn mempool_push_transaction() -> Result<(), crate::BoxError> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn mempool_advertise_transaction_ids() -> Result<(), crate::BoxError> {
     // get a block that has at least one non coinbase transaction
     let block: Block = zebra_test::vectors::BLOCK_MAINNET_982681_BYTES.zcash_deserialize_into()?;
@@ -308,7 +308,7 @@ async fn mempool_advertise_transaction_ids() -> Result<(), crate::BoxError> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
     // Get a block that has at least one non coinbase transaction
     let block: Block = zebra_test::vectors::BLOCK_MAINNET_982681_BYTES.zcash_deserialize_into()?;
@@ -585,7 +585,7 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
 /// Test that the inbound downloader rejects blocks above the lookahead limit.
 ///
 /// TODO: also test that it rejects blocks behind the tip limit. (Needs ~100 fake blocks.)
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn inbound_block_height_lookahead_limit() -> Result<(), crate::BoxError> {
     // Get services
     let (

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -43,7 +43,10 @@ use tokio::{sync::oneshot, task::JoinHandle};
 use tower::{Service, ServiceExt};
 use tracing_futures::Instrument;
 
-use zebra_chain::transaction::{self, UnminedTxId, VerifiedUnminedTx};
+use zebra_chain::{
+    block::Height,
+    transaction::{self, UnminedTxId, VerifiedUnminedTx},
+};
 use zebra_consensus::transaction as tx;
 use zebra_network as zn;
 use zebra_node_services::mempool::Gossip;
@@ -102,9 +105,6 @@ pub enum TransactionDownloadVerifyError {
 
     #[error("error in state service")]
     StateError(#[source] BoxError),
-
-    #[error("transaction not validated because the tip is empty")]
-    NoTip,
 
     #[error("error downloading transaction")]
     DownloadFailed(#[source] BoxError),
@@ -273,13 +273,16 @@ where
             // Don't download/verify if the transaction is already in the state.
             Self::transaction_in_state(&mut state, txid).await?;
 
-            let height = match state.oneshot(zs::Request::Tip).await {
-                Ok(zs::Response::Tip(None)) => Err(TransactionDownloadVerifyError::NoTip),
-                Ok(zs::Response::Tip(Some((height, _hash)))) => Ok(height),
+            let next_height = match state.oneshot(zs::Request::Tip).await {
+                Ok(zs::Response::Tip(None)) => Ok(Height(0)),
+                Ok(zs::Response::Tip(Some((height, _hash)))) => {
+                    let next_height =
+                        (height + 1).expect("valid heights are far below the maximum");
+                    Ok(next_height)
+                }
                 Ok(_) => unreachable!("wrong response"),
                 Err(e) => Err(TransactionDownloadVerifyError::StateError(e)),
             }?;
-            let height = (height + 1).expect("must have next height");
 
             let tx = match gossiped_tx {
                 Gossip::Id(txid) => {
@@ -322,7 +325,7 @@ where
             let result = verifier
                 .oneshot(tx::Request::Mempool {
                     transaction: tx.clone(),
-                    height,
+                    height: next_height,
                 })
                 .map_ok(|rsp| {
                     rsp.into_mempool_transaction()

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -457,9 +457,6 @@ impl Storage {
             TransactionDownloadVerifyError::InState |
             // An unknown error in the state service, better do nothing
             TransactionDownloadVerifyError::StateError(_) |
-            // Sync has just started. Mempool shouldn't even be enabled, so will not
-            // happen in practice.
-            TransactionDownloadVerifyError::NoTip |
             // If download failed, do nothing; the crawler will end up trying to
             // download it again.
             TransactionDownloadVerifyError::DownloadFailed(_) |

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -548,7 +548,7 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
     // Using the mainnet for now
     let network = Network::Mainnet;
 
-    let (mut mempool, _peer_set, mut state_service, mut tx_verifier, mut recent_syncs) =
+    let (mut mempool, _peer_set, _state_service, mut tx_verifier, mut recent_syncs) =
         setup(network, u64::MAX).await;
 
     // Get transactions to use in the test
@@ -559,20 +559,6 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
 
     // Enable the mempool
     mempool.enable(&mut recent_syncs).await;
-
-    // Push the genesis block to the state, since downloader needs a valid tip.
-    let genesis_block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
-        .zcash_deserialize_into()
-        .unwrap();
-    state_service
-        .ready()
-        .await
-        .unwrap()
-        .call(zebra_state::Request::CommitFinalizedBlock(
-            genesis_block.clone().into(),
-        ))
-        .await
-        .unwrap();
 
     // Queue first transaction for verification
     // (queue the transaction itself to avoid a download).
@@ -633,7 +619,7 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
     // Using the mainnet for now
     let network = Network::Mainnet;
 
-    let (mut mempool, mut peer_set, mut state_service, _tx_verifier, mut recent_syncs) =
+    let (mut mempool, mut peer_set, _state_service, _tx_verifier, mut recent_syncs) =
         setup(network, u64::MAX).await;
 
     // Get transactions to use in the test
@@ -644,20 +630,6 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
 
     // Enable the mempool
     mempool.enable(&mut recent_syncs).await;
-
-    // Push the genesis block to the state, since downloader needs a valid tip.
-    let genesis_block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
-        .zcash_deserialize_into()
-        .unwrap();
-    state_service
-        .ready()
-        .await
-        .unwrap()
-        .call(zebra_state::Request::CommitFinalizedBlock(
-            genesis_block.clone().into(),
-        ))
-        .await
-        .unwrap();
 
     // Queue second transaction for download and verification.
     let request = mempool

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -375,7 +375,7 @@ async fn mempool_service_disabled() -> Result<(), Report> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn mempool_cancel_mined() -> Result<(), Report> {
     let block1: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES
         .zcash_deserialize_into()
@@ -389,8 +389,6 @@ async fn mempool_cancel_mined() -> Result<(), Report> {
 
     let (mut mempool, _peer_set, mut state_service, _tx_verifier, mut recent_syncs) =
         setup(network, u64::MAX).await;
-
-    time::pause();
 
     // Enable the mempool
     mempool.enable(&mut recent_syncs).await;
@@ -470,7 +468,7 @@ async fn mempool_cancel_mined() -> Result<(), Report> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn mempool_cancel_downloads_after_network_upgrade() -> Result<(), Report> {
     let block1: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES
         .zcash_deserialize_into()


### PR DESCRIPTION
## Motivation

We want to improve Zebra's sync speed to avoid test timeouts in CI (#4155).

One way to speed up the sync is move blocking tasks to dedicated threads, so they don't stop other async tasks on the same thread from running. This PR moves disk writes to a `tokio` blocking thread.
Close #4779

Partially addresses #2188

Depends-On: #4792

### Specifications

https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html

## Solution

- Move CommitBlock and CommitFinalizedBlock requests to a `tokio` block-in-place thread

Related changes:
- Remove mempool downloader requirement for a populated state

Test fixes:
- Add blocking tokio threads to tests that now need them
    - Remove `tokio::time::pause()` from tests that don't need it (it doesn't work with blocking threads)
- In tests that need `tokio::time::pause()`, stop writing blocks to the state
    - Stop requiring a populated state in the mempool downloader
- Improve failure debug output in some tests
- Improve reliability of some tests with multithreaded executors

## Review

Anyone can review this PR, it's urgent because CI is failing, and it blocks a release.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- #4788