### PR TITLE
fix(test): truncate the number of transactions in send transaction test

### DIFF
--- a/zebra-rpc/src/queue.rs
+++ b/zebra-rpc/src/queue.rs
@@ -39,7 +39,7 @@ mod tests;
 const NUMBER_OF_BLOCKS_TO_EXPIRE: i64 = 5;
 
 /// Size of the queue and channel.
-const CHANNEL_AND_QUEUE_CAPACITY: usize = 20;
+pub const CHANNEL_AND_QUEUE_CAPACITY: usize = 20;
 
 /// The height to use in spacing calculation if we don't have a chain tip.
 const NO_CHAIN_TIP_HEIGHT: Height = Height(1);

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -94,7 +94,7 @@ pub(crate) const TRANSACTION_VERIFY_TIMEOUT: Duration = BLOCK_VERIFY_TIMEOUT;
 /// Since Zebra keeps an `inv` index, inbound downloads for malicious transactions
 /// will be directed to the malicious node that originally gossiped the hash.
 /// Therefore, this attack can be carried out by a single malicious node.
-pub(crate) const MAX_INBOUND_CONCURRENCY: usize = 10;
+pub const MAX_INBOUND_CONCURRENCY: usize = 10;
 
 /// Errors that can occur while downloading and verifying a transaction.
 #[derive(Error, Debug)]


### PR DESCRIPTION
## Motivation

We are seeing some full queue errors in some runs of the send transaction test. Close https://github.com/ZcashFoundation/zebra/issues/4847

## Solution

Truncate the transactions sent in this test. I think this should work but i need to test in CI.

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] `send_transaction_test` pass
  - [ ] All the other tests pass

