### PR TITLE
fix(ci): make full sync go all the way to the tip

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -672,9 +672,10 @@ jobs:
           --zone ${{ env.ZONE }} \
           --quiet \
           --ssh-flag="-o ServerAliveInterval=5" \
-          --command="docker wait ${{ inputs.test_id }}")
-
-          exit ${EXIT_CODE}
+          --command="docker wait ${{ inputs.test_id }}" \
+          )
+          echo "$EXIT_CODE"
+          exit "$EXIT_CODE"
 
 
   # create a state image from the instance's state disk, if requested by the caller

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -662,20 +662,28 @@ jobs:
 
       # Wait for the container to finish, then exit with the test's exit status.
       #
-      # `docker wait` prints the container exit status as a string, but we need to exit `ssh` with that status.
-      # `docker wait` can also wait for multiple containers, but we only ever wait for a single container.
+      # If the container has already finished, `docker wait` should return its status.
+      # But sometimes this doesn't work, so we use `docker inspect` as a fallback.
+      #
+      # `docker wait` prints the container exit status as a string, but we need to exit the `ssh` command
+      # with that status.
+      # (`docker wait` can also wait for multiple containers, but we only ever wait for a single container.)
       - name: Result of ${{ inputs.test_id }} test
         run: |
-          EXIT_CODE=$(\
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ env.ZONE }} \
           --quiet \
           --ssh-flag="-o ServerAliveInterval=5" \
-          --command="docker wait ${{ inputs.test_id }}" \
-          )
-          echo "$EXIT_CODE"
-          exit "$EXIT_CODE"
+          --command=' \
+          EXIT_STATUS=$( \
+          docker wait ${{ inputs.test_id }} || \
+          docker inspect --format "{{.State.ExitCode}}" ${{ inputs.test_id }} || \
+          echo "missing container, or missing exit status for container" \
+          ); \
+          echo "docker exit status: $EXIT_STATUS"; \
+          exit "$EXIT_STATUS" \
+          '
 
 
   # create a state image from the instance's state disk, if requested by the caller

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -100,8 +100,6 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
-      # Or will that break the slug-action variables we use to find the instance?
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
@@ -169,8 +167,6 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
-      # Or will that break the slug-action variables we use to find the instance?
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
@@ -345,8 +341,6 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
-      # Or will that break the slug-action variables we use to find the instance?
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
@@ -472,8 +466,6 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
-      # Or will that break the slug-action variables we use to find the instance?
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
@@ -533,8 +525,6 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
-      # Or will that break the slug-action variables we use to find the instance?
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
@@ -589,8 +579,6 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
-      # Or will that break the slug-action variables we use to find the instance?
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
@@ -648,8 +636,6 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
-      # Or will that break the slug-action variables we use to find the instance?
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
@@ -796,8 +782,6 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
-      # Or will that break the slug-action variables we use to find the instance?
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -463,7 +463,7 @@ jobs:
 
 
   # follow the logs of the test we just launched, up to Sapling activation (or the test finishing)
-  follow-logs-sprout:
+  logs-sprout:
     name: Log ${{ inputs.test_id }} test (sprout)
     needs: [ launch-with-cached-state, launch-without-cached-state ]
     # We run exactly one of without-cached-state or with-cached-state, and we always skip the other one.
@@ -524,9 +524,9 @@ jobs:
 
   # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)
   # TODO: split out sapling logs when the mandatory checkpoint is above NU5 activation
-  follow-logs-checkpoint:
+  logs-checkpoint:
     name: Log ${{ inputs.test_id }} test (checkpoint)
-    needs: [ follow-logs-sprout ]
+    needs: [ logs-sprout ]
     # If the previous job fails, we also want to run and fail this job,
     # so that the branch protection rule fails in Mergify and GitHub.
     if: ${{ !cancelled() }}
@@ -582,9 +582,9 @@ jobs:
           "
 
   # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)
-  follow-logs-end:
+  logs-end:
     name: Log ${{ inputs.test_id }} test (end)
-    needs: [ follow-logs-checkpoint ]
+    needs: [ logs-checkpoint ]
     # If the previous job fails, we also want to run and fail this job,
     # so that the branch protection rule fails in Mergify and GitHub.
     if: ${{ !cancelled() }}
@@ -644,7 +644,7 @@ jobs:
   test-result:
     # TODO: update the job name here, and in the branch protection rules
     name: Run ${{ inputs.test_id }} test
-    needs: [ follow-logs-end ]
+    needs: [ logs-end ]
     # If the previous job fails, we also want to run and fail this job,
     # so that the branch protection rule fails in Mergify and GitHub.
     if: ${{ !cancelled() }}

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -91,9 +91,12 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
+      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
+      # Or will that break the slug-action variables we use to find the instance?
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
+          fetch-depth: '2'
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -158,9 +161,12 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
+      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
+      # Or will that break the slug-action variables we use to find the instance?
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
+          fetch-depth: '2'
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -332,6 +338,8 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
+      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
+      # Or will that break the slug-action variables we use to find the instance?
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
@@ -458,9 +466,12 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
+      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
+      # Or will that break the slug-action variables we use to find the instance?
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
+          fetch-depth: '2'
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -510,9 +521,12 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
+      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
+      # Or will that break the slug-action variables we use to find the instance?
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
+          fetch-depth: '2'
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -563,6 +577,11 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
+      - uses: actions/checkout@v3.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: '2'
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
         with:
@@ -650,6 +669,13 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
+      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
+      # Or will that break the slug-action variables we use to find the instance?
+      - uses: actions/checkout@v3.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: '2'
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
         with:

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -512,6 +512,7 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
+          set -o pipefail; \
           docker logs \
           --tail all \
           --follow \
@@ -570,6 +571,7 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
+          set -o pipefail; \
           docker logs \
           --tail ${{ env.EXTRA_LOG_LINES }} \
           --follow \
@@ -627,6 +629,7 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
+          set -o pipefail; \
           docker logs \
           --tail ${{ env.EXTRA_LOG_LINES }} \
           --follow \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -512,7 +512,6 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
-          set -o pipefail; \
           docker logs \
           --tail all \
           --follow \
@@ -571,7 +570,6 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
-          set -o pipefail; \
           docker logs \
           --tail ${{ env.EXTRA_LOG_LINES }} \
           --follow \
@@ -629,7 +627,6 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
-          set -o pipefail; \
           docker logs \
           --tail ${{ env.EXTRA_LOG_LINES }} \
           --follow \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -680,15 +680,15 @@ jobs:
       # `docker wait` can also wait for multiple containers, but we only ever wait for a single container.
       - name: Result of ${{ inputs.test_id }} test
         run: |
+          EXIT_CODE=$(\
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ env.ZONE }} \
           --quiet \
           --ssh-flag="-o ServerAliveInterval=5" \
-          --command \
-          "\
-          exit $(docker wait ${{ inputs.test_id }}) \
-          "
+          --command="docker wait ${{ inputs.test_id }}")
+
+          exit ${EXIT_CODE}
 
 
   # create a state image from the instance's state disk, if requested by the caller

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -75,10 +75,19 @@ on:
         description: 'Application name for Google Cloud instance metadata'
 
 env:
+  # where we get the Docker image from
   IMAGE_NAME: zebrad-test
   GAR_BASE: us-docker.pkg.dev/zealous-zebra/zebra
+  # what kind of Google Cloud instance we want to launch
   ZONE: us-central1-a
   MACHINE_TYPE: c2d-standard-16
+  # How many previous log lines we show at the start of each new log job.
+  # Increase this number if some log lines are skipped between jobs
+  #
+  # We want to show all the logs since the last job finished,
+  # but we don't know how long it will be between jobs.
+  # 200 lines is about 6-15 minutes of sync logs, or one panic log.
+  EXTRA_LOG_LINES: 200
 
 jobs:
   # set up the test, if it doesn't use any cached state
@@ -453,9 +462,9 @@ jobs:
           "
 
 
-  # follow the logs of the test we just launched
-  follow-logs:
-    name: Show logs for ${{ inputs.test_id }} test
+  # follow the logs of the test we just launched, up to Sapling activation (or the test finishing)
+  follow-logs-sprout:
+    name: Log ${{ inputs.test_id }} test (sprout)
     needs: [ launch-with-cached-state, launch-without-cached-state ]
     # We run exactly one of without-cached-state or with-cached-state, and we always skip the other one.
     # If the previous job fails, we also want to run and fail this job,
@@ -492,8 +501,9 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Show all the logs since the container launched
-      - name: Show logs for ${{ inputs.test_id }} test
+      # Show all the logs since the container launched,
+      # following until Sapling activation (or the test finishes)
+      - name: Show logs for ${{ inputs.test_id }} test (sprout)
         run: |
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
@@ -502,17 +512,139 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
+          set -o pipefail; \
           docker logs \
           --tail all \
           --follow \
-          ${{ inputs.test_id }} \
+          ${{ inputs.test_id }} | \
+          tee /dev/tty | \
+          grep --max-count=1 --extended-regexp --color=always \
+          '(estimated progress.*network_upgrade.*=.*Sapling)|(test result:.*finished in)' \
           "
+
+  # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)
+  # TODO: split out sapling logs when the mandatory checkpoint is above NU5 activation
+  follow-logs-checkpoint:
+    name: Log ${{ inputs.test_id }} test (checkpoint)
+    needs: [ follow-logs-sprout ]
+    # If the previous job fails, we also want to run and fail this job,
+    # so that the branch protection rule fails in Mergify and GitHub.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
+      # Or will that break the slug-action variables we use to find the instance?
+      - uses: actions/checkout@v3.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: '2'
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
+      - name: Downcase network name for disks
+        run: |
+          NETWORK_CAPS=${{ inputs.network }}
+          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+
+      # Setup gcloud CLI
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.8.0
+        with:
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
+
+      # Show recent logs, following until the last checkpoint (or the test finishes)
+      - name: Show logs for ${{ inputs.test_id }} test (checkpoint)
+        run: |
+          gcloud compute ssh \
+          ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          --zone ${{ env.ZONE }} \
+          --quiet \
+          --ssh-flag="-o ServerAliveInterval=5" \
+          --command \
+          "\
+          set -o pipefail; \
+          docker logs \
+          --tail ${{ env.EXTRA_LOG_LINES }} \
+          --follow \
+          ${{ inputs.test_id }} | \
+          tee /dev/tty | \
+          grep --max-count=1 --extended-regexp --color=always \
+          '(verified final checkpoint)|(test result:.*finished in)' \
+          "
+
+  # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)
+  follow-logs-end:
+    name: Log ${{ inputs.test_id }} test (end)
+    needs: [ follow-logs-checkpoint ]
+    # If the previous job fails, we also want to run and fail this job,
+    # so that the branch protection rule fails in Mergify and GitHub.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      # TODO: can we delete this step and set create_credentials_file to false in Google Cloud?
+      # Or will that break the slug-action variables we use to find the instance?
+      - uses: actions/checkout@v3.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: '2'
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
+      - name: Downcase network name for disks
+        run: |
+          NETWORK_CAPS=${{ inputs.network }}
+          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+
+      # Setup gcloud CLI
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.8.0
+        with:
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
+
+      # Show recent logs, following until the test finishes
+      - name: Show logs for ${{ inputs.test_id }} test (end)
+        run: |
+          gcloud compute ssh \
+          ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          --zone ${{ env.ZONE }} \
+          --quiet \
+          --ssh-flag="-o ServerAliveInterval=5" \
+          --command \
+          "\
+          set -o pipefail; \
+          docker logs \
+          --tail ${{ env.EXTRA_LOG_LINES }} \
+          --follow \
+          ${{ inputs.test_id }} | \
+          tee /dev/tty | \
+          grep --max-count=1 --extended-regexp --color=always \
+          'test result:.*finished in' \
+          "
+
 
   # wait for the result of the test
   test-result:
     # TODO: update the job name here, and in the branch protection rules
     name: Run ${{ inputs.test_id }} test
-    needs: [ follow-logs ]
+    needs: [ follow-logs-end ]
     # If the previous job fails, we also want to run and fail this job,
     # so that the branch protection rule fails in Mergify and GitHub.
     if: ${{ !cancelled() }}

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -517,7 +517,7 @@ jobs:
           --tail all \
           --follow \
           ${{ inputs.test_id }} | \
-          tee /dev/tty | \
+          tee /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           '(estimated progress.*network_upgrade.*=.*Sapling)|(test result:.*finished in)' \
           "
@@ -576,7 +576,7 @@ jobs:
           --tail ${{ env.EXTRA_LOG_LINES }} \
           --follow \
           ${{ inputs.test_id }} | \
-          tee /dev/tty | \
+          tee /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           '(verified final checkpoint)|(test result:.*finished in)' \
           "
@@ -634,7 +634,7 @@ jobs:
           --tail ${{ env.EXTRA_LOG_LINES }} \
           --follow \
           ${{ inputs.test_id }} | \
-          tee /dev/tty | \
+          tee /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           'test result:.*finished in' \
           "

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -499,7 +499,10 @@ jobs:
           token_format: 'access_token'
 
       # Show all the logs since the container launched,
-      # following until Sapling activation (or the test finishes)
+      # following until Sapling activation (or the test finishes).
+      #
+      # The log pipeline ignores the exit status of `docker logs`.
+      # Errors in the tests are caught by the final test status job.
       - name: Show logs for ${{ inputs.test_id }} test (sprout)
         run: |
           gcloud compute ssh \
@@ -509,12 +512,11 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
-          set -o pipefail; \
           docker logs \
           --tail all \
           --follow \
           ${{ inputs.test_id }} | \
-          tee --output-error=exit-nopipe /dev/stderr | \
+          tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           '(estimated progress.*network_upgrade.*=.*Sapling)|(test result:.*finished in)' \
           "
@@ -567,12 +569,11 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
-          set -o pipefail; \
           docker logs \
           --tail ${{ env.EXTRA_LOG_LINES }} \
           --follow \
           ${{ inputs.test_id }} | \
-          tee --output-error=exit-nopipe /dev/stderr | \
+          tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           '(verified final checkpoint)|(test result:.*finished in)' \
           "
@@ -624,12 +625,11 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
-          set -o pipefail; \
           docker logs \
           --tail ${{ env.EXTRA_LOG_LINES }} \
           --follow \
           ${{ inputs.test_id }} | \
-          tee --output-error=exit-nopipe /dev/stderr | \
+          tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           'test result:.*finished in' \
           "

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -162,9 +162,8 @@ jobs:
   launch-without-cached-state:
     name: Launch ${{ inputs.test_id }} test
     needs: [ setup-without-cached-state ]
-    # If the previous job fails, we also want to run and fail this job,
-    # so that the branch protection rule fails in Mergify and GitHub.
-    if: ${{ !cancelled() && !inputs.needs_zebra_state }}
+    # If creating the Google Cloud instance fails, we don't want to launch another docker instance.
+    if: ${{ !cancelled() && !failure() && !inputs.needs_zebra_state }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -339,9 +338,8 @@ jobs:
   launch-with-cached-state:
     name: Launch ${{ inputs.test_id }} test
     needs: [ setup-with-cached-state ]
-    # If the previous job fails, we also want to run and fail this job,
-    # so that the branch protection rule fails in Mergify and GitHub.
-    if: ${{ !cancelled() && inputs.needs_zebra_state }}
+    # If creating the Google Cloud instance fails, we don't want to launch another docker instance.
+    if: ${{ !cancelled() && !failure() && inputs.needs_zebra_state }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -465,10 +463,9 @@ jobs:
   # follow the logs of the test we just launched, up to Sapling activation (or the test finishing)
   logs-sprout:
     name: Log ${{ inputs.test_id }} test (sprout)
-    needs: [ launch-with-cached-state, launch-without-cached-state ]
     # We run exactly one of without-cached-state or with-cached-state, and we always skip the other one.
-    # If the previous job fails, we also want to run and fail this job,
-    # so that the branch protection rule fails in Mergify and GitHub.
+    needs: [ launch-with-cached-state, launch-without-cached-state ]
+    # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
@@ -527,8 +524,7 @@ jobs:
   logs-checkpoint:
     name: Log ${{ inputs.test_id }} test (checkpoint)
     needs: [ logs-sprout ]
-    # If the previous job fails, we also want to run and fail this job,
-    # so that the branch protection rule fails in Mergify and GitHub.
+    # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
@@ -585,8 +581,7 @@ jobs:
   logs-end:
     name: Log ${{ inputs.test_id }} test (end)
     needs: [ logs-checkpoint ]
-    # If the previous job fails, we also want to run and fail this job,
-    # so that the branch protection rule fails in Mergify and GitHub.
+    # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -517,7 +517,7 @@ jobs:
           --tail all \
           --follow \
           ${{ inputs.test_id }} | \
-          tee /dev/stderr | \
+          tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           '(estimated progress.*network_upgrade.*=.*Sapling)|(test result:.*finished in)' \
           "
@@ -576,7 +576,7 @@ jobs:
           --tail ${{ env.EXTRA_LOG_LINES }} \
           --follow \
           ${{ inputs.test_id }} | \
-          tee /dev/stderr | \
+          tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           '(verified final checkpoint)|(test result:.*finished in)' \
           "
@@ -634,7 +634,7 @@ jobs:
           --tail ${{ env.EXTRA_LOG_LINES }} \
           --follow \
           ${{ inputs.test_id }} | \
-          tee /dev/stderr | \
+          tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           'test result:.*finished in' \
           "

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -135,8 +135,8 @@ use common::{
     sync::{
         create_cached_database_height, sync_until, MempoolBehavior, LARGE_CHECKPOINT_TEST_HEIGHT,
         LARGE_CHECKPOINT_TIMEOUT, MEDIUM_CHECKPOINT_TEST_HEIGHT, STOP_AT_HEIGHT_REGEX,
-        STOP_ON_LOAD_TIMEOUT, SYNC_FINISHED_REGEX, SYNC_FINISHED_REGEX_TMP_STOP_EARLY,
-        TINY_CHECKPOINT_TEST_HEIGHT, TINY_CHECKPOINT_TIMEOUT,
+        STOP_ON_LOAD_TIMEOUT, SYNC_FINISHED_REGEX, TINY_CHECKPOINT_TEST_HEIGHT,
+        TINY_CHECKPOINT_TIMEOUT,
     },
 };
 
@@ -882,7 +882,7 @@ fn full_sync_test(network: Network, timeout_argument_name: &str) -> Result<()> {
             // Use the checkpoints to sync quickly, then do full validation until the chain tip
             true,
             // Finish when we reach the chain tip
-            SYNC_FINISHED_REGEX_TMP_STOP_EARLY,
+            SYNC_FINISHED_REGEX,
         )
     } else {
         eprintln!(

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -45,12 +45,6 @@ pub const STOP_AT_HEIGHT_REGEX: &str = "stopping at configured height";
 pub const SYNC_FINISHED_REGEX: &str =
     r"finished initial sync to chain tip, using gossiped blocks .*sync_percent.*=.*100\.";
 
-/// Temporary workaround for slow syncs - stop at 97%.
-///
-/// TODO: revert this change (#4456)
-pub const SYNC_FINISHED_REGEX_TMP_STOP_EARLY: &str =
-    r"estimated progress to chain tip .*sync_percent.*=.*97\.";
-
 /// The maximum amount of time Zebra should take to reload after shutting down.
 ///
 /// This should only take a second, but sometimes CI VMs or RocksDB can be slow.


### PR DESCRIPTION
## Motivation

When sync started getting slow, we temporarily ended the full sync at 97%.

Now we've split the sync jobs, we can go all the way to 100%. This will speed up all the tests that use the cached state.

Depends-On: #4704

## Review

This is a high priority because it is the last blocker for PRs #4537 and #4639.

### Reviewer Checklist

  - [ ] Existing tests pass

