### PR TITLE
change(deps): update locked version of indirect dependency `crossbeam-channel` to `0.5.4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
The previously locked version (`0.5.2`) was [yanked](https://docs.rs/crossbeam-channel/0.5.2/crossbeam_channel/) from `crates.io`.

Depends-On: #4332

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->
I ran

```
cargo update -p crossbeam-channel
```

to force Cargo to update `Cargo.toml` to the latest compatible version of `crossbeam-channel`.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

