### PR TITLE
fix(deps): drop sentry dependencies when enable-sentry feature is disabled

### DIFF
--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -11,9 +11,13 @@ default-run = "zebrad"
 
 [features]
 default = []
+
+# Production features that activate extra dependencies
+enable-sentry = ["sentry", "sentry-tracing"]
+
+# Testing features that activate extra dependencies
 proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl", "zebra-state/proptest-impl", "zebra-consensus/proptest-impl", "zebra-network/proptest-impl"]
 
-enable-sentry = []
 test_sync_to_mandatory_checkpoint_mainnet = []
 test_sync_to_mandatory_checkpoint_testnet = []
 test_sync_past_mandatory_checkpoint_mainnet = []
@@ -57,12 +61,14 @@ dirs = "4.0.0"
 inferno = { version = "0.11.3", default-features = false }
 atty = "0.2.14"
 
-sentry-tracing = "0.23.0"
-sentry = { version = "0.23.0", default-features = false, features = ["backtrace", "contexts", "reqwest", "rustls"] }
-
 num-integer = "0.1.45"
 rand = { version = "0.8.5", package = "rand" }
 
+# prod feature enable-sentry
+sentry-tracing = { version = "0.23.0", optional = true }
+sentry = { version = "0.23.0", default-features = false, features = ["backtrace", "contexts", "reqwest", "rustls"], optional = true }
+
+# test feature proptest-impl
 proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -1,3 +1,5 @@
+//! The Abscissa component for Zebra's `tracing` implementation.
+
 use abscissa_core::{Component, FrameworkError, FrameworkErrorKind, Shutdown};
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{
@@ -48,10 +50,11 @@ impl Tracing {
             None
         };
 
-        let subscriber = builder
-            .finish()
-            .with(ErrorLayer::default())
-            .with(sentry_tracing::layer());
+        let subscriber = builder.finish().with(ErrorLayer::default());
+
+        #[cfg(feature = "enable-sentry")]
+        let subscriber = subscriber.with(sentry_tracing::layer());
+
         match (flamelayer, journaldlayer) {
             (None, None) => subscriber.init(),
             (Some(layer1), None) => subscriber.with(layer1).init(),

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -36,4 +36,6 @@ pub mod commands;
 pub mod components;
 pub mod config;
 pub mod prelude;
+
+#[cfg(feature = "enable-sentry")]
 pub mod sentry;


### PR DESCRIPTION
## Motivation

Zebra's `enable-sentry` feature enables sentry monitoring. But when it is disabled, the sentry dependencies and Zebra code are still compiled.

## Solution

When `enable-sentry` is off:
- Don't compile Zebra sentry code
- Drop sentry dependencies

## Review

Anyone can review this PR, it's a bit urgent because it blocks a PR that fixes a build failure.

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- fix #4367