### PR TITLE
Fix clippy::derive_partial_eq_without_eq in generated gRPC test code

### DIFF
--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -60,6 +60,10 @@ fn main() {
     tonic_build::configure()
         .build_client(true)
         .build_server(false)
+        // The lightwalletd gRPC types don't use floats or complex collections,
+        // so we can derive `Eq` as well as the default generated `PartialEq` derive.
+        // This fixes `clippy::derive_partial_eq_without_eq` warnings.
+        .type_attribute(".", "#[derive(Eq)]")
         .compile(
             &["tests/common/lightwalletd/proto/service.proto"],
             &["tests/common/lightwalletd/proto"],


### PR DESCRIPTION
## Motivation

`tonic`'s generated code causes `clippy::derive_partial_eq_without_eq` warnings, but Zebra's CI requires our test builds to have no clippy warnings.

The `tonic` developers removed clippy from their CI, so we have to fix it ourselves. (The standard approach is to silence clippy warnings in generated code.)

Close #4921.

## Solution

Since the lightwalletd gRPC types can all be compared for total equality, we can tell `tonic` to derive `Eq` for all those types.

## Review

This is critical priority because it is stopping other PRs merging.

### Reviewer Checklist

  - [x] Clippy CI passes

