### PR TITLE
2. add(log): Log when state requests take a long time

### DIFF
--- a/.github/workflows/continous-integration-docker.patch.yml
+++ b/.github/workflows/continous-integration-docker.patch.yml
@@ -63,6 +63,12 @@ jobs:
     steps:
       - run: 'echo "No build required"'
 
+  test-update-sync:
+    name: Zebra tip update / Run update-to-tip test
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
   lightwalletd-rpc-test:
     name: Zebra tip JSON-RPC / Run fully-synced-rpc test
     runs-on: ubuntu-latest

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -309,6 +309,33 @@ jobs:
       disk_suffix: tip
       height_grep_text: 'current_height.*=.*Height'
 
+  # Test that Zebra can sync to the chain tip, using a cached Zebra tip state,
+  # without launching `lightwalletd`.
+  #
+  # Runs:
+  # - after every PR is merged to `main`
+  # - on every PR update
+  #
+  # If the state version has changed, waits for the new cached state to be created.
+  # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
+  test-update-sync:
+    name: Zebra tip update
+    needs: test-full-sync
+    uses: ./.github/workflows/deploy-gcp-tests.yml
+    if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
+    with:
+      app_name: zebrad
+      test_id: update-to-tip
+      test_description: Test syncing to tip with a Zebra tip state
+      test_variables: '-e TEST_UPDATE_SYNC=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache'
+      needs_zebra_state: true
+      # TODO: do we want to update the disk on every PR, to increase CI speed?
+      saves_to_disk: false
+      disk_suffix: tip
+      root_state_path: '/var/cache'
+      # TODO: do we also want to test the `zebrad` part of the `lwd-cache`? (But not update it.)
+      zebra_state_dir: 'zebrad-cache'
+
   # Test that Zebra can answer a synthetic RPC call, using a cached Zebra tip state
   #
   # Runs:
@@ -410,6 +437,7 @@ jobs:
       test_variables: '-e TEST_LWD_UPDATE_SYNC=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache -e LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache'
       needs_zebra_state: true
       needs_lwd_state: true
+      # TODO: do we want to update the disk on every PR, to increase CI speed?
       saves_to_disk: false
       disk_prefix: lwd-cache
       disk_suffix: tip

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -38,6 +38,12 @@ case "$1" in
             cargo test --locked --release --features "test_sync_to_mandatory_checkpoint_${NETWORK,,},lightwalletd-grpc-tests" --package zebrad --test acceptance -- --nocapture --include-ignored "sync_to_mandatory_checkpoint_${NETWORK,,}"
             # TODO: replace with $ZEBRA_CACHED_STATE_DIR in Rust and workflows
             ls -lh "/zebrad-cache"/*/* || (echo "No /zebrad-cache/*/*"; ls -lhR "/zebrad-cache" | head -50 || echo "No /zebrad-cache directory")
+        elif [[ "$TEST_UPDATE_SYNC" -eq "1" ]]; then
+            # Run a Zebra sync starting at the cached tip, and syncing to the latest tip.
+            #
+            # List directory used by test
+            ls -lh "$ZEBRA_CACHED_STATE_DIR"/*/* || (echo "No $ZEBRA_CACHED_STATE_DIR/*/*"; ls -lhR  "$ZEBRA_CACHED_STATE_DIR" | head -50 || echo "No $ZEBRA_CACHED_STATE_DIR directory")
+            cargo test --locked --release --features lightwalletd-grpc-tests --package zebrad --test acceptance -- --nocapture --include-ignored zebrad_update_sync
         elif [[ "$TEST_CHECKPOINT_SYNC" -eq "1" ]]; then
             # Run a Zebra sync starting at the cached mandatory checkpoint, and syncing past it.
             #

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -56,6 +56,7 @@ humantime = "2.1.0"
 displaydoc = "0.2.3"
 static_assertions = "1.1.0"
 thiserror = "1.0.31"
+tracing = "0.1.31"
 
 # Serialization
 hex = { version = "0.4.3", features = ["serde"] }

--- a/zebra-chain/src/diagnostic.rs
+++ b/zebra-chain/src/diagnostic.rs
@@ -4,7 +4,7 @@
 
 use std::time::{Duration, Instant};
 
-use crate::fmt::humantime_milliseconds;
+use crate::fmt::duration_short;
 
 /// The default minimum info-level message time.
 pub const DEFAULT_MIN_INFO_TIME: Duration = Duration::from_secs(5);
@@ -78,7 +78,7 @@ impl CodeTimer {
         self.has_finished = true;
 
         let execution = self.start.elapsed();
-        let execution_time = humantime_milliseconds(execution);
+        let execution_time = duration_short(execution);
 
         let module_path = module_path.into();
         let line = line.into();

--- a/zebra-chain/src/diagnostic.rs
+++ b/zebra-chain/src/diagnostic.rs
@@ -1,0 +1,77 @@
+//! Tracing the execution time of functions.
+//!
+//! TODO: also trace polling time for futures, using a `Future` wrapper
+
+use std::time::{Duration, Instant};
+
+use crate::fmt::humantime_milliseconds;
+
+/// The default minimum info-level message time.
+pub const DEFAULT_MIN_INFO_TIME: Duration = Duration::from_secs(5);
+
+/// The default minimum warning message time.
+pub const DEFAULT_MIN_WARN_TIME: Duration = Duration::from_secs(20);
+
+/// A guard that logs code execution time when dropped.
+#[derive(Debug)]
+pub struct CodeTimer {
+    /// The time that the code started executing.
+    start: Instant,
+
+    /// The minimum duration for info-level messages.
+    min_info_time: Duration,
+
+    /// The minimum duration for warning messages.
+    min_warn_time: Duration,
+}
+
+impl CodeTimer {
+    /// Start timing the execution of a function, method, or other code region.
+    ///
+    /// Returns a guard that finishes timing the code when dropped,
+    /// or when [`CodeTimer::finish()`] is called.
+    #[track_caller]
+    pub fn start() -> Self {
+        trace!("starting code timer",);
+
+        Self {
+            start: Instant::now(),
+            min_info_time: DEFAULT_MIN_INFO_TIME,
+            min_warn_time: DEFAULT_MIN_WARN_TIME,
+        }
+    }
+
+    /// Finish timing the execution of a function, method, or other code region.
+    #[track_caller]
+    pub fn finish(self) {
+        std::mem::drop(self);
+    }
+}
+
+impl Drop for CodeTimer {
+    #[track_caller]
+    fn drop(&mut self) {
+        let execution = self.start.elapsed();
+        let execution_time = humantime_milliseconds(execution);
+
+        if execution >= self.min_warn_time {
+            warn!(
+                ?execution_time,
+                start_time = ?self.start,
+                "code took a long time to execute",
+            );
+        } else if execution >= self.min_info_time {
+            info!(
+                ?execution_time,
+                start_time = ?self.start,
+                "code took longer than expected to execute",
+            );
+        } else {
+            trace!(
+                ?execution_time,
+                start_time = ?self.start,
+                "finishing code timer",
+            );
+        }
+    }
+}

--- a/zebra-chain/src/fmt.rs
+++ b/zebra-chain/src/fmt.rs
@@ -8,7 +8,8 @@ use proptest::prelude::*;
 use proptest_derive::Arbitrary;
 
 pub mod time;
-pub use time::{humantime_milliseconds, humantime_seconds};
+
+pub use time::{duration_short, humantime_milliseconds, humantime_seconds};
 
 /// Wrapper to override `Debug`, redirecting it to only output the type's name.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/zebra-chain/src/fmt/time.rs
+++ b/zebra-chain/src/fmt/time.rs
@@ -2,6 +2,8 @@
 
 use std::time::Duration;
 
+// TODO: rename these functions to duration_*
+
 /// Returns a human-friendly formatted string for the whole number of seconds in `duration`.
 pub fn humantime_seconds(duration: impl Into<Duration>) -> String {
     let duration = duration.into();

--- a/zebra-chain/src/fmt/time.rs
+++ b/zebra-chain/src/fmt/time.rs
@@ -2,6 +2,20 @@
 
 use std::time::Duration;
 
+/// The minimum amount of time displayed with only seconds (no milliseconds).
+pub const MIN_SECONDS_ONLY_TIME: Duration = Duration::from_secs(5);
+
+/// Returns a human-friendly formatted string for the whole number of seconds in `duration`.
+pub fn duration_short(duration: impl Into<Duration>) -> String {
+    let duration = duration.into();
+
+    if duration >= MIN_SECONDS_ONLY_TIME {
+        humantime_seconds(duration)
+    } else {
+        humantime_milliseconds(duration)
+    }
+}
+
 // TODO: rename these functions to duration_*
 
 /// Returns a human-friendly formatted string for the whole number of seconds in `duration`.

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -10,14 +10,18 @@
 #![recursion_limit = "256"]
 
 #[macro_use]
+extern crate bitflags;
+
+#[macro_use]
 extern crate serde;
 
 #[macro_use]
-extern crate bitflags;
+extern crate tracing;
 
 pub mod amount;
 pub mod block;
 pub mod chain_tip;
+pub mod diagnostic;
 pub mod fmt;
 pub mod history_tree;
 pub mod orchard;

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -1137,7 +1137,7 @@ async fn send_periodic_heartbeats_with_shutdown_handle(
     // slow rate, and shutdown is a oneshot. If both futures
     // are ready, we want the shutdown to take priority over
     // sending a useless heartbeat.
-    let result = match future::select(shutdown_rx, heartbeat_run_loop).await {
+    match future::select(shutdown_rx, heartbeat_run_loop).await {
         Either::Left((Ok(CancelHeartbeatTask), _unused_run_loop)) => {
             tracing::trace!("shutting down because Client requested shut down");
             handle_heartbeat_shutdown(
@@ -1164,9 +1164,7 @@ async fn send_periodic_heartbeats_with_shutdown_handle(
 
             result
         }
-    };
-
-    result
+    }
 }
 
 /// Send periodical heartbeats to `server_tx`, and update the peer status through

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1036,6 +1036,7 @@ impl Service<Request> for StateService {
                 let timer = CodeTimer::start();
 
                 // TODO: move this work into the future, like Block and Transaction?
+                //       return heights instead, to improve lookup performance?
                 let res = self.find_best_chain_hashes(known_blocks, stop, count);
 
                 // And prepare data for concurrent execution

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1458,10 +1458,11 @@ fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> 
                     "([Aa]dding block to cache 1[7-9][0-9]{5})|([Ww]aiting for block)",
                 );
                 if log_result.is_err() {
+                    // This error takes up about 100 lines, and looks like a panic message
                     tracing::warn!(
-                    ?log_result,
-                    "ignoring a lightwalletd test failure, to work around a lightwalletd hang bug",
-                );
+                        multi_line_error = ?log_result,
+                        "ignoring a lightwalletd test failure, to work around a lightwalletd hang bug",
+                    );
                 }
             }
         }

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -57,6 +57,14 @@ pub const LIGHTWALLETD_UPDATE_TIP_DELAY: Duration = LIGHTWALLETD_FULL_SYNC_TIP_D
 /// and Zebra needs time to activate its mempool.
 pub const LIGHTWALLETD_FULL_SYNC_TIP_DELAY: Duration = Duration::from_secs(90 * 60);
 
+/// The amount of extra time we wait for Zebra to sync to the tip,
+/// after we ignore a lightwalletd failure.
+///
+/// Zebra logs a status entry every minute, so there should be at least 4 in this interval.
+///
+/// TODO: remove this extra time when lightwalletd hangs are fixed
+pub const ZEBRAD_EXTRA_DELAY_FOR_LIGHTWALLETD_WORKAROUND: Duration = Duration::from_secs(5 * 60);
+
 /// Extension trait for methods on `tempfile::TempDir` for using it as a test
 /// directory for `zebrad`.
 pub trait ZebradTestDirExt

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -45,7 +45,11 @@ pub const BETWEEN_NODES_DELAY: Duration = Duration::from_secs(2);
 /// The amount of time we wait for lightwalletd to update to the tip.
 ///
 /// The cached tip can be a few days old, and Zebra needs time to activate its mempool.
-pub const LIGHTWALLETD_UPDATE_TIP_DELAY: Duration = Duration::from_secs(20 * 60);
+///
+/// Currently, `zebrad` syncs are slower than `lightwalletd` syncs, so we re-use its timeout.
+///
+/// TODO: reduce to 20 minutes when `zebrad` sync performance improves
+pub const LIGHTWALLETD_UPDATE_TIP_DELAY: Duration = LIGHTWALLETD_FULL_SYNC_TIP_DELAY;
 
 /// The amount of time we wait for lightwalletd to do a full sync to the tip.
 ///

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -67,7 +67,7 @@ pub fn zebra_skip_lightwalletd_tests() -> bool {
     // TODO: check if the lightwalletd binary is in the PATH?
     //       (this doesn't seem to be implemented in the standard library)
     //
-    // See is_command_available in zebra-test/tests/command.rs for one way to do this.
+    // See is_command_available() in zebra-test/src/tests/command.rs for one way to do this.
 
     if env::var_os(ZEBRA_TEST_LIGHTWALLETD).is_none() {
         // This message is captured by the test runner, use
@@ -236,6 +236,14 @@ pub enum LightwalletdTestType {
     ///
     /// This test requires a cached Zebra and lightwalletd state.
     UpdateCachedState,
+
+    /// Launch `zebrad` and sync it to the tip, but don't launch `lightwalletd`.
+    ///
+    /// If this test fails, the failure is in `zebrad` without RPCs or `lightwalletd`.
+    /// If it succeeds, but the RPC tests fail, the problem is caused by RPCs or `lightwalletd`.
+    ///
+    /// This test requires a cached Zebra state.
+    UpdateZebraCachedStateNoRpc,
 }
 
 impl LightwalletdTestType {
@@ -243,26 +251,36 @@ impl LightwalletdTestType {
     pub fn needs_zebra_cached_state(&self) -> bool {
         match self {
             LaunchWithEmptyState => false,
-            FullSyncFromGenesis { .. } | UpdateCachedState => true,
+            FullSyncFromGenesis { .. } | UpdateCachedState | UpdateZebraCachedStateNoRpc => true,
         }
     }
 
-    /// Does this test need a lightwalletd cached state?
+    /// Does this test launch `lightwalletd`?
+    pub fn launches_lightwalletd(&self) -> bool {
+        match self {
+            UpdateZebraCachedStateNoRpc => false,
+            LaunchWithEmptyState | FullSyncFromGenesis { .. } | UpdateCachedState => true,
+        }
+    }
+
+    /// Does this test need a `lightwalletd` cached state?
     pub fn needs_lightwalletd_cached_state(&self) -> bool {
         match self {
-            LaunchWithEmptyState | FullSyncFromGenesis { .. } => false,
+            LaunchWithEmptyState | FullSyncFromGenesis { .. } | UpdateZebraCachedStateNoRpc => {
+                false
+            }
             UpdateCachedState => true,
         }
     }
 
-    /// Does this test allow a lightwalletd cached state, even if it is not required?
+    /// Does this test allow a `lightwalletd` cached state, even if it is not required?
     pub fn allow_lightwalletd_cached_state(&self) -> bool {
         match self {
             LaunchWithEmptyState => false,
             FullSyncFromGenesis {
                 allow_lightwalletd_cached_state,
             } => *allow_lightwalletd_cached_state,
-            UpdateCachedState => true,
+            UpdateCachedState | UpdateZebraCachedStateNoRpc => true,
         }
     }
 
@@ -287,13 +305,19 @@ impl LightwalletdTestType {
     /// Returns `None` if the test should be skipped,
     /// and `Some(Err(_))` if the config could not be created.
     pub fn zebrad_config(&self, test_name: String) -> Option<Result<ZebradConfig>> {
+        let config = if self.launches_lightwalletd() {
+            random_known_rpc_port_config()
+        } else {
+            default_test_config()
+        };
+
         if !self.needs_zebra_cached_state() {
-            return Some(random_known_rpc_port_config());
+            return Some(config);
         }
 
         let zebra_state_path = self.zebrad_state_path(test_name)?;
 
-        let mut config = match random_known_rpc_port_config() {
+        let mut config = match config {
             Ok(config) => config,
             Err(error) => return Some(Err(error)),
         };
@@ -307,8 +331,17 @@ impl LightwalletdTestType {
         Some(Ok(config))
     }
 
-    /// Returns the lightwalletd state path for this test, if set.
+    /// Returns the `lightwalletd` state path for this test, if set, and if allowed for this test.
     pub fn lightwalletd_state_path(&self, test_name: String) -> Option<PathBuf> {
+        if !self.launches_lightwalletd() {
+            tracing::info!(
+                "running {test_name:?} {self:?} lightwalletd test, \
+                 ignoring any cached state in the {LIGHTWALLETD_DATA_DIR:?} environment variable",
+            );
+
+            return None;
+        }
+
         match env::var_os(LIGHTWALLETD_DATA_DIR) {
             Some(path) => Some(path.into()),
             None => {
@@ -331,22 +364,23 @@ impl LightwalletdTestType {
 
     /// Returns the `zebrad` timeout for this test type.
     pub fn zebrad_timeout(&self) -> Duration {
-        // We use the same timeouts as lightwalletd,
-        // because the tests swap between checking zebrad and lightwalletd.
         match self {
             LaunchWithEmptyState => LIGHTWALLETD_DELAY,
             FullSyncFromGenesis { .. } => LIGHTWALLETD_FULL_SYNC_TIP_DELAY,
-            UpdateCachedState => LIGHTWALLETD_UPDATE_TIP_DELAY,
+            UpdateCachedState | UpdateZebraCachedStateNoRpc => LIGHTWALLETD_UPDATE_TIP_DELAY,
         }
     }
 
     /// Returns the `lightwalletd` timeout for this test type.
+    #[track_caller]
     pub fn lightwalletd_timeout(&self) -> Duration {
-        match self {
-            LaunchWithEmptyState => LIGHTWALLETD_DELAY,
-            FullSyncFromGenesis { .. } => LIGHTWALLETD_FULL_SYNC_TIP_DELAY,
-            UpdateCachedState => LIGHTWALLETD_UPDATE_TIP_DELAY,
+        if !self.launches_lightwalletd() {
+            panic!("lightwalletd must not be launched in the {self:?} test");
         }
+
+        // We use the same timeouts for zebrad and lightwalletd,
+        // because the tests swap between checking zebrad and lightwalletd.
+        self.zebrad_timeout()
     }
 
     /// Returns Zebra log regexes that indicate the tests have failed,
@@ -375,7 +409,12 @@ impl LightwalletdTestType {
 
     /// Returns `lightwalletd` log regexes that indicate the tests have failed,
     /// and regexes of any failures that should be ignored.
+    #[track_caller]
     pub fn lightwalletd_failure_messages(&self) -> (Vec<String>, Vec<String>) {
+        if !self.launches_lightwalletd() {
+            panic!("lightwalletd must not be launched in the {self:?} test");
+        }
+
         let mut lightwalletd_failure_messages: Vec<String> = LIGHTWALLETD_FAILURE_MESSAGES
             .iter()
             .chain(PROCESS_FAILURE_MESSAGES)


### PR DESCRIPTION
## Motivation

To work out why Zebra is slow, we need to know which state queries are slow.

Diagnostics for #4747.

Depends-On: #4813 

## Solution

- Time state init and each state request, log when it takes too long
  - Add a CodeTimer diagnostic struct for long-running code

Related Fixes:
- Instrument state futures and functions with tracing spans

## Review

I think we'll want this PR in `main` soon, so we can fix the remaining state bugs.

### Reviewer Checklist

  - [ ] Existing tests pass
