### PR TITLE
ci(build): re-enable Rust beta tests in ubuntu

### DIFF
--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -66,9 +66,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         rust: [stable, beta]
         exclude:
-        # TODO: re-enable beta Rust tests on ubuntu (#4929)
-          - os: ubuntu-latest
-            rust: beta
         # We're excluding macOS for the following reasons:
         # - the concurrent macOS runner limit is much lower than the Linux limit
         # - macOS is slower than Linux, and shouldn't have a build or test difference with Linux


### PR DESCRIPTION
## Previous behavior:
As we disabled beta Rust tests in PR #4930, because the parameter
downloads were unstable with beta Rust, we're no longer testing it.

## Expected behavior:
Re-enable beta rust tests in CI OSes

## Solution:
Remove the parameter exluding beta Rust

Fixes https://github.com/ZcashFoundation/zebra/issues/4929

## Review

Anyone can review this

### Reviewer Checklist

  - [ ] Beta Rust CI should pass
