### PR TITLE
Full sync with logging for very slow state block commits

### DIFF
--- a/zebra-chain/src/diagnostic.rs
+++ b/zebra-chain/src/diagnostic.rs
@@ -66,6 +66,11 @@ impl CodeTimer {
         self.finish_inner(Some(module_path), Some(line), description);
     }
 
+    /// Ignore this timer: it will not check the elapsed time or log any warnings.
+    pub fn ignore(mut self) {
+        self.has_finished = true;
+    }
+
     /// Finish timing the execution of a function, method, or other code region.
     ///
     /// This private method can be called from [`CodeTimer::finish()`] or `drop()`.

--- a/zebra-chain/src/diagnostic.rs
+++ b/zebra-chain/src/diagnostic.rs
@@ -7,10 +7,14 @@ use std::time::{Duration, Instant};
 use crate::fmt::duration_short;
 
 /// The default minimum info-level message time.
-pub const DEFAULT_MIN_INFO_TIME: Duration = Duration::from_secs(5);
+///
+/// This is high enough to ignore most slow code.
+pub const DEFAULT_MIN_INFO_TIME: Duration = Duration::from_secs(5 * 60);
 
 /// The default minimum warning message time.
-pub const DEFAULT_MIN_WARN_TIME: Duration = Duration::from_secs(20);
+///
+/// This is a little lower than the block verify timeout.
+pub const DEFAULT_MIN_WARN_TIME: Duration = Duration::from_secs(9 * 60);
 
 /// A guard that logs code execution time when dropped.
 #[derive(Debug)]

--- a/zebra-chain/src/parallel/tree.rs
+++ b/zebra-chain/src/parallel/tree.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 
 use crate::{
     block::{Block, Height},
+    diagnostic::CodeTimer,
     orchard, sapling, sprout,
 };
 
@@ -49,7 +50,8 @@ impl NoteCommitmentTrees {
         &mut self,
         block: &Arc<Block>,
     ) -> Result<(), NoteCommitmentTreeError> {
-        self.update_trees_parallel_list(
+        let timer = CodeTimer::start();
+        let res = self.update_trees_parallel_list(
             [(
                 block
                     .coinbase_height()
@@ -58,7 +60,9 @@ impl NoteCommitmentTrees {
             )]
             .into_iter()
             .collect(),
-        )
+        );
+        timer.finish(module_path!(), line!(), "update_trees_parallel");
+        res
     }
 
     /// Updates the note commitment trees using the transactions in `block`,
@@ -70,6 +74,7 @@ impl NoteCommitmentTrees {
         &mut self,
         block_list: BTreeMap<Height, Arc<Block>>,
     ) -> Result<(), NoteCommitmentTreeError> {
+        let timer = CodeTimer::start();
         // Prepare arguments for parallel threads
         let NoteCommitmentTrees {
             sprout,
@@ -77,67 +82,92 @@ impl NoteCommitmentTrees {
             orchard,
         } = self.clone();
 
+        timer.finish(module_path!(), line!(), "update_trees_parallel_list 1");
+
+        let timer = CodeTimer::start();
         let sprout_note_commitments: Vec<_> = block_list
             .values()
             .flat_map(|block| block.transactions.iter())
             .flat_map(|tx| tx.sprout_note_commitments())
             .cloned()
             .collect();
+        timer.finish(module_path!(), line!(), "update_trees_parallel_list 2");
+        let timer = CodeTimer::start();
         let sapling_note_commitments: Vec<_> = block_list
             .values()
             .flat_map(|block| block.transactions.iter())
             .flat_map(|tx| tx.sapling_note_commitments())
             .cloned()
             .collect();
+        timer.finish(module_path!(), line!(), "update_trees_parallel_list 3");
+
+        let timer = CodeTimer::start();
         let orchard_note_commitments: Vec<_> = block_list
             .values()
             .flat_map(|block| block.transactions.iter())
             .flat_map(|tx| tx.orchard_note_commitments())
             .cloned()
             .collect();
+        timer.finish(module_path!(), line!(), "update_trees_parallel_list 4");
 
         let mut sprout_result = None;
         let mut sapling_result = None;
         let mut orchard_result = None;
 
+        let all_trees_timer = CodeTimer::start();
         rayon::in_place_scope_fifo(|scope| {
             if !sprout_note_commitments.is_empty() {
                 scope.spawn_fifo(|_scope| {
+                    let timer = CodeTimer::start();
                     sprout_result = Some(Self::update_sprout_note_commitment_tree(
                         sprout,
                         sprout_note_commitments,
                     ));
+                    timer.finish(module_path!(), line!(), "updating sprout note commitment tree");
                 });
             }
 
             if !sapling_note_commitments.is_empty() {
                 scope.spawn_fifo(|_scope| {
+                    let timer = CodeTimer::start();
                     sapling_result = Some(Self::update_sapling_note_commitment_tree(
                         sapling,
                         sapling_note_commitments,
                     ));
+                    timer.finish(module_path!(), line!(), "updating sapling note commitment tree");
                 });
             }
 
             if !orchard_note_commitments.is_empty() {
                 scope.spawn_fifo(|_scope| {
+                    let timer = CodeTimer::start();
                     orchard_result = Some(Self::update_orchard_note_commitment_tree(
                         orchard,
                         orchard_note_commitments,
                     ));
+                    timer.finish(module_path!(), line!(), "updating orchard note commitment tree");
                 });
             }
         });
+        all_trees_timer.finish(module_path!(), line!(), "updating all note commitment trees in parallel");
 
+        let timer = CodeTimer::start();
         if let Some(sprout_result) = sprout_result {
             self.sprout = sprout_result?;
         }
+        timer.finish(module_path!(), line!(), "update_trees_parallel_list 8");
+
+        let timer = CodeTimer::start();
         if let Some(sapling_result) = sapling_result {
             self.sapling = sapling_result?;
         }
+        timer.finish(module_path!(), line!(), "update_trees_parallel_list 9");
+
+        let timer = CodeTimer::start();
         if let Some(orchard_result) = orchard_result {
             self.orchard = orchard_result?;
         }
+        timer.finish(module_path!(), line!(), "update_trees_parallel_list 10");
 
         Ok(())
     }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -244,7 +244,14 @@ impl StateService {
             .disk
             .queue_and_commit_finalized((finalized, rsp_tx))
             .map(ChainTipBlock::from);
+
+        let timer = CodeTimer::start();
         self.chain_tip_sender.set_finalized_tip(tip_block);
+        timer.finish(
+            module_path!(),
+            line!(),
+            "CommitFinalizedBlock/set_finalized_tip()",
+        );
 
         rsp_rx
     }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -678,6 +678,10 @@ impl Service<Request> for StateService {
 
                 self.pending_utxos.check_against(&finalized.new_outputs);
 
+                timer.finish(module_path!(), line!(), "pending_utxos.check_against()");
+
+                let timer = CodeTimer::start();
+
                 // # Performance
                 //
                 // Allow other async tasks to make progress while blocks are being verified

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -395,7 +395,7 @@ impl DiskWriteBatch {
 
         // Commit block and transaction data.
         // (Transaction indexes, note commitments, and UTXOs are committed later.)
-        self.prepare_block_header_transactions_batch(db, &finalized)?;
+        self.prepare_block_header_and_transaction_data_batch(db, &finalized)?;
 
         // # Consensus
         //
@@ -432,14 +432,14 @@ impl DiskWriteBatch {
         Ok(())
     }
 
-    /// Prepare a database batch containing the block header and transactions
+    /// Prepare a database batch containing the block header and transaction data
     /// from `finalized.block`, and return it (without actually writing anything).
     ///
     /// # Errors
     ///
     /// - This method does not currently return any errors.
     #[allow(clippy::unwrap_in_result)]
-    pub fn prepare_block_header_transactions_batch(
+    pub fn prepare_block_header_and_transaction_data_batch(
         &mut self,
         db: &DiskDb,
         finalized: &FinalizedBlock,

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -117,7 +117,7 @@ fn test_block_db_round_trip_with(
         // Skip validation by writing the block directly to the database
         let mut batch = DiskWriteBatch::new(Mainnet);
         batch
-            .prepare_block_header_transactions_batch(&state.db, &finalized)
+            .prepare_block_header_and_transaction_data_batch(&state.db, &finalized)
             .expect("block is valid for batch");
         state.db.write(batch).expect("block is valid for writing");
 


### PR DESCRIPTION
## Motivation

We want to find out which parts of state block commits are slow in CI, because we can't reproduce them locally.

These are diagnostics for ticket #4937, where some blocks take 15 minutes to write to the state.

## Solution

- change info threshold to 5 minutes and warn to 9 minutes
- add slow code logging for block commits, block writes, and note commitment tree updates

## Review

This PR doesn't need review.

### Reviewer Checklist

  - [ ] Logging works

## Follow Up Work

Read the logs to work out why #4937 is happening