### PR TITLE
fix(ci): Temporarily skip the lwd-update-sync test due to a CI bug

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -57,6 +57,12 @@ case "$1" in
             ls -lhR "$LIGHTWALLETD_DATA_DIR/db" || (echo "No $LIGHTWALLETD_DATA_DIR/db"; ls -lhR "$LIGHTWALLETD_DATA_DIR" | head -50 || echo "No $LIGHTWALLETD_DATA_DIR directory")
         elif [[ "$TEST_LWD_UPDATE_SYNC" -eq "1" ]]; then
             # Starting with a cached Zebra and lightwalletd tip, run a quick update sync.
+            #
+            # Temporarily skip this test, because the lwd cached state doesn't work.
+            # TODO: re-enable this test (#4415)
+            echo "Test skipped due to bug #4415"
+            exit 0
+
             ls -lh "$ZEBRA_CACHED_STATE_DIR"/*/* || (echo "No $ZEBRA_CACHED_STATE_DIR/*/*"; ls -lhR  "$ZEBRA_CACHED_STATE_DIR" | head -50 || echo "No $ZEBRA_CACHED_STATE_DIR directory")
             ls -lhR "$LIGHTWALLETD_DATA_DIR/db" || (echo "No $LIGHTWALLETD_DATA_DIR/db"; ls -lhR "$LIGHTWALLETD_DATA_DIR" | head -50 || echo "No $LIGHTWALLETD_DATA_DIR directory")
             cargo test --locked --release --features lightwalletd-grpc-tests --package zebrad --test acceptance -- --nocapture --include-ignored lightwalletd_update_sync


### PR DESCRIPTION
## Motivation

This test has been failing for about a week, it is unclear if we will have a permanent fix to #4415 any time soon.

## Solution

- skip the test in entrypoint.sh

## Review

Anyone can review this critical DevOps PR.

### Reviewer Checklist

  - [ ] Test shows as successful

## Follow Up Work

Revert this change once #4415 is fixed.