### PR TITLE
fix(panic): remove panic in `close_and_flush_next` fn

### DIFF
--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -209,6 +209,9 @@ impl ClientRequestReceiver {
         // The request stream terminates, because the sender is closed,
         // and the channel has a limited capacity.
         // Task notifications are not required, because the sender is closed.
+        //
+        // Despite what its documentation says, we've seen futures::channel::mpsc::Receiver::try_next()
+        // return an error after the channel is closed.
         self.inner.try_next().ok()?.map(Into::into)
     }
 }

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -201,7 +201,6 @@ impl ClientRequestReceiver {
     /// Closing the channel ensures that:
     /// - the request stream terminates, and
     /// - task notifications are not required.
-    #[allow(clippy::unwrap_in_result)]
     pub fn close_and_flush_next(&mut self) -> Option<InProgressClientRequest> {
         self.inner.close();
 
@@ -210,10 +209,7 @@ impl ClientRequestReceiver {
         // The request stream terminates, because the sender is closed,
         // and the channel has a limited capacity.
         // Task notifications are not required, because the sender is closed.
-        self.inner
-            .try_next()
-            .expect("channel is closed")
-            .map(Into::into)
+        self.inner.try_next().ok()?.map(Into::into)
     }
 }
 


### PR DESCRIPTION
## Motivation

Remove a community reported panic. Close https://github.com/ZcashFoundation/zebra/issues/4781


## Solution

- Return `None` instead of panic in `close_and_flush_next()`
- Remove not needed anymore lint. 

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
