### PR TITLE
fix(ci): Require cached state for the send transactions test

### DIFF
--- a/zebrad/tests/common/lightwalletd/send_transaction_test.rs
+++ b/zebrad/tests/common/lightwalletd/send_transaction_test.rs
@@ -52,12 +52,7 @@ pub async fn run() -> Result<()> {
 
     // We want a zebra state dir and a lightwalletd data dir in place,
     // so `UpdateCachedState` can be used as our test type
-    //
-    // But for now, we don't want to require the cached state, because it has been unreliable.
-    // TODO: use `UpdateCachedState`
-    let test_type = FullSyncFromGenesis {
-        allow_lightwalletd_cached_state: true,
-    };
+    let test_type = UpdateCachedState;
 
     let cached_state_path = test_type.zebrad_state_path("send_transaction_tests".to_string());
     if cached_state_path.is_none() {


### PR DESCRIPTION
## Motivation

We want the send transactions test to always be fast.

Depends-On: #4486

## Solution

Reverts ZcashFoundation/zebra#4416