### PR TITLE
fix(build): avoid docker cache contamination and invalidation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,13 @@
+# Before the docker CLI sends the context to the docker daemon, it looks for a file 
+# named .dockerignore in the root directory of the context. If this file exists, the 
+# CLI modifies the context to exclude files and directories that match patterns in it. 
+#
+# You may want to specify which files to include in the context, rather than which 
+# to exclude. To achieve this, specify * as the first pattern, followed by one or 
+# more ! exception patterns.
+# 
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
 # Exclude everything:
 #
 *

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@
 !tower-*
 !zebra-*
 !zebrad
+!docker/entrypoint.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,12 @@
-target
-Dockerfile
-.dockerignore
-.git
-.github
-.gitignore
+# Exclude everything:
+#
+*
+
+# Now un-exclude required files and folders:
+#
+!.cargo
+!*.toml
+!*.lock
+!tower-*
+!zebra-*
+!zebrad

--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -93,6 +93,7 @@ jobs:
           registry: us-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
+          logout: false
 
       - name: Login to Google Container Registry
         uses: docker/login-action@v1.14.1
@@ -100,6 +101,7 @@ jobs:
           registry: gcr.io
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
+          logout: false
 
       # Build and push image to Google Artifact Registry
       - name: Build & push

--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -121,5 +121,5 @@ jobs:
             CHECKPOINT_SYNC=${{ inputs.checkpoint_sync }}
             RUST_LOG=${{ inputs.rust_log }}
           push: true
-          cache-from: type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-buildcache
-          cache-to: type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-buildcache,mode=max
+          cache-from: type=gha,scope=${{ inputs.image_name }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.image_name }}


### PR DESCRIPTION
## Motivation

We've been having issues with image building, and cache is not being as effectively as when initially implemented. And jobs are failing mainly when an image takes more than 45 minutes to build. The specific root cause is unknown, but this is also a good workaround.

Fixes #4234

## Solution

- Fallback to use GHA cache
- Do not invalidate the cache if not required, just add needed folders and files to `.dockerignore`

## Review

@teor2345 and @dconnolly can review this

### Reviewer Checklist

  - [ ] Re-running a job uses the cache

## Follow Up Work

- Confirm that cache does not expire as frequently as before, as we're using `scopes` to target specific images. 