### PR TITLE
tests(rpc): Add `z_get_treestate` snapshot test

### DIFF
--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -16,9 +16,6 @@ use zebra_test::mock_service::MockService;
 use super::super::*;
 
 /// Snapshot test for RPC methods responses.
-///
-/// TODO:
-/// - Add a `z_gettreestate` test when #3990 is merged.
 #[tokio::test]
 async fn test_rpc_response_data() {
     zebra_test::init();
@@ -119,6 +116,13 @@ async fn test_rpc_response_data_for_network(network: Network) {
 
     snapshot_rpc_getrawmempool(get_raw_mempool, &settings);
 
+    // `z_gettreestate`
+    let tree_state = rpc
+        .z_get_treestate(BLOCK_HEIGHT.to_string())
+        .await
+        .expect("We should have a GetTreestate struct");
+    snapshot_rpc_z_gettreestate(tree_state, &settings);
+
     // `getrawtransaction`
     //
     // - similar to `getrawmempool` described above, a mempool request will be made to get the requested
@@ -215,6 +219,11 @@ fn snapshot_rpc_getbestblockhash(tip_hash: GetBestBlockHash, settings: &insta::S
 /// Snapshot `getrawmempool` response, using `cargo insta` and JSON serialization.
 fn snapshot_rpc_getrawmempool(raw_mempool: Vec<String>, settings: &insta::Settings) {
     settings.bind(|| insta::assert_json_snapshot!("get_raw_mempool", raw_mempool));
+}
+
+/// Snapshot `z_gettreestate` response, using `cargo insta` and JSON serialization.
+fn snapshot_rpc_z_gettreestate(tree_state: GetTreestate, settings: &insta::Settings) {
+    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate", tree_state));
 }
 
 /// Snapshot `getrawtransaction` response, using `cargo insta` and JSON serialization.

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate@mainnet_10.snap
@@ -1,0 +1,10 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+assertion_line: 226
+expression: tree_state
+---
+{
+  "hash": "0007bc227e1c57a4a70e237cad00e7b7ce565155ab49166bc57397a26d339283",
+  "height": 1,
+  "time": 1477671596
+}

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate@testnet_10.snap
@@ -1,0 +1,10 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+assertion_line: 226
+expression: tree_state
+---
+{
+  "hash": "025579869bcf52a989337342f5f57a84f3a28b968f7d6a8307902b065a668d23",
+  "height": 1,
+  "time": 1477674473
+}


### PR DESCRIPTION
## Motivation

In https://github.com/ZcashFoundation/zebra/pull/4352 we added snapthot tests for rpc methods responses. We left `z_get_treestate` out because it was work in progress at the moment of creating the tests. Now that https://github.com/ZcashFoundation/zebra/pull/3990 is merged we can add the missing test.

Close https://github.com/ZcashFoundation/zebra/issues/4379

## Solution

Imnplement a very basic tests where block height 1 is queried for tree states.

## Review

Anyone can review.
