### PR TITLE
fix(rpc): Fix some RPC response formats to match `zcashd`

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -273,8 +273,15 @@ where
     {
         let runner = Queue::start();
 
+        let mut app_version = app_version.to_string();
+
+        // Match zcashd's version format, if the version string has anything in it
+        if !app_version.is_empty() && !app_version.starts_with('v') {
+            app_version.insert(0, 'v');
+        }
+
         let rpc_impl = RpcImpl {
-            app_version: app_version.to_string(),
+            app_version,
             mempool: mempool.clone(),
             state: state.clone(),
             latest_chain_tip: latest_chain_tip.clone(),

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -562,10 +562,16 @@ where
 
             match response {
                 mempool::Response::TransactionIds(unmined_transaction_ids) => {
-                    Ok(unmined_transaction_ids
+                    let mut tx_ids: Vec<String> = unmined_transaction_ids
                         .iter()
                         .map(|id| id.mined_id().encode_hex())
-                        .collect())
+                        .collect();
+
+                    // Sort returned transaction IDs in numeric/string order.
+                    // (zcashd's sort order appears arbitrary.)
+                    tx_ids.sort();
+
+                    Ok(tx_ids)
                 }
                 _ => unreachable!("unmatched response to a transactionids request"),
             }

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -19,7 +19,6 @@ use tower::{buffer::Buffer, Service, ServiceExt};
 use tracing::Instrument;
 
 use zebra_chain::{
-    amount::{Amount, NonNegative},
     block::{self, Height, SerializedBlock},
     chain_tip::ChainTip,
     parameters::{ConsensusBranchId, Network, NetworkUpgrade},
@@ -438,9 +437,9 @@ where
             })?;
 
             match response {
-                zebra_state::ReadResponse::AddressBalance(balance) => {
-                    Ok(AddressBalance { balance })
-                }
+                zebra_state::ReadResponse::AddressBalance(balance) => Ok(AddressBalance {
+                    balance: u64::from(balance),
+                }),
                 _ => unreachable!("Unexpected response from state service: {response:?}"),
             }
         }
@@ -737,7 +736,7 @@ where
                 let height = utxo_data.2.height().0;
                 let output_index = utxo_data.2.output_index().as_usize();
                 let script = utxo_data.3.lock_script.to_string();
-                let satoshis = i64::from(utxo_data.3.value);
+                let satoshis = u64::from(utxo_data.3.value);
 
                 let entry = GetAddressUtxos {
                     address,
@@ -816,7 +815,7 @@ impl AddressStrings {
 /// The transparent balance of a set of addresses.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, serde::Serialize)]
 pub struct AddressBalance {
-    balance: Amount<NonNegative>,
+    balance: u64,
 }
 
 /// A hex-encoded [`ConsensusBranchId`] string.
@@ -906,7 +905,7 @@ pub struct GetAddressUtxos {
     #[serde(rename = "outputIndex")]
     output_index: usize,
     script: String,
-    satoshis: i64,
+    satoshis: u64,
 }
 
 impl GetRawTransaction {

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -328,10 +328,11 @@ proptest! {
             );
 
             let call_task = tokio::spawn(rpc.get_raw_mempool());
-            let expected_response: Vec<String> = transaction_ids
+            let mut expected_response: Vec<String> = transaction_ids
                 .iter()
                 .map(|id| id.mined_id().encode_hex())
                 .collect();
+            expected_response.sort();
 
             mempool
                 .expect_request(mempool::Request::TransactionIds)

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -632,7 +632,7 @@ proptest! {
             // Check that response contains the expected balance
             let received_balance = response?;
 
-            prop_assert_eq!(received_balance, AddressBalance { balance });
+            prop_assert_eq!(received_balance, AddressBalance { balance: balance.into() });
 
             // Check no further requests were made during this test
             mempool.expect_no_requests().await?;

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -38,8 +38,8 @@ async fn rpc_getinfo() {
     let get_info = rpc.get_info().expect("We should have a GetInfo struct");
 
     // make sure there is a `build` field in the response,
-    // and that is equal to the provided string.
-    assert_eq!(get_info.build, "RPC test");
+    // and that is equal to the provided string, with an added 'v' version prefix.
+    assert_eq!(get_info.build, "vRPC test");
 
     // make sure there is a `subversion` field,
     // and that is equal to the Zebra user agent.


### PR DESCRIPTION
## Motivation

As part of #4130, I discovered some differences between Zebra and `zcashd` responses.

These are some of the minor ones that were easy to fix.

### Specifications

https://zcash.github.io/rpc/getinfo.html
https://zcash.github.io/rpc/getaddressbalance.html
https://zcash.github.io/rpc/getrawmempool.html

## Solution

- Make the version number format match zcashd in getinfo
- Remove an extra array wrapper in getaddressbalance
- Return a stable sort order from getrawmempool
    - zcashd seems to return an arbitrary order here, so we might not be able to match it, and we probably shouldn't try

## Review

Anyone can review this PR, it's not urgent.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- PR #4218