### PR TITLE
feat(rpc): add support for verbosity=1 in getblock

### DIFF
--- a/zebra-chain/src/block/serialize.rs
+++ b/zebra-chain/src/block/serialize.rs
@@ -162,3 +162,9 @@ impl AsRef<[u8]> for SerializedBlock {
         self.bytes.as_ref()
     }
 }
+
+impl From<Vec<u8>> for SerializedBlock {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+}

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -126,16 +126,18 @@ pub trait Rpc {
     /// # Parameters
     ///
     /// - `height`: (string, required) The height number for the block to be returned.
+    /// - `verbosity`: (numeric, optional, default=1) 0 for hex encoded data, 1 for a json object,
+    ///     and 2 for json object with transaction data.
     ///
     /// # Notes
     ///
-    /// We only expose the `data` field as lightwalletd uses the non-verbose
-    /// mode for all getblock calls: <https://github.com/zcash/lightwalletd/blob/v0.4.9/common/common.go#L232>
+    /// With verbosity=1, [`lightwalletd` only reads the `tx` field of the
+    /// result](https://github.com/zcash/lightwalletd/blob/dfac02093d85fb31fb9a8475b884dd6abca966c7/common/common.go#L152),
+    /// so we only return that for now.
     ///
     /// `lightwalletd` only requests blocks by height, so we don't support
     /// getting blocks by hash. (But we parse the height as a JSON string, not an integer).
-    ///
-    /// The `verbosity` parameter is ignored but required in the call.
+    /// `lightwalletd` also does not use verbosity=2, so we don't support it.
     #[rpc(name = "getblock")]
     fn get_block(&self, height: String, verbosity: u8) -> BoxFuture<Result<GetBlock>>;
 
@@ -515,7 +517,7 @@ where
         .boxed()
     }
 
-    fn get_block(&self, height: String, _verbosity: u8) -> BoxFuture<Result<GetBlock>> {
+    fn get_block(&self, height: String, verbosity: u8) -> BoxFuture<Result<GetBlock>> {
         let mut state = self.state.clone();
 
         async move {
@@ -538,7 +540,21 @@ where
                 })?;
 
             match response {
-                zebra_state::ReadResponse::Block(Some(block)) => Ok(GetBlock(block.into())),
+                zebra_state::ReadResponse::Block(Some(block)) => match verbosity {
+                    0 => Ok(GetBlock::Raw(block.into())),
+                    1 => Ok(GetBlock::Object {
+                        tx: block
+                            .transactions
+                            .iter()
+                            .map(|tx| tx.hash().encode_hex())
+                            .collect(),
+                    }),
+                    _ => Err(Error {
+                        code: ErrorCode::InvalidParams,
+                        message: "Invalid verbosity value".to_string(),
+                        data: None,
+                    }),
+                },
                 zebra_state::ReadResponse::Block(None) => Err(Error {
                     code: MISSING_BLOCK_ERROR_CODE,
                     message: "Block not found".to_string(),
@@ -1070,7 +1086,16 @@ pub struct SentTransactionHash(#[serde(with = "hex")] transaction::Hash);
 ///
 /// See the notes for the [`Rpc::get_block` method].
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
-pub struct GetBlock(#[serde(with = "hex")] SerializedBlock);
+#[serde(untagged)]
+pub enum GetBlock {
+    /// The request block, hex-encoded.
+    Raw(#[serde(with = "hex")] SerializedBlock),
+    /// The block object.
+    Object {
+        /// Vector of hex-encoded TXIDs of the transactions of the block
+        tx: Vec<String>,
+    },
+}
 
 /// Response to a `getbestblockhash` RPC request.
 ///

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -82,13 +82,20 @@ async fn test_rpc_response_data_for_network(network: Network) {
         .expect("We should have an AddressBalance struct");
     snapshot_rpc_getaddressbalance(get_address_balance, &settings);
 
-    // `getblock`
+    // `getblock`, verbosity=0
     const BLOCK_HEIGHT: u32 = 1;
     let get_block = rpc
         .get_block(BLOCK_HEIGHT.to_string(), 0u8)
         .await
         .expect("We should have a GetBlock struct");
     snapshot_rpc_getblock(get_block, block_data.get(&BLOCK_HEIGHT).unwrap(), &settings);
+
+    // `getblock`, verbosity=1
+    let get_block = rpc
+        .get_block(BLOCK_HEIGHT.to_string(), 1u8)
+        .await
+        .expect("We should have a GetBlock struct");
+    snapshot_rpc_getblock_verbose(get_block, &settings);
 
     // `getbestblockhash`
     let get_best_block_hash = rpc
@@ -209,6 +216,11 @@ fn snapshot_rpc_getblock(block: GetBlock, block_data: &[u8], settings: &insta::S
             }),
         })
     });
+}
+
+/// Check `getblock` response with verbosity=1, using `cargo insta` and JSON serialization.
+fn snapshot_rpc_getblock_verbose(block: GetBlock, settings: &insta::Settings) {
+    settings.bind(|| insta::assert_json_snapshot!("get_block_verbose", block));
 }
 
 /// Snapshot `getbestblockhash` response, using `cargo insta` and JSON serialization.

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose@mainnet_10.snap
@@ -1,0 +1,9 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+expression: block
+---
+{
+  "tx": [
+    "851bf6fbf7a976327817c738c489d7fa657752445430922d94c983c0b9ed4609"
+  ]
+}

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose@testnet_10.snap
@@ -1,0 +1,9 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+expression: block
+---
+{
+  "tx": [
+    "f37e9f691fffb635de0999491d906ee85ba40cd36dae9f6e5911a8277d7c5f75"
+  ]
+}

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -77,14 +77,33 @@ async fn rpc_getblock() {
         Mainnet,
     );
 
-    // Make calls and check response
-    for (i, block) in blocks.into_iter().enumerate() {
+    // Make calls with verbosity=0 and check response
+    for (i, block) in blocks.iter().enumerate() {
         let get_block = rpc
             .get_block(i.to_string(), 0u8)
             .await
             .expect("We should have a GetBlock struct");
 
-        assert_eq!(get_block.0, block.into());
+        assert_eq!(get_block, GetBlock::Raw(block.clone().into()));
+    }
+
+    // Make calls with verbosity=1 and check response
+    for (i, block) in blocks.iter().enumerate() {
+        let get_block = rpc
+            .get_block(i.to_string(), 1u8)
+            .await
+            .expect("We should have a GetBlock struct");
+
+        assert_eq!(
+            get_block,
+            GetBlock::Object {
+                tx: block
+                    .transactions
+                    .iter()
+                    .map(|tx| tx.hash().encode_hex())
+                    .collect()
+            }
+        );
     }
 
     mempool.expect_no_requests().await;

--- a/zebra-rpc/src/tests/vectors.rs
+++ b/zebra-rpc/src/tests/vectors.rs
@@ -1,4 +1,4 @@
-use crate::methods::GetRawTransaction;
+use crate::methods::{GetBlock, GetRawTransaction};
 
 #[test]
 pub fn test_transaction_serialization() {
@@ -13,6 +13,23 @@ pub fn test_transaction_serialization() {
         height: 1,
     };
     let expected_json = r#"{"hex":"42","height":1}"#;
+    let j = serde_json::to_string(&expected_tx).unwrap();
+
+    assert_eq!(j, expected_json);
+}
+
+#[test]
+pub fn test_block_serialization() {
+    let expected_tx = GetBlock::Raw(vec![0x42].into());
+    let expected_json = r#""42""#;
+    let j = serde_json::to_string(&expected_tx).unwrap();
+
+    assert_eq!(j, expected_json);
+
+    let expected_tx = GetBlock::Object {
+        tx: vec!["42".into()],
+    };
+    let expected_json = r#"{"tx":["42"]}"#;
     let j = serde_json::to_string(&expected_tx).unwrap();
 
     assert_eq!(j, expected_json);


### PR DESCRIPTION
## Motivation

See https://github.com/ZcashFoundation/zebra/issues/4480

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

- [ ] Add support for getblock with verbosity=1, but only returning TXIDs
- [ ] Add tests / snapshots

Closes https://github.com/ZcashFoundation/zebra/issues/4480

## Review

This is required (i.e. will break CI if this is not merged) only if Aditya's lightwalletd is synced with upstream (which we have no idea when/if will happen). Anyone can review.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
