### PR TITLE
fix(state): return non-finalized UTXOs and tx IDs in address queries

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -704,6 +704,7 @@ where
                     hashes
                         .iter()
                         .map(|(tx_loc, tx_id)| {
+                            // TODO: downgrade to debug, because there's nothing the user can do
                             assert!(
                                 *tx_loc > last_tx_location,
                                 "Transactions were not in chain order:\n\
@@ -762,6 +763,7 @@ where
                 let satoshis = u64::from(utxo_data.3.value);
 
                 let output_location = *utxo_data.2;
+                // TODO: downgrade to debug, because there's nothing the user can do
                 assert!(
                     output_location > last_output_location,
                     "UTXOs were not in chain order:\n\

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -28,7 +28,7 @@ use zebra_chain::{
 };
 use zebra_network::constants::USER_AGENT;
 use zebra_node_services::{mempool, BoxError};
-use zebra_state::OutputIndex;
+use zebra_state::{OutputIndex, OutputLocation, TransactionLocation};
 
 use crate::queue::Queue;
 
@@ -699,7 +699,23 @@ where
 
             let hashes = match response {
                 zebra_state::ReadResponse::AddressesTransactionIds(hashes) => {
-                    hashes.values().map(|tx_id| tx_id.to_string()).collect()
+                    let mut last_tx_location = TransactionLocation::from_usize(Height(0), 0);
+
+                    hashes
+                        .iter()
+                        .map(|(tx_loc, tx_id)| {
+                            assert!(
+                                *tx_loc > last_tx_location,
+                                "Transactions were not in chain order:\n\
+                                 {tx_loc:?} {tx_id:?} was after:\n\
+                                 {last_tx_location:?}",
+                            );
+
+                            last_tx_location = *tx_loc;
+
+                            tx_id.to_string()
+                        })
+                        .collect()
                 }
                 _ => unreachable!("unmatched response to a TransactionsByAddresses request"),
             };
@@ -735,6 +751,8 @@ where
                 _ => unreachable!("unmatched response to a UtxosByAddresses request"),
             };
 
+            let mut last_output_location = OutputLocation::from_usize(Height(0), 0, 0);
+
             for utxo_data in utxos.utxos() {
                 let address = utxo_data.0;
                 let txid = *utxo_data.1;
@@ -742,6 +760,14 @@ where
                 let output_index = utxo_data.2.output_index();
                 let script = utxo_data.3.lock_script.clone();
                 let satoshis = u64::from(utxo_data.3.value);
+
+                let output_location = *utxo_data.2;
+                assert!(
+                    output_location > last_output_location,
+                    "UTXOs were not in chain order:\n\
+                     {output_location:?} {address:?} {txid:?} was after:\n\
+                     {last_output_location:?}",
+                );
 
                 let entry = GetAddressUtxos {
                     address,
@@ -752,6 +778,8 @@ where
                     height,
                 };
                 response_utxos.push(entry);
+
+                last_output_location = output_location;
             }
 
             Ok(response_utxos)

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -235,17 +235,19 @@ where
     C: AsRef<Chain>,
 {
     let mut utxo_error = None;
+    let address_count = addresses.len();
 
     // Retry the finalized UTXO query if it was interrupted by a finalizing block,
     // and the non-finalized chain doesn't overlap the changed heights.
     for attempt in 0..=FINALIZED_ADDRESS_INDEX_RETRIES {
-        info!(?attempt, "starting address UTXO query");
+        info!(?attempt, ?address_count, "starting address UTXO query");
 
         let (finalized_utxos, finalized_tip_range) = finalized_transparent_utxos(db, &addresses);
 
         info!(
             finalized_utxo_count = ?finalized_utxos.len(),
             ?finalized_tip_range,
+            ?address_count,
             ?attempt,
             "finalized address UTXO response",
         );
@@ -260,6 +262,7 @@ where
                 info!(
                     chain_utxo_count = ?created_chain_utxos.len(),
                     chain_utxo_spent = ?spent_chain_utxos.len(),
+                    ?address_count,
                     ?attempt,
                     "chain address UTXO response",
                 );
@@ -271,6 +274,7 @@ where
                 info!(
                     full_utxo_count = ?utxos.len(),
                     tx_id_count = ?tx_ids.len(),
+                    ?address_count,
                     ?attempt,
                     "full address UTXO response",
                 );
@@ -279,7 +283,12 @@ where
             }
 
             Err(chain_utxo_error) => {
-                info!(?chain_utxo_error, ?attempt, "chain address UTXO response",);
+                info!(
+                    ?chain_utxo_error,
+                    ?address_count,
+                    ?attempt,
+                    "chain address UTXO response",
+                );
 
                 utxo_error = Some(Err(chain_utxo_error))
             }

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -240,11 +240,11 @@ where
     // Retry the finalized UTXO query if it was interrupted by a finalizing block,
     // and the non-finalized chain doesn't overlap the changed heights.
     for attempt in 0..=FINALIZED_ADDRESS_INDEX_RETRIES {
-        info!(?attempt, ?address_count, "starting address UTXO query");
+        debug!(?attempt, ?address_count, "starting address UTXO query");
 
         let (finalized_utxos, finalized_tip_range) = finalized_transparent_utxos(db, &addresses);
 
-        info!(
+        debug!(
             finalized_utxo_count = ?finalized_utxos.len(),
             ?finalized_tip_range,
             ?address_count,
@@ -259,7 +259,7 @@ where
         // If the UTXOs are valid, return them, otherwise, retry or return an error.
         match chain_utxo_changes {
             Ok((created_chain_utxos, spent_chain_utxos)) => {
-                info!(
+                debug!(
                     chain_utxo_count = ?created_chain_utxos.len(),
                     chain_utxo_spent = ?spent_chain_utxos.len(),
                     ?address_count,
@@ -271,7 +271,7 @@ where
                     apply_utxo_changes(finalized_utxos, created_chain_utxos, spent_chain_utxos);
                 let tx_ids = lookup_tx_ids_for_utxos(chain, db, &addresses, &utxos);
 
-                info!(
+                debug!(
                     full_utxo_count = ?utxos.len(),
                     tx_id_count = ?tx_ids.len(),
                     ?address_count,
@@ -283,7 +283,7 @@ where
             }
 
             Err(chain_utxo_error) => {
-                info!(
+                debug!(
                     ?chain_utxo_error,
                     ?address_count,
                     ?attempt,
@@ -364,7 +364,7 @@ where
                 "unexpected non-finalized chain when finalized state is empty"
             );
 
-            info!(
+            debug!(
                 ?finalized_tip_range,
                 ?address_count,
                 "chain address UTXO query: state is empty, no UTXOs available",
@@ -398,7 +398,7 @@ where
 
     if chain.is_none() {
         if finalized_tip_status.is_ok() {
-            info!(
+            debug!(
                 ?finalized_tip_status,
                 ?required_min_non_finalized_root,
                 ?finalized_tip_range,
@@ -411,7 +411,7 @@ where
         } else {
             // We can't compensate for inconsistent database queries,
             // because the non-finalized chain is empty.
-            info!(
+            debug!(
                 ?finalized_tip_status,
                 ?required_min_non_finalized_root,
                 ?finalized_tip_range,
@@ -442,7 +442,7 @@ where
             // If we've already committed this entire chain, ignore its UTXO changes.
             // This is more likely if the non-finalized state is just getting started.
             if finalized_tip_height >= non_finalized_tip {
-                info!(
+                debug!(
                     ?non_finalized_root,
                     ?non_finalized_tip,
                     ?finalized_tip_status,
@@ -460,7 +460,7 @@ where
             // We can't compensate for inconsistent database queries,
             // because the non-finalized chain is below the inconsistent query range.
             if *required_non_finalized_overlap.end() > non_finalized_tip.0 {
-                info!(
+                debug!(
                     ?non_finalized_root,
                     ?non_finalized_tip,
                     ?finalized_tip_status,

--- a/zebra-utils/README.md
+++ b/zebra-utils/README.md
@@ -83,6 +83,7 @@ The script:
 2. sends the RPC request to both of them using `zcash-cli`
 3. compares the responses using `diff`
 4. leaves the full responses in files in a temporary directory, so you can check them in detail
+5. if possible, compares different RPC methods for consistency
 
 Assuming `zebrad`'s RPC port is 28232, you should be able to run:
 ```sh
@@ -131,3 +132,4 @@ so you can compare two `zcashd` or `zebrad` nodes if you want.
 You can override the binaries the script calls using these environmental variables:
 - `$ZCASH_CLI`
 - `$DIFF`
+- `$JQ`

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -147,8 +147,8 @@ if [ "$1" == "getaddressbalance" ]; then
     ZEBRAD_SUM_RESPONSE="$ZCASH_RPC_TMP_DIR/zebrad-$ZEBRAD_NET-$ZEBRAD_HEIGHT-getaddressutxos-sum.txt"
     ZCASHD_SUM_RESPONSE="$ZCASH_RPC_TMP_DIR/zcashd-$ZCASHD_NET-$ZCASHD_HEIGHT-getaddressutxos-sum.txt"
 
-    cat "$ZEBRAD_RESPONSE" | $JQ 'map(.satoshis) | add' > "$ZEBRAD_SUM_RESPONSE"
-    cat "$ZCASHD_RESPONSE" | $JQ 'map(.satoshis) | add' > "$ZCASHD_SUM_RESPONSE"
+    cat "$ZEBRAD_RESPONSE" | $JQ 'map(.satoshis) | add // 0' > "$ZEBRAD_SUM_RESPONSE"
+    cat "$ZCASHD_RESPONSE" | $JQ 'map(.satoshis) | add // 0' > "$ZCASHD_SUM_RESPONSE"
 
     echo
 

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -16,7 +16,7 @@ function usage()
 
 # Override the commands used by this script using these environmental variables:
 ZCASH_CLI="${ZCASH_CLI:-zcash-cli}"
-DIFF="${DIFF:-diff --unified --color}"
+DIFF="${DIFF:-diff --unified --color=always}"
 
 if [ $# -lt 2 ]; then
     usage

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -29,16 +29,35 @@ shift
 
 ZCASH_RPC_TMP_DIR=$(mktemp -d)
 
-ZEBRAD_BLOCKCHAIN_INFO="$ZCASH_RPC_TMP_DIR/zebrad-check-getblockchaininfo.json"
-ZCASHD_BLOCKCHAIN_INFO="$ZCASH_RPC_TMP_DIR/zcashd-check-getblockchaininfo.json"
+ZEBRAD_RELEASE_INFO="$ZCASH_RPC_TMP_DIR/first-check-getinfo.json"
+ZCASHD_RELEASE_INFO="$ZCASH_RPC_TMP_DIR/second-check-getinfo.json"
 
-echo "Checking zebrad network and tip height..."
+echo "Checking first node release info..."
+$ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" getinfo > "$ZEBRAD_RELEASE_INFO"
+
+ZEBRAD=$(cat "$ZEBRAD_RELEASE_INFO" | grep '"subversion"' | cut -d: -f2 | cut -d/ -f2 | \
+             sed 's/MagicBean/zcashd/' | tr 'A-Z' 'a-z')
+
+echo "Checking second node release info..."
+$ZCASH_CLI getinfo > "$ZCASHD_RELEASE_INFO"
+
+ZCASHD=$(cat "$ZCASHD_RELEASE_INFO" | grep '"subversion"' | cut -d: -f2 | cut -d/ -f2 | \
+             sed 's/MagicBean/zcashd/' | tr 'A-Z' 'a-z')
+
+echo "Connected to $ZEBRAD and $ZCASHD."
+
+echo
+
+ZEBRAD_BLOCKCHAIN_INFO="$ZCASH_RPC_TMP_DIR/$ZEBRAD-check-getblockchaininfo.json"
+ZCASHD_BLOCKCHAIN_INFO="$ZCASH_RPC_TMP_DIR/$ZCASHD-check-getblockchaininfo.json"
+
+echo "Checking $ZEBRAD network and tip height..."
 $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" getblockchaininfo > "$ZEBRAD_BLOCKCHAIN_INFO"
 
 ZEBRAD_NET=$(cat "$ZEBRAD_BLOCKCHAIN_INFO" | grep '"chain"' | cut -d: -f2 | tr -d ' ,"')
 ZEBRAD_HEIGHT=$(cat "$ZEBRAD_BLOCKCHAIN_INFO" | grep '"blocks"' | cut -d: -f2 | tr -d ' ,"')
 
-echo "Checking zcashd network and tip height..."
+echo "Checking $ZCASHD network and tip height..."
 $ZCASH_CLI getblockchaininfo > "$ZCASHD_BLOCKCHAIN_INFO"
 
 ZCASHD_NET=$(cat "$ZCASHD_BLOCKCHAIN_INFO" | grep '"chain"' | cut -d: -f2 | tr -d ' ,"')
@@ -48,35 +67,35 @@ echo
 
 if [ "$ZEBRAD_NET" != "$ZCASHD_NET" ]; then
     echo "WARNING: comparing RPC responses from different networks:"
-    echo "zcashd is on: $ZCASHD_NET"
-    echo "zebrad is on: $ZEBRAD_NET"
+    echo "$ZCASHD is on: $ZCASHD_NET"
+    echo "$ZEBRAD is on: $ZEBRAD_NET"
     echo
 fi
 
 if [ "$ZEBRAD_HEIGHT" -ne "$ZCASHD_HEIGHT" ]; then
     echo "WARNING: comparing RPC responses from different heights:"
-    echo "zcashd is at: $ZCASHD_HEIGHT"
-    echo "zebrad is at: $ZEBRAD_HEIGHT"
+    echo "$ZCASHD is at: $ZCASHD_HEIGHT"
+    echo "$ZEBRAD is at: $ZEBRAD_HEIGHT"
     echo
 fi
 
-ZEBRAD_RESPONSE="$ZCASH_RPC_TMP_DIR/zebrad-$ZEBRAD_NET-$ZEBRAD_HEIGHT-$1.json"
-ZCASHD_RESPONSE="$ZCASH_RPC_TMP_DIR/zcashd-$ZCASHD_NET-$ZCASHD_HEIGHT-$1.json"
+ZEBRAD_RESPONSE="$ZCASH_RPC_TMP_DIR/$ZEBRAD-$ZEBRAD_NET-$ZEBRAD_HEIGHT-$1.json"
+ZCASHD_RESPONSE="$ZCASH_RPC_TMP_DIR/$ZCASHD-$ZCASHD_NET-$ZCASHD_HEIGHT-$1.json"
 
 echo "Request:"
 echo "$@"
 echo
 
-echo "Querying zebrad $ZEBRAD_NET chain at height >=$ZEBRAD_HEIGHT..."
+echo "Querying $ZEBRAD $ZEBRAD_NET chain at height >=$ZEBRAD_HEIGHT..."
 $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" "$@" > "$ZEBRAD_RESPONSE"
 
-echo "Querying zcashd $ZCASHD_NET chain at height >=$ZCASHD_HEIGHT..."
+echo "Querying $ZCASHD $ZCASHD_NET chain at height >=$ZCASHD_HEIGHT..."
 $ZCASH_CLI "$@" > "$ZCASHD_RESPONSE"
 
 echo
 
 echo "Response diff:"
-echo "(between zcashd port and port $ZEBRAD_RPC_PORT)"
+echo "(between $ZCASHD port and $ZEBRAD port $ZEBRAD_RPC_PORT)"
 
 $DIFF "$ZEBRAD_RESPONSE" "$ZCASHD_RESPONSE" \
     && ( \
@@ -101,8 +120,8 @@ else
     exit $EXIT_STATUS
 fi
 
-ZEBRAD_CHECK_RESPONSE="$ZCASH_RPC_TMP_DIR/zebrad-$ZEBRAD_NET-$ZEBRAD_HEIGHT-$1.json"
-ZCASHD_CHECK_RESPONSE="$ZCASH_RPC_TMP_DIR/zcashd-$ZCASHD_NET-$ZCASHD_HEIGHT-$1.json"
+ZEBRAD_CHECK_RESPONSE="$ZCASH_RPC_TMP_DIR/$ZEBRAD-$ZEBRAD_NET-$ZEBRAD_HEIGHT-$1.json"
+ZCASHD_CHECK_RESPONSE="$ZCASH_RPC_TMP_DIR/$ZCASHD-$ZCASHD_NET-$ZCASHD_HEIGHT-$1.json"
 
 echo
 
@@ -110,16 +129,16 @@ echo "Cross-checking request:"
 echo "$@"
 echo
 
-echo "Querying zebrad $ZEBRAD_NET chain at height >=$ZEBRAD_HEIGHT..."
+echo "Querying $ZEBRAD $ZEBRAD_NET chain at height >=$ZEBRAD_HEIGHT..."
 $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" "$@" > "$ZEBRAD_CHECK_RESPONSE"
 
-echo "Querying zcashd $ZCASHD_NET chain at height >=$ZCASHD_HEIGHT..."
+echo "Querying $ZCASHD $ZCASHD_NET chain at height >=$ZCASHD_HEIGHT..."
 $ZCASH_CLI "$@" > "$ZCASHD_CHECK_RESPONSE"
 
 echo
 
 echo "Cross-check $1 response diff:"
-echo "(between zcashd port and port $ZEBRAD_RPC_PORT)"
+echo "(between $ZCASHD port and $ZEBRAD port $ZEBRAD_RPC_PORT)"
 
 $DIFF "$ZEBRAD_CHECK_RESPONSE" "$ZCASHD_CHECK_RESPONSE" \
     && ( \
@@ -136,16 +155,16 @@ if [ "$1" == "getaddressbalance" ]; then
 
     echo "Extracting getaddressbalance.balance..."
 
-    ZEBRAD_NUM_RESPONSE="$ZCASH_RPC_TMP_DIR/zebrad-$ZEBRAD_NET-$ZEBRAD_HEIGHT-getaddressbalance-num.txt"
-    ZCASHD_NUM_RESPONSE="$ZCASH_RPC_TMP_DIR/zcashd-$ZCASHD_NET-$ZCASHD_HEIGHT-getaddressbalance-num.txt"
+    ZEBRAD_NUM_RESPONSE="$ZCASH_RPC_TMP_DIR/$ZEBRAD-$ZEBRAD_NET-$ZEBRAD_HEIGHT-getaddressbalance-num.txt"
+    ZCASHD_NUM_RESPONSE="$ZCASH_RPC_TMP_DIR/$ZCASHD-$ZCASHD_NET-$ZCASHD_HEIGHT-getaddressbalance-num.txt"
 
     cat "$ZEBRAD_CHECK_RESPONSE" | $JQ '.balance' > "$ZEBRAD_NUM_RESPONSE"
     cat "$ZCASHD_CHECK_RESPONSE" | $JQ '.balance' > "$ZCASHD_NUM_RESPONSE"
 
     echo "Summing getaddressutxos.satoshis..."
 
-    ZEBRAD_SUM_RESPONSE="$ZCASH_RPC_TMP_DIR/zebrad-$ZEBRAD_NET-$ZEBRAD_HEIGHT-getaddressutxos-sum.txt"
-    ZCASHD_SUM_RESPONSE="$ZCASH_RPC_TMP_DIR/zcashd-$ZCASHD_NET-$ZCASHD_HEIGHT-getaddressutxos-sum.txt"
+    ZEBRAD_SUM_RESPONSE="$ZCASH_RPC_TMP_DIR/$ZEBRAD-$ZEBRAD_NET-$ZEBRAD_HEIGHT-getaddressutxos-sum.txt"
+    ZCASHD_SUM_RESPONSE="$ZCASH_RPC_TMP_DIR/$ZCASHD-$ZCASHD_NET-$ZCASHD_HEIGHT-getaddressutxos-sum.txt"
 
     cat "$ZEBRAD_RESPONSE" | $JQ 'map(.satoshis) | add // 0' > "$ZEBRAD_SUM_RESPONSE"
     cat "$ZCASHD_RESPONSE" | $JQ 'map(.satoshis) | add // 0' > "$ZCASHD_SUM_RESPONSE"
@@ -153,7 +172,8 @@ if [ "$1" == "getaddressbalance" ]; then
     echo
 
     echo "Balance diff:"
-    echo "(between zcashd port and port $ZEBRAD_RPC_PORT, for getaddressbalance and getaddressutxos)"
+    echo "(between $ZCASHD port and $ZEBRAD port $ZEBRAD_RPC_PORT,"
+    echo "for both getaddressbalance and getaddressutxos)"
 
     $DIFF --from-file="$ZEBRAD_NUM_RESPONSE" "$ZCASHD_NUM_RESPONSE" \
           "$ZEBRAD_SUM_RESPONSE" "$ZCASHD_SUM_RESPONSE" \

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -17,6 +17,7 @@ function usage()
 # Override the commands used by this script using these environmental variables:
 ZCASH_CLI="${ZCASH_CLI:-zcash-cli}"
 DIFF="${DIFF:-diff --unified --color=always}"
+JQ="${JQ:-jq}"
 
 if [ $# -lt 2 ]; then
     usage
@@ -66,15 +67,17 @@ echo "Request:"
 echo "$@"
 echo
 
-echo "Querying zebrad $ZEBRAD_NET chain at height $ZEBRAD_HEIGHT..."
+echo "Querying zebrad $ZEBRAD_NET chain at height >=$ZEBRAD_HEIGHT..."
 $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" "$@" > "$ZEBRAD_RESPONSE"
 
-echo "Querying zcashd $ZCASHD_NET chain at height $ZCASHD_HEIGHT..."
+echo "Querying zcashd $ZCASHD_NET chain at height >=$ZCASHD_HEIGHT..."
 $ZCASH_CLI "$@" > "$ZCASHD_RESPONSE"
 
 echo
 
-echo "Response diff (between zcashd port and port $ZEBRAD_RPC_PORT):"
+echo "Response diff:"
+echo "(between zcashd port and port $ZEBRAD_RPC_PORT)"
+
 $DIFF "$ZEBRAD_RESPONSE" "$ZCASHD_RESPONSE" \
     && ( \
         echo "RPC responses were identical"; \
@@ -82,3 +85,94 @@ $DIFF "$ZEBRAD_RESPONSE" "$ZCASHD_RESPONSE" \
         echo "$ZEBRAD_RESPONSE:"; \
         cat "$ZEBRAD_RESPONSE"; \
         )
+
+EXIT_STATUS=$?
+
+# Consistency checks between RPCs
+#
+# TODO:
+# - sum of getaddressutxos.satoshis equals getaddressbalance
+# - set of getaddressutxos.txid is a subset of getaddresstxids <addresses> 1 <max height>
+# - getblockchaininfo.bestblockhash equals getbestblockhash
+
+if [ "$1" == "getaddressutxos" ]; then
+    set "getaddressbalance" "$2"
+else
+    exit $EXIT_STATUS
+fi
+
+ZEBRAD_CHECK_RESPONSE="$ZCASH_RPC_TMP_DIR/zebrad-$ZEBRAD_NET-$ZEBRAD_HEIGHT-$1.json"
+ZCASHD_CHECK_RESPONSE="$ZCASH_RPC_TMP_DIR/zcashd-$ZCASHD_NET-$ZCASHD_HEIGHT-$1.json"
+
+echo
+
+echo "Cross-checking request:"
+echo "$@"
+echo
+
+echo "Querying zebrad $ZEBRAD_NET chain at height >=$ZEBRAD_HEIGHT..."
+$ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" "$@" > "$ZEBRAD_CHECK_RESPONSE"
+
+echo "Querying zcashd $ZCASHD_NET chain at height >=$ZCASHD_HEIGHT..."
+$ZCASH_CLI "$@" > "$ZCASHD_CHECK_RESPONSE"
+
+echo
+
+echo "Cross-check $1 response diff:"
+echo "(between zcashd port and port $ZEBRAD_RPC_PORT)"
+
+$DIFF "$ZEBRAD_CHECK_RESPONSE" "$ZCASHD_CHECK_RESPONSE" \
+    && ( \
+        echo "RPC check responses were identical"; \
+        echo ; \
+        echo "$ZEBRAD_CHECK_RESPONSE:"; \
+        cat "$ZEBRAD_CHECK_RESPONSE"; \
+        )
+
+CHECK_EXIT_STATUS=$?
+
+if [ "$1" == "getaddressbalance" ]; then
+    echo
+
+    echo "Extracting getaddressbalance.balance..."
+
+    ZEBRAD_NUM_RESPONSE="$ZCASH_RPC_TMP_DIR/zebrad-$ZEBRAD_NET-$ZEBRAD_HEIGHT-getaddressbalance-num.txt"
+    ZCASHD_NUM_RESPONSE="$ZCASH_RPC_TMP_DIR/zcashd-$ZCASHD_NET-$ZCASHD_HEIGHT-getaddressbalance-num.txt"
+
+    cat "$ZEBRAD_CHECK_RESPONSE" | $JQ '.balance' > "$ZEBRAD_NUM_RESPONSE"
+    cat "$ZCASHD_CHECK_RESPONSE" | $JQ '.balance' > "$ZCASHD_NUM_RESPONSE"
+
+    echo "Summing getaddressutxos.satoshis..."
+
+    ZEBRAD_SUM_RESPONSE="$ZCASH_RPC_TMP_DIR/zebrad-$ZEBRAD_NET-$ZEBRAD_HEIGHT-getaddressutxos-sum.txt"
+    ZCASHD_SUM_RESPONSE="$ZCASH_RPC_TMP_DIR/zcashd-$ZCASHD_NET-$ZCASHD_HEIGHT-getaddressutxos-sum.txt"
+
+    cat "$ZEBRAD_RESPONSE" | $JQ 'map(.satoshis) | add' > "$ZEBRAD_SUM_RESPONSE"
+    cat "$ZCASHD_RESPONSE" | $JQ 'map(.satoshis) | add' > "$ZCASHD_SUM_RESPONSE"
+
+    echo
+
+    echo "Balance diff:"
+    echo "(between zcashd port and port $ZEBRAD_RPC_PORT, for getaddressbalance and getaddressutxos)"
+
+    $DIFF --from-file="$ZEBRAD_NUM_RESPONSE" "$ZCASHD_NUM_RESPONSE" \
+          "$ZEBRAD_SUM_RESPONSE" "$ZCASHD_SUM_RESPONSE" \
+        && ( \
+             echo "RPC balances were identical"; \
+             echo ; \
+             echo "$ZEBRAD_NUM_RESPONSE:"; \
+             cat "$ZEBRAD_NUM_RESPONSE"; \
+        )
+
+    COMPARE_EXIT_STATUS=$?
+
+    if [ $COMPARE_EXIT_STATUS -ne 0 ]; then
+        exit $COMPARE_EXIT_STATUS
+    fi
+fi
+
+if [ $EXIT_STATUS -ne 0 ]; then
+    exit $EXIT_STATUS
+else
+    exit $CHECK_EXIT_STATUS
+fi

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -36,13 +36,13 @@ echo "Checking first node release info..."
 $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" getinfo > "$ZEBRAD_RELEASE_INFO"
 
 ZEBRAD=$(cat "$ZEBRAD_RELEASE_INFO" | grep '"subversion"' | cut -d: -f2 | cut -d/ -f2 | \
-             sed 's/MagicBean/zcashd/' | tr 'A-Z' 'a-z')
+             tr 'A-Z' 'a-z' | sed 's/magicbean/zcashd/ ; s/zebra$/zebrad/')
 
 echo "Checking second node release info..."
 $ZCASH_CLI getinfo > "$ZCASHD_RELEASE_INFO"
 
 ZCASHD=$(cat "$ZCASHD_RELEASE_INFO" | grep '"subversion"' | cut -d: -f2 | cut -d/ -f2 | \
-             sed 's/MagicBean/zcashd/' | tr 'A-Z' 'a-z')
+             tr 'A-Z' 'a-z' | sed 's/magicbean/zcashd/ ; s/zebra$/zebrad/')
 
 echo "Connected to $ZEBRAD (port $ZEBRAD_RPC_PORT) and $ZCASHD ($ZCASH_CLI zcash.conf port)."
 

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -44,7 +44,7 @@ $ZCASH_CLI getinfo > "$ZCASHD_RELEASE_INFO"
 ZCASHD=$(cat "$ZCASHD_RELEASE_INFO" | grep '"subversion"' | cut -d: -f2 | cut -d/ -f2 | \
              sed 's/MagicBean/zcashd/' | tr 'A-Z' 'a-z')
 
-echo "Connected to $ZEBRAD and $ZCASHD."
+echo "Connected to $ZEBRAD (port $ZEBRAD_RPC_PORT) and $ZCASHD ($ZCASH_CLI zcash.conf port)."
 
 echo
 
@@ -94,8 +94,7 @@ $ZCASH_CLI "$@" > "$ZCASHD_RESPONSE"
 
 echo
 
-echo "Response diff:"
-echo "(between $ZCASHD port and $ZEBRAD port $ZEBRAD_RPC_PORT)"
+echo "Response diff between $ZCASHD and $ZEBRAD:"
 
 $DIFF "$ZEBRAD_RESPONSE" "$ZCASHD_RESPONSE" \
     && ( \
@@ -137,8 +136,7 @@ $ZCASH_CLI "$@" > "$ZCASHD_CHECK_RESPONSE"
 
 echo
 
-echo "Cross-check $1 response diff:"
-echo "(between $ZCASHD port and $ZEBRAD port $ZEBRAD_RPC_PORT)"
+echo "$1 diff between $ZCASHD and $ZEBRAD:"
 
 $DIFF "$ZEBRAD_CHECK_RESPONSE" "$ZCASHD_CHECK_RESPONSE" \
     && ( \
@@ -171,9 +169,8 @@ if [ "$1" == "getaddressbalance" ]; then
 
     echo
 
-    echo "Balance diff:"
-    echo "(between $ZCASHD port and $ZEBRAD port $ZEBRAD_RPC_PORT,"
-    echo "for both getaddressbalance and getaddressutxos)"
+    echo "Balance diff between $ZCASHD and $ZEBRAD:"
+    echo "(for both getaddressbalance and getaddressutxos)"
 
     $DIFF --from-file="$ZEBRAD_NUM_RESPONSE" "$ZCASHD_NUM_RESPONSE" \
           "$ZEBRAD_SUM_RESPONSE" "$ZCASHD_SUM_RESPONSE" \


### PR DESCRIPTION
## Motivation

When I compare `zebrad` and `zcashd` RPC responses for `getaddressutxos`, using this command:
```sh
zebra-utils/zcash-rpc-diff 28232 getaddressutxos '{ "addresses": ["t3dvVE3SQEi7kqNzwrfNePxZ1d4hUyztBA1"] }'
```

All the non-finalized UTXOs are missing.

`getaddresstxids` has a similar bug.

### Specifications

The RPCs should return all relevant UTXOs and tx IDs, regardless of Zebra's internal architecture:
https://zcash.github.io/rpc/getaddressutxos.html
https://zcash.github.io/rpc/getaddresstxids.html

### Designs

Compare the correct chain heights when matching up finalized database queries with non-finalized chains.

## Solution

- Stop ignoring all non-finalized UTXOs in address queries
- Stop ignoring all non-finalized tx IDs in address queries

Related changes:
- Log address UTXOs and tx ID request processing
- Assert that address TxIDs and UTXOs are in chain order

Testing:
- Cross-check getaddressutxos and getaddressbalance in zcash-rpc-diff
- Always output colour by default in zcash-rpc-diff
- Display the actual connected node software in zcash-rpc-diff

After these fixes, the UTXOs and balances are the same in Zebra and `zcashd`, except for a slightly different UTXO order (`zcashd` returns coinbase transactions last in each block).

Close #4220

## Review

Anyone can review this PR, we should fix this bug before we write tests that depend on it.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
