### PR TITLE
fix(ci): Split a long full sync job

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -755,7 +755,7 @@ jobs:
   # follow the logs of the test we just launched, up to block 1,760,000 or later
   # (or the test finishing)
   #
-  # We chose this height because it was about 9 hours into the NU5 sync, at the end of August 2022.
+  # We chose this height because it was about 8 hours into the NU5 sync, at the end of August 2022.
   logs-1760k:
     name: Log ${{ inputs.test_id }} test (1760k)
     needs: [ logs-1740k ]
@@ -813,10 +813,71 @@ jobs:
           -e 'test result:.*finished in' \
           "
 
+  # follow the logs of the test we just launched, up to block 1,780,000 or later
+  # (or the test finishing)
+  #
+  # We chose this height because it was about 12 hours into the NU5 sync, at the end of August 2022.
+  logs-1780k:
+    name: Log ${{ inputs.test_id }} test (1780k)
+    needs: [ logs-1760k ]
+    # If the previous job fails, we still want to show the logs.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v3.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: '2'
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
+      - name: Downcase network name for disks
+        run: |
+          NETWORK_CAPS=${{ inputs.network }}
+          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+
+      # Setup gcloud CLI
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.8.0
+        with:
+          retries: '3'
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
+
+      # Show recent logs, following until block 1,780,000 (or the test finishes)
+      - name: Show logs for ${{ inputs.test_id }} test (1780k)
+        run: |
+          gcloud compute ssh \
+          ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          --zone ${{ env.ZONE }} \
+          --quiet \
+          --ssh-flag="-o ServerAliveInterval=5" \
+          --command \
+          "\
+          docker logs \
+          --tail all \
+          --follow \
+          ${{ inputs.test_id }} | \
+          tee --output-error=exit /dev/stderr | \
+          grep --max-count=1 --extended-regexp --color=always \
+          -e 'estimated progress.*current_height.*=.*17[8-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'test result:.*finished in' \
+          "
+
   # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)
   logs-checkpoint:
     name: Log ${{ inputs.test_id }} test (checkpoint)
-    needs: [ logs-1760k ]
+    needs: [ logs-1780k ]
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

A full sync job is timing out, so we want to split the job.

### Designs

I followed the instructions in:
https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/continuous-integration.md#resolving-ci-sync-timeouts

## Solution

- Add a job that stops at height 1780k, roughly 4 hours long

## Review

Anyone can review this PR, we need it to fix full syncs on `main`.

### Reviewer Checklist

  - [ ] CI passes

## Follow Up Work

We might want to find an alternative to all these extra jobs, maybe #4937 will speed up these syncs.