### PR TITLE
deps: upgrade ECC dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,8 +1487,18 @@ dependencies = [
 
 [[package]]
 name = "equihash"
-version = "0.1.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=6d75718076e592a41b6bd6ec916dc15420e4cc3c#6d75718076e592a41b6bd6ec916dc15420e4cc3c"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab579d7cf78477773b03e80bc2f89702ef02d7112c711d54ca93dcdce68533d5"
+dependencies = [
+ "blake2b_simd 1.0.0",
+ "byteorder",
+]
+
+[[package]]
+name = "equihash"
+version = "0.2.0"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=4567a37ceccbd506a58aaaded39ba14c952c1510#4567a37ceccbd506a58aaaded39ba14c952c1510"
 dependencies = [
  "blake2b_simd 1.0.0",
  "byteorder",
@@ -1891,7 +1901,25 @@ dependencies = [
  "bitvec",
  "ff",
  "group",
- "halo2_proofs",
+ "halo2_proofs 0.1.0",
+ "lazy_static",
+ "pasta_curves",
+ "rand 0.8.5",
+ "subtle",
+ "uint",
+]
+
+[[package]]
+name = "halo2_gadgets"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e10bf9924da1754e443641c9e7f9f00483749f8fb837fde696ef6ed6e2f079"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bitvec",
+ "ff",
+ "group",
+ "halo2_proofs 0.2.0",
  "lazy_static",
  "pasta_curves",
  "rand 0.8.5",
@@ -1911,6 +1939,21 @@ dependencies = [
  "pasta_curves",
  "rand_core 0.6.3",
  "rayon",
+]
+
+[[package]]
+name = "halo2_proofs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff771b9a2445cd2545c9ef26d863c290fbb44ae440c825a20eb7156f67a949a"
+dependencies = [
+ "blake2b_simd 1.0.0",
+ "ff",
+ "group",
+ "pasta_curves",
+ "rand_core 0.6.3",
+ "rayon",
+ "tracing",
 ]
 
 [[package]]
@@ -2951,8 +2994,8 @@ dependencies = [
  "ff",
  "fpe",
  "group",
- "halo2_gadgets",
- "halo2_proofs",
+ "halo2_gadgets 0.1.0",
+ "halo2_proofs 0.1.0",
  "hex",
  "incrementalmerkletree",
  "lazy_static",
@@ -2963,6 +3006,34 @@ dependencies = [
  "reddsa",
  "serde",
  "subtle",
+ "zcash_note_encryption 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "orchard"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7619db7f917afd9b1139044c595fab1b6166de2db62317794b5f5e34a2104ae1"
+dependencies = [
+ "aes",
+ "bitvec",
+ "blake2b_simd 1.0.0",
+ "ff",
+ "fpe",
+ "group",
+ "halo2_gadgets 0.2.0",
+ "halo2_proofs 0.2.0",
+ "hex",
+ "incrementalmerkletree",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "pasta_curves",
+ "rand 0.8.5",
+ "reddsa",
+ "serde",
+ "subtle",
+ "tracing",
  "zcash_note_encryption 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6026,7 +6097,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.1.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=6d75718076e592a41b6bd6ec916dc15420e4cc3c#6d75718076e592a41b6bd6ec916dc15420e4cc3c"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=4567a37ceccbd506a58aaaded39ba14c952c1510#4567a37ceccbd506a58aaaded39ba14c952c1510"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -6058,7 +6129,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.1.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=6d75718076e592a41b6bd6ec916dc15420e4cc3c#6d75718076e592a41b6bd6ec916dc15420e4cc3c"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=4567a37ceccbd506a58aaaded39ba14c952c1510#4567a37ceccbd506a58aaaded39ba14c952c1510"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -6081,7 +6152,7 @@ dependencies = [
  "bs58",
  "byteorder",
  "chacha20poly1305",
- "equihash 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash 0.1.0",
  "ff",
  "fpe",
  "group",
@@ -6092,7 +6163,7 @@ dependencies = [
  "lazy_static",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.1.0",
  "rand 0.8.5",
  "rand_core 0.6.3",
  "ripemd",
@@ -6105,8 +6176,45 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.6.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=6d75718076e592a41b6bd6ec916dc15420e4cc3c#6d75718076e592a41b6bd6ec916dc15420e4cc3c"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbb401f5dbc482b831954aaa7cba0a8fe148241db6d19fe7cebda78252ca680"
+dependencies = [
+ "aes",
+ "bip0039",
+ "bitvec",
+ "blake2b_simd 1.0.0",
+ "blake2s_simd",
+ "bls12_381",
+ "bs58",
+ "byteorder",
+ "chacha20poly1305",
+ "equihash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ff",
+ "fpe",
+ "group",
+ "hdwallet",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "orchard 0.2.0",
+ "rand 0.8.5",
+ "rand_core 0.6.3",
+ "ripemd",
+ "secp256k1",
+ "sha2",
+ "subtle",
+ "zcash_encoding 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_note_encryption 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.7.0"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=4567a37ceccbd506a58aaaded39ba14c952c1510#4567a37ceccbd506a58aaaded39ba14c952c1510"
 dependencies = [
  "aes",
  "bip0039",
@@ -6116,7 +6224,7 @@ dependencies = [
  "bls12_381",
  "byteorder",
  "chacha20poly1305",
- "equihash 0.1.0 (git+https://github.com/ZcashFoundation/librustzcash.git?rev=6d75718076e592a41b6bd6ec916dc15420e4cc3c)",
+ "equihash 0.2.0 (git+https://github.com/ZcashFoundation/librustzcash.git?rev=4567a37ceccbd506a58aaaded39ba14c952c1510)",
  "ff",
  "fpe",
  "group",
@@ -6126,19 +6234,19 @@ dependencies = [
  "lazy_static",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.2.0",
  "rand 0.8.5",
  "rand_core 0.6.3",
  "sha2",
  "subtle",
- "zcash_encoding 0.1.0 (git+https://github.com/ZcashFoundation/librustzcash.git?rev=6d75718076e592a41b6bd6ec916dc15420e4cc3c)",
- "zcash_note_encryption 0.1.0 (git+https://github.com/ZcashFoundation/librustzcash.git?rev=6d75718076e592a41b6bd6ec916dc15420e4cc3c)",
+ "zcash_encoding 0.1.0 (git+https://github.com/ZcashFoundation/librustzcash.git?rev=4567a37ceccbd506a58aaaded39ba14c952c1510)",
+ "zcash_note_encryption 0.1.0 (git+https://github.com/ZcashFoundation/librustzcash.git?rev=4567a37ceccbd506a58aaaded39ba14c952c1510)",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.6.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=6d75718076e592a41b6bd6ec916dc15420e4cc3c#6d75718076e592a41b6bd6ec916dc15420e4cc3c"
+version = "0.7.0"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?rev=4567a37ceccbd506a58aaaded39ba14c952c1510#4567a37ceccbd506a58aaaded39ba14c952c1510"
 dependencies = [
  "bellman",
  "blake2b_simd 1.0.0",
@@ -6151,7 +6259,7 @@ dependencies = [
  "lazy_static",
  "minreq",
  "rand_core 0.6.3",
- "zcash_primitives 0.6.0 (git+https://github.com/ZcashFoundation/librustzcash.git?rev=6d75718076e592a41b6bd6ec916dc15420e4cc3c)",
+ "zcash_primitives 0.7.0 (git+https://github.com/ZcashFoundation/librustzcash.git?rev=4567a37ceccbd506a58aaaded39ba14c952c1510)",
 ]
 
 [[package]]
@@ -6165,12 +6273,12 @@ dependencies = [
  "cc",
  "libc",
  "memuse",
- "orchard",
+ "orchard 0.1.0",
  "rand_core 0.6.3",
  "tracing",
  "zcash_encoding 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_primitives 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.6.0",
 ]
 
 [[package]]
@@ -6191,17 +6299,17 @@ dependencies = [
  "criterion",
  "displaydoc",
  "ed25519-zebra",
- "equihash 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash 0.1.0",
  "fpe",
  "futures",
  "group",
- "halo2_proofs",
+ "halo2_proofs 0.2.0",
  "hex",
  "incrementalmerkletree",
  "itertools",
  "jubjub",
  "lazy_static",
- "orchard",
+ "orchard 0.2.0",
  "primitive-types",
  "proptest",
  "proptest-derive",
@@ -6226,7 +6334,7 @@ dependencies = [
  "zcash_encoding 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_history",
  "zcash_note_encryption 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_primitives 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-test",
 ]
 
@@ -6247,13 +6355,13 @@ dependencies = [
  "displaydoc",
  "futures",
  "futures-util",
- "halo2_proofs",
+ "halo2_proofs 0.2.0",
  "hex",
  "jubjub",
  "lazy_static",
  "metrics",
  "once_cell",
- "orchard",
+ "orchard 0.2.0",
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
@@ -6372,7 +6480,7 @@ dependencies = [
  "dirs",
  "displaydoc",
  "futures",
- "halo2_proofs",
+ "halo2_proofs 0.2.0",
  "hex",
  "insta",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,4 +66,4 @@ lto = "thin"
 [patch.crates-io]
 
 # Currently pointing to `download-sprout-params` branch.
-zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "6d75718076e592a41b6bd6ec916dc15420e4cc3c" }
+zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "4567a37ceccbd506a58aaaded39ba14c952c1510" }

--- a/deny.toml
+++ b/deny.toml
@@ -26,10 +26,16 @@ allow = [
 skip = [
     #  wait for zcash_proofs fork be merged back into upstream
     # https://github.com/ZcashFoundation/zebra/issues/3831
-    { name = "equihash", version = "=0.1.0" },
+    { name = "equihash", version = "=0.2.0" },
     { name = "zcash_encoding", version = "=0.1.0" },
     { name = "zcash_note_encryption", version = "=0.1.0" },
-    { name = "zcash_primitives", version = "=0.6.0" },
+    { name = "zcash_primitives", version = "=0.7.0" },
+
+    # wait until zcash updates its halo2, orchard, etc. dependencies
+    # (which is likely to happen in the release after 5.0.0)
+    { name = "halo2_gadgets", version = "=0.1.0" },
+    { name = "halo2_proofs", version = "=0.1.0" },
+    { name = "orchard", version = "=0.1.0" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -27,7 +27,7 @@ displaydoc = "0.2.3"
 fpe = "0.5.1"
 futures = "0.3.21"
 group = "0.12.0"
-halo2 = { package = "halo2_proofs", version = "0.1.0" }
+halo2 = { package = "halo2_proofs", version = "0.2.0" }
 hex = { version = "0.4.3", features = ["serde"] }
 incrementalmerkletree = "0.3.0"
 itertools = "0.10.3"
@@ -49,11 +49,11 @@ thiserror = "1.0.31"
 uint = "0.9.1"
 x25519-dalek = { version = "1.2.0", features = ["serde"] }
 
-orchard = "0.1.0"
+orchard = "0.2.0"
 
 equihash = "0.1.0"
 zcash_note_encryption = "0.1"
-zcash_primitives = { version = "0.6.0", features = ["transparent-inputs"] }
+zcash_primitives = { version = "0.7.0", features = ["transparent-inputs"] }
 zcash_encoding = "0.1.0"
 zcash_history = "0.3.0"
 

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -16,7 +16,7 @@ bls12_381 = "0.7.0"
 jubjub = "0.9.0"
 rand = { version = "0.8.5", package = "rand" }
 
-halo2 = { package = "halo2_proofs", version = "0.1.0" }
+halo2 = { package = "halo2_proofs", version = "0.2.0" }
 
 chrono = "0.4.19"
 dirs = "4.0.0"
@@ -34,11 +34,11 @@ tower = { version = "0.4.13", features = ["timeout", "util", "buffer"] }
 tracing = "0.1.31"
 tracing-futures = "0.2.5"
 
-orchard = "0.1.0"
+orchard = "0.2.0"
 
 # TODO: replace with upstream librustzcash when these changes are merged (#3037)
 # Currently pointing to `download-sprout-params` branch.
-zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "6d75718076e592a41b6bd6ec916dc15420e4cc3c", features = ["local-prover", "multicore", "download-params"] }
+zcash_proofs = { git = "https://github.com/ZcashFoundation/librustzcash.git", rev = "4567a37ceccbd506a58aaaded39ba14c952c1510", features = ["local-prover", "multicore", "download-params"] }
 
 tower-fallback = { path = "../tower-fallback/" }
 tower-batch = { path = "../tower-batch/" }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -46,7 +46,7 @@ insta = { version = "1.15.0", features = ["ron"] }
 proptest = "0.10.1"
 proptest-derive = "0.3.0"
 
-halo2 = { package = "halo2_proofs", version = "0.1.0" }
+halo2 = { package = "halo2_proofs", version = "0.2.0" }
 jubjub = "0.9.0"
 
 tokio = { version = "1.19.2", features = ["full", "tracing", "test-util"] }


### PR DESCRIPTION
## Motivation

ECC upgraded some of dependencies, and that includes improved batched halo2 verification which we want.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

- Upgrade deps
- Sync our zcash_proofs fork with upstream and point to that
- Had to add some entries to `deny.toml` because those crates haven't been bumped in `zcash` itself, and that's what we need to use for `zcash_script`.

## Review

With this we should be able to improve sync performance, so it's important.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- Actually use the batch API: https://github.com/ZcashFoundation/zebra/issues/4672