### PR TITLE
fix(ci): Add lightwalletd gRPC, clippy, rustfmt patch jobs

### DIFF
--- a/.github/workflows/continous-integration-docker.patch-always.yml
+++ b/.github/workflows/continous-integration-docker.patch-always.yml
@@ -10,10 +10,6 @@ on:
     branches:
       - main
 
-  push:
-    branches:
-      - main
-
 jobs:
   regenerate-stateful-disks:
     name: Zebra checkpoint / Run sync-to-checkpoint test

--- a/.github/workflows/continous-integration-docker.patch.yml
+++ b/.github/workflows/continous-integration-docker.patch.yml
@@ -22,25 +22,6 @@ on:
       - '.github/workflows/deploy-gcp-tests.yml'
       - '.github/workflows/build-docker-image.yml'
 
-  push:
-    branches:
-      - main
-    paths-ignore:
-      # code and tests
-      - '**/*.rs'
-      # hard-coded checkpoints and proptest regressions
-      - '**/*.txt'
-      # test data snapshots
-      - '**/*.snap'
-      # dependencies
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      # workflow definitions
-      - 'docker/**'
-      - '.github/workflows/continous-integration-docker.yml'
-      - '.github/workflows/deploy-gcp-tests.yml'
-      - '.github/workflows/build-docker-image.yml'
-
 jobs:
   get-available-disks:
     name: Find available cached state disks

--- a/.github/workflows/continous-integration-docker.patch.yml
+++ b/.github/workflows/continous-integration-docker.patch.yml
@@ -107,3 +107,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
+
+  lightwalletd-grpc-test:
+    name: lightwalletd GRPC tests / Run lwd-grpc-wallet test
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/lint.patch.yml
+++ b/.github/workflows/lint.patch.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'


### PR DESCRIPTION
## Motivation

We forgot to add a patch job for the:
- lightwalletd GRPC tests
- clippy lint
- rustfmt lint

Some PRs will show as pending until this merges.

We're also running some patch jobs when we don't need to.

## Review

I might just admin-merge this.

