### PR TITLE
ci(mergify): increase batch sizes

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,9 +5,9 @@ queue_rules:
     allow_inplace_checks: True
     allow_checks_interruption: False
     speculative_checks: 1
-    batch_size: 5
+    batch_size: 8
     # Wait a short time to embark hotfixes together in a merge train
-    batch_max_wait_time: "2 minutes"
+    batch_max_wait_time: "1 minute"
     conditions:
       # Mergify automatically applies status check, approval, and conversation rules,
       # which are the same as the GitHub main branch protection rules
@@ -18,9 +18,9 @@ queue_rules:
     allow_inplace_checks: True
     allow_checks_interruption: True
     speculative_checks: 1
-    batch_size: 5
+    batch_size: 8
     # Wait for a few minutes to embark high priority tickets together in a merge train
-    batch_max_wait_time: "5 minutes"
+    batch_max_wait_time: "10 minutes"
     conditions:
       - base=main
 
@@ -28,9 +28,9 @@ queue_rules:
     allow_inplace_checks: True
     allow_checks_interruption: True
     speculative_checks: 1
-    batch_size: 5
+    batch_size: 8
     # Wait a bit longer to embark low priority tickets together in a merge train
-    batch_max_wait_time: "10 minutes"
+    batch_max_wait_time: "20 minutes"
     conditions:
       - base=main
 

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,7 +7,7 @@ queue_rules:
     speculative_checks: 1
     batch_size: 8
     # Wait a short time to embark hotfixes together in a merge train
-    batch_max_wait_time: "1 minute"
+    batch_max_wait_time: "2 minutes"
     conditions:
       # Mergify automatically applies status check, approval, and conversation rules,
       # which are the same as the GitHub main branch protection rules
@@ -18,7 +18,7 @@ queue_rules:
     allow_inplace_checks: True
     allow_checks_interruption: True
     speculative_checks: 1
-    batch_size: 8
+    batch_size: 20
     # Wait for a few minutes to embark high priority tickets together in a merge train
     batch_max_wait_time: "10 minutes"
     conditions:
@@ -28,7 +28,7 @@ queue_rules:
     allow_inplace_checks: True
     allow_checks_interruption: True
     speculative_checks: 1
-    batch_size: 8
+    batch_size: 20
     # Wait a bit longer to embark low priority tickets together in a merge train
     batch_max_wait_time: "20 minutes"
     conditions:


### PR DESCRIPTION
## Motivation

We've got a bunch of PRs waiting to merge, we can merge them faster in larger batches.

Depends-On: #4945

### Specifications

Mergify deals with failed PRs using a binary search, so powers of two are the most efficient batch size:
https://docs.mergify.com/actions/queue/#batch-size

## Solution

- Increase Mergify batch sizes
- Increase Mergify queue wait times for lower priority queues, to generate larger batches

## Review

Anyone can review this PR, I want to merge it soon to make other merges faster.

### Reviewer Checklist

  - [ ] Mergify config is valid

