### PR TITLE
fix(ci): Make reusable workflow job names match patch job names

### DIFF
--- a/.github/workflows/continous-integration-docker.patch.yml
+++ b/.github/workflows/continous-integration-docker.patch.yml
@@ -47,7 +47,7 @@ jobs:
       - run: 'echo "No build required"'
 
   build:
-    name: Build images
+    name: Build / Build images
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
@@ -55,7 +55,6 @@ jobs:
   test-all:
     name: Test all
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - run: 'echo "No build required"'
 
@@ -74,28 +73,47 @@ jobs:
   test-lightwalletd-integration:
     name: Test integration with lightwalletd
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - run: 'echo "No build required"'
 
-  # Create a patch job for each call to deploy-gcp-tests.yml
-  #
-  # GitHub's branch protection rules only match on the name (they ignore the job ID)
-  deploy-gcp-tests-patch:
-    name: Run ${{ matrix.test_id }} test
+  regenerate-stateful-disks:
+    name: Zebra checkpoint / Run sync-to-checkpoint test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # Keep this list in sync with the test_id inputs to each deploy-gcp-tests.yml call
-        # in continous-integration-docker.yml
-        test_id:
-          - 'sync-to-checkpoint'
-          - 'sync-past-checkpoint'
-          - 'full-sync-to-tip'
-          - 'fully-synced-rpc'
-          - 'lwd-full-sync'
-          - 'lwd-update-sync'
-          - 'lwd-send-transactions'
-          - 'lwd-grpc-wallet'
+    steps:
+      - run: 'echo "No build required"'
+
+  test-stateful-sync:
+    name: Zebra checkpoint update / Run sync-past-checkpoint test
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  test-full-sync:
+    name: Zebra tip / Run full-sync-to-tip test
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  lightwalletd-rpc-test:
+    name: Zebra tip JSON-RPC / Run fully-synced-rpc test
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  lightwalletd-transactions-test:
+    name: lightwalletd tip send / Run lwd-send-transactions test
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  lightwalletd-full-sync:
+    name: lightwalletd tip / Run lwd-full-sync test
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  lightwalletd-update-sync:
+    name: lightwalletd tip update / Run lwd-update-sync test
+    runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -134,7 +134,7 @@ jobs:
           fi
 
   build:
-    name: "Build"
+    name: Build
     uses: ./.github/workflows/build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile
@@ -244,7 +244,7 @@ jobs:
   #
   # Note: the output from get-available-disks should match with the caller workflow inputs
   regenerate-stateful-disks:
-    name: "Zebra checkpoint"
+    name: Zebra checkpoint
     needs: [ build, get-available-disks ]
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !fromJSON(needs.get-available-disks.outputs.zebra_checkpoint_disk) || github.event.inputs.regenerate-disks == 'true' }}
@@ -262,7 +262,7 @@ jobs:
   # If the state version has changed, waits for the new cached state to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   test-stateful-sync:
-    name: "Zebra checkpoint update"
+    name: Zebra checkpoint update
     needs: regenerate-stateful-disks
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
@@ -284,7 +284,7 @@ jobs:
   #
   # Note: the output from get-available-disks should match with the caller workflow inputs
   test-full-sync:
-    name: "Zebra tip"
+    name: Zebra tip
     needs: [ build, get-available-disks ]
     uses: ./.github/workflows/deploy-gcp-tests.yml
     # to also run on Mergify head branches,
@@ -309,7 +309,7 @@ jobs:
   # If the state version has changed, waits for the new cached state to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   lightwalletd-rpc-test:
-    name: "Zebra tip JSON-RPC"
+    name: Zebra tip JSON-RPC
     needs: test-full-sync
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
@@ -334,7 +334,7 @@ jobs:
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   # TODO: move this job under lightwalletd-full-sync to have a sequential logic
   lightwalletd-transactions-test:
-    name: "lightwalletd tip send"
+    name: lightwalletd tip send
     needs: lightwalletd-full-sync
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
@@ -360,7 +360,7 @@ jobs:
   # If the state version has changed, waits for the new cached state to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   lightwalletd-full-sync:
-    name: "lightwalletd tip"
+    name: lightwalletd tip
     needs: test-full-sync
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
@@ -386,7 +386,7 @@ jobs:
   # If the state version has changed, waits for the new cached states to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   lightwalletd-update-sync:
-    name: "lightwalletd tip update"
+    name: lightwalletd tip update
     needs: lightwalletd-full-sync
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -134,8 +134,7 @@ jobs:
           fi
 
   build:
-    # We use a blank name to match the patch workflow name
-    name: ""
+    name: "Build"
     uses: ./.github/workflows/build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile
@@ -245,8 +244,7 @@ jobs:
   #
   # Note: the output from get-available-disks should match with the caller workflow inputs
   regenerate-stateful-disks:
-    # We use a blank name to match the patch workflow name
-    name: ""
+    name: "Zebra checkpoint"
     needs: [ build, get-available-disks ]
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !fromJSON(needs.get-available-disks.outputs.zebra_checkpoint_disk) || github.event.inputs.regenerate-disks == 'true' }}
@@ -264,7 +262,7 @@ jobs:
   # If the state version has changed, waits for the new cached state to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   test-stateful-sync:
-    name: ""
+    name: "Zebra checkpoint update"
     needs: regenerate-stateful-disks
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
@@ -286,7 +284,7 @@ jobs:
   #
   # Note: the output from get-available-disks should match with the caller workflow inputs
   test-full-sync:
-    name: ""
+    name: "Zebra tip"
     needs: [ build, get-available-disks ]
     uses: ./.github/workflows/deploy-gcp-tests.yml
     # to also run on Mergify head branches,
@@ -311,7 +309,7 @@ jobs:
   # If the state version has changed, waits for the new cached state to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   lightwalletd-rpc-test:
-    name: ""
+    name: "Zebra tip JSON-RPC"
     needs: test-full-sync
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
@@ -336,7 +334,7 @@ jobs:
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   # TODO: move this job under lightwalletd-full-sync to have a sequential logic
   lightwalletd-transactions-test:
-    name: ""
+    name: "lightwalletd tip send"
     needs: lightwalletd-full-sync
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
@@ -362,7 +360,7 @@ jobs:
   # If the state version has changed, waits for the new cached state to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   lightwalletd-full-sync:
-    name: ""
+    name: "lightwalletd tip"
     needs: test-full-sync
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
@@ -388,7 +386,7 @@ jobs:
   # If the state version has changed, waits for the new cached states to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   lightwalletd-update-sync:
-    name: ""
+    name: "lightwalletd tip update"
     needs: lightwalletd-full-sync
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -134,6 +134,8 @@ jobs:
           fi
 
   build:
+    # We use a blank name to match the patch workflow name
+    name: ""
     uses: ./.github/workflows/build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile
@@ -243,6 +245,8 @@ jobs:
   #
   # Note: the output from get-available-disks should match with the caller workflow inputs
   regenerate-stateful-disks:
+    # We use a blank name to match the patch workflow name
+    name: ""
     needs: [ build, get-available-disks ]
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !fromJSON(needs.get-available-disks.outputs.zebra_checkpoint_disk) || github.event.inputs.regenerate-disks == 'true' }}
@@ -260,6 +264,7 @@ jobs:
   # If the state version has changed, waits for the new cached state to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   test-stateful-sync:
+    name: ""
     needs: regenerate-stateful-disks
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
@@ -281,6 +286,7 @@ jobs:
   #
   # Note: the output from get-available-disks should match with the caller workflow inputs
   test-full-sync:
+    name: ""
     needs: [ build, get-available-disks ]
     uses: ./.github/workflows/deploy-gcp-tests.yml
     # to also run on Mergify head branches,
@@ -305,6 +311,7 @@ jobs:
   # If the state version has changed, waits for the new cached state to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   lightwalletd-rpc-test:
+    name: ""
     needs: test-full-sync
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
@@ -329,6 +336,7 @@ jobs:
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   # TODO: move this job under lightwalletd-full-sync to have a sequential logic
   lightwalletd-transactions-test:
+    name: ""
     needs: lightwalletd-full-sync
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
@@ -354,6 +362,7 @@ jobs:
   # If the state version has changed, waits for the new cached state to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   lightwalletd-full-sync:
+    name: ""
     needs: test-full-sync
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
@@ -379,6 +388,7 @@ jobs:
   # If the state version has changed, waits for the new cached states to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   lightwalletd-update-sync:
+    name: ""
     needs: lightwalletd-full-sync
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}


### PR DESCRIPTION
## Motivation

To implement #4340, we need the real and patch workflow names to match.

## Solution

- Name each calling job, so we don't see job IDs in GitHub status reports
- Name each patch job after both the calling job name and the re-usable workflow job name

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [ ] Real and patch job names match in GitHub status reports on PRs

## Follow Up Work

- Add these workflows to GitHub settings