### PR TITLE
fix(test): use FuturesOrdered in fallback_verification test

### DIFF
--- a/tower-batch/tests/ed25519.rs
+++ b/tower-batch/tests/ed25519.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use color_eyre::{eyre::eyre, Report};
 use ed25519_zebra::*;
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::stream::{FuturesOrdered, StreamExt};
 use rand::thread_rng;
 use tower::{Service, ServiceExt};
 use tower_batch::Batch;
@@ -24,7 +24,7 @@ async fn sign_and_verify<V>(
 where
     V: Service<Ed25519Item, Response = ()>,
 {
-    let results = FuturesUnordered::new();
+    let mut results = FuturesOrdered::new();
     for i in 0..n {
         let span = tracing::trace_span!("sig", i);
         let sk = SigningKey::new(thread_rng());


### PR DESCRIPTION
## Motivation

The `fallback_verification` test assumed futures would be completed in order, but used `FuturesUnordered`

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Designs

<!--
If this PR implements a Zebra design, quote and link to the RFC:
https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
-->

## Solution

Use `FuturesOrdered` instead.

Closes https://github.com/ZcashFoundation/zebra/issues/4845

## Review

I couldn't replicate the issue locally, so I can't be sure if it really fixes it, but it seems to be the proper fix.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
