### PR TITLE
fix(state): only delete old database directories inside the cache directory

### DIFF
--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -184,15 +184,7 @@ fn parse_dir_name(entry: DirEntry) -> Option<String> {
 ///
 /// Returns `None` if parsing fails, or the directory name is not in the expected format.
 fn parse_version_number(dir_name: String) -> Option<u32> {
-    if dir_name.len() >= 2 && dir_name.starts_with('v') {
-        if let Some(potential_version_number) = dir_name.strip_prefix('v') {
-            return Some(
-                potential_version_number
-                    .to_string()
-                    .parse()
-                    .unwrap_or(u32::MAX),
-            );
-        }
-    }
-    None
+    dir_name
+        .strip_prefix('v')
+        .and_then(|version| version.parse().ok())
 }

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -159,14 +159,14 @@ fn delete_old_databases(config: Config) {
 
     info!("checking for old database versions");
 
-    let cache_dir = config.cache_dir.join("state");
-    let cache_dir_entries = match read_cache_dir(&cache_dir) {
-        Some(cache_dir_entries) => cache_dir_entries,
+    let state_dir = config.cache_dir.join("state");
+    let state_dir_entries = match read_state_dir(&state_dir) {
+        Some(state_dir_entries) => state_dir_entries,
         None => return,
     };
 
-    for entry in cache_dir_entries.flatten() {
-        let deleted_state = check_and_delete_database(&entry);
+    for entry in state_dir_entries.flatten() {
+        let deleted_state = check_and_delete_database(&config, &entry);
 
         if let Some(deleted_state) = deleted_state {
             info!(?deleted_state, "deleted outdated state directory");
@@ -174,12 +174,12 @@ fn delete_old_databases(config: Config) {
     }
 }
 
-/// Checks that `cache_dir` exists, and that it can be read.
+/// Checks that `state_dir` exists, and that it can be read.
 ///
 /// Returns `None` if any operation fails.
-fn read_cache_dir(cache_dir: &Path) -> Option<ReadDir> {
-    if cache_dir.exists() {
-        if let Ok(read_dir) = cache_dir.read_dir() {
+fn read_state_dir(state_dir: &Path) -> Option<ReadDir> {
+    if state_dir.exists() {
+        if let Ok(read_dir) = state_dir.read_dir() {
             return Some(read_dir);
         }
     }

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -37,6 +37,8 @@
 //!    * contextually verifies blocks
 //!    * handles in-memory storage of multiple non-finalized chains
 //!    * handles permanent storage of the best finalized chain
+//!  * Old State Version Cleanup Task
+//!    * deletes outdated state versions
 //!  * Block Gossip Task
 //!    * runs in the background and continuously queries the state for
 //!      newly committed blocks to be gossiped to peers
@@ -104,10 +106,6 @@ impl StartCmd {
     async fn start(&self) -> Result<(), Report> {
         let config = app_config().clone();
         info!(?config);
-
-        let mut old_databases_task_handle = tokio::spawn(
-            zebra_state::check_and_delete_old_databases(config.state.clone()).in_current_span(),
-        );
 
         info!("initializing node state");
         let (state_service, read_only_state_service, latest_chain_tip, chain_tip_change) =
@@ -215,6 +213,9 @@ impl StartCmd {
             Self::update_progress(config.network.network, latest_chain_tip, sync_status)
                 .in_current_span(),
         );
+
+        let mut old_databases_task_handle =
+            zebra_state::check_and_delete_old_databases(config.state.clone());
 
         info!("spawned initial Zebra tasks");
 

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -335,6 +335,7 @@ impl StartCmd {
 
         // startup tasks
         groth16_download_handle.abort();
+        old_databases_task_handle.abort();
 
         exit_status
     }


### PR DESCRIPTION
## Motivation

Users might have a weird Zebra state setup, where they have symlinked an outdated database path to another directory containing important files.

In this edge case, we want to skip deleting that directory.

Depends-On: #4586

## Solution

- Check that the canonical path of the outdated directory is inside the canonical path of the cache directory

Related Fixes:
- Simplify version parsing
- Use spawn_blocking to launch the task on a separate thread
- Abort the cleanup task when Zebra exits

Related Cleanups:
- Split and rename some functions, so it's easy to see that we are deleting the right directory
- Add references to make ownership easier

## Review

@oxarbitrage wrote the original PR #4586.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

This PR doesn't have any tests.