### PR TITLE
ci(build): allow to use lightwalletd images from PRs

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -126,6 +126,7 @@ jobs:
             ZEBRA_SKIP_IPV6_TESTS=${{ inputs.zebra_skip_ipv6_tests }}
             CHECKPOINT_SYNC=${{ inputs.checkpoint_sync }}
             RUST_LOG=${{ inputs.rust_log }}
+            LWD_VERSION=${{ env.GITHUB_REF_SLUG_URL }}
           push: true
           # To improve build speeds, for each branch we push an additional image to the registry,
           # to be used as the caching layer, using the `max` caching mode.

--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -11,7 +11,7 @@ on:
       # rebuild lightwalletd whenever the related Zebra code changes
       #
       # TODO: this code isn't compiled in this docker image
-      #       rebuild whenever the actual code at lightwalletd/master changes
+      # rebuild whenever the actual code at lightwalletd/master changes
       - 'zebra-rpc/**'
       - 'zebrad/tests/acceptance.rs'
       - 'zebrad/src/config.rs'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,7 +92,8 @@ FROM deps AS tests
 # TODO: do not hardcode the user /root/ even though is a safe assumption
 # Pre-download Zcash Sprout, Sapling parameters and Lightwalletd binary
 COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/zcash-params /root/.zcash-params /root/.zcash-params
-COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd /opt/lightwalletd /usr/local/bin
+ARG LWD_VERSION=latest
+COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd:${LWD_VERSION} /opt/lightwalletd /usr/local/bin
 
 # Re-hydrate the minimum project skeleton identified by `cargo chef prepare` in the planner stage,
 # and build it to cache all possible sentry and test dependencies.


### PR DESCRIPTION
## Previous behavior:
If the lightwalledt Dockerfile was changed in a PR, we couldn't test the
changes from the actual branch as the image being pulled was the one from
the `main` branch.

## Expected behavior:

If we change the lightwalletd Docker image in a PR, those changes in the
PR should be reflected in tests. Otherwise we won't know if our fixes work.

If the image is not changed, the latest `main` branch image is fine.

## Solution:
When building Zebra, allow to build using a lightwalletd image built from
the actual working branch/PR if lightwalletd code has likely changed

Fixes https://github.com/ZcashFoundation/zebra/issues/4612

## Review

Dependencies are not right here, this requires further work. No review is required yet.

### Reviewer Checklist
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

This might need a bigger refactor, as we shouldn't build Zebra before lightwalletd.