### PR TITLE
fix(ci): set a network env variable to be used in `get-available-disks`

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -64,6 +64,8 @@ env:
   # TODO: use the output from ./.github/workflows/build-docker-image.yml
   IMAGE_NAME: zebrad-test
   GAR_BASE: us-docker.pkg.dev/zealous-zebra/zebra
+  # TODO: use environmental secrets for dynamic values
+  NETWORK: Mainnet
 
 jobs:
   get-available-disks:
@@ -90,6 +92,15 @@ jobs:
           workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
+
+      # Disk images in GCP are required to be in lowercase, but the blockchain network
+      # uses sentence case, so we need to downcase ${{ inputs.network }}
+      #
+      # Passes ${{ inputs.network }} to subsequent steps using $NETWORK env variable
+      - name: Downcase network name for disks
+        run: |
+          NETWORK_CAPS=${{ env.NETWORK || github.event.inputs.network }}
+          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
 
       # Find a cached state disk for subsequent jobs needing a cached state without
       # restricting the result from any branch.

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -94,9 +94,9 @@ jobs:
           token_format: 'access_token'
 
       # Disk images in GCP are required to be in lowercase, but the blockchain network
-      # uses sentence case, so we need to downcase ${{ inputs.network }}
+      # uses sentence case, so we need to downcase ${{ env.NETWORK or github.event.inputs.network }}
       #
-      # Passes ${{ inputs.network }} to subsequent steps using $NETWORK env variable
+      # Passes a lowercase Network name to subsequent steps using $NETWORK env variable
       - name: Downcase network name for disks
         run: |
           NETWORK_CAPS=${{ env.NETWORK || github.event.inputs.network }}


### PR DESCRIPTION
## Motivation

The blockchain Network name is being used in the `get-available-disks` job, but this variable was not being passed to this job.

When merging https://github.com/ZcashFoundation/zebra/pull/4392 we didn't considered this environment variable was no longer available in this workflow

## Solution

- Add `Network` as a global env variable
- Downcase the `Network` to be used by disk image search (as images are in lowercase)

## Review

Anyone from @ZcashFoundation/devops-reviewers, but this is urgent as a bunch of VMs are being triggered and most jobs are not finding the appropriate image, and I might admin merge it if it runs successfully 

## Follow Up Work

Check is this was also causing the cached state issues
