### PR TITLE
fix(test): Show full Zebra test panic details in CI logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6543,6 +6543,7 @@ dependencies = [
  "color-eyre",
  "futures",
  "hex",
+ "humantime",
  "indexmap",
  "insta",
  "lazy_static",

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -26,9 +26,11 @@ color-eyre = "0.6.1"
 # Enable a feature that makes tinyvec compile much faster.
 tinyvec = { version = "1.6.0", features = ["rustc_1_55"] }
 
+humantime = "2.1.0"
 owo-colors = "3.4.0"
 spandoc = "0.2.2"
 thiserror = "1.0.32"
+
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 tracing-error = "0.2.0"
 tracing = "0.1.31"

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -812,6 +812,7 @@ impl<T> TestChild<T> {
     /// Note: the timeout is only checked after each full line is received from
     /// the child (#1140).
     #[instrument(skip(self, lines))]
+    #[allow(clippy::unwrap_in_result)]
     pub fn expect_line_matching_regexes<L>(
         &mut self,
         lines: &mut L,

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -567,7 +567,7 @@ impl<T> TestChild<T> {
     {
         self.apply_failure_regexes_to_outputs();
 
-        if let Some(line) = self.stdout.as_mut().and_then(|iter| iter.next()) {
+        if let Some(line_result) = self.stdout.as_mut().and_then(|iter| iter.next()) {
             let bypass_test_capture = self.bypass_test_capture;
 
             if let Some(write_context) = write_context.into() {
@@ -575,7 +575,8 @@ impl<T> TestChild<T> {
             }
 
             Self::write_to_test_logs(
-                line.context_from(self)
+                line_result
+                    .context_from(self)
                     .expect("failure reading test process logs"),
                 bypass_test_capture,
             );
@@ -599,7 +600,7 @@ impl<T> TestChild<T> {
     {
         self.apply_failure_regexes_to_outputs();
 
-        if let Some(line) = self.stderr.as_mut().and_then(|iter| iter.next()) {
+        if let Some(line_result) = self.stderr.as_mut().and_then(|iter| iter.next()) {
             let bypass_test_capture = self.bypass_test_capture;
 
             if let Some(write_context) = write_context.into() {
@@ -607,7 +608,8 @@ impl<T> TestChild<T> {
             }
 
             Self::write_to_test_logs(
-                line.context_from(self)
+                line_result
+                    .context_from(self)
                     .expect("failure reading test process logs"),
                 bypass_test_capture,
             );

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -714,9 +714,7 @@ impl<T> TestChild<T> {
             Err(report) => {
                 // Read all the log lines for error context
                 self.stdout = Some(lines);
-                let error = Err(report).context_from(self);
-
-                error
+                Err(report).context_from(self)
             }
         }
     }
@@ -748,9 +746,7 @@ impl<T> TestChild<T> {
             Err(report) => {
                 // Read all the log lines for error context
                 self.stderr = Some(lines);
-                let error = Err(report).context_from(self);
-
-                error
+                Err(report).context_from(self)
             }
         }
     }

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -838,7 +838,7 @@ impl<T> TestChild<T> {
             // If the process exits between is_running and kill, we will see
             // spurious errors here. So we want to ignore "no such process"
             // errors from kill.
-            self.kill(true).context_from(self)?;
+            self.kill(true)?;
         }
 
         let report = eyre!(

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -1254,12 +1254,10 @@ impl<T> ContextFrom<&mut TestChild<T>> for Report {
                 });
                 let _ = writeln!(&mut stdout_buf, "{}", line);
             }
-            source.stdout = None;
         } else if let Some(child) = &mut source.child {
             if let Some(stdout) = &mut child.stdout {
                 let _ = stdout.read_to_string(&mut stdout_buf);
             }
-            child.stdout = None;
         }
 
         if let Some(stderr) = &mut source.stderr {
@@ -1269,12 +1267,10 @@ impl<T> ContextFrom<&mut TestChild<T>> for Report {
                 });
                 let _ = writeln!(&mut stderr_buf, "{}", line);
             }
-            source.stderr = None;
         } else if let Some(child) = &mut source.child {
             if let Some(stderr) = &mut child.stderr {
                 let _ = stderr.read_to_string(&mut stderr_buf);
             }
-            child.stderr = None;
         }
 
         self.section(stdout_buf.header("Unread Stdout:"))

--- a/zebra-test/tests/command.rs
+++ b/zebra-test/tests/command.rs
@@ -185,19 +185,15 @@ fn kill_on_timeout_no_output() -> Result<()> {
 }
 
 /// Make sure failure regexes detect when a child process prints a failure message to stdout,
-/// and panic with a test failure message.
+/// and fail with a test failure message.
 #[test]
-#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stdout_failure_message() {
     let _init_guard = zebra_test::init();
 
     const TEST_CMD: &str = "echo";
     // Skip the test if the test system does not have the command
     if !is_command_available(TEST_CMD, &[]) {
-        panic!(
-            "skipping test: command not available\n\
-             fake panic message: Logged a failure message"
-        );
+        return;
     }
 
     let mut child = tempdir()
@@ -209,15 +205,21 @@ fn failure_regex_matches_stdout_failure_message() {
 
     // Any method that reads output should work here.
     // We use a non-matching regex, to trigger the failure panic.
-    child
+    let expected_error = child
         .expect_stdout_line_matches("this regex should not match")
         .unwrap_err();
+
+    let expected_error = format!("{:?}", expected_error);
+    assert!(
+        expected_error.contains("Logged a failure message"),
+        "error did not contain expected failure message: {}",
+        expected_error,
+    );
 }
 
 /// Make sure failure regexes detect when a child process prints a failure message to stderr,
 /// and panic with a test failure message.
 #[test]
-#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_matches_stderr_failure_message() {
     let _init_guard = zebra_test::init();
 
@@ -230,10 +232,7 @@ fn failure_regex_matches_stderr_failure_message() {
     const TEST_CMD: &str = "bash";
     // Skip the test if the test system does not have the command
     if !is_command_available(TEST_CMD, &["-c", "read -t 1 -p failure_message"]) {
-        panic!(
-            "skipping test: command not available\n\
-             fake panic message: Logged a failure message"
-        );
+        return;
     }
 
     let mut child = tempdir()
@@ -245,9 +244,16 @@ fn failure_regex_matches_stderr_failure_message() {
 
     // Any method that reads output should work here.
     // We use a non-matching regex, to trigger the failure panic.
-    child
+    let expected_error = child
         .expect_stderr_line_matches("this regex should not match")
         .unwrap_err();
+
+    let expected_error = format!("{:?}", expected_error);
+    assert!(
+        expected_error.contains("Logged a failure message"),
+        "error did not contain expected failure message: {}",
+        expected_error,
+    );
 }
 
 /// Make sure failure regexes detect when a child process prints a failure message to stdout,
@@ -260,10 +266,7 @@ fn failure_regex_matches_stdout_failure_message_drop() {
     const TEST_CMD: &str = "echo";
     // Skip the test if the test system does not have the command
     if !is_command_available(TEST_CMD, &[]) {
-        panic!(
-            "skipping test: command not available\n\
-             fake panic message: Logged a failure message"
-        );
+        return;
     }
 
     let _child = tempdir()
@@ -289,10 +292,7 @@ fn failure_regex_matches_stdout_failure_message_kill() {
     const TEST_CMD: &str = "echo";
     // Skip the test if the test system does not have the command
     if !is_command_available(TEST_CMD, &[]) {
-        panic!(
-            "skipping test: command not available\n\
-             fake panic message: Logged a failure message"
-        );
+        return;
     }
 
     let mut child = tempdir()
@@ -307,7 +307,7 @@ fn failure_regex_matches_stdout_failure_message_kill() {
 
     // Kill should read all unread output to generate the error context,
     // or the output should be read on drop.
-    child.kill().unwrap();
+    child.kill(true).unwrap();
 }
 
 /// Make sure failure regexes detect when a child process prints a failure message to stdout,
@@ -320,10 +320,7 @@ fn failure_regex_matches_stdout_failure_message_kill_on_error() {
     const TEST_CMD: &str = "echo";
     // Skip the test if the test system does not have the command
     if !is_command_available(TEST_CMD, &[]) {
-        panic!(
-            "skipping test: command not available\n\
-             fake panic message: Logged a failure message"
-        );
+        return;
     }
 
     let child = tempdir()
@@ -352,10 +349,7 @@ fn failure_regex_matches_stdout_failure_message_no_kill_on_error() {
     const TEST_CMD: &str = "echo";
     // Skip the test if the test system does not have the command
     if !is_command_available(TEST_CMD, &[]) {
-        panic!(
-            "skipping test: command not available\n\
-             fake panic message: Logged a failure message"
-        );
+        return;
     }
 
     let child = tempdir()
@@ -379,7 +373,6 @@ fn failure_regex_matches_stdout_failure_message_no_kill_on_error() {
 ///
 /// TODO: test the failure regex on timeouts with no output (#1140)
 #[test]
-#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_timeout_continuous_output() {
     let _init_guard = zebra_test::init();
 
@@ -389,10 +382,7 @@ fn failure_regex_timeout_continuous_output() {
     const TEST_CMD: &str = "hexdump";
     // Skip the test if the test system does not have the command
     if !is_command_available(TEST_CMD, &["/dev/null"]) {
-        panic!(
-            "skipping test: command not available\n\
-             fake panic message: Logged a failure message"
-        );
+        return;
     }
 
     // Without '-v', hexdump hides duplicate lines. But we want duplicate lines
@@ -406,9 +396,16 @@ fn failure_regex_timeout_continuous_output() {
 
     // We need to use expect_stdout_line_matches, because wait_with_output ignores timeouts.
     // We use a non-matching regex, to trigger the timeout and the failure panic.
-    child
+    let expected_error = child
         .expect_stdout_line_matches("this regex should not match")
         .unwrap_err();
+
+    let expected_error = format!("{:?}", expected_error);
+    assert!(
+        expected_error.contains("Logged a failure message"),
+        "error did not contain expected failure message: {}",
+        expected_error,
+    );
 }
 
 /// Make sure failure regexes are checked when a child process prints a failure message to stdout,
@@ -423,10 +420,7 @@ fn failure_regex_matches_stdout_failure_message_wait_for_output() {
     const TEST_CMD: &str = "echo";
     // Skip the test if the test system does not have the command
     if !is_command_available(TEST_CMD, &[]) {
-        panic!(
-            "skipping test: command not available\n\
-             fake panic message: Logged a failure message"
-        );
+        return;
     }
 
     let child = tempdir()
@@ -447,17 +441,13 @@ fn failure_regex_matches_stdout_failure_message_wait_for_output() {
 /// Make sure failure regex iters detect when a child process prints a failure message to stdout,
 /// and panic with a test failure message.
 #[test]
-#[should_panic(expected = "Logged a failure message")]
 fn failure_regex_iter_matches_stdout_failure_message() {
     let _init_guard = zebra_test::init();
 
     const TEST_CMD: &str = "echo";
     // Skip the test if the test system does not have the command
     if !is_command_available(TEST_CMD, &[]) {
-        panic!(
-            "skipping test: command not available\n\
-             fake panic message: Logged a failure message"
-        );
+        return;
     }
 
     let mut child = tempdir()
@@ -472,9 +462,16 @@ fn failure_regex_iter_matches_stdout_failure_message() {
 
     // Any method that reads output should work here.
     // We use a non-matching regex, to trigger the failure panic.
-    child
+    let expected_error = child
         .expect_stdout_line_matches("this regex should not match")
         .unwrap_err();
+
+    let expected_error = format!("{:?}", expected_error);
+    assert!(
+        expected_error.contains("Logged a failure message"),
+        "error did not contain expected failure message: {}",
+        expected_error,
+    );
 }
 
 /// Make sure ignore regexes override failure regexes.

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -248,7 +248,7 @@ pub fn sync_until(
 
         // make sure the child process is dead
         // if it has already exited, ignore that error
-        let _ = child.kill(true);
+        child.kill(true)?;
 
         Ok(child.dir.take().expect("dir was not already taken"))
     } else {
@@ -389,6 +389,8 @@ pub fn create_cached_database_height(
 
     child.expect_stdout_line_matches(stop_regex)?;
 
+    // make sure the child process is dead
+    // if it has already exited, ignore that error
     child.kill(true)?;
 
     Ok(())

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -248,7 +248,7 @@ pub fn sync_until(
 
         // make sure the child process is dead
         // if it has already exited, ignore that error
-        let _ = child.kill();
+        let _ = child.kill(true);
 
         Ok(child.dir.take().expect("dir was not already taken"))
     } else {
@@ -389,7 +389,7 @@ pub fn create_cached_database_height(
 
     child.expect_stdout_line_matches(stop_regex)?;
 
-    child.kill()?;
+    child.kill(true)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

We're seeing some Zebra panics in CI. Our custom test harness just reports "The application panicked (crashed).", with no details.

Example logs:
https://github.com/ZcashFoundation/zebra/runs/7981879420?check_suite_focus=true#step:6:1103

Depends-On: #4945

## Solution

- Add output logs to test context, and add test harness tests to check it works
- Let empty test child logs be read again (and produce empty output

Related refactors:
- Add an `ignore_exited` argument to test child process `kill()`
- Handle test failure regexes using Result::Err, rather than panicking

Related changes:
- Log the command timeout when an acceptance test fails

## Review

This is an urgent fix, so we can see panic details in our CI logs.

### Reviewer Checklist

  - [x] CI passes

