### PR TITLE
change(deps): Turn on tokio's internal parking_lot feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5611,6 +5611,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
+ "parking_lot 0.11.2",
  "regex",
  "serde",
  "serde_json",

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 futures = "0.3.21"
 futures-core = "0.3.21"
 pin-project = "1.0.10"
-tokio = { version = "1.18.2", features = ["time", "sync", "tracing", "macros"] }
+tokio = { version = "1.18.2", features = ["time", "sync", "tracing", "macros", "parking_lot"] }
 tower = { version = "0.4.12", features = ["util", "buffer"] }
 tracing = "0.1.31"
 tracing-futures = "0.2.5"
@@ -18,7 +18,7 @@ tracing-futures = "0.2.5"
 color-eyre = "0.6.0"
 ed25519-zebra = "3.0.0"
 rand = { version = "0.8.5", package = "rand" }
-tokio = { version = "1.18.2", features = ["full"] }
+tokio = { version = "1.18.2", features = ["full", "parking_lot"] }
 tokio-test = "0.4.2"
 tower-fallback = { path = "../tower-fallback/" }
 tower-test = "0.4.0"

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -13,4 +13,4 @@ tracing = "0.1.31"
 
 [dev-dependencies]
 zebra-test = { path = "../zebra-test/" }
-tokio = { version = "1.18.2", features = ["full"] }
+tokio = { version = "1.18.2", features = ["full", "parking_lot"] }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -62,7 +62,7 @@ proptest-derive = { version = "0.3.0", optional = true }
 
 rand = { version = "0.8.5", optional = true, package = "rand" }
 rand_chacha = { version = "0.3.1", optional = true }
-tokio = { version = "1.18.2", optional = true }
+tokio = { version = "1.18.2", features = ["parking_lot"], optional = true }
 
 # ZF deps
 ed25519-zebra = "3.0.0"
@@ -82,7 +82,7 @@ proptest-derive = "0.3.0"
 rand = { version = "0.8.5", package = "rand" }
 rand_chacha = "0.3.1"
 
-tokio = "1.18.2"
+tokio = { version = "1.18.2", features = ["parking_lot"] }
 
 zebra-test = { path = "../zebra-test/" }
 

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -29,7 +29,7 @@ futures = "0.3.21"
 futures-util = "0.3.21"
 metrics = "0.17.1"
 thiserror = "1.0.31"
-tokio = { version = "1.18.2", features = ["time", "sync", "tracing"] }
+tokio = { version = "1.18.2", features = ["time", "sync", "tracing", "parking_lot"] }
 tower = { version = "0.4.12", features = ["timeout", "util", "buffer"] }
 tracing = "0.1.31"
 tracing-futures = "0.2.5"
@@ -57,7 +57,7 @@ proptest = "0.10.1"
 proptest-derive = "0.3.0"
 rand07 = { package = "rand", version = "0.7" }
 spandoc = "0.2.2"
-tokio = { version = "1.18.2", features = ["full"] }
+tokio = { version = "1.18.2", features = ["full", "parking_lot"] }
 tracing-error = "0.1.2"
 tracing-subscriber = "0.2.25"
 

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -59,7 +59,7 @@ rand07 = { package = "rand", version = "0.7" }
 spandoc = "0.2.2"
 tokio = { version = "1.18.2", features = ["full", "parking_lot"] }
 tracing-error = "0.1.2"
-tracing-subscriber = "0.2.25"
+tracing-subscriber = { version = "0.2.25", features = ["parking_lot"] }
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.137", features = ["serde_derive"] }
 thiserror = "1.0.31"
 
 futures = "0.3.21"
-tokio = { version = "1.18.2", features = ["net", "time", "tracing", "macros", "rt-multi-thread"] }
+tokio = { version = "1.18.2", features = ["net", "time", "tracing", "macros", "rt-multi-thread", "parking_lot"] }
 tokio-stream = { version = "0.1.8", features = ["sync", "time"] }
 tokio-util = { version = "0.7.2", features = ["codec"] }
 tower = { version = "0.4.12", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
@@ -52,7 +52,7 @@ proptest = "0.10.1"
 proptest-derive = "0.3.0"
 
 static_assertions = "1.1.0"
-tokio = { version = "1.18.2", features = ["test-util"] }
+tokio = { version = "1.18.2", features = ["test-util", "parking_lot"] }
 toml = "0.5.9"
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -30,7 +30,7 @@ jsonrpc-http-server = "18.0.0"
 serde_json = { version = "1.0.81", features = ["preserve_order"] }
 indexmap = { version = "1.8.1", features = ["serde"] }
 
-tokio = { version = "1.18.2", features = ["time", "rt-multi-thread", "macros", "tracing"] }
+tokio = { version = "1.18.2", features = ["time", "rt-multi-thread", "macros", "tracing", "parking_lot"] }
 tower = "0.4.12"
 
 tracing = "0.1.31"
@@ -48,7 +48,7 @@ proptest = "0.10.1"
 proptest-derive = "0.3.0"
 serde_json = "1.0.81"
 thiserror = "1.0.31"
-tokio = { version = "1.18.2", features = ["full", "test-util"] }
+tokio = { version = "1.18.2", features = ["full", "test-util", "parking_lot"] }
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -27,7 +27,7 @@ rocksdb = { version = "0.18.0", default_features = false, features = ["lz4"] }
 serde = { version = "1.0.137", features = ["serde_derive"] }
 tempfile = "3.3.0"
 thiserror = "1.0.31"
-tokio = { version = "1.18.2", features = ["sync"] }
+tokio = { version = "1.18.2", features = ["sync", "parking_lot"] }
 tower = { version = "0.4.12", features = ["buffer", "util"] }
 tracing = "0.1.31"
 
@@ -48,7 +48,7 @@ proptest-derive = "0.3.0"
 halo2 = { package = "halo2_proofs", version = "0.1.0" }
 jubjub = "0.9.0"
 
-tokio = { version = "1.18.2", features = ["full"] }
+tokio = { version = "1.18.2", features = ["full", "parking_lot"] }
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/" }

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -17,7 +17,7 @@ once_cell = "1.11.0"
 rand = { version = "0.8.5", package = "rand" }
 regex = "1.5.5"
 
-tokio = { version = "1.18.2", features = ["full"] }
+tokio = { version = "1.18.2", features = ["full", "parking_lot"] }
 tower = { version = "0.4.12", features = ["util"] }
 futures = "0.3.21"
 

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -25,7 +25,7 @@ color-eyre = "0.5.11"
 owo-colors = "3.4.0"
 spandoc = "0.2.2"
 thiserror = "1.0.31"
-tracing-subscriber = "0.2.25"
+tracing-subscriber = { version = "0.2.25", features = ["parking_lot"] }
 tracing-error = "0.1.2"
 tracing = "0.1.31"
 

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -13,7 +13,7 @@ color-eyre = "0.6.0"
 hex = "0.4.3"
 serde_json = "1.0.81"
 tracing-error = { version = "0.1.2", features = ["traced-error"] }
-tracing-subscriber = { version = "0.2.25", features = ["tracing-log"] }
+tracing-subscriber = { version = "0.2.25", features = ["tracing-log", "parking_lot"] }
 
 zebra-chain = { path = "../zebra-chain" }
 zebra-consensus = { path = "../zebra-consensus" }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -48,7 +48,7 @@ toml = "0.5.9"
 
 hyper = { version = "0.14.18", features = ["full"] }
 futures = "0.3.21"
-tokio = { version = "1.18.2", features = ["time", "rt-multi-thread", "macros", "tracing", "signal"] }
+tokio = { version = "1.18.2", features = ["time", "rt-multi-thread", "macros", "tracing", "signal", "parking_lot"] }
 tower = { version = "0.4.12", features = ["hedge", "limit"] }
 pin-project = "1.0.10"
 
@@ -95,7 +95,7 @@ semver = "1.0.9"
 # zebra-rpc needs the preserve_order feature, it also makes test results more stable
 serde_json = { version = "1.0.81", features = ["preserve_order"] }
 tempfile = "3.3.0"
-tokio = { version = "1.18.2", features = ["full", "test-util"] }
+tokio = { version = "1.18.2", features = ["full", "test-util", "parking_lot"] }
 tokio-stream = "0.1.8"
 
 # test feature lightwalletd-grpc-tests

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -57,7 +57,7 @@ thiserror = "1.0.31"
 
 tracing-flame = "0.1.0"
 tracing-journald = "0.1.0"
-tracing-subscriber = { version = "0.2.25", features = ["tracing-log"] }
+tracing-subscriber = { version = "0.2.25", features = ["tracing-log", "parking_lot"] }
 tracing-error = "0.1.2"
 metrics = "0.17.1"
 metrics-exporter-prometheus = "0.7.0"


### PR DESCRIPTION
## Motivation

Using the `parking_lot` concurrency crate could make Zebra faster.

It is also recommended as part of #2112:
https://github.com/tokio-rs/console/blob/main/console-subscriber/README.md#crate-feature-flags

## Solution

Enable the `parking_lot` feature in:
- tokio
- tracing-subscriber

This should be compatible with Zebra's existing locking.

## Review

Anyone can review this PR, but we only want to merge it if it's faster than the alternative.

### Reviewer Checklist

  - [ ] Existing tests pass

