### PR TITLE
change(test): Stop requiring cached lightwalletd state for the send transaction test

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1163,8 +1163,7 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
     }
 
     if test_type.needs_lightwalletd_cached_state() {
-        // TODO: expect `[0-9]{7}` when we're using the tip cached state (#4155)
-        lightwalletd.expect_stdout_line_matches("Found [0-9]{6,7} blocks in cache")?;
+        lightwalletd.expect_stdout_line_matches("Found [0-9]{7} blocks in cache")?;
     } else if !test_type.allow_lightwalletd_cached_state() {
         // Timeout the test if we're somehow accidentally using a cached state in our temp dir
         lightwalletd.expect_stdout_line_matches("Found 0 blocks in cache")?;

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1486,11 +1486,8 @@ async fn fully_synced_rpc_test() -> Result<()> {
 
     let network = Network::Mainnet;
 
-    let (_zebrad, zebra_rpc_address) = spawn_zebrad_for_rpc_without_initial_peers(
-        network,
-        cached_state_path.unwrap(),
-        test_type.zebrad_timeout(),
-    )?;
+    let (_zebrad, zebra_rpc_address) =
+        spawn_zebrad_for_rpc_without_initial_peers(network, cached_state_path.unwrap(), test_type)?;
 
     // Make a getblock test that works only on synced node (high block number).
     // The block is before the mandatory checkpoint, so the checkpoint cached state can be used

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -18,15 +18,12 @@ use color_eyre::eyre::Result;
 use zebra_chain::parameters::Network;
 use zebra_test::{
     args,
-    command::{Arguments, TestDirExt, NO_MATCHES_REGEX_ITER},
+    command::{Arguments, TestDirExt},
     prelude::*,
 };
 use zebrad::config::ZebradConfig;
 
-use crate::common::{
-    failure_messages::{PROCESS_FAILURE_MESSAGES, ZEBRA_FAILURE_MESSAGES},
-    lightwalletd::random_known_rpc_port_config,
-};
+use crate::common::lightwalletd::{random_known_rpc_port_config, LightwalletdTestType};
 
 /// After we launch `zebrad`, wait this long for the command to start up,
 /// take the actions expected by the tests, and log the expected logs.
@@ -198,7 +195,7 @@ where
 pub fn spawn_zebrad_for_rpc_without_initial_peers<P: ZebradTestDirExt>(
     network: Network,
     zebra_directory: P,
-    timeout: Duration,
+    test_type: LightwalletdTestType,
 ) -> Result<(TestChild<P>, SocketAddr)> {
     let mut config = random_known_rpc_port_config()
         .expect("Failed to create a config file with a known RPC listener port");
@@ -209,19 +206,14 @@ pub fn spawn_zebrad_for_rpc_without_initial_peers<P: ZebradTestDirExt>(
     config.network.network = network;
     config.mempool.debug_enable_at_height = Some(0);
 
+    let (zebrad_failure_messages, zebrad_ignore_messages) = test_type.zebrad_failure_messages();
+
     let mut zebrad = zebra_directory
         .with_config(&mut config)?
         .spawn_child(args!["start"])?
         .bypass_test_capture(true)
-        .with_timeout(timeout)
-        .with_failure_regex_iter(
-            // TODO: replace with a function that returns the full list and correct return type
-            ZEBRA_FAILURE_MESSAGES
-                .iter()
-                .chain(PROCESS_FAILURE_MESSAGES)
-                .cloned(),
-            NO_MATCHES_REGEX_ITER.iter().cloned(),
-        );
+        .with_timeout(test_type.zebrad_timeout())
+        .with_failure_regex_iter(zebrad_failure_messages, zebrad_ignore_messages);
 
     let rpc_address = config.rpc.listen_addr.unwrap();
 

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -58,9 +58,6 @@ pub const ZEBRA_TEST_LIGHTWALLETD: &str = "ZEBRA_TEST_LIGHTWALLETD";
 /// by skipping the lightwalletd initial sync.
 pub const LIGHTWALLETD_DATA_DIR_VAR: &str = "LIGHTWALLETD_DATA_DIR";
 
-/// The maximum time that a `lightwalletd` integration test is expected to run.
-pub const LIGHTWALLETD_TEST_TIMEOUT: Duration = Duration::from_secs(60 * 60);
-
 /// Should we skip Zebra lightwalletd integration tests?
 #[allow(clippy::print_stderr)]
 pub fn zebra_skip_lightwalletd_tests() -> bool {

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -378,9 +378,7 @@ impl LightwalletdTestType {
         // lightwalletd state failures
         if self.needs_lightwalletd_cached_state() {
             // Fail if we need a cached lightwalletd state, but it isn't near the tip
-            //
-            // TODO: fail on `[0-9]{1,6}` when we're using the tip cached state (#4155)
-            lightwalletd_failure_messages.push("Found [0-9]{1,5} blocks in cache".to_string());
+            lightwalletd_failure_messages.push("Found [0-9]{1,6} blocks in cache".to_string());
         }
         if !self.allow_lightwalletd_cached_state() {
             // Fail if we need an empty lightwalletd state, but it has blocks

--- a/zebrad/tests/common/lightwalletd/send_transaction_test.rs
+++ b/zebrad/tests/common/lightwalletd/send_transaction_test.rs
@@ -52,7 +52,12 @@ pub async fn run() -> Result<()> {
 
     // We want a zebra state dir and a lightwalletd data dir in place,
     // so `UpdateCachedState` can be used as our test type
-    let test_type = UpdateCachedState;
+    //
+    // But for now, we don't want to require the cached state, because it's not ready yet.
+    // TODO: use `UpdateCachedState`
+    let test_type = FullSyncFromGenesis {
+        allow_lightwalletd_cached_state: true,
+    };
 
     let cached_state_path = test_type.zebrad_state_path("send_transaction_tests".to_string());
     if cached_state_path.is_none() {

--- a/zebrad/tests/common/lightwalletd/send_transaction_test.rs
+++ b/zebrad/tests/common/lightwalletd/send_transaction_test.rs
@@ -36,8 +36,7 @@ use crate::common::{
     lightwalletd::{
         wallet_grpc::{self, connect_to_lightwalletd, spawn_lightwalletd_with_rpc_server},
         zebra_skip_lightwalletd_tests,
-        LightwalletdTestType::UpdateCachedState,
-        LIGHTWALLETD_TEST_TIMEOUT,
+        LightwalletdTestType::*,
     },
     sync::perform_full_sync_starting_from,
 };
@@ -71,11 +70,8 @@ pub async fn run() -> Result<()> {
     let (transactions, partial_sync_path) =
         load_transactions_from_a_future_block(network, cached_state_path.unwrap()).await?;
 
-    let (_zebrad, zebra_rpc_address) = spawn_zebrad_for_rpc_without_initial_peers(
-        Network::Mainnet,
-        partial_sync_path,
-        LIGHTWALLETD_TEST_TIMEOUT,
-    )?;
+    let (_zebrad, zebra_rpc_address) =
+        spawn_zebrad_for_rpc_without_initial_peers(Network::Mainnet, partial_sync_path, test_type)?;
 
     let (_lightwalletd, lightwalletd_rpc_port) = spawn_lightwalletd_with_rpc_server(
         zebra_rpc_address,

--- a/zebrad/tests/common/lightwalletd/wallet_grpc_test.rs
+++ b/zebrad/tests/common/lightwalletd/wallet_grpc_test.rs
@@ -47,7 +47,6 @@ use crate::common::{
         },
         zebra_skip_lightwalletd_tests,
         LightwalletdTestType::UpdateCachedState,
-        LIGHTWALLETD_TEST_TIMEOUT,
     },
 };
 
@@ -80,11 +79,8 @@ pub async fn run() -> Result<()> {
     let network = Network::Mainnet;
 
     // Launch zebra using a predefined zebrad state path
-    let (_zebrad, zebra_rpc_address) = spawn_zebrad_for_rpc_without_initial_peers(
-        network,
-        zebrad_state_path.unwrap(),
-        LIGHTWALLETD_TEST_TIMEOUT,
-    )?;
+    let (_zebrad, zebra_rpc_address) =
+        spawn_zebrad_for_rpc_without_initial_peers(network, zebrad_state_path.unwrap(), test_type)?;
 
     // Launch lightwalletd
     let (_lightwalletd, lightwalletd_rpc_port) = spawn_lightwalletd_with_rpc_server(


### PR DESCRIPTION
## Motivation

We want to get the send transaction test working soon.

This PR stops requiring cached lightwalletd state for the send transaction tests.
(We can add the cached lightwalletd state later.)

## Solution

- Temporarily stop requiring cached lightwalletd state for the send transaction test

Related fixes:
- In tests, expect a Zebra cached state that is near the tip
- Consistently use the same `zebrad` timeouts and failure conditions in lightwalletd tests

## Review

This PR blocks PR #4267, it is urgent.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

