### PR TITLE
ci(concurrency)!: run a single CI workflow as required

### DIFF
--- a/.github/workflows/build-crates-individually.yml
+++ b/.github/workflows/build-crates-individually.yml
@@ -1,7 +1,7 @@
 name: Build crates individually
 
-# Ensures that only a single CI workflow runs at a time in Pull Requests. The latest
-# commit will cancel any previous running workflows from the same PR.
+# Ensures that only a single CI workflow runs at a time in Pull Requests. The
+# latest commit will cancel any previous running workflows from the same PR
 concurrency: 
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/build-crates-individually.yml
+++ b/.github/workflows/build-crates-individually.yml
@@ -1,8 +1,9 @@
 name: Build crates individually
 
-# Ensures that only a single CI workflow runs at a time in Pull Requests. The
-# latest commit will cancel any previous running workflows from the same PR
-concurrency: 
+# Ensures that only one workflow task will run at a time. Previous builds, if
+# already in process, will get cancelled. Only the latest commit will be allowed
+# to run, cancelling any workflows in between
+concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/build-crates-individually.yml
+++ b/.github/workflows/build-crates-individually.yml
@@ -1,5 +1,11 @@
 name: Build crates individually
 
+# Ensures that only a single CI workflow runs at a time in Pull Requests. The latest
+# commit will cancel any previous running workflows from the same PR.
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -1,8 +1,8 @@
 name: CD
 
-# Ensures that only one deploy task will run at a time. Previous deployments, if
-# already started, won't get cancelled. Following workflow runs will get queued
-# until the previous deployment(s) finishes
+# Ensures that only one workflow task will run at a time. Previous deployments, if
+# already in process, won't get cancelled. Instead, we let the first to complete
+# then queue the latest pending workflow, cancelling any workflows in between
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -1,5 +1,12 @@
 name: CD
 
+# Ensures that only one deploy task will run at a time. Previous deployments, if
+# already started, won't get cancelled. Following workflow runs will get queued
+# until the previous deployment(s) finishes
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -1,5 +1,11 @@
 name: CI Docker
 
+# Ensures that only a single CI workflow runs at a time in Pull Requests. The latest
+# commit will cancel any previous running workflows from the same PR.
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
     inputs:
@@ -312,6 +318,12 @@ jobs:
       saves_to_disk: true
       disk_suffix: tip
       height_grep_text: 'current_height.*=.*Height'
+    # As the general workflow concurrency group just get matched in Pull Requests,
+    # it has no impact on this job, but we want to cancel running full syncs in
+    # `main` if a new PR gets merged
+    concurrency: 
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
 
   # Test that Zebra can sync to the chain tip, using a cached Zebra tip state,
   # without launching `lightwalletd`.

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -1,7 +1,7 @@
 name: CI Docker
 
-# Ensures that only a single CI workflow runs at a time in Pull Requests. The latest
-# commit will cancel any previous running workflows from the same PR.
+# Ensures that only a single CI workflow runs at a time in Pull Requests. The
+# latest commit will cancel any previous running workflows from the same PR
 concurrency: 
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -318,12 +318,14 @@ jobs:
       saves_to_disk: true
       disk_suffix: tip
       height_grep_text: 'current_height.*=.*Height'
-    # As the general workflow concurrency group just get matched in Pull Requests,
-    # it has no impact on this job, but we want to cancel running full syncs in
-    # `main` if a new PR gets merged
+    # We don't want to cancel running full syncs on `main` if a new PR gets merged,
+    # because we might never finish a full sync during busy weeks. Instead, we let the
+    # first sync complete, then queue the latest pending sync, cancelling any syncs in between.
+    # (As the general workflow concurrency group just gets matched in Pull Requests,
+    # it has no impact on this job.)
     concurrency: 
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+      group: github.workflow−{{ github.ref }}
+      cancel-in-progress: false
 
   # Test that Zebra can sync to the chain tip, using a cached Zebra tip state,
   # without launching `lightwalletd`.

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -1,8 +1,9 @@
 name: CI Docker
 
-# Ensures that only a single CI workflow runs at a time in Pull Requests. The
-# latest commit will cancel any previous running workflows from the same PR
-concurrency: 
+# Ensures that only one workflow task will run at a time. Previous builds, if
+# already in process, will get cancelled. Only the latest commit will be allowed
+# to run, cancelling any workflows in between
+concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -1,5 +1,11 @@
 name: CI OSes
 
+# Ensures that only a single CI workflow runs at a time in Pull Requests. The latest
+# commit will cancel any previous running workflows from the same PR.
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   # we build Rust and Zcash parameter caches on main,

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -1,7 +1,7 @@
 name: CI OSes
 
-# Ensures that only a single CI workflow runs at a time in Pull Requests. The latest
-# commit will cancel any previous running workflows from the same PR.
+# Ensures that only a single CI workflow runs at a time in Pull Requests. The
+# latest commit will cancel any previous running workflows from the same PR
 concurrency: 
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -1,8 +1,9 @@
 name: CI OSes
 
-# Ensures that only a single CI workflow runs at a time in Pull Requests. The
-# latest commit will cancel any previous running workflows from the same PR
-concurrency: 
+# Ensures that only one workflow task will run at a time. Previous builds, if
+# already in process, will get cancelled. Only the latest commit will be allowed
+# to run, cancelling any workflows in between
+concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,12 @@
 name: Coverage
 
+# Ensures that only one workflow task will run at a time. Previous builds, if
+# already in process, will get cancelled. Only the latest commit will be allowed
+# to run, cancelling any workflows in between
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,12 @@
 name: Docs
 
+# Ensures that only one workflow task will run at a time. Previous deployments, if
+# already in process, won't get cancelled. Instead, we let the first to complete
+# then queue the latest pending workflow, cancelling any workflows in between
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,12 @@
 name: Lint
 
+# Ensures that only one workflow task will run at a time. Previous builds, if
+# already in process, will get cancelled. Only the latest commit will be allowed
+# to run, cancelling any workflows in between
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   # we build Rust caches on main, so they can be shared by all branches:
   # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache

--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -1,5 +1,12 @@
 name: zcash-params
 
+# Ensures that only one workflow task will run at a time. Previous deployments, if
+# already in process, won't get cancelled. Instead, we let the first to complete
+# then queue the latest pending workflow, cancelling any workflows in between
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
## Previous behavior:
Multiple Mainnet full syncs were able to run on the main branch at the
same time, and pushing multiple commits to the same branch would run
multiple CI workflows, when only the run from last commit was relevant

## Expected behavior:
Ensure that only a single CI workflow runs at the same time in PRs.
The latest commit should cancel any previous running workflows from the
same PR.

## Solution:
Use GitHub actions concurrency feature https://docs.github.com/en/actions/using-jobs/using-concurrency

Fixes https://github.com/ZcashFoundation/zebra/issues/4977
Fixes https://github.com/ZcashFoundation/zebra/issues/4857
Fixes https://github.com/ZcashFoundation/zebra/issues/1785

## Review

@teor2345 can review this

### Reviewer Checklist

  - [x] Re-run a workflow while running or push an empty commit
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors
