### PR TITLE
fix(sync): change default sync config to improve reliability

### DIFF
--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -57,7 +57,7 @@ const BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 3;
 
 /// A lower bound on the user-specified lookahead limit.
 ///
-/// Set to the maximum checkpoint interval, so the pipeline holds at least one checkpoint's
+/// Set to the maximum checkpoint interval, so the pipeline holds around a checkpoint's
 /// worth of blocks.
 ///
 /// ## Security
@@ -79,7 +79,9 @@ pub const MIN_LOOKAHEAD_LIMIT: usize = zebra_consensus::MAX_CHECKPOINT_HEIGHT_GA
 /// The default for the user-specified lookahead limit.
 ///
 /// See [`MIN_LOOKAHEAD_LIMIT`] for details.
-pub const DEFAULT_LOOKAHEAD_LIMIT: usize = zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP * 5;
+///
+/// TODO: increase to `MAX_CHECKPOINT_HEIGHT_GAP * 5`, after we implement orchard batching
+pub const DEFAULT_LOOKAHEAD_LIMIT: usize = MIN_LOOKAHEAD_LIMIT;
 
 /// The expected maximum number of hashes in an ObtainTips or ExtendTips response.
 ///

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -143,7 +143,9 @@ pub(super) const BLOCK_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
 ///
 /// If this timeout is set too low, the syncer will sometimes get stuck in a
 /// failure loop.
-pub(super) const BLOCK_VERIFY_TIMEOUT: Duration = Duration::from_secs(6 * 60);
+///
+/// TODO: reduce to `6 * 60`, after we implement orchard batching?
+pub(super) const BLOCK_VERIFY_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
 /// Controls how long we wait to restart syncing after finishing a sync run.
 ///

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -425,6 +425,9 @@ where
             .map_err(move |e| (e, hash)),
         );
 
+        // Try to start the spawned task before queueing the next block request
+        tokio::task::yield_now().await;
+
         self.pending.push(task);
         assert!(
             self.cancel_handles.insert(hash, cancel_tx).is_none(),


### PR DESCRIPTION
## Motivation

Zebra is a bit slow to verify orchard blocks with lots of transactions, which can cause a failure loop.

This PR should reduce the concurrency a bit, allowing it to sync more reliably.

## Solution

Concurrency:
- Decrease the default lookahead limit from 2000 to 400
- Increase the block verification timeout from 6 to 10 minutes
- Decrease the default concurrent downloads config from 50 to 25

Priority:
- Try to run the spawned download task before queueing the next download

Cancellation:
- Allow verification to be cancelled if the verifier is busy 

## Review

This is pretty urgent, it seems to be blocking a lot of other fixes and tests.

### Reviewer Checklist

  - [ ] Full sync works more reliably

