### PR TITLE
Revert: deserialize stored transactions in a rayon thread

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_format/block.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/block.rs
@@ -231,6 +231,8 @@ impl FromDisk for Transaction {
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
         let bytes = bytes.as_ref();
 
+        // TODO: skip cryptography verification during transaction deserialization from storage,
+        //       or do it in a rayon thread (ideally in parallel with other transactions)
         bytes
             .as_ref()
             .zcash_deserialize_into()

--- a/zebra-state/src/service/finalized_state/disk_format/block.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/block.rs
@@ -231,21 +231,10 @@ impl FromDisk for Transaction {
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
         let bytes = bytes.as_ref();
 
-        let mut tx = None;
-
-        // # Performance
-        //
-        // Move CPU-intensive deserialization cryptography into the rayon thread pool.
-        // This avoids blocking the tokio executor.
-        rayon::in_place_scope_fifo(|scope| {
-            scope.spawn_fifo(|_scope| {
-                tx = Some(bytes.as_ref().zcash_deserialize_into().expect(
-                    "deserialization format should match the serialization format used by IntoDisk",
-                ));
-            });
-        });
-
-        tx.expect("scope has already run")
+        bytes
+            .as_ref()
+            .zcash_deserialize_into()
+            .expect("deserialization format should match the serialization format used by IntoDisk")
     }
 }
 


### PR DESCRIPTION
## Motivation

This PR fixes a `lightwalletd` sync performance regression caused by PR #4801.

While that change was more correct, it also causes a 20% slowdown in `lightwalletd` sync performance:
- 34 minutes to get to block 1,700,000 after this PR
- 39-40 minutes to get to block 1,700,000 before this PR

Close #4831.

## Solution

Revert the rayon threads added in PR #4801.

## Review

This PR is important for some of our upcoming users, but it is not urgent.

### Reviewer Checklist

  - [x] CI passes

