### PR TITLE
feat(ci): add a codespell linting action

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,2 +1,3 @@
 [codespell]
 ignore-words-list=crate
+exclude-file=mermaid.min.js

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+ignore-words-list=crate

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-ignore-words-list=crate
+ignore-words-list=crate,Sur
 exclude-file=book/mermaid.min.js

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 ignore-words-list=crate
-exclude-file=mermaid.min.js
+exclude-file=book/mermaid.min.js

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,7 @@ jobs:
             **/Cargo.lock
             clippy.toml
             .cargo/config.toml
+            .github/workflows/lint.yml
 
       - name: Workflow files
         id: changed-files-workflows

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -122,7 +122,6 @@ jobs:
 
   codespell:
     runs-on: ubuntu-latest
-    if: ${{ needs.changed-files.outputs.rust == 'true' }}
     needs: changed-files
     steps:
       - uses: actions/checkout@v3.0.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -129,3 +129,4 @@ jobs:
       - uses: plettich/action-codespell@master
         with:
           github_token: ${{ secrets.github_token }}
+          level: warning

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -118,3 +118,13 @@ jobs:
         with:
           level: warning
           fail_on_error: false
+
+  codespell:
+    runs-on: ubuntu-latest
+    if: ${{ needs.changed-files.outputs.rust == 'true' }}
+    needs: changed-files
+    steps:
+      - uses: actions/checkout@v3.0.2
+      - uses: plettich/action-codespell@master
+        with:
+          github_token: ${{ secrets.github_token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,11 @@
 # Contributing
 
-* [Running and Debugging](#running-and-debugging)
-* [Bug Reports](#bug-reports)
-* [Pull Requests](#pull-requests)
-* [Zebra RFCs](#zebra-rfcs)
+- [Contributing](#contributing)
+  - [Running and Debugging](#running-and-debugging)
+  - [Bug Reports](#bug-reports)
+  - [Pull Requests](#pull-requests)
+  - [Coverage Reports](#coverage-reports)
+  - [Zebra RFCs](#zebra-rfcs)
 
 ## Running and Debugging
 [running-and-debugging]: #running-and-debugging
@@ -14,13 +16,13 @@ how to build, run, and instrument Zebra.
 ## Bug Reports
 [bug-reports]: #bug-reports
 
-[File an issue](https://github.com/ZcashFoundation/zebra/issues/new/choose)
-on the issue tracker using the bug report template.
+[File an issu](https://github.com/ZcashFoundation/zebra/issues/new/choose)
+on the issue tracker usin the bug report template.
 
 ## Pull Requests
 [pull-requests]: #pull-requests
 
-PRs are welcome for small and large changes, but please don't make large PRs
+PRs are welcome for small and large changes, but pleas don't make large PRs
 without coordinating with us via the issue tracker or Discord. This helps
 increase development coordination and makes PRs easier to merge.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,9 @@
 # Contributing
 
-- [Contributing](#contributing)
-  - [Running and Debugging](#running-and-debugging)
-  - [Bug Reports](#bug-reports)
-  - [Pull Requests](#pull-requests)
-  - [Coverage Reports](#coverage-reports)
-  - [Zebra RFCs](#zebra-rfcs)
+* [Running and Debugging](#running-and-debugging)
+* [Bug Reports](#bug-reports)
+* [Pull Requests](#pull-requests)
+* [Zebra RFCs](#zebra-rfcs)
 
 ## Running and Debugging
 [running-and-debugging]: #running-and-debugging
@@ -16,13 +14,13 @@ how to build, run, and instrument Zebra.
 ## Bug Reports
 [bug-reports]: #bug-reports
 
-[File an issu](https://github.com/ZcashFoundation/zebra/issues/new/choose)
-on the issue tracker usin the bug report template.
+[File an issue](https://github.com/ZcashFoundation/zebra/issues/new/choose)
+on the issue tracker using the bug report template.
 
 ## Pull Requests
 [pull-requests]: #pull-requests
 
-PRs are welcome for small and large changes, but pleas don't make large PRs
+PRs are welcome for small and large changes, but please don't make large PRs
 without coordinating with us via the issue tracker or Discord. This helps
 increase development coordination and makes PRs easier to merge.
 


### PR DESCRIPTION
## Motivation

Codespell looks for common (and a lot of) misspellings instead of checking dictionary membership. It does not check for word membership in a complete dictionary, but instead looks for a set of common misspellings. Therefore it should catch errors like "adn", but it will not catch "adnasdfasdf". This also means it shouldn't generate false-positives when you use a niche term it doesn't know about.

Fixes #3318

## Solution

- Add a codespell action to to the `Lint` workflow and activate it when a rust file is changed

## Review

@upbqdn or anyone from @ZcashFoundation/devops-reviewers 

### Reviewer Checklist

  - [ ] Codespell is not generating false-positives
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- Validate if we can fix the amount of errors now
- If not, add a `continue-on-error` on the job
