### PR TITLE
fix(test) switch zebrad to a non-blocking tracing logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5531,7 +5531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.7",
+ "time 0.3.14",
  "tracing-subscriber 0.3.11",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5525,6 +5525,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time 0.3.7",
+ "tracing-subscriber 0.3.11",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6630,6 +6641,7 @@ dependencies = [
  "tonic-build",
  "tower",
  "tracing",
+ "tracing-appender",
  "tracing-error",
  "tracing-flame",
  "tracing-futures",

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -354,6 +354,7 @@ impl FinalizedState {
         let _ = stderr().lock().flush();
 
         // Give some time to logger thread to flush out any remaining lines to stdout
+        // and yield so that tests pass on MacOS
         std::thread::sleep(std::time::Duration::from_secs(3));
 
         // Exits before calling drop on the WorkerGuard for the logger thread,

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -353,6 +353,9 @@ impl FinalizedState {
         let _ = stdout().lock().flush();
         let _ = stderr().lock().flush();
 
+        // Give some time to logger thread to flush out any remaining lines to stdout
+        std::thread::sleep(std::time::Duration::from_secs(3));
+
         // Exits before calling drop on the WorkerGuard for the logger thread,
         // dropping any lines that haven't already been written to stdout.
         // This is okay for now because this is test-only code

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -106,6 +106,11 @@ impl FinalizedState {
                 // So we want to drop it before we exit.
                 std::mem::drop(new_state);
 
+                // Drops tracing log output that's hasn't already been written to stdout
+                // since this exits before calling drop on the WorkerGuard for the logger thread.
+                // This is okay for now because this is test-only code
+                //
+                // TODO: Call ZebradApp.shutdown or drop its Tracing component before calling exit_process to flush logs to stdout
                 Self::exit_process();
             }
         }
@@ -307,6 +312,11 @@ impl FinalizedState {
             // We're just about to do a forced exit, so it's ok to do a forced db shutdown
             self.db.shutdown(true);
 
+            // Drops tracing log output that's hasn't already been written to stdout
+            // since this exits before calling drop on the WorkerGuard for the logger thread.
+            // This is okay for now because this is test-only code
+            //
+            // TODO: Call ZebradApp.shutdown or drop its Tracing component before calling exit_process to flush logs to stdout
             Self::exit_process();
         }
 
@@ -343,6 +353,9 @@ impl FinalizedState {
         let _ = stdout().lock().flush();
         let _ = stderr().lock().flush();
 
+        // Exits before calling drop on the WorkerGuard for the logger thread,
+        // dropping any lines that haven't already been written to stdout.
+        // This is okay for now because this is test-only code
         std::process::exit(0);
     }
 }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -99,6 +99,7 @@ tinyvec = { version = "1.6.0", features = ["rustc_1_55"] }
 thiserror = "1.0.33"
 
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
+tracing-appender = "0.2.2"
 tracing-error = "0.2.0"
 tracing-futures = "0.2.5"
 tracing = "0.1.31"

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -18,7 +18,7 @@ use zebra_state::constants::{DATABASE_FORMAT_VERSION, LOCK_FILE_ERROR};
 
 use crate::{commands::ZebradCmd, components::tracing::Tracing, config::ZebradConfig};
 
-/// See https://docs.rs/abscissa_core/latest/src/abscissa_core/application/exit.rs.html#7-10Z
+/// See <https://docs.rs/abscissa_core/latest/src/abscissa_core/application/exit.rs.html#7-10>
 /// Print a fatal error message and exit
 fn fatal_error(app_name: String, err: &dyn std::error::Error) -> ! {
     status_err!("{} fatal error: {}", app_name, err);

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -20,7 +20,7 @@ use crate::{commands::ZebradCmd, components::tracing::Tracing, config::ZebradCon
 
 /// See https://docs.rs/abscissa_core/latest/src/abscissa_core/application/exit.rs.html#7-10Z
 /// Print a fatal error message and exit
-fn fatal_error(app_name: String, err: &dyn std::error::Error) {
+fn fatal_error(app_name: String, err: &dyn std::error::Error) -> ! {
     status_err!("{} fatal error: {}", app_name, err);
     process::exit(1)
 }
@@ -470,6 +470,8 @@ impl Application for ZebradApp {
 
         if let Err(e) = self.state().components.shutdown(self, shutdown) {
             let app_name = self.name().to_string();
+
+            // Swap out a fake app so we can trigger the destructor on the original
             let _ = std::mem::take(self);
             fatal_error(app_name, &e);
         }

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -6,6 +6,8 @@ use tracing_subscriber::{
     fmt::Formatter, layer::SubscriberExt, reload::Handle, util::SubscriberInitExt, EnvFilter,
 };
 
+use tracing_appender::non_blocking::WorkerGuard;
+
 use crate::{application::app_version, config::TracingSection};
 
 #[cfg(feature = "flamegraph")]
@@ -25,8 +27,7 @@ pub struct Tracing {
     #[cfg(feature = "flamegraph")]
     flamegrapher: Option<flame::Grapher>,
 
-    #[cfg(not(all(feature = "tokio-console", tokio_unstable)))]
-    _guard: tracing_appender::non_blocking::WorkerGuard,
+    _guard: WorkerGuard,
 }
 
 impl Tracing {
@@ -34,6 +35,7 @@ impl Tracing {
     pub fn new(config: TracingSection) -> Result<Self, FrameworkError> {
         let filter = config.filter.unwrap_or_else(|| "".to_string());
         let flame_root = &config.flamegraph;
+        let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
 
         // Only use color if tracing output is being sent to a terminal or if it was explicitly
         // forced to.
@@ -45,10 +47,9 @@ impl Tracing {
         //
         // TODO: when fmt::Subscriber supports per-layer filtering, always enable this code
         #[cfg(not(all(feature = "tokio-console", tokio_unstable)))]
-        let (subscriber, _guard, filter_handle) = {
+        let (subscriber, filter_handle) = {
             use tracing_subscriber::FmtSubscriber;
             // By default, the built NonBlocking will be lossy. (with a line limit of 128_000)
-            let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
 
             let logger = FmtSubscriber::builder()
                 .with_ansi(use_color)
@@ -68,7 +69,7 @@ impl Tracing {
 
             let subscriber = logger.finish().with(ErrorLayer::default());
 
-            (subscriber, _guard, filter_handle)
+            (subscriber, filter_handle)
         };
 
         // Construct a tracing registry with the supplied per-layer logging filter,
@@ -88,6 +89,7 @@ impl Tracing {
             // Using `FmtSubscriber` as the base subscriber, all the logs get filtered.
             let logger = fmt::Layer::new()
                 .with_ansi(use_color)
+                .with_writer(non_blocking)
                 .with_filter(EnvFilter::from(&filter));
 
             let subscriber = subscriber.with(logger);
@@ -191,7 +193,6 @@ impl Tracing {
             initial_filter: filter,
             #[cfg(feature = "flamegraph")]
             flamegrapher,
-            #[cfg(not(all(feature = "tokio-console", tokio_unstable)))]
             _guard,
         })
     }

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -47,7 +47,8 @@ impl Tracing {
         let filter = config.filter.unwrap_or_else(|| "".to_string());
         let flame_root = &config.flamegraph;
 
-        // By default, the built NonBlocking will be lossy. (with a line limit of 128_000)
+        // By default, the built NonBlocking will be lossy with a line limit of 128_000, lines sent to the worker past
+        // this limit will be dropped without being written to stdout
         let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
 
         // Only use color if tracing output is being sent to a terminal or if it was explicitly

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -3,10 +3,14 @@
 use abscissa_core::{Component, FrameworkError, Shutdown};
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{
-    fmt::Formatter, layer::SubscriberExt, reload::Handle, util::SubscriberInitExt, EnvFilter,
+    fmt::{format, Formatter},
+    layer::SubscriberExt,
+    reload::Handle,
+    util::SubscriberInitExt,
+    EnvFilter,
 };
 
-use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 
 use crate::{application::app_version, config::TracingSection};
 
@@ -18,7 +22,12 @@ pub struct Tracing {
     /// The installed filter reloading handle, if enabled.
     //
     // TODO: when fmt::Subscriber supports per-layer filtering, remove the Option
-    filter_handle: Option<Handle<EnvFilter, Formatter>>,
+    filter_handle: Option<
+        Handle<
+            EnvFilter,
+            Formatter<format::DefaultFields, format::Format<format::Full>, NonBlocking>,
+        >,
+    >,
 
     /// The originally configured filter.
     initial_filter: String,
@@ -56,8 +65,8 @@ impl Tracing {
 
             let logger = FmtSubscriber::builder()
                 .with_ansi(use_color)
-                .with_env_filter(&filter)
-                .with_writer(non_blocking);
+                .with_writer(non_blocking)
+                .with_env_filter(&filter);
 
             // Enable reloading if that feature is selected.
             #[cfg(feature = "filter-reload")]

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -93,6 +93,12 @@ pub struct TracingSection {
     /// verification of every 1000th block.
     pub filter: Option<String>,
 
+    /// The buffer_limit size sets the number of log lines that can be queued by the tracing subscriber
+    /// to be written to stdout before logs are dropped.
+    ///
+    /// Defaults to 128,000 with a minimum of 100.
+    pub buffer_limit: usize,
+
     /// The address used for an ad-hoc RPC endpoint allowing dynamic control of the tracing filter.
     ///
     /// Install Zebra using `cargo install --features=filter-reload` to enable this config.
@@ -140,6 +146,7 @@ impl Default for TracingSection {
             use_color: true,
             force_use_color: false,
             filter: None,
+            buffer_limit: 128_000,
             endpoint_addr: None,
             flamegraph: None,
             use_journald: false,

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1295,7 +1295,7 @@ fn non_blocking_logger() -> Result<()> {
 
     match test_task_handle.now_or_never() {
         Some(Ok(result)) => result,
-        Some(Err(_)) => Err(eyre!("join error")),
+        Some(Err(error)) => Err(eyre!("join error: {:?}", error)),
         None => Err(eyre!("unexpected test task hang")),
     }
 }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1250,7 +1250,7 @@ async fn non_blocking_logger() -> Result<()> {
     // Create an http client
     let client = reqwest::Client::new();
 
-    for _ in 0..10_000 {
+    for _ in 0..20_000 {
         let res = client
             .post(format!("http://{}", &zebra_rpc_address))
             .body(r#"{"jsonrpc":"1.0","method":"getinfo","params":[],"id":123}"#)

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1237,6 +1237,7 @@ async fn non_blocking_logger() -> Result<()> {
     // [Note on port conflict](#Note on port conflict)
     let mut config = random_known_rpc_port_config()?;
     let zebra_rpc_address = config.rpc.listen_addr.unwrap();
+    config.tracing.filter = Some("trace".to_string());
 
     let dir = testdir()?.with_config(&mut config)?;
     let mut child = dir.spawn_child(args!["start"])?;

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1261,7 +1261,7 @@ fn non_blocking_logger() -> Result<()> {
         let client = reqwest::Client::new();
 
         // Most of Zebra's lines are 100-200 characters long, so 500 requests should print enough to fill the unix pipe,
-        // fill the channel logs are queued onto, and drop logs rather than block execution.
+        // fill the channel that tracing logs are queued onto, and drop logs rather than block execution.
         for _ in 0..5_000 {
             let res = client
                 .post(format!("http://{}", &zebra_rpc_address))

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1231,16 +1231,18 @@ async fn rpc_endpoint(parallel_cpu_threads: bool) -> Result<()> {
 
 #[test]
 fn non_blocking_logger() -> Result<()> {
-    use futures::FutureExt as _;
+    use futures::FutureExt;
+    use std::{sync::mpsc, time::Duration};
 
     let rt = tokio::runtime::Runtime::new().unwrap();
+    let (done_tx, done_rx) = mpsc::channel();
 
-    let test_task_handle: tokio::task::JoinHandle<Result<()>> = rt.spawn(async {
+    let test_task_handle: tokio::task::JoinHandle<Result<()>> = rt.spawn(async move {
         let _init_guard = zebra_test::init();
 
         // Write a configuration that has RPC listen_addr set
         // [Note on port conflict](#Note on port conflict)
-        let mut config = random_known_rpc_port_config()?;
+        let mut config = random_known_rpc_port_config(false)?;
         config.tracing.filter = Some("trace".to_string());
         config.tracing.buffer_limit = 100;
         let zebra_rpc_address = config.rpc.listen_addr.unwrap();
@@ -1252,17 +1254,12 @@ fn non_blocking_logger() -> Result<()> {
             format!("Opened RPC endpoint at {}", config.rpc.listen_addr.unwrap()).as_str(),
         )?;
 
-        let mut cmd2 = std::process::Command::new("echo")
-            .stdin(Stdio::piped())
-            .stdout(Stdio::null())
-            .spawn()?;
-
         // Create an http client
         let client = reqwest::Client::new();
 
         // Most of Zebra's lines are 100-200 characters long, so 500 requests should print enough to fill the unix pipe,
         // fill the channel that tracing logs are queued onto, and drop logs rather than block execution.
-        for _ in 0..5_000 {
+        for _ in 0..500 {
             let res = client
                 .post(format!("http://{}", &zebra_rpc_address))
                 .body(r#"{"jsonrpc":"1.0","method":"getinfo","params":[],"id":123}"#)
@@ -1274,7 +1271,6 @@ fn non_blocking_logger() -> Result<()> {
             assert!(res.status().is_success());
         }
 
-        cmd2.kill()?;
         child.kill(false)?;
 
         let output = child.wait_with_output()?;
@@ -1285,11 +1281,15 @@ fn non_blocking_logger() -> Result<()> {
             .assert_was_killed()
             .wrap_err("Possible port conflict. Are there other acceptance tests running?")?;
 
+        done_tx.send(())?;
+
         Ok(())
     });
 
-    // Wait until the spawned task finishes
-    std::thread::sleep(Duration::from_secs(10));
+    // Wait until the spawned task finishes or return an error in 45 seconds
+    if done_rx.recv_timeout(Duration::from_secs(45)).is_err() {
+        return Err(eyre!("unexpected test task hang"));
+    }
 
     rt.shutdown_timeout(Duration::from_secs(3));
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1248,6 +1248,11 @@ async fn non_blocking_logger() -> Result<()> {
         format!("Opened RPC endpoint at {}", config.rpc.listen_addr.unwrap()).as_str(),
     )?;
 
+    let mut cmd2 = std::process::Command::new("echo")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .spawn()?;
+
     // Create an http client
     let client = reqwest::Client::new();
 
@@ -1265,6 +1270,7 @@ async fn non_blocking_logger() -> Result<()> {
         assert!(res.status().is_success());
     }
 
+    cmd2.kill()?;
     child.kill(false)?;
 
     let output = child.wait_with_output()?;


### PR DESCRIPTION
## Motivation

We want to switch zebrad to a non-blocking tracing logger to use a separate thread when writing tracing logs to stdout so that our tests won't deadlock.

Fixes #4834.

## Solution

- Provide tracing FmtSubscriber (or fmt::Layer when tokio-console feature is enabled) with a lossy [non-blocking writer](https://docs.rs/tracing-appender/0.2.2/tracing_appender/#non-blocking-writer) to use instead of stdout

## Review

Anyone can review this PR

### Reviewer Checklist

  - [ ] Tests for Expected Behaviour
