### PR TITLE
fix(ci): add cached state version to disk images

### DIFF
--- a/.github/workflows/gcp-test-deploy.yml
+++ b/.github/workflows/gcp-test-deploy.yml
@@ -56,6 +56,10 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
+      - uses: actions/checkout@v3.0.2
+        with:
+          persist-credentials: false
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
         with:


### PR DESCRIPTION
## Motivation

After the workflow refactor, the disk images are being built without the cached state version number in the images name. Causing failures in CI as this information is confirmed before starting a test.

## Solution

- The repo code was not being checked out to allow a grep on the file

## Review

Anyone from @ZcashFoundation/devops-reviewers 

