### PR TITLE
fix(test): Skip some RPC tests when ZEBRA_SKIP_NETWORK_TESTS is set

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1287,6 +1287,10 @@ async fn lightwalletd_test_suite() -> Result<()> {
 fn lightwalletd_integration_test(test_type: LightwalletdTestType) -> Result<()> {
     zebra_test::init();
 
+    if zebra_test::net::zebra_skip_network_tests() {
+        return Ok(());
+    }
+
     // Skip the test unless the user specifically asked for it
     //
     // TODO: pass test_type to zebra_skip_lightwalletd_tests() and check for lightwalletd launch in there

--- a/zebrad/tests/common/lightwalletd/send_transaction_test.rs
+++ b/zebrad/tests/common/lightwalletd/send_transaction_test.rs
@@ -43,6 +43,10 @@ use crate::common::{
 pub async fn run() -> Result<()> {
     zebra_test::init();
 
+    if zebra_test::net::zebra_skip_network_tests() {
+        return Ok(());
+    }
+
     // Skip the test unless the user specifically asked for it
     if zebra_skip_lightwalletd_tests() {
         return Ok(());


### PR DESCRIPTION
## Motivation

We forgot to check ZEBRA_SKIP_NETWORK_TESTS in some RPC tests.

## Review

If we're developing without the network over the next few weeks, we might want this fix.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

