### PR TITLE
Replace diagnostic to target what is taking most time

### DIFF
--- a/zebra-chain/src/diagnostic.rs
+++ b/zebra-chain/src/diagnostic.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use crate::fmt::duration_short;
 
 /// The default minimum info-level message time.
-pub const DEFAULT_MIN_INFO_TIME: Duration = Duration::from_secs(5);
+pub const DEFAULT_MIN_INFO_TIME: Duration = Duration::from_secs(1);
 
 /// The default minimum warning message time.
 pub const DEFAULT_MIN_WARN_TIME: Duration = Duration::from_secs(20);

--- a/zebra-chain/src/parallel/tree.rs
+++ b/zebra-chain/src/parallel/tree.rs
@@ -114,40 +114,42 @@ impl NoteCommitmentTrees {
         let mut sapling_result = None;
         let mut orchard_result = None;
 
+        let all_trees_timer = CodeTimer::start();
         rayon::in_place_scope_fifo(|scope| {
-            let timer = CodeTimer::start();
             if !sprout_note_commitments.is_empty() {
                 scope.spawn_fifo(|_scope| {
+                    let timer = CodeTimer::start();
                     sprout_result = Some(Self::update_sprout_note_commitment_tree(
                         sprout,
                         sprout_note_commitments,
                     ));
+                    timer.finish(module_path!(), line!(), "updating sprout note commitment tree");
                 });
             }
-            timer.finish(module_path!(), line!(), "update_trees_parallel_list 5");
 
-            let timer = CodeTimer::start();
             if !sapling_note_commitments.is_empty() {
                 scope.spawn_fifo(|_scope| {
+                    let timer = CodeTimer::start();
                     sapling_result = Some(Self::update_sapling_note_commitment_tree(
                         sapling,
                         sapling_note_commitments,
                     ));
+                    timer.finish(module_path!(), line!(), "updating sapling note commitment tree");
                 });
             }
-            timer.finish(module_path!(), line!(), "update_trees_parallel_list 6");
 
-            let timer = CodeTimer::start();
             if !orchard_note_commitments.is_empty() {
                 scope.spawn_fifo(|_scope| {
+                    let timer = CodeTimer::start();
                     orchard_result = Some(Self::update_orchard_note_commitment_tree(
                         orchard,
                         orchard_note_commitments,
                     ));
+                    timer.finish(module_path!(), line!(), "updating orchard note commitment tree");
                 });
             }
-            timer.finish(module_path!(), line!(), "update_trees_parallel_list 7");
         });
+        all_trees_timer.finish(module_path!(), line!(), "updating all note commitment trees in parallel");
 
         let timer = CodeTimer::start();
         if let Some(sprout_result) = sprout_result {


### PR DESCRIPTION
## Motivation

With previous diagnostics we discovered we had performance issues in commiting blocks. This PR updates the diagnostics and move them to a specific part of the code that takes longer than a second to complete.

Blocks are written to the disk in batches, sometimes this can be of more than 100. Each block will pass through this code that takes more than a second resulting in delays of more than 100 seconds, specially closer to the tip.

## Solution

Move diagnostics to time taker code.

## Review

This is just a diagnostic PR, i am unsure if it will be merged.

