### PR TITLE
cleanup(clippy): Remove redundant bindings, allocations, and generics

### DIFF
--- a/tower-batch/tests/ed25519.rs
+++ b/tower-batch/tests/ed25519.rs
@@ -38,7 +38,7 @@ impl Ed25519Verifier {
 
 pub type Ed25519Item = batch::Item;
 
-impl<'msg> Service<BatchControl<Ed25519Item>> for Ed25519Verifier {
+impl Service<BatchControl<Ed25519Item>> for Ed25519Verifier {
     type Response = ();
     type Error = Error;
     type Future = Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'static>>;

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -1,6 +1,6 @@
 //! Zebrad Abscissa Application
 
-use std::{io::Write, process};
+use std::{fmt::Write as _, io::Write as _, process};
 
 use abscissa_core::{
     application::{self, fatal_error, AppCell},
@@ -263,7 +263,8 @@ impl Application for ZebradApp {
         let mut metadata_section = "Metadata:".to_string();
         for (k, v) in panic_metadata {
             builder = builder.add_issue_metadata(k, v.clone());
-            metadata_section.push_str(&format!("\n{}: {}", k, &v));
+            write!(&mut metadata_section, "\n{}: {}", k, &v)
+                .expect("unexpected failure writing to string");
         }
 
         builder = builder

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -371,7 +371,7 @@ impl Service<Request> for Mempool {
 
             // Send transactions that were not rejected nor expired to peers
             if !send_to_peers_ids.is_empty() {
-                let _ = self.transaction_sender.send(send_to_peers_ids)?;
+                self.transaction_sender.send(send_to_peers_ids)?;
             }
         }
 

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -55,7 +55,7 @@ async fn mempool_service_basic_single() -> Result<(), Report> {
         setup(network, cost_limit).await;
 
     // Enable the mempool
-    let _ = service.enable(&mut recent_syncs).await;
+    service.enable(&mut recent_syncs).await;
 
     // Insert the genesis block coinbase transaction into the mempool storage.
     let mut inserted_ids = HashSet::new();
@@ -202,7 +202,7 @@ async fn mempool_queue_single() -> Result<(), Report> {
         setup(network, cost_limit).await;
 
     // Enable the mempool
-    let _ = service.enable(&mut recent_syncs).await;
+    service.enable(&mut recent_syncs).await;
 
     // Insert [transactions...] into the mempool storage.
     // This will cause the at least one transaction to be rejected, since
@@ -286,7 +286,7 @@ async fn mempool_service_disabled() -> Result<(), Report> {
     assert!(!service.is_enabled());
 
     // Enable the mempool
-    let _ = service.enable(&mut recent_syncs).await;
+    service.enable(&mut recent_syncs).await;
 
     assert!(service.is_enabled());
 
@@ -325,7 +325,7 @@ async fn mempool_service_disabled() -> Result<(), Report> {
     assert_eq!(service.tx_downloads().in_flight(), 1);
 
     // Disable the mempool
-    let _ = service.disable(&mut recent_syncs).await;
+    service.disable(&mut recent_syncs).await;
 
     // Test if mempool is disabled again
     assert!(!service.is_enabled());
@@ -393,7 +393,7 @@ async fn mempool_cancel_mined() -> Result<(), Report> {
     time::pause();
 
     // Enable the mempool
-    let _ = mempool.enable(&mut recent_syncs).await;
+    mempool.enable(&mut recent_syncs).await;
     assert!(mempool.is_enabled());
 
     // Push the genesis block to the state
@@ -486,7 +486,7 @@ async fn mempool_cancel_downloads_after_network_upgrade() -> Result<(), Report> 
         setup(network, u64::MAX).await;
 
     // Enable the mempool
-    let _ = mempool.enable(&mut recent_syncs).await;
+    mempool.enable(&mut recent_syncs).await;
     assert!(mempool.is_enabled());
 
     // Push the genesis block to the state
@@ -560,7 +560,7 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
     time::pause();
 
     // Enable the mempool
-    let _ = mempool.enable(&mut recent_syncs).await;
+    mempool.enable(&mut recent_syncs).await;
 
     // Push the genesis block to the state, since downloader needs a valid tip.
     let genesis_block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
@@ -645,7 +645,7 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
     time::pause();
 
     // Enable the mempool
-    let _ = mempool.enable(&mut recent_syncs).await;
+    mempool.enable(&mut recent_syncs).await;
 
     // Push the genesis block to the state, since downloader needs a valid tip.
     let genesis_block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES


### PR DESCRIPTION
## Motivation

Nightly clippy has some new warnings, we should resolve them so we can build without warnings.

## Solution

- Remove redundant bindings to the unit struct `()`
- Remove a redundant string allocation
- Remove a redundant generic lifetime

## Review

Anyone can review this low priority cleanup.

### Reviewer Checklist

  - [ ] Existing tests pass

