### PR TITLE
fix(perf): Decrease the peer handshake timeout to 3 seconds, to speed up the initial sync

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -88,7 +88,7 @@ pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 /// This timeout should remain small, because it helps stop slow peers getting
 /// into the peer set. This is particularly important for network-constrained
 /// nodes, and on testnet.
-pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(4);
+pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// We expect to receive a message from a live peer at least once in this time duration.
 ///


### PR DESCRIPTION
## Motivation

In #4155, we want to speed up Zebra's initial sync.

One way to do that is to choose faster peers.

## Solution

- Decrease the peer handshake timeout to 3 seconds

Close #4155

## Review

Anyone can review this PR.

If it makes the sync faster, we should merge it, and open a ticket for a longer-term solution.
If it doesn't make the sync faster, we should close it.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- open a ticket for a longer-term solution