### PR TITLE
fix(sync): Set the full verify concurrency limit to 5 blocks

### DIFF
--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -220,12 +220,14 @@ impl Default for SyncSection {
             // A few max-length checkpoints.
             checkpoint_verify_concurrency_limit: sync::DEFAULT_CHECKPOINT_CONCURRENCY_LIMIT,
 
-            // Guaranteed to verify a bunch of large blocks in under 60 seconds
-            // (so that the committed block height changes in every progress log).
+            // This default is deliberately very low, so Zebra can verify a few large blocks in under 60 seconds,
+            // even on machines with only a few cores.
             //
-            // TODO: when we implement orchard proof batching, try increasing to 100 or more
+            // This lets users see the committed block height changing in every progress log.
+            //
+            // TODO: when we implement orchard proof batching, try increasing to 20 or more
             //       limit full verification concurrency based on block transaction counts?
-            full_verify_concurrency_limit: 30,
+            full_verify_concurrency_limit: 5,
         }
     }
 }


### PR DESCRIPTION
## Motivation

Syncing is a lot better, but still occasionally stalls.

We have other PRs that will make this better, but right now the easiest solution is to verify fewer blocks in parallel.

## Solution

- Set the full verify concurrency limit to 5 blocks

## Review

Anyone can review this urgent PR, it blocks most other PRs merging.

### Reviewer Checklist

  - [ ] Full sync passes (we can check this after we merge to `main`)

## Follow Up Work

This should get better after:
- #4750
- #3263 
- #4672 