### PR TITLE
cleanup(net): Group PeerSet fields into themes

### DIFF
--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -1,3 +1,5 @@
+//! Peer set unit tests, and test setup code.
+
 use std::{net::SocketAddr, sync::Arc};
 
 use futures::{channel::mpsc, stream, Stream, StreamExt};

--- a/zebra-network/src/peer_set/set/tests/prop.rs
+++ b/zebra-network/src/peer_set/set/tests/prop.rs
@@ -1,3 +1,5 @@
+//! Randomised property tests for the peer set.
+
 use std::net::SocketAddr;
 
 use futures::FutureExt;


### PR DESCRIPTION
## Motivation

I did this work as a cleanup for some peer set changes, but I don't know if we need them any more.

So I just want to merge the cleanup separately.

## Solution

- Group peer set fields into themes
- Add missing module comments

## Review

Anyone can review this optional PR.

### Reviewer Checklist

  - [ ] Existing tests pass

