### PR TITLE
fix(ci): Speed up CI tests by disabling debug logs

### DIFF
--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -145,7 +145,7 @@ jobs:
             COLORBT_SHOW_HIDDEN=${{ env.COLORBT_SHOW_HIDDEN }}
             ZEBRA_SKIP_NETWORK_TESTS="1"
             CHECKPOINT_SYNC=${{ github.event.inputs.checkpoint_sync || true }}
-            RUST_LOG=debug
+            RUST_LOG=info
             SENTRY_DSN=${{ secrets.SENTRY_ENDPOINT }}
           push: true
           cache-from: type=registry,ref=${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_REF_SLUG_URL }}-buildcache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,7 +147,7 @@ jobs:
             COLORBT_SHOW_HIDDEN=${{ env.COLORBT_SHOW_HIDDEN }}
             ZEBRA_SKIP_NETWORK_TESTS="1"
             CHECKPOINT_SYNC=${{ github.event.inputs.checkpoint_sync || true }}
-            RUST_LOG=debug
+            RUST_LOG=info
             SENTRY_DSN=${{ secrets.SENTRY_ENDPOINT }}
           push: true
           cache-from: type=registry,ref=${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:${{ env.GITHUB_REF_SLUG_URL }}-buildcache


### PR DESCRIPTION
## Motivation

We want to speed up Zebra's full sync (#4155). But logging lots of debug info can be really slow.

Zebra doesn't use `RUST_LOG` itself, but some other dependencies do. (And the compiler does.)

### Specifications

https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/config_log.html

## Solution

- change `RUST_LOG` to `info`

## Review

Anyone can review this high-priority PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

