### PR TITLE
fix(ci): Fix a regular expression typo in a full sync job

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -716,7 +716,7 @@ jobs:
           ${{ inputs.test_id }} | \
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          '(estimated progress.*current_height.*=.*17[4-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks)|(estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks)||(estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks)|(test result:.*finished in)' \
+          '(estimated progress.*current_height.*=.*17[4-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks)|(estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks)|(estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks)|(test result:.*finished in)' \
           "
 
   # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)


### PR DESCRIPTION
## Motivation

There's a mistaken `||` in a regular expression in a full sync job, which causes the job to end really quickly, so the next job times out.

This only impacts full syncs, the update syncs are short enough that the timeout doesn't happen.

## Review

Anyone can review this PR, it's needed to fully apply the fix in #4945 to the cached state disks.
But it doesn't block other PRs merging.

### Reviewer Checklist

  - [ ] Fix makes sense

