### PR TITLE
fix(ci): Require full sync to reach 100%

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -309,7 +309,7 @@ jobs:
       needs_zebra_state: false
       saves_to_disk: true
       disk_suffix: tip
-      height_grep_text: 'estimated progress to chain tip sync_percent=99.* current_height=Height'
+      height_grep_text: 'finished initial sync to chain tip, using gossiped blocks sync_percent=100.* current_height=Height'
 
   # Test that Zebra can answer a synthetic RPC call, using a cached Zebra tip state
   #

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -53,7 +53,7 @@ use common::{
     sync::{
         create_cached_database_height, sync_until, MempoolBehavior, LARGE_CHECKPOINT_TEST_HEIGHT,
         LARGE_CHECKPOINT_TIMEOUT, MEDIUM_CHECKPOINT_TEST_HEIGHT, STOP_AT_HEIGHT_REGEX,
-        STOP_ON_LOAD_TIMEOUT, SYNC_FINISHED_REGEX_TMP_STOP_EARLY, TINY_CHECKPOINT_TEST_HEIGHT,
+        STOP_ON_LOAD_TIMEOUT, SYNC_FINISHED_REGEX, TINY_CHECKPOINT_TEST_HEIGHT,
         TINY_CHECKPOINT_TIMEOUT,
     },
 };
@@ -692,7 +692,7 @@ fn full_sync_test(network: Network, timeout_argument_name: &str) -> Result<()> {
             // Use the checkpoints to sync quickly, then do full validation until the chain tip
             true,
             // Finish when we reach the chain tip
-            SYNC_FINISHED_REGEX_TMP_STOP_EARLY,
+            SYNC_FINISHED_REGEX,
         )
     } else {
         tracing::info!(

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -53,7 +53,7 @@ use common::{
     sync::{
         create_cached_database_height, sync_until, MempoolBehavior, LARGE_CHECKPOINT_TEST_HEIGHT,
         LARGE_CHECKPOINT_TIMEOUT, MEDIUM_CHECKPOINT_TEST_HEIGHT, STOP_AT_HEIGHT_REGEX,
-        STOP_ON_LOAD_TIMEOUT, SYNC_FINISHED_REGEX, TINY_CHECKPOINT_TEST_HEIGHT,
+        STOP_ON_LOAD_TIMEOUT, SYNC_FINISHED_REGEX_TMP_STOP_EARLY, TINY_CHECKPOINT_TEST_HEIGHT,
         TINY_CHECKPOINT_TIMEOUT,
     },
 };
@@ -692,7 +692,7 @@ fn full_sync_test(network: Network, timeout_argument_name: &str) -> Result<()> {
             // Use the checkpoints to sync quickly, then do full validation until the chain tip
             true,
             // Finish when we reach the chain tip
-            SYNC_FINISHED_REGEX,
+            SYNC_FINISHED_REGEX_TMP_STOP_EARLY,
         )
     } else {
         tracing::info!(

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -39,10 +39,7 @@ pub const STOP_AT_HEIGHT_REGEX: &str = "stopping at configured height";
 /// - we have synced all known checkpoints,
 /// - the syncer has stopped downloading lots of blocks, and
 /// - we are regularly downloading some blocks via the syncer or block gossip.
-///
-/// Temporary workaround for slow syncs - stop at 99.5%.
-/// TODO: revert this change (#4456)
-pub const SYNC_FINISHED_REGEX: &str = "estimated progress to chain tip sync_percent=99";
+pub const SYNC_FINISHED_REGEX: &str = "finished initial sync to chain tip, using gossiped blocks";
 
 /// The maximum amount of time Zebra should take to reload after shutting down.
 ///

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -39,10 +39,13 @@ pub const STOP_AT_HEIGHT_REGEX: &str = "stopping at configured height";
 /// - we have synced all known checkpoints,
 /// - the syncer has stopped downloading lots of blocks, and
 /// - we are regularly downloading some blocks via the syncer or block gossip.
+pub const SYNC_FINISHED_REGEX: &str = "estimated progress to chain tip sync_percent=100";
+
+/// Temporary workaround for slow syncs - stop at 97%.
 ///
-/// Temporary workaround for slow syncs - stop at 99.5%.
 /// TODO: revert this change (#4456)
-pub const SYNC_FINISHED_REGEX: &str = "estimated progress to chain tip sync_percent=99";
+pub const SYNC_FINISHED_REGEX_TMP_STOP_EARLY: &str =
+    "estimated progress to chain tip sync_percent=97";
 
 /// The maximum amount of time Zebra should take to reload after shutting down.
 ///

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -39,13 +39,10 @@ pub const STOP_AT_HEIGHT_REGEX: &str = "stopping at configured height";
 /// - we have synced all known checkpoints,
 /// - the syncer has stopped downloading lots of blocks, and
 /// - we are regularly downloading some blocks via the syncer or block gossip.
-pub const SYNC_FINISHED_REGEX: &str = "estimated progress to chain tip sync_percent=100";
-
-/// Temporary workaround for slow syncs - stop at 97%.
 ///
+/// Temporary workaround for slow syncs - stop at 99.5%.
 /// TODO: revert this change (#4456)
-pub const SYNC_FINISHED_REGEX_TMP_STOP_EARLY: &str =
-    "estimated progress to chain tip sync_percent=97";
+pub const SYNC_FINISHED_REGEX: &str = "estimated progress to chain tip sync_percent=99";
 
 /// The maximum amount of time Zebra should take to reload after shutting down.
 ///


### PR DESCRIPTION
## Motivation

PRs #4457 and #4483 were a temporary fix, we want to restore full test coverage after we find another way to speed up the sync.

### Scheduling

Depends-On: #4456 

## Solution

Reverts ZcashFoundation/zebra#4457
Reverts ZcashFoundation/zebra#4483