### PR TITLE
Use the latest lightwalletd version

### DIFF
--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -53,11 +53,7 @@ jobs:
       - uses: actions/checkout@v3.0.2
         with:
           repository: adityapk00/lightwalletd
-          # Temporarily use an earlier lightwalletd version,
-          # to check if commit e146dbf5c2860e535fdbe2ba5ab20c4744d7c941 contains a mempool refresh deadlock bug.
-          #
-          # TODO: switch back to 'master' after the bug is resolved
-          ref: 'c1bab818a683e4de69cd952317000f9bb2932274'
+          ref: 'master'
           persist-credentials: false
 
       - uses: actions/checkout@v3.0.2


### PR DESCRIPTION
## Motivation

In PR #4268 we tried using an earlier version of `lightwalletd`, because we were seeing `lightwalletd` hang with logs like:
```
{"app":"lightwalletd","level":"warning","msg":"Another refresh in progress, returning","time":"2022-05-13T18:32:11Z"}
{"app":"lightwalletd","level":"warning","msg":"Another refresh in progress, returning","time":"2022-05-13T18:32:13Z"}
{"app":"lightwalletd","level":"warning","msg":"Another refresh in progress, returning","time":"2022-05-13T18:32:15Z"}
...
```
https://github.com/ZcashFoundation/zebra/runs/6427494279?check_suite_focus=true#step:9:1118

But these logs are still happening with the earlier version as well.

## Solution

Use `lightwalletd` `master` branch from https://github.com/adityapk00/lightwalletd

This reverts commit f71a1f5d1970860574351d7939a9361710e1ea09.

## Review

Anyone can review this PR, it is urgent because it is causing CI failures.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

If the bug still continues on the `master` branch:
- temporarily disable that part of the `zebrad` test
- ask Aditya to fix the `lightwalletd` bug
