### PR TITLE
doc: add tokio-console page in book dev section

### DIFF
--- a/book/src/dev/tokio-console.md
+++ b/book/src/dev/tokio-console.md
@@ -1,0 +1,33 @@
+# `tokio-console` support
+
+`tokio-console` is a diagnostics and debugging tool for asynchronous Rust programs. This tool can be
+useful to lint runtime behavior, collect diagnostic data from processes, and debugging performance
+issues. ["it's like top(1) for tasks!"][top]
+
+## Setup
+
+Support for `tokio-console` is not enabled by default for zebrad. To activate this feature, run:
+ ```sh
+ $ RUSTFLAGS="--cfg tokio_unstable" cargo build --no-default-features --features="tokio-console" --bin zebrad
+ ```
+
+Install [`tokio-console`][install].
+
+Then start `zebrad` however you wish.
+
+When `zebrad` is running, run:
+```
+$ tokio-console
+```
+
+The default options are used, so `tokio-console` should connect to the running `zebrad` without other configuration.
+
+## More
+
+For more details, see the [`tokio` docs][enabling_tokio_instrumentation].
+
+
+[top]: https://github.com/tokio-rs/console#extremely-cool-and-amazing-screenshots
+[install]: https://github.com/tokio-rs/console#running-the-console]
+[enabling_tokio_instrumentation]: https://github.com/tokio-rs/console/blob/main/console-subscriber/README.md#enabling-tokio-instrumentation
+

--- a/book/src/dev/tokio-console.md
+++ b/book/src/dev/tokio-console.md
@@ -4,7 +4,7 @@
 useful to lint runtime behavior, collect diagnostic data from processes, and debugging performance
 issues. ["it's like top(1) for tasks!"][top]
 
-## Setup
+### Setup
 
 Support for `tokio-console` is not enabled by default for zebrad. To activate this feature, run:
  ```sh
@@ -22,7 +22,12 @@ $ tokio-console
 
 The default options are used, so `tokio-console` should connect to the running `zebrad` without other configuration.
 
-## More
+### Example
+
+<img width="788" alt="image" src="https://user-images.githubusercontent.com/552961/174457604-53c6ffc6-64f6-4952-94c6-ac7eb37c3871.png">
+
+
+### More
 
 For more details, see the [`tokio` docs][enabling_tokio_instrumentation].
 


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

While getting `tokio-console` working against `zebrad` I longed for handy docs like the ones we have for `lightwalletd`. 

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

Adds a page to the dev section of the Zebra book with instructions of how to build `zebrad` with the optional `tokio-console` support enabled, install `tokio-console`, and use it with `zebrad`. This is a dev page and not a user page as we don't expect 'regular' users to be profiling `zebrad` performance with `tokio-console`.  

## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

There is some slight duplication between comments in the `zebrad/Cargo.toml` on how to compile `zebrad` with the appropriate `RUSTFLAGS` and `--features` - should we deduplicate? Or is this low concern?

### Reviewer Checklist

  - [ ] Instructions are sufficient
  - [ ] Instructions are appropriately categorized
  - [ ] Deduplication required?

