### PR TITLE
Update supported Rust versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ for your platform:
 
 1. Install [`cargo` and `rustc`](https://www.rust-lang.org/tools/install).
      - Zebra is tested with the latest `stable` Rust version.
-        Earlier versions are not supported or tested, but they might work.
-        (Rust 1.57 and earlier are not supported, due to missing features.)
+       Earlier versions are not supported or tested.
+       Any Zebra release can remove support for older Rust versions, without any notice.
+       (Rust 1.59 and earlier are definitely not supported, due to missing features.)
 2. Install Zebra's build dependencies:
      - **libclang:** the `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` packages, depending on your package manager
      - **clang** or another C++ compiler: `g++`, `Xcode`, or `MSVC`


### PR DESCRIPTION
## Motivation

We just discovered that an older Rust version definitely isn't supported.

## Review

This is a routine documentation update.

### Reviewer Checklist

  - [ ] Docs make sense

