### PR TITLE
fix(ci): Update docker patch jobs for recent changes

### DIFF
--- a/.github/workflows/continous-integration-docker.patch.yml
+++ b/.github/workflows/continous-integration-docker.patch.yml
@@ -52,7 +52,6 @@ jobs:
     steps:
       - run: 'echo "No build required"'
 
-  # Run all the zebra tests, including tests that are ignored by default
   test-all:
     name: Test all
     runs-on: ubuntu-latest
@@ -63,15 +62,12 @@ jobs:
   test-fake-activation-heights:
     name: Test with fake activation heights
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - run: 'echo "No build required"'
 
-  # Test that Zebra syncs and checkpoints a few thousand blocks from an empty state
   test-empty-sync:
     name: Test checkpoint sync from empty state
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - run: 'echo "No build required"'
 
@@ -82,25 +78,24 @@ jobs:
     steps:
       - run: 'echo "No build required"'
 
-  regenerate-stateful-disks:
-    name: Regenerate stateful disks
+  # Create a patch job for each call to deploy-gcp-tests.yml
+  #
+  # GitHub's branch protection rules only match on the name (they ignore the job ID)
+  deploy-gcp-tests-patch:
+    name: Run ${{ matrix.test_id }} test
     runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - run: 'echo "No build required"'
-
-  # Test that Zebra syncs and fully validates a few thousand blocks from a cached post-checkpoint state
-  test-stateful-sync:
-    name: Test full validation sync from cached state
-    runs-on: ubuntu-latest
-    needs: [build, regenerate-stateful-disks]
-    steps:
-      - run: 'echo "No build required"'
-
-  # Test that Zebra can run a full mainnet sync after a PR is approved
-  test-full-sync:
-    name: Test a full sync up to the tip
-    runs-on: ubuntu-latest
-    needs: [build, regenerate-stateful-disks]
+    strategy:
+      matrix:
+        # Keep this list in sync with the test_id inputs to each deploy-gcp-tests.yml call
+        # in continous-integration-docker.yml
+        test_id:
+          - 'sync-to-checkpoint'
+          - 'sync-past-checkpoint'
+          - 'full-sync-to-tip'
+          - 'fully-synced-rpc'
+          - 'lwd-full-sync'
+          - 'lwd-update-sync'
+          - 'lwd-send-transactions'
+          - 'lwd-grpc-wallet'
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -95,7 +95,7 @@ jobs:
       # restricting the result from any branch.
       #
       # This search is executed considering the actual version from constants.rs
-      # 
+      #
       # Generate one of the following outputs with a boolean to pass to subsequent jobs:
       # - lwd_tip_disk
       # - zebra_tip_disk


### PR DESCRIPTION
## Motivation

We need a patch job to match each job in `continous-integration-docker.yml`, so that we can require those jobs in CI.

This is part of #4340.

## Solution

- Add a patch job for each `continous-integration-docker.yml` job, including the new job in PR #4453
- Remove unnecessary job dependencies and comments

This PR does not depend on PR #4453, they can merge independently.

## Review

Anyone can review this PR, it is not urgent.

### Reviewer Checklist

  - [ ] Job names match `continous-integration-docker.yml`

## Follow Up Work

- Require these jobs in the `main` branch protection rule settings