### PR TITLE
deps(build): Bump insta to 1.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,19 +2276,19 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.17.1"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1585a0f4924236ca3c8dac97bc6a3efaacc08b1ed9264ff2155ec7ab2906a8ea"
+checksum = "fc61e98be01e89296f3343a878e9f8ca75a494cb5aaf29df65ef55734aeb85f5"
 dependencies = [
  "console",
+ "linked-hash-map",
  "once_cell",
  "pest",
  "pest_derive",
  "ron",
  "serde",
- "serde_json",
- "serde_yaml",
  "similar",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -2513,9 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -4421,18 +4421,6 @@ dependencies = [
  "proc-macro2 1.0.42",
  "quote 1.0.20",
  "syn 1.0.98",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap",
- "ryu",
- "serde",
- "yaml-rust",
 ]
 
 [[package]]

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -43,7 +43,7 @@ zebra-node-services = { path = "../zebra-node-services" }
 zebra-state = { path = "../zebra-state" }
 
 [dev-dependencies]
-insta = { version = "1.17.1", features = ["redactions"] }
+insta = { version = "1.19.1", features = ["redactions", "json"] }
 proptest = "0.10.1"
 proptest-derive = "0.3.0"
 serde_json = "1.0.83"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -47,7 +47,7 @@ once_cell = "1.13.0"
 spandoc = "0.2.2"
 
 hex = { version = "0.4.3", features = ["serde"] }
-insta = { version = "1.17.1", features = ["ron"] }
+insta = { version = "1.19.1", features = ["ron"] }
 
 proptest = "0.10.1"
 proptest-derive = "0.3.0"

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 hex = "0.4.3"
 indexmap = "1.9.1"
 lazy_static = "1.4.0"
-insta = "1.17.1"
+insta = "1.19.1"
 proptest = "0.10.1"
 once_cell = "1.13.0"
 rand = { version = "0.8.5", package = "rand" }


### PR DESCRIPTION
## Motivation

Replace https://github.com/ZcashFoundation/zebra/pull/4924 by upgrading to 1.19.1 where a bug in the json map was fixed (https://github.com/ZcashFoundation/zebra/issues/4821).

Anyone can review.
