### PR TITLE
ci(lightwalletd): Zebra's Dockerfile needs `latest` lwd image

### DIFF
--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -73,6 +73,7 @@ jobs:
           images: |
             ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}
           # generate Docker tags based on the following events/attributes
+          # set latest tag for default branch
           tags: |
             type=schedule
             type=ref,event=branch
@@ -81,6 +82,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up QEMU
         id: qemu


### PR DESCRIPTION
## Motivation

We need to add this condition to lightwalletd docker build, to always create a `latest` tag when merging to the default branch: `main`, as we're fetching this tag from the Zebra Dockerfile build, but this tag is not being added when building lightwalletd

Fixes #4590 

### Designs

By default `docker/metadata-action` creates tags based on the event being triggered, but the latest tag is reserved for releases. As we can't wait releases for this specific use case, we're building the `latest` when merging to the default branch.

## Solution

- Add this condition to `docker/metadata-action` --> `type=raw,value=latest,enable={{is_default_branch}}`

## Review

Anyone from @ZcashFoundation/devops-reviewers or @conradoplg 
