### PR TITLE
feat(actions): delete old GCP resources

### DIFF
--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -37,5 +37,5 @@ jobs:
 
           for TEMPLATE in $TEMPLATES
           do
-            gcloud compute instance-templates ${TEMPLATE}
+            gcloud compute instance-templates delete ${TEMPLATE}
           done

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -5,8 +5,8 @@ on:
     - cron: "0 0 1 * *"
   workflow_dispatch:
   push:
-    branches:
-      - "!main"
+    # branches:
+    #   - "!main"
 
 jobs:
   delete-resources:
@@ -30,9 +30,8 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Deletes the instances that has been recently deployed in the actual commit after all
-      # previous jobs have run, no matter the outcome of the job.
-      - name: Delete test instance
+      # Deletes all the instances template older than 30 days
+      - name: Delete old instance templates
         run: |
           TEMPLATES=$(gcloud compute instance-templates list --sort-by=creationTimestamp  --filter="creationTimestamp < $(date --date='30 days ago' + %y%m%d)" --format='value(NAME)')
 

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -33,7 +33,7 @@ jobs:
       # Deletes all the instances template older than 30 days
       - name: Delete old instance templates
         run: |
-          TEMPLATES=$(gcloud compute instance-templates list --sort-by=creationTimestamp  --filter="creationTimestamp < $(date --date='30 days ago' + %y%m%d)" --format='value(NAME)')
+          TEMPLATES=$(gcloud compute instance-templates list --sort-by=creationTimestamp  --filter="creationTimestamp < $(date --date='30 days ago' '+%Y%m%d')" --format='value(NAME)')
 
           for TEMPLATE in $TEMPLATES
           do

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -1,0 +1,42 @@
+name: Delete GCP resources
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+  push:
+    branches:
+      - "!main"
+
+jobs:
+  delete-resources:
+    name: Delete old GCP resources
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
+      # Setup gcloud CLI
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.8.0
+        with:
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
+
+      # Deletes the instances that has been recently deployed in the actual commit after all
+      # previous jobs have run, no matter the outcome of the job.
+      - name: Delete test instance
+        run: |
+          TEMPLATES=$(gcloud compute instance-templates list --sort-by=creationTimestamp  --filter="creationTimestamp < $(date --date='30 days ago' + %y%m%d)" --format='value(NAME)')
+
+          for TEMPLATE in $TEMPLATES
+          do
+            gcloud compute instance-templates ${TEMPLATE}
+          done

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -37,5 +37,5 @@ jobs:
 
           for TEMPLATE in $TEMPLATES
           do
-            gcloud compute instance-templates delete ${TEMPLATE}
+            gcloud compute instance-templates delete ${TEMPLATE} --quiet || continue
           done

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: "0 0 1 * *"
   workflow_dispatch:
-  push:
-    # branches:
-    #   - "!main"
 
 jobs:
   delete-resources:
@@ -16,11 +13,6 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
-        with:
-          short-length: 7
-
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth


### PR DESCRIPTION
## Motivation

We'd like to delete old resources, in this specific case we're starting with instance templates, as those resources commonly hit GCP's quota limit.

Fixes #2090 

### Designs

- Create a workflow specifically to delete resources based on an scheduled action (monthly)
- This action should be generic, and be able to receive multiple resources not just the ones specified in this PR

## Solution

- Create `delete-gcp-resources.yml` action
- Add a `Delete instance templates` step which list instances with 30+ days of creation and delete them all

## Review

Not ready for review
