### PR TITLE
Dedup `rayon` from `zebra-chain/Cargo.toml`

### DIFF
--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -82,7 +82,6 @@ rand_chacha = { version = "0.3.1", optional = true }
 tokio = { version = "1.20.0", features = ["tracing"], optional = true }
 
 zebra-test = { path = "../zebra-test/", optional = true }
-rayon = "1.5.3"
 
 [dev-dependencies]
 


### PR DESCRIPTION
-------

## Motivation

We have accidentally added `rayon = "1.5.3"` to `zebra-chain/Cargo.toml` twice.

## Solution

This PR removes the duplicate entry `rayon = "1.5.3"` from `zebra-chain/Cargo.toml`.

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] `cargo fmt` passes