### PR TITLE
fix(ci): Increase clippy timeout

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
 
   clippy:
     name: Clippy
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     needs: changed-files
     if: ${{ needs.changed-files.outputs.rust == 'true' }}


### PR DESCRIPTION
## Motivation

PR #4462 failed in the mergify queue due to a clippy timeout:
https://github.com/ZcashFoundation/zebra/runs/6566342529?check_suite_focus=true#step:7:1118

## Review

This is an urgent fix to stop CI failing.

### Reviewer Checklist

  - [ ] CI passes

