### PR TITLE
fix(consensus): Increase the number of blocks checked for legacy transactions

### DIFF
--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -22,7 +22,7 @@ pub const DATABASE_FORMAT_VERSION: u32 = 25;
 
 /// The maximum number of blocks to check for NU5 transactions,
 /// before we assume we are on a pre-NU5 legacy chain.
-pub const MAX_LEGACY_CHAIN_BLOCKS: usize = 100;
+pub const MAX_LEGACY_CHAIN_BLOCKS: usize = 1000;
 
 use lazy_static::lazy_static;
 use regex::Regex;

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -20,7 +20,8 @@ use zebra_test::{prelude::*, transcript::Transcript};
 
 use crate::{
     arbitrary::Prepare,
-    constants, init_test,
+    constants::{self, MAX_LEGACY_CHAIN_BLOCKS},
+    init_test,
     service::{arbitrary::populated_state, chain_tip::TipAction, StateService},
     tests::setup::{partial_nu5_chain_strategy, transaction_v4_from_coinbase},
     BoxError, Config, FinalizedBlock, PreparedBlock, Request, Response,
@@ -326,7 +327,7 @@ proptest! {
         prop_assert_eq!(
             response,
             Err(format!(
-                "could not find any transactions in recent blocks: checked 1000 blocks back from {tip_height:?}",
+                "could not find any transactions in recent blocks: checked {MAX_LEGACY_CHAIN_BLOCKS} blocks back from {tip_height:?}",
             ))
         );
     }


### PR DESCRIPTION
## Motivation

In NU5 we added a check for previous Zebra versions that had followed an incorrect chain.

But we only check 100 blocks for legacy transactions. Sometimes testnet has no transactions for 100 blocks (2 hours), and fails the check.

## Solution

- Increase the number of blocks checked to 1000
- Improve logging

## Review

Anyone can review this PR.
This bug needs to be fixed eventually, but at the moment I've only seen it happen rarely, and only on testnet.

### Reviewer Checklist

  - [ ] Test pass

