### PR TITLE
fix(tests): Update timeout for Zebra sync tests

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -629,7 +629,8 @@ jobs:
           '(estimated progress.*network_upgrade.*=.*Nu5)|(test result:.*finished in)' \
           "
 
-  # follow the logs of the test we just launched, up to block 1,740,000 (or the test finishing)
+  # follow the logs of the test we just launched, up to block 1,740,000 or later
+  # (or the test finishing)
   #
   # We chose this height because it was about 5 hours into the NU5 sync, at the end of July 2022.
   # This is a temporary workaround until we improve sync speeds.
@@ -683,7 +684,7 @@ jobs:
           ${{ inputs.test_id }} | \
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          '(estimated progress.*current_height.*=.*174[0-9][0-9][0-9][0-9].*remaining_sync_blocks)|(test result:.*finished in)' \
+          '(estimated progress.*current_height.*=.*17[4-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks)|(estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks)||(estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks)|(test result:.*finished in)' \
           "
 
   # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -48,12 +48,12 @@ pub const BETWEEN_NODES_DELAY: Duration = Duration::from_secs(2);
 /// and `zebrad` takes about 30 minutes to update to the tip.
 ///
 /// TODO: reduce to 20 minutes when `zebrad` sync performance improves
-pub const LIGHTWALLETD_UPDATE_TIP_DELAY: Duration = Duration::from_secs(60 * 60);
+pub const LIGHTWALLETD_UPDATE_TIP_DELAY: Duration = Duration::from_secs(11 * 60 * 60);
 
 /// The amount of time we wait for lightwalletd to do a full sync to the tip.
 ///
 /// See [`LIGHTWALLETD_UPDATE_TIP_DELAY`] for details.
-pub const LIGHTWALLETD_FULL_SYNC_TIP_DELAY: Duration = Duration::from_secs(150 * 60);
+pub const LIGHTWALLETD_FULL_SYNC_TIP_DELAY: Duration = Duration::from_secs(11 * 60 * 60);
 
 /// The amount of extra time we wait for Zebra to sync to the tip,
 /// after we ignore a lightwalletd failure.

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -363,7 +363,7 @@ pub fn create_cached_database_height(
 ) -> Result<()> {
     eprintln!("creating cached database");
 
-    // 16 hours
+    // 20 hours
     let timeout = Duration::from_secs(60 * 60 * 20);
 
     // Use a persistent state, so we can handle large syncs

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -364,7 +364,7 @@ pub fn create_cached_database_height(
     eprintln!("creating cached database");
 
     // 16 hours
-    let timeout = Duration::from_secs(60 * 60 * 16);
+    let timeout = Duration::from_secs(60 * 60 * 20);
 
     // Use a persistent state, so we can handle large syncs
     let mut config = cached_mandatory_checkpoint_test_config()?;


### PR DESCRIPTION
## Motivation

Currently Zebra CI is failing due to multiple timeouts.

Close https://github.com/zcashfoundation/zebra/issues/4910

## Solution

Increase the full sync timeout from 16 hours to 20 hours.
Increase the update sync timeout from 1-3 hours to 11 hours.

## Review

Anyone can review, if the CI pass i think we should merge this fast as it is blocking all the other PRs.

### Reviewer Checklist

  - [ ] CI fully pass

## Follow Up Work

Update the checkpoints.