### PR TITLE
fix(panic): Reduce the minimum lookahead limit, and fix a config panic

### DIFF
--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -57,8 +57,8 @@ const BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 3;
 
 /// A lower bound on the user-specified lookahead limit.
 ///
-/// Set to two checkpoint intervals, so that we're sure that the lookahead
-/// limit always contains at least one complete checkpoint.
+/// Set to the maximum checkpoint interval, so the pipeline holds at least one checkpoint's
+/// worth of blocks.
 ///
 /// ## Security
 ///
@@ -74,7 +74,7 @@ const BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 3;
 /// Once these malicious blocks start failing validation, the syncer will cancel all
 /// the pending download and verify tasks, drop all the blocks, and start a new
 /// ObtainTips with a new set of peers.
-pub const MIN_LOOKAHEAD_LIMIT: usize = zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP * 2;
+pub const MIN_LOOKAHEAD_LIMIT: usize = zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP;
 
 /// The default for the user-specified lookahead limit.
 ///
@@ -318,24 +318,27 @@ where
         // We apply a timeout to the verifier to avoid hangs due to missing earlier blocks.
         let verifier = Timeout::new(verifier, BLOCK_VERIFY_TIMEOUT);
 
-        assert!(
-            config.sync.lookahead_limit >= MIN_LOOKAHEAD_LIMIT,
-            "configured lookahead limit {} too low, must be at least {}",
-            config.sync.lookahead_limit,
-            MIN_LOOKAHEAD_LIMIT
-        );
+        let mut lookahead_limit = config.sync.lookahead_limit;
+        if lookahead_limit < MIN_LOOKAHEAD_LIMIT {
+            warn!(
+                "configured lookahead limit {} too low, increasing to {}",
+                config.sync.lookahead_limit, MIN_LOOKAHEAD_LIMIT,
+            );
+
+            lookahead_limit = MIN_LOOKAHEAD_LIMIT;
+        }
 
         let (sync_status, recent_syncs) = SyncStatus::new();
 
         let new_syncer = Self {
             genesis_hash: genesis_hash(config.network.network),
-            lookahead_limit: config.sync.lookahead_limit,
+            lookahead_limit,
             tip_network,
             downloads: Box::pin(Downloads::new(
                 block_network,
                 verifier,
                 latest_chain_tip.clone(),
-                config.sync.lookahead_limit,
+                lookahead_limit,
             )),
             state,
             latest_chain_tip,


### PR DESCRIPTION
## Motivation

We're seeing a lot of Orchard actions on the network, so we might want to reduce the concurrency and lookahead limits.

## Solution

- Reduce the minimum lookahead limit to 400 blocks (a single checkpoint)
- If the user configures a limit that's too low, don't panic, just warn and fix it

## Review

This might help fix some of the syncing issues, so it's a high priority.

### Reviewer Checklist

  - [ ] `lookahead_limit = 400` works in the config

