### PR TITLE
fix(ci): Always run patch jobs that depend on cached cloud disks

### DIFF
--- a/.github/workflows/continous-integration-docker.patch-always.yml
+++ b/.github/workflows/continous-integration-docker.patch-always.yml
@@ -1,0 +1,28 @@
+# These jobs can be skipped based on cached Google Cloud state disks,
+# so they always need to run on every PR.
+#
+# TODO: when we refactor checking disks into a re-usable workflow,
+#       call it here, and patch if the disks *are* available
+name: CI Docker
+
+on:
+  pull_request:
+    branches:
+      - main
+
+  push:
+    branches:
+      - main
+
+jobs:
+  regenerate-stateful-disks:
+    name: Zebra checkpoint / Run sync-to-checkpoint test
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  test-full-sync:
+    name: Zebra tip / Run full-sync-to-tip test
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/continous-integration-docker.patch.yml
+++ b/.github/workflows/continous-integration-docker.patch.yml
@@ -1,5 +1,7 @@
 name: CI Docker
 
+# These jobs *don't* depend on cached Google Cloud state disks,
+# so they can be skipped when the modified files make the actual workflow run.
 on:
   pull_request:
     branches:
@@ -76,20 +78,8 @@ jobs:
     steps:
       - run: 'echo "No build required"'
 
-  regenerate-stateful-disks:
-    name: Zebra checkpoint / Run sync-to-checkpoint test
-    runs-on: ubuntu-latest
-    steps:
-      - run: 'echo "No build required"'
-
   test-stateful-sync:
     name: Zebra checkpoint update / Run sync-past-checkpoint test
-    runs-on: ubuntu-latest
-    steps:
-      - run: 'echo "No build required"'
-
-  test-full-sync:
-    name: Zebra tip / Run full-sync-to-tip test
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'


### PR DESCRIPTION
## Motivation

To implement #4340 correctly, we need to run some patch jobs on every PR, because they depend on changed files *and* cached Google Cloud disks.

(It's ok to skip patch jobs that just depend on changed files, because we know the real jobs will always run.)

## Solution

- Split the docker patch workflow into conditional and always workflows

## Review

Anyone can review this PR, it's blocking the rest of #4340.

### Reviewer Checklist

  - [ ] Patch jobs appear correctly (we'll test this as part of #4340)

## Follow Up Work

- Require these job names in branch protection rules (#4340)