### PR TITLE
change(state): Wrap commitment trees into `Arc`

### DIFF
--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
@@ -219,7 +219,7 @@ fn snapshot_block_and_transaction_data(state: &FinalizedState) {
             .orchard_note_commitment_tree_by_height(&block::Height::MIN)
             .expect("the genesis block in the database has an Orchard tree");
 
-        assert_eq!(sapling_tree, sapling::tree::NoteCommitmentTree::default());
+        assert_eq!(*sapling_tree, sapling::tree::NoteCommitmentTree::default());
         assert_eq!(orchard_tree, orchard::tree::NoteCommitmentTree::default());
 
         // Blocks

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
@@ -220,7 +220,7 @@ fn snapshot_block_and_transaction_data(state: &FinalizedState) {
             .expect("the genesis block in the database has an Orchard tree");
 
         assert_eq!(*sapling_tree, sapling::tree::NoteCommitmentTree::default());
-        assert_eq!(orchard_tree, orchard::tree::NoteCommitmentTree::default());
+        assert_eq!(*orchard_tree, orchard::tree::NoteCommitmentTree::default());
 
         // Blocks
         let mut stored_block_hashes = Vec::new();

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -243,7 +243,6 @@ impl DiskWriteBatch {
         transaction: &Transaction,
         note_commitment_trees: &mut NoteCommitmentTrees,
     ) -> Result<(), BoxError> {
-        // Update the note commitment trees
         let sprout_nct = Arc::make_mut(&mut note_commitment_trees.sprout);
 
         for sprout_note_commitment in transaction.sprout_note_commitments() {

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -386,7 +386,7 @@ impl NonFinalizedState {
         &mut self,
         parent_hash: block::Hash,
         sprout_note_commitment_tree: Arc<sprout::tree::NoteCommitmentTree>,
-        sapling_note_commitment_tree: sapling::tree::NoteCommitmentTree,
+        sapling_note_commitment_tree: Arc<sapling::tree::NoteCommitmentTree>,
         orchard_note_commitment_tree: orchard::tree::NoteCommitmentTree,
         history_tree: HistoryTree,
     ) -> Result<Arc<Chain>, ValidateContextError> {

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -387,7 +387,7 @@ impl NonFinalizedState {
         parent_hash: block::Hash,
         sprout_note_commitment_tree: Arc<sprout::tree::NoteCommitmentTree>,
         sapling_note_commitment_tree: Arc<sapling::tree::NoteCommitmentTree>,
-        orchard_note_commitment_tree: orchard::tree::NoteCommitmentTree,
+        orchard_note_commitment_tree: Arc<orchard::tree::NoteCommitmentTree>,
         history_tree: HistoryTree,
     ) -> Result<Arc<Chain>, ValidateContextError> {
         match self.find_chain(|chain| chain.non_finalized_tip_hash() == parent_hash) {

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -385,7 +385,7 @@ impl NonFinalizedState {
     fn parent_chain(
         &mut self,
         parent_hash: block::Hash,
-        sprout_note_commitment_tree: sprout::tree::NoteCommitmentTree,
+        sprout_note_commitment_tree: Arc<sprout::tree::NoteCommitmentTree>,
         sapling_note_commitment_tree: sapling::tree::NoteCommitmentTree,
         orchard_note_commitment_tree: orchard::tree::NoteCommitmentTree,
         history_tree: HistoryTree,

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -264,8 +264,9 @@ impl Chain {
     /// Fork a chain at the block with the given hash, if it is part of this
     /// chain.
     ///
-    /// The trees must match the trees of the finalized tip and are used
-    /// to rebuild them after the fork.
+    /// The passed trees must match the trees of the finalized tip. They are
+    /// extended by the commitments from the newly forked chain up to the passed
+    /// `fork_tip`.
     #[allow(clippy::unwrap_in_result)]
     pub fn fork(
         &self,

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -294,9 +294,6 @@ impl Chain {
         let sprout_nct = Arc::make_mut(&mut forked.sprout_note_commitment_tree);
 
         // Rebuild the note commitment trees, starting from the finalized tip tree.
-        // TODO: change to a more efficient approach by removing nodes
-        // from the tree of the original chain (in [`Self::pop_tip`]).
-        // See https://github.com/ZcashFoundation/zebra/issues/2378
         for block in forked.blocks.values() {
             for transaction in block.block.transactions.iter() {
                 for sprout_note_commitment in transaction.sprout_note_commitments() {

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -129,8 +129,7 @@ where
     // in memory, but `db` stores blocks on disk, with a memory cache.)
     chain
         .as_ref()
-        .and_then(|chain| chain.as_ref().sapling_tree(hash_or_height).cloned())
-        .map(Arc::new)
+        .and_then(|chain| chain.as_ref().sapling_tree(hash_or_height))
         .or_else(|| db.sapling_tree(hash_or_height))
 }
 

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -152,8 +152,7 @@ where
     // state, we check the most efficient alternative first. (`chain` is always
     // in memory, but `db` stores blocks on disk, with a memory cache.)
     chain
-        .and_then(|chain| chain.as_ref().orchard_tree(hash_or_height).cloned())
-        .map(Arc::new)
+        .and_then(|chain| chain.as_ref().orchard_tree(hash_or_height))
         .or_else(|| db.orchard_tree(hash_or_height))
 }
 

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -97,7 +97,6 @@ where
     // we check the most efficient alternative first. (`chain` is always in
     // memory, but `db` stores transactions on disk, with a memory cache.)
     chain
-        .as_ref()
         .and_then(|chain| {
             chain
                 .as_ref()
@@ -128,7 +127,6 @@ where
     // state, we check the most efficient alternative first. (`chain` is always
     // in memory, but `db` stores blocks on disk, with a memory cache.)
     chain
-        .as_ref()
         .and_then(|chain| chain.as_ref().sapling_tree(hash_or_height))
         .or_else(|| db.sapling_tree(hash_or_height))
 }
@@ -154,7 +152,6 @@ where
     // state, we check the most efficient alternative first. (`chain` is always
     // in memory, but `db` stores blocks on disk, with a memory cache.)
     chain
-        .as_ref()
         .and_then(|chain| chain.as_ref().orchard_tree(hash_or_height).cloned())
         .map(Arc::new)
         .or_else(|| db.orchard_tree(hash_or_height))


### PR DESCRIPTION
## Motivation

Zebra maintains a copy of the same note commitment tree with each non-finalized state when handling multiple non-finalized states. It would be better to maintain only `Arc`s, and use copy-on-write.

## Solution

This PR wraps Sprout, Sapling and Orchard note commitment trees into `Arc`s in both finalized and non-finalized states.

Closes #4766.

## Review

We should check if the changes affect syncing speed.