### PR TITLE
feat(clippy): Add `fallible_impl_from` lint

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -50,7 +50,10 @@ rustflags = [
     "-Aclippy::try_err",
 
     # Links in public docs can point to private items.
-    "-Arustdoc::private_intra_doc_links"
+    "-Arustdoc::private_intra_doc_links",
+
+    # Panics
+    "-Wclippy::fallible_impl_from",
 
     # TODOs:
     # `cargo fix` might help do these fixes,

--- a/zebra-chain/src/orchard/keys.rs
+++ b/zebra-chain/src/orchard/keys.rs
@@ -1,7 +1,7 @@
 //! Orchard key types.
 //!
 //! <https://zips.z.cash/protocol/nu5.pdf#orchardkeycomponents>
-
+#![allow(clippy::fallible_impl_from)]
 #![allow(dead_code)]
 
 #[cfg(test)]
@@ -308,7 +308,9 @@ impl From<SpendValidatingKey> for [u8; 32] {
 
 impl From<SpendAuthorizingKey> for SpendValidatingKey {
     fn from(ask: SpendAuthorizingKey) -> Self {
-        let sk = redpallas::SigningKey::<SpendAuth>::try_from(<[u8; 32]>::from(ask)).unwrap();
+        let sk = redpallas::SigningKey::<SpendAuth>::try_from(<[u8; 32]>::from(ask)).expect(
+            "a scalar converted to byte array and then converted back to a scalar should not fail",
+        );
 
         Self(redpallas::VerificationKey::from(&sk))
     }

--- a/zebra-chain/src/sapling/keys.rs
+++ b/zebra-chain/src/sapling/keys.rs
@@ -8,6 +8,7 @@
 //! [ps]: https://zips.z.cash/protocol/protocol.pdf#saplingkeycomponents
 //! [3.1]: https://zips.z.cash/protocol/protocol.pdf#addressesandkeys
 #![allow(clippy::unit_arg)]
+#![allow(clippy::fallible_impl_from)]
 #![allow(dead_code)]
 
 #[cfg(test)]
@@ -507,7 +508,9 @@ impl From<AuthorizingKey> for [u8; 32] {
 
 impl From<SpendAuthorizingKey> for AuthorizingKey {
     fn from(ask: SpendAuthorizingKey) -> Self {
-        let sk = redjubjub::SigningKey::<SpendAuth>::try_from(<[u8; 32]>::from(ask)).unwrap();
+        let sk = redjubjub::SigningKey::<SpendAuth>::try_from(<[u8; 32]>::from(ask)).expect(
+            "a scalar converted to byte array and then converted back to a scalar should not fail",
+        );
         Self(redjubjub::VerificationKey::from(&sk))
     }
 }

--- a/zebra-chain/src/work/u256.rs
+++ b/zebra-chain/src/work/u256.rs
@@ -3,6 +3,7 @@
 // it raises a lot of issues in the macro.
 #![allow(clippy::all)]
 #![allow(clippy::range_plus_one)]
+#![allow(clippy::fallible_impl_from)]
 
 use uint::construct_uint;
 

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -352,7 +352,11 @@ where
             // use specific varieties of `RejectReason`.
             ccode: RejectReason::Other,
 
-            reason: e.source().unwrap().to_string(),
+            reason: if let Some(reason) = e.source() {
+                reason.to_string()
+            } else {
+                String::from("")
+            },
 
             // Allow this to be overridden but not populated by default, methinks.
             data: None,


### PR DESCRIPTION
## Motivation

In https://github.com/ZcashFoundation/zebra/issues/2297 we want to add some panic lints to zebra. This is part 1 of 3 where the `fallible_impl_from` is added. 

## Solution

Add the lint and fix the code where needed.

## Review

Please review carefully, there are error messages that might be changed. I think @dconnolly wrote most of the changed code in orchard and sapling keys but anyone that can take a look is welcome.

### Reviewer Checklist

  - [ ] Current test pass
  - [ ] Errors strings added are correct

## Follow Up Work

We want to add 2 more related lints but i think it was too much to add them in a single PR so i splitted into 3. 
