### PR TITLE
ci(docs): test `cargo doc` warnings and errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions-rs/toolchain@v1.0.1
+      - uses: actions-rs/toolchain@v1.0.6
         with:
           toolchain: stable
           components: rustfmt
@@ -107,6 +107,31 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  docs:
+    name: Rust doc
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.rust == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v3.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions-rs/toolchain@v1.0.6
+        with:
+          profile: minimal
+          toolchain: stable
+          components: docs
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: doc
+          args: --no-deps --document-private-items --all-features
 
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -122,12 +122,10 @@ jobs:
 
       - uses: actions-rs/toolchain@v1.0.6
         with:
-          profile: minimal
           toolchain: stable
-          components: doc
+          profile: minimal
           override: true
 
-      - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: doc

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -122,8 +122,9 @@ jobs:
 
       - uses: actions-rs/toolchain@v1.0.6
         with:
+          profile: minimal
           toolchain: stable
-          components: docs
+          components: doc
           override: true
 
       - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -122,7 +122,6 @@ jobs:
 
       - uses: actions-rs/toolchain@v1.0.6
         with:
-          profile: minimal
           toolchain: stable
           components: docs
           override: true


### PR DESCRIPTION
## Motivation

We want to make sure we don't introduce new errors in documentation. To do that, we have to test with `cargo doc` in CI.

Fixes #4524 

## Solution

- Add a new job to the `Lint` workflow including `cargo doc`
- Use the following arguments for cargo doc: `--no-deps --document-private-items --all-features`

## Review

Anyone from @ZcashFoundation/devops-reviewers 

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
