### PR TITLE
fix(ci): Install cmake to fix zcash-params Dockerfile build failure

### DIFF
--- a/docker/zcash-params/Dockerfile
+++ b/docker/zcash-params/Dockerfile
@@ -18,12 +18,11 @@ RUN apt-get -qq update && \
     libclang-dev \
     clang \
     ca-certificates \
+    cmake \
+    protobuf-compiler \
     ; \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
-# Optimize builds. In particular, regenerate-stateful-test-disks.yml was reaching the
-# GitHub Actions time limit (6 hours), so we needed to make it faster.
-ENV RUSTFLAGS -O
 ENV CARGO_HOME /app/.cargo/
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook --release --features enable-sentry --recipe-path recipe.json


### PR DESCRIPTION
## Motivation

The zcash-params dockerfile builds some of the new gRPC test dependencies, even though it doesn't use them.

This is the same fix as commit dfe4e8be1f0eb91523694f2e8633d421796801c2 in PR #4068.

## Review

@dconnolly or @gustavovalverde this causes all builds on `main` merges to fail, so it's urgent.

### Reviewer Checklist

  - [ ] zcash-params build works after this PR is merged to `main`

## Follow Up Work

- run the zcash-params build when we change its dependencies in a PR (but we can't do this too often, because we'll hit params download rate-limits)
- stop requiring these test dependencies unless we're running the `zebrad` acceptance tests