### PR TITLE
feat(verify): Concurrently verify proof and signature batches

### DIFF
--- a/.github/workflows/continous-integration-docker.patch-always.yml
+++ b/.github/workflows/continous-integration-docker.patch-always.yml
@@ -7,8 +7,6 @@ name: CI Docker
 
 on:
   pull_request:
-    branches:
-      - main
 
 jobs:
   regenerate-stateful-disks:

--- a/.github/workflows/continous-integration-docker.patch.yml
+++ b/.github/workflows/continous-integration-docker.patch.yml
@@ -4,8 +4,6 @@ name: CI Docker
 # so they can be skipped when the modified files make the actual workflow run.
 on:
   pull_request:
-    branches:
-      - main
     paths-ignore:
       # code and tests
       - '**/*.rs'

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -23,8 +23,6 @@ on:
         required: true
 
   pull_request:
-    branches:
-      - main
     paths:
       # code and tests
       - '**/*.rs'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5446,6 +5446,7 @@ dependencies = [
  "futures-core",
  "pin-project 1.0.11",
  "rand 0.8.5",
+ "rayon",
  "tokio",
  "tokio-test",
  "tokio-util 0.7.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3792,9 +3792,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg 1.1.0",
  "crossbeam-deque",
@@ -3804,14 +3804,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -6368,6 +6367,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "rand 0.8.5",
+ "rayon",
  "serde",
  "spandoc",
  "thiserror",
@@ -6576,6 +6576,7 @@ dependencies = [
  "proptest-derive",
  "prost",
  "rand 0.8.5",
+ "rayon",
  "regex",
  "reqwest",
  "semver 1.0.11",

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 futures = "0.3.21"
 futures-core = "0.3.21"
 pin-project = "1.0.10"
+rayon = "1.5.3"
 tokio = { version = "1.19.2", features = ["time", "sync", "tracing", "macros"] }
 tokio-util = "0.7.3"
 tower = { version = "0.4.13", features = ["util", "buffer"] }
@@ -24,7 +25,6 @@ tokio = { version = "1.19.2", features = ["full", "tracing", "test-util"] }
 tokio-test = "0.4.2"
 tower-fallback = { path = "../tower-fallback/" }
 tower-test = "0.4.0"
-tracing = "0.1.31"
 
 zebra-consensus = { path = "../zebra-consensus/" }
 zebra-test = { path = "../zebra-test/" }

--- a/tower-batch/src/layer.rs
+++ b/tower-batch/src/layer.rs
@@ -47,6 +47,7 @@ impl<S, Request> Layer<S> for BatchLayer<Request>
 where
     S: Service<BatchControl<Request>> + Send + 'static,
     S::Future: Send,
+    S::Response: Send,
     S::Error: Into<crate::BoxError> + Send + Sync,
     Request: Send + 'static,
 {

--- a/tower-batch/src/layer.rs
+++ b/tower-batch/src/layer.rs
@@ -1,7 +1,11 @@
-use super::{service::Batch, BatchControl};
+//! Tower service layer for batch processing.
+
 use std::{fmt, marker::PhantomData};
+
 use tower::layer::Layer;
 use tower::Service;
+
+use super::{service::Batch, BatchControl};
 
 /// Adds a layer performing batch processing of requests.
 ///
@@ -10,8 +14,10 @@ use tower::Service;
 ///
 /// See the module documentation for more details.
 pub struct BatchLayer<Request> {
-    max_items: usize,
+    max_items_in_batch: usize,
+    max_batches_in_queue: Option<usize>,
     max_latency: std::time::Duration,
+
     _p: PhantomData<fn(Request)>,
 }
 
@@ -19,13 +25,21 @@ impl<Request> BatchLayer<Request> {
     /// Creates a new `BatchLayer`.
     ///
     /// The wrapper is responsible for telling the inner service when to flush a
-    /// batch of requests.  Two parameters control this policy:
+    /// batch of requests. These parameters control this policy:
     ///
-    /// * `max_items` gives the maximum number of items per batch.
-    /// * `max_latency` gives the maximum latency for a batch item.
-    pub fn new(max_items: usize, max_latency: std::time::Duration) -> Self {
+    /// * `max_items_in_batch` gives the maximum number of items per batch.
+    /// * `max_batches_in_queue` is an upper bound on the number of batches in the queue.
+    ///   If this is `None`, the `Batch` uses the current number of [`rayon`] threads.
+    ///   The final value is automatically limited to [`MAX_BATCHES_IN_QUEUE`].
+    /// * `max_latency` gives the maximum latency for a batch item to start verifying.
+    pub fn new(
+        max_items_in_batch: usize,
+        max_batches_in_queue: impl Into<Option<usize>>,
+        max_latency: std::time::Duration,
+    ) -> Self {
         BatchLayer {
-            max_items,
+            max_items_in_batch,
+            max_batches_in_queue: max_batches_in_queue.into(),
             max_latency,
             _p: PhantomData,
         }
@@ -42,14 +56,20 @@ where
     type Service = Batch<S, Request>;
 
     fn layer(&self, service: S) -> Self::Service {
-        Batch::new(service, self.max_items, self.max_latency)
+        Batch::new(
+            service,
+            self.max_items_in_batch,
+            self.max_batches_in_queue,
+            self.max_latency,
+        )
     }
 }
 
 impl<Request> fmt::Debug for BatchLayer<Request> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("BufferLayer")
-            .field("max_items", &self.max_items)
+            .field("max_items_in_batch", &self.max_items_in_batch)
+            .field("max_batches_in_queue", &self.max_batches_in_queue)
             .field("max_latency", &self.max_latency)
             .finish()
     }

--- a/tower-batch/src/layer.rs
+++ b/tower-batch/src/layer.rs
@@ -15,33 +15,30 @@ use super::{service::Batch, BatchControl};
 /// See the module documentation for more details.
 pub struct BatchLayer<Request> {
     max_items_in_batch: usize,
-    max_batches_in_queue: Option<usize>,
+    max_batches: Option<usize>,
     max_latency: std::time::Duration,
 
-    _p: PhantomData<fn(Request)>,
+    // TODO: is the variance correct here?
+    // https://doc.rust-lang.org/1.33.0/nomicon/subtyping.html#variance
+    // https://doc.rust-lang.org/nomicon/phantom-data.html#table-of-phantomdata-patterns
+    _handles_requests: PhantomData<fn(Request)>,
 }
 
 impl<Request> BatchLayer<Request> {
     /// Creates a new `BatchLayer`.
     ///
     /// The wrapper is responsible for telling the inner service when to flush a
-    /// batch of requests. These parameters control this policy:
-    ///
-    /// * `max_items_in_batch` gives the maximum number of items per batch.
-    /// * `max_batches_in_queue` is an upper bound on the number of batches in the queue.
-    ///   If this is `None`, the `Batch` uses the current number of [`rayon`] threads.
-    ///   The final value is automatically limited to [`MAX_BATCHES_IN_QUEUE`].
-    /// * `max_latency` gives the maximum latency for a batch item to start verifying.
+    /// batch of requests. See [`Batch::new()`] for details.
     pub fn new(
         max_items_in_batch: usize,
-        max_batches_in_queue: impl Into<Option<usize>>,
+        max_batches: impl Into<Option<usize>>,
         max_latency: std::time::Duration,
     ) -> Self {
         BatchLayer {
             max_items_in_batch,
-            max_batches_in_queue: max_batches_in_queue.into(),
+            max_batches: max_batches.into(),
             max_latency,
-            _p: PhantomData,
+            _handles_requests: PhantomData,
         }
     }
 }
@@ -59,7 +56,7 @@ where
         Batch::new(
             service,
             self.max_items_in_batch,
-            self.max_batches_in_queue,
+            self.max_batches,
             self.max_latency,
         )
     }
@@ -69,7 +66,7 @@ impl<Request> fmt::Debug for BatchLayer<Request> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("BufferLayer")
             .field("max_items_in_batch", &self.max_items_in_batch)
-            .field("max_batches_in_queue", &self.max_batches_in_queue)
+            .field("max_batches", &self.max_batches)
             .field("max_latency", &self.max_latency)
             .finish()
     }

--- a/tower-batch/src/service.rs
+++ b/tower-batch/src/service.rs
@@ -117,6 +117,7 @@ where
     where
         T: Send + 'static,
         T::Future: Send,
+        T::Response: Send,
         T::Error: Send + Sync,
         Request: Send + 'static,
     {

--- a/tower-batch/src/worker.rs
+++ b/tower-batch/src/worker.rs
@@ -209,11 +209,6 @@ where
                             running_batches = self.concurrent_batches.len(),
                             "batch finished executing",
                         );
-
-                        /* TODO: let other tasks run while we're waiting
-                        // Correctness: allow other tasks to run at the end of every batch.
-                        tokio::task::yield_now().await;
-                         */
                     }
                     Err(error) => {
                         let error = error.into();

--- a/tower-batch/tests/ed25519.rs
+++ b/tower-batch/tests/ed25519.rs
@@ -61,7 +61,7 @@ async fn batch_flushes_on_max_items() -> Result<(), Report> {
     // flushing is happening based on hitting max_items.
     //
     // Create our own verifier, so we don't shut down a shared verifier used by other tests.
-    let verifier = Batch::new(Ed25519Verifier::default(), 10, Duration::from_secs(1000));
+    let verifier = Batch::new(Ed25519Verifier::default(), 10, 5, Duration::from_secs(1000));
     timeout(Duration::from_secs(1), sign_and_verify(verifier, 100, None))
         .await
         .map_err(|e| eyre!(e))?
@@ -79,7 +79,12 @@ async fn batch_flushes_on_max_latency() -> Result<(), Report> {
     // flushing is happening based on hitting max_latency.
     //
     // Create our own verifier, so we don't shut down a shared verifier used by other tests.
-    let verifier = Batch::new(Ed25519Verifier::default(), 100, Duration::from_millis(500));
+    let verifier = Batch::new(
+        Ed25519Verifier::default(),
+        100,
+        10,
+        Duration::from_millis(500),
+    );
     timeout(Duration::from_secs(1), sign_and_verify(verifier, 10, None))
         .await
         .map_err(|e| eyre!(e))?
@@ -94,7 +99,12 @@ async fn fallback_verification() -> Result<(), Report> {
 
     // Create our own verifier, so we don't shut down a shared verifier used by other tests.
     let verifier = Fallback::new(
-        Batch::new(Ed25519Verifier::default(), 10, Duration::from_millis(100)),
+        Batch::new(
+            Ed25519Verifier::default(),
+            10,
+            1,
+            Duration::from_millis(100),
+        ),
         tower::service_fn(|item: Ed25519Item| async move { item.verify_single() }),
     );
 

--- a/tower-batch/tests/worker.rs
+++ b/tower-batch/tests/worker.rs
@@ -13,7 +13,7 @@ async fn wakes_pending_waiters_on_close() {
 
     let (service, mut handle) = mock::pair::<_, ()>();
 
-    let (mut service, worker) = Batch::pair(service, 1, Duration::from_secs(1));
+    let (mut service, worker) = Batch::pair(service, 1, 1, Duration::from_secs(1));
     let mut worker = task::spawn(worker.run());
 
     // // keep the request in the worker
@@ -72,7 +72,7 @@ async fn wakes_pending_waiters_on_failure() {
 
     let (service, mut handle) = mock::pair::<_, ()>();
 
-    let (mut service, worker) = Batch::pair(service, 1, Duration::from_secs(1));
+    let (mut service, worker) = Batch::pair(service, 1, 1, Duration::from_secs(1));
     let mut worker = task::spawn(worker.run());
 
     // keep the request in the worker

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -13,10 +13,10 @@ proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl", "ze
 blake2b_simd = "1.0.0"
 bellman = "0.13.0"
 bls12_381 = "0.7.0"
+halo2 = { package = "halo2_proofs", version = "0.2.0" }
 jubjub = "0.9.0"
 rand = { version = "0.8.5", package = "rand" }
-
-halo2 = { package = "halo2_proofs", version = "0.2.0" }
+rayon = "1.5.3"
 
 chrono = "0.4.19"
 dirs = "4.0.0"

--- a/zebra-consensus/src/primitives/ed25519.rs
+++ b/zebra-consensus/src/primitives/ed25519.rs
@@ -124,7 +124,6 @@ impl Verifier {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         tokio::task::spawn_blocking(|| {
             // TODO:
-            // - spawn multiple batches at the same time
             // - spawn batches so rayon executes them in FIFO order
             //   possible implementation: return a closure in a Future,
             //   then run it using scope_fifo() in the worker task,

--- a/zebra-consensus/src/primitives/ed25519.rs
+++ b/zebra-consensus/src/primitives/ed25519.rs
@@ -145,7 +145,7 @@ impl Verifier {
             // TODO:
             // - when a batch fails, spawn all its individual items into rayon using Vec::par_iter()
             // - spawn fallback individual verifications so rayon executes them in FIFO order,
-            //   using Vec::par_iter() within a scope_fifo()
+            //   if possible
             rayon::iter::once(item)
                 .map(|item| item.verify_single())
                 .collect()

--- a/zebra-consensus/src/primitives/ed25519.rs
+++ b/zebra-consensus/src/primitives/ed25519.rs
@@ -49,6 +49,7 @@ pub static VERIFIER: Lazy<
         Batch::new(
             Verifier::default(),
             super::MAX_BATCH_SIZE,
+            None,
             super::MAX_BATCH_LATENCY,
         ),
         // We want to fallback to individual verification if batch verification fails,

--- a/zebra-consensus/src/primitives/ed25519.rs
+++ b/zebra-consensus/src/primitives/ed25519.rs
@@ -11,6 +11,7 @@ use futures::{future::BoxFuture, FutureExt};
 use once_cell::sync::Lazy;
 use rand::thread_rng;
 
+use rayon::prelude::*;
 use tokio::sync::watch;
 use tower::{util::ServiceFn, Service};
 use tower_batch::{Batch, BatchControl};
@@ -106,38 +107,50 @@ impl Verifier {
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    /// This function blocks until the batch is completed on the thread pool.
+    /// This returns immediately, usually before the batch is completed.
     fn flush_blocking(&mut self) {
         let (batch, tx) = self.take();
 
-        // # Correctness
+        // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         //
-        // Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        //
-        // TODO: replace with the rayon thread pool
-        tokio::task::block_in_place(|| Self::verify(batch, tx));
+        // We don't care about execution order here, because this method is only called on drop.
+        tokio::task::block_in_place(|| rayon::spawn_fifo(|| Self::verify(batch, tx)));
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    /// This function returns a future that becomes ready when the batch is completed.
+    ///
+    /// This function returns a future that becomes ready when the batch has been queued,
+    /// which is usually before the batch is completed.
     fn flush_spawning(batch: BatchVerifier, tx: Sender) -> impl Future<Output = ()> {
-        // # Correctness
-        //
-        // Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        //
-        // TODO: spawn on the rayon thread pool inside spawn_blocking
-        tokio::task::spawn_blocking(|| Self::verify(batch, tx))
-            .map(|join_result| join_result.expect("panic in ed25519 batch verifier"))
+        // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
+        tokio::task::spawn_blocking(|| {
+            // TODO:
+            // - spawn batches so rayon executes them in FIFO order
+            //   possible implementation: return a closure in a Future,
+            //   then run it using scope_fifo() in the worker task,
+            //   limiting the number of concurrent batches to the number of rayon threads
+            rayon::spawn_fifo(|| Self::verify(batch, tx))
+        })
+        .map(|join_result| join_result.expect("panic in ed25519 batch verifier"))
     }
 
     /// Verify a single item using a thread pool, and return the result.
     /// This function returns a future that becomes ready when the item is completed.
     fn verify_single_spawning(item: Item) -> impl Future<Output = VerifyResult> {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        //
-        // TODO: spawn on the rayon thread pool inside spawn_blocking
-        tokio::task::spawn_blocking(|| item.verify_single())
-            .map(|join_result| join_result.expect("panic in ed25519 fallback verifier"))
+        tokio::task::spawn_blocking(|| {
+            // Rayon doesn't have a spawn function that returns a value,
+            // so we use a parallel iterator instead.
+            //
+            // TODO:
+            // - when a batch fails, spawn all its individual items into rayon using Vec::par_iter()
+            // - spawn fallback individual verifications so rayon executes them in FIFO order,
+            //   using Vec::par_iter() within a scope_fifo()
+            rayon::iter::once(item)
+                .map(|item| item.verify_single())
+                .collect()
+        })
+        .map(|join_result| join_result.expect("panic in ed25519 fallback verifier"))
     }
 }
 
@@ -192,9 +205,7 @@ impl Service<BatchControl<Item>> for Verifier {
 impl Drop for Verifier {
     fn drop(&mut self) {
         // We need to flush the current batch in case there are still any pending futures.
-        // This blocks the current thread and any futures running on it, until the batch is complete.
-        //
-        // TODO: move the batch onto the rayon thread pool, then drop the verifier immediately.
+        // This returns immediately, usually before the batch is completed.
         self.flush_blocking();
     }
 }

--- a/zebra-consensus/src/primitives/ed25519/tests.rs
+++ b/zebra-consensus/src/primitives/ed25519/tests.rs
@@ -44,7 +44,7 @@ async fn batch_flushes_on_max_items() -> Result<()> {
 
     // Use a very long max_latency and a short timeout to check that
     // flushing is happening based on hitting max_items.
-    let verifier = Batch::new(Verifier::default(), 10, Duration::from_secs(1000));
+    let verifier = Batch::new(Verifier::default(), 10, 5, Duration::from_secs(1000));
     timeout(Duration::from_secs(5), sign_and_verify(verifier, 100))
         .await?
         .map_err(|e| eyre!(e))?;
@@ -63,7 +63,7 @@ async fn batch_flushes_on_max_latency() -> Result<()> {
 
     // Use a very high max_items and a short timeout to check that
     // flushing is happening based on hitting max_latency.
-    let verifier = Batch::new(Verifier::default(), 100, Duration::from_millis(500));
+    let verifier = Batch::new(Verifier::default(), 100, 10, Duration::from_millis(500));
     timeout(Duration::from_secs(5), sign_and_verify(verifier, 10))
         .await?
         .map_err(|e| eyre!(e))?;

--- a/zebra-consensus/src/primitives/groth16.rs
+++ b/zebra-consensus/src/primitives/groth16.rs
@@ -425,7 +425,6 @@ impl Verifier {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         tokio::task::spawn_blocking(move || {
             // TODO:
-            // - spawn multiple batches at the same time
             // - spawn batches so rayon executes them in FIFO order
             //   possible implementation: return a closure in a Future,
             //   then run it using scope_fifo() in the worker task,

--- a/zebra-consensus/src/primitives/groth16.rs
+++ b/zebra-consensus/src/primitives/groth16.rs
@@ -414,9 +414,7 @@ impl Verifier {
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    ///
-    /// This function returns a future that becomes ready when the batch has been queued,
-    /// which is usually before the batch is completed.
+    /// This function returns a future that becomes ready when the batch is completed.
     fn flush_spawning(
         batch: BatchVerifier,
         vk: &'static BatchVerifyingKey,
@@ -425,11 +423,12 @@ impl Verifier {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         tokio::task::spawn_blocking(move || {
             // TODO:
+            // - spawn multiple batches at the same time
             // - spawn batches so rayon executes them in FIFO order
             //   possible implementation: return a closure in a Future,
             //   then run it using scope_fifo() in the worker task,
             //   limiting the number of concurrent batches to the number of rayon threads
-            rayon::spawn_fifo(move || Self::verify(batch, vk, tx))
+            rayon::scope_fifo(move |s| s.spawn_fifo(move |_s| Self::verify(batch, vk, tx)))
         })
         .map(|join_result| join_result.expect("panic in groth16 batch verifier"))
     }

--- a/zebra-consensus/src/primitives/groth16.rs
+++ b/zebra-consensus/src/primitives/groth16.rs
@@ -80,6 +80,7 @@ pub static SPEND_VERIFIER: Lazy<
         Batch::new(
             Verifier::new(&GROTH16_PARAMETERS.sapling.spend.vk),
             super::MAX_BATCH_SIZE,
+            None,
             super::MAX_BATCH_LATENCY,
         ),
         // We want to fallback to individual verification if batch verification fails,
@@ -118,6 +119,7 @@ pub static OUTPUT_VERIFIER: Lazy<
         Batch::new(
             Verifier::new(&GROTH16_PARAMETERS.sapling.output.vk),
             super::MAX_BATCH_SIZE,
+            None,
             super::MAX_BATCH_LATENCY,
         ),
         // We want to fallback to individual verification if batch verification

--- a/zebra-consensus/src/primitives/groth16.rs
+++ b/zebra-consensus/src/primitives/groth16.rs
@@ -449,7 +449,7 @@ impl Verifier {
             // TODO:
             // - when a batch fails, spawn all its individual items into rayon using Vec::par_iter()
             // - spawn fallback individual verifications so rayon executes them in FIFO order,
-            //   using Vec::par_iter() within a scope_fifo()
+            //   if possible
             rayon::iter::once(item)
                 .map(move |item| item.verify_single(pvk))
                 .collect()

--- a/zebra-consensus/src/primitives/groth16/tests.rs
+++ b/zebra-consensus/src/primitives/groth16/tests.rs
@@ -75,6 +75,7 @@ async fn verify_sapling_groth16() {
         Batch::new(
             Verifier::new(&GROTH16_PARAMETERS.sapling.spend.vk),
             crate::primitives::MAX_BATCH_SIZE,
+            None,
             crate::primitives::MAX_BATCH_LATENCY,
         ),
         tower::service_fn(
@@ -87,6 +88,7 @@ async fn verify_sapling_groth16() {
         Batch::new(
             Verifier::new(&GROTH16_PARAMETERS.sapling.output.vk),
             crate::primitives::MAX_BATCH_SIZE,
+            None,
             crate::primitives::MAX_BATCH_LATENCY,
         ),
         tower::service_fn(
@@ -179,6 +181,7 @@ async fn correctly_err_on_invalid_output_proof() {
         Batch::new(
             Verifier::new(&GROTH16_PARAMETERS.sapling.output.vk),
             crate::primitives::MAX_BATCH_SIZE,
+            None,
             crate::primitives::MAX_BATCH_LATENCY,
         ),
         tower::service_fn(

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -316,7 +316,7 @@ impl Verifier {
             // TODO:
             // - when a batch fails, spawn all its individual items into rayon using Vec::par_iter()
             // - spawn fallback individual verifications so rayon executes them in FIFO order,
-            //   using Vec::par_iter() within a scope_fifo()
+            //   if possible
             rayon::iter::once(item)
                 .map(move |item| item.verify_single(pvk).map_err(Halo2Error::from))
                 .collect()

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -292,7 +292,6 @@ impl Verifier {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         tokio::task::spawn_blocking(move || {
             // TODO:
-            // - spawn multiple batches at the same time
             // - spawn batches so rayon executes them in FIFO order
             //   possible implementation: return a closure in a Future,
             //   then run it using scope_fifo() in the worker task,

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -205,6 +205,7 @@ pub static VERIFIER: Lazy<
         Batch::new(
             Verifier::new(&VERIFYING_KEY),
             HALO2_MAX_BATCH_SIZE,
+            None,
             super::MAX_BATCH_LATENCY,
         ),
         // We want to fallback to individual verification if batch verification fails,

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -12,6 +12,8 @@ use futures::{future::BoxFuture, FutureExt};
 use once_cell::sync::Lazy;
 use orchard::circuit::VerifyingKey;
 use rand::{thread_rng, CryptoRng, RngCore};
+
+use rayon::prelude::*;
 use thiserror::Error;
 use tokio::sync::watch;
 use tower::{util::ServiceFn, Service};
@@ -269,32 +271,35 @@ impl Verifier {
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    /// This function blocks until the batch is completed on the thread pool.
+    /// This returns immediately, usually before the batch is completed.
     fn flush_blocking(&mut self) {
         let (batch, vk, tx) = self.take();
 
-        // # Correctness
+        // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         //
-        // Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        //
-        // TODO: replace with the rayon thread pool
-        tokio::task::block_in_place(|| Self::verify(batch, vk, tx));
+        // We don't care about execution order here, because this method is only called on drop.
+        tokio::task::block_in_place(|| rayon::spawn_fifo(|| Self::verify(batch, vk, tx)));
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    /// This function returns a future that becomes ready when the batch is completed.
+    ///
+    /// This function returns a future that becomes ready when the batch has been queued,
+    /// which is usually before the batch is completed.
     fn flush_spawning(
         batch: BatchVerifier,
         vk: &'static BatchVerifyingKey,
         tx: Sender,
     ) -> impl Future<Output = ()> {
-        // # Correctness
-        //
-        // Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        //
-        // TODO: spawn on the rayon thread pool inside spawn_blocking
-        tokio::task::spawn_blocking(move || Self::verify(batch, vk, tx))
-            .map(|join_result| join_result.expect("panic in halo2 batch verifier"))
+        // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
+        tokio::task::spawn_blocking(move || {
+            // TODO:
+            // - spawn batches so rayon executes them in FIFO order
+            //   possible implementation: return a closure in a Future,
+            //   then run it using scope_fifo() in the worker task,
+            //   limiting the number of concurrent batches to the number of rayon threads
+            rayon::spawn_fifo(move || Self::verify(batch, vk, tx))
+        })
+        .map(|join_result| join_result.expect("panic in halo2 batch verifier"))
     }
 
     /// Verify a single item using a thread pool, and return the result.
@@ -304,10 +309,19 @@ impl Verifier {
         pvk: &'static ItemVerifyingKey,
     ) -> impl Future<Output = VerifyResult> {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        //
-        // TODO: spawn on the rayon thread pool inside spawn_blocking
-        tokio::task::spawn_blocking(move || item.verify_single(pvk).map_err(Halo2Error::from))
-            .map(|join_result| join_result.expect("panic in halo2 fallback verifier"))
+        tokio::task::spawn_blocking(move || {
+            // Rayon doesn't have a spawn function that returns a value,
+            // so we use a parallel iterator instead.
+            //
+            // TODO:
+            // - when a batch fails, spawn all its individual items into rayon using Vec::par_iter()
+            // - spawn fallback individual verifications so rayon executes them in FIFO order,
+            //   using Vec::par_iter() within a scope_fifo()
+            rayon::iter::once(item)
+                .map(move |item| item.verify_single(pvk).map_err(Halo2Error::from))
+                .collect()
+        })
+        .map(|join_result| join_result.expect("panic in halo2 fallback verifier"))
     }
 }
 
@@ -377,9 +391,7 @@ impl Service<BatchControl<Item>> for Verifier {
 impl Drop for Verifier {
     fn drop(&mut self) {
         // We need to flush the current batch in case there are still any pending futures.
-        // This blocks the current thread and any futures running on it, until the batch is complete.
-        //
-        // TODO: move the batch onto the rayon thread pool, then drop the verifier immediately.
+        // This returns immediately, usually before the batch is completed.
         self.flush_blocking()
     }
 }

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -282,9 +282,7 @@ impl Verifier {
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    ///
-    /// This function returns a future that becomes ready when the batch has been queued,
-    /// which is usually before the batch is completed.
+    /// This function returns a future that becomes ready when the batch is completed.
     fn flush_spawning(
         batch: BatchVerifier,
         vk: &'static BatchVerifyingKey,
@@ -293,11 +291,12 @@ impl Verifier {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         tokio::task::spawn_blocking(move || {
             // TODO:
+            // - spawn multiple batches at the same time
             // - spawn batches so rayon executes them in FIFO order
             //   possible implementation: return a closure in a Future,
             //   then run it using scope_fifo() in the worker task,
             //   limiting the number of concurrent batches to the number of rayon threads
-            rayon::spawn_fifo(move || Self::verify(batch, vk, tx))
+            rayon::scope_fifo(move |s| s.spawn_fifo(move |_s| Self::verify(batch, vk, tx)))
         })
         .map(|join_result| join_result.expect("panic in halo2 batch verifier"))
     }

--- a/zebra-consensus/src/primitives/halo2/tests.rs
+++ b/zebra-consensus/src/primitives/halo2/tests.rs
@@ -151,6 +151,7 @@ async fn verify_generated_halo2_proofs() {
         Batch::new(
             Verifier::new(&VERIFYING_KEY),
             crate::primitives::MAX_BATCH_SIZE,
+            None,
             crate::primitives::MAX_BATCH_LATENCY,
         ),
         tower::service_fn(
@@ -217,6 +218,7 @@ async fn correctly_err_on_invalid_halo2_proofs() {
         Batch::new(
             Verifier::new(&VERIFYING_KEY),
             crate::primitives::MAX_BATCH_SIZE,
+            None,
             crate::primitives::MAX_BATCH_LATENCY,
         ),
         tower::service_fn(

--- a/zebra-consensus/src/primitives/redjubjub.rs
+++ b/zebra-consensus/src/primitives/redjubjub.rs
@@ -119,18 +119,17 @@ impl Verifier {
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    ///
-    /// This function returns a future that becomes ready when the batch has been queued,
-    /// which is usually before the batch is completed.
+    /// This function returns a future that becomes ready when the batch is completed.
     fn flush_spawning(batch: BatchVerifier, tx: Sender) -> impl Future<Output = ()> {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         tokio::task::spawn_blocking(|| {
             // TODO:
+            // - spawn multiple batches at the same time
             // - spawn batches so rayon executes them in FIFO order
             //   possible implementation: return a closure in a Future,
             //   then run it using scope_fifo() in the worker task,
             //   limiting the number of concurrent batches to the number of rayon threads
-            rayon::spawn_fifo(|| Self::verify(batch, tx))
+            rayon::scope_fifo(|s| s.spawn_fifo(|_s| Self::verify(batch, tx)))
         })
         .map(|join_result| join_result.expect("panic in redjubjub batch verifier"))
     }

--- a/zebra-consensus/src/primitives/redjubjub.rs
+++ b/zebra-consensus/src/primitives/redjubjub.rs
@@ -11,6 +11,7 @@ use futures::{future::BoxFuture, FutureExt};
 use once_cell::sync::Lazy;
 use rand::thread_rng;
 
+use rayon::prelude::*;
 use tokio::sync::watch;
 use tower::{util::ServiceFn, Service};
 use tower_batch::{Batch, BatchControl};
@@ -107,38 +108,50 @@ impl Verifier {
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    /// This function blocks until the batch is completed on the thread pool.
+    /// This returns immediately, usually before the batch is completed.
     fn flush_blocking(&mut self) {
         let (batch, tx) = self.take();
 
-        // # Correctness
+        // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         //
-        // Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        //
-        // TODO: replace with the rayon thread pool
-        tokio::task::block_in_place(|| Self::verify(batch, tx));
+        // We don't care about execution order here, because this method is only called on drop.
+        tokio::task::block_in_place(|| rayon::spawn_fifo(|| Self::verify(batch, tx)));
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    /// This function returns a future that becomes ready when the batch is completed.
+    ///
+    /// This function returns a future that becomes ready when the batch has been queued,
+    /// which is usually before the batch is completed.
     fn flush_spawning(batch: BatchVerifier, tx: Sender) -> impl Future<Output = ()> {
-        // # Correctness
-        //
-        // Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        //
-        // TODO: spawn on the rayon thread pool inside spawn_blocking
-        tokio::task::spawn_blocking(|| Self::verify(batch, tx))
-            .map(|join_result| join_result.expect("panic in redjubjub batch verifier"))
+        // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
+        tokio::task::spawn_blocking(|| {
+            // TODO:
+            // - spawn batches so rayon executes them in FIFO order
+            //   possible implementation: return a closure in a Future,
+            //   then run it using scope_fifo() in the worker task,
+            //   limiting the number of concurrent batches to the number of rayon threads
+            rayon::spawn_fifo(|| Self::verify(batch, tx))
+        })
+        .map(|join_result| join_result.expect("panic in redjubjub batch verifier"))
     }
 
     /// Verify a single item using a thread pool, and return the result.
     /// This function returns a future that becomes ready when the item is completed.
     fn verify_single_spawning(item: Item) -> impl Future<Output = VerifyResult> {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        //
-        // TODO: spawn on the rayon thread pool inside spawn_blocking
-        tokio::task::spawn_blocking(|| item.verify_single())
-            .map(|join_result| join_result.expect("panic in redjubjub fallback verifier"))
+        tokio::task::spawn_blocking(|| {
+            // Rayon doesn't have a spawn function that returns a value,
+            // so we use a parallel iterator instead.
+            //
+            // TODO:
+            // - when a batch fails, spawn all its individual items into rayon using Vec::par_iter()
+            // - spawn fallback individual verifications so rayon executes them in FIFO order,
+            //   using Vec::par_iter() within a scope_fifo()
+            rayon::iter::once(item)
+                .map(|item| item.verify_single())
+                .collect()
+        })
+        .map(|join_result| join_result.expect("panic in redjubjub fallback verifier"))
     }
 }
 
@@ -194,9 +207,7 @@ impl Service<BatchControl<Item>> for Verifier {
 impl Drop for Verifier {
     fn drop(&mut self) {
         // We need to flush the current batch in case there are still any pending futures.
-        // This blocks the current thread and any futures running on it, until the batch is complete.
-        //
-        // TODO: move the batch onto the rayon thread pool, then drop the verifier immediately.
+        // This returns immediately, usually before the batch is completed.
         self.flush_blocking();
     }
 }

--- a/zebra-consensus/src/primitives/redjubjub.rs
+++ b/zebra-consensus/src/primitives/redjubjub.rs
@@ -50,6 +50,7 @@ pub static VERIFIER: Lazy<
         Batch::new(
             Verifier::default(),
             super::MAX_BATCH_SIZE,
+            None,
             super::MAX_BATCH_LATENCY,
         ),
         // We want to fallback to individual verification if batch verification fails,

--- a/zebra-consensus/src/primitives/redjubjub.rs
+++ b/zebra-consensus/src/primitives/redjubjub.rs
@@ -146,7 +146,7 @@ impl Verifier {
             // TODO:
             // - when a batch fails, spawn all its individual items into rayon using Vec::par_iter()
             // - spawn fallback individual verifications so rayon executes them in FIFO order,
-            //   using Vec::par_iter() within a scope_fifo()
+            //   if possible
             rayon::iter::once(item)
                 .map(|item| item.verify_single())
                 .collect()

--- a/zebra-consensus/src/primitives/redjubjub.rs
+++ b/zebra-consensus/src/primitives/redjubjub.rs
@@ -125,7 +125,6 @@ impl Verifier {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         tokio::task::spawn_blocking(|| {
             // TODO:
-            // - spawn multiple batches at the same time
             // - spawn batches so rayon executes them in FIFO order
             //   possible implementation: return a closure in a Future,
             //   then run it using scope_fifo() in the worker task,

--- a/zebra-consensus/src/primitives/redjubjub/tests.rs
+++ b/zebra-consensus/src/primitives/redjubjub/tests.rs
@@ -56,7 +56,7 @@ async fn batch_flushes_on_max_items() -> Result<()> {
 
     // Use a very long max_latency and a short timeout to check that
     // flushing is happening based on hitting max_items.
-    let verifier = Batch::new(Verifier::default(), 10, Duration::from_secs(1000));
+    let verifier = Batch::new(Verifier::default(), 10, 5, Duration::from_secs(1000));
     timeout(Duration::from_secs(5), sign_and_verify(verifier, 100))
         .await?
         .map_err(|e| eyre!(e))?;
@@ -75,7 +75,7 @@ async fn batch_flushes_on_max_latency() -> Result<()> {
 
     // Use a very high max_items and a short timeout to check that
     // flushing is happening based on hitting max_latency.
-    let verifier = Batch::new(Verifier::default(), 100, Duration::from_millis(500));
+    let verifier = Batch::new(Verifier::default(), 100, 10, Duration::from_millis(500));
     timeout(Duration::from_secs(5), sign_and_verify(verifier, 10))
         .await?
         .map_err(|e| eyre!(e))?;

--- a/zebra-consensus/src/primitives/redpallas.rs
+++ b/zebra-consensus/src/primitives/redpallas.rs
@@ -10,6 +10,8 @@ use std::{
 use futures::{future::BoxFuture, FutureExt};
 use once_cell::sync::Lazy;
 use rand::thread_rng;
+
+use rayon::prelude::*;
 use tokio::sync::watch;
 use tower::{util::ServiceFn, Service};
 use tower_batch::{Batch, BatchControl};
@@ -106,38 +108,50 @@ impl Verifier {
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    /// This function blocks until the batch is completed on the thread pool.
+    /// This returns immediately, usually before the batch is completed.
     fn flush_blocking(&mut self) {
         let (batch, tx) = self.take();
 
-        // # Correctness
+        // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         //
-        // Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        //
-        // TODO: replace with the rayon thread pool
-        tokio::task::block_in_place(|| Self::verify(batch, tx));
+        // We don't care about execution order here, because this method is only called on drop.
+        tokio::task::block_in_place(|| rayon::spawn_fifo(|| Self::verify(batch, tx)));
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    /// This function returns a future that becomes ready when the batch is completed.
+    ///
+    /// This function returns a future that becomes ready when the batch has been queued,
+    /// which is usually before the batch is completed.
     fn flush_spawning(batch: BatchVerifier, tx: Sender) -> impl Future<Output = ()> {
-        // # Correctness
-        //
-        // Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        //
-        // TODO: spawn on the rayon thread pool inside spawn_blocking
-        tokio::task::spawn_blocking(|| Self::verify(batch, tx))
-            .map(|join_result| join_result.expect("panic in redpallas batch verifier"))
+        // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
+        tokio::task::spawn_blocking(|| {
+            // TODO:
+            // - spawn batches so rayon executes them in FIFO order
+            //   possible implementation: return a closure in a Future,
+            //   then run it using scope_fifo() in the worker task,
+            //   limiting the number of concurrent batches to the number of rayon threads
+            rayon::spawn_fifo(|| Self::verify(batch, tx))
+        })
+        .map(|join_result| join_result.expect("panic in ed25519 batch verifier"))
     }
 
     /// Verify a single item using a thread pool, and return the result.
     /// This function returns a future that becomes ready when the item is completed.
     fn verify_single_spawning(item: Item) -> impl Future<Output = VerifyResult> {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        //
-        // TODO: spawn on the rayon thread pool inside spawn_blocking
-        tokio::task::spawn_blocking(|| item.verify_single())
-            .map(|join_result| join_result.expect("panic in redpallas fallback verifier"))
+        tokio::task::spawn_blocking(|| {
+            // Rayon doesn't have a spawn function that returns a value,
+            // so we use a parallel iterator instead.
+            //
+            // TODO:
+            // - when a batch fails, spawn all its individual items into rayon using Vec::par_iter()
+            // - spawn fallback individual verifications so rayon executes them in FIFO order,
+            //   using Vec::par_iter() within a scope_fifo()
+            rayon::iter::once(item)
+                .map(|item| item.verify_single())
+                .collect()
+        })
+        .map(|join_result| join_result.expect("panic in redpallas fallback verifier"))
     }
 }
 
@@ -192,9 +206,7 @@ impl Service<BatchControl<Item>> for Verifier {
 impl Drop for Verifier {
     fn drop(&mut self) {
         // We need to flush the current batch in case there are still any pending futures.
-        // This blocks the current thread and any futures running on it, until the batch is complete.
-        //
-        // TODO: move the batch onto the rayon thread pool, then drop the verifier immediately.
+        // This returns immediately, usually before the batch is completed.
         self.flush_blocking();
     }
 }

--- a/zebra-consensus/src/primitives/redpallas.rs
+++ b/zebra-consensus/src/primitives/redpallas.rs
@@ -50,6 +50,7 @@ pub static VERIFIER: Lazy<
         Batch::new(
             Verifier::default(),
             super::MAX_BATCH_SIZE,
+            None,
             super::MAX_BATCH_LATENCY,
         ),
         // We want to fallback to individual verification if batch verification fails,

--- a/zebra-consensus/src/primitives/redpallas.rs
+++ b/zebra-consensus/src/primitives/redpallas.rs
@@ -146,7 +146,7 @@ impl Verifier {
             // TODO:
             // - when a batch fails, spawn all its individual items into rayon using Vec::par_iter()
             // - spawn fallback individual verifications so rayon executes them in FIFO order,
-            //   using Vec::par_iter() within a scope_fifo()
+            //   if possible
             rayon::iter::once(item)
                 .map(|item| item.verify_single())
                 .collect()

--- a/zebra-consensus/src/primitives/redpallas.rs
+++ b/zebra-consensus/src/primitives/redpallas.rs
@@ -119,18 +119,17 @@ impl Verifier {
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    ///
-    /// This function returns a future that becomes ready when the batch has been queued,
-    /// which is usually before the batch is completed.
+    /// This function returns a future that becomes ready when the batch is completed.
     fn flush_spawning(batch: BatchVerifier, tx: Sender) -> impl Future<Output = ()> {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         tokio::task::spawn_blocking(|| {
             // TODO:
+            // - spawn multiple batches at the same time
             // - spawn batches so rayon executes them in FIFO order
             //   possible implementation: return a closure in a Future,
             //   then run it using scope_fifo() in the worker task,
             //   limiting the number of concurrent batches to the number of rayon threads
-            rayon::spawn_fifo(|| Self::verify(batch, tx))
+            rayon::scope_fifo(|s| s.spawn_fifo(|_s| Self::verify(batch, tx)))
         })
         .map(|join_result| join_result.expect("panic in ed25519 batch verifier"))
     }

--- a/zebra-consensus/src/primitives/redpallas.rs
+++ b/zebra-consensus/src/primitives/redpallas.rs
@@ -125,7 +125,6 @@ impl Verifier {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         tokio::task::spawn_blocking(|| {
             // TODO:
-            // - spawn multiple batches at the same time
             // - spawn batches so rayon executes them in FIFO order
             //   possible implementation: return a closure in a Future,
             //   then run it using scope_fifo() in the worker task,

--- a/zebra-consensus/src/primitives/redpallas/tests.rs
+++ b/zebra-consensus/src/primitives/redpallas/tests.rs
@@ -51,7 +51,7 @@ async fn batch_flushes_on_max_items() -> Result<()> {
 
     // Use a very long max_latency and a short timeout to check that
     // flushing is happening based on hitting max_items.
-    let verifier = Batch::new(Verifier::default(), 10, Duration::from_secs(1000));
+    let verifier = Batch::new(Verifier::default(), 10, 5, Duration::from_secs(1000));
     timeout(Duration::from_secs(5), sign_and_verify(verifier, 100))
         .await?
         .map_err(|e| eyre!(e))?;
@@ -65,7 +65,7 @@ async fn batch_flushes_on_max_latency() -> Result<()> {
 
     // Use a very high max_items and a short timeout to check that
     // flushing is happening based on hitting max_latency.
-    let verifier = Batch::new(Verifier::default(), 100, Duration::from_millis(500));
+    let verifier = Batch::new(Verifier::default(), 100, 10, Duration::from_millis(500));
     timeout(Duration::from_secs(5), sign_and_verify(verifier, 10))
         .await?
         .map_err(|e| eyre!(e))?;

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -86,6 +86,7 @@ serde = { version = "1.0.137", features = ["serde_derive"] }
 toml = "0.5.9"
 
 futures = "0.3.21"
+rayon = "1.5.3"
 tokio = { version = "1.19.2", features = ["time", "rt-multi-thread", "macros", "tracing", "signal"] }
 tower = { version = "0.4.13", features = ["hedge", "limit"] }
 pin-project = "1.0.10"

--- a/zebrad/src/components/tokio.rs
+++ b/zebrad/src/components/tokio.rs
@@ -5,7 +5,7 @@
 //! - blocking network and file tasks, via [`spawn_blocking`](tokio::task::spawn_blocking).
 //!
 //! The rayon thread pool is used for:
-//! - long-running CPU-bound tasks like cryptography, via [`rayon::spawn`].
+//! - long-running CPU-bound tasks like cryptography, via [`rayon::spawn_fifo`].
 
 use std::{future::Future, time::Duration};
 

--- a/zebrad/src/components/tokio.rs
+++ b/zebrad/src/components/tokio.rs
@@ -1,10 +1,19 @@
 //! A component owning the Tokio runtime.
+//!
+//! The tokio runtime is used for:
+//! - non-blocking async tasks, via [`Future`]s and
+//! - blocking network and file tasks, via [`spawn_blocking`](tokio::task::spawn_blocking).
+//!
+//! The rayon thread pool is used for:
+//! - long-running CPU-bound tasks like cryptography, via [`rayon::spawn`].
 
-use crate::prelude::*;
+use std::{future::Future, time::Duration};
+
 use abscissa_core::{Application, Component, FrameworkError, Shutdown};
 use color_eyre::Report;
-use std::{future::Future, time::Duration};
 use tokio::runtime::Runtime;
+
+use crate::prelude::*;
 
 /// When Zebra is shutting down, wait this long for tokio tasks to finish.
 const TOKIO_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(20);

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -229,11 +229,14 @@ impl Default for SyncSection {
             // This default is deliberately very low, so Zebra can verify a few large blocks in under 60 seconds,
             // even on machines with only a few cores.
             //
-            // This lets users see the committed block height changing in every progress log.
+            // This lets users see the committed block height changing in every progress log,
+            // and avoids hangs due to out-of-order verifications flooding the CPUs.
             //
-            // TODO: when we implement orchard proof batching, try increasing to 20 or more
-            //       limit full verification concurrency based on block transaction counts?
-            full_verify_concurrency_limit: 5,
+            // TODO:
+            // - limit full verification concurrency based on block transaction counts?
+            // - move more disk work to blocking tokio threads,
+            //   and CPU work to the rayon thread pool inside blocking tokio threads
+            full_verify_concurrency_limit: 20,
 
             // Use one thread per CPU.
             //

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -209,6 +209,12 @@ pub struct SyncSection {
     /// This is set to a low value by default, to avoid verification timeouts on large blocks.
     /// Increasing this value may improve performance on machines with many cores.
     pub full_verify_concurrency_limit: usize,
+
+    /// The number of threads used to verify signatures, proofs, and other CPU-intensive code.
+    ///
+    /// Set to `0` by default, which uses one thread per available CPU core.
+    /// For details, see [the rayon documentation](https://docs.rs/rayon/latest/rayon/struct.ThreadPoolBuilder.html#method.num_threads).
+    pub parallel_cpu_threads: usize,
 }
 
 impl Default for SyncSection {
@@ -228,6 +234,12 @@ impl Default for SyncSection {
             // TODO: when we implement orchard proof batching, try increasing to 20 or more
             //       limit full verification concurrency based on block transaction counts?
             full_verify_concurrency_limit: 5,
+
+            // Use one thread per CPU.
+            //
+            // If this causes tokio executor starvation, move CPU-intensive tasks to rayon threads,
+            // or reserve a few cores for tokio threads, based on `num_cpus()`.
+            parallel_cpu_threads: 0,
         }
     }
 }


### PR DESCRIPTION
## Motivation

Currently, Zebra only verifies one batch of each type of cryptography.
This PR verifies multiple batches in parallel, up to the number of available CPUs.

In practice, I've seen it use all the physical cores on my machine for a few seconds. To see this, I needed to set the number of concurrent blocks to 100.

After the blocks all get verified, Zebra waits for other CPU-bound tasks, or writing the blocks to disk.

(We can improve performance more by moving other CPU-bound tasks to `rayon`, and disk-bound tasks to blocking `tokio` threads. But that belongs in a separate ticket.)

### Specifications

`tokio`'s warning about CPU-bound tasks:
https://docs.rs/tokio/latest/tokio/index.html#cpu-bound-tasks-and-blocking-code

`rayon::scope_fifo()`:
https://docs.rs/rayon/latest/rayon/fn.scope_fifo.html

## Solution

Increase the batch item queue size:
- Queue enough batch items so there's a batch ready for each available CPU
- During full verification, verify 20 blocks concurrently

Run all verifier cryptography on blocking CPU-bound threads:
- Initialize the rayon thread pool with a configurable number of threads
- Spawn on a rayon thread pool inside `tokio::spawn_blocking()`
- Spawn multiple batches concurrently
- Store a list of concurrently running batches
- Clear pending batches once they finish
- Stop accepting new batch items once we're at the concurrent batch limit

Related cleanups:
- Simplify batch worker loop
- Improve tracing output
- Improve error handling

Related fixes:
- Run docker tests on PR series
 
## Review

<!--
Is this PR blocking any other work?
If you want a specific reviewer for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] CI passes

