### PR TITLE
fix(lint): stop actionlint from failing in main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -116,5 +116,5 @@ jobs:
       - uses: actions/checkout@v3.0.2
       - uses: reviewdog/action-actionlint@v1.24.0
         with:
-          reporter: github-check
+          level: warning
           fail_on_error: false


### PR DESCRIPTION
## Motivation

This linter has been failing on each push to main. I'm changing the configuration to reduce this noise.

## Solution

- Remove the reporter
- Make warning the highest level

## Review

Anyone can review this