### PR TITLE
fix(log): Increase slow code log thresholds to reduce verbose logs and warnings

### DIFF
--- a/zebra-chain/src/diagnostic.rs
+++ b/zebra-chain/src/diagnostic.rs
@@ -7,10 +7,14 @@ use std::time::{Duration, Instant};
 use crate::fmt::duration_short;
 
 /// The default minimum info-level message time.
-pub const DEFAULT_MIN_INFO_TIME: Duration = Duration::from_secs(5);
+///
+/// This is high enough to ignore most slow code.
+pub const DEFAULT_MIN_INFO_TIME: Duration = Duration::from_secs(5 * 60);
 
 /// The default minimum warning message time.
-pub const DEFAULT_MIN_WARN_TIME: Duration = Duration::from_secs(20);
+///
+/// This is a little lower than the block verify timeout.
+pub const DEFAULT_MIN_WARN_TIME: Duration = Duration::from_secs(9 * 60);
 
 /// A guard that logs code execution time when dropped.
 #[derive(Debug)]


### PR DESCRIPTION
## Motivation

We've decided that Zebra's current performance is mostly ok, so we want to reduce the number of performance logs.

Closes ticket #4932

## Solution

- change info threshold to 5 minutes and warn to 9 minutes

## Review

This is a routine usability fix.

### Reviewer Checklist

  - [ ] CI passes


