### PR TITLE
fix(ci): test RPCs with zcash/lightwalletd, to fix post-NU5 failures in adityapk00/lightwalletd

### DIFF
--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -2,7 +2,8 @@ name: zcash-lightwalletd
 
 on:
   workflow_dispatch:
-  
+
+  # Update the lightwalletd image when related changes merge to the `zebra/main` branch
   push:
     branches:
       - 'main'
@@ -10,7 +11,7 @@ on:
       # rebuild lightwalletd whenever the related Zebra code changes
       #
       # TODO: this code isn't compiled in this docker image
-      #       rebuild whenever the actual code at adityapk00/lightwalletd/master changes
+      #       rebuild whenever the actual code at zcash/lightwalletd/master changes
       - 'zebra-rpc/**'
       - 'zebrad/tests/acceptance.rs'
       - 'zebrad/src/config.rs'
@@ -20,9 +21,6 @@ on:
       - '.github/workflows/zcash-lightwalletd.yml'
 
   # Update the lightwalletd image when each related PR changes
-  #
-  # TODO: after NU5 mainnet activation and wallet orchard features are stable,
-  #       consider just rebuilding the image on `main` merges
   pull_request:
     branches:
       - main
@@ -52,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.0.2
         with:
-          repository: adityapk00/lightwalletd
+          repository: zcash/lightwalletd
           ref: 'master'
           persist-credentials: false
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1106,7 +1106,12 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
         return Ok(());
     }
 
-    tracing::info!(?test_type, "running lightwalletd & zebrad integration test");
+    tracing::info!(
+        ?test_type,
+        ?config,
+        ?lightwalletd_state_path,
+        "running lightwalletd & zebrad integration test",
+    );
 
     // Get the lists of process failure logs
     let (zebrad_failure_messages, zebrad_ignore_messages) = test_type.zebrad_failure_messages();

--- a/zebrad/tests/common/cached_state.rs
+++ b/zebrad/tests/common/cached_state.rs
@@ -63,13 +63,19 @@ pub async fn load_tip_height_from_state_directory(
 
 /// Recursively copy a chain state directory into a new temporary directory.
 pub async fn copy_state_directory(source: impl AsRef<Path>) -> Result<TempDir> {
+    let source = source.as_ref();
     let destination = testdir()?;
 
-    let mut remaining_directories = vec![PathBuf::from(source.as_ref())];
+    tracing::info!(
+        ?source,
+        ?destination,
+        "copying cached state files (this may take some time)...",
+    );
+
+    let mut remaining_directories = vec![PathBuf::from(source)];
 
     while let Some(directory) = remaining_directories.pop() {
-        let sub_directories =
-            copy_directory(&directory, source.as_ref(), destination.as_ref()).await?;
+        let sub_directories = copy_directory(&directory, source, destination.as_ref()).await?;
 
         remaining_directories.extend(sub_directories);
     }

--- a/zebrad/tests/common/failure_messages.rs
+++ b/zebrad/tests/common/failure_messages.rs
@@ -80,7 +80,6 @@ pub const LIGHTWALLETD_FAILURE_MESSAGES: &[&str] = &[
     "received overlong message",
     "received unexpected height block",
     "Reorg exceeded max",
-    "unable to issue RPC call",
     // Missing fields for each specific RPC
     //
     // get_block_chain_info

--- a/zebrad/tests/common/failure_messages.rs
+++ b/zebrad/tests/common/failure_messages.rs
@@ -74,9 +74,9 @@ pub const LIGHTWALLETD_FAILURE_MESSAGES: &[&str] = &[
     "error parsing JSON",
     "error reading JSON response",
     "error with",
-    // We expect these errors when lightwalletd reaches the end of the zebrad cached state
-    // "error requesting block: 0: Block not found",
-    // "error zcashd getblock rpc",
+    // Block error messages
+    "error requesting block: 0: Block not found",
+    "error zcashd getblock rpc",
     "received overlong message",
     "received unexpected height block",
     "Reorg exceeded max",

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -309,10 +309,17 @@ impl LightwalletdTestType {
         match env::var_os(LIGHTWALLETD_DATA_DIR) {
             Some(path) => Some(path.into()),
             None => {
-                tracing::info!(
-                    "skipped {test_name:?} {self:?} lightwalletd test, \
-                     set the {LIGHTWALLETD_DATA_DIR:?} environment variable to run the test",
-                );
+                if self.needs_lightwalletd_cached_state() {
+                    tracing::info!(
+                        "skipped {test_name:?} {self:?} lightwalletd test, \
+                         set the {LIGHTWALLETD_DATA_DIR:?} environment variable to run the test",
+                    );
+                } else if self.allow_lightwalletd_cached_state() {
+                    tracing::info!(
+                        "running {test_name:?} {self:?} lightwalletd test without cached state, \
+                         set the {LIGHTWALLETD_DATA_DIR:?} environment variable to run with cached state",
+                    );
+                }
 
                 None
             }

--- a/zebrad/tests/common/lightwalletd/send_transaction_test.rs
+++ b/zebrad/tests/common/lightwalletd/send_transaction_test.rs
@@ -161,10 +161,7 @@ async fn load_transactions_from_a_future_block(
     let full_sync_path =
         perform_full_sync_starting_from(network, partial_sync_path.as_ref()).await?;
 
-    tracing::info!(
-        ?full_sync_path,
-        "loading transactions...",
-    );
+    tracing::info!(?full_sync_path, "loading transactions...");
 
     let transactions =
         load_transactions_from_block_after(partial_sync_height, network, full_sync_path.as_ref())

--- a/zebrad/tests/common/lightwalletd/send_transaction_test.rs
+++ b/zebrad/tests/common/lightwalletd/send_transaction_test.rs
@@ -54,8 +54,8 @@ pub async fn run() -> Result<()> {
     // so `UpdateCachedState` can be used as our test type
     let test_type = UpdateCachedState;
 
-    let cached_state_path = test_type.zebrad_state_path("send_transaction_tests".to_string());
-    if cached_state_path.is_none() {
+    let zebrad_state_path = test_type.zebrad_state_path("send_transaction_tests".to_string());
+    if zebrad_state_path.is_none() {
         return Ok(());
     }
 
@@ -67,11 +67,30 @@ pub async fn run() -> Result<()> {
 
     let network = Network::Mainnet;
 
+    tracing::info!(
+        ?network,
+        ?test_type,
+        ?zebrad_state_path,
+        ?lightwalletd_state_path,
+        "running gRPC send transaction test using lightwalletd & zebrad",
+    );
+
     let (transactions, partial_sync_path) =
-        load_transactions_from_a_future_block(network, cached_state_path.unwrap()).await?;
+        load_transactions_from_a_future_block(network, zebrad_state_path.unwrap()).await?;
+
+    tracing::info!(
+        transaction_count = ?transactions.len(),
+        ?partial_sync_path,
+        "got transactions to send",
+    );
 
     let (_zebrad, zebra_rpc_address) =
         spawn_zebrad_for_rpc_without_initial_peers(Network::Mainnet, partial_sync_path, test_type)?;
+
+    tracing::info!(
+        ?zebra_rpc_address,
+        "spawned disconnected zebrad with shorter chain",
+    );
 
     let (_lightwalletd, lightwalletd_rpc_port) = spawn_lightwalletd_with_rpc_server(
         zebra_rpc_address,
@@ -80,7 +99,17 @@ pub async fn run() -> Result<()> {
         true,
     )?;
 
+    tracing::info!(
+        ?lightwalletd_rpc_port,
+        "spawned lightwalletd connected to zebrad",
+    );
+
     let mut rpc_client = connect_to_lightwalletd(lightwalletd_rpc_port).await?;
+
+    tracing::info!(
+        transaction_count = ?transactions.len(),
+        "connected gRPC client to lightwalletd, sending transactions...",
+    );
 
     for transaction in transactions {
         let expected_response = wallet_grpc::SendResponse {
@@ -112,13 +141,30 @@ pub async fn run() -> Result<()> {
 /// synchronized chain.
 async fn load_transactions_from_a_future_block(
     network: Network,
-    cached_state_path: PathBuf,
+    zebrad_state_path: PathBuf,
 ) -> Result<(Vec<Arc<Transaction>>, TempDir)> {
+    tracing::info!(
+        ?network,
+        ?zebrad_state_path,
+        "preparing partial sync, copying files...",
+    );
+
     let (partial_sync_path, partial_sync_height) =
-        prepare_partial_sync(network, cached_state_path).await?;
+        prepare_partial_sync(network, zebrad_state_path).await?;
+
+    tracing::info!(
+        ?partial_sync_height,
+        ?partial_sync_path,
+        "performing full sync...",
+    );
 
     let full_sync_path =
         perform_full_sync_starting_from(network, partial_sync_path.as_ref()).await?;
+
+    tracing::info!(
+        ?full_sync_path,
+        "loading transactions...",
+    );
 
     let transactions =
         load_transactions_from_block_after(partial_sync_height, network, full_sync_path.as_ref())
@@ -133,9 +179,9 @@ async fn load_transactions_from_a_future_block(
 /// height of the partially synchronized chain.
 async fn prepare_partial_sync(
     network: Network,
-    cached_zebra_state: PathBuf,
+    zebrad_state_path: PathBuf,
 ) -> Result<(TempDir, block::Height)> {
-    let partial_sync_path = copy_state_directory(cached_zebra_state).await?;
+    let partial_sync_path = copy_state_directory(zebrad_state_path).await?;
     let tip_height =
         load_tip_height_from_state_directory(network, partial_sync_path.as_ref()).await?;
 
@@ -149,15 +195,15 @@ async fn prepare_partial_sync(
 ///
 /// # Panics
 ///
-/// If the specified `state_path` contains a chain state that's not synchronized to a tip that's
+/// If the specified `zebrad_state_path` contains a chain state that's not synchronized to a tip that's
 /// after `height`.
 async fn load_transactions_from_block_after(
     height: block::Height,
     network: Network,
-    state_path: &Path,
+    zebrad_state_path: &Path,
 ) -> Result<Vec<Arc<Transaction>>> {
     let (_read_write_state_service, mut state, latest_chain_tip, _chain_tip_change) =
-        start_state_service_with_cache_dir(network, state_path).await?;
+        start_state_service_with_cache_dir(network, zebrad_state_path).await?;
 
     let tip_height = latest_chain_tip
         .best_tip_height()

--- a/zebrad/tests/common/lightwalletd/wallet_grpc_test.rs
+++ b/zebrad/tests/common/lightwalletd/wallet_grpc_test.rs
@@ -121,10 +121,7 @@ pub async fn run() -> Result<()> {
     let mut rpc_client = connect_to_lightwalletd(lightwalletd_rpc_port).await?;
 
     // End of the setup and start the tests
-    tracing::info!(
-        ?lightwalletd_rpc_port,
-        "sending gRPC queries...",
-    );
+    tracing::info!(?lightwalletd_rpc_port, "sending gRPC queries...");
 
     // Call `GetLatestBlock`
     let block_tip = rpc_client

--- a/zebrad/tests/common/lightwalletd/wallet_grpc_test.rs
+++ b/zebrad/tests/common/lightwalletd/wallet_grpc_test.rs
@@ -83,9 +83,23 @@ pub async fn run() -> Result<()> {
     // This test is only for the mainnet
     let network = Network::Mainnet;
 
+    tracing::info!(
+        ?network,
+        ?test_type,
+        ?zebrad_state_path,
+        ?lightwalletd_state_path,
+        "running gRPC query tests using lightwalletd & zebrad, \
+         launching disconnected zebrad...",
+    );
+
     // Launch zebra using a predefined zebrad state path
     let (_zebrad, zebra_rpc_address) =
         spawn_zebrad_for_rpc_without_initial_peers(network, zebrad_state_path.unwrap(), test_type)?;
+
+    tracing::info!(
+        ?zebra_rpc_address,
+        "launching lightwalletd connected to zebrad...",
+    );
 
     // Launch lightwalletd
     let (_lightwalletd, lightwalletd_rpc_port) = spawn_lightwalletd_with_rpc_server(
@@ -98,10 +112,19 @@ pub async fn run() -> Result<()> {
     // Give lightwalletd a few seconds to open its grpc port before connecting to it
     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
 
+    tracing::info!(
+        ?lightwalletd_rpc_port,
+        "connecting gRPC client to lightwalletd...",
+    );
+
     // Connect to the lightwalletd instance
     let mut rpc_client = connect_to_lightwalletd(lightwalletd_rpc_port).await?;
 
     // End of the setup and start the tests
+    tracing::info!(
+        ?lightwalletd_rpc_port,
+        "sending gRPC queries...",
+    );
 
     // Call `GetLatestBlock`
     let block_tip = rpc_client


### PR DESCRIPTION
## Motivation

[adityapk00/lightwalletd](https://github.com/adityapk00/lightwalletd) has not been updated for NU5, so we need to switch to [zcash/lightwalletd](https://github.com/zcash/lightwalletd) for testing.

(It seems to be the most up-to-date fork.)

Close #4551

## Solution

- Update test log regexes for `zcash/lightwalletd`
- Update Docker image to use `zcash/lightwalletd`

Related changes:
- Add progress logging to the gRPC tests
- Add the gRPC tests to the lightwalletd test suite

I tested this locally using:
```sh
TMPDIR=$HOME/.cache/zebra-tmp \
ZEBRA_CACHED_STATE_DIR=$HOME/.cache/zebra-custom \
LIGHTWALLETD_DATA_DIR=$HOME/.cache/lightwalletd-custom \
RUST_LOG=info \
cargo test --features lightwalletd-grpc-tests -- --nocapture --include-ignored lightwalletd_test_suite
```

## Review

I added PR comments for each important change.
(The rest is diagnostic logging, logging fixes, test fixes, and doc updates.)

This is urgent - most other PRs will fail until it merges.

### Reviewer Checklist

  - [ ] Existing tests pass

