### PR TITLE
fix(ci): wrong file being referenced by CI

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -197,7 +197,7 @@ jobs:
   # Test that Zebra syncs and fully validates a few thousand blocks from a cached mandatory checkpoint disk
   test-stateful-sync:
     needs: build
-    uses: ./.github/workflows/gcp-test-deploy.yml
+    uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
     with:
       test_id: sync-past-checkpoint
@@ -231,7 +231,7 @@ jobs:
   # Test that Zebra can answer a synthetic RPC call, using a cached Zebra tip state
   lightwalletd-rpc-test:
     needs: build
-    uses: ./.github/workflows/gcp-test-deploy.yml
+    uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
     with:
       app_name: lightwalletd
@@ -248,7 +248,7 @@ jobs:
   # TODO: use a cached lightwalletd tip state to speed up the test (#4303)
   lightwalletd-transactions-test:
     needs: build
-    uses: ./.github/workflows/gcp-test-deploy.yml
+    uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
     with:
       app_name: lightwalletd


### PR DESCRIPTION
## Motivation

When working with https://github.com/ZcashFoundation/zebra/pull/3941 an old reference was kept (introducing a bug). This wasn't raised in the checks as this makes the workflow crash, and the only way to realize it is if the Actions tabs is manually checked


## Solution

- Replace the old name by the new one

## Review

Anyone from @ZcashFoundation/devops-reviewers 
