### PR TITLE
feat(state): delete old database directories

### DIFF
--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -128,24 +128,25 @@ impl Default for Config {
 /// Iterate over the files and directories in the databases folder and delete if:
 /// - The state directory exists.
 /// - The entry is a directory.
-/// - The directory name has a lenght of at least 2 characters.
+/// - The directory name has a length of at least 2 characters.
 /// - The directory name has a prefix `v`.
 /// - The directory name without the prefix can be parsed as an unsigned number.
 /// - The parsed number is lower than the hardcoded `DATABASE_FORMAT_VERSION`.
 pub async fn check_and_delete_old_databases(config: Config) {
-    if !config.ephemeral && config.delete_old_database {
-        info!("checking old database versions");
+    if config.ephemeral || !config.delete_old_database {
+        return;
+    }
 
-        let cache_dir = config.cache_dir.join("state");
-        if let Some(read_dir) = read_dir(cache_dir.clone()) {
-            for entry in read_dir.flatten() {
-                if let Some(dir_name) = parse_dir_name(entry) {
-                    if let Some(version_number) = parse_version_number(dir_name.clone()) {
-                        if version_number < crate::constants::DATABASE_FORMAT_VERSION {
-                            let delete_path = cache_dir.join(dir_name);
-                            if remove_dir_all(delete_path.clone()).is_ok() {
-                                info!("deleted outdated state directory {:?}", delete_path);
-                            }
+    info!("checking old database versions");
+    let cache_dir = config.cache_dir.join("state");
+    if let Some(read_dir) = read_dir(cache_dir.clone()) {
+        for entry in read_dir.flatten() {
+            if let Some(dir_name) = parse_dir_name(entry) {
+                if let Some(version_number) = parse_version_number(dir_name.clone()) {
+                    if version_number < crate::constants::DATABASE_FORMAT_VERSION {
+                        let delete_path = cache_dir.join(dir_name);
+                        if remove_dir_all(delete_path.clone()).is_ok() {
+                            info!("deleted outdated state directory {:?}", delete_path);
                         }
                     }
                 }

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -57,6 +57,13 @@ pub struct Config {
     ///
     /// Set to `None` by default: Zebra continues syncing indefinitely.
     pub debug_stop_at_height: Option<u32>,
+
+    /// Whether to delete the old database directories when present.
+    ///
+    /// Set to `true` by default. If this is set to `false`,
+    /// no check for old database versions will be made and nothing will be
+    /// deleted.
+    pub delete_old_database: bool,
 }
 
 fn gen_temp_path(prefix: &str) -> PathBuf {
@@ -108,6 +115,7 @@ impl Default for Config {
             cache_dir,
             ephemeral: false,
             debug_stop_at_height: None,
+            delete_old_database: true,
         }
     }
 }

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -132,16 +132,20 @@ impl Default for Config {
 /// - The directory name has a prefix `v`.
 /// - The directory name without the prefix can be parsed as an unsigned number.
 /// - The parsed number is lower than the hardcoded `DATABASE_FORMAT_VERSION`.
-pub fn check_and_delete_old_databases(cache_dir: PathBuf) {
-    let cache_dir = cache_dir.join("state");
-    if let Some(read_dir) = read_dir(cache_dir.clone()) {
-        for entry in read_dir.flatten() {
-            if let Some(dir_name) = parse_dir_name(entry) {
-                if let Some(version_number) = parse_version_number(dir_name.clone()) {
-                    if version_number < crate::constants::DATABASE_FORMAT_VERSION {
-                        let delete_path = cache_dir.join(dir_name);
-                        if remove_dir_all(delete_path.clone()).is_ok() {
-                            info!("deleted outdated state directory {:?}", delete_path);
+pub async fn check_and_delete_old_databases(config: Config) {
+    if !config.ephemeral && config.delete_old_database {
+        info!("checking old database versions");
+
+        let cache_dir = config.cache_dir.join("state");
+        if let Some(read_dir) = read_dir(cache_dir.clone()) {
+            for entry in read_dir.flatten() {
+                if let Some(dir_name) = parse_dir_name(entry) {
+                    if let Some(version_number) = parse_version_number(dir_name.clone()) {
+                        if version_number < crate::constants::DATABASE_FORMAT_VERSION {
+                            let delete_path = cache_dir.join(dir_name);
+                            if remove_dir_all(delete_path.clone()).is_ok() {
+                                info!("deleted outdated state directory {:?}", delete_path);
+                            }
                         }
                     }
                 }

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -28,7 +28,7 @@ mod util;
 #[cfg(test)]
 mod tests;
 
-pub use config::Config;
+pub use config::{check_and_delete_old_databases, Config};
 pub use constants::MAX_BLOCK_REORG_HEIGHT;
 pub use error::{BoxError, CloneError, CommitBlockError, ValidateContextError};
 pub use request::{FinalizedBlock, HashOrHeight, PreparedBlock, ReadRequest, Request};

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -620,27 +620,14 @@ fn check_and_delete_old_databases(cache_dir: PathBuf) -> Result<(), Report> {
     let cache_dir = cache_dir.join("state");
     if cache_dir.exists() {
         for entry in (cache_dir.read_dir()?).flatten() {
-            if entry.file_type()?.is_dir() {
-                let dir_name = entry
-                    .file_name()
-                    .into_string()
-                    .expect("conversion from osstring to string should work.");
-                if dir_name.len() >= 2 && dir_name.starts_with('v') {
-                    let potential_version_number_string = dir_name
-                        .strip_prefix('v')
-                        .expect("should not panic as we know there is a `v` prefix.")
-                        .to_string();
-                    let version_number: u32 =
-                        potential_version_number_string.parse().unwrap_or(u32::MAX);
+            if let Some(dir_name) = parse_dir_name(entry) {
+                if let Some(version_number) = parse_version_number(dir_name.clone()) {
                     if version_number < zebra_state::constants::DATABASE_FORMAT_VERSION {
                         let delete_path = cache_dir.join(dir_name);
-                        info!(
-                            "deleting {}",
-                            delete_path
-                                .to_str()
-                                .expect("path is valid, should not panic")
-                        );
-                        remove_dir_all(delete_path)?;
+                        info!("deleting outdated state directory {:?}", delete_path,);
+                        if remove_dir_all(delete_path).is_err() {
+                            continue;
+                        }
                     }
                 }
             }
@@ -648,4 +635,29 @@ fn check_and_delete_old_databases(cache_dir: PathBuf) -> Result<(), Report> {
     }
 
     Ok(())
+}
+
+fn parse_dir_name(entry: std::fs::DirEntry) -> Option<String> {
+    if let Ok(file_type) = entry.file_type() {
+        if file_type.is_dir() {
+            if let Ok(dir_name) = entry.file_name().into_string() {
+                return Some(dir_name);
+            }
+        }
+    }
+    None
+}
+
+fn parse_version_number(dir_name: String) -> Option<u32> {
+    if dir_name.len() >= 2 && dir_name.starts_with('v') {
+        if let Some(potential_version_number) = dir_name.strip_prefix('v') {
+            return Some(
+                potential_version_number
+                    .to_string()
+                    .parse()
+                    .unwrap_or(u32::MAX),
+            );
+        }
+    }
+    None
 }

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -105,7 +105,7 @@ impl StartCmd {
         let config = app_config().clone();
         info!(?config);
 
-        if config.state.delete_old_database {
+        if !config.state.ephemeral && config.state.delete_old_database {
             info!("checking old database versions");
             check_and_delete_old_databases(config.state.cache_dir.clone())?;
         }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1660,13 +1660,13 @@ async fn delete_old_databases() -> Result<()> {
     create_dir(&outside_dir)?;
     assert!(outside_dir.as_path().exists());
 
-    // create a `v1` dir insidecache dir that should be deleted
+    // create a `v1` dir inside cache dir that should be deleted
     let inside_dir = cache_dir.join("v1");
     create_dir(&inside_dir)?;
     assert!(inside_dir.as_path().exists());
 
-    // modify config with our cache dir and not ephimeral configuration
-    // (delete old databases function will not run when epehemeral = true)
+    // modify config with our cache dir and not ephemeral configuration
+    // (delete old databases function will not run when ephemeral = true)
     config.state.cache_dir = cache_dir;
     config.state.ephemeral = false;
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1686,6 +1686,9 @@ async fn delete_old_databases() -> Result<()> {
     ))?;
     assert!(!inside_dir.as_path().exists());
 
+    // deleting old databases task ended
+    child.expect_stdout_line_matches("finished old database version cleanup task".to_string())?;
+
     // outside dir was not deleted
     assert!(outside_dir.as_path().exists());
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1644,7 +1644,7 @@ async fn fully_synced_rpc_test() -> Result<()> {
 
 #[tokio::test]
 async fn delete_old_databases() -> Result<()> {
-    use std::fs::create_dir;
+    use std::fs::{canonicalize, create_dir};
 
     zebra_test::init();
 
@@ -1663,6 +1663,7 @@ async fn delete_old_databases() -> Result<()> {
     // create a `v1` dir inside cache dir that should be deleted
     let inside_dir = cache_dir.join("v1");
     create_dir(&inside_dir)?;
+    let canonicalized_inside_dir = canonicalize(inside_dir.clone()).ok().unwrap();
     assert!(inside_dir.as_path().exists());
 
     // modify config with our cache dir and not ephemeral configuration
@@ -1681,7 +1682,7 @@ async fn delete_old_databases() -> Result<()> {
     // inside dir was deleted
     child.expect_stdout_line_matches(format!(
         "deleted outdated state directory deleted_state={:?}",
-        inside_dir
+        canonicalized_inside_dir
     ))?;
     assert!(!inside_dir.as_path().exists());
 


### PR DESCRIPTION
## Motivation

When the database format change, a new full blockchain will be downloaded when zebra starts. The old blockchain will remain in the file system occupying a lot of hard drive space.

We want to delete this old versions of the blockchain by default when zebra starts, but we also want a config option to not do it if the user want to keep the different versions for whatever reason.

This PR will close https://github.com/ZcashFoundation/zebra/issues/1213 if it gets merged.

## Solution

When zebra start and if the `delete_old_database` config option is set to `true`, the code added here will check the database directories and delete the ones that are considered all. Directory will be deleted will all the content inside them. 

## Review

I think anyone can review, open for improvements, probably some code in the `check_and_delete_old_databases` can be simplified a bit.

No tests were made, i do tested manually. `check_and_delete_old_databases` function could be tested with different scenarios but i am unsure if it will worth to do it.
