### PR TITLE
Use `config.toml` instead of inner attributes for private links

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -49,6 +49,9 @@ rustflags = [
     # Code styles we want to accept
     "-Aclippy::try_err",
 
+    # Links in public docs can point to private items.
+    "-Arustdoc::private_intra_doc_links"
+
     # TODOs:
     # `cargo fix` might help do these fixes,
     # or add a config.toml to sub-directories which should allow these lints,

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -6,7 +6,6 @@
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_chain")]
-#![allow(rustdoc::private_intra_doc_links)]
 // Required by bitvec! macro
 #![recursion_limit = "256"]
 

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -33,7 +33,6 @@
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_consensus")]
-#![allow(rustdoc::private_intra_doc_links)]
 
 mod block;
 mod checkpoint;

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -124,7 +124,6 @@
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_network")]
-#![allow(rustdoc::private_intra_doc_links)]
 
 #[macro_use]
 extern crate pin_project;

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -11,7 +11,6 @@
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_state")]
-#![allow(rustdoc::private_intra_doc_links)]
 
 #[macro_use]
 extern crate tracing;

--- a/zebra-test/src/lib.rs
+++ b/zebra-test/src/lib.rs
@@ -2,7 +2,6 @@
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_test")]
-#![allow(rustdoc::private_intra_doc_links)]
 // Each lazy_static variable uses additional recursion
 #![recursion_limit = "512"]
 use color_eyre::section::PanicMessage;

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -17,7 +17,6 @@
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebrad")]
-#![allow(rustdoc::private_intra_doc_links)]
 // Tracing causes false positives on this lint:
 // https://github.com/tokio-rs/tracing/issues/553
 #![allow(clippy::cognitive_complexity)]


### PR DESCRIPTION


## Motivation & Solution

This PR addresses https://github.com/ZcashFoundation/zebra/pull/4611#pullrequestreview-1006677722.

The PR removes the inner attributes `#![allow(rustdoc::private_intra_doc_links)]` from the `lib.rs` files of all crates that contained this attribute, and adds a corresponding rustflag to `.cargo/config.toml` instead.

### Reviewer Checklist

- [ ] Running `cargo doc --document-private-items --all-features --no-deps` doesn't produce any warnnings.
