### PR TITLE
change(perf): Decrease the request timeout to 15 seconds, to speed up the initial sync

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -81,7 +81,7 @@ pub const PEERSET_BUFFER_SIZE: usize = 3;
 
 /// The timeout for sending a message to a remote peer,
 /// and receiving a response from a remote peer.
-pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// The timeout for handshakes when connecting to new peers.
 ///

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -101,7 +101,7 @@ pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(4);
 /// This avoids explicit synchronization, but relies on the peer
 /// connector actually setting up channels and these heartbeats in a
 /// specific manner that matches up with this math.
-pub const MIN_PEER_RECONNECTION_DELAY: Duration = Duration::from_secs(59 + 20 + 20 + 20);
+pub const MIN_PEER_RECONNECTION_DELAY: Duration = Duration::from_secs(59 + 15 + 15 + 15);
 
 /// Zebra rotates its peer inventory registry every time this interval elapses.
 ///


### PR DESCRIPTION
## Motivation

In #4155, we want to speed up Zebra's initial sync.

One way to do that is to give up sooner when peers are slow to respond.

## Solution

- Decrease the peer request timeout to 15 seconds

## Review

Anyone can review this PR.

If it makes the sync faster, we should merge it, and open a ticket for a longer-term solution.
If it doesn't make the sync faster, we should close it.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- open a ticket for a longer-term solution