### PR TITLE
0. fix(ci): only use cached state disks with the same state version

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -218,7 +218,7 @@ jobs:
           #
           # TODO: require ${NETWORK} in the name after PR #4391 merges to main, and runs a full sync
           #       network should replace [a-z]*
-          CACHED_DISK_NAME=$(gcloud compute images list --verbosity=debug --filter="name~${{ inputs.disk_prefix }}-main-[0-9a-f]+-v${LOCAL_STATE_VERSION}-[a-z]*-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          CACHED_DISK_NAME=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-main-[0-9a-f]+-v${LOCAL_STATE_VERSION}-[a-z]*-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
           echo "main Disk: $CACHED_DISK_NAME"
 
           if [[ -z "$CACHED_DISK_NAME" ]]; then
@@ -226,7 +226,7 @@ jobs:
               #
               # TODO: require ${NETWORK} in the name after PRs #4391 and #4385 merge to main
               #       network should replace [a-z]*
-              CACHED_DISK_NAME=$(gcloud compute images list --verbosity=debug --filter="name~${{ inputs.disk_prefix }}-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-[a-z]*-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+              CACHED_DISK_NAME=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-[a-z]*-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
               echo "Disk: $CACHED_DISK_NAME"
           fi
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -196,21 +196,39 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Before executing any further steps, make sure the branch and cached state versions are the same.
+      # Find a cached state disk for this job, matching all of:
+      # - disk kind (disk_prefix)
+      # - disk target height (disk_suffix)
+      # - state version (from the source code)
       #
-      # If this step fails, there is probably a bug in the calling workflow.
-      # Calling workflows must depend on the cached state rebuild job.
+      # If there are multiple disks:
+      # - prefer images generated from the `main` branch, then any other branch
+      # - prefer newer images to older images
       #
-      # Aftwards, get the disk name to be used on further steps
-      - name: Validate local state version with cached state
+      # Passes the disk name to subsequent steps using an environmental variable.
+      - name: Find cached state disk
         id: get-disk-name
         run: |
           LOCAL_STATE_VERSION=$(grep -oE "DATABASE_FORMAT_VERSION: .* [0-9]+" "$GITHUB_WORKSPACE/zebra-state/src/constants.rs" | grep -oE "[0-9]+" | tail -n1)
           echo "LOCAL_STATE_VERSION: $LOCAL_STATE_VERSION"
 
-          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }} AND name~v$LOCAL_STATE_VERSION AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          # Try to find an image generated from the main branch
+          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-main AND name~v$LOCAL_STATE_VERSION AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          echo "main Disk: $ZEBRA_STATE_DISK"
 
-          echo "Disk: $ZEBRA_STATE_DISK"
+          if [[ -z "$ZEBRA_STATE_DISK" ]]; then
+              # Try to find an image generated from any other branch
+              ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }} AND name~v$LOCAL_STATE_VERSION AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+              echo "Disk: $ZEBRA_STATE_DISK"
+          fi
+
+          if [[ -z "$ZEBRA_STATE_DISK" ]]; then
+              echo "No cached state disk available"
+              echo "Expected ${{ inputs.disk_prefix }} v$LOCAL_STATE_VERSION ${{ inputs.disk_suffix }}"
+              echo "Cached state test jobs must depend on the cached state rebuild job"
+              exit 1
+          fi
+
           echo "Description: $(gcloud compute images describe $ZEBRA_STATE_DISK --format='value(DESCRIPTION)')"
 
           echo "ZEBRA_CACHED_DISK_NAME=$ZEBRA_STATE_DISK" >> $GITHUB_ENV

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -215,15 +215,17 @@ jobs:
           # Try to find an image generated from the main branch
           # Fields are listed in the "Create image from state disk" step
           #
-          # TODO: require ${NETWORK} in the name after PR #4391 merges to main and runs a full sync
-          CACHED_DISK_NAME=$(gcloud compute images list --verbosity=debug --filter="name~${{ inputs.disk_prefix }}-main-[0-9a-f]+-v${LOCAL_STATE_VERSION}-(${NETWORK})?-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          # TODO: require ${NETWORK} in the name after PR #4391 merges to main, and runs a full sync
+          #       network should replace [a-z]*
+          CACHED_DISK_NAME=$(gcloud compute images list --verbosity=debug --filter="name~${{ inputs.disk_prefix }}-main-[0-9a-f]+-v${LOCAL_STATE_VERSION}-[a-z]*-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
           echo "main Disk: $CACHED_DISK_NAME"
 
           if [[ -z "$CACHED_DISK_NAME" ]]; then
               # Try to find an image generated from any other branch
               #
               # TODO: require ${NETWORK} in the name after PRs #4391 and #4385 merge to main
-              CACHED_DISK_NAME=$(gcloud compute images list --verbosity=debug --filter="name~${{ inputs.disk_prefix }}-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-(${NETWORK})?-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+              #       network should replace [a-z]*
+              CACHED_DISK_NAME=$(gcloud compute images list --verbosity=debug --filter="name~${{ inputs.disk_prefix }}-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-[a-z]*-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
               echo "Disk: $CACHED_DISK_NAME"
           fi
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -213,12 +213,12 @@ jobs:
           echo "LOCAL_STATE_VERSION: $LOCAL_STATE_VERSION"
 
           # Try to find an image generated from the main branch
-          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-main AND name~v$LOCAL_STATE_VERSION AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-main- AND name~-v{$LOCAL_STATE_VERSION}- AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
           echo "main Disk: $ZEBRA_STATE_DISK"
 
           if [[ -z "$ZEBRA_STATE_DISK" ]]; then
               # Try to find an image generated from any other branch
-              ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }} AND name~v$LOCAL_STATE_VERSION AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+              ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}- AND name~-v{$LOCAL_STATE_VERSION}- AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
               echo "Disk: $ZEBRA_STATE_DISK"
           fi
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -213,12 +213,12 @@ jobs:
           echo "LOCAL_STATE_VERSION: $LOCAL_STATE_VERSION"
 
           # Try to find an image generated from the main branch
-          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~'${{ inputs.disk_prefix }}-main-' AND name~'-v${LOCAL_STATE_VERSION}-' AND name~'-${{ inputs.disk_suffix }}'" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="(name~${{ inputs.disk_prefix }}-main- AND name~-v${LOCAL_STATE_VERSION}-) AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
           echo "main Disk: $ZEBRA_STATE_DISK"
 
           if [[ -z "$ZEBRA_STATE_DISK" ]]; then
               # Try to find an image generated from any other branch
-              ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~'${{ inputs.disk_prefix }}-' AND name~'-v${LOCAL_STATE_VERSION}-' AND name~'-${{ inputs.disk_suffix }}'" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+              ZEBRA_STATE_DISK=$(gcloud compute images list --filter="(name~${{ inputs.disk_prefix }}- AND name~-v${LOCAL_STATE_VERSION}-) AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
               echo "Disk: $ZEBRA_STATE_DISK"
           fi
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -214,12 +214,16 @@ jobs:
 
           # Try to find an image generated from the main branch
           # Fields are listed in the "Create image from state disk" step
-          CACHED_DISK_NAME=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-main-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          #
+          # TODO: require ${NETWORK} in the name after PR #4391 merges to main and runs a full sync
+          CACHED_DISK_NAME=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-main-[0-9a-f]+-v${LOCAL_STATE_VERSION}-(${NETWORK})?-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
           echo "main Disk: $CACHED_DISK_NAME"
 
           if [[ -z "$CACHED_DISK_NAME" ]]; then
               # Try to find an image generated from any other branch
-              CACHED_DISK_NAME=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+              #
+              # TODO: require ${NETWORK} in the name after PRs #4391 and #4385 merge to main
+              CACHED_DISK_NAME=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-(${NETWORK})?-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
               echo "Disk: $CACHED_DISK_NAME"
           fi
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -196,8 +196,10 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Before executing any further steps, validate the local state and remote version are the same,
-      # or at least that the local state version is greater than the available cached state version from main.
+      # Before executing any further steps, make sure the branch and cached state versions are the same.
+      #
+      # If this step fails, there is probably a bug in the calling workflow.
+      # Calling workflows must depend on the cached state rebuild job.
       #
       # Aftwards, get the disk name to be used on further steps
       - name: Validate local state version with cached state
@@ -206,14 +208,10 @@ jobs:
           LOCAL_STATE_VERSION=$(grep -oE "DATABASE_FORMAT_VERSION: .* [0-9]+" "$GITHUB_WORKSPACE/zebra-state/src/constants.rs" | grep -oE "[0-9]+" | tail -n1)
           echo "LOCAL_STATE_VERSION: $LOCAL_STATE_VERSION"
 
-          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }} AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }} AND name~v$LOCAL_STATE_VERSION AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+
           echo "Disk: $ZEBRA_STATE_DISK"
           echo "Description: $(gcloud compute images describe $ZEBRA_STATE_DISK --format='value(DESCRIPTION)')"
-
-          GCP_STATE_VERSION=$(echo "$ZEBRA_STATE_DISK" | grep -oE "v[0-9]+" | grep -oE "[0-9]+")
-          echo "GCP_STATE_VERSION: $GCP_STATE_VERSION"
-
-          if [[ "$LOCAL_STATE_VERSION" -lt "$GCP_STATE_VERSION" ]]; then echo "Local version is lower than cached version" && exit 1; fi
 
           echo "ZEBRA_CACHED_DISK_NAME=$ZEBRA_STATE_DISK" >> $GITHUB_ENV
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -6,6 +6,7 @@ on:
       network:
         required: false
         type: string
+        default: Mainnet
       app_name:
         required: false
         type: string
@@ -45,7 +46,6 @@ on:
         type: string
 
 env:
-  NETWORK: Mainnet
   IMAGE_NAME: zebrad-test
   GAR_BASE: us-docker.pkg.dev/zealous-zebra/zebra
   ZONE: us-central1-a
@@ -184,7 +184,7 @@ jobs:
 
       - name: Downcase network name for disks
         run: |
-          NETWORK_CAPS=${{ github.event.inputs.network || env.NETWORK }}
+          NETWORK_CAPS=${{ inputs.network }}
           echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
 
       # Setup gcloud CLI

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -213,14 +213,13 @@ jobs:
           echo "LOCAL_STATE_VERSION: $LOCAL_STATE_VERSION"
 
           # Try to find an image generated from the main branch
-          # name~${{ inputs.disk_prefix }}-main- AND
-          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~-v${LOCAL_STATE_VERSION}- AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          # Fields are listed in the "Create image from state disk" step
+          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-main-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
           echo "main Disk: $ZEBRA_STATE_DISK"
 
           if [[ -z "$ZEBRA_STATE_DISK" ]]; then
               # Try to find an image generated from any other branch
-              # name~${{ inputs.disk_prefix }}- AND
-              ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~-v${LOCAL_STATE_VERSION}- AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+              ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
               echo "Disk: $ZEBRA_STATE_DISK"
           fi
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -214,25 +214,25 @@ jobs:
 
           # Try to find an image generated from the main branch
           # Fields are listed in the "Create image from state disk" step
-          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-main-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
-          echo "main Disk: $ZEBRA_STATE_DISK"
+          CACHED_DISK_NAME=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-main-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          echo "main Disk: $CACHED_DISK_NAME"
 
-          if [[ -z "$ZEBRA_STATE_DISK" ]]; then
+          if [[ -z "$CACHED_DISK_NAME" ]]; then
               # Try to find an image generated from any other branch
-              ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
-              echo "Disk: $ZEBRA_STATE_DISK"
+              CACHED_DISK_NAME=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+              echo "Disk: $CACHED_DISK_NAME"
           fi
 
-          if [[ -z "$ZEBRA_STATE_DISK" ]]; then
+          if [[ -z "$CACHED_DISK_NAME" ]]; then
               echo "No cached state disk available"
               echo "Expected ${{ inputs.disk_prefix }}-(branch)-(commit)-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}"
               echo "Cached state test jobs must depend on the cached state rebuild job"
               exit 1
           fi
 
-          echo "Description: $(gcloud compute images describe $ZEBRA_STATE_DISK --format='value(DESCRIPTION)')"
+          echo "Description: $(gcloud compute images describe $CACHED_DISK_NAME --format='value(DESCRIPTION)')"
 
-          echo "ZEBRA_CACHED_DISK_NAME=$ZEBRA_STATE_DISK" >> $GITHUB_ENV
+          echo "CACHED_DISK_NAME=$CACHED_DISK_NAME" >> $GITHUB_ENV
 
       # Creates Compute Engine virtual machine instance w/ disks
       - name: Create GCP compute instance
@@ -241,7 +241,7 @@ jobs:
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 100GB \
           --boot-disk-type pd-ssd \
-          --create-disk image=${{ env.ZEBRA_CACHED_DISK_NAME }},name="${{ inputs.disk_prefix }}-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.disk_prefix }}-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=100GB,type=pd-ssd \
+          --create-disk image=${{ env.CACHED_DISK_NAME }},name="${{ inputs.disk_prefix }}-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.disk_prefix }}-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=100GB,type=pd-ssd \
           --container-image debian:buster \
           --container-restart-policy=never \
           --machine-type ${{ env.MACHINE_TYPE }} \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -197,9 +197,10 @@ jobs:
           token_format: 'access_token'
 
       # Find a cached state disk for this job, matching all of:
-      # - disk kind (disk_prefix)
-      # - disk target height (disk_suffix)
-      # - state version (from the source code)
+      # - disk kind (disk_prefix) - zebra or lwd
+      # - state version (from the source code) - v{N}
+      # - network (network) - mainnet or testnet
+      # - disk target height kind (disk_suffix) - checkpoint or tip
       #
       # If there are multiple disks:
       # - prefer images generated from the `main` branch, then any other branch

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -213,12 +213,12 @@ jobs:
           echo "LOCAL_STATE_VERSION: $LOCAL_STATE_VERSION"
 
           # Try to find an image generated from the main branch
-          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-main- AND name~-v{$LOCAL_STATE_VERSION}- AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~'${{ inputs.disk_prefix }}-main-' AND name~'-v${LOCAL_STATE_VERSION}-' AND name~'-${{ inputs.disk_suffix }}'" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
           echo "main Disk: $ZEBRA_STATE_DISK"
 
           if [[ -z "$ZEBRA_STATE_DISK" ]]; then
               # Try to find an image generated from any other branch
-              ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}- AND name~-v{$LOCAL_STATE_VERSION}- AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+              ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~'${{ inputs.disk_prefix }}-' AND name~'-v${LOCAL_STATE_VERSION}-' AND name~'-${{ inputs.disk_suffix }}'" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
               echo "Disk: $ZEBRA_STATE_DISK"
           fi
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -213,12 +213,14 @@ jobs:
           echo "LOCAL_STATE_VERSION: $LOCAL_STATE_VERSION"
 
           # Try to find an image generated from the main branch
-          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="(name~${{ inputs.disk_prefix }}-main- AND name~-v${LOCAL_STATE_VERSION}-) AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          # name~${{ inputs.disk_prefix }}-main- AND
+          ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~-v${LOCAL_STATE_VERSION}- AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
           echo "main Disk: $ZEBRA_STATE_DISK"
 
           if [[ -z "$ZEBRA_STATE_DISK" ]]; then
               # Try to find an image generated from any other branch
-              ZEBRA_STATE_DISK=$(gcloud compute images list --filter="(name~${{ inputs.disk_prefix }}- AND name~-v${LOCAL_STATE_VERSION}-) AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+              # name~${{ inputs.disk_prefix }}- AND
+              ZEBRA_STATE_DISK=$(gcloud compute images list --filter="name~-v${LOCAL_STATE_VERSION}- AND name~-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
               echo "Disk: $ZEBRA_STATE_DISK"
           fi
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -216,14 +216,14 @@ jobs:
           # Fields are listed in the "Create image from state disk" step
           #
           # TODO: require ${NETWORK} in the name after PR #4391 merges to main and runs a full sync
-          CACHED_DISK_NAME=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-main-[0-9a-f]+-v${LOCAL_STATE_VERSION}-(${NETWORK})?-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          CACHED_DISK_NAME=$(gcloud compute images list --verbosity=debug --filter="name~${{ inputs.disk_prefix }}-main-[0-9a-f]+-v${LOCAL_STATE_VERSION}-(${NETWORK})?-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
           echo "main Disk: $CACHED_DISK_NAME"
 
           if [[ -z "$CACHED_DISK_NAME" ]]; then
               # Try to find an image generated from any other branch
               #
               # TODO: require ${NETWORK} in the name after PRs #4391 and #4385 merge to main
-              CACHED_DISK_NAME=$(gcloud compute images list --filter="name~${{ inputs.disk_prefix }}-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-(${NETWORK})?-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+              CACHED_DISK_NAME=$(gcloud compute images list --verbosity=debug --filter="name~${{ inputs.disk_prefix }}-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-(${NETWORK})?-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
               echo "Disk: $CACHED_DISK_NAME"
           fi
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -225,7 +225,7 @@ jobs:
 
           if [[ -z "$ZEBRA_STATE_DISK" ]]; then
               echo "No cached state disk available"
-              echo "Expected ${{ inputs.disk_prefix }} v$LOCAL_STATE_VERSION ${{ inputs.disk_suffix }}"
+              echo "Expected ${{ inputs.disk_prefix }}-(branch)-(commit)-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}"
               echo "Cached state test jobs must depend on the cached state rebuild job"
               exit 1
           fi

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -229,7 +229,7 @@ jobs:
 
           if [[ -z "$CACHED_DISK_NAME" ]]; then
               echo "No cached state disk available"
-              echo "Expected ${{ inputs.disk_prefix }}-(branch)-(commit)-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}"
+              echo "Expected ${{ inputs.disk_prefix }}-(branch)-[0-9a-f]+-v${LOCAL_STATE_VERSION}-(${NETWORK})?-${{ inputs.disk_suffix }}"
               echo "Cached state test jobs must depend on the cached state rebuild job"
               exit 1
           fi

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -232,7 +232,7 @@ jobs:
 
           if [[ -z "$CACHED_DISK_NAME" ]]; then
               echo "No cached state disk available"
-              echo "Expected ${{ inputs.disk_prefix }}-(branch)-[0-9a-f]+-v${LOCAL_STATE_VERSION}-(${NETWORK})?-${{ inputs.disk_suffix }}"
+              echo "Expected ${{ inputs.disk_prefix }}-(branch)-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}"
               echo "Cached state test jobs must depend on the cached state rebuild job"
               exit 1
           fi


### PR DESCRIPTION
## Motivation

This PR implements the exact state version search from ticket #4153.

### Designs

As specified in #4153:

We want to re-use the cached state from any branch, as long as:
- the state version is the same, and
- the state kind is the same (checkpoint or tip, and zebra or lwd) 

If there is a state with that version on `main`, and on another branch, use the one from `main`.

## Solution

- Only use cached state disks with the exact same state version
- Prefer `main` branch disks to disks generated from other branches

Related changes:
- Standardise the environmental variable names
- Provide a `network` input default
    - Delete a redundant `NETWORK` environmental variable
    - Temporarily allow disk names with and without network names

## Review

@gustavovalverde can review this PR, it blocks PR #4268.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- PR #4385
- Require network names in disk names