### PR TITLE
Fix incorrect AddressBalance name in diagram

### DIFF
--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -688,7 +688,7 @@ graph TD;
     OutputLocation ==> OutputIndex;
     AddressLocation -.->|"utxo_loc_by_transparent_addr_loc<br/>(AddressUnspentOutput[16])"| OutputLocation;
 
-    AddressBalance["AddressLocation[8]"];
+    AddressBalance["AddressBalance[16]"];
     Amount["Amount[8]"];
     Height["Height[3]"];
     Address["Address[21]"];

--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -688,7 +688,7 @@ graph TD;
     OutputLocation ==> OutputIndex;
     AddressLocation -.->|"utxo_loc_by_transparent_addr_loc<br/>(AddressUnspentOutput[16])"| OutputLocation;
 
-    AddressBalance["AddressLocation[16]"];
+    AddressBalance["AddressLocation[8]"];
     Amount["Amount[8]"];
     Height["Height[3]"];
     Address["Address[21]"];


### PR DESCRIPTION
## Motivation

I think one of the `AddressLocation`s in the new database diagram should be an `AddressBalance`.

[Rendered](https://github.com/ZcashFoundation/zebra/blob/adeb21d28b63d6bac4a543208e108319a9149454/book/src/dev/rfcs/0005-state-updates.md#rocksdb-data-structures) (scroll down)

## Review

@conradoplg will know if this is correct.


