### PR TITLE
fix(verify): Only verify halo2 proofs once per transaction

### DIFF
--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -909,25 +909,25 @@ where
         let mut async_checks = AsyncChecks::new();
 
         if let Some(orchard_shielded_data) = orchard_shielded_data {
+            // # Consensus
+            //
+            // > The proof 𝜋 MUST be valid given a primary input (cv, rt^{Orchard},
+            // > nf, rk, cm_x, enableSpends, enableOutputs)
+            //
+            // https://zips.z.cash/protocol/protocol.pdf#actiondesc
+            //
+            // Queue the verification of the Halo2 proof for each Action
+            // description while adding the resulting future to our
+            // collection of async checks that (at a minimum) must pass for
+            // the transaction to verify.
+            async_checks.push(
+                primitives::halo2::VERIFIER
+                    .clone()
+                    .oneshot(primitives::halo2::Item::from(orchard_shielded_data)),
+            );
+
             for authorized_action in orchard_shielded_data.actions.iter().cloned() {
                 let (action, spend_auth_sig) = authorized_action.into_parts();
-
-                // # Consensus
-                //
-                // > The proof 𝜋 MUST be valid given a primary input (cv, rt^{Orchard},
-                // > nf, rk, cm_x, enableSpends, enableOutputs)
-                //
-                // https://zips.z.cash/protocol/protocol.pdf#actiondesc
-                //
-                // Queue the verification of the Halo2 proof for each Action
-                // description while adding the resulting future to our
-                // collection of async checks that (at a minimum) must pass for
-                // the transaction to verify.
-                async_checks.push(
-                    primitives::halo2::VERIFIER
-                        .clone()
-                        .oneshot(primitives::halo2::Item::from(orchard_shielded_data)),
-                );
 
                 // # Consensus
                 //

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -916,9 +916,9 @@ where
             //
             // https://zips.z.cash/protocol/protocol.pdf#actiondesc
             //
-            // Unlike Sapling, Orchard shielded transactions have a single 
-            // aggregated Halo2 proof per transaction, even with multiple 
-            // Actions in one transaction. So we queue it for verification 
+            // Unlike Sapling, Orchard shielded transactions have a single
+            // aggregated Halo2 proof per transaction, even with multiple
+            // Actions in one transaction. So we queue it for verification
             // only once instead of queuing it up for every Action description.
             async_checks.push(
                 primitives::halo2::VERIFIER

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -916,10 +916,10 @@ where
             //
             // https://zips.z.cash/protocol/protocol.pdf#actiondesc
             //
-            // Queue the verification of the Halo2 proof for each Action
-            // description while adding the resulting future to our
-            // collection of async checks that (at a minimum) must pass for
-            // the transaction to verify.
+            // Unlike Sapling, Orchard shielded transactions have a single 
+            // aggregated Halo2 proof per transaction, even with multiple 
+            // Actions in one transaction. So we queue it for verification 
+            // only once instead of queuing it up for every Action description.
             async_checks.push(
                 primitives::halo2::VERIFIER
                     .clone()


### PR DESCRIPTION
## Motivation

There is only one aggregated halo2 proof per transaction, but Zebra is verifying the same proof for each action.

This uses a lot of RAM and CPU, and stops Zebra syncing to the tip.

## Solution

Only verify the halo2 proof once per transaction.

## Review

This bug is blocking almost all other work, it's urgent.

### Reviewer Checklist

  - [x] All Halo2 proofs and Orchard Actions are being verified
  - [ ] CI passes
  - [ ] Full sync passes

