### PR TITLE
fix(ci): remove forcing colored logs in the full sync

### DIFF
--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -203,7 +203,7 @@ jobs:
           --container-restart-policy=never \
           --container-stdin \
           --container-tty \
-          --container-env=ZEBRA_SKIP_IPV6_TESTS=1,TEST_FULL_SYNC=1,ZEBRA_FORCE_USE_COLOR=1,FULL_SYNC_MAINNET_TIMEOUT_MINUTES=600 \
+          --container-env=ZEBRA_SKIP_IPV6_TESTS=1,TEST_FULL_SYNC=1,FULL_SYNC_MAINNET_TIMEOUT_MINUTES=600 \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=true,google-logging-enabled=true \


### PR DESCRIPTION

## Motivation

This is probably causing some parsing errors in the full sync at some point in the logs, which results in an "unexpected EOF" error while reading the logs.

This can be merged before #4198 to confirm, and if not...follow up with #4198 

Related to https://github.com/ZcashFoundation/zebra/issues/3991.

## Solution

Remove the variable `ZEBRA_FORCE_USE_COLOR` from the full sync test

## Review

@teor2345 and @dconnolly can review this

### Reviewer Checklist

  - [ ] Full sync should not fail

