### PR TITLE
fix(clippy): Resolve some lifetime and reference lints 

### DIFF
--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -335,7 +335,8 @@ impl NoteCommitmentTree {
             .cached_root
             .write()
             .expect("a thread that previously held exclusive lock access panicked");
-        match *write_root {
+        let read_root = write_root.as_ref().cloned();
+        match read_root {
             // Another thread got write access first, return cached root.
             Some(root) => root,
             None => {

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -340,7 +340,8 @@ impl NoteCommitmentTree {
             .cached_root
             .write()
             .expect("a thread that previously held exclusive lock access panicked");
-        match *write_root {
+        let read_root = write_root.as_ref().cloned();
+        match read_root {
             // Another thread got write access first, return cached root.
             Some(root) => root,
             None => {

--- a/zebra-chain/src/sprout/tree.rs
+++ b/zebra-chain/src/sprout/tree.rs
@@ -274,7 +274,8 @@ impl NoteCommitmentTree {
             .cached_root
             .write()
             .expect("a thread that previously held exclusive lock access panicked");
-        match *write_root {
+        let read_root = write_root.as_ref().cloned();
+        match read_root {
             // Another thread got write access first, return cached root.
             Some(root) => root,
             None => {

--- a/zebra-chain/src/transparent/serialize.rs
+++ b/zebra-chain/src/transparent/serialize.rs
@@ -98,7 +98,7 @@ pub(crate) fn parse_coinbase_height(
     mut data: Vec<u8>,
 ) -> Result<(block::Height, CoinbaseData), SerializationError> {
     use block::Height;
-    match (data.get(0), data.len()) {
+    match (data.first(), data.len()) {
         // Blocks 1 through 16 inclusive encode block height with OP_N opcodes.
         (Some(op_n @ 0x51..=0x60), len) if len >= 1 => Ok((
             Height((op_n - 0x50) as u32),

--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -68,7 +68,7 @@ where
     type Bytes = T::Bytes;
 
     fn as_bytes(&self) -> Self::Bytes {
-        T::as_bytes(&*self)
+        T::as_bytes(self)
     }
 }
 


### PR DESCRIPTION
## Motivation

Clippy has some new lints on nightly, we should resolve them to avoid subtle bugs.

## Solution

- Fix significant drop in match scrutinee by copying (small) values
- Fix deref immutable value
- Fix `get(0)` when `first()` works and is clearer

## Review

Anyone can review this PR, it is optional.

### Reviewer Checklist

  - [ ] Existing tests pass

