### PR TITLE
feat(ci): clarify lint workflow names

### DIFF
--- a/.github/workflows/lint.patch.yml
+++ b/.github/workflows/lint.patch.yml
@@ -1,4 +1,4 @@
-name: Lint Rust files
+name: Lint
 
 on:
   pull_request:
@@ -21,6 +21,12 @@ jobs:
 
   fmt:
     name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  actionlint:
+    name: Actionlint
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint Rust files
+name: Lint
 
 on:
   # we build Rust caches on main, so they can be shared by all branches:


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

We are doing linting of several types (Rust code, GitHub Workflows), we should align the visible names with the work the workflow is doing.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Rename the `lint.yml` and `lint.patch.yml` display names.

This was extracted from https://github.com/ZcashFoundation/zebra/pull/3941

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

Anyone can review 


