### PR TITLE
fix(ci): delete GCP resources, but keep some recent cached state images

### DIFF
--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Delete old instance templates
         run: |
           DELETE_BEFORE_DATE=$(date --date="$DELETE_AGE_DAYS days ago" '+%Y%m%d')
-          TEMPLATES=$(gcloud compute instance-templates list --sort-by=creationTimestamp  --filter="creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          TEMPLATES=$(gcloud compute instance-templates list --sort-by=creationTimestamp  --filter="name~-[0-9a-f]+$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
 
           for TEMPLATE in $TEMPLATES
           do
@@ -55,7 +55,7 @@ jobs:
           DELETE_BEFORE_DATE=$(date --date="$DELETE_AGE_DAYS days ago" '+%Y%m%d')
 
           # Disks created by PR jobs, and other jobs that use a commit hash
-          COMMIT_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp  --filter="name~-[0-9a-f]+$ creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          COMMIT_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp  --filter="name~-[0-9a-f]+$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
 
           for DISK in $COMMIT_DISKS
           do
@@ -63,7 +63,7 @@ jobs:
           done
           
           # Disks created by managed instance groups, and other jobs that start with "zebrad-"
-          ZEBRAD_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp  --filter="name~^zebrad- creationTimestamp < $(date --date='7 days ago' '+%Y%m%d')" --format='value(NAME)')
+          ZEBRAD_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp  --filter="name~^zebrad- AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
 
           for DISK in $ZEBRAD_DISKS
           do
@@ -122,12 +122,5 @@ jobs:
               continue
             fi
             
-            gcloud compute images delete ${IMAGE} || continue
-          done
-          
-          # TODO: delete this after the first run, the images were created by an outdated workflow
-          CANOPY_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~canopy$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
-          for IMAGE in $CANOPY_IMAGES
-          do
             gcloud compute images delete ${IMAGE} || continue
           done

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -10,7 +10,9 @@ env:
   # Delete all resources created before $DELETE_AGE_DAYS days ago.
   DELETE_AGE_DAYS: 7
   # But keep the latest $KEEP_LATEST_IMAGE_COUNT images of each type.
-  KEEP_LATEST_IMAGE_COUNT: 2
+  #
+  # TODO: reduce this to 1 or 2 after "The resource is not ready" errors get fixed?
+  KEEP_LATEST_IMAGE_COUNT: 3
 
 jobs:
   delete-resources:
@@ -75,7 +77,8 @@ jobs:
       # - zebrad tip cache
       # - lightwalletd + zebrad tip cache
       #
-      # TODO: when we add testnet to the workflows, keep the latest 2 testnet images, and the latest 2 mainnet images.
+      # TODO: when we add testnet to the workflows, keep the latest $KEEP_LATEST_IMAGE_COUNT testnet images, 
+      #       and the latest $KEEP_LATEST_IMAGE_COUNT mainnet images.
       - name: Delete old cache disks
         run: |
           DELETE_BEFORE_DATE=$(date --date="$DELETE_AGE_DAYS days ago" '+%Y%m%d')
@@ -91,7 +94,7 @@ jobs:
               continue
             fi
             
-            echo gcloud compute images delete ${IMAGE} || continue
+            gcloud compute images delete ${IMAGE} || continue
           done
 
           ZEBRAD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*net-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
@@ -105,7 +108,7 @@ jobs:
               continue
             fi
             
-            echo gcloud compute images delete ${IMAGE} || continue
+            gcloud compute images delete ${IMAGE} || continue
           done
           
           LWD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^lwd-cache-.*net-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
@@ -119,12 +122,12 @@ jobs:
               continue
             fi
             
-            echo gcloud compute images delete ${IMAGE} || continue
+            gcloud compute images delete ${IMAGE} || continue
           done
           
           # TODO: delete this after the first run, the images were created by an outdated workflow
-          CANOPY_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~canopy AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          CANOPY_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~canopy$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
           for IMAGE in $CANOPY_IMAGES
           do
-            echo gcloud compute images delete ${IMAGE} || continue
+            gcloud compute images delete ${IMAGE} || continue
           done

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -22,6 +22,7 @@ jobs:
           workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
+          create_credentials_file: false
 
       # Deletes all the instances template older than 30 days
       - name: Delete old instance templates

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -30,33 +30,33 @@ jobs:
 
           for TEMPLATE in $TEMPLATES
           do
-            gcloud compute instance-templates delete ${TEMPLATE} --quiet || continue
+            gcloud compute instance-templates delete ${TEMPLATE} || continue
           done
 
-      # Deletes cached images older than 90 days
+      # Deletes cached images older than 7-14 days.
       #
       # A search is done is done for each of this images:
-      # - Images created on Pull Requests older than 30 days
-      # - Images created on the `main` branch older than 60 days
-      # - Any other remaining image older than 90 days
+      # - Images created on Pull Requests older than 7 days
+      # - Images created on the `main` branch older than 14 days
+      # - Any other remaining images older than 14 days
+      #
       # TODO: we should improve this approach and filter by disk type, and just keep the 2 latest images of each type (zebra checkpoint, zebra tip, lwd tip)
       - name: Delete old cache disks
         run: |
-          PR_OLD_CACHE_DISKS=$(gcloud compute images list --sort-by=creationTimestamp --filter="name~-cache-.+[0-9a-f]+-merge AND creationTimestamp < $(date --date='30 days ago' '+%Y%m%d')" --format='value(NAME)')
+          PR_OLD_CACHE_DISKS=$(gcloud compute images list --sort-by=creationTimestamp --filter="name~-cache-.+[0-9a-f]+-merge AND creationTimestamp < $(date --date='7 days ago' '+%Y%m%d')" --format='value(NAME)')
           for DISK in $PR_OLD_CACHE_DISKS
           do
-            gcloud compute image delete ${DISK} --quiet || continue
+            gcloud compute images delete ${DISK} || continue
           done
 
-          MAIN_OLD_CACHE_DISKS=$(gcloud compute images list --sort-by=creationTimestamp --filter="name~-cache-main AND creationTimestamp < $(date --date='60 days ago' '+%Y%m%d')" --format='value(NAME)')
+          MAIN_OLD_CACHE_DISKS=$(gcloud compute images list --sort-by=creationTimestamp --filter="name~-cache-main AND creationTimestamp < $(date --date='14 days ago' '+%Y%m%d')" --format='value(NAME)')
           for DISK in $MAIN_OLD_CACHE_DISKS
           do
-            gcloud compute image delete ${DISK} --quiet || continue
+            gcloud compute images delete ${DISK} || continue
           done
 
-
-          ALL_OLD_CACHE_DISKS=$(gcloud compute images list --sort-by=creationTimestamp --filter="name~-cache- AND creationTimestamp < $(date --date='90 days ago' '+%Y%m%d')" --format='value(NAME)')
+          ALL_OLD_CACHE_DISKS=$(gcloud compute images list --sort-by=creationTimestamp --filter="name~-cache- AND creationTimestamp < $(date --date='14 days ago' '+%Y%m%d')" --format='value(NAME)')
           for DISK in $ALL_OLD_CACHE_DISKS
           do
-            gcloud compute image delete ${DISK} --quiet || continue
+            gcloud compute images delete ${DISK} || continue
           done

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -57,7 +57,7 @@ jobs:
 
           for DISK in $COMMIT_DISKS
           do
-            gcloud compute disks delete ${DISK} || continue
+            gcloud compute disks delete --verbosity=info ${DISK} || continue
           done
           
           # Disks created by managed instance groups, and other jobs that start with "zebrad-"
@@ -65,7 +65,7 @@ jobs:
 
           for DISK in $ZEBRAD_DISKS
           do
-            gcloud compute disks delete ${DISK} || continue
+            gcloud compute disks delete --verbosity=info ${DISK} || continue
           done
 
       # Deletes cache images older than $DELETE_AGE_DAYS days.

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -1,9 +1,16 @@
 name: Delete GCP resources
 
 on:
+  # Run right before Teor's week starts (UTC+10)
   schedule:
-    - cron: "0 0 1 * *"
+    - cron: "0 19 * * 0"
   workflow_dispatch:
+
+env:
+  # Delete all resources created before $DELETE_AGE_DAYS days ago.
+  DELETE_AGE_DAYS: 7
+  # But keep the latest $KEEP_LATEST_IMAGE_COUNT images of each type.
+  KEEP_LATEST_IMAGE_COUNT: 2
 
 jobs:
   delete-resources:
@@ -13,6 +20,10 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
+      - uses: actions/checkout@v3.0.2
+        with:
+          persist-credentials: false
+
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
@@ -22,42 +33,98 @@ jobs:
           workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
-          create_credentials_file: false
 
-      # Deletes all the instances template older than 30 days
+      # Deletes all the instance templates older than $DELETE_AGE_DAYS days.
       - name: Delete old instance templates
         run: |
-          TEMPLATES=$(gcloud compute instance-templates list --sort-by=creationTimestamp  --filter="creationTimestamp < $(date --date='30 days ago' '+%Y%m%d')" --format='value(NAME)')
+          DELETE_BEFORE_DATE=$(date --date="$DELETE_AGE_DAYS days ago" '+%Y%m%d')
+          TEMPLATES=$(gcloud compute instance-templates list --sort-by=creationTimestamp  --filter="creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
 
           for TEMPLATE in $TEMPLATES
           do
             gcloud compute instance-templates delete ${TEMPLATE} || continue
           done
 
-      # Deletes cached images older than 7-14 days.
+      # Deletes all the disks older than $DELETE_AGE_DAYS days.
       #
-      # A search is done is done for each of this images:
-      # - Images created on Pull Requests older than 7 days
-      # - Images created on the `main` branch older than 14 days
-      # - Any other remaining images older than 14 days
+      # Disks that are attached to an instance template can't be deleted, so it is safe to delete all disks here.
+      - name: Delete old disks
+        run: |
+          DELETE_BEFORE_DATE=$(date --date="$DELETE_AGE_DAYS days ago" '+%Y%m%d')
+
+          # Disks created by PR jobs, and other jobs that use a commit hash
+          COMMIT_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp  --filter="name~-[0-9a-f]+$ creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+
+          for DISK in $COMMIT_DISKS
+          do
+            gcloud compute disks delete ${DISK} || continue
+          done
+          
+          # Disks created by managed instance groups, and other jobs that start with "zebrad-"
+          ZEBRAD_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp  --filter="name~^zebrad- creationTimestamp < $(date --date='7 days ago' '+%Y%m%d')" --format='value(NAME)')
+
+          for DISK in $ZEBRAD_DISKS
+          do
+            gcloud compute disks delete ${DISK} || continue
+          done
+
+      # Deletes cache images older than $DELETE_AGE_DAYS days.
       #
-      # TODO: we should improve this approach and filter by disk type, and just keep the 2 latest images of each type (zebra checkpoint, zebra tip, lwd tip)
+      # Keeps the latest $KEEP_LATEST_IMAGE_COUNT images of each type:
+      # - zebrad checkpoint cache
+      # - zebrad tip cache
+      # - lightwalletd + zebrad tip cache
+      #
+      # TODO: when we add testnet to the workflows, keep the latest 2 testnet images, and the latest 2 mainnet images.
       - name: Delete old cache disks
         run: |
-          PR_OLD_CACHE_DISKS=$(gcloud compute images list --sort-by=creationTimestamp --filter="name~-cache-.+[0-9a-f]+-merge AND creationTimestamp < $(date --date='7 days ago' '+%Y%m%d')" --format='value(NAME)')
-          for DISK in $PR_OLD_CACHE_DISKS
+          DELETE_BEFORE_DATE=$(date --date="$DELETE_AGE_DAYS days ago" '+%Y%m%d')
+
+          ZEBRAD_CHECKPOINT_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*net-checkpoint AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          KEPT_IMAGES=0
+          for IMAGE in $ZEBRAD_CHECKPOINT_IMAGES
           do
-            gcloud compute images delete ${DISK} || continue
+            if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
+            then              
+              KEPT_IMAGES=$((KEPT_IMAGES+1))
+              echo "Keeping image $KEPT_IMAGES named $IMAGE"
+              continue
+            fi
+            
+            echo gcloud compute images delete ${IMAGE} || continue
           done
 
-          MAIN_OLD_CACHE_DISKS=$(gcloud compute images list --sort-by=creationTimestamp --filter="name~-cache-main AND creationTimestamp < $(date --date='14 days ago' '+%Y%m%d')" --format='value(NAME)')
-          for DISK in $MAIN_OLD_CACHE_DISKS
+          ZEBRAD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*net-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          KEPT_IMAGES=0
+          for IMAGE in $ZEBRAD_TIP_IMAGES
           do
-            gcloud compute images delete ${DISK} || continue
+            if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
+            then              
+              KEPT_IMAGES=$((KEPT_IMAGES+1))
+              echo "Keeping image $KEPT_IMAGES named $IMAGE"
+              continue
+            fi
+            
+            echo gcloud compute images delete ${IMAGE} || continue
           done
-
-          ALL_OLD_CACHE_DISKS=$(gcloud compute images list --sort-by=creationTimestamp --filter="name~-cache- AND creationTimestamp < $(date --date='14 days ago' '+%Y%m%d')" --format='value(NAME)')
-          for DISK in $ALL_OLD_CACHE_DISKS
+          
+          LWD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^lwd-cache-.*net-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          KEPT_IMAGES=0
+          for IMAGE in $LWD_TIP_IMAGES
           do
-            gcloud compute images delete ${DISK} || continue
+            if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
+            then              
+              KEPT_IMAGES=$((KEPT_IMAGES+1))
+              echo "Keeping image $KEPT_IMAGES named $IMAGE"
+              continue
+            fi
+            
+            echo gcloud compute images delete ${IMAGE} || continue
+          done
+          
+          # TODO: delete this after the first run, the images were created by an outdated workflow
+          CANOPY_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~canopy AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          for IMAGE in $CANOPY_IMAGES
+          do
+            echo gcloud compute images delete ${IMAGE} || continue
           done

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -1,7 +1,7 @@
 name: Delete GCP resources
 
 on:
-  # Run right before Teor's week starts (UTC+10)
+  # Run right before Teor's week starts (0500 in UTC+10)
   schedule:
     - cron: "0 19 * * 0"
   workflow_dispatch:

--- a/book/src/dev/continuous-integration.md
+++ b/book/src/dev/continuous-integration.md
@@ -20,6 +20,26 @@ any branch and commit, as long as the state version is the same.
 Zebra also does [a smaller set of tests](https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/continous-integration-os.yml) on tier 2 platforms using GitHub actions runners.
 
 
+## Manually Using Google Cloud
+
+Some Zebra developers have access to the Zcash Foundation's Google Cloud instance, which also runs our automatic CI.
+
+Please shut down large instances when they are not being used.
+
+### Automated Deletion
+
+The [Delete GCP Resources](https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/delete-gcp-resources.yml)
+workflow automatically deletes instance templates, disks, and images older than 1 week.
+
+Running instances and their disks are protected from deletion.
+
+If you want to keep instance templates, disks, or images in Google Cloud, name them so they don't match the automated names:
+- deleted instance templates and disks end in a commit hash, so use a name ending in `-` or `-[^0-9a-f]+`
+- deleted images start with `zebrad-cache` or `lwd-cache`, so use a name starting with anything else
+
+Our other Google Cloud projects don't have automated deletion, so you can also use them for experiments or production deployments.
+
+
 ## Troubleshooting
 
 To improve CI performance, some Docker tests are stateful.


### PR DESCRIPTION
## Motivation

- The current GCP delete command has a typo
- Some of the deletion schedules are very long, and storing terabytes of data is expensive
- We're deleting the only checkpoint disk every 60 days, forcing the next PR that runs to rebuild it

## Solution

Functional changes:
- start deleting disks (as well as images and instances)
- delete instances, disks, and images after 7 days
- preserve the last 3 images of each type
- use the correct delete command
- change the schedule to weekly, just before Teor starts their week (so there is someone around if it causes any issues)

Diagnostic changes:
- show which images and disks are deleted
- show output of failed commands
- silence the warning about GCP credential files

## Review

I think @gustavovalverde might want to review this PR.

### Reviewer Checklist

  - [ ] Manual workflow run passes