### PR TITLE
fix(network messages): add limits to rejection message and reason

### DIFF
--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -6,7 +6,6 @@ use chrono::{DateTime, Utc};
 
 use zebra_chain::{
     block::{self, Block},
-    serialization::ZcashSerialize,
     transaction::UnminedTx,
 };
 
@@ -351,40 +350,37 @@ const MAX_REJECT_MESSAGE_LENGTH: usize = 12;
 /// This is equivalent to `MAX_REJECT_MESSAGE_LENGTH` in zcashd.
 const MAX_REJECT_REASON_LENGTH: usize = 111;
 
+// TODO: add tests for Error conversion and Reject message serialization (#4633)
+// (Zebra does not currently send reject messages, and it ignores received reject messages.)
 impl<E> From<E> for Message
 where
     E: Error,
 {
     fn from(e: E) -> Self {
-        let message_bytes = e.to_string().zcash_serialize_to_vec().unwrap_or_default();
+        let message = e
+            .to_string()
+            .escape_default()
+            .take(MAX_REJECT_MESSAGE_LENGTH)
+            .collect();
+        let reason = e
+            .source()
+            .map(ToString::to_string)
+            .unwrap_or_default()
+            .escape_default()
+            .take(MAX_REJECT_REASON_LENGTH)
+            .collect();
 
         Message::Reject {
-            message: String::from_utf8(
-                message_bytes[0..std::cmp::min(MAX_REJECT_MESSAGE_LENGTH, message_bytes.len())]
-                    .to_vec(),
-            )
-            .unwrap_or_else(|_| String::from("")),
+            message,
 
             // The generic case, impls for specific error types should
             // use specific varieties of `RejectReason`.
             ccode: RejectReason::Other,
 
-            reason: if let Some(reason) = e.source() {
-                let reason_bytes = reason
-                    .to_string()
-                    .zcash_serialize_to_vec()
-                    .unwrap_or_default();
+            reason,
 
-                String::from_utf8(
-                    reason_bytes[0..std::cmp::min(MAX_REJECT_REASON_LENGTH, reason_bytes.len())]
-                        .to_vec(),
-                )
-                .unwrap_or_else(|_| String::from(""))
-            } else {
-                String::from("")
-            },
-
-            // Allow this to be overridden but not populated by default, methinks.
+            // The hash of the rejected block or transaction.
+            // We don't have that data here, so the caller needs to fill it in later.
             data: None,
         }
     }

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -356,10 +356,11 @@ where
     E: Error,
 {
     fn from(e: E) -> Self {
+        let message_bytes = e.to_string().zcash_serialize_to_vec().unwrap_or_default();
+
         Message::Reject {
             message: String::from_utf8(
-                e.to_string().zcash_serialize_to_vec().unwrap_or_default()
-                    [0..MAX_REJECT_MESSAGE_LENGTH]
+                message_bytes[0..std::cmp::min(MAX_REJECT_MESSAGE_LENGTH, message_bytes.len())]
                     .to_vec(),
             )
             .unwrap_or_else(|_| String::from("")),
@@ -369,11 +370,13 @@ where
             ccode: RejectReason::Other,
 
             reason: if let Some(reason) = e.source() {
+                let reason_bytes = reason
+                    .to_string()
+                    .zcash_serialize_to_vec()
+                    .unwrap_or_default();
+
                 String::from_utf8(
-                    reason
-                        .to_string()
-                        .zcash_serialize_to_vec()
-                        .unwrap_or_default()[0..MAX_REJECT_REASON_LENGTH]
+                    reason_bytes[0..std::cmp::min(MAX_REJECT_REASON_LENGTH, reason_bytes.len())]
                         .to_vec(),
                 )
                 .unwrap_or_else(|_| String::from(""))

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -358,11 +358,11 @@ where
     fn from(e: E) -> Self {
         Message::Reject {
             message: String::from_utf8(
-                e.to_string().zcash_serialize_to_vec().unwrap_or(Vec::new())
+                e.to_string().zcash_serialize_to_vec().unwrap_or_default()
                     [0..MAX_REJECT_MESSAGE_LENGTH]
                     .to_vec(),
             )
-            .unwrap_or(String::from("")),
+            .unwrap_or_else(|_| String::from("")),
 
             // The generic case, impls for specific error types should
             // use specific varieties of `RejectReason`.
@@ -373,10 +373,10 @@ where
                     reason
                         .to_string()
                         .zcash_serialize_to_vec()
-                        .unwrap_or(Vec::new())[0..MAX_REJECT_REASON_LENGTH]
+                        .unwrap_or_default()[0..MAX_REJECT_REASON_LENGTH]
                         .to_vec(),
                 )
-                .unwrap_or(String::from(""))
+                .unwrap_or_else(|_| String::from(""))
             } else {
                 String::from("")
             },

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -340,20 +340,29 @@ pub enum Message {
     FilterClear,
 }
 
+/// The maximum size of the rejection message
+const MAX_REJECT_MESSAGE_LENGTH: usize = 12;
+/// The maximum size of the rejection reason
+const MAX_REJECT_REASON_LENGTH: usize = 100;
+
 impl<E> From<E> for Message
 where
     E: Error,
 {
     fn from(e: E) -> Self {
+        let mut message = e.to_string();
+        message.truncate(MAX_REJECT_MESSAGE_LENGTH);
         Message::Reject {
-            message: e.to_string(),
+            message,
 
             // The generic case, impls for specific error types should
             // use specific varieties of `RejectReason`.
             ccode: RejectReason::Other,
 
             reason: if let Some(reason) = e.source() {
-                reason.to_string()
+                let mut reason = reason.to_string();
+                reason.truncate(MAX_REJECT_REASON_LENGTH);
+                reason
             } else {
                 String::from("")
             },

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -341,10 +341,15 @@ pub enum Message {
     FilterClear,
 }
 
-/// The maximum size of the rejection message
+/// The maximum size of the rejection message.
+///
+/// This is equivalent to `COMMAND_SIZE` in zcashd.
 const MAX_REJECT_MESSAGE_LENGTH: usize = 12;
-/// The maximum size of the rejection reason
-const MAX_REJECT_REASON_LENGTH: usize = 100;
+
+/// The maximum size of the rejection reason.
+///
+/// This is equivalent to `MAX_REJECT_MESSAGE_LENGTH` in zcashd.
+const MAX_REJECT_REASON_LENGTH: usize = 111;
 
 impl<E> From<E> for Message
 where


### PR DESCRIPTION
## Motivation

Zcash limits the rejection  message and the reason to specific constants. We want to do similar for Zebra.

Close https://github.com/ZcashFoundation/zebra/issues/4632

Depends-On: #4714

## Solution

Add constants and truncate `Mesage::Reject::message` to `MAX_REJECT_MESSAGE_LENGTH` and `Mesage::Reject::reason` to `MAX_REJECT_REASON_LENGTH` 

## Review

I think anyone can review, i left some comments with references to zcashd.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
