### PR TITLE
fix(build): Remove duplicate `rayon` dependency from zebra-chain

### DIFF
--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -82,7 +82,6 @@ rand_chacha = { version = "0.3.1", optional = true }
 tokio = { version = "1.20.0", features = ["tracing"], optional = true }
 
 zebra-test = { path = "../zebra-test/", optional = true }
-rayon = "1.5.3"
 
 [dev-dependencies]
 


### PR DESCRIPTION
## Motivation

PR #4805 got merged without any build checks, causing a duplicate `rayon` dependency in `zebra-chain/Cargo.toml` on the `main` branch.
This breaks all the builds.

## Solution

Remove the duplicate dependency.

## Review

This is a critical build fix.

### Reviewer Checklist

  - [ ] CI passes, except for the lightwalletd sync test

