### PR TITLE
feat(net): return peer metadata from `connect_isolated` functions

### DIFF
--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -4,15 +4,12 @@ use std::{future::Future, net::SocketAddr};
 
 use futures::future::TryFutureExt;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tower::{
-    util::{BoxService, Oneshot},
-    Service, ServiceExt,
-};
+use tower::{util::Oneshot, Service};
 
 use zebra_chain::{chain_tip::NoChainTip, parameters::Network};
 
 use crate::{
-    peer::{self, ConnectedAddr, HandshakeRequest},
+    peer::{self, Client, ConnectedAddr, HandshakeRequest},
     peer_set::ActiveConnectionCounter,
     BoxError, Config, Request, Response,
 };
@@ -51,7 +48,7 @@ pub fn connect_isolated<PeerTransport>(
     network: Network,
     data_stream: PeerTransport,
     user_agent: String,
-) -> impl Future<Output = Result<BoxService<Request, Response, BoxError>, BoxError>>
+) -> impl Future<Output = Result<Client, BoxError>>
 where
     PeerTransport: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
@@ -79,7 +76,7 @@ pub fn connect_isolated_with_inbound<PeerTransport, InboundService>(
     data_stream: PeerTransport,
     user_agent: String,
     inbound_service: InboundService,
-) -> impl Future<Output = Result<BoxService<Request, Response, BoxError>, BoxError>>
+) -> impl Future<Output = Result<Client, BoxError>>
 where
     PeerTransport: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     InboundService:
@@ -111,7 +108,6 @@ where
             connection_tracker,
         },
     )
-    .map_ok(|client| BoxService::new(client.map_err(Into::into)))
 }
 
 /// Creates a direct TCP Zcash peer connection to `addr`.
@@ -129,7 +125,7 @@ pub fn connect_isolated_tcp_direct(
     network: Network,
     addr: SocketAddr,
     user_agent: String,
-) -> impl Future<Output = Result<BoxService<Request, Response, BoxError>, BoxError>> {
+) -> impl Future<Output = Result<Client, BoxError>> {
     let nil_inbound_service =
         tower::service_fn(|_req| async move { Ok::<Response, BoxError>(Response::Nil) });
 
@@ -150,7 +146,7 @@ pub fn connect_isolated_tcp_direct_with_inbound<InboundService>(
     addr: SocketAddr,
     user_agent: String,
     inbound_service: InboundService,
-) -> impl Future<Output = Result<BoxService<Request, Response, BoxError>, BoxError>>
+) -> impl Future<Output = Result<Client, BoxError>>
 where
     InboundService:
         Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,

--- a/zebra-network/src/isolated/tests/vectors.rs
+++ b/zebra-network/src/isolated/tests/vectors.rs
@@ -9,6 +9,7 @@ use crate::{
     constants::CURRENT_NETWORK_PROTOCOL_VERSION,
     protocol::external::{AddrInVersion, Codec, Message},
     types::PeerServices,
+    VersionMessage,
 };
 
 use super::super::*;
@@ -127,7 +128,7 @@ async fn check_version_message<PeerTransport>(
     PeerTransport: AsyncRead + Unpin,
 {
     // We don't need to send any bytes to get a version message.
-    if let Message::Version {
+    if let Message::Version(VersionMessage {
         version,
         services,
         timestamp,
@@ -137,7 +138,7 @@ async fn check_version_message<PeerTransport>(
         user_agent,
         start_height,
         relay,
-    } = inbound_stream
+    }) = inbound_stream
         .next()
         .await
         .expect("stream item")

--- a/zebra-network/src/isolated/tor.rs
+++ b/zebra-network/src/isolated/tor.rs
@@ -4,11 +4,14 @@ use std::sync::{Arc, Mutex};
 
 use arti_client::{DataStream, TorAddr, TorClient, TorClientConfig};
 use tor_rtcompat::tokio::TokioRuntimeHandle;
-use tower::{util::BoxService, Service};
+use tower::Service;
 
 use zebra_chain::parameters::Network;
 
-use crate::{connect_isolated, connect_isolated_with_inbound, BoxError, Request, Response};
+use crate::{
+    connect_isolated, connect_isolated_with_inbound, peer::Client as ZebraClient, BoxError,
+    Request, Response,
+};
 
 #[cfg(test)]
 mod tests;
@@ -44,7 +47,7 @@ pub async fn connect_isolated_tor(
     network: Network,
     hostname: String,
     user_agent: String,
-) -> Result<BoxService<Request, Response, BoxError>, BoxError> {
+) -> Result<ZebraClient, BoxError> {
     let tor_stream = new_tor_stream(hostname).await?;
 
     // Calling connect_isolated_tor_with_inbound causes lifetime issues.
@@ -68,7 +71,7 @@ pub async fn connect_isolated_tor_with_inbound<InboundService>(
     hostname: String,
     user_agent: String,
     inbound_service: InboundService,
-) -> Result<BoxService<Request, Response, BoxError>, BoxError>
+) -> Result<ZebraClient, BoxError>
 where
     InboundService:
         Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -168,10 +168,14 @@ pub use crate::{
     config::Config,
     isolated::{connect_isolated, connect_isolated_tcp_direct},
     meta_addr::PeerAddrState,
-    peer::{Client, HandshakeError, PeerError, SharedPeerError},
+    peer::{Client, ConnectedAddr, ConnectionInfo, HandshakeError, PeerError, SharedPeerError},
     peer_set::init,
     policies::RetryLimit,
-    protocol::internal::{InventoryResponse, Request, Response},
+    protocol::{
+        external::Version,
+        internal::{InventoryResponse, Request, Response},
+        types::PeerServices,
+    },
 };
 
 /// Types used in the definition of [`Request`] and [`Response`] messages.

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -168,7 +168,7 @@ pub use crate::{
     config::Config,
     isolated::{connect_isolated, connect_isolated_tcp_direct},
     meta_addr::PeerAddrState,
-    peer::{HandshakeError, PeerError, SharedPeerError},
+    peer::{Client, HandshakeError, PeerError, SharedPeerError},
     peer_set::init,
     policies::RetryLimit,
     protocol::internal::{InventoryResponse, Request, Response},

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -177,7 +177,7 @@ pub use crate::{
     },
 };
 
-/// Types used in the definition of [`Request`], [`Response`], and [`Message::Version`] messages.
+/// Types used in the definition of [`Request`], [`Response`], and [`VersionMessage`].
 pub mod types {
     pub use crate::{
         meta_addr::MetaAddr,

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -172,7 +172,7 @@ pub use crate::{
     peer_set::init,
     policies::RetryLimit,
     protocol::{
-        external::Version,
+        external::{Version, VersionMessage},
         internal::{InventoryResponse, Request, Response},
         types::PeerServices,
     },

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -174,13 +174,18 @@ pub use crate::{
     protocol::{
         external::{Version, VersionMessage},
         internal::{InventoryResponse, Request, Response},
-        types::PeerServices,
     },
 };
 
-/// Types used in the definition of [`Request`] and [`Response`] messages.
+/// Types used in the definition of [`Request`], [`Response`], and [`Message::Version`] messages.
 pub mod types {
-    pub use crate::{meta_addr::MetaAddr, protocol::types::PeerServices};
+    pub use crate::{
+        meta_addr::MetaAddr,
+        protocol::{
+            external::{AddrInVersion, Nonce},
+            types::PeerServices,
+        },
+    };
 
     #[cfg(any(test, feature = "proptest-impl"))]
     pub use crate::protocol::external::InventoryHash;

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -25,7 +25,7 @@ pub use client::Client;
 pub use connection::Connection;
 pub use connector::{Connector, OutboundConnectorRequest};
 pub use error::{ErrorSlot, HandshakeError, PeerError, SharedPeerError};
-pub use handshake::{ConnectedAddr, Handshake, HandshakeRequest};
+pub use handshake::{ConnectedAddr, ConnectionInfo, Handshake, HandshakeRequest};
 pub use load_tracked_client::LoadTrackedClient;
 pub use minimum_peer_version::MinimumPeerVersion;
 pub use priority::{AttributePreference, PeerPreference};

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -50,9 +50,6 @@ pub struct Client {
     /// so that the peer set can route retries to other clients.
     pub(crate) inv_collector: broadcast::Sender<InventoryChange>,
 
-    /// The peer address for registering missing inventory.
-    pub(crate) transient_addr: Option<SocketAddr>,
-
     /// A slot for an error shared between the Connection and the Client that uses it.
     ///
     /// `None` unless the connection or client have errored.
@@ -87,6 +84,8 @@ pub(crate) struct ClientRequest {
     pub inv_collector: Option<broadcast::Sender<InventoryChange>>,
 
     /// The peer address for registering missing inventory.
+    ///
+    /// TODO: replace this with [`ConnectedAddr`]?
     pub transient_addr: Option<SocketAddr>,
 
     /// The tracing context for the request, so that work the connection task does
@@ -600,7 +599,7 @@ impl Service<Request> for Client {
             request,
             tx,
             inv_collector: Some(self.inv_collector.clone()),
-            transient_addr: self.transient_addr,
+            transient_addr: self.connection_info.connected_addr.get_transient_addr(),
             span,
         }) {
             Err(e) => {

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -85,7 +85,7 @@ pub(crate) struct ClientRequest {
 
     /// The peer address for registering missing inventory.
     ///
-    /// TODO: replace this with [`ConnectedAddr`]?
+    /// TODO: replace this with `ConnectedAddr`?
     pub transient_addr: Option<SocketAddr>,
 
     /// The tracing context for the request, so that work the connection task does

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -6,6 +6,7 @@ use std::{
     iter,
     net::SocketAddr,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -37,7 +38,7 @@ pub mod tests;
 /// The "client" duplex half of a peer connection.
 pub struct Client {
     /// The metadata for the connected peer `service`.
-    pub connection_info: ConnectionInfo,
+    pub connection_info: Arc<ConnectionInfo>,
 
     /// Used to shut down the corresponding heartbeat.
     /// This is always Some except when we take it on drop.

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -19,10 +19,13 @@ use tokio::{sync::broadcast, task::JoinHandle};
 use tower::Service;
 
 use crate::{
-    peer::error::{AlreadyErrored, ErrorSlot, PeerError, SharedPeerError},
+    peer::{
+        error::{AlreadyErrored, ErrorSlot, PeerError, SharedPeerError},
+        ConnectionInfo,
+    },
     peer_set::InventoryChange,
     protocol::{
-        external::{types::Version, InventoryHash},
+        external::InventoryHash,
         internal::{Request, Response},
     },
     BoxError,
@@ -33,6 +36,9 @@ pub mod tests;
 
 /// The "client" duplex half of a peer connection.
 pub struct Client {
+    /// The metadata for the connected peer `service`.
+    pub connection_info: ConnectionInfo,
+
     /// Used to shut down the corresponding heartbeat.
     /// This is always Some except when we take it on drop.
     pub(crate) shutdown_tx: Option<oneshot::Sender<CancelHeartbeatTask>>,
@@ -51,9 +57,6 @@ pub struct Client {
     ///
     /// `None` unless the connection or client have errored.
     pub(crate) error_slot: ErrorSlot,
-
-    /// The peer connection's protocol version.
-    pub(crate) version: Version,
 
     /// A handle to the task responsible for connecting to the peer.
     pub(crate) connection_task: JoinHandle<()>,
@@ -170,7 +173,10 @@ impl std::fmt::Debug for Client {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // skip the channels, they don't tell us anything useful
         f.debug_struct("Client")
+            .field("connection_info", &self.connection_info)
             .field("error_slot", &self.error_slot)
+            .field("connection_task", &self.connection_task)
+            .field("heartbeat_task", &self.heartbeat_task)
             .finish()
     }
 }

--- a/zebra-network/src/peer/client/tests.rs
+++ b/zebra-network/src/peer/client/tests.rs
@@ -21,7 +21,7 @@ use crate::{
         ErrorSlot,
     },
     peer_set::InventoryChange,
-    protocol::external::types::Version,
+    protocol::{external::types::Version, types::PeerServices},
     BoxError,
 };
 
@@ -296,6 +296,8 @@ where
             remote_version,
             negotiated_version,
             connected_addr: crate::peer::ConnectedAddr::Isolated,
+            peer_services: PeerServices::default(),
+            user_agent: "client tests".to_string(),
         };
 
         let client = Client {

--- a/zebra-network/src/peer/client/tests.rs
+++ b/zebra-network/src/peer/client/tests.rs
@@ -15,7 +15,10 @@ use tokio::{
 };
 
 use crate::{
-    peer::{error::SharedPeerError, CancelHeartbeatTask, Client, ClientRequest, ErrorSlot},
+    peer::{
+        error::SharedPeerError, CancelHeartbeatTask, Client, ClientRequest, ConnectionInfo,
+        ErrorSlot,
+    },
     peer_set::InventoryChange,
     protocol::external::types::Version,
     BoxError,
@@ -285,13 +288,15 @@ where
         let (heartbeat_task, heartbeat_aborter) =
             Self::spawn_background_task_or_fallback_with_result(self.heartbeat_task);
 
+        let connection_info = ConnectionInfo { version };
+
         let client = Client {
+            connection_info,
             shutdown_tx: Some(shutdown_sender),
             server_tx: client_request_sender,
             inv_collector: inv_sender,
             transient_addr: None,
             error_slot: error_slot.clone(),
-            version,
             connection_task,
             heartbeat_task,
         };

--- a/zebra-network/src/peer/client/tests.rs
+++ b/zebra-network/src/peer/client/tests.rs
@@ -295,6 +295,7 @@ where
         let connection_info = ConnectionInfo {
             remote_version,
             negotiated_version,
+            connected_addr: crate::peer::ConnectedAddr::Isolated,
         };
 
         let client = Client {
@@ -302,7 +303,6 @@ where
             shutdown_tx: Some(shutdown_sender),
             server_tx: client_request_sender,
             inv_collector: inv_sender,
-            transient_addr: None,
             error_slot: error_slot.clone(),
             connection_task,
             heartbeat_task,

--- a/zebra-network/src/peer/client/tests.rs
+++ b/zebra-network/src/peer/client/tests.rs
@@ -5,6 +5,7 @@
 
 use std::{
     net::{Ipv4Addr, SocketAddrV4},
+    sync::Arc,
     time::Duration,
 };
 
@@ -319,11 +320,11 @@ where
             relay: true,
         };
 
-        let connection_info = ConnectionInfo {
+        let connection_info = Arc::new(ConnectionInfo {
             connected_addr: crate::peer::ConnectedAddr::Isolated,
             remote,
             negotiated_version,
-        };
+        });
 
         let client = Client {
             connection_info,

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -514,7 +514,7 @@ pub struct Connection<S, Tx> {
 impl<S, Tx> fmt::Debug for Connection<S, Tx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // skip the channels, they don't tell us anything useful
-        f.debug_struct("Connection")
+        f.debug_struct(std::any::type_name::<Connection<S, Tx>>())
             .field("connection_info", &self.connection_info)
             .field("state", &self.state)
             .field("request_timer", &self.request_timer)

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -536,6 +536,8 @@ impl<S, Tx> Connection<S, Tx> {
         connection_tracker: ConnectionTracker,
         connection_info: ConnectionInfo,
     ) -> Self {
+        let metrics_label = connection_info.connected_addr.get_transient_addr_label();
+
         Connection {
             connection_info,
             state: State::AwaitingRequest,
@@ -546,7 +548,7 @@ impl<S, Tx> Connection<S, Tx> {
             error_slot,
             peer_tx: peer_tx.into(),
             connection_tracker,
-            metrics_label: connection_info.connected_addr.get_transient_addr_label(),
+            metrics_label,
             last_metrics_state: None,
         }
     }

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -452,7 +452,7 @@ pub struct Connection<S, Tx> {
     ///
     /// This field is used for debugging.
     #[allow(dead_code)]
-    pub connection_info: ConnectionInfo,
+    pub connection_info: Arc<ConnectionInfo>,
 
     /// The state of this connection's current request or response.
     pub(super) state: State,
@@ -534,7 +534,7 @@ impl<S, Tx> Connection<S, Tx> {
         error_slot: ErrorSlot,
         peer_tx: Tx,
         connection_tracker: ConnectionTracker,
-        connection_info: ConnectionInfo,
+        connection_info: Arc<ConnectionInfo>,
     ) -> Self {
         let metrics_label = connection_info.connected_addr.get_transient_addr_label();
 

--- a/zebra-network/src/peer/connection/tests.rs
+++ b/zebra-network/src/peer/connection/tests.rs
@@ -11,7 +11,7 @@ use crate::{
     constants::CURRENT_NETWORK_PROTOCOL_VERSION,
     peer::{ClientRequest, ConnectedAddr, Connection, ConnectionInfo, ErrorSlot},
     peer_set::ActiveConnectionCounter,
-    protocol::external::Message,
+    protocol::{external::Message, types::PeerServices},
     Request, Response,
 };
 
@@ -50,6 +50,8 @@ fn new_test_connection<A>() -> (
         remote_version: CURRENT_NETWORK_PROTOCOL_VERSION,
         negotiated_version: CURRENT_NETWORK_PROTOCOL_VERSION,
         connected_addr: ConnectedAddr::Isolated,
+        peer_services: PeerServices::default(),
+        user_agent: "connection tests".to_string(),
     };
 
     let connection = Connection::new(

--- a/zebra-network/src/peer/connection/tests.rs
+++ b/zebra-network/src/peer/connection/tests.rs
@@ -3,6 +3,7 @@
 use std::{
     io,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    sync::Arc,
 };
 
 use chrono::Utc;
@@ -81,7 +82,7 @@ fn new_test_connection<A>() -> (
         shared_error_slot.clone(),
         peer_tx,
         ActiveConnectionCounter::new_counter().track_connection(),
-        connection_info,
+        Arc::new(connection_info),
     );
 
     (

--- a/zebra-network/src/peer/connection/tests.rs
+++ b/zebra-network/src/peer/connection/tests.rs
@@ -8,7 +8,8 @@ use zebra_chain::serialization::SerializationError;
 use zebra_test::mock_service::MockService;
 
 use crate::{
-    peer::{ClientRequest, ConnectedAddr, Connection, ErrorSlot},
+    constants::CURRENT_NETWORK_PROTOCOL_VERSION,
+    peer::{ClientRequest, ConnectedAddr, Connection, ConnectionInfo, ErrorSlot},
     peer_set::ActiveConnectionCounter,
     protocol::external::Message,
     Request, Response,
@@ -45,13 +46,19 @@ fn new_test_connection<A>() -> (
     };
     let peer_tx = peer_tx.sink_map_err(error_converter);
 
+    let connection_info = ConnectionInfo {
+        remote_version: CURRENT_NETWORK_PROTOCOL_VERSION,
+        negotiated_version: CURRENT_NETWORK_PROTOCOL_VERSION,
+        connected_addr: ConnectedAddr::Isolated,
+    };
+
     let connection = Connection::new(
         mock_inbound_service.clone(),
         client_rx,
         shared_error_slot.clone(),
         peer_tx,
         ActiveConnectionCounter::new_counter().track_connection(),
-        ConnectedAddr::Isolated,
+        connection_info,
     );
 
     (

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -127,7 +127,7 @@ pub struct ConnectionInfo {
     /// which will appear as the connected address to the OS and Zebra.
     pub connected_addr: ConnectedAddr,
 
-    /// The network protocol [`Message::Version`](crate::Message) sent by the remote peer.
+    /// The network protocol [`VersionMessage`](crate::VersionMessage) sent by the remote peer.
     pub remote: VersionMessage,
 
     /// The network protocol version negotiated with the remote peer.
@@ -566,7 +566,7 @@ where
 /// We split `Handshake` into its components before calling this function,
 /// to avoid infectious `Sync` bounds on the returned future.
 ///
-/// Returns the [`Message::Version`](crate::Message) sent by the remote peer.
+/// Returns the [`VersionMessage`](crate::VersionMessage) sent by the remote peer.
 #[allow(clippy::too_many_arguments)]
 pub async fn negotiate_version<PeerTransport>(
     peer_conn: &mut Framed<PeerTransport, Codec>,

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -98,6 +98,13 @@ where
     }
 }
 
+/// The metadata for a peer connection.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ConnectionInfo {
+    /// The network protocol version reported by the remote peer.
+    pub version: Version,
+}
+
 /// The peer address that we are handshaking with.
 ///
 /// Typically, we can rely on outbound addresses, but inbound addresses don't
@@ -964,6 +971,9 @@ where
                 })
                 .boxed();
 
+            let connection_info = ConnectionInfo {
+                version: remote_version,
+            };
             let server = Connection::new(
                 inbound_service,
                 server_rx,
@@ -993,12 +1003,12 @@ where
             );
 
             let client = Client {
+                connection_info,
                 shutdown_tx: Some(shutdown_tx),
                 server_tx,
                 inv_collector,
                 transient_addr: connected_addr.get_transient_addr(),
                 error_slot,
-                version: remote_version,
                 connection_task,
                 heartbeat_task,
             };

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -76,6 +76,25 @@ where
     parent_span: Span,
 }
 
+impl<S, C> fmt::Debug for Handshake<S, C>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send,
+    C: ChainTip + Clone + Send + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // skip the channels, they don't tell us anything useful
+        f.debug_struct(std::any::type_name::<Handshake<S, C>>())
+            .field("config", &self.config)
+            .field("user_agent", &self.user_agent)
+            .field("our_services", &self.our_services)
+            .field("relay", &self.relay)
+            .field("minimum_peer_version", &self.minimum_peer_version)
+            .field("parent_span", &self.parent_span)
+            .finish()
+    }
+}
+
 impl<S, C> Clone for Handshake<S, C>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -899,12 +899,12 @@ where
             let negotiated_version =
                 std::cmp::min(remote.version, constants::CURRENT_NETWORK_PROTOCOL_VERSION);
 
-            // TODO: consider wrapping this struct in an Arc in Connection, Client, and LoadTrackedClient
-            let connection_info = ConnectionInfo {
+            // Limit containing struct size, and avoid multiple duplicates of 300+ bytes of data.
+            let connection_info = Arc::new(ConnectionInfo {
                 connected_addr,
                 remote,
                 negotiated_version,
-            };
+            });
 
             // Reconfigure the codec to use the negotiated version.
             //

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -132,7 +132,7 @@ pub struct ConnectionInfo {
     /// The network protocol version negotiated with the remote peer.
     ///
     /// Derived from `remote_version` and the
-    /// [protocol version implemented by `zebra_network`](constants::CURRENT_NETWORK_PROTOCOL_VERSION).
+    /// [current `zebra_network` protocol version](constants::CURRENT_NETWORK_PROTOCOL_VERSION).
     pub negotiated_version: Version,
 
     /// The service bits reported by the remote peer.
@@ -152,7 +152,10 @@ pub enum ConnectedAddr {
     ///
     /// In an honest network, a Zcash peer is listening on this exact address
     /// and port.
-    OutboundDirect { addr: SocketAddr },
+    OutboundDirect {
+        /// The connected outbound remote address and port.
+        addr: SocketAddr,
+    },
 
     /// The address we received from the OS, when a remote peer directly
     /// connected to our Zcash listener port.
@@ -161,7 +164,10 @@ pub enum ConnectedAddr {
     /// if its outbound address is the same as its listener address. But the port
     /// is an ephemeral outbound TCP port, not a listener port.
     InboundDirect {
+        /// The connected inbound remote address.
         maybe_ip: IpAddr,
+
+        /// The connected inbound transient remote port.
         transient_port: u16,
     },
 
@@ -171,7 +177,10 @@ pub enum ConnectedAddr {
     /// outbound address and port can be used as an identifier for the duration
     /// of this connection.
     OutboundProxy {
+        /// The remote address and port of the proxy.
         proxy_addr: SocketAddr,
+
+        /// The local address and transient port we used to connect to the proxy.
         transient_local_addr: SocketAddr,
     },
 
@@ -180,7 +189,10 @@ pub enum ConnectedAddr {
     ///
     /// The proxy's ephemeral outbound address can be used as an identifier for
     /// the duration of this connection.
-    InboundProxy { transient_addr: SocketAddr },
+    InboundProxy {
+        /// The local address and transient port we used to connect to the proxy.
+        transient_addr: SocketAddr,
+    },
 
     /// An isolated connection, where we deliberately don't have any connection metadata.
     Isolated,

--- a/zebra-network/src/peer/load_tracked_client.rs
+++ b/zebra-network/src/peer/load_tracked_client.rs
@@ -10,7 +10,7 @@ use tower::{
 
 use crate::{
     constants::{EWMA_DECAY_TIME_NANOS, EWMA_DEFAULT_RTT},
-    peer::Client,
+    peer::{Client, ConnectionInfo},
     protocol::external::types::Version,
 };
 
@@ -18,14 +18,17 @@ use crate::{
 ///
 /// It also keeps track of the peer's reported protocol version.
 pub struct LoadTrackedClient {
+    /// A service representing a connected peer, wrapped in a load tracker.
     service: PeakEwma<Client>,
-    version: Version,
+
+    /// The metadata for the connected peer `service`.
+    connection_info: ConnectionInfo,
 }
 
 /// Create a new [`LoadTrackedClient`] wrapping the provided `client` service.
 impl From<Client> for LoadTrackedClient {
     fn from(client: Client) -> Self {
-        let version = client.version;
+        let connection_info = client.connection_info;
 
         let service = PeakEwma::new(
             client,
@@ -34,14 +37,17 @@ impl From<Client> for LoadTrackedClient {
             tower::load::CompleteOnResponse::default(),
         );
 
-        LoadTrackedClient { service, version }
+        LoadTrackedClient {
+            service,
+            connection_info,
+        }
     }
 }
 
 impl LoadTrackedClient {
     /// Retrieve the peer's reported protocol version.
     pub fn version(&self) -> Version {
-        self.version
+        self.connection_info.version
     }
 }
 

--- a/zebra-network/src/peer/load_tracked_client.rs
+++ b/zebra-network/src/peer/load_tracked_client.rs
@@ -47,7 +47,7 @@ impl From<Client> for LoadTrackedClient {
 impl LoadTrackedClient {
     /// Retrieve the peer's reported protocol version.
     pub fn remote_version(&self) -> Version {
-        self.connection_info.remote_version
+        self.connection_info.remote.version
     }
 }
 

--- a/zebra-network/src/peer/load_tracked_client.rs
+++ b/zebra-network/src/peer/load_tracked_client.rs
@@ -46,8 +46,8 @@ impl From<Client> for LoadTrackedClient {
 
 impl LoadTrackedClient {
     /// Retrieve the peer's reported protocol version.
-    pub fn version(&self) -> Version {
-        self.connection_info.version
+    pub fn remote_version(&self) -> Version {
+        self.connection_info.remote_version
     }
 }
 

--- a/zebra-network/src/peer/load_tracked_client.rs
+++ b/zebra-network/src/peer/load_tracked_client.rs
@@ -28,7 +28,7 @@ pub struct LoadTrackedClient {
 /// Create a new [`LoadTrackedClient`] wrapping the provided `client` service.
 impl From<Client> for LoadTrackedClient {
     fn from(client: Client) -> Self {
-        let connection_info = client.connection_info;
+        let connection_info = client.connection_info.clone();
 
         let service = PeakEwma::new(
             client,

--- a/zebra-network/src/peer/load_tracked_client.rs
+++ b/zebra-network/src/peer/load_tracked_client.rs
@@ -1,7 +1,10 @@
 //! A peer connection service wrapper type to handle load tracking and provide access to the
 //! reported protocol version.
 
-use std::task::{Context, Poll};
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use tower::{
     load::{Load, PeakEwma},
@@ -22,7 +25,7 @@ pub struct LoadTrackedClient {
     service: PeakEwma<Client>,
 
     /// The metadata for the connected peer `service`.
-    connection_info: ConnectionInfo,
+    connection_info: Arc<ConnectionInfo>,
 }
 
 /// Create a new [`LoadTrackedClient`] wrapping the provided `client` service.

--- a/zebra-network/src/peer/minimum_peer_version.rs
+++ b/zebra-network/src/peer/minimum_peer_version.rs
@@ -1,5 +1,7 @@
 //! Watches for chain tip height updates to determine the minimum supported peer protocol version.
 
+use std::fmt;
+
 use zebra_chain::{block::Height, chain_tip::ChainTip, parameters::Network};
 
 use crate::protocol::external::types::Version;
@@ -14,6 +16,17 @@ pub struct MinimumPeerVersion<C> {
     chain_tip: C,
     current_minimum: Version,
     has_changed: bool,
+}
+
+impl<C> fmt::Debug for MinimumPeerVersion<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // skip the chain tip to avoid locking issues
+        f.debug_struct(std::any::type_name::<MinimumPeerVersion<C>>())
+            .field("network", &self.network)
+            .field("current_minimum", &self.current_minimum)
+            .field("has_changed", &self.has_changed)
+            .finish()
+    }
 }
 
 impl<C> MinimumPeerVersion<C>

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -439,7 +439,7 @@ where
                     let cancel = self.cancel_handles.remove(&key);
                     assert!(cancel.is_some(), "missing cancel handle");
 
-                    if svc.version() >= self.minimum_peer_version.current() {
+                    if svc.remote_version() >= self.minimum_peer_version.current() {
                         self.ready_services.insert(key, svc);
                     }
                 }
@@ -509,7 +509,7 @@ where
             let preselected_p2c_peer = &mut self.preselected_p2c_peer;
 
             self.ready_services.retain(|address, peer| {
-                if peer.version() >= minimum_version {
+                if peer.remote_version() >= minimum_version {
                     true
                 } else {
                     if *preselected_p2c_peer == Some(*address) {
@@ -562,7 +562,7 @@ where
     /// If the service is for a connection to an outdated peer, the request is cancelled and the
     /// service is dropped.
     fn push_unready(&mut self, key: D::Key, svc: D::Service) {
-        let peer_version = svc.version();
+        let peer_version = svc.remote_version();
         let (tx, rx) = oneshot::channel();
 
         self.unready_services.push(UnreadyService {

--- a/zebra-network/src/peer_set/set/tests/prop.rs
+++ b/zebra-network/src/peer_set/set/tests/prop.rs
@@ -299,7 +299,7 @@ where
     let poll_result = peer_set.ready().now_or_never();
     let all_peers_are_outdated = harnesses
         .iter()
-        .all(|harness| harness.version() < minimum_version);
+        .all(|harness| harness.remote_version() < minimum_version);
 
     if all_peers_are_outdated {
         prop_assert!(matches!(poll_result, None));
@@ -309,7 +309,7 @@ where
 
     let mut number_of_connected_peers = 0;
     for harness in harnesses {
-        let is_outdated = harness.version() < minimum_version;
+        let is_outdated = harness.remote_version() < minimum_version;
         let is_connected = harness.wants_connection_heartbeats();
 
         prop_assert!(

--- a/zebra-network/src/protocol/external.rs
+++ b/zebra-network/src/protocol/external.rs
@@ -20,6 +20,6 @@ pub use addr::{canonical_socket_addr, AddrInVersion};
 pub use codec::Codec;
 pub use inv::InventoryHash;
 pub use message::{Message, VersionMessage};
-pub use types::Version;
+pub use types::{Nonce, Version};
 
 pub use zebra_chain::serialization::MAX_PROTOCOL_MESSAGE_LEN;

--- a/zebra-network/src/protocol/external.rs
+++ b/zebra-network/src/protocol/external.rs
@@ -19,7 +19,7 @@ mod tests;
 pub use addr::{canonical_socket_addr, AddrInVersion};
 pub use codec::Codec;
 pub use inv::InventoryHash;
-pub use message::Message;
+pub use message::{Message, VersionMessage};
 pub use types::Version;
 
 pub use zebra_chain::serialization::MAX_PROTOCOL_MESSAGE_LEN;

--- a/zebra-network/src/protocol/external.rs
+++ b/zebra-network/src/protocol/external.rs
@@ -20,4 +20,6 @@ pub use addr::{canonical_socket_addr, AddrInVersion};
 pub use codec::Codec;
 pub use inv::InventoryHash;
 pub use message::Message;
+pub use types::Version;
+
 pub use zebra_chain::serialization::MAX_PROTOCOL_MESSAGE_LEN;

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -9,7 +9,7 @@ use zebra_chain::{
     transaction::UnminedTx,
 };
 
-use crate::meta_addr::MetaAddr;
+use crate::{meta_addr::MetaAddr, BoxError};
 
 use super::{addr::AddrInVersion, inv::InventoryHash, types::*};
 
@@ -45,54 +45,7 @@ pub enum Message {
     /// is distinct from a simple version number.
     ///
     /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#version)
-    Version {
-        /// The network version number supported by the sender.
-        version: Version,
-
-        /// The network services advertised by the sender.
-        services: PeerServices,
-
-        /// The time when the version message was sent.
-        ///
-        /// This is a 64-bit field. Zebra rejects out-of-range times as invalid.
-        #[cfg_attr(
-            any(test, feature = "proptest-impl"),
-            proptest(strategy = "datetime_full()")
-        )]
-        timestamp: DateTime<Utc>,
-
-        /// The network address of the node receiving this message, and its
-        /// advertised network services.
-        ///
-        /// Q: how does the handshake know the remote peer's services already?
-        address_recv: AddrInVersion,
-
-        /// The network address of the node sending this message, and its
-        /// advertised network services.
-        address_from: AddrInVersion,
-
-        /// Node random nonce, randomly generated every time a version
-        /// packet is sent. This nonce is used to detect connections
-        /// to self.
-        nonce: Nonce,
-
-        /// The Zcash user agent advertised by the sender.
-        user_agent: String,
-
-        /// The last block received by the emitting node.
-        start_height: block::Height,
-
-        /// Whether the remote peer should announce relayed
-        /// transactions or not, see [BIP 0037].
-        ///
-        /// Zebra does not implement the bloom filters in [BIP 0037].
-        /// Instead, it only relays:
-        /// - newly verified best chain block hashes and mempool transaction IDs,
-        /// - after it reaches the chain tip.
-        ///
-        /// [BIP 0037]: https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki
-        relay: bool,
-    },
+    Version(VersionMessage),
 
     /// A `verack` message.
     ///
@@ -340,6 +293,69 @@ pub enum Message {
     FilterClear,
 }
 
+/// A `version` message.
+///
+/// Note that although this is called `version` in Bitcoin, its role is really
+/// analogous to a `ClientHello` message in TLS, used to begin a handshake, and
+/// is distinct from a simple version number.
+///
+/// This struct provides a type that is guaranteed to be a `version` message,
+/// and allows [`Message::Version`] fields to be accessed directly.
+///
+/// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#version)
+#[derive(Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
+pub struct VersionMessage {
+    /// The network version number supported by the sender.
+    pub version: Version,
+
+    /// The network services advertised by the sender.
+    pub services: PeerServices,
+
+    /// The time when the version message was sent.
+    ///
+    /// This is a 64-bit field. Zebra rejects out-of-range times as invalid.
+    ///
+    /// TODO: replace with a custom DateTime64 type (#2171)
+    #[cfg_attr(
+        any(test, feature = "proptest-impl"),
+        proptest(strategy = "datetime_full()")
+    )]
+    pub timestamp: DateTime<Utc>,
+
+    /// The network address of the node receiving this message, and its
+    /// advertised network services.
+    ///
+    /// Q: how does the handshake know the remote peer's services already?
+    pub address_recv: AddrInVersion,
+
+    /// The network address of the node sending this message, and its
+    /// advertised network services.
+    pub address_from: AddrInVersion,
+
+    /// Node random nonce, randomly generated every time a version
+    /// packet is sent. This nonce is used to detect connections
+    /// to self.
+    pub nonce: Nonce,
+
+    /// The Zcash user agent advertised by the sender.
+    pub user_agent: String,
+
+    /// The last block received by the emitting node.
+    pub start_height: block::Height,
+
+    /// Whether the remote peer should announce relayed
+    /// transactions or not, see [BIP 0037].
+    ///
+    /// Zebra does not implement the bloom filters in [BIP 0037].
+    /// Instead, it only relays:
+    /// - newly verified best chain block hashes and mempool transaction IDs,
+    /// - after it reaches the chain tip.
+    ///
+    /// [BIP 0037]: https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki
+    pub relay: bool,
+}
+
 /// The maximum size of the rejection message.
 ///
 /// This is equivalent to `COMMAND_SIZE` in zcashd.
@@ -349,6 +365,27 @@ const MAX_REJECT_MESSAGE_LENGTH: usize = 12;
 ///
 /// This is equivalent to `MAX_REJECT_MESSAGE_LENGTH` in zcashd.
 const MAX_REJECT_REASON_LENGTH: usize = 111;
+
+impl From<VersionMessage> for Message {
+    fn from(version_message: VersionMessage) -> Self {
+        Message::Version(version_message)
+    }
+}
+
+impl TryFrom<Message> for VersionMessage {
+    type Error = BoxError;
+
+    fn try_from(message: Message) -> Result<Self, Self::Error> {
+        match message {
+            Message::Version(version_message) => Ok(version_message),
+            _ => Err(format!(
+                "{} message is not a version message: {message:?}",
+                message.command()
+            )
+            .into()),
+        }
+    }
+}
 
 // TODO: add tests for Error conversion and Reject message serialization (#4633)
 // (Zebra does not currently send reject messages, and it ignores received reject messages.)
@@ -408,13 +445,13 @@ pub enum RejectReason {
 impl fmt::Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(&match self {
-            Message::Version {
+            Message::Version(VersionMessage {
                 version,
                 address_recv,
                 address_from,
                 user_agent,
                 ..
-            } => format!(
+            }) => format!(
                 "version {{ network: {}, recv: {},_from: {}, user_agent: {:?} }}",
                 version,
                 address_recv.addr(),
@@ -481,7 +518,7 @@ impl Message {
     /// Returns the Zcash protocol message command as a string.
     pub fn command(&self) -> &'static str {
         match self {
-            Message::Version { .. } => "version",
+            Message::Version(_) => "version",
             Message::Verack => "verack",
             Message::Ping(_) => "ping",
             Message::Pong(_) => "pong",

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -300,7 +300,7 @@ pub enum Message {
 /// is distinct from a simple version number.
 ///
 /// This struct provides a type that is guaranteed to be a `version` message,
-/// and allows [`Message::Version`] fields to be accessed directly.
+/// and allows [`Message::Version`](Message) fields to be accessed directly.
 ///
 /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#version)
 #[derive(Clone, Eq, PartialEq, Debug)]

--- a/zebra-network/tests/acceptance.rs
+++ b/zebra-network/tests/acceptance.rs
@@ -1,6 +1,9 @@
 //! Acceptance tests for zebra-network APIs.
 
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::{
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    sync::Arc,
+};
 
 use chrono::Utc;
 
@@ -34,9 +37,9 @@ fn connection_info_types_are_public() {
         relay: true,
     };
 
-    let _connection_info = ConnectionInfo {
+    let _connection_info = Arc::new(ConnectionInfo {
         connected_addr,
         remote,
         negotiated_version,
-    };
+    });
 }

--- a/zebra-network/tests/acceptance.rs
+++ b/zebra-network/tests/acceptance.rs
@@ -1,0 +1,42 @@
+//! Acceptance tests for zebra-network APIs.
+
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+use chrono::Utc;
+
+use zebra_chain::block::Height;
+use zebra_network::{
+    types::{AddrInVersion, Nonce, PeerServices},
+    ConnectedAddr, ConnectionInfo, Version, VersionMessage,
+};
+
+/// Test that the types used in [`ConnectionInfo`] are public,
+/// by compiling code that explicitly uses those types.
+#[test]
+fn connection_info_types_are_public() {
+    let fake_addr: SocketAddr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 3).into();
+    let fake_version = Version(3);
+    let fake_services = PeerServices::default();
+
+    // Each struct field must have its type explicitly listed here
+    let connected_addr: ConnectedAddr = ConnectedAddr::OutboundDirect { addr: fake_addr };
+    let negotiated_version: Version = fake_version;
+
+    let remote = VersionMessage {
+        version: fake_version,
+        services: fake_services,
+        timestamp: Utc::now(),
+        address_recv: AddrInVersion::new(fake_addr, fake_services),
+        address_from: AddrInVersion::new(fake_addr, fake_services),
+        nonce: Nonce::default(),
+        user_agent: "public API compile test".to_string(),
+        start_height: Height(0),
+        relay: true,
+    };
+
+    let _connection_info = ConnectionInfo {
+        connected_addr,
+        remote,
+        negotiated_version,
+    };
+}

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -607,10 +607,7 @@ async fn setup(
 ) -> (
     // real services
     // connected peer which responds with isolated_peer_response
-    Buffer<
-        BoxService<zebra_network::Request, zebra_network::Response, BoxError>,
-        zebra_network::Request,
-    >,
+    Buffer<zebra_network::Client, zebra_network::Request>,
     // inbound service
     BoxCloneService<zebra_network::Request, zebra_network::Response, BoxError>,
     // outbound peer set (only has the connected peer)


### PR DESCRIPTION
## Motivation

We want to support development of an alternate DNS seeder based on `zebra-network`.

Depends-On: #4869

Closes #4678

### Designs

See the detailed design in ticket #4678.

## Solution

Interface changes:
- Return a Client instance from connect_isolated_* functions
- Export the Client type from zebra-network
- Add a copy of the Version message to the ConnectionInfo struct
- Export the types required to use the new APIs

Refactors & improvements:
- Move LoadTrackedCient version into a ConnectionInfo struct
- Add negotiated version to ConnectionInfo
- Add the peer address to ConnectionInfo, add ConnectionInfo to Connection
- Add peer services and user agent to ConnectionInfo

Related fixes:
- Add and improve debug formatting

## Review

Zebra developers should feel free to review this, but we need to check if it works for the zebra-network users first.

### Reviewer Checklist

  - [ ] Code implements Design
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors


## Follow Up Tasks

- Add a copy of the `ConnectionInfo` to `MetaAddr`
- Write tests that make sure remote peer metadata gets turned into the correct `ConnectionInfo` fields
    - peer set connections
    - isolated connections