### PR TITLE
fix(ci): allow builds over 1 hour and tests without the sentry feature

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -85,6 +85,10 @@ jobs:
           workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
+          # Some builds might take over an hour, and Google's default lifetime duration for
+          # an access token is 1 hour (3600s). We increase this to 3 hours (10800s)
+          # as some builds take over an hour.
+          access_token_lifetime: 10800s
 
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v2.0.0

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Run all zebrad tests
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run --name zebrad-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features enable-sentry --workspace -- --include-ignored
+          docker run --name zebrad-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --workspace -- --include-ignored
 
   # This test changes zebra-chain's activation heights,
   # which can recompile all the Zebra crates,
@@ -155,7 +155,7 @@ jobs:
       - name: Run zebrad large sync tests
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run --name zebrad-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features enable-sentry --test acceptance sync_large_checkpoints_ -- --ignored
+          docker run --name zebrad-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --test acceptance sync_large_checkpoints_ -- --ignored
 
   # Test launching lightwalletd with an empty lightwalletd and Zebra state
   test-lightwalletd-integration:
@@ -172,7 +172,7 @@ jobs:
       - name: Run tests with empty lightwalletd launch
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run -e ZEBRA_TEST_LIGHTWALLETD --name lightwalletd-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features enable-sentry --test acceptance -- lightwalletd_integration --nocapture
+          docker run -e ZEBRA_TEST_LIGHTWALLETD --name lightwalletd-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --test acceptance -- lightwalletd_integration --nocapture
         env:
           ZEBRA_TEST_LIGHTWALLETD: '1'
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,17 +5,17 @@ set -x
 case "$1" in
     -- | cargo)
         if [[ "$RUN_ALL_TESTS" -eq "1" ]]; then
-            exec cargo "test" "--locked" "--release" "--features" "enable-sentry" "--workspace" "--" "--include-ignored"
+            exec cargo "test" "--locked" "--release" "--workspace" "--" "--include-ignored"
         elif [[ "$TEST_FULL_SYNC" -eq "1" ]]; then
-            exec cargo "test" "--locked" "--release" "--features" "enable-sentry" "--test" "acceptance" "--" "--nocapture" "--ignored" "full_sync_mainnet"
+            exec cargo "test" "--locked" "--release" "--test" "acceptance" "--" "--nocapture" "--ignored" "full_sync_mainnet"
         elif [[ "$TEST_DISK_REBUILD" -eq "1" ]]; then
-            exec cargo "test" "--locked" "--release" "--features" "enable-sentry,test_sync_to_mandatory_checkpoint_${NETWORK,,}" "--manifest-path" "zebrad/Cargo.toml" "sync_to_mandatory_checkpoint_${NETWORK,,}"
+            exec cargo "test" "--locked" "--release" "--features" "test_sync_to_mandatory_checkpoint_${NETWORK,,}" "--manifest-path" "zebrad/Cargo.toml" "sync_to_mandatory_checkpoint_${NETWORK,,}"
         elif [[ "$TEST_CHECKPOINT_SYNC" -eq "1" ]]; then
-            exec cargo "test" "--locked" "--release" "--features" "enable-sentry,test_sync_past_mandatory_checkpoint_${NETWORK,,}" "--manifest-path" "zebrad/Cargo.toml" "sync_past_mandatory_checkpoint_${NETWORK,,}"
+            exec cargo "test" "--locked" "--release" "--features" "test_sync_past_mandatory_checkpoint_${NETWORK,,}" "--manifest-path" "zebrad/Cargo.toml" "sync_past_mandatory_checkpoint_${NETWORK,,}"
         elif [[ "$TEST_LWD_RPC_CALL" -eq "1" ]]; then
-            exec cargo "test" "--locked" "--release" "--features" "enable-sentry" "--test" "acceptance" "--" "--nocapture" "--ignored" "fully_synced_rpc_test"
+            exec cargo "test" "--locked" "--release" "--test" "acceptance" "--" "--nocapture" "--ignored" "fully_synced_rpc_test"
         elif [[ "$TEST_LWD_TRANSACTIONS" -eq "1" ]]; then
-            exec cargo "test" "--locked" "--release" "--features" "enable-sentry" "--test" "acceptance" "--" "--nocapture" "--ignored" "sending_transactions_using_lightwalletd"
+            exec cargo "test" "--locked" "--release" "--test" "acceptance" "--" "--nocapture" "--ignored" "sending_transactions_using_lightwalletd"
         else
             exec "$@"
         fi


### PR DESCRIPTION
## Motivation

After implementing https://github.com/ZcashFoundation/zebra/pull/4298 we were still hitting the issue from https://github.com/ZcashFoundation/zebra/issues/4234 and, additionally, some tests were failing as in #4298 we removed the sentry feature from the tests build.

Fixes #4234 

## Solution

- Add 3 hours to the access token expiration, which would allow longer build times
- Remove `--features enable-sentry` from all the tests, as this feature is no longer included in the Dockerfile for test builds.

## Review

@conradoplg or @dconnolly  can review this one
