### PR TITLE
fix(ci): update Cargo.lock check job name in patch workflow 

### DIFF
--- a/.github/workflows/continous-integration-os.patch.yml
+++ b/.github/workflows/continous-integration-os.patch.yml
@@ -59,8 +59,8 @@ jobs:
     steps:
       - run: 'echo "No build required"'
 
-  build:
-    name: Build stable on ubuntu-latest
+  check-cargo-lock:
+    name: Check Cargo.lock is up to date
     timeout-minutes: 60
     runs-on: ubuntu-latest
 

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -259,7 +259,7 @@ jobs:
           override: true
 
       - uses: Swatinem/rust-cache@v1
-      
+
       - name: Check Cargo.lock is up to date
         uses: actions-rs/cargo@v1.0.3
         with:


### PR DESCRIPTION
## Motivation

In a previous PR, we updated a job name, but didn't update the patch file.

This is related to #4340, but doesn't close that ticket.

## Solution

- Use the same job name in the patch file

## Review

Anyone can review this low priority, low risk PR.

### Reviewer Checklist

  - [ ] CI passes, except for the known lightwalletd-update-sync test failure (#4415)

## Follow Up Work

- require jobs from this patch file to merge PRs