### PR TITLE
fix(sync): Slightly increase some syncer defaults

### DIFF
--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -81,7 +81,7 @@ pub const MIN_LOOKAHEAD_LIMIT: usize = zebra_consensus::MAX_CHECKPOINT_HEIGHT_GA
 /// See [`MIN_LOOKAHEAD_LIMIT`] for details.
 ///
 /// TODO: increase to `MAX_CHECKPOINT_HEIGHT_GAP * 5`, after we implement orchard batching
-pub const DEFAULT_LOOKAHEAD_LIMIT: usize = MIN_LOOKAHEAD_LIMIT;
+pub const DEFAULT_LOOKAHEAD_LIMIT: usize = zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP * 3;
 
 /// The expected maximum number of hashes in an ObtainTips or ExtendTips response.
 ///

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -198,7 +198,7 @@ impl Default for SyncSection {
     fn default() -> Self {
         Self {
             // TODO: increase to 50, after we implement orchard batching
-            max_concurrent_block_requests: 25,
+            max_concurrent_block_requests: 40,
             lookahead_limit: sync::DEFAULT_LOOKAHEAD_LIMIT,
         }
     }


### PR DESCRIPTION
## Motivation

We changed the syncer defaults to make full verification more reliable, but that slowed down syncing by about 15%.

This is a partial revert of PR #4670.

## Solution

- Increase the syncer defaults to about halfway between the previous and current defaults

This is a temporary fix until we get orchard batch verification.

## Review

This PR needs a full sync test before it gets merged.

### Reviewer Checklist

  - [ ] Full sync is greater than 85% at 6 hours


