### PR TITLE
fix(build): add `beta` rust to CI

### DIFF
--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -153,47 +153,6 @@ jobs:
           # Note: this only runs the zebrad acceptance tests, because re-running all the test binaries is slow on Windows
           args: --verbose --package zebrad --test acceptance -- --nocapture --include-ignored sync_large_checkpoints_
 
-  test-fake-activation-heights:
-    name: Test ${{ matrix.rust }} zebra-state with fake activation heights on ubuntu-latest
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable, beta]
-
-    steps:
-      - uses: actions/checkout@v3.0.2
-        with:
-          persist-credentials: false
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
-
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: fetch
-
-      # This test changes zebra-chain's activation heights,
-      # which can recompile all the Zebra crates,
-      # so we want its build products to be cached separately.
-      #
-      # Also, we don't want to accidentally use the fake heights in other tests.
-      - name: Run tests with fake activation heights
-        uses: actions-rs/cargo@v1.0.3
-        env:
-          TEST_FAKE_ACTIVATION_HEIGHTS: ''
-        with:
-          command: test
-          # Note: this only runs the zebra-state crate tests,
-          # because re-running all the test binaries can be slow
-          args: --verbose --package zebra-state --lib -- --nocapture --include-ignored with_fake_activation_heights
-
   build-chain-no-features:
     name: Build ${{ matrix.rust }} zebra-chain w/o features on ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
         os: [ubuntu-latest, macos-latest]
-        rust: [stable]
+        rust: [stable, beta]
 
     steps:
       - uses: actions/checkout@v3.0.2
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable]
+        rust: [stable, beta]
 
     steps:
       - uses: actions/checkout@v3.0.2

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -54,6 +54,13 @@ jobs:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
         os: [ubuntu-latest, macos-latest]
         rust: [stable, beta]
+        # We're excluding macOS for the following reasons:
+        # - the concurrent macOS runner limit is much lower than the Linux limit
+        # - macOS is slower than Linux, and shouldn't have a build or test difference with Linux
+        # - macOS is a second-tier Zebra support platform
+        exclude:
+          - os: macos-latest
+            rust: beta
 
     steps:
       - uses: actions/checkout@v3.0.2


### PR DESCRIPTION
## Motivation

On 29 July 2021, Zebra's tests started failing on beta Rust (https://github.com/rust-lang/rust/pull/87483). This Rust PR fixed the test build failure we were seeing: https://github.com/rust-lang/rust/pull/87483 and it was also backported.

Fixes #2541

Depends-On: #4668

## Solution

- Re-enable the Rust beta tests in the CI matrix.

## Review

Anyone from @ZcashFoundation/devops-reviewers 
