### PR TITLE
breaking(diagnostics): rename "enable-sentry" feature to "sentry"

### DIFF
--- a/book/src/user/requirements.md
+++ b/book/src/user/requirements.md
@@ -26,7 +26,7 @@ tested its exact limits yet.
 
 ## Sentry Production Monitoring
 
-Compile Zebra with `--features enable-sentry` to monitor it using Sentry in production.
+Compile Zebra with `--features sentry` to monitor it using Sentry in production.
 
 ## Lightwalletd Test Requirements
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -100,7 +100,7 @@ COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd /lightwalletd /us
 # This is the caching Docker layer for Rust!
 #
 # TODO: is it faster to use --tests here?
-RUN cargo chef cook --release --features enable-sentry,lightwalletd-grpc-tests --workspace --recipe-path recipe.json
+RUN cargo chef cook --release --features sentry,lightwalletd-grpc-tests --workspace --recipe-path recipe.json
 
 COPY . .
 RUN cargo test --locked --release --features lightwalletd-grpc-tests --workspace --no-run
@@ -118,11 +118,11 @@ CMD [ "cargo"]
 # `test` stage. This step is a dependency for the `runtime` stage, which uses the resulting
 # zebrad binary from this step.
 FROM deps AS release
-RUN cargo chef cook --release --features enable-sentry --recipe-path recipe.json
+RUN cargo chef cook --release --features sentry --recipe-path recipe.json
 
 COPY . .
 # Build zebra
-RUN cargo build --locked --release --features enable-sentry --package zebrad --bin zebrad
+RUN cargo build --locked --release --features sentry --package zebrad --bin zebrad
 
 # This stage is only used when deploying nodes or when only the resulting zebrad binary is needed
 #

--- a/docker/zcash-params/Dockerfile
+++ b/docker/zcash-params/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -qq update && \
 
 ENV CARGO_HOME /app/.cargo/
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --features enable-sentry --package zebrad --recipe-path recipe.json
+RUN cargo chef cook --release --features sentry --package zebrad --recipe-path recipe.json
 
 ARG RUST_BACKTRACE=0
 ENV RUST_BACKTRACE ${RUST_BACKTRACE}
@@ -36,4 +36,4 @@ ENV COLORBT_SHOW_HIDDEN ${COLORBT_SHOW_HIDDEN}
 
 COPY . .
 # Pre-download Zcash Sprout and Sapling parameters
-RUN cargo run --locked --release --features enable-sentry --package zebrad --bin zebrad download
+RUN cargo run --locked --release --features sentry --package zebrad --bin zebrad download

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -18,8 +18,7 @@ default = ["release_max_level_info"]
 
 # Production features that activate extra dependencies
 
-# TODO: rename to just "sentry"?
-enable-sentry = ["sentry", "sentry-tracing"]
+sentry = ["dep:sentry", "sentry-tracing"]
 flamegraph = ["tracing-flame", "inferno"]
 journald = ["tracing-journald"]
 filter-reload = ["hyper"]
@@ -106,7 +105,7 @@ atty = "0.2.14"
 num-integer = "0.1.45"
 rand = { version = "0.8.5", package = "rand" }
 
-# prod feature enable-sentry
+# prod feature sentry
 sentry-tracing = { version = "0.26.0", optional = true }
 sentry = { version = "0.26.0", default-features = false, features = ["backtrace", "contexts", "reqwest", "rustls"], optional = true }
 

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -314,7 +314,7 @@ impl Application for ZebradApp {
 
         // The Sentry default config pulls in the DSN from the `SENTRY_DSN`
         // environment variable.
-        #[cfg(feature = "enable-sentry")]
+        #[cfg(feature = "sentry")]
         let guard = sentry::init(sentry::ClientOptions {
             debug: true,
             release: Some(app_version().to_string().into()),
@@ -325,7 +325,7 @@ impl Application for ZebradApp {
             let panic_report = panic_hook.panic_report(panic_info);
             eprintln!("{}", panic_report);
 
-            #[cfg(feature = "enable-sentry")]
+            #[cfg(feature = "sentry")]
             {
                 let event = crate::sentry::panic_event_from(panic_report);
                 sentry::capture_event(event);

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -128,7 +128,7 @@ impl Tracing {
         #[cfg(feature = "journald")]
         let subscriber = subscriber.with(journaldlayer);
 
-        #[cfg(feature = "enable-sentry")]
+        #[cfg(feature = "sentry")]
         let subscriber = subscriber.with(sentry_tracing::layer());
 
         // spawn the console server in the background, and apply the console layer
@@ -170,7 +170,7 @@ impl Tracing {
             }
         }
 
-        #[cfg(feature = "enable-sentry")]
+        #[cfg(feature = "sentry")]
         info!("installed sentry tracing layer");
 
         #[cfg(all(feature = "tokio-console", tokio_unstable))]

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -38,5 +38,5 @@ pub mod components;
 pub mod config;
 pub mod prelude;
 
-#[cfg(feature = "enable-sentry")]
+#[cfg(feature = "sentry")]
 pub mod sentry;

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1388,6 +1388,7 @@ fn zebra_zcash_listener_conflict() -> Result<()> {
 /// exclusive use of the port. The second node will panic with the Zcash metrics
 /// conflict hint added in #1535.
 #[test]
+#[cfg(feature = "prometheus")]
 fn zebra_metrics_conflict() -> Result<()> {
     zebra_test::init();
 
@@ -1416,6 +1417,7 @@ fn zebra_metrics_conflict() -> Result<()> {
 /// exclusive use of the port. The second node will panic with the Zcash tracing
 /// conflict hint added in #1535.
 #[test]
+#[cfg(feature = "filter-reload")]
 fn zebra_tracing_conflict() -> Result<()> {
     zebra_test::init();
 


### PR DESCRIPTION
## Motivation

Rust features usually enable extra functionality, so the name `enable-sentry` is redundant.

Depends-On: #4539

## Solution

- Rename `enable-sentry` feature to `sentry`

This is mostly:
```sh
fastmod enable-sentry sentry
```

## Review

@upbqdn asked for this change, it's not urgent.

But we might want PR #4539 and this PR in the same release, so there is only one set of breaking feature changes.

### Reviewer Checklist

  - [ ] Existing tests pass
