### PR TITLE
fix(ci): update OS patch jobs for Rust & feature changes

### DIFF
--- a/.github/workflows/continous-integration-os.patch.yml
+++ b/.github/workflows/continous-integration-os.patch.yml
@@ -14,46 +14,21 @@ on:
 jobs:
   test:
     name: Test ${{ matrix.rust }} on ${{ matrix.os }}
-    # The large timeout is to accommodate:
-    # - Windows builds (75 minutes, typically 30-50 minutes)
-    # - parameter downloads (40 minutes, but only when the cache expires)
-    timeout-minutes: 115
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
         os: [ubuntu-latest, macos-latest]
-        rust: [stable]
-
-    steps:
-      - run: 'echo "No build required"'
-
-  test-fake-activation-heights:
-    name: Test ${{ matrix.rust }} zebra-state with fake activation heights on ubuntu-latest
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable]
-
-    steps:
-      - run: 'echo "No build required"'
-
-  build-chain-no-features:
-    name: Build ${{ matrix.rust }} zebra-chain w/o features on ubuntu-latest
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
         rust: [stable, beta]
+        exclude:
+          - os: macos-latest
+            rust: beta
 
     steps:
       - run: 'echo "No build required"'
 
   install-from-lockfile-no-cache:
     name: Install zebrad from lockfile without cache on ubuntu-latest
-    timeout-minutes: 60
     runs-on: ubuntu-latest
 
     steps:
@@ -61,23 +36,20 @@ jobs:
 
   check-cargo-lock:
     name: Check Cargo.lock is up to date
-    timeout-minutes: 60
     runs-on: ubuntu-latest
 
     steps:
       - run: 'echo "No build required"'
 
   cargo-deny:
-    name: Check deny.toml ${{ matrix.checks }}
+    name: Check deny.toml ${{ matrix.checks }} ${{ matrix.features }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         checks:
           - bans
           - sources
-
-    # Prevent sudden announcement of a new advisory from failing ci:
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
+        features: ['', '--all-features', '--no-default-features']
 
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/continous-integration-os.patch.yml
+++ b/.github/workflows/continous-integration-os.patch.yml
@@ -27,6 +27,17 @@ jobs:
     steps:
       - run: 'echo "No build required"'
 
+  build-chain-no-features:
+    name: Build ${{ matrix.rust }} zebra-chain w/o features on ubuntu-latest
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, beta]
+
+    steps:
+      - run: 'echo "No build required"'
+
   install-from-lockfile-no-cache:
     name: Install zebrad from lockfile without cache on ubuntu-latest
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

In PRs #4637 and #4640 we changed some job names, but didn't update some patch jobs.

We probably want to merge this with PR #4637.

## Solution

- add beta Rust job name (#4637)
- update `cargo deny` job names (#4640)
- delete duplicate zebra chain fake activation heights test (#4637 ?)
- delete redundant fields in patch jobs

## Review

@gustavovalverde made most of these changes.

### Reviewer Checklist

  - [ ] Required jobs never cause PRs to hang

