### PR TITLE
fix(ci): Increase docs job timeout

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   build:
     name: Build and Deploy Docs (+beta)
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code


### PR DESCRIPTION
## Motivation

Some docs jobs are timing out:
https://github.com/ZcashFoundation/zebra/runs/6216121370?check_suite_focus=true

But they are almost finished at 30 minutes.

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [ ] Job works when it is merged to main