### PR TITLE
tests(rpc): Add grpc test for `GetTaddressBalanceStream` and `GetAddressUtxosStream`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6533,6 +6533,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "toml",
  "tonic",
  "tonic-build",

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -93,6 +93,7 @@ semver = "1.0.9"
 serde_json = { version = "1.0.81", features = ["preserve_order"] }
 tempfile = "3.3.0"
 tokio = { version = "1.18.2", features = ["full", "test-util"] }
+tokio-stream = "0.1.8"
 
 # test feature lightwalletd-grpc-tests
 prost = "0.10.3"

--- a/zebrad/tests/common/lightwalletd/wallet_grpc_test.rs
+++ b/zebrad/tests/common/lightwalletd/wallet_grpc_test.rs
@@ -41,9 +41,9 @@ use crate::common::{
     launch::spawn_zebrad_for_rpc_without_initial_peers,
     lightwalletd::{
         wallet_grpc::{
-            connect_to_lightwalletd, spawn_lightwalletd_with_rpc_server, AddressList, BlockId,
-            BlockRange, ChainSpec, Empty, GetAddressUtxosArg, TransparentAddressBlockFilter,
-            TxFilter,
+            connect_to_lightwalletd, spawn_lightwalletd_with_rpc_server, Address, AddressList,
+            BlockId, BlockRange, ChainSpec, Empty, GetAddressUtxosArg,
+            TransparentAddressBlockFilter, TxFilter,
         },
         zebra_skip_lightwalletd_tests,
         LightwalletdTestType::UpdateCachedState,
@@ -202,7 +202,48 @@ pub async fn run() -> Result<()> {
     // because new coins are created in each block
     assert!(balance.value_zat > 0);
 
-    // TODO: Create call and check for `GetTaddressBalanceStream`
+    // Call `GetTaddressBalanceStream` with the ZF funding stream address as a stream argument
+    let zf_stream_address = Address {
+        address: "t3dvVE3SQEi7kqNzwrfNePxZ1d4hUyztBA1".to_string(),
+    };
+
+    let balance_zf = rpc_client
+        .get_taddress_balance_stream(tokio_stream::iter(vec![zf_stream_address.clone()]))
+        .await?
+        .into_inner();
+
+    // With ZFND funding stream address, the balance will always be greater than zero,
+    // because new coins are created in each block
+    assert!(balance_zf.value_zat > 0);
+
+    // Call `GetTaddressBalanceStream` with the MG funding stream address as a stream argument
+    let mg_stream_address = Address {
+        address: "t3XyYW8yBFRuMnfvm5KLGFbEVz25kckZXym".to_string(),
+    };
+
+    let balance_mg = rpc_client
+        .get_taddress_balance_stream(tokio_stream::iter(vec![mg_stream_address.clone()]))
+        .await?
+        .into_inner();
+
+    // With Major Grants funding stream address, the balance will always be greater than zero,
+    // because new coins are created in each block
+    assert!(balance_mg.value_zat > 0);
+
+    // Call `GetTaddressBalanceStream` with both, the ZFND and the MG funding stream addresses as a stream argument
+    let balance_both = rpc_client
+        .get_taddress_balance_stream(tokio_stream::iter(vec![
+            zf_stream_address,
+            mg_stream_address,
+        ]))
+        .await?
+        .into_inner();
+
+    // The result is the sum of the values in both addresses
+    assert_eq!(
+        balance_both.value_zat,
+        balance_zf.value_zat + balance_mg.value_zat
+    );
 
     // TODO: Create call and checks for `GetMempoolTx` and `GetMempoolTxStream`?
 


### PR DESCRIPTION
## Motivation

We skipped a few grpc tests that had streams involved. This PR add tests for `GetTaddressBalanceStream` and `GetAddressUtxosStream`.

Close https://github.com/ZcashFoundation/zebra/issues/4362

## Solution

Add simple grpc tests for `GetTaddressBalanceStream` and `GetAddressUtxosStream`.

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

