### PR TITLE
change(doc): Make the release instructions more explicit

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -163,8 +163,10 @@ After you have the version increments, the updated checkpoints and the updated c
 - [ ] Set the release to target the `main` branch
 - [ ] Set the release title to `Zebra ` followed by the version tag,
       for example: `Zebra 1.0.0-alpha.0`
-- [ ] Copy the final changelog of this release to the release description
-      (starting just _after_ the title `## [Zebra ...`)
+- [ ] Replace the prepopulated draft changelog in the release description by the final
+      changelog you created; starting just _after_ the title `## [Zebra ...` of
+      the current version being released, and ending just _before_ the title of
+      the previous release.
 - [ ] Mark the release as 'pre-release' (until we are no longer alpha/beta)
 - [ ] Publish the release
 


### PR DESCRIPTION
## Motivation & Solution

When doing the release, the author of the release has to _replace_ the prepopulated draft changelog with the final changelog they created instead of just _copying_ it into the release description.

This is a small and optional change that makes the checklist a bit easier to follow when doing the release.