### PR TITLE
fix(sync): Temporarily set full verification concurrency to 30 blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Next Release (Draft)
 
-(Draft notes for the next release can be added here.)
+This release improves Zebra's sync and verification performance under heavy load.
+(TODO - complete the summary.)
 
+### Configuration Changes
+
+- Split the checkpoint and full verification [`sync` concurrency options](https://doc.zebra.zfnd.org/zebrad/config/struct.SyncSection.html) (#4726):
+  - Add a new `full_verify_concurrency_limit`
+  - Rename `max_concurrent_block_requests` to `download_concurrency_limit`
+  - Rename `lookahead_limit` to `checkpoint_verify_concurrency_limit`
+  For backwards compatibility, the old names are still accepted as aliases.
+
+(TODO - insert changelog here)
 
 ## [Zebra 1.0.0-beta.12](https://github.com/ZcashFoundation/zebra/releases/tag/v1.0.0-beta.12) - 2022-06-29
 

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -27,7 +27,7 @@ use tower::{buffer::Buffer, util::BoxService, Service, ServiceExt};
 use tracing::{instrument, Span};
 
 use zebra_chain::{
-    block::{self, Block},
+    block::{self, Block, Height},
     parameters::Network,
 };
 
@@ -163,7 +163,8 @@ where
 /// config parameter and if the download is not already started.
 ///
 /// Returns a block verifier, transaction verifier,
-/// and the Groth16 parameter download task [`JoinHandle`].
+/// the Groth16 parameter download task [`JoinHandle`],
+/// and the maximum configured checkpoint verification height.
 ///
 /// The consensus configuration is specified by `config`, and the Zcash network
 /// to verify blocks for is specified by `network`.
@@ -203,6 +204,7 @@ pub async fn init<S>(
         transaction::Request,
     >,
     JoinHandle<()>,
+    Height,
 )
 where
     S: Service<zs::Request, Response = zs::Response, Error = BoxError> + Send + Clone + 'static,
@@ -266,5 +268,10 @@ where
 
     let chain = Buffer::new(BoxService::new(chain), VERIFIER_BUFFER_BOUND);
 
-    (chain, transaction, groth16_download_handle)
+    (
+        chain,
+        transaction,
+        groth16_download_handle,
+        max_checkpoint_height,
+    )
 }

--- a/zebra-consensus/src/chain/tests.rs
+++ b/zebra-consensus/src/chain/tests.rs
@@ -64,7 +64,7 @@ async fn verifiers_from_network(
         + 'static,
 ) {
     let state_service = zs::init_test(network);
-    let (chain_verifier, _transaction_verifier, _groth16_download_handle) =
+    let (chain_verifier, _transaction_verifier, _groth16_download_handle, _max_checkpoint_height) =
         crate::chain::init(Config::default(), network, state_service.clone(), true).await;
 
     // We can drop the download task handle here, because:
@@ -161,7 +161,7 @@ async fn verify_checkpoint(config: Config) -> Result<(), Report> {
     // init_from_verifiers.
     //
     // Download task panics and timeouts are propagated to the tests that use Groth16 verifiers.
-    let (chain_verifier, _transaction_verifier, _groth16_download_handle) =
+    let (chain_verifier, _transaction_verifier, _groth16_download_handle, _max_checkpoint_height) =
         super::init(config.clone(), network, zs::init_test(network), true).await;
 
     // Add a timeout layer

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -125,7 +125,7 @@ impl StartCmd {
             zebra_network::init(config.network.clone(), inbound, latest_chain_tip.clone()).await;
 
         info!("initializing verifiers");
-        let (chain_verifier, tx_verifier, mut groth16_download_handle) =
+        let (chain_verifier, tx_verifier, mut groth16_download_handle, max_checkpoint_height) =
             zebra_consensus::chain::init(
                 config.consensus.clone(),
                 config.network.network,

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -137,6 +137,7 @@ impl StartCmd {
         info!("initializing syncer");
         let (syncer, sync_status) = ChainSync::new(
             &config,
+            max_checkpoint_height,
             peer_set.clone(),
             chain_verifier.clone(),
             state.clone(),

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -117,7 +117,10 @@ impl StartCmd {
         let inbound = ServiceBuilder::new()
             .load_shed()
             .buffer(inbound::downloads::MAX_INBOUND_CONCURRENCY)
-            .service(Inbound::new(setup_rx));
+            .service(Inbound::new(
+                config.sync.full_verify_concurrency_limit,
+                setup_rx,
+            ));
 
         let (peer_set, address_book) =
             zebra_network::init(config.network.clone(), inbound, latest_chain_tip.clone()).await;

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -708,7 +708,7 @@ async fn setup(
     let mut state_service = ServiceBuilder::new().buffer(1).service(state);
 
     // Download task panics and timeouts are propagated to the tests that use Groth16 verifiers.
-    let (block_verifier, _transaction_verifier, _groth16_download_handle) =
+    let (block_verifier, _transaction_verifier, _groth16_download_handle, _max_checkpoint_height) =
         zebra_consensus::chain::init(
             consensus_config.clone(),
             network,

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -29,7 +29,7 @@ use zebra_test::mock_service::{MockService, PanicAssertion};
 
 use crate::{
     components::{
-        inbound::{Inbound, InboundSetupData},
+        inbound::{downloads::MAX_INBOUND_CONCURRENCY, Inbound, InboundSetupData},
         mempool::{
             gossip_mempool_transaction_id, unmined_transactions_in_blocks, Config as MempoolConfig,
             Mempool, MempoolError, SameEffectsChainRejectionError, UnboxMempoolError,
@@ -785,7 +785,7 @@ async fn setup(
 
     let inbound_service = ServiceBuilder::new()
         .load_shed()
-        .service(Inbound::new(setup_rx));
+        .service(Inbound::new(MAX_INBOUND_CONCURRENCY, setup_rx));
     let inbound_service = BoxService::new(inbound_service);
     let inbound_service = ServiceBuilder::new().buffer(1).service(inbound_service);
 

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -29,7 +29,7 @@ use zebra_test::mock_service::{MockService, PanicAssertion};
 
 use crate::{
     components::{
-        inbound::{Inbound, InboundSetupData},
+        inbound::{downloads::MAX_INBOUND_CONCURRENCY, Inbound, InboundSetupData},
         mempool::{gossip_mempool_transaction_id, Config as MempoolConfig, Mempool},
         sync::{self, BlockGossipError, SyncStatus},
     },
@@ -637,7 +637,7 @@ async fn setup(
 
     // Inbound
     let (setup_tx, setup_rx) = oneshot::channel();
-    let inbound_service = Inbound::new(setup_rx);
+    let inbound_service = Inbound::new(MAX_INBOUND_CONCURRENCY, setup_rx);
     let inbound_service = ServiceBuilder::new()
         .boxed_clone()
         .load_shed()

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -831,8 +831,18 @@ where
         &mut self,
         hashes: IndexSet<block::Hash>,
     ) -> Result<(), BlockDownloadVerifyError> {
-        debug!(hashes.len = hashes.len(), "requesting blocks");
-        for hash in hashes.into_iter() {
+        let lookahead_limit = self.lookahead_limit();
+
+        debug!(
+            hashes.len = hashes.len(),
+            ?lookahead_limit,
+            "requesting blocks",
+        );
+
+        // Allow a limit's worth of verifying hashes, and a limit's worth of downloading hashes.
+        //
+        // TODO: Return excess block hashes, and submit them when some lower blocks have been verified.
+        for hash in hashes.into_iter().take(lookahead_limit * 2) {
             self.downloads.download_and_verify(hash).await?;
         }
 

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -451,19 +451,6 @@ where
             }
             self.update_metrics();
 
-            // If we have too many pending tasks, wait for some to finish.
-            //
-            // Starting to wait is interesting, but logging each wait can be
-            // very verbose.
-            if self.downloads.in_flight() >= self.lookahead_limit(extra_hashes.len()) {
-                tracing::info!(
-                    tips.len = self.prospective_tips.len(),
-                    in_flight = self.downloads.in_flight(),
-                    extra_hashes = extra_hashes.len(),
-                    lookahead_limit = self.lookahead_limit(extra_hashes.len()),
-                    "waiting for pending blocks",
-                );
-            }
             while self.downloads.in_flight() >= self.lookahead_limit(extra_hashes.len()) {
                 trace!(
                     tips.len = self.prospective_tips.len(),

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -327,6 +327,7 @@ where
                 // that will timeout before being verified.
                 let tip_height = latest_chain_tip.best_tip_height();
 
+                // TODO: don't use VERIFICATION_PIPELINE_SCALING_MULTIPLIER for full verification?
                 let max_lookahead_height = if let Some(tip_height) = tip_height {
                     // Scale the height limit with the lookahead limit,
                     // so users with low capacity or under DoS can reduce them both.
@@ -375,9 +376,7 @@ where
                         ?tip_height,
                         ?max_lookahead_height,
                         lookahead_limit = ?lookahead_limit,
-                        "synced block height too far ahead of the tip: dropped downloaded block. \
-                         Hint: Try increasing the value of the lookahead_limit field \
-                         in the sync section of the configuration file."
+                        "synced block height too far ahead of the tip: dropped downloaded block",
                     );
                     metrics::counter!("sync.max.height.limit.dropped.block.count", 1);
 

--- a/zebrad/src/components/sync/tests/timing.rs
+++ b/zebrad/src/components/sync/tests/timing.rs
@@ -11,7 +11,10 @@ use std::{
 use futures::future;
 use tokio::time::{timeout, Duration};
 
-use zebra_chain::parameters::{Network, POST_BLOSSOM_POW_TARGET_SPACING};
+use zebra_chain::{
+    block::Height,
+    parameters::{Network, POST_BLOSSOM_POW_TARGET_SPACING},
+};
 use zebra_network::constants::{
     DEFAULT_CRAWL_NEW_PEER_INTERVAL, HANDSHAKE_TIMEOUT, INVENTORY_ROTATION_INTERVAL,
 };
@@ -163,6 +166,7 @@ fn request_genesis_is_rate_limited() {
     // start the sync
     let (mut chain_sync, _) = ChainSync::new(
         &ZebradConfig::default(),
+        Height(0),
         peer_service,
         verifier_service,
         state_service,

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -6,7 +6,7 @@ use color_eyre::Report;
 use futures::{Future, FutureExt};
 
 use zebra_chain::{
-    block::{self, Block},
+    block::{self, Block, Height},
     chain_tip::mock::{MockChainTip, MockChainTipSender},
     serialization::ZcashDeserializeInto,
 };
@@ -966,6 +966,7 @@ fn setup() -> (
 
     let (chain_sync, sync_status) = ChainSync::new(
         &config,
+        Height(0),
         peer_set.clone(),
         chain_verifier.clone(),
         state_service.clone(),

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -174,7 +174,8 @@ impl Default for MetricsSection {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct SyncSection {
-    /// The maximum number of concurrent block download requests during sync.
+    /// The concurrency limit on block download requests and full verify requests,
+    /// for the syncer.
     ///
     /// This is set to a low value by default, to avoid task and
     /// network contention. Increasing this value may improve
@@ -182,8 +183,9 @@ pub struct SyncSection {
     /// connection.
     pub max_concurrent_block_requests: usize,
 
-    /// Controls how far ahead of the chain tip the syncer tries to
-    /// download before waiting for queued verifications to complete.
+    /// How far ahead of the chain tip the syncer tries to download,
+    /// before waiting for queued checkpoint verifications to complete.
+    /// Also the concurrency limit on block checkpoint verify requests.
     ///
     /// Increasing this limit increases the buffer size, so it reduces
     /// the impact of an individual block request failing. However, it

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -216,7 +216,9 @@ impl Default for SyncSection {
         Self {
             download_concurrency_limit: 50,
             checkpoint_verify_concurrency_limit: sync::DEFAULT_CHECKPOINT_CONCURRENCY_LIMIT,
-            full_verify_concurrency_limit: 25,
+            // TODO: try increasing to 25 when we implement orchard proof batching?
+            //       limit full verification concurrency based on block transaction counts?
+            full_verify_concurrency_limit: 5,
         }
     }
 }

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -214,11 +214,18 @@ pub struct SyncSection {
 impl Default for SyncSection {
     fn default() -> Self {
         Self {
+            // 2/3 of the default outbound peer limit.
             download_concurrency_limit: 50,
+
+            // A few max-length checkpoints.
             checkpoint_verify_concurrency_limit: sync::DEFAULT_CHECKPOINT_CONCURRENCY_LIMIT,
-            // TODO: try increasing to 25 when we implement orchard proof batching?
+
+            // Guaranteed to verify a bunch of large blocks in under 60 seconds
+            // (so that the committed block height changes in every progress log).
+            //
+            // TODO: when we implement orchard proof batching, try increasing to 100 or more
             //       limit full verification concurrency based on block transaction counts?
-            full_verify_concurrency_limit: 5,
+            full_verify_concurrency_limit: 30,
         }
     }
 }

--- a/zebrad/tests/common/config.rs
+++ b/zebrad/tests/common/config.rs
@@ -36,7 +36,7 @@ pub fn default_test_config() -> Result<ZebradConfig> {
 
     let sync = SyncSection {
         // Avoid downloading unnecessary blocks.
-        lookahead_limit: sync::MIN_LOOKAHEAD_LIMIT,
+        checkpoint_verify_concurrency_limit: sync::MIN_CHECKPOINT_CONCURRENCY_LIMIT,
         ..SyncSection::default()
     };
 

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -298,7 +298,8 @@ impl LightwalletdTestType {
             Err(error) => return Some(Err(error)),
         };
 
-        config.sync.checkpoint_verify_concurrency_limit = zebrad::components::sync::DEFAULT_CHECKPOINT_CONCURRENCY_LIMIT;
+        config.sync.checkpoint_verify_concurrency_limit =
+            zebrad::components::sync::DEFAULT_CHECKPOINT_CONCURRENCY_LIMIT;
 
         config.state.ephemeral = false;
         config.state.cache_dir = zebra_state_path;

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -298,7 +298,7 @@ impl LightwalletdTestType {
             Err(error) => return Some(Err(error)),
         };
 
-        config.sync.lookahead_limit = zebrad::components::sync::DEFAULT_LOOKAHEAD_LIMIT;
+        config.sync.checkpoint_verify_concurrency_limit = zebrad::components::sync::DEFAULT_CHECKPOINT_CONCURRENCY_LIMIT;
 
         config.state.ephemeral = false;
         config.state.cache_dir = zebra_state_path;

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -204,7 +204,8 @@ pub fn sync_until(
     // Use the default lookahead limit if we're syncing lots of blocks.
     // (Most tests use a smaller limit to minimise redundant block downloads.)
     if height > MIN_HEIGHT_FOR_DEFAULT_LOOKAHEAD {
-        config.sync.checkpoint_verify_concurrency_limit = sync::DEFAULT_CHECKPOINT_CONCURRENCY_LIMIT;
+        config.sync.checkpoint_verify_concurrency_limit =
+            sync::DEFAULT_CHECKPOINT_CONCURRENCY_LIMIT;
     }
 
     let tempdir = if let Some(reuse_tempdir) = reuse_tempdir {

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -75,7 +75,7 @@ pub const FINISH_PARTIAL_SYNC_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 /// But if we're going to be downloading lots of blocks, we use the default lookahead limit,
 /// so that the sync is faster. This can increase the RAM needed for tests.
 pub const MIN_HEIGHT_FOR_DEFAULT_LOOKAHEAD: Height =
-    Height(3 * sync::DEFAULT_LOOKAHEAD_LIMIT as u32);
+    Height(3 * sync::DEFAULT_CHECKPOINT_CONCURRENCY_LIMIT as u32);
 
 /// What the expected behavior of the mempool is for a test that uses [`sync_until`].
 pub enum MempoolBehavior {
@@ -204,7 +204,7 @@ pub fn sync_until(
     // Use the default lookahead limit if we're syncing lots of blocks.
     // (Most tests use a smaller limit to minimise redundant block downloads.)
     if height > MIN_HEIGHT_FOR_DEFAULT_LOOKAHEAD {
-        config.sync.lookahead_limit = sync::DEFAULT_LOOKAHEAD_LIMIT;
+        config.sync.checkpoint_verify_concurrency_limit = sync::DEFAULT_CHECKPOINT_CONCURRENCY_LIMIT;
     }
 
     let tempdir = if let Some(reuse_tempdir) = reuse_tempdir {
@@ -317,7 +317,7 @@ pub fn cached_mandatory_checkpoint_test_config() -> Result<ZebradConfig> {
     // If we're syncing past the checkpoint with cached state, we don't need the extra lookahead.
     // But the extra downloaded blocks shouldn't slow down the test that much,
     // and testing with the defaults gives us better test coverage.
-    config.sync.lookahead_limit = sync::DEFAULT_LOOKAHEAD_LIMIT;
+    config.sync.checkpoint_verify_concurrency_limit = sync::DEFAULT_CHECKPOINT_CONCURRENCY_LIMIT;
 
     Ok(config)
 }


### PR DESCRIPTION
## Motivation

We're seeing a lot of sync failures in CI and on developer machines, because some large orchard blocks take a long time to verify.

Depends-On: #4752
Close #4715
Close #4729 
Close #4650


## Solution

Until we implement orchard batching, temporarily limit full verification to 30 blocks in parallel.

Syncer changes:
- Limit the number of blocks submitted to download and verify
    - By the syncer
    - By the inbound service
- Keep unused extra hashes and submit them to the sync downloader later
- Split the checkpoint and full verify concurrency configs
    - Adjust lookahead limits when transitioning to full verification
    - Use a lower concurrency limit during full verification
    - Decrease full verification concurrency to 5 blocks

Related changes:
- Return the maximum checkpoint height from the chain verifier
- Return the verified block height from the sync downloader (actually not needed, I can remove these changes if we want)
- Remove a verbose log

## Review

This bug causes a lot of CI workflows to run slow or fail, so it's a high priority.

I'm still testing it locally, it also needs a full sync test.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Existing CI sync tests pass

