### PR TITLE
change(net): immediately disconnect from pre-NU5 nodes

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -281,23 +281,13 @@ lazy_static! {
     ///
     /// If peer versions are too old, we will disconnect from them.
     ///
-    /// The minimum network protocol version typically changes after Mainnet and/or
+    /// The minimum network protocol version typically changes after Mainnet and
     /// Testnet network upgrades.
     pub static ref INITIAL_MIN_NETWORK_PROTOCOL_VERSION: HashMap<Network, Version> = {
         let mut hash_map = HashMap::new();
 
-        // TODO: update to Nu5 when there are enough Nu5 mainnet nodes deployed (#4117)
-        hash_map.insert(Mainnet, Version::min_specified_for_upgrade(Mainnet, Canopy));
-
-        // This is the `zcashd` network protocol version:
-        // - after the first NU5 testnet activation, and
-        // - after updating to the second NU5 testnet activation consensus rules,
-        // - but before setting the second NU5 testnet activation height.
-        //
-        // TODO: update to:
-        // Version::min_specified_for_upgrade(Mainnet, Nu5)
-        // when there are enough Nu5 testnet nodes deployed (#4116)
-        hash_map.insert(Testnet, Version(170_040));
+        hash_map.insert(Mainnet, Version::min_specified_for_upgrade(Mainnet, Nu5));
+        hash_map.insert(Testnet, Version::min_specified_for_upgrade(Testnet, Nu5));
 
         hash_map
     };

--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -22,7 +22,7 @@ fn peer_set_ready_single_connection() {
     let peer_versions = PeerVersions {
         peer_versions: vec![Version::min_specified_for_upgrade(
             Network::Mainnet,
-            NetworkUpgrade::Canopy,
+            NetworkUpgrade::Nu5,
         )],
     };
 
@@ -114,7 +114,7 @@ fn peer_set_ready_single_connection() {
 #[test]
 fn peer_set_ready_multiple_connections() {
     // Use three peers with the same version
-    let peer_version = Version::min_specified_for_upgrade(Network::Mainnet, NetworkUpgrade::Canopy);
+    let peer_version = Version::min_specified_for_upgrade(Network::Mainnet, NetworkUpgrade::Nu5);
     let peer_versions = PeerVersions {
         peer_versions: vec![peer_version, peer_version, peer_version],
     };
@@ -178,7 +178,7 @@ fn peer_set_route_inv_empty_registry() {
     let test_hash = block::Hash([0; 32]);
 
     // Use two peers with the same version
-    let peer_version = Version::min_specified_for_upgrade(Network::Mainnet, NetworkUpgrade::Canopy);
+    let peer_version = Version::min_specified_for_upgrade(Network::Mainnet, NetworkUpgrade::Nu5);
     let peer_versions = PeerVersions {
         peer_versions: vec![peer_version, peer_version],
     };
@@ -260,7 +260,7 @@ fn peer_set_route_inv_advertised_registry_order(advertised_first: bool) {
     let test_change = InventoryStatus::new_available(test_inv, test_peer);
 
     // Use two peers with the same version
-    let peer_version = Version::min_specified_for_upgrade(Network::Mainnet, NetworkUpgrade::Canopy);
+    let peer_version = Version::min_specified_for_upgrade(Network::Mainnet, NetworkUpgrade::Nu5);
     let peer_versions = PeerVersions {
         peer_versions: vec![peer_version, peer_version],
     };
@@ -369,7 +369,7 @@ fn peer_set_route_inv_missing_registry_order(missing_first: bool) {
     let test_change = InventoryStatus::new_missing(test_inv, test_peer);
 
     // Use two peers with the same version
-    let peer_version = Version::min_specified_for_upgrade(Network::Mainnet, NetworkUpgrade::Canopy);
+    let peer_version = Version::min_specified_for_upgrade(Network::Mainnet, NetworkUpgrade::Nu5);
     let peer_versions = PeerVersions {
         peer_versions: vec![peer_version, peer_version],
     };
@@ -472,7 +472,7 @@ fn peer_set_route_inv_all_missing_fail() {
     let test_change = InventoryStatus::new_missing(test_inv, test_peer);
 
     // Use one peer
-    let peer_version = Version::min_specified_for_upgrade(Network::Mainnet, NetworkUpgrade::Canopy);
+    let peer_version = Version::min_specified_for_upgrade(Network::Mainnet, NetworkUpgrade::Nu5);
     let peer_versions = PeerVersions {
         peer_versions: vec![peer_version],
     };


### PR DESCRIPTION
## Motivation

We want to ignore pre-NU5 nodes, because they will follow a different chain.

Close #4117.

### Scheduling

This PR needs to be merged:
- after NU5 mainnet activation, and
- before the next Zebra release.

## Solution

- immediately disconnect from pre-NU5 nodes on mainnet and testnet

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [ ] Existing tests pass

