### PR TITLE
try to do deserialization of transaction in a rayon thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6408,6 +6408,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
+ "rayon",
  "regex",
  "serde",
  "static_assertions",

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -24,6 +24,7 @@ lazy_static = "1.4.0"
 ordered-map = "0.4.2"
 pin-project = "1.0.10"
 rand = { version = "0.8.5", package = "rand" }
+rayon = "1.5.3"
 regex = "1.5.6"
 serde = { version = "1.0.137", features = ["serde_derive"] }
 thiserror = "1.0.31"

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -572,7 +572,6 @@ impl Codec {
 
     fn read_block<R: Read + std::marker::Send>(&self, reader: R) -> Result<Message, Error> {
         let result = Self::deserialize_block_spawning(reader);
-
         Ok(Message::Block(result?.into()))
     }
 
@@ -629,7 +628,6 @@ impl Codec {
 
     fn read_tx<R: Read + std::marker::Send>(&self, reader: R) -> Result<Message, Error> {
         let result = Self::deserialize_transaction_spawning(reader);
-
         Ok(Message::Tx(result?.into()))
     }
 
@@ -679,14 +677,14 @@ impl Codec {
         Ok(Message::FilterClear)
     }
 
-    /// TBA
+    /// Given the reader, deserialize the transaction in the rayon thread pool.
     #[allow(clippy::unwrap_in_result)]
     fn deserialize_transaction_spawning<R: Read + std::marker::Send>(
         reader: R,
     ) -> Result<Transaction, Error> {
         let mut result = None;
 
-        // Correctness: TBA
+        // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         //
         // Since we use `block_in_place()`, other futures running on the connection task will be blocked:
         // https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html
@@ -703,12 +701,12 @@ impl Codec {
         result.expect("scope has already finished")
     }
 
-    /// TBA
+    /// Given the reader, deserialize the block in the rayon thread pool.
     #[allow(clippy::unwrap_in_result)]
     fn deserialize_block_spawning<R: Read + std::marker::Send>(reader: R) -> Result<Block, Error> {
         let mut result = None;
 
-        // Correctness: TBA
+        // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         //
         // Since we use `block_in_place()`, other futures running on the connection task will be blocked:
         // https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -969,7 +969,8 @@ mod tests {
     fn max_msg_size_round_trip() {
         use zebra_chain::serialization::ZcashDeserializeInto;
 
-        let rt = zebra_test::init_async();
+        //let rt = zebra_test::init_async();
+        zebra_test::init();
 
         // make tests with a Tx message
         let tx: Transaction = zebra_test::vectors::DUMMY_TX1
@@ -983,7 +984,7 @@ mod tests {
         let size = 85;
 
         // reducing the max size to body size - 1
-        rt.block_on(async {
+        zebra_test::MULTI_THREADED_RUNTIME.block_on(async {
             let mut bytes = Vec::new();
             {
                 let mut fw = FramedWrite::new(
@@ -997,7 +998,7 @@ mod tests {
         });
 
         // send again with the msg body size as max size
-        let msg_bytes = rt.block_on(async {
+        let msg_bytes = zebra_test::MULTI_THREADED_RUNTIME.block_on(async {
             let mut bytes = Vec::new();
             {
                 let mut fw = FramedWrite::new(
@@ -1012,7 +1013,7 @@ mod tests {
         });
 
         // receive with a reduced max size
-        rt.block_on(async {
+        zebra_test::MULTI_THREADED_RUNTIME.block_on(async {
             let mut fr = FramedRead::new(
                 Cursor::new(&msg_bytes),
                 Codec::builder().with_max_body_len(size - 1).finish(),
@@ -1024,7 +1025,7 @@ mod tests {
         });
 
         // receive again with the tx size as max size
-        rt.block_on(async {
+        zebra_test::MULTI_THREADED_RUNTIME.block_on(async {
             let mut fr = FramedRead::new(
                 Cursor::new(&msg_bytes),
                 Codec::builder().with_max_body_len(size).finish(),

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -336,7 +336,7 @@ async fn inbound_tx_empty_state_notfound() -> Result<(), crate::BoxError> {
 ///
 /// Uses a Zebra network stack's peer set to query an isolated Zebra TCP connection,
 /// with an unrelated transaction test responder.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn outbound_tx_unrelated_response_notfound() -> Result<(), crate::BoxError> {
     // We respond with an unrelated transaction, so the peer gives up on the request.
     let unrelated_response: Transaction =
@@ -486,7 +486,7 @@ async fn outbound_tx_unrelated_response_notfound() -> Result<(), crate::BoxError
 /// - returns a `NotFoundRegistry` error for repeated requests to a non-responsive peer.
 ///
 /// The requests are coming from the full stack to the isolated peer.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn outbound_tx_partial_response_notfound() -> Result<(), crate::BoxError> {
     // We repeatedly respond with the same transaction, so the peer gives up on the second response.
     let repeated_tx: Transaction = zebra_test::vectors::DUMMY_TX1.zcash_deserialize_into()?;


### PR DESCRIPTION
## Motivation

We want to add the deserialization of transactions and blocks in the zebra-network crate into the rayon pool. Resolves https://github.com/ZcashFoundation/zebra/issues/4787

## Solution

Implement deserialize transactions and blocks in a rayon thread. 

## Review

