### PR TITLE
change: fail early when using Rust 1.57 and earlier, because they don't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ install mechanism. To run `zebrad`, follow the instructions to compile `zebrad`
 for your platform:
 
 1. Install [`cargo` and `rustc`](https://www.rust-lang.org/tools/install).
-     - You will need version 1.58 or later; if you're using the version shipped with your OS it
-       might be outdated. Run `rustc --version` to check. If it's outdated, install it following
-       the instructions in the link. We always test with the latest `stable` version.
+     - Zebra is tested with the latest `stable` Rust version.
+        Earlier versions are not supported or tested, but they might work.
+        (Rust 1.57 and earlier are not supported, due to missing features.)
 2. Install Zebra's build dependencies:
      - **libclang:** the `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` packages, depending on your package manager
      - **clang** or another C++ compiler: `g++`, `Xcode`, or `MSVC`

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ for your platform:
 1. Install [`cargo` and `rustc`](https://www.rust-lang.org/tools/install).
      - You will need version 1.58 or later; if you're using the version shipped with your OS it
        might be outdated. Run `rustc --version` to check. If it's outdated, install it following
-       the instructions in the link. We always test with the latest version.
+       the instructions in the link. We always test with the latest `stable` version.
 2. Install Zebra's build dependencies:
      - **libclang:** the `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` packages, depending on your package manager
      - **clang** or another C++ compiler: `g++`, `Xcode`, or `MSVC`

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ install mechanism. To run `zebrad`, follow the instructions to compile `zebrad`
 for your platform:
 
 1. Install [`cargo` and `rustc`](https://www.rust-lang.org/tools/install).
+     - You will need version 1.58 or later; if you're using the version shipped with your OS it
+       might be outdated. Run `rustc --version` to check. If it's outdated, install it following
+       the instructions in the link. We always test with the latest version.
 2. Install Zebra's build dependencies:
      - **libclang:** the `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` packages, depending on your package manager
      - **clang** or another C++ compiler: `g++`, `Xcode`, or `MSVC`

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -4,6 +4,7 @@ authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 version = "1.0.0-beta.10"
 edition = "2021"
+rust-version = "1.58"
 repository = "https://github.com/ZcashFoundation/zebra"
 # make `cargo run` use `zebrad` by default
 # when run in the workspace directory

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -4,6 +4,8 @@ authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 version = "1.0.0-beta.10"
 edition = "2021"
+# Zebra is only supported on the latest stable Rust version. Some earlier versions might work.
+# Zebra uses features introduced in Rust 1.58.
 rust-version = "1.58"
 repository = "https://github.com/ZcashFoundation/zebra"
 # make `cargo run` use `zebrad` by default


### PR DESCRIPTION
We recently adopted formatting features introduced in Rust 1.58, but we're not enforcing the minimum version, which caused [issues for people compiling with Ubuntu 20](https://github.com/ZcashFoundation/zebra/issues/4433) (which ships 1.57).

## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

Use `rust-version` for `zebrad` to enforce the version and document it.

## Review

Urgent, blocking beta.10 release.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

I'll create an issue to address this in CI to make sure we always comply with the minimum version.