### PR TITLE
fix(ci): Increase CI disk size to 200GB

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -130,9 +130,9 @@ jobs:
         id: create-instance
         run: |
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
-          --boot-disk-size 100GB \
+          --boot-disk-size 200GB \
           --boot-disk-type pd-ssd \
-          --create-disk name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=100GB,type=pd-ssd \
+          --create-disk name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=200GB,type=pd-ssd \
           --container-image debian:buster \
           --container-restart-policy=never \
           --machine-type ${{ env.MACHINE_TYPE }} \
@@ -313,9 +313,9 @@ jobs:
         id: create-instance
         run: |
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
-          --boot-disk-size 100GB \
+          --boot-disk-size 200GB \
           --boot-disk-type pd-ssd \
-          --create-disk image=${{ env.CACHED_DISK_NAME }},name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=100GB,type=pd-ssd \
+          --create-disk image=${{ env.CACHED_DISK_NAME }},name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=200GB,type=pd-ssd \
           --container-image debian:buster \
           --container-restart-policy=never \
           --machine-type ${{ env.MACHINE_TYPE }} \


### PR DESCRIPTION
## Motivation

Some tests are failing because they run out of disk space.

We can limit the size of the database by changing how it is configured in Zebra, but right now we just need to make CI pass.

### Logs

> Unread Stderr: 
> ...
>  Message: expected that errors would not occur when writing to disk or updating note commitment and history trees: Error { message: "IO error: No space left on device: While appending to file: /var/cache/zebrad-cache/state/v25/mainnet/017386.log: No space left on device" } 
> Location: zebra-state/src/service.rs:301

https://github.com/ZcashFoundation/zebra/runs/8002360538?check_suite_focus=true#step:6:1216

## Solution

- Increase the size of cached state disks to 200GB
- Increase the size of boot disks to 200GB (the send transaction test copies the state to `/tmp`)

## Review

This is an urgent fix to CI, anyone can review it.

### Reviewer Checklist

  - [ ] CI passes

