### PR TITLE
2. fix(state): Make FindHeaders and FindHashes run concurrently with state updates

### DIFF
--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -73,6 +73,14 @@ impl ZebraDb {
         self.db.zs_get(&hash_by_height, &height)
     }
 
+    /// Returns `true` if `hash` is present in the finalized state.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn contains_hash(&self, hash: block::Hash) -> bool {
+        let height_by_hash = self.db.cf_handle("height_by_hash").unwrap();
+
+        self.db.zs_contains(&height_by_hash, &hash)
+    }
+
     /// Returns the height of the given block if it exists.
     #[allow(clippy::unwrap_in_result)]
     pub fn height(&self, hash: block::Hash) -> Option<block::Height> {

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -457,6 +457,18 @@ impl Chain {
             .get(tx_loc.index.as_usize())
     }
 
+    /// Returns the [`block::Hash`] for `height`, if it exists in this chain.
+    pub fn hash_by_height(&self, height: Height) -> Option<block::Hash> {
+        let hash = self.blocks.get(&height)?.hash;
+
+        Some(hash)
+    }
+
+    /// Returns the [`Height`] for `hash`, if it exists in this chain.
+    pub fn height_by_hash(&self, hash: block::Hash) -> Option<Height> {
+        self.height_by_hash.get(&hash).cloned()
+    }
+
     /// Returns the non-finalized tip block hash and height.
     #[allow(dead_code)]
     pub fn non_finalized_tip(&self) -> (block::Hash, block::Height) {

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -11,7 +11,7 @@
 //! [5]: super::Chain
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
-    ops::RangeInclusive,
+    ops::{RangeBounds, RangeInclusive},
     sync::Arc,
 };
 
@@ -49,6 +49,8 @@ const FINALIZED_ADDRESS_INDEX_RETRIES: usize = 3;
 /// The genesis coinbase transactions are ignored by a consensus rule,
 /// so they are not included in any address indexes.
 pub const ADDRESS_HEIGHTS_FULL_RANGE: RangeInclusive<Height> = Height(1)..=Height::MAX;
+
+// Blocks and Transactions
 
 /// Returns the [`Block`] with [`block::Hash`](zebra_chain::block::Hash) or
 /// [`Height`], if it exists in the non-finalized `chain` or finalized `db`.
@@ -108,7 +110,7 @@ pub(crate) fn transaction<C>(
     chain: Option<C>,
     db: &ZebraDb,
     hash: transaction::Hash,
-) -> Option<(Arc<Transaction>, block::Height)>
+) -> Option<(Arc<Transaction>, Height)>
 where
     C: AsRef<Chain>,
 {
@@ -130,6 +132,344 @@ where
         })
         .or_else(|| db.transaction(hash))
 }
+
+// FindBlockHeaders / FindBlockHashes
+
+/// Returns the tip of `chain`.
+/// If there is no chain, returns the tip of `db`.
+pub(crate) fn tip_height<C>(chain: Option<C>, db: &ZebraDb) -> Option<Height>
+where
+    C: AsRef<Chain>,
+{
+    chain
+        .map(|chain| chain.as_ref().non_finalized_tip_height())
+        .or_else(|| db.finalized_tip_height())
+}
+
+/// Return the height for the block at `hash`, if `hash` is in the chain.
+pub fn height_by_hash<C>(chain: Option<C>, db: &ZebraDb, hash: block::Hash) -> Option<Height>
+where
+    C: AsRef<Chain>,
+{
+    chain
+        .and_then(|chain| chain.as_ref().height_by_hash(hash))
+        .or_else(|| db.height(hash))
+}
+
+/// Return the hash for the block at `height`, if `height` is in the chain.
+pub fn hash_by_height<C>(chain: Option<C>, db: &ZebraDb, height: Height) -> Option<block::Hash>
+where
+    C: AsRef<Chain>,
+{
+    chain
+        .and_then(|chain| chain.as_ref().hash_by_height(height))
+        .or_else(|| db.hash(height))
+}
+
+/// Return true if `hash` is in the chain.
+pub fn chain_contains_hash<C>(chain: Option<C>, db: &ZebraDb, hash: block::Hash) -> bool
+where
+    C: AsRef<Chain>,
+{
+    chain
+        .map(|chain| chain.as_ref().height_by_hash.contains_key(&hash))
+        .unwrap_or(false)
+        || db.contains_hash(hash)
+}
+
+/// Find the first hash that's in the peer's `known_blocks` and the chain.
+///
+/// Returns `None` if:
+///   * there is no matching hash in the chain, or
+///   * the state is empty.
+fn find_chain_intersection<C>(
+    chain: Option<C>,
+    db: &ZebraDb,
+    known_blocks: Vec<block::Hash>,
+) -> Option<block::Hash>
+where
+    C: AsRef<Chain>,
+{
+    // We can get a block locator request before we have downloaded the genesis block
+    if chain.is_none() && db.is_empty() {
+        return None;
+    }
+
+    let chain = chain.as_ref();
+
+    known_blocks
+        .iter()
+        .find(|&&hash| chain_contains_hash(chain, db, hash))
+        .cloned()
+}
+
+/// Returns a range of [`Height`]s in the chain,
+/// starting after the `intersection` hash on the chain.
+///
+/// See [`find_chain_hashes()`] for details.
+fn find_chain_height_range<C>(
+    chain: Option<C>,
+    db: &ZebraDb,
+    intersection: Option<block::Hash>,
+    stop: Option<block::Hash>,
+    max_len: u32,
+) -> impl RangeBounds<u32> + Iterator<Item = u32>
+where
+    C: AsRef<Chain>,
+{
+    #[allow(clippy::reversed_empty_ranges)]
+    const EMPTY_RANGE: RangeInclusive<u32> = 1..=0;
+
+    assert!(max_len > 0, "max_len must be at least 1");
+
+    let chain = chain.as_ref();
+
+    // We can get a block locator request before we have downloaded the genesis block
+    let chain_tip_height = if let Some(height) = tip_height(chain, db) {
+        height
+    } else {
+        tracing::debug!(
+            response_len = ?0,
+            "responding to peer GetBlocks or GetHeaders with empty state",
+        );
+
+        return EMPTY_RANGE;
+    };
+
+    // Find the intersection height
+    let intersection_height = match intersection {
+        Some(intersection_hash) => match height_by_hash(chain, db, intersection_hash) {
+            Some(intersection_height) => Some(intersection_height),
+
+            // A recently committed block dropped the intersection we previously found
+            None => {
+                info!(
+                    ?intersection,
+                    ?stop,
+                    ?max_len,
+                    "state found intersection but then dropped it, ignoring request",
+                );
+                return EMPTY_RANGE;
+            }
+        },
+        // There is no intersection
+        None => None,
+    };
+
+    // Now find the start and maximum heights
+    let (start_height, max_height) = match intersection_height {
+        // start after the intersection_height, and return max_len hashes or headers
+        Some(intersection_height) => (
+            Height(intersection_height.0 + 1),
+            Height(intersection_height.0 + max_len),
+        ),
+        // start at genesis, and return max_len hashes or headers
+        None => (Height(0), Height(max_len - 1)),
+    };
+
+    let stop_height = stop.and_then(|hash| height_by_hash(chain, db, hash));
+
+    // Compute the final height, making sure it is:
+    //   * at or below our chain tip, and
+    //   * at or below the height of the stop hash.
+    let final_height = std::cmp::min(max_height, chain_tip_height);
+    let final_height = stop_height
+        .map(|stop_height| std::cmp::min(final_height, stop_height))
+        .unwrap_or(final_height);
+
+    // TODO: implement Step for Height, when Step stabilises
+    //       https://github.com/rust-lang/rust/issues/42168
+    let height_range = start_height.0..=final_height.0;
+    let response_len = height_range.clone().into_iter().count();
+
+    tracing::debug!(
+        ?start_height,
+        ?final_height,
+        ?response_len,
+        ?chain_tip_height,
+        ?stop_height,
+        ?intersection_height,
+        ?intersection,
+        ?stop,
+        ?max_len,
+        "responding to peer GetBlocks or GetHeaders",
+    );
+
+    // Check the function implements the Find protocol
+    assert!(
+        response_len <= max_len.try_into().expect("fits in usize"),
+        "a Find response must not exceed the maximum response length",
+    );
+
+    height_range
+}
+
+/// Returns a list of [`block::Hash`]es in the chain,
+/// following the `intersection` with the chain.
+///
+///
+/// See [`find_chain_hashes()`] for details.
+fn collect_chain_hashes<C>(
+    chain: Option<C>,
+    db: &ZebraDb,
+    intersection: Option<block::Hash>,
+    stop: Option<block::Hash>,
+    max_len: u32,
+) -> Vec<block::Hash>
+where
+    C: AsRef<Chain>,
+{
+    let chain = chain.as_ref();
+
+    let height_range = find_chain_height_range(chain, db, intersection, stop, max_len);
+
+    // All the hashes should be in the chain.
+    // If they are not, we don't want to return them.
+    let hashes: Vec<block::Hash> = height_range.into_iter().map_while(|height| {
+            let hash = hash_by_height(chain, db, Height(height));
+
+        // A recently committed block dropped the intersection we previously found.
+            if hash.is_none() {
+                info!(
+                    ?intersection,
+                    ?stop,
+                    ?max_len,
+                    "state found height range, but then partially dropped it, returning partial response",
+                );
+            }
+
+            tracing::trace!(
+                ?hash,
+                ?height,
+                ?intersection,
+                ?stop,
+                ?max_len,
+                "adding hash to peer Find response",
+            );
+
+            hash
+        }).collect();
+
+    // Check the function implements the Find protocol
+    assert!(
+        intersection
+            .map(|hash| !hashes.contains(&hash))
+            .unwrap_or(true),
+        "the list must not contain the intersection hash",
+    );
+
+    if let (Some(stop), Some((_, hashes_except_last))) = (stop, hashes.split_last()) {
+        assert!(
+            !hashes_except_last.contains(&stop),
+            "if the stop hash is in the list, it must be the final hash",
+        );
+    }
+
+    hashes
+}
+
+/// Returns a list of [`block::Header`]s in the chain,
+/// following the `intersection` with the chain.
+///
+/// See [`find_chain_hashes()`] for details.
+fn collect_chain_headers<C>(
+    chain: Option<C>,
+    db: &ZebraDb,
+    intersection: Option<block::Hash>,
+    stop: Option<block::Hash>,
+    max_len: u32,
+) -> Vec<Arc<block::Header>>
+where
+    C: AsRef<Chain>,
+{
+    let chain = chain.as_ref();
+
+    let height_range = find_chain_height_range(chain, db, intersection, stop, max_len);
+
+    // We don't check that this function implements the Find protocol,
+    // because fetching extra hashes (or re-calculating hashes) is expensive.
+    // (This was one of the most expensive and longest-running functions in the state.)
+
+    // All the headers should be in the chain.
+    // If they are not, we don't want to return them.
+    height_range.into_iter().map_while(|height| {
+            let header = block_header(chain, db, Height(height).into());
+
+            // A recently committed block dropped the intersection we previously found
+            if header.is_none() {
+                info!(
+                    ?intersection,
+                    ?stop,
+                    ?max_len,
+                    "state found height range, but then partially dropped it, returning partial response",
+                );
+            }
+
+            tracing::trace!(
+                ?height,
+                ?intersection,
+                ?stop,
+                ?max_len,
+                "adding header to peer Find response",
+            );
+
+            header
+        }).collect()
+}
+
+/// Finds the first hash that's in the peer's `known_blocks` and the chain.
+/// Returns a list of hashes that follow that intersection, from the chain.
+///
+/// Starts from the first matching hash in the chain, ignoring all other hashes in
+/// `known_blocks`. If there is no matching hash in the chain, starts from the genesis
+/// hash.
+///
+/// Includes finalized and non-finalized blocks.
+///
+/// Stops the list of hashes after:
+///   * adding the tip,
+///   * adding the `stop` hash to the list, if it is in the chain, or
+///   * adding 500 hashes to the list.
+///
+/// Returns an empty list if the state is empty,
+/// and a partial or empty list if the found heights are concurrently modified.
+pub fn find_chain_hashes<C>(
+    chain: Option<C>,
+    db: &ZebraDb,
+    known_blocks: Vec<block::Hash>,
+    stop: Option<block::Hash>,
+    max_len: u32,
+) -> Vec<block::Hash>
+where
+    C: AsRef<Chain>,
+{
+    let chain = chain.as_ref();
+    let intersection = find_chain_intersection(chain, db, known_blocks);
+
+    collect_chain_hashes(chain, db, intersection, stop, max_len)
+}
+
+/// Finds the first hash that's in the peer's `known_blocks` and the chain.
+/// Returns a list of headers that follow that intersection, from the chain.
+///
+/// See [`find_chain_hashes()`] for details.
+pub fn find_chain_headers<C>(
+    chain: Option<C>,
+    db: &ZebraDb,
+    known_blocks: Vec<block::Hash>,
+    stop: Option<block::Hash>,
+    max_len: u32,
+) -> Vec<Arc<block::Header>>
+where
+    C: AsRef<Chain>,
+{
+    let chain = chain.as_ref();
+    let intersection = find_chain_intersection(chain, db, known_blocks);
+
+    collect_chain_headers(chain, db, intersection, stop, max_len)
+}
+
+// Note Commitment Trees
 
 /// Returns the Sapling
 /// [`NoteCommitmentTree`](sapling::tree::NoteCommitmentTree) specified by a
@@ -180,6 +520,8 @@ where
         .and_then(|chain| chain.as_ref().orchard_tree(hash_or_height))
         .or_else(|| db.orchard_tree(hash_or_height))
 }
+
+// Address Balance
 
 /// Returns the total transparent balance for the supplied [`transparent::Address`]es.
 ///
@@ -300,6 +642,8 @@ fn apply_balance_change(
 
     balance?.constrain()
 }
+
+// Address UTXOs
 
 /// Returns the unspent transparent outputs (UTXOs) for the supplied [`transparent::Address`]es,
 /// in chain order; and the transaction IDs for the transactions containing those UTXOs.
@@ -632,6 +976,8 @@ where
         })
         .collect()
 }
+
+// Address TX IDs
 
 /// Returns the transaction IDs that sent or received funds from the supplied [`transparent::Address`]es,
 /// within `query_height_range`, in chain order.


### PR DESCRIPTION
## Motivation

Zebra reads 160 headers for each FindHeaders request.
The FindHeaders requests used to take 5-10 seconds to answer, they might still be a bit slow.

So we want to run them concurrently with state updates.

Depends-On: #4825

## Solution

- Make FindHeaders and FindHashes run concurrently with state updates
    - Use the new methods in existing state methods
- Make some state queries more efficient

## Review

This is an urgent PR to fix Zebra sync performance.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

