### PR TITLE
imp(docs): manage`cargo-mdbook` as a GitHub action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,10 +37,10 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
-      - name: Install mdbook
-        run: |
-          cargo install mdbook
-          cargo install mdbook-mermaid
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1.1.14
+        with:
+          mdbook-version: '0.4.18'
 
       - name: Build Zebra book
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,11 @@ jobs:
         with:
           mdbook-version: '0.4.18'
 
+      # TODO: actions-mdbook does not yet have an option to install mdbook-mermaid https://github.com/peaceiris/actions-mdbook/issues/426
+      - name: Install mdbook
+        run: |
+          cargo install mdbook-mermaid
+
       - name: Build Zebra book
         run: |
           mdbook build book/


### PR DESCRIPTION
## Motivation

Hardcoding versions (or just 'latest') of build tools with no notifications of updates from Dependabot is not ideal.

Fixes #4396

## Solution

- Use https://github.com/peaceiris/actions-mdbook instead

## Review

Anyone from @ZcashFoundation/devops-reviewers 