### PR TITLE
fix(network): when connecting to peers, ignore invalid ports, and prefer canonical ports

### DIFF
--- a/zebra-network/src/address_book/tests/prop.rs
+++ b/zebra-network/src/address_book/tests/prop.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use proptest::{collection::vec, prelude::*};
 use tracing::Span;
 
-use zebra_chain::serialization::Duration32;
+use zebra_chain::{parameters::Network::*, serialization::Duration32};
 
 use crate::{
     constants::{MAX_ADDRS_IN_ADDRESS_BOOK, MAX_PEER_ACTIVE_FOR_GOSSIP},
@@ -29,6 +29,7 @@ proptest! {
 
         let address_book = AddressBook::new_with_addrs(
             local_listener,
+            Mainnet,
             MAX_ADDRS_IN_ADDRESS_BOOK,
             Span::none(),
             addresses
@@ -57,6 +58,7 @@ proptest! {
 
         let address_book = AddressBook::new_with_addrs(
             local_listener,
+            Mainnet,
             MAX_ADDRS_IN_ADDRESS_BOOK,
             Span::none(),
             addresses
@@ -94,6 +96,7 @@ proptest! {
 
         let mut address_book = AddressBook::new_with_addrs(
             local_listener,
+            Mainnet,
             addr_limit,
             Span::none(),
             initial_addrs.clone(),
@@ -115,6 +118,7 @@ proptest! {
 
         let mut address_book = AddressBook::new_with_addrs(
             local_listener,
+            Mainnet,
             addr_limit,
             Span::none(),
             initial_addrs,

--- a/zebra-network/src/address_book/tests/vectors.rs
+++ b/zebra-network/src/address_book/tests/vectors.rs
@@ -5,7 +5,10 @@ use std::time::Instant;
 use chrono::Utc;
 use tracing::Span;
 
-use zebra_chain::serialization::{DateTime32, Duration32};
+use zebra_chain::{
+    parameters::Network::*,
+    serialization::{DateTime32, Duration32},
+};
 
 use crate::{
     constants::MAX_ADDRS_IN_ADDRESS_BOOK, meta_addr::MetaAddr,
@@ -15,7 +18,7 @@ use crate::{
 /// Make sure an empty address book is actually empty.
 #[test]
 fn address_book_empty() {
-    let address_book = AddressBook::new("0.0.0.0:0".parse().unwrap(), Span::current());
+    let address_book = AddressBook::new("0.0.0.0:0".parse().unwrap(), Mainnet, Span::current());
 
     assert_eq!(
         address_book
@@ -44,6 +47,7 @@ fn address_book_peer_order() {
     let addrs = vec![meta_addr1, meta_addr2];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
+        Mainnet,
         MAX_ADDRS_IN_ADDRESS_BOOK,
         Span::current(),
         addrs,
@@ -59,6 +63,7 @@ fn address_book_peer_order() {
     let addrs = vec![meta_addr2, meta_addr1];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
+        Mainnet,
         MAX_ADDRS_IN_ADDRESS_BOOK,
         Span::current(),
         addrs,
@@ -77,6 +82,7 @@ fn address_book_peer_order() {
     let addrs = vec![meta_addr1, meta_addr2];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
+        Mainnet,
         MAX_ADDRS_IN_ADDRESS_BOOK,
         Span::current(),
         addrs,
@@ -92,6 +98,7 @@ fn address_book_peer_order() {
     let addrs = vec![meta_addr2, meta_addr1];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
+        Mainnet,
         MAX_ADDRS_IN_ADDRESS_BOOK,
         Span::current(),
         addrs,

--- a/zebra-network/src/address_book_updater.rs
+++ b/zebra-network/src/address_book_updater.rs
@@ -50,7 +50,11 @@ impl AddressBookUpdater {
         // based on the maximum number of inbound and outbound peers.
         let (worker_tx, mut worker_rx) = mpsc::channel(config.peerset_total_connection_limit());
 
-        let address_book = AddressBook::new(local_listener, span!(Level::TRACE, "address book"));
+        let address_book = AddressBook::new(
+            local_listener,
+            config.network,
+            span!(Level::TRACE, "address book"),
+        );
         let address_metrics = address_book.address_metrics_watcher();
         let address_book = Arc::new(std::sync::Mutex::new(address_book));
 

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -12,6 +12,7 @@ use zebra_chain::serialization::DateTime32;
 
 use crate::{
     constants,
+    peer::peer_preference,
     protocol::{external::canonical_socket_addr, types::PeerServices},
 };
 
@@ -529,8 +530,8 @@ impl MetaAddr {
     ///
     /// Since the addresses in the address book are unique, this check can be
     /// used to permanently reject entire [`MetaAddr`]s.
-    pub fn address_is_valid_for_outbound(&self) -> bool {
-        !self.addr.ip().is_unspecified() && self.addr.port() != 0
+    pub fn address_is_valid_for_outbound(&self, network: Network) -> bool {
+        peer_preference(self.addr, network).is_ok()
     }
 
     /// Is the last known information for this peer valid for outbound

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -374,6 +374,11 @@ impl MetaAddr {
         self.addr
     }
 
+    /// Return the address preference level for this `MetaAddr`.
+    pub fn peer_preference(&self) -> Result<PeerPreference, &'static str> {
+        PeerPreference::new(&self.addr, None)
+    }
+
     /// Returns the time of the last successful interaction with this peer.
     ///
     /// Initially set to the unverified "last seen time" gossiped by the remote
@@ -855,7 +860,7 @@ impl Ord for MetaAddr {
     /// `MetaAddr`s are sorted in approximate reconnection attempt order, but
     /// with `Responded` peers sorted first as a group.
     ///
-    /// This order should not be used for reconnection attempts: use
+    /// But this order should not be used for reconnection attempts: use
     /// [`reconnection_peers`][rp] instead.
     ///
     /// See [`CandidateSet`] for more details.
@@ -867,6 +872,10 @@ impl Ord for MetaAddr {
 
         // First, try states that are more likely to work
         let more_reliable_state = self.last_connection_state.cmp(&other.last_connection_state);
+
+        // Then, try addresses that are more likely to be valid.
+        // Currently, this prefers addresses with canonical Zcash ports.
+        let more_likely_valid = self.peer_preference().cmp(&other.peer_preference());
 
         // # Security and Correctness
         //
@@ -936,6 +945,7 @@ impl Ord for MetaAddr {
         let port_tie_breaker = self.addr.port().cmp(&other.addr.port());
 
         more_reliable_state
+            .then(more_likely_valid)
             .then(older_attempt)
             .then(older_failure)
             .then(older_response)

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -12,7 +12,7 @@ use zebra_chain::{parameters::Network, serialization::DateTime32};
 
 use crate::{
     constants,
-    peer::peer_preference,
+    peer::PeerPreference,
     protocol::{external::canonical_socket_addr, types::PeerServices},
 };
 
@@ -532,7 +532,7 @@ impl MetaAddr {
     /// Since the addresses in the address book are unique, this check can be
     /// used to permanently reject entire [`MetaAddr`]s.
     pub fn address_is_valid_for_outbound(&self, network: Network) -> bool {
-        peer_preference(&self.addr, network).is_ok()
+        PeerPreference::new(&self.addr, network).is_ok()
     }
 
     /// Is the last known information for this peer valid for outbound

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -532,7 +532,7 @@ impl MetaAddr {
     /// Since the addresses in the address book are unique, this check can be
     /// used to permanently reject entire [`MetaAddr`]s.
     pub fn address_is_valid_for_outbound(&self, network: Network) -> bool {
-        peer_preference(self.addr, network).is_ok()
+        peer_preference(&self.addr, network).is_ok()
     }
 
     /// Is the last known information for this peer valid for outbound

--- a/zebra-network/src/meta_addr/arbitrary.rs
+++ b/zebra-network/src/meta_addr/arbitrary.rs
@@ -1,8 +1,10 @@
+//! Randomised test data generation for MetaAddr.
+
 use std::net::SocketAddr;
 
 use proptest::{arbitrary::any, collection::vec, prelude::*};
 
-use zebra_chain::serialization::DateTime32;
+use zebra_chain::{parameters::Network::*, serialization::DateTime32};
 
 use crate::protocol::external::arbitrary::canonical_socket_addr_strategy;
 
@@ -97,7 +99,7 @@ impl MetaAddrChange {
                 if change
                     .into_new_meta_addr()
                     .expect("unexpected invalid alternate change")
-                    .last_known_info_is_valid_for_outbound()
+                    .last_known_info_is_valid_for_outbound(Mainnet)
                 {
                     Some(change)
                 } else {

--- a/zebra-network/src/meta_addr/tests/prop.rs
+++ b/zebra-network/src/meta_addr/tests/prop.rs
@@ -11,7 +11,7 @@ use tokio::time::Instant;
 use tower::service_fn;
 use tracing::Span;
 
-use zebra_chain::serialization::DateTime32;
+use zebra_chain::{parameters::Network::*, serialization::DateTime32};
 
 use crate::{
     constants::{MAX_ADDRS_IN_ADDRESS_BOOK, MAX_RECENT_PEER_AGE, MIN_PEER_RECONNECTION_DELAY},
@@ -43,9 +43,9 @@ proptest! {
     fn sanitize_avoids_leaks(addr in MetaAddr::arbitrary()) {
         zebra_test::init();
 
-        if let Some(sanitized) = addr.sanitize() {
+        if let Some(sanitized) = addr.sanitize(Mainnet) {
             // check that all sanitized addresses are valid for outbound
-            prop_assert!(addr.last_known_info_is_valid_for_outbound());
+            prop_assert!(addr.last_known_info_is_valid_for_outbound(Mainnet));
             // also check the address, port, and services individually
             prop_assert!(!addr.addr.ip().is_unspecified());
             prop_assert_ne!(addr.addr.port(), 0);
@@ -114,7 +114,7 @@ proptest! {
         let mut attempt_count: usize = 0;
 
         for change in changes {
-            while addr.is_ready_for_connection_attempt(instant_now, chrono_now) {
+            while addr.is_ready_for_connection_attempt(instant_now, chrono_now, Mainnet) {
                 attempt_count += 1;
                 // Assume that this test doesn't last longer than MIN_PEER_RECONNECTION_DELAY
                 prop_assert!(attempt_count <= 1);
@@ -151,6 +151,7 @@ proptest! {
 
         let address_book = AddressBook::new_with_addrs(
             local_listener,
+            Mainnet,
             MAX_ADDRS_IN_ADDRESS_BOOK,
             Span::none(),
             address_book_addrs
@@ -167,7 +168,7 @@ proptest! {
         // regardless of where they have come from
         prop_assert_eq!(
             book_sanitized_local_listener.cloned(),
-            expected_local_listener.sanitize(),
+            expected_local_listener.sanitize(Mainnet),
             "address book: {:?}, sanitized_addrs: {:?}, canonical_local_listener: {:?}",
             address_book,
             sanitized_addrs,
@@ -205,6 +206,7 @@ proptest! {
             // Check address book update - return value
             let mut address_book = AddressBook::new_with_addrs(
                 local_listener,
+                Mainnet,
                 1,
                 Span::none(),
                 Vec::new(),
@@ -215,8 +217,8 @@ proptest! {
             let book_contents: Vec<MetaAddr> = address_book.peers().collect();
 
             // Ignore the same addresses that the address book ignores
-            let expected_result = if !expected_result.address_is_valid_for_outbound()
-                || ( !expected_result.last_known_info_is_valid_for_outbound()
+            let expected_result = if !expected_result.address_is_valid_for_outbound(Mainnet)
+                || ( !expected_result.last_known_info_is_valid_for_outbound(Mainnet)
                       && expected_result.last_connection_state.is_never_attempted())
             {
                None
@@ -309,7 +311,7 @@ proptest! {
 
         // Only put valid addresses in the address book.
         // This means some tests will start with an empty address book.
-        let addrs = if addr.last_known_info_is_valid_for_outbound() {
+        let addrs = if addr.last_known_info_is_valid_for_outbound(Mainnet) {
             Some(addr)
         } else {
             None
@@ -317,6 +319,7 @@ proptest! {
 
         let address_book = Arc::new(std::sync::Mutex::new(AddressBook::new_with_addrs(
             SocketAddr::from_str("0.0.0.0:0").unwrap(),
+            Mainnet,
             MAX_ADDRS_IN_ADDRESS_BOOK,
             Span::none(),
             addrs,
@@ -355,7 +358,7 @@ proptest! {
                         LIVE_PEER_INTERVALS,
                         overall_test_time,
                         peer_change_interval,
-                        addr.last_known_info_is_valid_for_outbound(),
+                        addr.last_known_info_is_valid_for_outbound(Mainnet),
                     );
                 }
 
@@ -422,7 +425,7 @@ proptest! {
                     let addr = addrs.entry(addr.addr).or_insert(*addr);
                     let change = changes.get(change_index);
 
-                    while addr.is_ready_for_connection_attempt(instant_now, chrono_now) {
+                    while addr.is_ready_for_connection_attempt(instant_now, chrono_now, Mainnet) {
                         *attempt_counts.entry(addr.addr).or_default() += 1;
                         prop_assert!(
                             *attempt_counts.get(&addr.addr).unwrap() <= LIVE_PEER_INTERVALS + 1

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -3,10 +3,15 @@
 use std::net::SocketAddr;
 
 use chrono::Utc;
-use zebra_chain::serialization::{DateTime32, Duration32};
+
+use zebra_chain::{
+    parameters::Network::*,
+    serialization::{DateTime32, Duration32},
+};
+
+use crate::{constants::MAX_PEER_ACTIVE_FOR_GOSSIP, protocol::types::PeerServices};
 
 use super::{super::MetaAddr, check};
-use crate::{constants::MAX_PEER_ACTIVE_FOR_GOSSIP, protocol::types::PeerServices};
 
 /// Margin of error for time-based tests.
 ///
@@ -39,10 +44,10 @@ fn sanitize_extremes() {
         last_connection_state: Default::default(),
     };
 
-    if let Some(min_sanitized) = min_time_entry.sanitize() {
+    if let Some(min_sanitized) = min_time_entry.sanitize(Mainnet) {
         check::sanitize_avoids_leaks(&min_time_entry, &min_sanitized);
     }
-    if let Some(max_sanitized) = max_time_entry.sanitize() {
+    if let Some(max_sanitized) = max_time_entry.sanitize(Mainnet) {
         check::sanitize_avoids_leaks(&max_time_entry, &max_sanitized);
     }
 }

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -28,4 +28,4 @@ pub use error::{ErrorSlot, HandshakeError, PeerError, SharedPeerError};
 pub use handshake::{ConnectedAddr, Handshake, HandshakeRequest};
 pub use load_tracked_client::LoadTrackedClient;
 pub use minimum_peer_version::MinimumPeerVersion;
-pub use priority::{peer_preference, AttributePreference, PeerPreference};
+pub use priority::{AttributePreference, PeerPreference};

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -1,4 +1,4 @@
-//! Peer handling.
+//! Peer connection handling.
 
 mod client;
 mod connection;
@@ -7,6 +7,7 @@ mod error;
 mod handshake;
 mod load_tracked_client;
 mod minimum_peer_version;
+mod priority;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use client::tests::ClientTestHarness;
@@ -27,3 +28,4 @@ pub use error::{ErrorSlot, HandshakeError, PeerError, SharedPeerError};
 pub use handshake::{ConnectedAddr, Handshake, HandshakeRequest};
 pub use load_tracked_client::LoadTrackedClient;
 pub use minimum_peer_version::MinimumPeerVersion;
+pub use priority::{peer_preference, AttributePreference, PeerPreference};

--- a/zebra-network/src/peer/priority.rs
+++ b/zebra-network/src/peer/priority.rs
@@ -41,6 +41,7 @@ impl AttributePreference {
     }
 
     /// Returns `true` for `Preferred` attributes.
+    #[allow(dead_code)]
     pub fn is_preferred(&self) -> bool {
         match self {
             Preferred => true,

--- a/zebra-network/src/peer/priority.rs
+++ b/zebra-network/src/peer/priority.rs
@@ -1,4 +1,4 @@
-//! Priorising outbound peer connections based on peer attributes.
+//! Prioritizing outbound peer connections based on peer attributes.
 
 use std::net::SocketAddr;
 
@@ -9,9 +9,19 @@ use AttributePreference::*;
 /// A level of preference for a peer attribute.
 ///
 /// Invalid peer attributes are represented as errors.
+///
+/// Outbound peer connections are initiated in the sorted [order](std::ops::Ord) of this type.
+///
+/// The derived order depends on the order of the variants in the enum.
+/// The variants are sorted in the order they are listed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub enum AttributePreference {
     /// This peer is more likely to be a valid Zcash network peer.
+    ///
+    /// # Correctness
+    ///
+    /// This variant must be declared as the first enum variant,
+    /// so that `Preferred` peers sort before `Acceptable` peers.
     Preferred,
 
     /// This peer is possibly a valid Zcash network peer.
@@ -22,8 +32,8 @@ pub enum AttributePreference {
 ///
 /// Outbound peer connections are initiated in the sorted [order](std::ops::Ord) of this type.
 ///
-/// In particular, public addresses and non-canonical ports are preferred to
-/// private addresses and canonical ports.
+/// The derived order depends on the order of the fields in the struct.
+/// The first field determines the overall order, then later fields sort equal first field values.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct PeerPreference {
     /// Is the peer using the canonical Zcash port for the configured [`Network`]?

--- a/zebra-network/src/peer/priority.rs
+++ b/zebra-network/src/peer/priority.rs
@@ -105,6 +105,10 @@ fn address_is_valid_for_outbound_connections(
             return Err(
                 "invalid peer port: port is for Testnet, but this node is configured for Mainnet",
             );
+        } else if peer_addr.port() == 18344 {
+            return Err(
+                "invalid peer port: port is for Regtest, but Zebra does not support that network",
+            );
         } else if [16125, 26125].contains(&peer_addr.port()) {
             // 16125/26125 is used by Flux/ZelCash, which uses the same network magic numbers as Zcash,
             // so we have to reject it by port

--- a/zebra-network/src/peer/priority.rs
+++ b/zebra-network/src/peer/priority.rs
@@ -49,21 +49,23 @@ impl AttributePreference {
     }
 }
 
-/// Return a preference for the peer at `peer_addr` on `network`.
-///
-/// Use the [`PeerPreference`] [`Ord`] implementation to sort preferred peers first.
-pub fn peer_preference(
-    peer_addr: &SocketAddr,
-    network: impl Into<Option<Network>>,
-) -> Result<PeerPreference, &'static str> {
-    address_is_valid_for_outbound_connections(peer_addr, network)?;
+impl PeerPreference {
+    /// Return a preference for the peer at `peer_addr` on `network`.
+    ///
+    /// Use the [`PeerPreference`] [`Ord`] implementation to sort preferred peers first.
+    pub fn new(
+        peer_addr: &SocketAddr,
+        network: impl Into<Option<Network>>,
+    ) -> Result<PeerPreference, &'static str> {
+        address_is_valid_for_outbound_connections(peer_addr, network)?;
 
-    // This check only prefers the configured network,
-    // because the address book and initial peer connections reject the port used by the other network.
-    let canonical_port =
-        AttributePreference::preferred_from([8232, 18232].contains(&peer_addr.port()));
+        // This check only prefers the configured network,
+        // because the address book and initial peer connections reject the port used by the other network.
+        let canonical_port =
+            AttributePreference::preferred_from([8232, 18232].contains(&peer_addr.port()));
 
-    Ok(PeerPreference { canonical_port })
+        Ok(PeerPreference { canonical_port })
+    }
 }
 
 /// Is the [`SocketAddr`] we have for this peer valid for outbound

--- a/zebra-network/src/peer/priority.rs
+++ b/zebra-network/src/peer/priority.rs
@@ -1,0 +1,70 @@
+//! Priorising outbound peer connections based on peer attributes.
+
+use std::net::SocketAddr;
+
+use zebra_chain::parameters::Network;
+
+use AttributePreference::*;
+
+/// A level of preference for a peer attribute.
+///
+/// Invalid peer attributes are represented as errors.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum AttributePreference {
+    /// This peer is more likely to be a valid Zcash network peer.
+    Preferred,
+
+    /// This peer is possibly a valid Zcash network peer.
+    _Acceptable,
+}
+
+/// A level of preference for a peer.
+///
+/// Outbound peer connections are initiated in the sorted [order](std::ops::Ord) of this type.
+///
+/// In particular, public addresses and non-canonical ports are preferred to
+/// private addresses and canonical ports.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct PeerPreference {
+    /// Does the peer have a publicly routable IP address?
+    ///
+    /// TODO: make private addresses an error unless a debug config is set (#3117)
+    public_address: AttributePreference,
+
+    /// Is the peer using the canonical Zcash port for the configured [`Network`]?
+    canonical_port: AttributePreference,
+}
+
+/// Return a preference for the peer at `peer_addr` on `network`.
+///
+/// Use the [`PeerPreference`] [`Ord`] implementation to sort preferred peers first.
+pub fn peer_preference(
+    peer_addr: SocketAddr,
+    _network: Network,
+) -> Result<PeerPreference, &'static str> {
+    if !address_is_valid_for_outbound_connections(peer_addr) {
+        return Err("invalid address: can not be used for outbound connections");
+    }
+
+    Ok(PeerPreference {
+        public_address: Preferred,
+        canonical_port: Preferred,
+    })
+}
+
+/// Is the [`SocketAddr`] we have for this peer valid for outbound
+/// connections?
+///
+/// Since the addresses in the address book are unique, this check can be
+/// used to permanently reject entire [`MetaAddr`]s.
+fn address_is_valid_for_outbound_connections(peer_addr: SocketAddr) -> bool {
+    if peer_addr.ip().is_unspecified() {
+        return false;
+    }
+
+    if peer_addr.port() == 0 {
+        return false;
+    }
+
+    true
+}

--- a/zebra-network/src/peer/priority.rs
+++ b/zebra-network/src/peer/priority.rs
@@ -39,7 +39,7 @@ pub struct PeerPreference {
 ///
 /// Use the [`PeerPreference`] [`Ord`] implementation to sort preferred peers first.
 pub fn peer_preference(
-    peer_addr: SocketAddr,
+    peer_addr: &SocketAddr,
     _network: Network,
 ) -> Result<PeerPreference, &'static str> {
     if !address_is_valid_for_outbound_connections(peer_addr) {
@@ -57,7 +57,7 @@ pub fn peer_preference(
 ///
 /// Since the addresses in the address book are unique, this check can be
 /// used to permanently reject entire [`MetaAddr`]s.
-fn address_is_valid_for_outbound_connections(peer_addr: SocketAddr) -> bool {
+fn address_is_valid_for_outbound_connections(peer_addr: &SocketAddr) -> bool {
     if peer_addr.ip().is_unspecified() {
         return false;
     }

--- a/zebra-network/src/peer_set/candidate_set/tests/prop.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/prop.rs
@@ -10,14 +10,15 @@ use proptest::{collection::vec, prelude::*};
 use tokio::time::{sleep, timeout};
 use tracing::Span;
 
-use zebra_chain::serialization::DateTime32;
+use zebra_chain::{parameters::Network::*, serialization::DateTime32};
 
-use super::super::{validate_addrs, CandidateSet};
 use crate::{
     constants::MIN_PEER_CONNECTION_INTERVAL,
     meta_addr::{MetaAddr, MetaAddrChange},
     AddressBook, BoxError, Request, Response,
 };
+
+use super::super::{validate_addrs, CandidateSet};
 
 /// The maximum number of candidates for a "next peer" test.
 const MAX_TEST_CANDIDATES: u32 = 4;
@@ -64,7 +65,7 @@ proptest! {
         });
 
         // Since the address book is empty, there won't be any available peers
-        let address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Span::none());
+        let address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Mainnet, Span::none());
 
         let mut candidate_set = CandidateSet::new(Arc::new(std::sync::Mutex::new(address_book)), peer_service);
 
@@ -102,7 +103,7 @@ proptest! {
             unreachable!("Mock peer service is never used");
         });
 
-        let mut address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Span::none());
+        let mut address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Mainnet, Span::none());
         address_book.extend(peers);
 
         let mut candidate_set = CandidateSet::new(Arc::new(std::sync::Mutex::new(address_book)), peer_service);

--- a/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
@@ -1,3 +1,5 @@
+//! Fixed test vectors for CandidateSet.
+
 use std::{
     convert::TryInto,
     net::{IpAddr, SocketAddr},
@@ -10,15 +12,16 @@ use chrono::{DateTime, Duration, Utc};
 use tokio::time::{self, Instant};
 use tracing::Span;
 
-use zebra_chain::serialization::DateTime32;
+use zebra_chain::{parameters::Network::*, serialization::DateTime32};
 use zebra_test::mock_service::{MockService, PanicAssertion};
 
-use super::super::{validate_addrs, CandidateSet};
 use crate::{
     constants::{GET_ADDR_FANOUT, MIN_PEER_GET_ADDR_INTERVAL},
     types::{MetaAddr, PeerServices},
     AddressBook, Request, Response,
 };
+
+use super::super::{validate_addrs, CandidateSet};
 
 /// Test that offset is applied when all addresses have `last_seen` times in the future.
 #[test]
@@ -136,7 +139,11 @@ fn candidate_set_updates_are_rate_limited() {
     let runtime = zebra_test::init_async();
     let _guard = runtime.enter();
 
-    let address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Span::none());
+    let address_book = AddressBook::new(
+        SocketAddr::from_str("0.0.0.0:0").unwrap(),
+        Mainnet,
+        Span::none(),
+    );
     let mut peer_service = MockService::build().for_unit_tests();
     let mut candidate_set = CandidateSet::new(
         Arc::new(std::sync::Mutex::new(address_book)),
@@ -177,7 +184,11 @@ fn candidate_set_update_after_update_initial_is_rate_limited() {
     let runtime = zebra_test::init_async();
     let _guard = runtime.enter();
 
-    let address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Span::none());
+    let address_book = AddressBook::new(
+        SocketAddr::from_str("0.0.0.0:0").unwrap(),
+        Mainnet,
+        Span::none(),
+    );
     let mut peer_service = MockService::build().for_unit_tests();
     let mut candidate_set = CandidateSet::new(
         Arc::new(std::sync::Mutex::new(address_book)),

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -1260,7 +1260,7 @@ where
     }
 
     // Manually initialize an address book without a timestamp tracker.
-    let mut address_book = AddressBook::new(config.listen_addr, Span::current());
+    let mut address_book = AddressBook::new(config.listen_addr, config.network, Span::current());
 
     // Add enough fake peers to go over the limit, even if the limit is zero.
     let over_limit_peers = config.peerset_outbound_connection_limit() * 2 + 1;

--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -307,7 +307,7 @@ impl PeerSetGuard {
         let local_listener = "127.0.0.1:1000"
             .parse()
             .expect("Invalid local listener address");
-        let address_book = AddressBook::new(local_listener, Span::none());
+        let address_book = AddressBook::new(local_listener, Network::Mainnet, Span::none());
 
         Arc::new(std::sync::Mutex::new(address_book))
     }

--- a/zebra-network/src/protocol/external/tests/preallocate.rs
+++ b/zebra-network/src/protocol/external/tests/preallocate.rs
@@ -4,9 +4,12 @@ use std::convert::TryInto;
 
 use proptest::prelude::*;
 
-use zebra_chain::serialization::{
-    arbitrary::max_allocation_is_big_enough, TrustedPreallocate, ZcashSerialize,
-    MAX_PROTOCOL_MESSAGE_LEN,
+use zebra_chain::{
+    parameters::Network::*,
+    serialization::{
+        arbitrary::max_allocation_is_big_enough, TrustedPreallocate, ZcashSerialize,
+        MAX_PROTOCOL_MESSAGE_LEN,
+    },
 };
 
 use crate::{
@@ -75,7 +78,7 @@ proptest! {
         zebra_test::init();
 
         // We require sanitization before serialization
-        let addr = addr.sanitize();
+        let addr = addr.sanitize(Mainnet);
         prop_assume!(addr.is_some());
 
         let addr: AddrV1 = addr.unwrap().into();
@@ -94,7 +97,7 @@ proptest! {
         zebra_test::init();
 
         // We require sanitization before serialization
-        let addr = addr.sanitize();
+        let addr = addr.sanitize(Mainnet);
         prop_assume!(addr.is_some());
 
         let addr: AddrV1 = addr.unwrap().into();
@@ -126,7 +129,7 @@ proptest! {
         zebra_test::init();
 
         // We require sanitization before serialization
-        let addr = addr.sanitize();
+        let addr = addr.sanitize(Mainnet);
         prop_assume!(addr.is_some());
 
         let addr: AddrV2 = addr.unwrap().into();
@@ -145,7 +148,7 @@ proptest! {
         zebra_test::init();
 
         // We require sanitization before serialization
-        let addr = addr.sanitize();
+        let addr = addr.sanitize(Mainnet);
         prop_assume!(addr.is_some());
 
         let addr: AddrV2 = addr.unwrap().into();

--- a/zebra-network/src/protocol/external/tests/prop.rs
+++ b/zebra-network/src/protocol/external/tests/prop.rs
@@ -6,9 +6,12 @@ use bytes::BytesMut;
 use proptest::{collection::vec, prelude::*};
 use tokio_util::codec::{Decoder, Encoder};
 
-use zebra_chain::serialization::{
-    SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
-    MAX_PROTOCOL_MESSAGE_LEN,
+use zebra_chain::{
+    parameters::Network::*,
+    serialization::{
+        SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
+        MAX_PROTOCOL_MESSAGE_LEN,
+    },
 };
 
 use crate::{
@@ -108,7 +111,7 @@ proptest! {
 
         // We require sanitization before serialization,
         // but we also need the original address for this test
-        let sanitized_addr = addr.sanitize();
+        let sanitized_addr = addr.sanitize(Mainnet);
         prop_assume!(sanitized_addr.is_some());
         let sanitized_addr = sanitized_addr.unwrap();
 
@@ -181,7 +184,7 @@ proptest! {
 
         // We require sanitization before serialization,
         // but we also need the original address for this test
-        let sanitized_addr = addr.sanitize();
+        let sanitized_addr = addr.sanitize(Mainnet);
         prop_assume!(sanitized_addr.is_some());
         let sanitized_addr = sanitized_addr.unwrap();
 

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -17,7 +17,7 @@ use tracing::Span;
 use zebra_chain::{
     amount::Amount,
     block::Block,
-    parameters::Network,
+    parameters::Network::{self, *},
     serialization::ZcashDeserializeInto,
     transaction::{UnminedTx, UnminedTxId, VerifiedUnminedTx},
 };
@@ -692,10 +692,14 @@ async fn setup(
 ) {
     zebra_test::init();
 
-    let network = Network::Mainnet;
+    let network = Mainnet;
     let consensus_config = ConsensusConfig::default();
     let state_config = StateConfig::ephemeral();
-    let address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Span::none());
+    let address_book = AddressBook::new(
+        SocketAddr::from_str("0.0.0.0:0").unwrap(),
+        Mainnet,
+        Span::none(),
+    );
     let address_book = Arc::new(std::sync::Mutex::new(address_book));
     let (sync_status, mut recent_syncs) = SyncStatus::new();
     let (state, _read_only_state_service, latest_chain_tip, chain_tip_change) =


### PR DESCRIPTION
## Motivation

We're seeing a lot of invalid peers on the Zcash network, we should try to filter them out.

## Solution

Port rejections:
- Reject Flux/ZelCash and misconfigured Zcash peers
- Check before making initial peer connections, and before adding peers to the address book

Port preference:
- When making outbound connections, prefer peers on the canonical Zcash port for the configured network
- Apply this preference to initial peer connections, and ongoing address book peer connections

Related refactors:
- Move peer address validation to its own module
- Add a network parameter to AddressBook and some MetaAddr methods

This should be covered by existing tests, except for peer port preferences.

## Review

Anyone can review this PR, it might be urgent if the network continues to have a lot of Flux peers, and they're getting gossiped in Zcash address books.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

We might want to prefer publicly routable IP addresses, or reject private addresses with a config - #3117