### PR TITLE
change(sync): Activate the mempool after 2 syncer runs at the chain tip, rather than 4

### DIFF
--- a/zebrad/src/components/sync/recent_sync_lengths.rs
+++ b/zebrad/src/components/sync/recent_sync_lengths.rs
@@ -31,7 +31,7 @@ impl RecentSyncLengths {
     /// * clearing temporary errors and temporary syncs quickly
     /// * distinguishing between temporary and sustained syncs/errors
     /// * activating the syncer shortly after reaching the chain tip
-    pub const MAX_RECENT_LENGTHS: usize = 4;
+    pub const MAX_RECENT_LENGTHS: usize = 2;
 
     /// Create a new instance of [`RecentSyncLengths`]
     /// and a [`watch::Receiver`] endpoint for receiving recent sync lengths.


### PR DESCRIPTION
## Motivation

We want to speed up the full sync, as part of #4456.

Activating the mempool sooner also helps with usability and wallet performance. Users might be confused or frustrated if it takes 4-6 minutes for the mempool to activate after reaching the tip.

## Solution

- Average recently synced blocks over 2 syncer runs, rather than 4

This makes spurious mempool activation slightly more likely, but the consistent speed increase is worth it.

## Review

Anyone can review this PR, it's urgent because slow syncs block other work.

### Reviewer Checklist

  - [ ] Existing tests pass

