### PR TITLE
change(test): add an identifiable suffix to zcash-rpc-diff temp directories

### DIFF
--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -27,7 +27,9 @@ fi
 ZEBRAD_RPC_PORT=$1
 shift
 
-ZCASH_RPC_TMP_DIR=$(mktemp -d)
+# Use an easily identified temp directory name,
+# but fall back to a generic name if `mktemp` is outdated.
+ZCASH_RPC_TMP_DIR=$(mktemp --suffix=.rpc-diff -d 2>/dev/null || mktemp -d)
 
 ZEBRAD_RELEASE_INFO="$ZCASH_RPC_TMP_DIR/first-check-getinfo.json"
 ZCASHD_RELEASE_INFO="$ZCASH_RPC_TMP_DIR/second-check-getinfo.json"

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -28,7 +28,7 @@ ZEBRAD_RPC_PORT=$1
 shift
 
 # Use an easily identified temp directory name,
-# but fall back to a generic name if `mktemp` is outdated.
+# but fall back to the default temp name if `mktemp` does not understand `--suffix`.
 ZCASH_RPC_TMP_DIR=$(mktemp --suffix=.rpc-diff -d 2>/dev/null || mktemp -d)
 
 ZEBRAD_RELEASE_INFO="$ZCASH_RPC_TMP_DIR/first-check-getinfo.json"


### PR DESCRIPTION
## Motivation

Some `zcash-rpc-diff` queries can produce very large outputs, so developers might need to delete its temporary directories.

But they can be hard to find on disk.

## Solution

- add a `.rpc-diff` suffix to temporary directories
- fall back to a generic name if the suffix doesn't work

## Review

Anyone can review this low priority PR.

### Reviewer Checklist

  - [ ] manual tests still work
