### PR TITLE
refactor(test): fix confusing environmental variable names in Rust code

### DIFF
--- a/zebrad/tests/common/cached_state.rs
+++ b/zebrad/tests/common/cached_state.rs
@@ -13,7 +13,7 @@ use zebra_state::{ChainTipChange, LatestChainTip};
 use crate::common::config::testdir;
 
 /// Path to a directory containing a cached Zebra state.
-pub const ZEBRA_CACHED_STATE_DIR_VAR: &str = "ZEBRA_CACHED_STATE_DIR";
+pub const ZEBRA_CACHED_STATE_DIR: &str = "ZEBRA_CACHED_STATE_DIR";
 
 /// Type alias for a boxed state service.
 pub type BoxStateService =

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -20,7 +20,7 @@ use zebra_test::{
 use zebrad::config::ZebradConfig;
 
 use super::{
-    cached_state::ZEBRA_CACHED_STATE_DIR_VAR,
+    cached_state::ZEBRA_CACHED_STATE_DIR,
     config::default_test_config,
     failure_messages::{
         LIGHTWALLETD_EMPTY_ZEBRA_STATE_IGNORE_MESSAGES, LIGHTWALLETD_FAILURE_MESSAGES,
@@ -56,7 +56,7 @@ pub const ZEBRA_TEST_LIGHTWALLETD: &str = "ZEBRA_TEST_LIGHTWALLETD";
 ///
 /// Can also be used to speed up the [`sending_transactions_using_lightwalletd`] test,
 /// by skipping the lightwalletd initial sync.
-pub const LIGHTWALLETD_DATA_DIR_VAR: &str = "LIGHTWALLETD_DATA_DIR";
+pub const LIGHTWALLETD_DATA_DIR: &str = "LIGHTWALLETD_DATA_DIR";
 
 /// The maximum time that a `lightwalletd` integration test is expected to run.
 pub const LIGHTWALLETD_TEST_TIMEOUT: Duration = Duration::from_secs(60 * 60);
@@ -267,12 +267,12 @@ impl LightwalletdTestType {
 
     /// Returns the Zebra state path for this test, if set.
     pub fn zebrad_state_path(&self, test_name: String) -> Option<PathBuf> {
-        match env::var_os(ZEBRA_CACHED_STATE_DIR_VAR) {
+        match env::var_os(ZEBRA_CACHED_STATE_DIR) {
             Some(path) => Some(path.into()),
             None => {
                 tracing::info!(
                     "skipped {test_name:?} {self:?} lightwalletd test, \
-                     set the {ZEBRA_CACHED_STATE_DIR_VAR:?} environment variable to run the test",
+                     set the {ZEBRA_CACHED_STATE_DIR:?} environment variable to run the test",
                 );
 
                 None
@@ -306,12 +306,12 @@ impl LightwalletdTestType {
 
     /// Returns the lightwalletd state path for this test, if set.
     pub fn lightwalletd_state_path(&self, test_name: String) -> Option<PathBuf> {
-        match env::var_os(LIGHTWALLETD_DATA_DIR_VAR) {
+        match env::var_os(LIGHTWALLETD_DATA_DIR) {
             Some(path) => Some(path.into()),
             None => {
                 tracing::info!(
                     "skipped {test_name:?} {self:?} lightwalletd test, \
-                     set the {LIGHTWALLETD_DATA_DIR_VAR:?} environment variable to run the test",
+                     set the {LIGHTWALLETD_DATA_DIR:?} environment variable to run the test",
                 );
 
                 None


### PR DESCRIPTION
## Motivation

We have Rust variables that store environmental variable names, to detect typos.

But the Rust variables were named differently to the environmental variables, which made them confusing to use.

## Solution

```sh
fastmod _VAR "" zebra*
```

## Review

Anyone can review this low priority PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

