### PR TITLE
change(doc): add item to release checklist to update dependencies in the README

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -84,6 +84,9 @@ As we resolve various outstanding known issues and implement new functionality w
 We should check and update if necessary:
 
 - [ ] The "Known Issues" section
+- [ ] The "Build and Run Instructions" section. Check if any new dependencies were introduced and
+      list them if needed; one possible approach is to check for changes in the `Dockerfile`
+      since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
 
 to ensure that any items that are resolved in the latest release are no longer listed in the README.
 

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -83,12 +83,10 @@ As we resolve various outstanding known issues and implement new functionality w
 
 We should check and update if necessary:
 
-- [ ] The "Known Issues" section
+- [ ] The "Known Issues" section to ensure that any items that are resolved in the latest release are no longer listed in the README.
 - [ ] The "Build and Run Instructions" section. Check if any new dependencies were introduced and
       list them if needed; one possible approach is to check for changes in the `Dockerfile`
       since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
-
-to ensure that any items that are resolved in the latest release are no longer listed in the README.
 
 ## Change Log
 


### PR DESCRIPTION
## Motivation

Recently we added a `cmake` dependency which we forgot to list in the README, which caused errors for users following the build instructions. In that particular case we were able to change it to a dev-dependency, but the same issue could happen in the future. 

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

Add a item to the checklist to check for new dependencies and list them.

## Solution

Not urgent, anyone can review.

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
