### PR TITLE
fix(ci): Ignore lightwalletd hangs for now

### DIFF
--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -838,14 +838,15 @@ fn zip143_sighash() -> Result<()> {
             Some(output) => mock_pre_v5_output_list(output, input_index.unwrap()),
             None => vec![],
         };
-        let result =
-            hex::encode(transaction.sighash(
+        let result = hex::encode(
+            transaction.sighash(
                 NetworkUpgrade::from_branch_id(test.consensus_branch_id)
                     .expect("must be a valid branch ID"),
                 HashType::from_bits(test.hash_type).expect("must be a valid HashType"),
                 &all_previous_outputs,
                 input_index,
-            ));
+            ),
+        );
         let expected = hex::encode(test.sighash);
         assert_eq!(expected, result, "test #{}: sighash does not match", i);
     }
@@ -873,14 +874,15 @@ fn zip243_sighash() -> Result<()> {
             Some(output) => mock_pre_v5_output_list(output, input_index.unwrap()),
             None => vec![],
         };
-        let result =
-            hex::encode(transaction.sighash(
+        let result = hex::encode(
+            transaction.sighash(
                 NetworkUpgrade::from_branch_id(test.consensus_branch_id)
                     .expect("must be a valid branch ID"),
                 HashType::from_bits(test.hash_type).expect("must be a valid HashType"),
                 &all_previous_outputs,
                 input_index,
-            ));
+            ),
+        );
         let expected = hex::encode(test.sighash);
         assert_eq!(expected, result, "test #{}: sighash does not match", i);
     }

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -838,15 +838,14 @@ fn zip143_sighash() -> Result<()> {
             Some(output) => mock_pre_v5_output_list(output, input_index.unwrap()),
             None => vec![],
         };
-        let result = hex::encode(
-            transaction.sighash(
+        let result =
+            hex::encode(transaction.sighash(
                 NetworkUpgrade::from_branch_id(test.consensus_branch_id)
                     .expect("must be a valid branch ID"),
                 HashType::from_bits(test.hash_type).expect("must be a valid HashType"),
                 &all_previous_outputs,
                 input_index,
-            ),
-        );
+            ));
         let expected = hex::encode(test.sighash);
         assert_eq!(expected, result, "test #{}: sighash does not match", i);
     }
@@ -874,15 +873,14 @@ fn zip243_sighash() -> Result<()> {
             Some(output) => mock_pre_v5_output_list(output, input_index.unwrap()),
             None => vec![],
         };
-        let result = hex::encode(
-            transaction.sighash(
+        let result =
+            hex::encode(transaction.sighash(
                 NetworkUpgrade::from_branch_id(test.consensus_branch_id)
                     .expect("must be a valid branch ID"),
                 HashType::from_bits(test.hash_type).expect("must be a valid HashType"),
                 &all_previous_outputs,
                 input_index,
-            ),
-        );
+            ));
         let expected = hex::encode(test.sighash);
         assert_eq!(expected, result, "test #{}: sighash does not match", i);
     }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1300,7 +1300,8 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
     // lightwalletd will keep retrying getblock.
     if !test_type.allow_lightwalletd_cached_state() {
         if test_type.needs_zebra_cached_state() {
-            lightwalletd.expect_stdout_line_matches("([Aa]dding block to cache)|([Ww]aiting for block)")?;
+            lightwalletd
+                .expect_stdout_line_matches("([Aa]dding block to cache)|([Ww]aiting for block)")?;
         } else {
             lightwalletd.expect_stdout_line_matches(regex::escape(
                 "Waiting for zcashd height to reach Sapling activation height (419200)",
@@ -1313,7 +1314,8 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
         zebrad.expect_stdout_line_matches(SYNC_FINISHED_REGEX)?;
 
         // Wait for lightwalletd to sync some blocks
-        lightwalletd.expect_stdout_line_matches("([Aa]dding block to cache)|([Ww]aiting for block)")?;
+        lightwalletd
+            .expect_stdout_line_matches("([Aa]dding block to cache)|([Ww]aiting for block)")?;
 
         // Wait for lightwalletd to sync to Zebra's tip
         //


### PR DESCRIPTION
## Motivation

Sometimes `lightwalletd` hangs when it gets near the tip.

We can't really fix that, so we just check that it has synced some blocks instead.

Depends-On: #4669, #4675

## Solution

- Allow "adding block to cache" as an alternative tip log, where we previously required "waiting for block"

## Review

This is pretty urgent, it's blocking some lightwalletd tests.

### Reviewer Checklist

  - [ ] CI passes

## Follow Up Tasks

- #4600 
- #4537