### PR TITLE
build(deps): bump prost, tonic, tonic-build and console-subscriber

### DIFF
--- a/.github/workflows/build-crates-individually.yml
+++ b/.github/workflows/build-crates-individually.yml
@@ -110,6 +110,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install last version of Protoc
+        uses: arduino/setup-protoc@v1
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/build-crates-individually.yml
+++ b/.github/workflows/build-crates-individually.yml
@@ -112,6 +112,8 @@ jobs:
 
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/build-crates-individually.yml
+++ b/.github/workflows/build-crates-individually.yml
@@ -114,6 +114,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -80,6 +80,8 @@ jobs:
 
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -204,6 +206,8 @@ jobs:
 
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -82,6 +82,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -208,6 +209,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -78,6 +78,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install last version of Protoc
+        uses: arduino/setup-protoc@v1
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -202,6 +202,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install last version of Protoc
+        uses: arduino/setup-protoc@v1
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install last version of Protoc
+        uses: arduino/setup-protoc@v1
+
       - name: Install latest beta
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
 
       - name: Install latest beta
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install latest beta
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,9 +37,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Install last version of Protoc
-        uses: arduino/setup-protoc@v1
-
       - name: Rust files
         id: changed-files-rust
         uses: tj-actions/changed-files@v29.0.3
@@ -70,6 +67,9 @@ jobs:
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
+
+      - name: Install last version of Protoc
+        uses: arduino/setup-protoc@v1
 
       - name: Check workflow permissions
         id: check_permissions
@@ -112,6 +112,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install last version of Protoc
+        uses: arduino/setup-protoc@v1
+
       - uses: actions-rs/toolchain@v1.0.6
         with:
           toolchain: stable
@@ -136,6 +139,9 @@ jobs:
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
+
+      - name: Install last version of Protoc
+        uses: arduino/setup-protoc@v1
 
       - uses: actions-rs/toolchain@v1.0.6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Install last version of Protoc
+        uses: arduino/setup-protoc@v1
+
       - name: Rust files
         id: changed-files-rust
         uses: tj-actions/changed-files@v29.0.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,6 +70,8 @@ jobs:
 
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
 
       - name: Check workflow permissions
         id: check_permissions
@@ -114,6 +116,8 @@ jobs:
 
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
 
       - uses: actions-rs/toolchain@v1.0.6
         with:
@@ -142,6 +146,8 @@ jobs:
 
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
 
       - uses: actions-rs/toolchain@v1.0.6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,6 +72,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check workflow permissions
         id: check_permissions
@@ -118,6 +119,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1.0.6
         with:
@@ -148,6 +150,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1.0.6
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,21 +882,21 @@ dependencies = [
 
 [[package]]
 name = "console-api"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c5fd425783d81668ed68ec98408a80498fb4ae2fd607797539e1a9dfa3618f"
+checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
 dependencies = [
- "prost 0.10.4",
- "prost-types 0.10.1",
- "tonic 0.7.2",
+ "prost",
+ "prost-types",
+ "tonic",
  "tracing-core",
 ]
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31432bc31ff8883bf6a693a79371862f73087822470c82d6a1ec778781ee3978"
+checksum = "22a3a81dfaf6b66bce5d159eddae701e3a002f194d378cbf7be5f053c281d9be"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -904,13 +904,13 @@ dependencies = [
  "futures",
  "hdrhistogram",
  "humantime",
- "prost-types 0.10.1",
+ "prost-types",
  "serde",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic 0.7.2",
+ "tonic",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.11",
@@ -3569,22 +3569,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
-dependencies = [
- "bytes",
- "prost-derive 0.10.1",
-]
-
-[[package]]
-name = "prost"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
 dependencies = [
  "bytes",
- "prost-derive 0.11.0",
+ "prost-derive",
 ]
 
 [[package]]
@@ -3600,24 +3590,11 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost 0.11.0",
- "prost-types 0.11.1",
+ "prost",
+ "prost-types",
  "regex",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.99",
 ]
 
 [[package]]
@@ -3635,22 +3612,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
-dependencies = [
- "bytes",
- "prost 0.10.4",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
 dependencies = [
  "bytes",
- "prost 0.11.0",
+ "prost",
 ]
 
 [[package]]
@@ -5020,38 +4987,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be9d60db39854b30b835107500cf0aca0b0d14d6e1c3de124217c23a29c2ddb"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project 1.0.12",
- "prost 0.10.4",
- "prost-derive 0.10.1",
- "tokio",
- "tokio-stream",
- "tokio-util 0.7.3",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tonic"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498f271adc46acce75d66f639e4d35b31b2394c295c82496727dafa16d465dd2"
@@ -5070,8 +5005,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project 1.0.12",
- "prost 0.11.0",
- "prost-derive 0.11.0",
+ "prost",
+ "prost-derive",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.3",
@@ -6683,7 +6618,7 @@ dependencies = [
  "pin-project 1.0.12",
  "proptest",
  "proptest-derive",
- "prost 0.11.0",
+ "prost",
  "rand 0.8.5",
  "rayon",
  "regex",
@@ -6699,7 +6634,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
- "tonic 0.8.0",
+ "tonic",
  "tonic-build",
  "tower",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,15 +807,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "coarsetime"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,9 +886,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06c5fd425783d81668ed68ec98408a80498fb4ae2fd607797539e1a9dfa3618f"
 dependencies = [
- "prost",
- "prost-types",
- "tonic",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
+ "tonic 0.7.2",
  "tracing-core",
 ]
 
@@ -913,13 +904,13 @@ dependencies = [
  "futures",
  "hdrhistogram",
  "humantime",
- "prost-types",
+ "prost-types 0.10.1",
  "serde",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.7.2",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.11",
@@ -3583,26 +3574,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.10.1",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.0",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120fbe7988713f39d780a58cf1a7ef0d7ef66c6d87e5aa3438940c05357929f4"
+checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
 dependencies = [
  "bytes",
- "cfg-if 1.0.0",
- "cmake",
  "heck 0.4.0",
  "itertools",
  "lazy_static",
  "log",
  "multimap",
  "petgraph",
- "prost",
- "prost-types",
+ "prost 0.11.0",
+ "prost-types 0.11.1",
  "regex",
  "tempfile",
  "which",
@@ -3622,13 +3621,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2 1.0.42",
+ "quote 1.0.20",
+ "syn 1.0.99",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.10.4",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
+dependencies = [
+ "bytes",
+ "prost 0.11.0",
 ]
 
 [[package]]
@@ -5016,8 +5038,40 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project 1.0.12",
- "prost",
- "prost-derive",
+ "prost 0.10.4",
+ "prost-derive 0.10.1",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.3",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498f271adc46acce75d66f639e4d35b31b2394c295c82496727dafa16d465dd2"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project 1.0.12",
+ "prost 0.11.0",
+ "prost-derive 0.11.0",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.3",
@@ -5030,9 +5084,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9263bf4c9bfaae7317c1c2faf7f18491d2fe476f70c414b73bf5d445b00ffa1"
+checksum = "2fbcd2800e34e743b9ae795867d5f77b535d3a3be69fd731e39145719752df8c"
 dependencies = [
  "prettyplease",
  "proc-macro2 1.0.42",
@@ -6629,7 +6683,7 @@ dependencies = [
  "pin-project 1.0.12",
  "proptest",
  "proptest-derive",
- "prost",
+ "prost 0.11.0",
  "rand 0.8.5",
  "rayon",
  "regex",
@@ -6645,7 +6699,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
- "tonic",
+ "tonic 0.8.0",
  "tonic-build",
  "tower",
  "tracing",

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -139,7 +139,7 @@ proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 
 # test feature tokio-console
-console-subscriber = { version = "0.1.6", optional = true }
+console-subscriber = { version = "0.1.7", optional = true }
 
 [build-dependencies]
 vergen = { version = "7.4.2", default-features = false, features = ["cargo", "git"] }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -145,7 +145,7 @@ console-subscriber = { version = "0.1.6", optional = true }
 vergen = { version = "7.4.2", default-features = false, features = ["cargo", "git"] }
 
 # test feature lightwalletd-grpc-tests
-tonic-build = { version = "0.7.2", optional = true }
+tonic-build = { version = "0.8.0", optional = true }
 
 [dev-dependencies]
 abscissa_core = { version = "0.5", features = ["testing"] }
@@ -165,8 +165,8 @@ tokio = { version = "1.21.0", features = ["full", "tracing", "test-util"] }
 tokio-stream = "0.1.9"
 
 # test feature lightwalletd-grpc-tests
-prost = "0.10.4"
-tonic = "0.7.2"
+prost = "0.11.0"
+tonic = "0.8.0"
 
 proptest = "0.10.1"
 proptest-derive = "0.3.0"

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -139,7 +139,7 @@ proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 
 # test feature tokio-console
-console-subscriber = { version = "0.1.7", optional = true }
+console-subscriber = { version = "0.1.8", optional = true }
 
 [build-dependencies]
 vergen = { version = "7.4.2", default-features = false, features = ["cargo", "git"] }


### PR DESCRIPTION
## Motivation

We want to update `prost`, `tonic`, `tonic-build` and `console-subscriber` at the same time. 

Replaces https://github.com/ZcashFoundation/zebra/pull/4853

## Solution

Upgrade the 4 crates manually, clippy issues that were blocking this were resolved.

## Review

I think anyone can review.

### Reviewer Checklist

  - [ ] PR builds
  - [ ] All tests pass
