### PR TITLE
perf(commitments): generate sapling point outside the method

### DIFF
--- a/zebra-chain/src/orchard/commitment.rs
+++ b/zebra-chain/src/orchard/commitment.rs
@@ -301,15 +301,14 @@ impl ValueCommitment {
     /// <https://zips.z.cash/protocol/nu5.pdf#concretehomomorphiccommit>
     #[allow(non_snake_case)]
     pub fn new(rcv: pallas::Scalar, value: Amount) -> Self {
-        lazy_static! {
-            static ref V: pallas::Point = pallas_group_hash(b"z.cash:Orchard-cv", b"v");
-            static ref R: pallas::Point = pallas_group_hash(b"z.cash:Orchard-cv", b"r");
-        }
-
         let v = pallas::Scalar::from(value);
-
         Self::from(*V * v + *R * rcv)
     }
+}
+
+lazy_static! {
+    static ref V: pallas::Point = pallas_group_hash(b"z.cash:Orchard-cv", b"v");
+    static ref R: pallas::Point = pallas_group_hash(b"z.cash:Orchard-cv", b"r");
 }
 
 #[cfg(test)]

--- a/zebra-chain/src/sapling/commitment.rs
+++ b/zebra-chain/src/sapling/commitment.rs
@@ -12,6 +12,7 @@ use std::{
 
 use bitvec::prelude::*;
 use jubjub::ExtendedPoint;
+use lazy_static::lazy_static;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::{
@@ -279,14 +280,13 @@ impl ValueCommitment {
     #[allow(non_snake_case)]
     pub fn new(rcv: jubjub::Fr, value: Amount) -> Self {
         let v = jubjub::Fr::from(value);
-
-        // TODO: These generator points can be generated once somewhere else to
-        // avoid having to recompute them on every new commitment.
-        let V = find_group_hash(*b"Zcash_cv", b"v");
-        let R = find_group_hash(*b"Zcash_cv", b"r");
-
-        Self::from(V * v + R * rcv)
+        Self::from(*V * v + *R * rcv)
     }
+}
+
+lazy_static! {
+    static ref V: ExtendedPoint = find_group_hash(*b"Zcash_cv", b"v");
+    static ref R: ExtendedPoint = find_group_hash(*b"Zcash_cv", b"r");
 }
 
 /// A Homomorphic Pedersen commitment to the value of a note, used in Spend and


### PR DESCRIPTION
## Motivation

Fix https://github.com/ZcashFoundation/zebra/issues/4783

## Solution

Generate the sapling points once as a global for sapling (https://github.com/ZcashFoundation/zebra/commit/f79c438ca4096d08ce27d720ee464631db934597).

Orchard is already doing it buy the lazy_static is inside the method. Maybe this is ok but i changed it anyway for consistency (https://github.com/ZcashFoundation/zebra/commit/4cbe1fcd37f3d6035890c548ec47bfb6f946dace).

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
