### PR TITLE
ci(resources): delete old disk images created in GCP

### DIFF
--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -32,3 +32,31 @@ jobs:
           do
             gcloud compute instance-templates delete ${TEMPLATE} --quiet || continue
           done
+
+      # Deletes cached images older than 90 days
+      #
+      # A search is done is done for each of this images:
+      # - Images created on Pull Requests older than 30 days
+      # - Images created on the `main` branch older than 60 days
+      # - Any other remaining image older than 90 days
+      # TODO: we should improve this approach and filter by disk type, and just keep the 2 latest images of each type (zebra checkpoint, zebra tip, lwd tip)
+      - name: Delete old cache disks
+        run: |
+          PR_OLD_CACHE_DISKS=$(gcloud compute images list --sort-by=creationTimestamp --filter="name~-cache-.+[0-9a-f]+-merge AND creationTimestamp < $(date --date='30 days ago' '+%Y%m%d')" --format='value(NAME)')
+          for DISK in $PR_OLD_CACHE_DISKS
+          do
+            gcloud compute image delete ${DISK} --quiet || continue
+          done
+
+          MAIN_OLD_CACHE_DISKS=$(gcloud compute images list --sort-by=creationTimestamp --filter="name~-cache-main AND creationTimestamp < $(date --date='60 days ago' '+%Y%m%d')" --format='value(NAME)')
+          for DISK in $MAIN_OLD_CACHE_DISKS
+          do
+            gcloud compute image delete ${DISK} --quiet || continue
+          done
+
+
+          ALL_OLD_CACHE_DISKS=$(gcloud compute images list --sort-by=creationTimestamp --filter="name~-cache- AND creationTimestamp < $(date --date='90 days ago' '+%Y%m%d')" --format='value(NAME)')
+          for DISK in $ALL_OLD_CACHE_DISKS
+          do
+            gcloud compute image delete ${DISK} --quiet || continue
+          done


### PR DESCRIPTION
## Previous behavior:
Disk images are being accumulated in GCP for a few years, but this
generates unneeded costs as we're not using images older than 1-2 weeks.

## Expected behavior:
Delete previously unused images based on a timefrime.

## Solution:
Delete images created on a pull request older than 30 days, from the
`main` branch if older than 60 days, and any other image older than 90
days.

Fixes #4965

## Review

Anyone from the DevOps team

### Reviewer Checklist

  ~~- [ ] Tests for Expected Behavior~~
  ~~- [ ] Tests for Errors~~

## Follow Up Work

A `TODO` is on place as we'd like to keep at least the 2 latest images of
each type (zebra checkpoint, zebra tip, lwd tip). Once we've excluded
those images, we can delete any older images after 1 week.

