### PR TITLE
Warn the user when Zebra doesn't recognize the format of `zebrad.toml`

### DIFF
--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -207,7 +207,7 @@ impl Application for ZebradApp {
             Some(path) => match self.load_config(&path) {
                 Ok(config) => config,
                 Err(e) => {
-                    status_err!("Zebra could not parse the provided config file. This might mean you are using a deprecated format of the file.");
+                    status_err!("Zebra could not parse the provided config file. This might mean you are using a deprecated format of the file. You can generate a valid config by running \"zebrad generate\", and diff it against yours to examine any format inconsistencies.");
                     return Err(e);
                 }
             },

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -5,6 +5,7 @@ use std::{fmt::Write as _, io::Write as _, process};
 use abscissa_core::{
     application::{self, fatal_error, AppCell},
     config::{self, Configurable},
+    status_err,
     terminal::{component::Terminal, stderr, stdout, ColorChoice},
     Application, Component, EntryPoint, FrameworkError, Shutdown, StandardPaths, Version,
 };
@@ -202,11 +203,16 @@ impl Application for ZebradApp {
 
         // Load config *after* framework components so that we can
         // report an error to the terminal if it occurs.
-        let config = command
-            .config_path()
-            .map(|path| self.load_config(&path))
-            .transpose()?
-            .unwrap_or_default();
+        let config = match command.config_path() {
+            Some(path) => match self.load_config(&path) {
+                Ok(config) => config,
+                Err(e) => {
+                    status_err!("Zebra could not parse the provided config file. This might mean you are using a deprecated format of the file.");
+                    return Err(e);
+                }
+            },
+            None => ZebradConfig::default(),
+        };
 
         let config = command.process_config(config)?;
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -501,12 +501,17 @@ fn version_args() -> Result<()> {
     Ok(())
 }
 
+/// Run config tests that use the default ports and paths.
+///
+/// Unlike the other tests, these tests can not be run in parallel, because
+/// they use the generated config. So parallel execution can cause port and
+/// cache conflicts.
 #[test]
 fn config_test() -> Result<()> {
-    // Unlike the other tests, these tests can not be run in parallel, because
-    // they use the generated config. So parallel execution can cause port and
-    // cache conflicts.
     valid_generated_config("start", "Starting zebrad")?;
+
+    // Check what happens when Zebra parses an invalid config
+    invalid_generated_config()?;
 
     // Check that an older stored configuration we have for Zebra works
     stored_config_works()?;
@@ -514,6 +519,7 @@ fn config_test() -> Result<()> {
     Ok(())
 }
 
+/// Test that `zebrad start` can parse the output from `zebrad generate`.
 fn valid_generated_config(command: &str, expect_stdout_line_contains: &str) -> Result<()> {
     zebra_test::init();
 
@@ -565,7 +571,6 @@ fn valid_generated_config(command: &str, expect_stdout_line_contains: &str) -> R
 
 /// Checks that Zebra prints an informative message when it cannot parse the
 /// config file.
-#[test]
 fn invalid_generated_config() -> Result<()> {
     zebra_test::init();
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -103,10 +103,10 @@
 //!
 //! Please refer to the documentation of each test for more information.
 
-use std::{collections::HashSet, env, path::PathBuf};
+use std::{collections::HashSet, env, fs, path::PathBuf, time::Duration};
 
 use color_eyre::{
-    eyre::{Result, WrapErr},
+    eyre::{eyre, Result, WrapErr},
     Help,
 };
 
@@ -355,7 +355,6 @@ fn misconfigured_ephemeral_missing_directory() -> Result<()> {
 }
 
 fn ephemeral(cache_dir_config: EphemeralConfig, cache_dir_check: EphemeralCheck) -> Result<()> {
-    use std::fs;
     use std::io::ErrorKind;
 
     zebra_test::init();
@@ -503,11 +502,13 @@ fn version_args() -> Result<()> {
 }
 
 #[test]
-fn valid_generated_config_test() -> Result<()> {
+fn config_test() -> Result<()> {
     // Unlike the other tests, these tests can not be run in parallel, because
     // they use the generated config. So parallel execution can cause port and
     // cache conflicts.
     valid_generated_config("start", "Starting zebrad")?;
+
+    invalid_generated_config()?;
 
     Ok(())
 }
@@ -561,6 +562,75 @@ fn valid_generated_config(command: &str, expect_stdout_line_contains: &str) -> R
     Ok(())
 }
 
+/// Checks that Zebra prints an informative message when it cannot parse the
+/// config file.
+fn invalid_generated_config() -> Result<()> {
+    zebra_test::init();
+
+    let testdir = &testdir()?;
+
+    // Add a config file name to tempdir path.
+    let config_path = testdir.path().join("zebrad.toml");
+
+    // Generate a valid config file in the temp dir.
+    let child = testdir.spawn_child(args!["generate", "-o": config_path.to_str().unwrap()])?;
+
+    let output = child.wait_with_output()?;
+    let output = output.assert_success()?;
+
+    assert_with_context!(
+        config_path.exists(),
+        &output,
+        "generated config file not found"
+    );
+
+    // Load the valid config file that Zebra generated.
+    let mut config_file = fs::read_to_string(config_path.to_str().unwrap()).unwrap();
+
+    // Let's now alter the config file so that it contains a deprecated format
+    // of `mempool.eviction_memory_time`.
+
+    config_file = config_file
+        .lines()
+        // Remove the valid `eviction_memory_time` key/value pair from the
+        // config.
+        .filter(|line| !line.contains("eviction_memory_time"))
+        .map(|line| line.to_owned() + "\n")
+        .collect();
+
+    // Append the `eviction_memory_time` key/value pair in a deprecated format.
+    config_file += r"
+
+            [mempool.eviction_memory_time]
+            nanos = 0
+            secs = 3600
+    ";
+
+    // Write the altered config file so that Zebra can pick it up.
+    fs::write(config_path.to_str().unwrap(), config_file.as_bytes())
+        .expect("Could not write the altered config file.");
+
+    // Run Zebra in a temp dir so that it loads the config.
+    let mut child = testdir.spawn_child(args!["start"])?;
+
+    // Return an error if Zebra is running for more than two seconds.
+    //
+    // Since the config is invalid, Zebra should terminate instantly after its
+    // start. Two seconds should be sufficient for Zebra to read the config file
+    // and terminate.
+    std::thread::sleep(Duration::from_secs(2));
+    if child.is_running() {
+        child.kill()?;
+        return Err(eyre!("Zebra should not be running anymore."));
+    }
+
+    let output = child.wait_with_output()?;
+
+    // Check that Zebra produced an informative message.
+    output.stderr_contains("Zebra could not parse the provided config file. This might mean you are using a deprecated format of the file.")?;
+
+    Ok(())
+}
 /// Test if `zebrad` can sync the first checkpoint on mainnet.
 ///
 /// The first checkpoint contains a single genesis block.
@@ -1558,8 +1628,6 @@ where
     // See #1781.
     #[cfg(target_os = "linux")]
     if node2.is_running() {
-        use color_eyre::eyre::eyre;
-
         return node2
             .kill_on_error::<(), _>(Err(eyre!(
                 "conflicted node2 was still running, but the test expected a panic"


### PR DESCRIPTION
## Motivation

When the format of zebrad.toml changes, Zebra doesn't recognize it appropriately and returns an unclear error saying that it couldn't read some data. This becomes an issue when users install a new version of Zebra that uses a new format of zebrad.toml, but keep their old `zebrad.toml` file.

## Solution

Zebra now provides a message saying that it could not parse the provided config file, and suggests that the user might be using a deprecated format of the file.

Close #4665

### Reviewer Checklist

  - [ ] Tests for Expected Behaviour
