### PR TITLE
1. fix(state): when sending `headers` to peers, only deserialize the header data from disk

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -1,6 +1,6 @@
 //! Blocks and block-related structures (heights, headers, etc.)
 
-use std::{collections::HashMap, fmt, ops::Neg};
+use std::{collections::HashMap, fmt, ops::Neg, sync::Arc};
 
 use crate::{
     amount::NegativeAllowed,
@@ -46,9 +46,9 @@ pub use arbitrary::LedgerState;
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Serialize))]
 pub struct Block {
     /// The block header, containing block metadata.
-    pub header: Header,
+    pub header: Arc<Header>,
     /// The block transactions.
-    pub transactions: Vec<std::sync::Arc<Transaction>>,
+    pub transactions: Vec<Arc<Transaction>>,
 }
 
 impl fmt::Display for Block {
@@ -219,7 +219,7 @@ impl Block {
 
 impl<'a> From<&'a Block> for Hash {
     fn from(block: &'a Block) -> Hash {
-        block.header.into()
+        block.header.as_ref().into()
     }
 }
 

--- a/zebra-chain/src/block/hash.rs
+++ b/zebra-chain/src/block/hash.rs
@@ -1,4 +1,4 @@
-use std::{fmt, io};
+use std::{fmt, io, sync::Arc};
 
 use hex::{FromHex, ToHex};
 
@@ -102,6 +102,22 @@ impl From<Header> for Hash {
     #[allow(clippy::needless_borrow)]
     fn from(block_header: Header) -> Self {
         (&block_header).into()
+    }
+}
+
+impl From<&Arc<Header>> for Hash {
+    // The borrow is actually needed to use From<&Header>
+    #[allow(clippy::needless_borrow)]
+    fn from(block_header: &Arc<Header>) -> Self {
+        block_header.as_ref().into()
+    }
+}
+
+impl From<Arc<Header>> for Hash {
+    // The borrow is actually needed to use From<&Header>
+    #[allow(clippy::needless_borrow)]
+    fn from(block_header: Arc<Header>) -> Self {
+        block_header.as_ref().into()
     }
 }
 

--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -1,12 +1,12 @@
 //! The block header.
 
-use std::usize;
+use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
 use thiserror::Error;
 
 use crate::{
-    serialization::{CompactSizeMessage, TrustedPreallocate, MAX_PROTOCOL_MESSAGE_LEN},
+    serialization::{TrustedPreallocate, MAX_PROTOCOL_MESSAGE_LEN},
     work::{difficulty::CompactDifficulty, equihash::Solution},
 };
 
@@ -125,18 +125,14 @@ impl Header {
 }
 
 /// A header with a count of the number of transactions in its block.
-///
 /// This structure is used in the Bitcoin network protocol.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+///
+/// The transaction count field is always zero, so we don't store it in the struct.
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct CountedHeader {
     /// The header for a block
-    pub header: Header,
-
-    /// The number of transactions that come after the header
-    ///
-    /// TODO: should this always be zero? (#1924)
-    pub transaction_count: CompactSizeMessage,
+    pub header: Arc<Header>,
 }
 
 /// The serialized size of a Zcash block header.

--- a/zebra-chain/src/block/serialize.rs
+++ b/zebra-chain/src/block/serialize.rs
@@ -1,11 +1,14 @@
-use std::{borrow::Borrow, convert::TryInto, io};
+//! Serialization and deserialization for Zcash blocks.
+
+use std::{borrow::Borrow, io};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use chrono::{TimeZone, Utc};
 
 use crate::{
     serialization::{
-        ReadZcashExt, SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
+        CompactSizeMessage, ReadZcashExt, SerializationError, ZcashDeserialize,
+        ZcashDeserializeInto, ZcashSerialize,
     },
     work::{difficulty::CompactDifficulty, equihash},
 };
@@ -93,19 +96,30 @@ impl ZcashDeserialize for Header {
 }
 
 impl ZcashSerialize for CountedHeader {
+    #[allow(clippy::unwrap_in_result)]
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         self.header.zcash_serialize(&mut writer)?;
-        self.transaction_count.zcash_serialize(&mut writer)?;
+
+        // A header-only message has zero transactions in it.
+        let transaction_count =
+            CompactSizeMessage::try_from(0).expect("0 is below the message size limit");
+        transaction_count.zcash_serialize(&mut writer)?;
+
         Ok(())
     }
 }
 
 impl ZcashDeserialize for CountedHeader {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        Ok(CountedHeader {
+        let header = CountedHeader {
             header: (&mut reader).zcash_deserialize_into()?,
-            transaction_count: (&mut reader).zcash_deserialize_into()?,
-        })
+        };
+
+        // We ignore the number of transactions in a header-only message,
+        // it should always be zero.
+        let _transaction_count: CompactSizeMessage = (&mut reader).zcash_deserialize_into()?;
+
+        Ok(header)
     }
 }
 

--- a/zebra-chain/src/block/tests/generate.rs
+++ b/zebra-chain/src/block/tests/generate.rs
@@ -148,7 +148,7 @@ fn multi_transaction_block(oversized: bool) -> Block {
 
     // Add the transactions into a block
     let block = Block {
-        header: block_header,
+        header: block_header.into(),
         transactions,
     };
 
@@ -228,7 +228,7 @@ fn single_transaction_block_many_inputs(oversized: bool) -> Block {
     let transactions = vec![Arc::new(big_transaction)];
 
     let block = Block {
-        header: block_header,
+        header: block_header.into(),
         transactions,
     };
 
@@ -306,7 +306,7 @@ fn single_transaction_block_many_outputs(oversized: bool) -> Block {
     let transactions = vec![Arc::new(big_transaction)];
 
     let block = Block {
-        header: block_header,
+        header: block_header.into(),
         transactions,
     };
 

--- a/zebra-consensus/src/chain/tests.rs
+++ b/zebra-consensus/src/chain/tests.rs
@@ -9,7 +9,7 @@ use tower::{layer::Layer, timeout::TimeoutLayer, Service};
 use zebra_chain::{
     block::{self, Block},
     parameters::Network,
-    serialization::ZcashDeserialize,
+    serialization::{ZcashDeserialize, ZcashDeserializeInto},
 };
 use zebra_state as zs;
 use zebra_test::transcript::{ExpectedTranscriptError, Transcript};
@@ -36,7 +36,9 @@ const VERIFY_TIMEOUT_SECONDS: u64 = 10;
 /// The generated block should fail validation.
 pub fn block_no_transactions() -> Block {
     Block {
-        header: block::Header::zcash_deserialize(&zebra_test::vectors::DUMMY_HEADER[..]).unwrap(),
+        header: zebra_test::vectors::DUMMY_HEADER[..]
+            .zcash_deserialize_into()
+            .unwrap(),
         transactions: Vec::new(),
     }
 }

--- a/zebra-state/src/service/chain_tip/tests/prop.rs
+++ b/zebra-state/src/service/chain_tip/tests/prop.rs
@@ -1,3 +1,5 @@
+//! Randomised property tests for the Zebra chain tip.
+
 use std::{collections::HashSet, env, sync::Arc};
 
 use futures::FutureExt;
@@ -50,7 +52,9 @@ proptest! {
             // prepare the update
             if connection.is_grow() {
                 if let (Some(mut block), Some(last_block_hash)) = (update.block(), last_block_hash) {
-                    Arc::make_mut(&mut block).header.previous_block_hash = last_block_hash;
+                    let block_mut = Arc::make_mut(&mut block);
+                    Arc::make_mut(&mut block_mut.header).previous_block_hash = last_block_hash;
+
                     *update.block_mut() = Some(block);
                 }
             }

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -511,7 +511,7 @@ fn rejection_restores_internal_state_genesis() -> Result<()> {
         prop_assert_eq!(state.best_tip(), reject_state.best_tip());
         prop_assert!(state.eq_internal_state(&reject_state));
 
-        bad_block.header.previous_block_hash = valid_tip_hash;
+        Arc::make_mut(&mut bad_block.header).previous_block_hash = valid_tip_hash;
         let bad_block = Arc::new(bad_block.0).prepare();
         let reject_result = reject_state.commit_block(bad_block, &finalized_state);
 

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -2,7 +2,7 @@
 //!
 //! TODO: move these tests into tests::vectors and tests::prop modules.
 
-use std::{convert::TryInto, env, sync::Arc};
+use std::{env, sync::Arc};
 
 use tower::{buffer::Buffer, util::BoxService};
 
@@ -40,12 +40,7 @@ async fn test_populated_state_responds_correctly(
     let block_headers: Vec<CountedHeader> = blocks
         .iter()
         .map(|block| CountedHeader {
-            header: block.header,
-            transaction_count: block
-                .transactions
-                .len()
-                .try_into()
-                .expect("test block transaction counts are valid"),
+            header: block.header.clone(),
         })
         .collect();
 

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -1,4 +1,6 @@
-use std::{convert::TryFrom, mem, sync::Arc};
+//! Tests for the Zebra state service.
+
+use std::{mem, sync::Arc};
 
 use zebra_chain::{
     block::{self, Block},
@@ -42,7 +44,7 @@ impl FakeChainHelper for Arc<Block> {
         }
 
         child.transactions.push(tx);
-        child.header.previous_block_hash = parent_hash;
+        Arc::make_mut(&mut child.header).previous_block_hash = parent_hash;
 
         Arc::new(child)
     }
@@ -52,13 +54,13 @@ impl FakeChainHelper for Arc<Block> {
         let expanded = work_to_expanded(work);
 
         let block = Arc::make_mut(&mut self);
-        block.header.difficulty_threshold = expanded.into();
+        Arc::make_mut(&mut block.header).difficulty_threshold = expanded.into();
         self
     }
 
     fn set_block_commitment(mut self, block_commitment: [u8; 32]) -> Arc<Block> {
         let block = Arc::make_mut(&mut self);
-        block.header.commitment_bytes = block_commitment;
+        Arc::make_mut(&mut block.header).commitment_bytes = block_commitment;
         self
     }
 }


### PR DESCRIPTION
## Motivation

When Zebra sends block headers to peers, it fetches the entire block from disk, then throws away the transactions.

This is slow for two reasons:
- fetching extra data costs disk reads
- deserializing transaction data cost CPU time

If we stop deserializing the transactions, it helps with bug #4788, because we avoid some block fetches entirely.

Close #1924, since we were removing transaction counts anyway.

## Solution

- When sending `headers` to peers, only deserialize the header data from disk
    - Call the new `block_header()` method from the existing `block()` method
- Wrap the block header in an `Arc`, so a headers response can be sent to the network without copying 200 kB of data
    - Implement `block::Hash` from `Arc<Header>`
    - Update a lot of tests to use `Arc<Header>`
- Remove incorrect counts from `CountedHeader`

## Review

Anyone can review this PR, it's urgent because it improves sync speed.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

