### PR TITLE
change(build): Disable debug logging at compile time in release builds

### DIFF
--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -18,6 +18,20 @@ default = []
 # Production features that activate extra dependencies
 enable-sentry = ["sentry", "sentry-tracing"]
 
+# Production features that modify dependency behaviour
+
+# Remove verbose logging at compile-time in release or all builds.
+#
+# Release builds are defined as "cfg(not(debug_assertions))".
+# https://docs.rs/tracing/latest/tracing/level_filters/index.html#compile-time-filters
+release_max_level_warn = ["tracing/release_max_level_warn", "log/release_max_level_warn"]
+release_max_level_info = ["tracing/release_max_level_info", "log/release_max_level_info"]
+release_max_level_debug = ["tracing/release_max_level_debug", "log/release_max_level_debug"]
+
+max_level_warn = ["tracing/max_level_warn", "log/max_level_warn"]
+max_level_info = ["tracing/max_level_info", "log/max_level_info"]
+max_level_debug = ["tracing/max_level_debug", "log/max_level_debug"]
+
 # Testing features that activate extra dependencies
 proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl", "zebra-state/proptest-impl", "zebra-consensus/proptest-impl", "zebra-network/proptest-impl"]
 
@@ -75,8 +89,10 @@ rand = { version = "0.8.5", package = "rand" }
 sentry-tracing = { version = "0.23.0", optional = true }
 sentry = { version = "0.23.0", default-features = false, features = ["backtrace", "contexts", "reqwest", "rustls"], optional = true }
 
+# prod feature release_max_level_info
+#
 # zebrad uses tracing for logging,
-# we only use `log` to print the static log levels in transitive dependencies
+# we only use `log` to set and print the static log levels in transitive dependencies
 log = "0.4.14"
 
 # test feature proptest-impl

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -13,7 +13,8 @@ repository = "https://github.com/ZcashFoundation/zebra"
 default-run = "zebrad"
 
 [features]
-default = []
+# In release builds, don't compile debug logging code, to improve performance.
+default = ["release_max_level_info"]
 
 # Production features that activate extra dependencies
 enable-sentry = ["sentry", "sentry-tracing"]


### PR DESCRIPTION
## Motivation

Compiling out debug and trace logs saves about 15 minutes of sync time (5%).

Part of #4456.

Depends-On: #4515

### Specifications

https://docs.rs/tracing/latest/tracing/level_filters/index.html#compile-time-filters
https://docs.rs/log/latest/log/#compile-time-filters

## Solution

- Add zebrad features that disable info, debug, or trace logs
- Disable debug and trace logs in release builds by default

## Review

Anyone can review this PR, it's on the critical path towards getting lightwalletd syncs working.

### Reviewer Checklist

  - [ ] Existing tests pass

