### PR TITLE
fix(panic): Stop panicking when the connection error slot is not set

### DIFF
--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -19,15 +19,13 @@ use tokio::{sync::broadcast, task::JoinHandle};
 use tower::Service;
 
 use crate::{
-    peer::error::AlreadyErrored,
+    peer::error::{AlreadyErrored, ErrorSlot, PeerError, SharedPeerError},
     peer_set::InventoryChange,
     protocol::{
         external::{types::Version, InventoryHash},
         internal::{Request, Response},
     },
 };
-
-use super::{ErrorSlot, PeerError, SharedPeerError};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod tests;
@@ -491,11 +489,12 @@ impl Client {
 
     /// Poll for space in the shared request sender channel.
     fn poll_request(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), SharedPeerError>> {
-        if ready!(self.server_tx.poll_ready(cx)).is_err() {
+        let server_result = ready!(self.server_tx.poll_ready(cx));
+        if server_result.is_err() {
             Poll::Ready(Err(self
                 .error_slot
                 .try_get_error()
-                .expect("failed servers must set their error slot")))
+                .unwrap_or_else(|| PeerError::ConnectionTaskExited.into())))
         } else if let Some(error) = self.error_slot.try_get_error() {
             Poll::Ready(Err(error))
         } else {
@@ -569,13 +568,15 @@ impl Service<Request> for Client {
         }) {
             Err(e) => {
                 if e.is_disconnected() {
-                    let ClientRequest { tx, .. } = e.into_inner();
-                    let _ = tx.send(Err(PeerError::ConnectionClosed.into()));
-                    future::ready(Err(self
+                    let peer_error = self
                         .error_slot
                         .try_get_error()
-                        .expect("failed servers must set their error slot")))
-                    .boxed()
+                        .unwrap_or_else(|| PeerError::ConnectionTaskExited.into());
+
+                    let ClientRequest { tx, .. } = e.into_inner();
+                    let _ = tx.send(Err(peer_error.clone()));
+
+                    future::ready(Err(peer_error)).boxed()
                 } else {
                     // sending fails when there's not enough
                     // channel space, but we called poll_ready


### PR DESCRIPTION
## Motivation

Every few days, my Zebra instances panic with "failed servers must set their error slot".
This PR fixes the panic in ticket #3263 by removing it.

We still need to clean up the code to avoid deadlocks, but that is less urgent.

## Solution

- Remove the `expect()` and use a `ConnectionTaskExited` error instead of panicking

## Review

I'd like to get this fix in this release, so reviewing this PR is urgent.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Existing tests pass

## Follow Up Work

The rest of #3263.