### PR TITLE
change(deps): Upgrade tracing-subscriber and related dependencies

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -266,7 +266,7 @@ jobs:
       needs_zebra_state: false
       saves_to_disk: true
       disk_suffix: checkpoint
-      height_grep_text: 'flushing database to disk height=Height'
+      height_grep_text: 'flushing database to disk .*height.*=.*Height'
 
   # Test that Zebra syncs and fully validates a few thousand blocks from a cached mandatory checkpoint disk
   #
@@ -309,7 +309,7 @@ jobs:
       needs_zebra_state: false
       saves_to_disk: true
       disk_suffix: tip
-      height_grep_text: 'estimated progress to chain tip sync_percent=99.* current_height=Height'
+      height_grep_text: 'current_height.*=.*Height'
 
   # Test that Zebra can answer a synthetic RPC call, using a cached Zebra tip state
   #

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -363,7 +363,7 @@ jobs:
       # disk description.
       #
       # The regex used to grep the sync height is provided by ${{ inputs.height_grep_text }},
-      # this allows to dynamically change the height as needed by different situations or 
+      # this allows to dynamically change the height as needed by different situations or
       # based on the logs output from different tests
       #
       # Passes the sync height to subsequent steps using $SYNC_HEIGHT env variable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,7 +2582,6 @@ dependencies = [
  "quanta",
  "thiserror",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,6 +2486,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5490,7 +5499,7 @@ dependencies = [
  "ansi_term 0.11.0",
  "chrono",
  "lazy_static",
- "matchers",
+ "matchers 0.0.1",
  "owning_ref",
  "regex",
  "smallvec 0.6.14",
@@ -5505,9 +5514,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term 0.12.1",
+ "lazy_static",
+ "matchers 0.1.0",
+ "regex",
  "sharded-slab",
  "smallvec 1.8.0",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,45 +815,18 @@ dependencies = [
 
 [[package]]
 name = "color-eyre"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1885697ee8a177096d42f158922251a41973117f6d8a234cee94b9509157b7"
-dependencies = [
- "backtrace",
- "color-spantrace 0.1.6",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors 1.3.0",
- "tracing-error 0.1.2",
- "url",
-]
-
-[[package]]
-name = "color-eyre"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ebf286c900a6d5867aeff75cfee3192857bb7f24b547d4f0df2ed6baa812c90"
 dependencies = [
  "backtrace",
- "color-spantrace 0.2.0",
+ "color-spantrace",
  "eyre",
  "indenter",
  "once_cell",
- "owo-colors 3.4.0",
- "tracing-error 0.2.0",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
-dependencies = [
- "once_cell",
- "owo-colors 1.3.0",
- "tracing-core",
- "tracing-error 0.1.2",
+ "owo-colors",
+ "tracing-error",
+ "url",
 ]
 
 [[package]]
@@ -863,9 +836,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
 dependencies = [
  "once_cell",
- "owo-colors 3.4.0",
+ "owo-colors",
  "tracing-core",
- "tracing-error 0.2.0",
+ "tracing-error",
 ]
 
 [[package]]
@@ -1211,20 +1184,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
-dependencies = [
- "cfg-if 1.0.0",
- "num_cpus",
-]
-
-[[package]]
 name = "debugid"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "serde",
  "uuid",
@@ -1432,12 +1395,6 @@ checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if 1.0.0",
 ]
-
-[[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-iterator"
@@ -2593,9 +2550,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.17.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55586aa936c35f34ba8aa5d97356d554311206e1ce1f9e68fe7b07288e5ad827"
+checksum = "2e52eb6380b6d2a10eb3434aec0885374490f5b82c8aaf5cd487a183c98be834"
 dependencies = [
  "ahash",
  "metrics-macros",
@@ -2603,11 +2560,12 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aee04ed06085ea4eb1e1378c4fd973d95e0d3e32897913cd58aedc3b10e71452"
+checksum = "8b93b470b04c005178058e18ac8bb2eb3fda562cf87af5ea05ba8d44190d458c"
 dependencies = [
  "hyper",
+ "indexmap",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -2615,41 +2573,34 @@ dependencies = [
  "quanta",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "metrics-macros"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0daa0ab3a0ae956d0e2c1f42511422850e577d36a255357d1a7d08d45ee3a2f1"
+checksum = "49e30813093f757be5cf21e50389a24dc7dbb22c49f23b7e8f51d69b508a5ffa"
 dependencies = [
- "lazy_static",
  "proc-macro2 1.0.36",
  "quote 1.0.15",
- "regex",
  "syn 1.0.92",
 ]
 
 [[package]]
 name = "metrics-util"
-version = "0.10.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1174223789e331d9d47a4a953dac36e397db60fa8d2a111ac505388c6c7fe32e"
+checksum = "65a9e83b833e1d2e07010a386b197c13aa199bbd0fca5cf69bfa147972db890a"
 dependencies = [
- "ahash",
- "aho-corasick",
  "atomic-shim",
  "crossbeam-epoch",
  "crossbeam-utils",
- "dashmap",
  "hashbrown",
- "indexmap",
  "metrics",
  "num_cpus",
- "ordered-float",
  "parking_lot 0.11.2",
  "quanta",
- "radix_trie",
  "sketches-ddsketch",
 ]
 
@@ -2750,15 +2701,6 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec 1.8.0",
 ]
 
 [[package]]
@@ -2976,15 +2918,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "ordered-map"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3002,12 +2935,6 @@ checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
 dependencies = [
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "owo-colors"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
 
 [[package]]
 name = "owo-colors"
@@ -3655,16 +3582,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4210,9 +4127,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546b9b6f76c26c60ffbcf0b7136e15169fe13d43949b4aadb7c1edc1c3f3a26f"
+checksum = "904eca4fb30c6112a1dae60c0a9e29cfb42f42129da4260f1ee20e94151b62e3"
 dependencies = [
  "httpdate",
  "reqwest",
@@ -4224,9 +4141,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd0cba2aff36ac98708f7a6e7abbdde82dbaf180d5870c41084dc1b473648b9"
+checksum = "1671189d1b759879fa4bdde46c50a499abb14332ed81f84fc6f60658f41b2fdb"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -4236,14 +4153,12 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bacf1c62427c6c97b896640d0c4dd204bbd3b79dd192d7cb40891aa5ee11d58"
+checksum = "db80ceff16bb1a4b2689b8758e5e61e405fc4d8ff9f2d1b5b845b76ce37fa34e"
 dependencies = [
  "hostname",
- "lazy_static",
  "libc",
- "regex",
  "rustc_version",
  "sentry-core",
  "uname",
@@ -4251,11 +4166,10 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a957270c9a430218f8031c866493061a27e35a70250e9527f093563a33ce6b"
+checksum = "6c9f509d3959ed4dbbd80ca42572caad682aaa1cdd92c719e0815d0e87f82c96"
 dependencies = [
- "chrono",
  "lazy_static",
  "rand 0.8.5",
  "sentry-types",
@@ -4265,26 +4179,28 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d291df287241b0ef97f5bf9e9a595691ef8dfb49bc6acfd55b9dc2ade681f1c9"
+checksum = "d4e2796e40502893ed0d04646e507f91e74f1cbf09e370d42bb1cdbcaeeca9bb"
 dependencies = [
  "sentry-core",
  "tracing-core",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.11",
 ]
 
 [[package]]
 name = "sentry-types"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4dd2266fee014a86e250e98e389191ecd23be546b5c42b6a2fb9af2972fadac"
+checksum = "254b600e93e9ef00a48382c9f1e86d27884bd9a5489efa4eb9210c20c72e88a6"
 dependencies = [
- "chrono",
  "debugid",
+ "getrandom 0.2.5",
+ "hex",
  "serde",
  "serde_json",
  "thiserror",
+ "time 0.3.7",
  "url",
  "uuid",
 ]
@@ -5405,7 +5321,7 @@ dependencies = [
 name = "tower-batch"
 version = "0.2.25"
 dependencies = [
- "color-eyre 0.6.1",
+ "color-eyre",
  "ed25519-zebra",
  "futures",
  "futures-core",
@@ -5514,33 +5430,23 @@ dependencies = [
 
 [[package]]
 name = "tracing-error"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
-dependencies = [
- "tracing",
- "tracing-subscriber 0.2.25",
-]
-
-[[package]]
-name = "tracing-error"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber 0.3.11",
 ]
 
 [[package]]
 name = "tracing-flame"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd520fe41c667b437952383f3a1ec14f1fa45d653f719a77eedd6e6a02d8fa54"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
 dependencies = [
  "lazy_static",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.11",
 ]
 
 [[package]]
@@ -5555,12 +5461,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-journald"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe1f0ed2b7a5fcb6da2bc9e783587d9a0c8b9535e50224afe04e543eae8a2d6"
+checksum = "ba316a74e8fc3c3896a850dba2375928a9fa171b085ecddfc7c054d39970f3fd"
 dependencies = [
+ "libc",
  "tracing-core",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.11",
 ]
 
 [[package]]
@@ -5571,16 +5478,6 @@ checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static",
  "log",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
  "tracing-core",
 ]
 
@@ -5603,35 +5500,16 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term 0.12.1",
- "chrono",
- "lazy_static",
- "matchers",
- "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec 1.8.0",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
 ]
 
 [[package]]
@@ -5752,9 +5630,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "93bbc61e655a4833cf400d0d15bf3649313422fa7572886ad6dab16d79886365"
 dependencies = [
  "getrandom 0.2.5",
  "serde",
@@ -6256,7 +6134,7 @@ dependencies = [
  "bs58",
  "byteorder",
  "chrono",
- "color-eyre 0.6.1",
+ "color-eyre",
  "criterion",
  "displaydoc",
  "ed25519-zebra",
@@ -6311,7 +6189,7 @@ dependencies = [
  "blake2b_simd 1.0.0",
  "bls12_381",
  "chrono",
- "color-eyre 0.6.1",
+ "color-eyre",
  "dirs",
  "displaydoc",
  "futures",
@@ -6335,9 +6213,9 @@ dependencies = [
  "tower-batch",
  "tower-fallback",
  "tracing",
- "tracing-error 0.1.2",
+ "tracing-error",
  "tracing-futures",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.11",
  "zcash_proofs",
  "zebra-chain",
  "zebra-script",
@@ -6374,7 +6252,7 @@ dependencies = [
  "tor-rtcompat",
  "tower",
  "tracing",
- "tracing-error 0.1.2",
+ "tracing-error",
  "tracing-futures",
  "zebra-chain",
  "zebra-test",
@@ -6435,7 +6313,7 @@ version = "1.0.0-beta.10"
 dependencies = [
  "bincode",
  "chrono",
- "color-eyre 0.6.1",
+ "color-eyre",
  "dirs",
  "displaydoc",
  "futures",
@@ -6468,14 +6346,14 @@ dependencies = [
 name = "zebra-test"
 version = "1.0.0-beta.10"
 dependencies = [
- "color-eyre 0.5.11",
+ "color-eyre",
  "futures",
  "hex",
  "indexmap",
  "insta",
  "lazy_static",
  "once_cell",
- "owo-colors 3.4.0",
+ "owo-colors",
  "proptest",
  "rand 0.8.5",
  "regex",
@@ -6485,20 +6363,20 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
- "tracing-error 0.1.2",
- "tracing-subscriber 0.2.25",
+ "tracing-error",
+ "tracing-subscriber 0.3.11",
 ]
 
 [[package]]
 name = "zebra-utils"
 version = "1.0.0-beta.10"
 dependencies = [
- "color-eyre 0.6.1",
+ "color-eyre",
  "hex",
  "serde_json",
  "structopt",
- "tracing-error 0.1.2",
- "tracing-subscriber 0.2.25",
+ "tracing-error",
+ "tracing-subscriber 0.3.11",
  "zebra-chain",
  "zebra-consensus",
  "zebra-state",
@@ -6511,7 +6389,7 @@ dependencies = [
  "abscissa_core",
  "atty",
  "chrono",
- "color-eyre 0.5.11",
+ "color-eyre",
  "dirs",
  "futures",
  "gumdrop",
@@ -6546,11 +6424,11 @@ dependencies = [
  "tonic-build",
  "tower",
  "tracing",
- "tracing-error 0.1.2",
+ "tracing-error",
  "tracing-flame",
  "tracing-futures",
  "tracing-journald",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.11",
  "vergen",
  "zebra-chain",
  "zebra-consensus",

--- a/deny.toml
+++ b/deny.toml
@@ -36,17 +36,14 @@ skip = [
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [
-    # ticket #2983: criterion dependencies
+    # wait for criterion to de-duplicate itertools transitive dependencies
     { name = "criterion", version = "=0.3.5" },
 
-    # ticket #3000: tower-fallback dependencies
+    # ticket #3000: upgrade tower-fallback dependencies
     { name = "pin-project", version = "=0.4.29" },
 
-    # ticket #3315: ordered-map dependencies that should be dev-dependencies
+    # wait for ordered-map to release a dependency fix
     { name = "ordered-map", version = "=0.4.2" },
-
-    # ticket #2984: owo-colors dependencies
-    { name = "color-eyre", version = "=0.5.11" },
 
     # wait for structopt upgrade (or upgrade to clap 3)
     { name = "heck", version = "=0.3.3" },
@@ -64,20 +61,18 @@ skip-tree = [
     # wait for curve25519-dalek to upgrade
     { name = "digest", version = "=0.9.0" },
 
-    # Wait for inferno -> num-format to upgrade
+    # wait for inferno -> num-format to upgrade
     { name = "arrayvec", version = "=0.4.12" },
 
-    # upgrade sentry, metrics-exporter-prometheus, reqwest, hyper,
-    # which needs #2953: upgrade tracing to the latest major version
-    #
-    # also wait for tower-test and tokio-test to upgrade
+    # wait for tokio-test -> tokio-stream to upgrade
     { name = "tokio-util", version = "=0.6.9" },
-    { name = "tracing-subscriber", version = "=0.1.6" },
 
     # upgrade abscissa and arti
+    { name = "darling", version = "=0.10.2" },
     { name = "darling", version = "=0.12.4" },
-    { name = "darling", version = "=0.13.4" },
+    { name = "tracing-subscriber", version = "=0.1.6" },
 
+    # wait for primitive-types to upgrade
     { name = "proc-macro-crate", version = "=0.1.5" },
 ]
 

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -15,7 +15,7 @@ tracing = "0.1.31"
 tracing-futures = "0.2.5"
 
 [dev-dependencies]
-color-eyre = "0.6.0"
+color-eyre = "0.6.1"
 ed25519-zebra = "3.0.0"
 rand = { version = "0.8.5", package = "rand" }
 tokio = { version = "1.18.2", features = ["full"] }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -71,7 +71,7 @@ redjubjub = "0.5.0"
 zebra-test = { path = "../zebra-test/", optional = true }
 
 [dev-dependencies]
-color-eyre = "0.6.0"
+color-eyre = "0.6.1"
 criterion = { version = "0.3.5", features = ["html_reports"] }
 itertools = "0.10.3"
 spandoc = "0.2.2"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.137", features = ["serde_derive"] }
 
 futures = "0.3.21"
 futures-util = "0.3.21"
-metrics = "0.17.1"
+metrics = "0.18.1"
 thiserror = "1.0.31"
 tokio = { version = "1.18.2", features = ["time", "sync", "tracing"] }
 tower = { version = "0.4.12", features = ["timeout", "util", "buffer"] }
@@ -51,15 +51,15 @@ proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
-color-eyre = "0.6.0"
+color-eyre = "0.6.1"
 hex = "0.4.3"
 proptest = "0.10.1"
 proptest-derive = "0.3.0"
 rand07 = { package = "rand", version = "0.7" }
 spandoc = "0.2.2"
 tokio = { version = "1.18.2", features = ["full"] }
-tracing-error = "0.1.2"
-tracing-subscriber = "0.2.25"
+tracing-error = "0.2.0"
+tracing-subscriber = "0.3.11"
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -347,7 +347,7 @@ where
         }
         metrics::gauge!(
             "checkpoint.queued.continuous.height",
-            pending_height.0 as f64
+            pending_height.0 as f64,
         );
 
         // Now find the start of the checkpoint range
@@ -369,7 +369,7 @@ where
         if let Some(block::Height(target_checkpoint)) = target_checkpoint {
             metrics::gauge!(
                 "checkpoint.processing.next.height",
-                target_checkpoint as f64
+                target_checkpoint as f64,
             );
         } else {
             // Use the start height if there is no potential next checkpoint
@@ -578,7 +578,7 @@ where
                 .keys()
                 .next_back()
                 .expect("queued has at least one entry")
-                .0 as f64
+                .0 as f64,
         );
 
         let is_checkpoint = self.checkpoint_list.contains(height);
@@ -767,7 +767,7 @@ where
 
         let block_count = rev_valid_blocks.len();
         tracing::info!(?block_count, ?current_range, "verified checkpoint range");
-        metrics::counter!("checkpoint.verified.block.count", block_count as _);
+        metrics::counter!("checkpoint.verified.block.count", block_count as u64);
 
         // All the blocks we've kept are valid, so let's verify them
         // in height order.

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -32,9 +32,9 @@ tokio-stream = { version = "0.1.8", features = ["sync", "time"] }
 tokio-util = { version = "0.7.2", features = ["codec"] }
 tower = { version = "0.4.12", features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 
-metrics = "0.17.1"
+metrics = "0.18.1"
 tracing-futures = "0.2.5"
-tracing-error = { version = "0.1.2", features = ["traced-error"] }
+tracing-error = { version = "0.2.0", features = ["traced-error"] }
 tracing = "0.1.31"
 
 # tor dependencies

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -519,7 +519,7 @@ impl AddressBook {
         metrics::gauge!("candidate_set.gossiped", m.never_attempted_gossiped as f64);
         metrics::gauge!(
             "candidate_set.alternate",
-            m.never_attempted_alternate as f64
+            m.never_attempted_alternate as f64,
         );
         metrics::gauge!("candidate_set.failed", m.failed as f64);
         metrics::gauge!("candidate_set.pending", m.attempt_pending as f64);
@@ -529,7 +529,7 @@ impl AddressBook {
         // TODO: rename to address_book.responded.stopped_responding
         metrics::gauge!(
             "candidate_set.disconnected",
-            m.recently_stopped_responding as f64
+            m.recently_stopped_responding as f64,
         );
 
         std::mem::drop(_guard);

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -678,7 +678,7 @@ where
         // the value is the remote version of the most recent rejected handshake from each peer
         metrics::gauge!(
             "zcash.net.peers.version.obsolete",
-            remote_version.0.into(),
+            remote_version.0 as f64,
             "remote_ip" => their_addr.to_string(),
         );
 
@@ -709,7 +709,7 @@ where
         // the value is the remote version of the most recent connected handshake from each peer
         metrics::gauge!(
             "zcash.net.peers.version.connected",
-            remote_version.0.into(),
+            remote_version.0 as f64,
             "remote_ip" => their_addr.to_string(),
         );
     }

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -681,7 +681,7 @@ where
             handshakes
                 .len()
                 .checked_sub(1)
-                .expect("the pool always contains an unresolved future") as f64
+                .expect("the pool always contains an unresolved future") as f64,
         );
 
         let crawler_action = tokio::select! {

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -17,7 +17,7 @@ futures = "0.3.21"
 hex = "0.4.3"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
-metrics = "0.17.1"
+metrics = "0.18.1"
 mset = "0.1.0"
 proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
@@ -35,7 +35,7 @@ zebra-chain = { path = "../zebra-chain" }
 zebra-test = { path = "../zebra-test/", optional = true }
 
 [dev-dependencies]
-color-eyre = "0.6.0"
+color-eyre = "0.6.1"
 once_cell = "1.12.0"
 spandoc = "0.2.2"
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -301,13 +301,16 @@ impl StateService {
         if let Some(tip_block_height) = tip_block_height {
             metrics::gauge!(
                 "state.full_verifier.committed.block.height",
-                tip_block_height.0 as _
+                tip_block_height.0 as f64,
             );
 
             // This height gauge is updated for both fully verified and checkpoint blocks.
             // These updates can't conflict, because the state makes sure that blocks
             // are committed in order.
-            metrics::gauge!("zcash.chain.verified.block.height", tip_block_height.0 as _);
+            metrics::gauge!(
+                "zcash.chain.verified.block.height",
+                tip_block_height.0 as f64,
+            );
         }
 
         tracing::trace!("finished processing queued block");

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -161,19 +161,19 @@ impl FinalizedState {
 
         if self.queued_by_prev_hash.is_empty() {
             self.max_queued_height = f64::NAN;
-        } else if self.max_queued_height.is_nan() || self.max_queued_height < height.0 as _ {
+        } else if self.max_queued_height.is_nan() || self.max_queued_height < height.0 as f64 {
             // if there are still blocks in the queue, then either:
             //   - the new block was lower than the old maximum, and there was a gap before it,
             //     so the maximum is still the same (and we skip this code), or
             //   - the new block is higher than the old maximum, and there is at least one gap
             //     between the finalized tip and the new maximum
-            self.max_queued_height = height.0 as _;
+            self.max_queued_height = height.0 as f64;
         }
 
         metrics::gauge!("state.checkpoint.queued.max.height", self.max_queued_height);
         metrics::gauge!(
             "state.checkpoint.queued.block.count",
-            self.queued_by_prev_hash.len() as f64
+            self.queued_by_prev_hash.len() as f64,
         );
 
         highest_queue_commit
@@ -193,13 +193,16 @@ impl FinalizedState {
             metrics::counter!("state.checkpoint.finalized.block.count", 1);
             metrics::gauge!(
                 "state.checkpoint.finalized.block.height",
-                finalized.height.0 as _
+                finalized.height.0 as f64,
             );
 
             // This height gauge is updated for both fully verified and checkpoint blocks.
             // These updates can't conflict, because the state makes sure that blocks
             // are committed in order.
-            metrics::gauge!("zcash.chain.verified.block.height", finalized.height.0 as _);
+            metrics::gauge!(
+                "zcash.chain.verified.block.height",
+                finalized.height.0 as f64,
+            );
             metrics::counter!("zcash.chain.verified.block.total", 1);
 
             Ok(finalized)
@@ -207,7 +210,7 @@ impl FinalizedState {
             metrics::counter!("state.checkpoint.error.block.count", 1);
             metrics::gauge!(
                 "state.checkpoint.error.block.height",
-                finalized.height.0 as _
+                finalized.height.0 as f64,
             );
 
             Err(())

--- a/zebra-state/src/service/finalized_state/zebra_db/metrics.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/metrics.rs
@@ -52,7 +52,7 @@ pub(crate) fn block_precommit_metrics(block: &Block, hash: block::Hash, height: 
     );
 
     metrics::counter!("state.finalized.block.count", 1);
-    metrics::gauge!("state.finalized.block.height", height.0 as _);
+    metrics::gauge!("state.finalized.block.height", height.0 as f64);
 
     metrics::counter!(
         "state.finalized.cumulative.transactions",

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -422,7 +422,7 @@ impl NonFinalizedState {
     /// Update the metrics after `block` is committed
     fn update_metrics_for_committed_block(&self, height: block::Height, hash: block::Hash) {
         metrics::counter!("state.memory.committed.block.count", 1);
-        metrics::gauge!("state.memory.committed.block.height", height.0 as _);
+        metrics::gauge!("state.memory.committed.block.height", height.0 as f64);
 
         if self
             .best_chain()
@@ -436,7 +436,7 @@ impl NonFinalizedState {
             == hash
         {
             metrics::counter!("state.memory.best.committed.block.count", 1);
-            metrics::gauge!("state.memory.best.committed.block.height", height.0 as _);
+            metrics::gauge!("state.memory.best.committed.block.height", height.0 as f64);
         }
 
         self.update_metrics_for_chains();
@@ -444,7 +444,10 @@ impl NonFinalizedState {
 
     /// Update the metrics after `self.chain_set` is modified
     fn update_metrics_for_chains(&self) {
-        metrics::gauge!("state.memory.chain.count", self.chain_set.len() as _);
-        metrics::gauge!("state.memory.best.chain.length", self.best_chain_len() as _);
+        metrics::gauge!("state.memory.chain.count", self.chain_set.len() as f64);
+        metrics::gauge!(
+            "state.memory.best.chain.length",
+            self.best_chain_len() as f64,
+        );
     }
 }

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -107,10 +107,8 @@ async fn test_populated_state_responds_correctly(
 
                 let from_coinbase = transaction.is_coinbase();
                 for (index, output) in transaction.outputs().iter().cloned().enumerate() {
-                    let outpoint = transparent::OutPoint {
-                        hash: transaction_hash,
-                        index: index as _,
-                    };
+                    let outpoint = transparent::OutPoint::from_usize(transaction_hash, index);
+
                     let utxo = transparent::Utxo {
                         output,
                         height,

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -25,7 +25,7 @@ color-eyre = "0.6.1"
 owo-colors = "3.4.0"
 spandoc = "0.2.2"
 thiserror = "1.0.31"
-tracing-subscriber = "0.3.11"
+tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 tracing-error = "0.2.0"
 tracing = "0.1.31"
 

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -21,12 +21,12 @@ tokio = { version = "1.18.2", features = ["full"] }
 tower = { version = "0.4.12", features = ["util"] }
 futures = "0.3.21"
 
-color-eyre = "0.5.11"
+color-eyre = "0.6.1"
 owo-colors = "3.4.0"
 spandoc = "0.2.2"
 thiserror = "1.0.31"
-tracing-subscriber = "0.2.25"
-tracing-error = "0.1.2"
+tracing-subscriber = "0.3.11"
+tracing-error = "0.2.0"
 tracing = "0.1.31"
 
 [dev-dependencies]

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -12,8 +12,8 @@ structopt = "0.3.26"
 color-eyre = "0.6.1"
 hex = "0.4.3"
 serde_json = "1.0.81"
-tracing-error = { version = "0.2.0", features = ["traced-error"] }
-tracing-subscriber = { version = "0.3.11", features = ["tracing-log"] }
+tracing-error = "0.2.0"
+tracing-subscriber = "0.3.11"
 
 zebra-chain = { path = "../zebra-chain" }
 zebra-consensus = { path = "../zebra-consensus" }

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 
 [dependencies]
 structopt = "0.3.26"
-color-eyre = "0.6.0"
+color-eyre = "0.6.1"
 hex = "0.4.3"
 serde_json = "1.0.81"
-tracing-error = { version = "0.1.2", features = ["traced-error"] }
-tracing-subscriber = { version = "0.2.25", features = ["tracing-log"] }
+tracing-error = { version = "0.2.0", features = ["traced-error"] }
+tracing-subscriber = { version = "0.3.11", features = ["tracing-log"] }
 
 zebra-chain = { path = "../zebra-chain" }
 zebra-consensus = { path = "../zebra-consensus" }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -72,12 +72,13 @@ thiserror = "1.0.31"
 
 tracing-flame = "0.2.0"
 tracing-journald = "0.3.0"
-tracing-subscriber = { version = "0.3.11", features = ["tracing-log"] }
+tracing-subscriber = { version = "0.3.11", features = ["tracing-log", "env-filter"] }
 tracing-error = "0.2.0"
-metrics = "0.18.1"
-metrics-exporter-prometheus = "0.9.0"
 tracing-futures = "0.2.5"
 tracing = "0.1.31"
+
+metrics = "0.18.1"
+metrics-exporter-prometheus = "0.9.0"
 
 dirs = "4.0.0"
 inferno = { version = "0.11.3", default-features = false }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -75,7 +75,7 @@ thiserror = "1.0.31"
 
 tracing-flame = "0.2.0"
 tracing-journald = "0.3.0"
-tracing-subscriber = { version = "0.3.11", features = ["tracing-log", "env-filter"] }
+tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 tracing-error = "0.2.0"
 tracing-futures = "0.2.5"
 tracing = "0.1.31"

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -21,6 +21,9 @@ enable-sentry = ["sentry", "sentry-tracing"]
 
 # Production features that modify dependency behaviour
 
+# Enable additional error debugging in release builds
+error-debug = ["color-eyre/track-caller", "color-eyre/capture-spantrace"]
+
 # Remove verbose logging at compile-time in release or all builds.
 #
 # Release builds are defined as "cfg(not(debug_assertions))".

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -67,7 +67,7 @@ tokio = { version = "1.18.2", features = ["time", "rt-multi-thread", "macros", "
 tower = { version = "0.4.12", features = ["hedge", "limit"] }
 pin-project = "1.0.10"
 
-color-eyre = { version = "0.6.1", features = ["issue-url"] }
+color-eyre = { version = "0.6.1", default_features = false, features = ["issue-url"] }
 thiserror = "1.0.31"
 
 tracing-flame = "0.2.0"
@@ -126,6 +126,9 @@ tonic = "0.7.2"
 
 proptest = "0.10.1"
 proptest-derive = "0.3.0"
+
+# enable span traces and track caller in tests
+color-eyre = { version = "0.6.1", features = ["issue-url"] }
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
 zebra-consensus = { path = "../zebra-consensus/", features = ["proptest-impl"] }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -78,7 +78,7 @@ tracing-futures = "0.2.5"
 tracing = "0.1.31"
 
 metrics = "0.18.1"
-metrics-exporter-prometheus = "0.9.0"
+metrics-exporter-prometheus = { version = "0.9.0", default-features = false, features = ["http-listener"] }
 
 dirs = "4.0.0"
 inferno = { version = "0.11.3", default-features = false }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -67,15 +67,15 @@ tokio = { version = "1.18.2", features = ["time", "rt-multi-thread", "macros", "
 tower = { version = "0.4.12", features = ["hedge", "limit"] }
 pin-project = "1.0.10"
 
-color-eyre = { version = "0.5.11", features = ["issue-url"] }
+color-eyre = { version = "0.6.1", features = ["issue-url"] }
 thiserror = "1.0.31"
 
-tracing-flame = "0.1.0"
-tracing-journald = "0.1.0"
-tracing-subscriber = { version = "0.2.25", features = ["tracing-log"] }
-tracing-error = "0.1.2"
-metrics = "0.17.1"
-metrics-exporter-prometheus = "0.7.0"
+tracing-flame = "0.2.0"
+tracing-journald = "0.3.0"
+tracing-subscriber = { version = "0.3.11", features = ["tracing-log"] }
+tracing-error = "0.2.0"
+metrics = "0.18.1"
+metrics-exporter-prometheus = "0.9.0"
 tracing-futures = "0.2.5"
 tracing = "0.1.31"
 
@@ -87,8 +87,8 @@ num-integer = "0.1.45"
 rand = { version = "0.8.5", package = "rand" }
 
 # prod feature enable-sentry
-sentry-tracing = { version = "0.23.0", optional = true }
-sentry = { version = "0.23.0", default-features = false, features = ["backtrace", "contexts", "reqwest", "rustls"], optional = true }
+sentry-tracing = { version = "0.26.0", optional = true }
+sentry = { version = "0.26.0", default-features = false, features = ["backtrace", "contexts", "reqwest", "rustls"], optional = true }
 
 # prod feature release_max_level_info
 #
@@ -111,7 +111,7 @@ abscissa_core = { version = "0.5", features = ["testing"] }
 hex = "0.4.3"
 once_cell = "1.12.0"
 regex = "1.5.6"
-reqwest = "0.11"
+reqwest = "0.11.10"
 semver = "1.0.9"
 # zebra-rpc needs the preserve_order feature, it also makes test results more stable
 serde_json = { version = "1.0.81", features = ["preserve_order"] }

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -186,7 +186,7 @@ where
                 "block hash already queued for inbound download: ignored block"
             );
 
-            metrics::gauge!("gossip.queued.block.count", self.pending.len() as _);
+            metrics::gauge!("gossip.queued.block.count", self.pending.len() as f64);
             metrics::counter!("gossip.already.queued.dropped.block.hash.count", 1);
 
             return DownloadAction::AlreadyQueued;
@@ -200,7 +200,7 @@ where
                 "too many blocks queued for inbound download: ignored block"
             );
 
-            metrics::gauge!("gossip.queued.block.count", self.pending.len() as _);
+            metrics::gauge!("gossip.queued.block.count", self.pending.len() as f64);
             metrics::counter!("gossip.full.queue.dropped.block.hash.count", 1);
 
             return DownloadAction::FullQueue;
@@ -356,7 +356,7 @@ where
             ?MAX_INBOUND_CONCURRENCY,
             "queued hash for download"
         );
-        metrics::gauge!("gossip.queued.block.count", self.pending.len() as _);
+        metrics::gauge!("gossip.queued.block.count", self.pending.len() as f64);
 
         DownloadAction::AddedToQueue
     }

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -237,7 +237,7 @@ where
             );
             metrics::gauge!(
                 "mempool.currently.queued.transactions",
-                self.pending.len() as _
+                self.pending.len() as f64,
             );
 
             return Err(MempoolError::AlreadyQueued);
@@ -252,7 +252,7 @@ where
             );
             metrics::gauge!(
                 "mempool.currently.queued.transactions",
-                self.pending.len() as _
+                self.pending.len() as f64,
             );
 
             return Err(MempoolError::FullQueue);
@@ -370,7 +370,7 @@ where
         );
         metrics::gauge!(
             "mempool.currently.queued.transactions",
-            self.pending.len() as _
+            self.pending.len() as f64,
         );
         metrics::counter!("mempool.queued.transactions.total", 1);
 
@@ -411,7 +411,7 @@ where
         assert!(self.cancel_handles.is_empty());
         metrics::gauge!(
             "mempool.currently.queued.transactions",
-            self.pending.len() as _
+            self.pending.len() as f64,
         );
     }
 
@@ -456,6 +456,6 @@ where
     ZS::Future: Send,
 {
     fn drop(self: Pin<&mut Self>) {
-        metrics::gauge!("mempool.currently.queued.transactions", 0 as _);
+        metrics::gauge!("mempool.currently.queued.transactions", 0 as f64);
     }
 }

--- a/zebrad/src/components/mempool/gossip.rs
+++ b/zebrad/src/components/mempool/gossip.rs
@@ -46,6 +46,6 @@ where
         // broadcast requests don't return errors, and we'd just want to ignore them anyway
         let _ = broadcast_network.ready().await?.call(request).await;
 
-        metrics::counter!("mempool.gossiped.transactions.total", txs_len as _);
+        metrics::counter!("mempool.gossiped.transactions.total", txs_len as u64);
     }
 }

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -532,14 +532,14 @@ impl Storage {
     fn update_rejected_metrics(&mut self) {
         metrics::gauge!(
             "mempool.rejected.transaction.ids",
-            self.rejected_transaction_count() as _
+            self.rejected_transaction_count() as f64,
         );
         // This is just an approximation.
         // TODO: make it more accurate #2869
         let item_size = size_of::<(transaction::Hash, SameEffectsTipRejectionError)>();
         metrics::gauge!(
             "mempool.rejected.transaction.ids.bytes",
-            (self.rejected_transaction_count() * item_size) as _
+            (self.rejected_transaction_count() * item_size) as f64,
         );
     }
 }

--- a/zebrad/src/components/mempool/storage/verified_set.rs
+++ b/zebrad/src/components/mempool/storage/verified_set.rs
@@ -261,12 +261,12 @@ impl VerifiedSet {
     fn update_metrics(&mut self) {
         metrics::gauge!(
             "zcash.mempool.size.transactions",
-            self.transaction_count() as _
+            self.transaction_count() as f64,
         );
         metrics::gauge!(
             "zcash.mempool.size.bytes",
-            self.transactions_serialized_size as _
+            self.transactions_serialized_size as f64,
         );
-        metrics::gauge!("zcash.mempool.cost.bytes", self.total_cost as _);
+        metrics::gauge!("zcash.mempool.cost.bytes", self.total_cost as f64);
     }
 }

--- a/zebrad/src/components/metrics.rs
+++ b/zebrad/src/components/metrics.rs
@@ -13,9 +13,11 @@ impl MetricsEndpoint {
     pub fn new(config: &ZebradConfig) -> Result<Self, FrameworkError> {
         if let Some(addr) = config.metrics.endpoint_addr {
             info!("Trying to open metrics endpoint at {}...", addr);
+
             let endpoint_result = metrics_exporter_prometheus::PrometheusBuilder::new()
-                .listen_address(addr)
+                .with_http_listener(addr)
                 .install();
+
             match endpoint_result {
                 Ok(()) => {
                     info!("Opened metrics endpoint at {}", addr);

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -853,11 +853,11 @@ where
     fn update_metrics(&mut self) {
         metrics::gauge!(
             "sync.prospective_tips.len",
-            self.prospective_tips.len() as f64
+            self.prospective_tips.len() as f64,
         );
         metrics::gauge!(
             "sync.downloads.in_flight",
-            self.downloads.in_flight() as f64
+            self.downloads.in_flight() as f64,
         );
     }
 

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -45,7 +45,7 @@ pub const BETWEEN_NODES_DELAY: Duration = Duration::from_secs(2);
 /// The amount of time we wait for lightwalletd to update to the tip.
 ///
 /// The cached tip can be a few days old, and Zebra needs time to activate its mempool.
-pub const LIGHTWALLETD_UPDATE_TIP_DELAY: Duration = Duration::from_secs(10 * 60);
+pub const LIGHTWALLETD_UPDATE_TIP_DELAY: Duration = Duration::from_secs(20 * 60);
 
 /// The amount of time we wait for lightwalletd to do a full sync to the tip.
 ///

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -350,12 +350,12 @@ impl LightwalletdTestType {
 
         if self.needs_zebra_cached_state() {
             // Fail if we need a cached Zebra state, but it's empty
-            zebrad_failure_messages.push("loaded Zebra state cache tip=None".to_string());
+            zebrad_failure_messages.push("loaded Zebra state cache .*tip.*=.*None".to_string());
         }
         if *self == LaunchWithEmptyState {
             // Fail if we need an empty Zebra state, but it has blocks
             zebrad_failure_messages
-                .push(r"loaded Zebra state cache tip=.*Height\([1-9][0-9]*\)".to_string());
+                .push(r"loaded Zebra state cache .*tip.*=.*Height\([1-9][0-9]*\)".to_string());
         }
 
         let zebrad_ignore_messages = Vec::new();

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -39,14 +39,17 @@ pub const STOP_AT_HEIGHT_REGEX: &str = "stopping at configured height";
 /// - we have synced all known checkpoints,
 /// - the syncer has stopped downloading lots of blocks, and
 /// - we are regularly downloading some blocks via the syncer or block gossip.
+///
+/// The trailing `\.` is required, so the regex finds the fractional percentage,
+/// and the other integers on that line are ignored.
 pub const SYNC_FINISHED_REGEX: &str =
-    "finished initial sync to chain tip, using gossiped blocks sync_percent=100";
+    r"finished initial sync to chain tip, using gossiped blocks .*sync_percent.*=.*100\.";
 
 /// Temporary workaround for slow syncs - stop at 97%.
 ///
 /// TODO: revert this change (#4456)
 pub const SYNC_FINISHED_REGEX_TMP_STOP_EARLY: &str =
-    "estimated progress to chain tip sync_percent=97";
+    r"estimated progress to chain tip .*sync_percent.*=.*97\.";
 
 /// The maximum amount of time Zebra should take to reload after shutting down.
 ///


### PR DESCRIPTION
## Motivation

Before we integrate tokio-console (#2112), we need to upgrade tracing-subscriber to the latest version.

Close #2953.

## Solution

Upgrade dependencies using `cargo upgrade`:
* tracing-error
* tracing-subscrber
    * Enable the env-filter feature
* color-eyre
    * Disable span traces and track caller by default, to improve performance
* tracing-flame
* tracing-journald
* sentry
* sentry-tracing
* metrics
    * Fix type inference for metrics
* metrics-exporter-prometheus
    * Update metrics-exporter-prometheus API 
    * Disable unused features
* reqwest

Update duplicate dependency checks
Tidy up some unrelated test code

## Review

Anyone can review this PR.

I've marked it as a high priority because it could cause merge conflicts with other PRs.

### Reviewer Checklist

  - [ ] Existing tests pass

