### PR TITLE
Breaking: fix(rpc): Add a config for multi-threaded RPC server requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6459,6 +6459,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-derive",
  "jsonrpc-http-server",
+ "num_cpus",
  "proptest",
  "proptest-derive",
  "serde",

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [Beta Releases](#beta-releases)
 - [Getting Started](#getting-started)
   - [Build and Run Instructions](#build-and-run-instructions)
+  - [Configuring JSON-RPC for lightwalletd](#configuring-json-rpc-for-lightwalletd)
   - [Optional Features](#optional-features)
   - [System Requirements](#system-requirements)
     - [Memory Troubleshooting](#memory-troubleshooting)
@@ -90,6 +91,22 @@ for your platform:
 4. Run `zebrad start` (see [Running Zebra](https://zebra.zfnd.org/user/run.html) for more information)
 
 For more detailed instructions, refer to the [documentation](https://zebra.zfnd.org/user/install.html).
+
+### Configuring JSON-RPC for lightwalletd
+
+To use `zebrad` as a `lightwalletd` backend, give it this `~/.config/zebrad.toml`:
+
+```toml
+[rpc]
+# listen for RPC queries on localhost
+listen_addr = '127.0.0.1:8232'
+
+# automatically use multiple CPU threads
+parallel_cpu_threads = 0
+```
+
+**WARNING:** This config allows multiple Zebra instances to share the same RPC port.
+See the [RPC config documentation](https://doc.zebra.zfnd.org/zebra_rpc/config/struct.Config.html) for details.
 
 ### Optional Features
 

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -21,6 +21,8 @@ hyper = { version = "0.14.20", features = ["http1", "server"] }
 jsonrpc-core = "18.0.0"
 jsonrpc-derive = "18.0.0"
 jsonrpc-http-server = "18.0.0"
+num_cpus = "1.13.1"
+
 # zebra-rpc needs the preserve_order feature in serde_json, which is a dependency of jsonrpc-core
 serde_json = { version = "1.0.83", features = ["preserve_order"] }
 indexmap = { version = "1.9.1", features = ["serde"] }

--- a/zebra-rpc/src/config.rs
+++ b/zebra-rpc/src/config.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddr;
 use serde::{Deserialize, Serialize};
 
 /// RPC configuration section.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
     /// IP address and port for the RPC server.
@@ -27,4 +27,38 @@ pub struct Config {
     /// anyone on the internet can send transactions via your node.
     /// They can also query your node's state.
     pub listen_addr: Option<SocketAddr>,
+
+    /// The number of threads used to process RPC requests and responses.
+    ///
+    /// Zebra's RPC server has a separate thread pool and a `tokio` executor for each thread.
+    /// State queries are run concurrently using the shared thread pool controlled by
+    /// the [`SyncSection.parallel_cpu_threads`](https://doc.zebra.zfnd.org/zebrad/config/struct.SyncSection.html#structfield.parallel_cpu_threads) config.
+    ///
+    /// We recommend setting both configs to `0` (automatic scaling) for the best performance.
+    /// This uses one thread per available CPU core.
+    ///
+    /// Set to `1` by default, which runs all RPC queries on a single thread, and detects RPC
+    /// port conflicts from multiple Zebra or `zcashd` instances.
+    ///
+    /// For details, see [the `jsonrpc_http_server` documentation](https://docs.rs/jsonrpc-http-server/latest/jsonrpc_http_server/struct.ServerBuilder.html#method.threads).
+    ///
+    /// ## Warning
+    ///
+    /// Changing this config disables RPC port conflict detection.
+    /// This can allow multiple Zebra instances to share the same RPC port.
+    ///
+    /// If some of those instances are outdated or failed, RPC queries can be slow or inconsistent.
+    pub parallel_cpu_threads: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            // Disable RPCs by default.
+            listen_addr: None,
+
+            // Use a single thread, so we can detect RPC port conflicts.
+            parallel_cpu_threads: 1,
+        }
+    }
 }

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -37,7 +37,7 @@ fn rpc_server_spawn(parallel_cpu_threads: bool) {
     let port = zebra_test::net::random_known_port();
     let config = Config {
         listen_addr: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port).into()),
-        parallel_cpu_threads: 1,
+        parallel_cpu_threads: if parallel_cpu_threads { 2 } else { 1 },
     };
 
     let rt = tokio::runtime::Runtime::new().unwrap();
@@ -101,7 +101,7 @@ fn rpc_server_spawn_unallocated_port(parallel_cpu_threads: bool) {
     let port = zebra_test::net::random_unallocated_port();
     let config = Config {
         listen_addr: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port).into()),
-        parallel_cpu_threads: 1,
+        parallel_cpu_threads: if parallel_cpu_threads { 0 } else { 1 },
     };
 
     let rt = tokio::runtime::Runtime::new().unwrap();

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -213,7 +213,7 @@ pub struct SyncSection {
     /// The number of threads used to verify signatures, proofs, and other CPU-intensive code.
     ///
     /// Set to `0` by default, which uses one thread per available CPU core.
-    /// For details, see [the rayon documentation](https://docs.rs/rayon/latest/rayon/struct.ThreadPoolBuilder.html#method.num_threads).
+    /// For details, see [the `rayon` documentation](https://docs.rs/rayon/latest/rayon/struct.ThreadPoolBuilder.html#method.num_threads).
     pub parallel_cpu_threads: usize,
 }
 

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -212,7 +212,8 @@ pub fn spawn_zebrad_for_rpc_without_initial_peers<P: ZebradTestDirExt + std::fmt
     zebra_directory: P,
     test_type: LightwalletdTestType,
 ) -> Result<(TestChild<P>, SocketAddr)> {
-    let mut config = random_known_rpc_port_config()
+    // This is what we recommend our users configure.
+    let mut config = random_known_rpc_port_config(true)
         .expect("Failed to create a config file with a known RPC listener port");
 
     config.state.ephemeral = false;


### PR DESCRIPTION
## Changelog

See the README changes in this PR for a changelog breaking change notice.

## Motivation

Our users have asked for multi-threaded RPCs.

## Solution

- Add a config for multi-threaded RPCs
- Add tests for multi and single threaded RPC calls
- Run `lightwalletd` tests with multi-threaded RPCs

Depends-On: #4806
Fixes #5012

## Review

This is a routine bug fix.

### Reviewer Checklist

  - [x] Code implements Specs and Designs
  - [x] Tests for Expected Behaviour
  - [x] Tests for Errors
