### PR TITLE
fix(clippy): resolve various clippy warnings

### DIFF
--- a/zebra-chain/src/block/error.rs
+++ b/zebra-chain/src/block/error.rs
@@ -3,7 +3,7 @@
 use thiserror::Error;
 
 #[allow(dead_code, missing_docs)]
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum BlockError {
     #[error("transaction has wrong consensus branch id for block network upgrade")]
     WrongTransactionConsensusBranchId,

--- a/zebra-chain/src/orchard/commitment.rs
+++ b/zebra-chain/src/orchard/commitment.rs
@@ -38,7 +38,7 @@ where
 }
 
 /// The randomness used in the Simsemilla hash for note commitment.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct CommitmentRandomness(pallas::Scalar);
 
 impl From<SeedRandomness> for CommitmentRandomness {
@@ -54,7 +54,7 @@ impl From<SeedRandomness> for CommitmentRandomness {
 }
 
 /// Note commitments for the output notes.
-#[derive(Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
 pub struct NoteCommitment(#[serde(with = "serde_helpers::Affine")] pub pallas::Affine);
 
 impl fmt::Debug for NoteCommitment {
@@ -75,8 +75,6 @@ impl fmt::Debug for NoteCommitment {
         }
     }
 }
-
-impl Eq for NoteCommitment {}
 
 impl From<pallas::Point> for NoteCommitment {
     fn from(projective_point: pallas::Point) -> Self {
@@ -159,7 +157,7 @@ impl NoteCommitment {
 /// Action descriptions.
 ///
 /// https://zips.z.cash/protocol/nu5.pdf#concretehomomorphiccommit
-#[derive(Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
 pub struct ValueCommitment(#[serde(with = "serde_helpers::Affine")] pub pallas::Affine);
 
 impl<'a> std::ops::Add<&'a ValueCommitment> for ValueCommitment {
@@ -208,8 +206,6 @@ impl From<pallas::Point> for ValueCommitment {
         Self(pallas::Affine::from(projective_point))
     }
 }
-
-impl Eq for ValueCommitment {}
 
 /// LEBS2OSP256(repr_P(cv))
 ///

--- a/zebra-chain/src/orchard/keys.rs
+++ b/zebra-chain/src/orchard/keys.rs
@@ -1,7 +1,7 @@
 //! Orchard key types.
 //!
 //! <https://zips.z.cash/protocol/nu5.pdf#orchardkeycomponents>
-#![allow(clippy::unit_arg)]
+
 #![allow(dead_code)]
 
 #[cfg(test)]
@@ -983,7 +983,7 @@ impl PartialEq<[u8; 32]> for TransmissionKey {
 ///
 /// <https://zips.z.cash/protocol/nu5.pdf#saplingandorchardencrypt>
 // TODO: derive `OutgoingCipherKey`: https://github.com/ZcashFoundation/zebra/issues/2041
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct OutgoingCipherKey([u8; 32]);
 
 impl fmt::Debug for OutgoingCipherKey {
@@ -1040,7 +1040,7 @@ impl PartialEq<[u8; 32]> for EphemeralPrivateKey {
 ///
 /// <https://zips.z.cash/protocol/nu5.pdf#concreteorchardkeyagreement>
 /// <https://zips.z.cash/protocol/nu5.pdf#saplingandorchardencrypt>
-#[derive(Copy, Clone, Deserialize, PartialEq, Serialize)]
+#[derive(Copy, Clone, Deserialize, PartialEq, Eq, Serialize)]
 pub struct EphemeralPublicKey(#[serde(with = "serde_helpers::Affine")] pub(crate) pallas::Affine);
 
 impl fmt::Debug for EphemeralPublicKey {
@@ -1061,8 +1061,6 @@ impl fmt::Debug for EphemeralPublicKey {
         }
     }
 }
-
-impl Eq for EphemeralPublicKey {}
 
 impl From<EphemeralPublicKey> for [u8; 32] {
     fn from(epk: EphemeralPublicKey) -> [u8; 32] {

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -334,9 +334,9 @@ impl NoteCommitmentTree {
             .cached_root
             .write()
             .expect("a thread that previously held exclusive lock access panicked");
-        match write_root.deref() {
+        match *write_root {
             // Another thread got write access first, return cached root.
-            Some(root) => *root,
+            Some(root) => root,
             None => {
                 // Compute root and cache it.
                 let root = Root(self.inner.root().0);

--- a/zebra-chain/src/sapling/commitment.rs
+++ b/zebra-chain/src/sapling/commitment.rs
@@ -44,11 +44,11 @@ where
 }
 
 /// The randomness used in the Pedersen Hash for note commitment.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct CommitmentRandomness(jubjub::Fr);
 
 /// Note commitments for the output notes.
-#[derive(Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
 pub struct NoteCommitment(#[serde(with = "serde_helpers::AffinePoint")] pub jubjub::AffinePoint);
 
 impl fmt::Debug for NoteCommitment {
@@ -59,8 +59,6 @@ impl fmt::Debug for NoteCommitment {
             .finish()
     }
 }
-
-impl Eq for NoteCommitment {}
 
 impl From<jubjub::ExtendedPoint> for NoteCommitment {
     fn from(extended_point: jubjub::ExtendedPoint) -> Self {
@@ -157,7 +155,7 @@ impl NoteCommitment {
 /// [`NotSmallOrderValueCommitment`].
 ///
 /// https://zips.z.cash/protocol/protocol.pdf#concretehomomorphiccommit
-#[derive(Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
 pub struct ValueCommitment(#[serde(with = "serde_helpers::AffinePoint")] jubjub::AffinePoint);
 
 impl<'a> std::ops::Add<&'a ValueCommitment> for ValueCommitment {
@@ -198,8 +196,6 @@ impl From<jubjub::ExtendedPoint> for ValueCommitment {
         Self(jubjub::AffinePoint::from(extended_point))
     }
 }
-
-impl Eq for ValueCommitment {}
 
 /// LEBS2OSP256(repr_J(cv))
 ///

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -340,9 +340,9 @@ impl NoteCommitmentTree {
             .cached_root
             .write()
             .expect("a thread that previously held exclusive lock access panicked");
-        match write_root.deref() {
+        match *write_root {
             // Another thread got write access first, return cached root.
-            Some(root) => *root,
+            Some(root) => root,
             None => {
                 // Compute root and cache it.
                 let root = Root::try_from(self.inner.root().0).unwrap();

--- a/zebra-chain/src/sprout/commitment.rs
+++ b/zebra-chain/src/sprout/commitment.rs
@@ -1,13 +1,11 @@
 //! Sprout commitment types.
 
-#![allow(clippy::unit_arg)]
-
 use sha2::{Digest, Sha256};
 
 use super::note::Note;
 
 /// The randomness used in the Pedersen Hash for note commitment.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     any(test, feature = "proptest-impl"),
     derive(proptest_derive::Arbitrary)
@@ -21,14 +19,12 @@ impl AsRef<[u8]> for CommitmentRandomness {
 }
 
 /// Note commitments for the output notes.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[cfg_attr(
     any(test, feature = "proptest-impl"),
     derive(proptest_derive::Arbitrary)
 )]
 pub struct NoteCommitment(pub(crate) [u8; 32]);
-
-impl Eq for NoteCommitment {}
 
 impl From<[u8; 32]> for NoteCommitment {
     fn from(bytes: [u8; 32]) -> Self {

--- a/zebra-chain/src/sprout/tree.rs
+++ b/zebra-chain/src/sprout/tree.rs
@@ -273,9 +273,9 @@ impl NoteCommitmentTree {
             .cached_root
             .write()
             .expect("a thread that previously held exclusive lock access panicked");
-        match write_root.deref() {
+        match *write_root {
             // Another thread got write access first, return cached root.
-            Some(root) => *root,
+            Some(root) => root,
             None => {
                 // Compute root and cache it.
                 let root = Root(self.inner.root().0);

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -102,7 +102,7 @@ where
 ///
 /// Typically, we can rely on outbound addresses, but inbound addresses don't
 /// give us enough information to reconnect to that peer.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ConnectedAddr {
     /// The address we used to make a direct outbound connection.
     ///

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -24,7 +24,7 @@
 use std::{collections::HashSet, convert::TryInto, env, path::PathBuf};
 
 use color_eyre::{
-    eyre::{eyre, Result, WrapErr},
+    eyre::{Result, WrapErr},
     Help,
 };
 
@@ -1439,6 +1439,8 @@ where
     // See #1781.
     #[cfg(target_os = "linux")]
     if node2.is_running() {
+        use color_eyre::eyre::eyre;
+
         return node2
             .kill_on_error::<(), _>(Err(eyre!(
                 "conflicted node2 was still running, but the test expected a panic"


### PR DESCRIPTION
## Motivation

Clippy has some new warnings on nightly, and we also have some warnings in CI on non-linux platforms.

Depends-On: #4483

## Solution

Potential performance/locking changes:
- move cached root dereference earlier, so the lock isn't held for the entire match statement

Trivial changes:
- fix unused import warning on non-linux platforms
- derive `Eq` where we already derive `PartialEq`

We should run all the tests to check for any breaking changes.

## Review

This PR is a low priority.

### Reviewer Checklist

  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

