### PR TITLE
fix(ci): Permanently fix unreliable sync finished log regex

### DIFF
--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -39,7 +39,8 @@ pub const STOP_AT_HEIGHT_REGEX: &str = "stopping at configured height";
 /// - we have synced all known checkpoints,
 /// - the syncer has stopped downloading lots of blocks, and
 /// - we are regularly downloading some blocks via the syncer or block gossip.
-pub const SYNC_FINISHED_REGEX: &str = "estimated progress to chain tip sync_percent=100";
+pub const SYNC_FINISHED_REGEX: &str =
+    "finished initial sync to chain tip, using gossiped blocks sync_percent=100";
 
 /// Temporary workaround for slow syncs - stop at 97%.
 ///


### PR DESCRIPTION
## Motivation

The full sync to tip regex is unreliable, and causing some tests to sometimes fail.

## Solution

Use a regex that Zebra is guaranteed to log eventually.

Unlike the other recent changes, this is a permanent fix.

## Review

This is an urgent fix to stop CI and merges sometimes failing.

### Reviewer Checklist

  - [ ] CI passes

