### PR TITLE
fix(rpc): fixes for RPC snapshot tests

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -57,8 +57,12 @@ skip-tree = [
     # wait for halo2 to upgrade
     { name = "blake2b_simd", version = "=0.5.11" },
 
-    # wait for zcash_primitives to remove duplicated dependency
+    # wait for zcash_primitives to remove duplicated dependencies
+    { name = "block-buffer", version = "=0.7.3" },
     { name = "block-buffer", version = "=0.9.0" },
+
+    # wait for insta to remove duplicated dependencies
+    { name = "sha-1", version = "=0.8.2" },
 
     # wait for orchard -> bigint to upgrade
     { name = "crunchy", version = "=0.1.6" },

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -42,7 +42,7 @@ async fn test_rpc_response_data_for_network(network: Network) {
     let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
     // Create a populated state service
     let (_state, read_state, latest_chain_tip, _chain_tip_change) =
-        zebra_state::populated_state(blocks.clone(), Mainnet).await;
+        zebra_state::populated_state(blocks.clone(), network).await;
 
     // Init RPC
     let (rpc, _rpc_tx_queue_task_handle) = RpcImpl::new(
@@ -50,7 +50,7 @@ async fn test_rpc_response_data_for_network(network: Network) {
         Buffer::new(mempool.clone(), 1),
         read_state,
         latest_chain_tip,
-        Mainnet,
+        network,
     );
 
     // Start snapshots of RPC responses.
@@ -72,7 +72,7 @@ async fn test_rpc_response_data_for_network(network: Network) {
 
     // build addresses
     let address = &first_block_first_transaction.outputs()[1]
-        .address(Mainnet)
+        .address(network)
         .unwrap();
     let addresses = vec![address.to_string()];
 

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -1,14 +1,14 @@
-//! RPC responses
+//! Snapshot tests for Zebra JSON-RPC responses.
+
+use std::sync::Arc;
 
 use insta::dynamic_redaction;
-use std::sync::Arc;
 
 use zebra_chain::{
     block::Block,
     parameters::Network::{Mainnet, Testnet},
     serialization::ZcashDeserializeInto,
 };
-
 use zebra_network::constants::USER_AGENT;
 use zebra_node_services::BoxError;
 use zebra_test::mock_service::MockService;

--- a/zebra-rpc/src/methods/tests/snapshots/get_address_utxos@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_address_utxos@testnet_10.snap
@@ -1,11 +1,10 @@
 ---
 source: zebra-rpc/src/methods/tests/snapshot.rs
-assertion_line: 234
 expression: utxos
 ---
 [
   {
-    "address": "t3gPoRoqzu3ZpsqogjFv7VTrbS3k4ywcCQj",
+    "address": "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
     "txid": "f37e9f691fffb635de0999491d906ee85ba40cd36dae9f6e5911a8277d7c5f75",
     "outputIndex": 1,
     "script": "a914ef775f1f997f122a062fff1a2d7443abd1f9c64287",
@@ -13,7 +12,7 @@ expression: utxos
     "height": 1
   },
   {
-    "address": "t3gPoRoqzu3ZpsqogjFv7VTrbS3k4ywcCQj",
+    "address": "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
     "txid": "5822c0532da8a008259ac39933d3210e508c17e3ba21d2b2c428785efdccb3d5",
     "outputIndex": 1,
     "script": "a914ef775f1f997f122a062fff1a2d7443abd1f9c64287",
@@ -21,7 +20,7 @@ expression: utxos
     "height": 2
   },
   {
-    "address": "t3gPoRoqzu3ZpsqogjFv7VTrbS3k4ywcCQj",
+    "address": "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
     "txid": "4a3bf3f814a3aef93423890c8afa9709229aaf3daf4da98c70d810253d3b9550",
     "outputIndex": 1,
     "script": "a914ef775f1f997f122a062fff1a2d7443abd1f9c64287",
@@ -29,7 +28,7 @@ expression: utxos
     "height": 3
   },
   {
-    "address": "t3gPoRoqzu3ZpsqogjFv7VTrbS3k4ywcCQj",
+    "address": "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
     "txid": "3373ed6deb1130f310d8788db5dfdb92e52980b34ca02ea124ced11aa247f80b",
     "outputIndex": 1,
     "script": "a914ef775f1f997f122a062fff1a2d7443abd1f9c64287",
@@ -37,7 +36,7 @@ expression: utxos
     "height": 4
   },
   {
-    "address": "t3gPoRoqzu3ZpsqogjFv7VTrbS3k4ywcCQj",
+    "address": "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
     "txid": "476480f7c2580a9e39b9d78892fea996c389e6627c8962700563c19b68cc7bee",
     "outputIndex": 1,
     "script": "a914ef775f1f997f122a062fff1a2d7443abd1f9c64287",
@@ -45,7 +44,7 @@ expression: utxos
     "height": 5
   },
   {
-    "address": "t3gPoRoqzu3ZpsqogjFv7VTrbS3k4ywcCQj",
+    "address": "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
     "txid": "23daf8408d825feb09dfeaaceccf1307ed1008265c7145573374872b332c57ab",
     "outputIndex": 1,
     "script": "a914ef775f1f997f122a062fff1a2d7443abd1f9c64287",
@@ -53,7 +52,7 @@ expression: utxos
     "height": 6
   },
   {
-    "address": "t3gPoRoqzu3ZpsqogjFv7VTrbS3k4ywcCQj",
+    "address": "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
     "txid": "47aebd007159819c19519a31bb87b8b40b9b09701fcc0e40bc61c98d283117f2",
     "outputIndex": 1,
     "script": "a914ef775f1f997f122a062fff1a2d7443abd1f9c64287",
@@ -61,7 +60,7 @@ expression: utxos
     "height": 7
   },
   {
-    "address": "t3gPoRoqzu3ZpsqogjFv7VTrbS3k4ywcCQj",
+    "address": "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
     "txid": "29f8982be208c9d8737200f0ecfd3f42c175b7dd67a0aba85812283fc443a443",
     "outputIndex": 1,
     "script": "a914ef775f1f997f122a062fff1a2d7443abd1f9c64287",
@@ -69,7 +68,7 @@ expression: utxos
     "height": 8
   },
   {
-    "address": "t3gPoRoqzu3ZpsqogjFv7VTrbS3k4ywcCQj",
+    "address": "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
     "txid": "9eec40dcf5f72aa0619472cbc3c336229fce2ff983b47ebccc7bf8800759781c",
     "outputIndex": 1,
     "script": "a914ef775f1f997f122a062fff1a2d7443abd1f9c64287",
@@ -77,7 +76,7 @@ expression: utxos
     "height": 9
   },
   {
-    "address": "t3gPoRoqzu3ZpsqogjFv7VTrbS3k4ywcCQj",
+    "address": "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
     "txid": "3887181b326c25e1ea1b6885c9b437280ca3372dc5b67af72423c88c18a1da2e",
     "outputIndex": 1,
     "script": "a914ef775f1f997f122a062fff1a2d7443abd1f9c64287",

--- a/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@testnet_10.snap
@@ -1,37 +1,41 @@
 ---
 source: zebra-rpc/src/methods/tests/snapshot.rs
-assertion_line: 177
 expression: info
 ---
 {
-  "chain": "main",
+  "chain": "test",
   "blocks": 10,
   "bestblockhash": "079f4c752729be63e6341ee9bce42fbbe37236aba22e3deb82405f3c2805c112",
   "estimatedheight": "[Height]",
   "upgrades": {
     "5ba81b19": {
       "name": "Overwinter",
-      "activationheight": 347500,
+      "activationheight": 207500,
       "status": "pending"
     },
     "76b809bb": {
       "name": "Sapling",
-      "activationheight": 419200,
+      "activationheight": 280000,
       "status": "pending"
     },
     "2bb40e60": {
       "name": "Blossom",
-      "activationheight": 653600,
+      "activationheight": 584000,
       "status": "pending"
     },
     "f5b9230b": {
       "name": "Heartwood",
-      "activationheight": 903000,
+      "activationheight": 903800,
       "status": "pending"
     },
     "e9ff75a6": {
       "name": "Canopy",
-      "activationheight": 1046400,
+      "activationheight": 1028500,
+      "status": "pending"
+    },
+    "c2d6d0b4": {
+      "name": "Nu5",
+      "activationheight": 1842420,
       "status": "pending"
     }
   },


### PR DESCRIPTION
## Motivation

These fixes should help with PR #4352.

Some of them are needed to pass CI.

## Solution

Test fixes:
- Snapshot testnet state, RPCs, and transparent addresses (before this fix, we were always snapshotting Mainnet in some tests)

CI fixes:
- Ignore some duplicated dependencies we don't control 

Refactors:
- Create the snapshot settings once

## Review

@oxarbitrage wrote the original PR.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

