### PR TITLE
fix(ci): Expand cached state disks before running tests

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -367,7 +367,7 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
-          sudo e2fsck -v -f /dev/sdb \
+          sudo e2fsck -v -f -p /dev/sdb \
           && \
           sudo resize2fs -p /dev/sdb \
           && \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -367,6 +367,11 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
+          sudo apt-get --quiet update --yes \
+          && \
+          sudo apt-get --quiet install --yes --no-install-recommends \
+          cloud-guest-utils \
+          && \
           sudo growpart --verbose /dev/sdb 1 \
           && \
           sudo resize2fs -p /dev/sdb \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -367,12 +367,7 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
-          sudo apt-get --quiet update --yes \
-          && \
-          sudo apt-get --quiet install --yes --no-install-recommends \
-          cloud-guest-utils \
-          && \
-          sudo growpart --verbose /dev/sdb 1 \
+          sudo e2fsck -v -f /dev/sdb \
           && \
           sudo resize2fs -p /dev/sdb \
           && \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -938,14 +938,22 @@ jobs:
         with:
           short-length: 7
 
-      # Disk images in GCP are required to be in lowercase, but the blockchain network
-      # uses sentence case, so we need to downcase ${{ inputs.network }}
+      # Performs formatting on disk name components.
       #
-      # Passes ${{ inputs.network }} to subsequent steps using $NETWORK env variable
-      - name: Downcase network name for disks
+      # Disk images in GCP are required to be in lowercase, but the blockchain network
+      # uses sentence case, so we need to downcase ${{ inputs.network }}.
+      #
+      # Disk image names in GCP are limited to 63 characters, so we need to limit
+      # branch names to 13 characters.
+      #
+      # Passes ${{ inputs.network }} to subsequent steps using $NETWORK env variable.
+      # Passes ${{ env.GITHUB_REF_SLUG_URL }} to subsequent steps using $SHORT_GITHUB_REF env variable.
+      - name: Format network name and branch name for disks
         run: |
           NETWORK_CAPS=${{ inputs.network }}
           echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+          LONG_GITHUB_REF=${{ env.GITHUB_REF_SLUG_URL }}
+          echo "SHORT_GITHUB_REF=${LONG_GITHUB_REF:0:13}" >> $GITHUB_ENV
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
@@ -990,7 +998,7 @@ jobs:
           SYNC_HEIGHT=$(echo $DOCKER_LOGS | grep -oE '${{ inputs.height_grep_text }}\([0-9]+\)' | grep -oE '[0-9]+' | tail -1 || [[ $? == 1 ]])
           echo "SYNC_HEIGHT=$SYNC_HEIGHT" >> $GITHUB_ENV
 
-      # Sets the $UPDATE_SUFFIX env var to "-update" if using cached state,
+      # Sets the $UPDATE_SUFFIX env var to "-u" if using cached state,
       # and the empty string otherwise.
       #
       # Also sets a unique date and time suffix $TIME_SUFFIX.
@@ -999,26 +1007,32 @@ jobs:
           UPDATE_SUFFIX=""
 
           if [[ "${{ inputs.needs_zebra_state }}" == "true" ]]; then
-              UPDATE_SUFFIX="-update"
+              UPDATE_SUFFIX="-u"
           fi
 
-          TIME_SUFFIX=$(date '+%Y-%m-%d-%H-%M-%S' --utc)
+          # We're going to delete old images after a month, so we don't need the year here
+          TIME_SUFFIX=$(date '+%m%d%H%M%S' --utc)
 
           echo "UPDATE_SUFFIX=$UPDATE_SUFFIX" >> $GITHUB_ENV
           echo "TIME_SUFFIX=$TIME_SUFFIX" >> $GITHUB_ENV
 
-      # Create an image from disk that will be used for following/other tests
+      # Create an image from disk that will be used for following/other tests.
+      #
       # This image can contain:
       # - Zebra cached state
       # - Zebra + lightwalletd cached state
-      # Which cached state is being saved to the disk is defined by ${{ inputs.disk_prefix }}
+      # Which cached state is being saved to the disk is defined by ${{ inputs.disk_prefix }}.
+      #
+      # The image name must be unique, and be 63 characters or less.
+      # The timestamp makes images from the same commit unique,
+      # as long as they don't finish in the same second.
       #
       # Force the image creation (--force) as the disk is still attached even though is not being
-      # used by the container
+      # used by the container.
       - name: Create image from state disk
         run: |
           gcloud compute images create \
-          "${{ inputs.disk_prefix }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-v${{ env.STATE_VERSION }}-${{ env.NETWORK }}-${{ inputs.disk_suffix }}$UPDATE_SUFFIX-$TIME_SUFFIX" \
+          "${{ inputs.disk_prefix }}-${SHORT_GITHUB_REF}-${{ env.GITHUB_SHA_SHORT }}-v${{ env.STATE_VERSION }}-${{ env.NETWORK }}-${{ inputs.disk_suffix }}${UPDATE_SUFFIX}-${TIME_SUFFIX}" \
           --force \
           --source-disk=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} \
           --source-disk-zone=${{ env.ZONE }} \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -148,6 +148,9 @@ jobs:
           --zone ${{ env.ZONE }}
           sleep 60
 
+      # Create a docker volume with the new disk we just created.
+      #
+      # SSH into the just created VM, and create a docker volume with the newly created disk.
       - name: Create ${{ inputs.test_id }} Docker volume
         run: |
           gcloud compute ssh \
@@ -157,7 +160,7 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
-          sudo mkfs.ext4 /dev/sdb \
+          sudo mkfs.ext4 -v /dev/sdb \
           && \
           docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
           ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} \
@@ -351,7 +354,10 @@ jobs:
 
       # Create a docker volume with the selected cached state.
       #
-      # SSH into the just created VM, and create a docker volume with the recently attached disk.
+      # SSH into the just created VM, expand the partition and filesystem to fill the entire disk,
+      # then create a docker volume with the recently attached disk.
+      # (The cached state and disk are usually the same size,
+      # but the cached state can be smaller if we just increased the disk size.)
       - name: Create ${{ inputs.test_id }} Docker volume
         run: |
           gcloud compute ssh \
@@ -361,6 +367,10 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command \
           "\
+          sudo growpart --verbose /dev/sdb 1 \
+          && \
+          sudo resize2fs -p /dev/sdb \
+          && \
           docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
           ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} \
           "

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -288,11 +288,16 @@ jobs:
               DISK_PREFIX=${{ inputs.zebra_state_dir || inputs.disk_prefix }}
           fi
 
-          # Try to find an image generated from this branch and commit
-          # Fields are listed in the "Create image from state disk" step
-          COMMIT_DISK_PREFIX="${DISK_PREFIX}-${GITHUB_REF_SLUG_URL}-${GITHUB_SHA_SHORT}-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}"
+          # Try to find an image generated from a previous step or run of this commit.
+          # Fields are listed in the "Create image from state disk" step.
+          #
+          # We can't match the full branch name here,
+          # because it might have been shortened for the image.
+          #
+          # The probability of two matching short commit hashes within the same month is very low.
+          COMMIT_DISK_PREFIX="${DISK_PREFIX}-.+-${{ env.GITHUB_SHA_SHORT }}-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}"
           COMMIT_CACHED_DISK_NAME=$(gcloud compute images list --filter="name~${COMMIT_DISK_PREFIX}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
-          echo "${GITHUB_REF_SLUG_URL}-${GITHUB_SHA_SHORT} Disk: $COMMIT_CACHED_DISK_NAME"
+          echo "${GITHUB_REF_SLUG_URL}-${{ env.GITHUB_SHA_SHORT }} Disk: $COMMIT_CACHED_DISK_NAME"
           if [[ -n "$COMMIT_CACHED_DISK_NAME" ]]; then
               echo "Description: $(gcloud compute images describe $COMMIT_CACHED_DISK_NAME --format='value(DESCRIPTION)')"
           fi


### PR DESCRIPTION
## Motivation

In PR #4945, we increased the cached state disk size to 200GB. But that only applies to newly created cached states. (Which take 24 hours to run, and still need fixes like PR #4961.)

So we want to expand older cached state disks to the latest size before using them.

Also fixes #4295.

## Solution

- Grow the disk partition to the full disk size
- Resize the filesystem to the full partition size
- Actually run the test

Related fixes:
- Keep cached state image names within the 63-character google cloud limit (bugfix on PR #4949)
- Adapt cached state image search for short branch names by ignoring branch names (just use short commit hashes)

## Review

This is urgent because it's stopping all the other PRs from passing.

### Reviewer Checklist

  - [ ] CI passes

