### PR TITLE
fix(clippy): Resolve unnecessary borrow lint and remove redundant imports

### DIFF
--- a/zebra-chain/src/block/merkle.rs
+++ b/zebra-chain/src/block/merkle.rs
@@ -1,7 +1,6 @@
 //! The Bitcoin-inherited Merkle tree of transactions.
 #![allow(clippy::unit_arg)]
 
-use std::convert::TryInto;
 use std::iter;
 use std::{fmt, io::Write};
 
@@ -74,7 +73,7 @@ pub struct Root(pub [u8; 32]);
 
 impl fmt::Debug for Root {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("Root").field(&hex::encode(&self.0)).finish()
+        f.debug_tuple("Root").field(&hex::encode(self.0)).finish()
     }
 }
 
@@ -150,7 +149,7 @@ pub struct AuthDataRoot(pub(crate) [u8; 32]);
 impl fmt::Debug for AuthDataRoot {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("AuthRoot")
-            .field(&hex::encode(&self.0))
+            .field(&hex::encode(self.0))
             .finish()
     }
 }

--- a/zebra-chain/src/orchard/keys.rs
+++ b/zebra-chain/src/orchard/keys.rs
@@ -7,10 +7,7 @@
 #[cfg(test)]
 mod tests;
 
-use std::{
-    convert::{From, Into, TryFrom, TryInto},
-    fmt, io,
-};
+use std::{fmt, io};
 
 use aes::Aes256;
 use bech32::{self, ToBase32, Variant};
@@ -765,7 +762,7 @@ impl ConstantTimeEq for OutgoingViewingKey {
 impl fmt::Debug for OutgoingViewingKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("OutgoingViewingKey")
-            .field(&hex::encode(&self.0))
+            .field(&hex::encode(self.0))
             .finish()
     }
 }
@@ -898,7 +895,7 @@ pub struct Diversifier(pub(crate) [u8; 11]);
 impl fmt::Debug for Diversifier {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("Diversifier")
-            .field(&hex::encode(&self.0))
+            .field(&hex::encode(self.0))
             .finish()
     }
 }

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -105,7 +105,7 @@ pub struct Root(#[serde(with = "serde_helpers::Base")] pub(crate) pallas::Base);
 impl fmt::Debug for Root {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("Root")
-            .field(&hex::encode(&self.0.to_repr()))
+            .field(&hex::encode(self.0.to_repr()))
             .finish()
     }
 }

--- a/zebra-chain/src/sapling/keys.rs
+++ b/zebra-chain/src/sapling/keys.rs
@@ -17,7 +17,6 @@ mod test_vectors;
 mod tests;
 
 use std::{
-    convert::{From, Into, TryFrom, TryInto},
     fmt,
     io::{self, Write},
     str::FromStr,
@@ -426,7 +425,7 @@ pub struct OutgoingViewingKey(pub(crate) [u8; 32]);
 impl fmt::Debug for OutgoingViewingKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("OutgoingViewingKey")
-            .field(&hex::encode(&self.0))
+            .field(&hex::encode(self.0))
             .finish()
     }
 }
@@ -741,7 +740,7 @@ pub struct Diversifier(pub(crate) [u8; 11]);
 impl fmt::Debug for Diversifier {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("Diversifier")
-            .field(&hex::encode(&self.0))
+            .field(&hex::encode(self.0))
             .finish()
     }
 }

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -106,7 +106,7 @@ pub struct Root(#[serde(with = "serde_helpers::Fq")] pub(crate) jubjub::Base);
 impl fmt::Debug for Root {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("Root")
-            .field(&hex::encode(&self.0.to_bytes()))
+            .field(&hex::encode(self.0.to_bytes()))
             .finish()
     }
 }

--- a/zebra-chain/src/serialization/sha256d.rs
+++ b/zebra-chain/src/serialization/sha256d.rs
@@ -49,7 +49,7 @@ impl<'a> From<&'a [u8]> for Checksum {
 impl fmt::Debug for Checksum {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("Sha256dChecksum")
-            .field(&hex::encode(&self.0))
+            .field(&hex::encode(self.0))
             .finish()
     }
 }

--- a/zebra-chain/src/sprout/address.rs
+++ b/zebra-chain/src/sprout/address.rs
@@ -37,7 +37,7 @@ impl fmt::Debug for SproutShieldedAddress {
             // Use hex formatting for the transmission key.
             .field(
                 "transmission_key",
-                &hex::encode(&self.transmission_key.as_bytes()),
+                &hex::encode(self.transmission_key.as_bytes()),
             )
             .finish()
     }

--- a/zebra-chain/src/sprout/keys.rs
+++ b/zebra-chain/src/sprout/keys.rs
@@ -196,7 +196,7 @@ impl AsRef<[u8]> for PayingKey {
 impl fmt::Debug for PayingKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("PayingKey")
-            .field(&hex::encode(&self.0))
+            .field(&hex::encode(self.0))
             .finish()
     }
 }
@@ -245,11 +245,8 @@ impl fmt::Debug for IncomingViewingKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("IncomingViewingKey")
             .field("network", &self.network)
-            .field("paying_key", &hex::encode(&self.paying_key.0))
-            .field(
-                "receiving_key",
-                &hex::encode(&self.receiving_key.to_bytes()),
-            )
+            .field("paying_key", &hex::encode(self.paying_key.0))
+            .field("receiving_key", &hex::encode(self.receiving_key.to_bytes()))
             .finish()
     }
 }

--- a/zebra-chain/src/sprout/tree.rs
+++ b/zebra-chain/src/sprout/tree.rs
@@ -98,7 +98,7 @@ pub struct Root([u8; 32]);
 
 impl fmt::Debug for Root {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("Root").field(&hex::encode(&self.0)).finish()
+        f.debug_tuple("Root").field(&hex::encode(self.0)).finish()
     }
 }
 

--- a/zebra-chain/src/transaction/auth_digest.rs
+++ b/zebra-chain/src/transaction/auth_digest.rs
@@ -1,3 +1,5 @@
+//! Authorizing digests for Zcash transactions.
+
 use std::{fmt, sync::Arc};
 
 #[cfg(any(test, feature = "proptest-impl"))]
@@ -78,7 +80,7 @@ impl fmt::Display for AuthDigest {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut reversed_bytes = self.0;
         reversed_bytes.reverse();
-        f.write_str(&hex::encode(&reversed_bytes))
+        f.write_str(&hex::encode(reversed_bytes))
     }
 }
 

--- a/zebra-chain/src/transparent/address.rs
+++ b/zebra-chain/src/transparent/address.rs
@@ -244,7 +244,7 @@ impl Address {
     /// <https://en.bitcoin.it/Base58Check_encoding#Encoding_a_Bitcoin_address>
     fn hash_payload(bytes: &[u8]) -> [u8; 20] {
         let sha_hash = Sha256::digest(bytes);
-        let ripe_hash = Ripemd160::digest(&sha_hash);
+        let ripe_hash = Ripemd160::digest(sha_hash);
         let mut payload = [0u8; 20];
         payload[..].copy_from_slice(&ripe_hash[..]);
         payload

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -15,7 +15,6 @@ use crate::{block, parameters::Network};
 
 use std::{
     cmp::{Ordering, PartialEq, PartialOrd},
-    convert::TryFrom,
     fmt,
     iter::Sum,
     ops::Add,
@@ -108,7 +107,7 @@ impl fmt::Debug for ExpandedDifficulty {
         // Use the same byte order as block::Hash
         self.0.to_big_endian(&mut buf);
         f.debug_tuple("ExpandedDifficulty")
-            .field(&hex::encode(&buf))
+            .field(&hex::encode(buf))
             .finish()
     }
 }

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -20,7 +20,7 @@ pub struct Magic(pub [u8; 4]);
 
 impl fmt::Debug for Magic {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("Magic").field(&hex::encode(&self.0)).finish()
+        f.debug_tuple("Magic").field(&hex::encode(self.0)).finish()
     }
 }
 

--- a/zebra-utils/src/bin/zebra-checkpoints/main.rs
+++ b/zebra-utils/src/bin/zebra-checkpoints/main.rs
@@ -102,7 +102,7 @@ fn main() -> Result<()> {
         let mut cmd = passthrough_cmd();
 
         // get block data
-        cmd.args(&["getblock", &x.to_string()]);
+        cmd.args(["getblock", &x.to_string()]);
         let output = cmd_output(&mut cmd)?;
         // parse json
         let v: Value = serde_json::from_str(&output)?;

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -192,7 +192,7 @@ where
             let cache_dir = dir.join("state");
             fs::create_dir_all(&cache_dir)?;
         } else {
-            fs::create_dir_all(&dir)?;
+            fs::create_dir_all(dir)?;
         }
 
         let config_file = dir.join("zebrad.toml");


### PR DESCRIPTION
## Motivation

We want to keep clippy lints up to date by doing them when they arrive in nightly Rust.

## Solution

Partly generated by:
```sh
cargo +nightly clippy --fix --all-features --all-targets
```

## Review

This just needs to get fixed eventually.

### Reviewer Checklist

  - [x] CI passes

