### PR TITLE
fix(ci): mount the lwd-cache dir to the `lightwalletd-full-sync`

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -378,7 +378,7 @@ jobs:
     # add `|| (github.event_name == 'push' && startsWith(github.head_ref, 'mergify/merge-queue/'))`:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1
     # TODO: this test is unreliable, in the meanwhile we'll only generate a new lwd cached state when a full sync is also triggered
-    if: ${{ (!cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true') || !fromJSON(needs.get-available-disks.outputs.lwd_tip_disk) }}
+    if: ${{ (github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true') || !fromJSON(needs.get-available-disks.outputs.lwd_tip_disk) }}
     with:
       app_name: lightwalletd
       test_id: lwd-full-sync

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -378,7 +378,7 @@ jobs:
     # add `|| (github.event_name == 'push' && startsWith(github.head_ref, 'mergify/merge-queue/'))`:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1
     # TODO: this test is unreliable, in the meanwhile we'll only generate a new lwd cached state when a full sync is also triggered
-    if: ${{ (github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true') || !fromJSON(needs.get-available-disks.outputs.lwd_tip_disk) }}
+    if: ${{ (!cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true') || !fromJSON(needs.get-available-disks.outputs.lwd_tip_disk) }}
     with:
       app_name: lightwalletd
       test_id: lwd-full-sync

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -372,9 +372,12 @@ jobs:
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   lightwalletd-full-sync:
     name: lightwalletd tip
-    needs: test-full-sync
+    needs: [ test-full-sync, get-available-disks ]
     uses: ./.github/workflows/deploy-gcp-tests.yml
-    if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
+    # to also run on Mergify head branches,
+    # add `|| (github.event_name == 'push' && startsWith(github.head_ref, 'mergify/merge-queue/'))`:
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1
+    if: ${{ (!cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true') || !fromJSON(needs.get-available-disks.outputs.lwd_tip_disk) }}
     with:
       app_name: lightwalletd
       test_id: lwd-full-sync

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -377,6 +377,7 @@ jobs:
     # to also run on Mergify head branches,
     # add `|| (github.event_name == 'push' && startsWith(github.head_ref, 'mergify/merge-queue/'))`:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1
+    # TODO: this test is unreliable, in the meanwhile we'll only generate a new lwd cached state when a full sync is also triggered
     if: ${{ (!cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true') || !fromJSON(needs.get-available-disks.outputs.lwd_tip_disk) }}
     with:
       app_name: lightwalletd

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -300,7 +300,7 @@ jobs:
         # lightwalletd-full-sync test is an exception to this rule, as it does not need a lwd cached state,
         # but it does saves a lwd cached state
         # TODO: we should find a better logic for this use cases
-        if: ${{ inputs.needs_zebra_state && !inputs.needs_lwd_state && inputs.test_id != "lightwalletd-full-sync" }}
+        if: ${{ inputs.needs_zebra_state && !inputs.needs_lwd_state && inputs.test_id != 'lightwalletd-full-sync' }}
         run: |
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
@@ -346,7 +346,7 @@ jobs:
         # lightwalletd-full-sync test is an exception to this rule, as it does not need a lwd cached state,
         # but it does saves a lwd cached state
         # TODO: we should find a better logic for this use cases
-        if: ${{ inputs.needs_zebra_state && inputs.needs_lwd_state || inputs.test_id == "lightwalletd-full-sync" }}
+        if: ${{ inputs.needs_zebra_state && inputs.needs_lwd_state || inputs.test_id == 'lightwalletd-full-sync' }}
         run: |
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -300,7 +300,7 @@ jobs:
         # lightwalletd-full-sync test is an exception to this rule, as it does not need a lwd cached state,
         # but it does saves a lwd cached state
         # TODO: we should find a better logic for this use cases
-        if: ${{ inputs.needs_zebra_state && !inputs.needs_lwd_state && inputs.test_id != 'lwd-full-sync' }}
+        if: ${{ (inputs.needs_zebra_state && !inputs.needs_lwd_state) && inputs.test_id != 'lwd-full-sync' }}
         run: |
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
@@ -346,7 +346,7 @@ jobs:
         # lightwalletd-full-sync test is an exception to this rule, as it does not need a lwd cached state,
         # but it does saves a lwd cached state
         # TODO: we should find a better logic for this use cases
-        if: ${{ inputs.needs_zebra_state && inputs.needs_lwd_state && inputs.test_id == 'lwd-full-sync' }}
+        if: ${{ (inputs.needs_zebra_state && inputs.needs_lwd_state) || inputs.test_id == 'lwd-full-sync' }}
         run: |
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -297,7 +297,10 @@ jobs:
       - name: Run ${{ inputs.test_id }} test
         # This step mounts the volume only when a single cached state is needed, in this case
         # the cached state from Zebra.
-        if: ${{ inputs.needs_zebra_state && !inputs.needs_lwd_state }}
+        # lightwalletd-full-sync test is an exception to this rule, as it does not need a lwd cached state,
+        # but it does saves a lwd cached state
+        # TODO: we should find a better logic for this use cases
+        if: ${{ inputs.needs_zebra_state && !inputs.needs_lwd_state && inputs.test_id != lightwalletd-full-sync }}
         run: |
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
@@ -340,7 +343,10 @@ jobs:
       - name: Run ${{ inputs.test_id }} test
         # This step mounts the volume only when both cached states are needed, in this case
         # the cached state from Zebra and Lightwalletd
-        if: ${{ inputs.needs_zebra_state && inputs.needs_lwd_state }}
+        # lightwalletd-full-sync test is an exception to this rule, as it does not need a lwd cached state,
+        # but it does saves a lwd cached state
+        # TODO: we should find a better logic for this use cases
+        if: ${{ inputs.needs_zebra_state && inputs.needs_lwd_state || inputs.test_id == lightwalletd-full-sync }}
         run: |
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -300,7 +300,7 @@ jobs:
         # lightwalletd-full-sync test is an exception to this rule, as it does not need a lwd cached state,
         # but it does saves a lwd cached state
         # TODO: we should find a better logic for this use cases
-        if: ${{ (inputs.needs_zebra_state && !inputs.needs_lwd_state) || inputs.test_id != 'lwd-full-sync' }}
+        if: ${{ inputs.needs_zebra_state && !inputs.needs_lwd_state && inputs.test_id != 'lwd-full-sync' }}
         run: |
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
@@ -346,7 +346,7 @@ jobs:
         # lightwalletd-full-sync test is an exception to this rule, as it does not need a lwd cached state,
         # but it does saves a lwd cached state
         # TODO: we should find a better logic for this use cases
-        if: ${{ (inputs.needs_zebra_state && inputs.needs_lwd_state) || inputs.test_id == 'lwd-full-sync' }}
+        if: ${{ inputs.needs_zebra_state && inputs.needs_lwd_state && inputs.test_id == 'lwd-full-sync' }}
         run: |
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -300,7 +300,7 @@ jobs:
         # lightwalletd-full-sync test is an exception to this rule, as it does not need a lwd cached state,
         # but it does saves a lwd cached state
         # TODO: we should find a better logic for this use cases
-        if: ${{ inputs.needs_zebra_state && !inputs.needs_lwd_state && inputs.test_id != 'lightwalletd-full-sync' }}
+        if: ${{ (inputs.needs_zebra_state && !inputs.needs_lwd_state) || inputs.test_id != 'lwd-full-sync' }}
         run: |
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
@@ -346,7 +346,7 @@ jobs:
         # lightwalletd-full-sync test is an exception to this rule, as it does not need a lwd cached state,
         # but it does saves a lwd cached state
         # TODO: we should find a better logic for this use cases
-        if: ${{ inputs.needs_zebra_state && inputs.needs_lwd_state || inputs.test_id == 'lightwalletd-full-sync' }}
+        if: ${{ (inputs.needs_zebra_state && inputs.needs_lwd_state) || inputs.test_id == 'lwd-full-sync' }}
         run: |
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -300,7 +300,7 @@ jobs:
         # lightwalletd-full-sync test is an exception to this rule, as it does not need a lwd cached state,
         # but it does saves a lwd cached state
         # TODO: we should find a better logic for this use cases
-        if: ${{ inputs.needs_zebra_state && !inputs.needs_lwd_state && inputs.test_id != lightwalletd-full-sync }}
+        if: ${{ inputs.needs_zebra_state && !inputs.needs_lwd_state && inputs.test_id != "lightwalletd-full-sync" }}
         run: |
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
@@ -346,7 +346,7 @@ jobs:
         # lightwalletd-full-sync test is an exception to this rule, as it does not need a lwd cached state,
         # but it does saves a lwd cached state
         # TODO: we should find a better logic for this use cases
-        if: ${{ inputs.needs_zebra_state && inputs.needs_lwd_state || inputs.test_id == lightwalletd-full-sync }}
+        if: ${{ inputs.needs_zebra_state && inputs.needs_lwd_state || inputs.test_id == "lightwalletd-full-sync" }}
         run: |
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \


### PR DESCRIPTION
## Motivation

Tests which needs a lightwalletd cached state have been failing for a while, this issue was introduced in a refactor where we wrongly stoped mounting the `lwd_state_dir` to the `lightwalletd-full-sync` test.

Fixes #4415 

### Designs

We need a condition that consider this type of scenarios, in the meanwhile we're adding this test id as an exception, until another refactor is done in this file.

## Solution

- Add `lightwalletd-full-sync` as an exception when just a zebra cached state is needed and run it when a lwd cached state is needed, even if this specific test does not need one, as we need to mount the path to save the content.
- Run this test just if a zebra full sync is run or if there's no lwd cache available. As a result this will always run in `main`, when a state upgrade happens and if a manual full sync is triggered.

## Review

@teor2345 can review this, or anyone from @ZcashFoundation/devops-reviewers if every test runs as expected

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- Improve this conditions
