### PR TITLE
fix(doc): Update disk usage based on recent data

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ cargo install --features=<name> ...
 ### System Requirements
 
 The recommended requirements for compiling and running `zebrad` are:
-- 4+ CPU cores
-- 16+ GB RAM
-- 300 GB+ available disk space for building binaries and storing cached chain state
-- 100+ Mbps network connection, with 100+ GB of uploads and downloads per month 
+- 4 CPU cores
+- 16 GB RAM
+- 300 GB available disk space for building binaries and storing cached chain state
+- 100 Mbps network connection, with 300 GB of uploads and downloads per month 
 
 We continuously test that our builds and tests pass on:
 
@@ -157,10 +157,11 @@ If this is a problem for you, please
 [open a ticket.](https://github.com/ZcashFoundation/zebra/issues/new/choose)
 
 `zebrad`'s typical mainnet network usage is:
-- Initial sync: 50 GB download, we expect the initial download to grow to hundreds of gigabytes over time
-- Ongoing updates: 10 MB - 1 GB upload and download per day, depending on user-created transaction size, and peer requests
+- Initial sync: 100 GB download, we expect the initial download to grow to hundreds of gigabytes over time
+- Ongoing updates: 10 MB - 10 GB upload and download per day, depending on user-created transaction size and peer requests
 
-Zebra also performs an initial sync every time its internal database version changes.
+Zebra performs an initial sync every time its internal database version changes,
+so some version upgrades might require a full download of the whole chain.
 
 For more detailed information, refer to the [documentation](https://zebra.zfnd.org/user/run.html).
 
@@ -177,7 +178,7 @@ See our [roadmap](#future-work) for details.
 Zebra uses around 100 GB of space for cached mainnet data, and 10 GB of space for cached testnet data.
 We expect disk usage to grow over time, so we recommend reserving at least 300 GB for mainnet nodes.
 
-RocksDB cleans up outdated data periodically, and when the database is closed and re-opened.
+Zebra's database cleans up outdated data periodically, and when Zebra is shut down and restarted.
 
 #### Disk Troubleshooting
 


### PR DESCRIPTION
## Motivation

The initial sync size in our docs was too low, it's actually at least 85 GB.

## Solution

- Make initial sync at least 100 GB
- Update some related docs

## Review

This is a routine doc update.

### Reviewer Checklist

  - [ ] Docs make sense

