### PR TITLE
fix(ci): Split out Canopy logs into a separate job

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -510,13 +510,12 @@ jobs:
           ${{ inputs.test_id }} | \
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          '(estimated progress.*network_upgrade.*=.*Sapling)|(test result:.*finished in)' \
+          '(estimated progress.*network_upgrade.*=.*Sapling)|(estimated progress.*network_upgrade.*=.*Blossom)|(estimated progress.*network_upgrade.*=.*Heartwood)|(estimated progress.*network_upgrade.*=.*Canopy)|(estimated progress.*network_upgrade.*=.*Nu5)|(test result:.*finished in)' \
           "
 
-  # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)
-  # TODO: split out sapling logs when the mandatory checkpoint is above NU5 activation
-  logs-checkpoint:
-    name: Log ${{ inputs.test_id }} test (checkpoint)
+  # follow the logs of the test we just launched, up to Canopy activation (or the test finishing)
+  logs-heartwood:
+    name: Log ${{ inputs.test_id }} test (heartwood)
     needs: [ logs-sprout ]
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() }}
@@ -549,7 +548,63 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
+      # Show recent logs, following until Canopy activation (or the test finishes)
+      - name: Show logs for ${{ inputs.test_id }} test (heartwood)
+        run: |
+          gcloud compute ssh \
+          ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          --zone ${{ env.ZONE }} \
+          --quiet \
+          --ssh-flag="-o ServerAliveInterval=5" \
+          --command \
+          "\
+          docker logs \
+          --tail all \
+          --follow \
+          ${{ inputs.test_id }} | \
+          tee --output-error=exit /dev/stderr | \
+          grep --max-count=1 --extended-regexp --color=always \
+          '(estimated progress.*network_upgrade.*=.*Canopy)|(estimated progress.*network_upgrade.*=.*Nu5)|(test result:.*finished in)' \
+          "
+
+  # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)
+  logs-checkpoint:
+    name: Log ${{ inputs.test_id }} test (checkpoint)
+    needs: [ logs-heartwood ]
+    # If the previous job fails, we still want to show the logs.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v3.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: '2'
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
+      - name: Downcase network name for disks
+        run: |
+          NETWORK_CAPS=${{ inputs.network }}
+          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+
+      # Setup gcloud CLI
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.8.0
+        with:
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
+
       # Show recent logs, following until the last checkpoint (or the test finishes)
+      #
+      # TODO: when doing obtain/extend tips, log the verifier in use, and check for full verification here
       - name: Show logs for ${{ inputs.test_id }} test (checkpoint)
         run: |
           gcloud compute ssh \
@@ -568,7 +623,7 @@ jobs:
           '(verified final checkpoint)|(test result:.*finished in)' \
           "
 
-  # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)
+  # follow the logs of the test we just launched, until it finishes
   logs-end:
     name: Log ${{ inputs.test_id }} test (end)
     needs: [ logs-checkpoint ]


### PR DESCRIPTION
## Motivation

We've seen timeouts when checkpointing 1.2 million blocks from Sapling to Canopy in a single GitHub Actions job.

## Solution

- Split into Sprout-Heartwood and Canopy-Nu5 jobs (about 600K blocks each)

## Review

This is urgent because it stops CI failures and timeouts.

### Reviewer Checklist

  - [ ] Existing tests pass
  - [ ] Full sync passes


