### PR TITLE
ci(deploy): do not run `versioning` job when pushing to `main`

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       major_version: ${{ steps.set.outputs.major_version }}
+    if: ${{ github.event_name == 'release' }}
     steps:
       - name: Getting Zebrad Version
         id: get
@@ -87,7 +88,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    if: ${{ (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'release' }}
+    if: ${{ !cancelled() && !failure() && ((github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'release') }}
 
     steps:
       - name: Inject slug/short variables


### PR DESCRIPTION
## Previous behavior:
When a push was detected in the `main` branch, the workflow would run the
`versioning` job and crash trying to detect the version being deployed as
there was none.

## Expected behavior:
Do not fail the `versioning` job when pushing to `main`

## Solution:
Limit the `versioning` job to only run when a release event is triggered
and allow the `deploy-nodes` job to run even if `versioning` is skipped

## Review

This is an urgent PR to anyone from the @ZcashFoundation/devops-reviewers to review
