### PR TITLE
fix(deny.toml): Change an exception to the earlier pin-project version

### DIFF
--- a/book/src/dev/continuous-integration.md
+++ b/book/src/dev/continuous-integration.md
@@ -76,12 +76,13 @@ To fix duplicate dependencies, follow these steps until the duplicate dependenci
    a. Check for features that Zebra activates in its `Cargo.toml` files, and try turning them off, then
   
    b. Try adding `default-features = false` to Zebra's dependencies (see [PR #4082](https://github.com/ZcashFoundation/zebra/pull/4082/files)).
-3. If there are still duplicate dependencies, add an exception to [`deny.toml`](https://github.com/ZcashFoundation/zebra/blob/main/deny.toml):
+
+3. If there are still duplicate dependencies, add or update the exceptions in [`deny.toml`](https://github.com/ZcashFoundation/zebra/blob/main/deny.toml):
 
    a. Prefer exceptions for dependencies that are closer to Zebra in the dependency tree (sometimes this resolves other duplicates as well),
-  
-   b. Add exceptions for the earlier version of duplicate dependencies, not the later version, and
-  
+
+   b. Add or update exceptions for the earlier version of duplicate dependencies, not the later version, and
+
    c. Add a comment about why the dependency exception is needed: what was the dependency update that caused it?
   
    d. For an example, see [PR #4890](https://github.com/ZcashFoundation/zebra/pull/4890/files).

--- a/book/src/dev/continuous-integration.md
+++ b/book/src/dev/continuous-integration.md
@@ -45,18 +45,20 @@ To fix a CI sync timeout, follow these steps until the timeouts are fixed:
 1. Check for recent PRs that could have caused a performance decrease
 2. [Update Zebra's checkpoints](https://github.com/ZcashFoundation/zebra/blob/main/zebra-utils/README.md#zebra-checkpoints)
 3. Wait for a full or update sync to finish with the new checkpoints
+
 4. The GitHub actions job limit is 6 hours, so the ideal job time is 4-5 hours.
    If any GitHub actions job times out, or takes over 5 hours:
-   
+
     a. [Split the job based on the sync height](https://github.com/ZcashFoundation/zebra/pull/4961/files#diff-4c3718f100312ddc9472f5d4ab2ee0a50a46f2af21352a25fca849734e3f7514R732), or
-    
+
     b. Adjust the sync heights in existing jobs.
+
 5. If a Rust test fails with "command did not log any matches for the given regex, within the ... timeout":
 
     a. If it's the full sync test, [increase the full sync timeout](https://github.com/ZcashFoundation/zebra/commit/9fb87425b76ba3747985ea2f22043ff0276a03bd#diff-8fbc73b0a92a4f48656ffe7d85d55c612c755202dcb7284d8f6742a38a6e9614R367)
 
     b. If it's an update sync test, [increase the update sync timeouts](https://github.com/ZcashFoundation/zebra/commit/9fb87425b76ba3747985ea2f22043ff0276a03bd#diff-92f93c26e696014d82c3dc1dbf385c669aa61aa292f44848f52167ab747cb6f6R51)
-   
+
 ### Resolving Duplicate Dependencies in `Check deny.toml bans`
 
 Zebra's CI checks for duplicate crate dependencies: multiple dependencies on different versions of the same crate.
@@ -65,16 +67,18 @@ If a developer or dependabot adds a duplicate dependency, the `Check deny.toml b
 You can view Zebra's entire dependency tree using `cargo tree`. It can also show the active features on each dependency.
 
 To fix duplicate dependencies, follow these steps until the duplicate dependencies are fixed:
+
 1. Check for updates to the crates mentioned in the `Check deny.toml bans` logs, and try doing them in the same PR.
    For an example, see [PR #5009](https://github.com/ZcashFoundation/zebra/pull/5009#issuecomment-1232488943).
-   
+
    a. Check for open dependabot PRs, and
-  
+
    b. Manually check for updates to those crates on https://crates.io .
+
 2. If there are still duplicate dependencies, try removing those dependencies by disabling crate features:
 
    a. Check for features that Zebra activates in its `Cargo.toml` files, and try turning them off, then
-  
+
    b. Try adding `default-features = false` to Zebra's dependencies (see [PR #4082](https://github.com/ZcashFoundation/zebra/pull/4082/files)).
 
 3. If there are still duplicate dependencies, add or update the exceptions in [`deny.toml`](https://github.com/ZcashFoundation/zebra/blob/main/deny.toml):
@@ -84,6 +88,7 @@ To fix duplicate dependencies, follow these steps until the duplicate dependenci
    b. Add or update exceptions for the earlier version of duplicate dependencies, not the later version, and
 
    c. Add a comment about why the dependency exception is needed: what was the dependency update that caused it?
-  
+
    d. For an example, see [PR #4890](https://github.com/ZcashFoundation/zebra/pull/4890/files).
+
 4. Repeat step 3 until the dependency warnings are fixed. Adding a single exception can resolve multiple warnings.

--- a/deny.toml
+++ b/deny.toml
@@ -45,8 +45,7 @@ skip-tree = [
     { name = "criterion", version = "=0.3.6" },
 
     # ticket #3000: upgrade tower-fallback dependencies
-    { name = "pin-project", version = "=0.4.29" },
-    { name = "pin-project", version = "=1.0.12" },
+    { name = "pin-project", version = "=0.4.30" },
 
     # wait for ordered-map to release a dependency fix
     { name = "ordered-map", version = "=0.4.2" },


### PR DESCRIPTION
## Motivation

We want to add `deny.toml` exceptions for the earlier versions of duplicate crates.

## Solution

- add an exception for pin-project 0.4.30
- remove the exceptions for other pin-project versions
- update the documentation

## Review

@oxarbitrage created the original PR #4914 for pin-project.

### Reviewer Checklist

  - [ ] CI passes

