### PR TITLE
increase lightwalletd timeout, remove testnet tests

### DIFF
--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -11,7 +11,7 @@ on:
       # rebuild lightwalletd whenever the related Zebra code changes
       #
       # TODO: this code isn't compiled in this docker image
-      #       rebuild whenever the actual code at zcash/lightwalletd/master changes
+      #       rebuild whenever the actual code at lightwalletd/master changes
       - 'zebra-rpc/**'
       - 'zebrad/tests/acceptance.rs'
       - 'zebrad/src/config.rs'

--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.0.2
         with:
-          repository: zcash/lightwalletd
+          repository: adityapk00/lightwalletd
           ref: 'master'
           persist-credentials: false
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,7 +92,7 @@ FROM deps AS tests
 # TODO: do not hardcode the user /root/ even though is a safe assumption
 # Pre-download Zcash Sprout, Sapling parameters and Lightwalletd binary
 COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/zcash-params /root/.zcash-params /root/.zcash-params
-COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd:pr-4584 /lightwalletd /usr/local/bin
+COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd /lightwalletd /usr/local/bin
 
 # Re-hydrate the minimum project skeleton identified by `cargo chef prepare` in the planner stage,
 # and build it to cache all possible sentry and test dependencies.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,7 +92,7 @@ FROM deps AS tests
 # TODO: do not hardcode the user /root/ even though is a safe assumption
 # Pre-download Zcash Sprout, Sapling parameters and Lightwalletd binary
 COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/zcash-params /root/.zcash-params /root/.zcash-params
-COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd /lightwalletd /usr/local/bin
+COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd:pr-4584 /lightwalletd /usr/local/bin
 
 # Re-hydrate the minimum project skeleton identified by `cargo chef prepare` in the planner stage,
 # and build it to cache all possible sentry and test dependencies.

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -501,7 +501,7 @@ fn sync_one_checkpoint_mainnet() -> Result<()> {
 /// Test if `zebrad` can sync the first checkpoint on testnet.
 ///
 /// The first checkpoint contains a single genesis block.
-// TODO: disable because testnet is not currently reliable
+// TODO: disabled because testnet is not currently reliable
 // #[test]
 #[allow(dead_code)]
 fn sync_one_checkpoint_testnet() -> Result<()> {
@@ -525,7 +525,8 @@ fn restart_stop_at_height() -> Result<()> {
     zebra_test::init();
 
     restart_stop_at_height_for_network(Network::Mainnet, TINY_CHECKPOINT_TEST_HEIGHT)?;
-    restart_stop_at_height_for_network(Network::Testnet, TINY_CHECKPOINT_TEST_HEIGHT)?;
+    // TODO: disabled because testnet is not currently reliable
+    // restart_stop_at_height_for_network(Network::Testnet, TINY_CHECKPOINT_TEST_HEIGHT)?;
 
     Ok(())
 }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -501,7 +501,9 @@ fn sync_one_checkpoint_mainnet() -> Result<()> {
 /// Test if `zebrad` can sync the first checkpoint on testnet.
 ///
 /// The first checkpoint contains a single genesis block.
-#[test]
+// TODO: disable because testnet is not currently reliable
+// #[test]
+#[allow(dead_code)]
 fn sync_one_checkpoint_testnet() -> Result<()> {
     sync_until(
         TINY_CHECKPOINT_TEST_HEIGHT,

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -51,7 +51,7 @@ pub const LIGHTWALLETD_UPDATE_TIP_DELAY: Duration = Duration::from_secs(20 * 60)
 ///
 /// `lightwalletd` takes about half an hour to fully sync,
 /// and Zebra needs time to activate its mempool.
-pub const LIGHTWALLETD_FULL_SYNC_TIP_DELAY: Duration = Duration::from_secs(45 * 60);
+pub const LIGHTWALLETD_FULL_SYNC_TIP_DELAY: Duration = Duration::from_secs(90 * 60);
 
 /// Extension trait for methods on `tempfile::TempDir` for using it as a test
 /// directory for `zebrad`.

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -49,7 +49,7 @@ pub const LIGHTWALLETD_UPDATE_TIP_DELAY: Duration = Duration::from_secs(20 * 60)
 
 /// The amount of time we wait for lightwalletd to do a full sync to the tip.
 ///
-/// `lightwalletd` takes about half an hour to fully sync,
+/// `lightwalletd` takes about an hour to fully sync,
 /// and Zebra needs time to activate its mempool.
 pub const LIGHTWALLETD_FULL_SYNC_TIP_DELAY: Duration = Duration::from_secs(90 * 60);
 


### PR DESCRIPTION
## Motivation

While trying to fix #4551 I managed to make it use the upstream lightwalletd, but for some reason it takes much more time to sync.

This increases the timeout to make it pass.

It also reverts to Aditya's fork because upstream seems to be deadlocking. (Increasing the timeout is still required because the recent Aditya's is also slower)

It also remove network tests that used the testnet, because it's not currently reliable (seeders are not returning any proper peers).

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

- Increase timeout
- Revert to Aditya's fork (it synced with upstream so now it supports NU5)
- Disable testnet tests

## Review

It's a draft for now because I want to confirm it it works first.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
