### PR TITLE
fix(docker): Copy lightwalletd from the correct path during Docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,7 +92,7 @@ FROM deps AS tests
 # TODO: do not hardcode the user /root/ even though is a safe assumption
 # Pre-download Zcash Sprout, Sapling parameters and Lightwalletd binary
 COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/zcash-params /root/.zcash-params /root/.zcash-params
-COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd /lightwalletd /usr/local/bin
+COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd /usr/local/bin/lightwalletd /usr/local/bin
 
 # Re-hydrate the minimum project skeleton identified by `cargo chef prepare` in the planner stage,
 # and build it to cache all possible sentry and test dependencies.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,7 +92,7 @@ FROM deps AS tests
 # TODO: do not hardcode the user /root/ even though is a safe assumption
 # Pre-download Zcash Sprout, Sapling parameters and Lightwalletd binary
 COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/zcash-params /root/.zcash-params /root/.zcash-params
-COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd /usr/local/bin/lightwalletd /usr/local/bin
+COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd /opt/lightwalletd /usr/local/bin
 
 # Re-hydrate the minimum project skeleton identified by `cargo chef prepare` in the planner stage,
 # and build it to cache all possible sentry and test dependencies.

--- a/docker/zcash-lightwalletd/Dockerfile
+++ b/docker/zcash-lightwalletd/Dockerfile
@@ -36,7 +36,7 @@ RUN set -ex; \
     echo "rpcport=8232"; \
   } > "${ZCASHD_CONF_PATH}"
 
-ENTRYPOINT ["/lightwalletd"]
+ENTRYPOINT ["/opt/lightwalletd"]
 CMD ["--no-tls-very-insecure", "--grpc-bind-addr=0.0.0.0:9067",  "--http-bind-addr=0.0.0.0:9068", "--log-file=/dev/stdout", "--log-level=7"]
 
 ##


### PR DESCRIPTION
## Motivation

After PR #4786 merged to main, new builds started failing because the Docker lightwalletd binary path changed:
> Error: buildx failed with: error: failed to solve: failed to compute cache key: failed to calculate checksum of ref uolxlp2jcfip5a0uijnmc10kf::mqxvue803jy58xssyqyxm7uyp: "/lightwalletd": not found

https://github.com/ZcashFoundation/zebra/runs/7663736881?check_suite_focus=true#step:8:484

## Solution

- Use the correct lightwalletd binary path to copy to the Zebra Dockerfile
- 
related fixes:
- Use the correct lightwalletd binary path in the build stage entrypoint in the lightwalletd Dockerfile

## Review

This is an urgent fix to get PRs building again.

### Reviewer Checklist

  - [ ] CI passes

## Follow Up Work

#4612 would have caught this, it's scheduled for next sprint.
