### PR TITLE
fix(ci): Give each build image a unique name, and fix workflow run conditions

### DIFF
--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   build:
     # this job name is a duplicate, it is shared by every workflow that calls this workflow
-    name: Build images
+    name: Build ${{ inputs.image_name }} images
     timeout-minutes: 210
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   build:
-    name: Build images
+    name: Build ${{ inputs.image_name }} images
     timeout-minutes: 210
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -38,19 +38,9 @@ on:
         type: string
 
 jobs:
-  # Convert the image name input to a single-item matrix, so it can be used in the build job's name
-  image-name-to-job-name:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - id: set-matrix
-        run: echo "::set-output name=matrix::{\"include\":[{\"image_name\":\"" ${{ inputs.image_name }} "\"}]}"
   build:
-    needs: image-name-to-job-name
-    name: Build ${{ matrix.image_name }} images
-    strategy:
-      matrix: ${{fromJSON(needs.image-name-to-job-name.outputs.matrix)}}
+   # this job name is a duplicate, it is shared by every workflow that calls this workflow
+    name: Build images
     timeout-minutes: 210
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -38,8 +38,19 @@ on:
         type: string
 
 jobs:
+  # Convert the image name input to a single-item matrix, so it can be used in the build job's name
+  image-name-to-job-name:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: echo "::set-output name=matrix::{\"include\":[{\"image_name\":\"" ${{ inputs.image_name }} "\"}]}"
   build:
-    name: Build ${{ inputs.image_name }} images
+    needs: image-name-to-job-name
+    name: Build ${{ matrix.image_name }} images
+    strategy:
+      matrix: ${{fromJSON(needs.image-name-to-job-name.outputs.matrix)}}
     timeout-minutes: 210
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   build:
-   # this job name is a duplicate, it is shared by every workflow that calls this workflow
+    # this job name is a duplicate, it is shared by every workflow that calls this workflow
     name: Build images
     timeout-minutes: 210
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -39,7 +39,6 @@ on:
 
 jobs:
   build:
-    # this job name is a duplicate, it is shared by every workflow that calls this workflow
     name: Build ${{ inputs.image_name }} images
     timeout-minutes: 210
     runs-on: ubuntu-latest

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -48,7 +48,7 @@ on:
 env:
   NETWORK: Mainnet
   PROJECT_ID: zealous-zebra
-  IMAGE_NAME: zebrad-test
+  IMAGE_NAME: zebrad-test-full-sync
   GAR_BASE: us-docker.pkg.dev/zealous-zebra/zebra
   REGION: us-central1
   ZONE: us-central1-a
@@ -64,7 +64,7 @@ jobs:
     with:
       dockerfile_path: ./docker/Dockerfile
       dockerfile_target: tester
-      image_name: zebrad-test
+      image_name: zebrad-test-full-sync
       network: Mainnet
       checkpoint_sync: true
       rust_backtrace: full

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -27,6 +27,7 @@ on:
       # workflow definitions
       - 'docker/**'
       - '.github/workflows/test-full-sync.yml'
+      - '.github/workflows/docker-image-build.yml'
   push:
     branches:
       - main

--- a/.github/workflows/test-full-sync.yml
+++ b/.github/workflows/test-full-sync.yml
@@ -28,6 +28,7 @@ on:
       - 'docker/**'
       - '.github/workflows/test-full-sync.yml'
       - '.github/workflows/docker-image-build.yml'
+
   push:
     branches:
       - main

--- a/.github/workflows/test.patch.yml
+++ b/.github/workflows/test.patch.yml
@@ -16,8 +16,8 @@ on:
 
 jobs:
   build:
-    # this job name must match the image name from test.yml
-    name: Build zebrad-test images
+    # this job name is a duplicate shared between test.yml, test-full-sync.yml, and zcash-params.yml
+    name: Build images
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/test.patch.yml
+++ b/.github/workflows/test.patch.yml
@@ -16,8 +16,9 @@ on:
 
 jobs:
   build:
-    # this job name is a duplicate shared between test.yml, test-full-sync.yml, and zcash-params.yml
-    name: Build images
+    # This job name only matches test.yml.
+    # To match test-full-sync.yml or zcash-params.yml, use their image names in the job name.
+    name: Build zebrad-test images
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/test.patch.yml
+++ b/.github/workflows/test.patch.yml
@@ -14,9 +14,12 @@ on:
       - '.github/workflows/test.yml'
       - '.github/workflows/docker-image-build.yml'
 
+env:
+  IMAGE_NAME: zebrad-test
+
 jobs:
   build:
-    name: Build images
+    name: Build ${{ env.IMAGE_NAME }} images
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/test.patch.yml
+++ b/.github/workflows/test.patch.yml
@@ -14,12 +14,10 @@ on:
       - '.github/workflows/test.yml'
       - '.github/workflows/docker-image-build.yml'
 
-env:
-  IMAGE_NAME: zebrad-test
-
 jobs:
   build:
-    name: Build ${{ env.IMAGE_NAME }} images
+    # this job name must match the image name from test.yml
+    name: Build zebrad-test images
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ on:
       # workflow definitions
       - 'docker/**'
       - '.github/workflows/test.yml'
+      - '.github/workflows/docker-image-build.yml'
 
   push:
     branches:


### PR DESCRIPTION
## Motivation

We currently have 2 images named "zebrad-test".

We're also seeing some weird CI failures like:
- #4234 

Previous bugs like #3991 were caused by conflicting operations on the same image. So if we make all our image names unique, we can rule out duplicate names as a cause of these bugs. (And any other future bugs.)

We need to test these changes in this PR, so I also fixed a bug in the workflow conditions from PR #4173. If the build images sub-workflow changes in a PR, we need to run every workflow that calls it. (Previously, we were only calling it on merge.)

## Solution

- Name each image with a unique name

This is a quick fix for duplicate names. We can choose better names in PR #3941.

I also:
- fixed the workflow PR run conditions for build image callers
- stopped requiring the "Build Images" job in GitHub branch protection, because it wasn't really working anyway.

## Review

Anyone can review this urgent PR - the #4234 failures seem to be happening a lot lately.

### Reviewer Checklist

  - [ ] All the jobs pass on the PR and merge queue
  - [ ] The zcash-params job passes after merging

