### PR TITLE
fix(ci): Wait 1 day before creating cached state image updates 

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -420,7 +420,7 @@ jobs:
       test_variables: '-e TEST_LWD_UPDATE_SYNC=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache -e LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache'
       needs_zebra_state: true
       needs_lwd_state: true
-      # since we do a full sync in every PR, the new cached state is only be an hour new than the original one
+      # since we do a full sync in every PR, the new cached state will only be a few minutes newer than the original one
       saves_to_disk: false
       disk_prefix: lwd-cache
       disk_suffix: tip

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -169,6 +169,8 @@ jobs:
       zebra_skip_ipv6_tests: '1'
       rust_log: info
 
+  # zebrad tests without cached state
+
   # Run all the zebra tests, including tests that are ignored by default.
   # Skips tests that need a cached state disk or a lightwalletd binary.
   #
@@ -256,6 +258,8 @@ jobs:
         env:
           ZEBRA_TEST_LIGHTWALLETD: '1'
 
+  # zebrad cached checkpoint state tests
+
   # Regenerate mandatory checkpoint Zebra cached state disks.
   #
   # Runs:
@@ -275,7 +279,7 @@ jobs:
       needs_zebra_state: false
       saves_to_disk: true
       disk_suffix: checkpoint
-      height_grep_text: 'flushing database to disk .*height.*=.*Height'
+      height_grep_text: 'flushing database to disk .*height.*=.*Height.*\('
 
   # Test that Zebra syncs and fully validates a few thousand blocks from a cached mandatory checkpoint disk
   #
@@ -293,6 +297,8 @@ jobs:
       needs_zebra_state: true
       saves_to_disk: false
       disk_suffix: checkpoint
+
+  # zebrad cached tip state tests
 
   # Test that Zebra can run a full mainnet sync,
   # and regenerate chain tip Zebra cached state disks.
@@ -318,7 +324,7 @@ jobs:
       needs_zebra_state: false
       saves_to_disk: true
       disk_suffix: tip
-      height_grep_text: 'current_height.*=.*Height'
+      height_grep_text: 'current_height.*=.*Height.*\('
     # We don't want to cancel running full syncs on `main` if a new PR gets merged,
     # because we might never finish a full sync during busy weeks. Instead, we let the
     # first sync complete, then queue the latest pending sync, cancelling any syncs in between.
@@ -357,6 +363,68 @@ jobs:
       disk_suffix: tip
       root_state_path: '/var/cache'
       zebra_state_dir: 'zebrad-cache'
+      height_grep_text: 'current_height.*=.*Height.*\('
+
+  # lightwalletd cached tip state tests
+
+  # Test full sync of lightwalletd with a Zebra tip state
+  #
+  # Runs:
+  # - after every PR is merged to `main`
+  # - on every PR update
+  #
+  # If the state version has changed, waits for the new cached state to be created.
+  # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
+  lightwalletd-full-sync:
+    name: lightwalletd tip
+    needs: [ test-full-sync, get-available-disks ]
+    uses: ./.github/workflows/deploy-gcp-tests.yml
+    # to also run on Mergify head branches,
+    # add `|| (github.event_name == 'push' && startsWith(github.head_ref, 'mergify/merge-queue/'))`:
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1
+    if: ${{ (!cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true') || !fromJSON(needs.get-available-disks.outputs.lwd_tip_disk) }}
+    with:
+      app_name: lightwalletd
+      test_id: lwd-full-sync
+      test_description: Test lightwalletd full sync
+      test_variables: '-e TEST_LWD_FULL_SYNC=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache -e LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache'
+      needs_zebra_state: true
+      needs_lwd_state: false
+      saves_to_disk: true
+      disk_prefix: lwd-cache
+      disk_suffix: tip
+      root_state_path: '/var/cache'
+      zebra_state_dir: 'zebrad-cache'
+      lwd_state_dir: 'lwd-cache'
+      height_grep_text: '(current_height.*=.*Height.*\()|(Adding block to cache )'
+
+  # Test update sync of lightwalletd with a lightwalletd and Zebra tip state
+  # Runs:
+  # - after every PR is merged to `main`
+  # - on every PR update
+  #
+  # If the state version has changed, waits for the new cached states to be created.
+  # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
+  lightwalletd-update-sync:
+    name: lightwalletd tip update
+    needs: lightwalletd-full-sync
+    uses: ./.github/workflows/deploy-gcp-tests.yml
+    if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
+    with:
+      app_name: lightwalletd
+      test_id: lwd-update-sync
+      test_description: Test lightwalletd update sync with both states
+      test_variables: '-e TEST_LWD_UPDATE_SYNC=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache -e LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache'
+      needs_zebra_state: true
+      needs_lwd_state: true
+      # update the disk on every PR, to increase CI speed
+      saves_to_disk: true
+      disk_prefix: lwd-cache
+      disk_suffix: tip
+      root_state_path: '/var/cache'
+      zebra_state_dir: 'zebrad-cache'
+      lwd_state_dir: 'lwd-cache'
+      height_grep_text: '(current_height.*=.*Height.*\()|(Adding block to cache )'
 
   # Test that Zebra can answer a synthetic RPC call, using a cached Zebra tip state
   #
@@ -404,63 +472,6 @@ jobs:
       needs_zebra_state: true
       needs_lwd_state: true
       saves_to_disk: false
-      disk_suffix: tip
-      root_state_path: '/var/cache'
-      zebra_state_dir: 'zebrad-cache'
-      lwd_state_dir: 'lwd-cache'
-
-  # Test full sync of lightwalletd with a Zebra tip state
-  #
-  # Runs:
-  # - after every PR is merged to `main`
-  # - on every PR update
-  #
-  # If the state version has changed, waits for the new cached state to be created.
-  # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
-  lightwalletd-full-sync:
-    name: lightwalletd tip
-    needs: [ test-full-sync, get-available-disks ]
-    uses: ./.github/workflows/deploy-gcp-tests.yml
-    # to also run on Mergify head branches,
-    # add `|| (github.event_name == 'push' && startsWith(github.head_ref, 'mergify/merge-queue/'))`:
-    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1
-    if: ${{ (!cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true') || !fromJSON(needs.get-available-disks.outputs.lwd_tip_disk) }}
-    with:
-      app_name: lightwalletd
-      test_id: lwd-full-sync
-      test_description: Test lightwalletd full sync
-      test_variables: '-e TEST_LWD_FULL_SYNC=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache -e LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache'
-      needs_zebra_state: true
-      needs_lwd_state: false
-      saves_to_disk: true
-      disk_prefix: lwd-cache
-      disk_suffix: tip
-      root_state_path: '/var/cache'
-      zebra_state_dir: 'zebrad-cache'
-      lwd_state_dir: 'lwd-cache'
-
-  # Test update sync of lightwalletd with a lightwalletd and Zebra tip state
-  # Runs:
-  # - after every PR is merged to `main`
-  # - on every PR update
-  #
-  # If the state version has changed, waits for the new cached states to be created.
-  # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
-  lightwalletd-update-sync:
-    name: lightwalletd tip update
-    needs: lightwalletd-full-sync
-    uses: ./.github/workflows/deploy-gcp-tests.yml
-    if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
-    with:
-      app_name: lightwalletd
-      test_id: lwd-update-sync
-      test_description: Test lightwalletd update sync with both states
-      test_variables: '-e TEST_LWD_UPDATE_SYNC=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache -e LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache'
-      needs_zebra_state: true
-      needs_lwd_state: true
-      # update the disk on every PR, to increase CI speed
-      saves_to_disk: true
-      disk_prefix: lwd-cache
       disk_suffix: tip
       root_state_path: '/var/cache'
       zebra_state_dir: 'zebrad-cache'

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -273,6 +273,7 @@ jobs:
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !fromJSON(needs.get-available-disks.outputs.zebra_checkpoint_disk) || github.event.inputs.regenerate-disks == 'true' }}
     with:
+      app_name: zebrad
       test_id: sync-to-checkpoint
       test_description: Test sync up to mandatory checkpoint
       test_variables: '-e TEST_DISK_REBUILD=1 -e ZEBRA_FORCE_USE_COLOR=1'
@@ -291,6 +292,7 @@ jobs:
     uses: ./.github/workflows/deploy-gcp-tests.yml
     if: ${{ !cancelled() && !failure() && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' }}
     with:
+      app_name: zebrad
       test_id: sync-past-checkpoint
       test_description: Test full validation sync from a cached state
       test_variables: '-e TEST_CHECKPOINT_SYNC=1 -e ZEBRA_FORCE_USE_COLOR=1'
@@ -318,6 +320,7 @@ jobs:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1
     if: ${{ (github.event_name == 'push' && github.ref_name == 'main') || !fromJSON(needs.get-available-disks.outputs.zebra_tip_disk) || github.event.inputs.run-full-sync == 'true' }}
     with:
+      app_name: zebrad
       test_id: full-sync-to-tip
       test_description: Test a full sync up to the tip
       test_variables: '-e TEST_FULL_SYNC=1 -e ZEBRA_FORCE_USE_COLOR=1 -e FULL_SYNC_MAINNET_TIMEOUT_MINUTES=600'
@@ -417,8 +420,8 @@ jobs:
       test_variables: '-e TEST_LWD_UPDATE_SYNC=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache -e LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache'
       needs_zebra_state: true
       needs_lwd_state: true
-      # update the disk on every PR, to increase CI speed
-      saves_to_disk: true
+      # since we do a full sync in every PR, the new cached state is only be an hour new than the original one
+      saves_to_disk: false
       disk_prefix: lwd-cache
       disk_suffix: tip
       root_state_path: '/var/cache'

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1189,7 +1189,7 @@ jobs:
       #
       # If the height is missing from the image labels, uses zero instead.
       # TODO: fail the job if needs_zebra_state but the height is missing
-      #       after all the old images have been deleted, this should happen around 15 September 2022
+      #       we can make this change after all the old images have been deleted, this should happen around 15 September 2022
       #       we'll also need to do a manual checkpoint rebuild before opening the PR for this change
       #
       # Passes the original height to subsequent steps using $ORIGINAL_HEIGHT env variable.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1114,7 +1114,7 @@ jobs:
           token_format: 'access_token'
 
       # Get the state version from the local constants.rs file to be used in the image creation,
-      # as the state version is part of the disk image.
+      # as the state version is part of the disk image name.
       #
       # Passes the state version to subsequent steps using $STATE_VERSION env variable
       - name: Get state version from constants.rs

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -78,7 +78,7 @@ on:
         required: false
         type: string
         default: 'zebra'
-        description: 'Application name for Google Cloud instance metadata'
+        description: 'Application name, used to work out when a job is an update job'
 
 env:
   # where we get the Docker image from
@@ -94,6 +94,9 @@ env:
   # but we don't know how long it will be between jobs.
   # 200 lines is about 6-15 minutes of sync logs, or one panic log.
   EXTRA_LOG_LINES: 200
+  # How many blocks to wait before creating an updated cached state image.
+  # 1 day is approximately 1152 blocks.
+  CACHED_STATE_UPDATE_LIMIT: 1152
 
 jobs:
   # set up the test, if it doesn't use any cached state
@@ -1111,7 +1114,7 @@ jobs:
           token_format: 'access_token'
 
       # Get the state version from the local constants.rs file to be used in the image creation,
-      # as the state version is part of the disk image name.
+      # as the state version is part of the disk image.
       #
       # Passes the state version to subsequent steps using $STATE_VERSION env variable
       - name: Get state version from constants.rs
@@ -1120,31 +1123,8 @@ jobs:
           echo "STATE_VERSION: $LOCAL_STATE_VERSION"
 
           echo "STATE_VERSION=$LOCAL_STATE_VERSION" >> $GITHUB_ENV
-
-      # Get the sync height from the test logs, which is later used as part of the
-      # disk description.
-      #
-      # The regex used to grep the sync height is provided by ${{ inputs.height_grep_text }},
-      # this allows to dynamically change the height as needed by different situations or
-      # based on the logs output from different tests
-      #
-      # Passes the sync height to subsequent steps using $SYNC_HEIGHT env variable
-      - name: Get sync height from logs
-        run: |
-          SYNC_HEIGHT=""
-
-          DOCKER_LOGS=$(\
-          gcloud compute ssh \
-          ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
-          --zone ${{ env.ZONE }} \
-          --quiet \
-          --ssh-flag="-o ServerAliveInterval=5" \
-          --command="docker logs ${{ inputs.test_id }} --tail 200")
-
-          SYNC_HEIGHT=$(echo $DOCKER_LOGS | grep -oE '${{ inputs.height_grep_text }}[0-9]+' | grep -oE '[0-9]+' | tail -1 || [[ $? == 1 ]])
-          echo "SYNC_HEIGHT=$SYNC_HEIGHT" >> $GITHUB_ENV
-
-      # Sets the $UPDATE_SUFFIX env var to "-u" if using cached state,
+          
+      # Sets the $UPDATE_SUFFIX env var to "-u" if updating a previous cached state,
       # and the empty string otherwise.
       #
       # Also sets a unique date and time suffix $TIME_SUFFIX.
@@ -1152,20 +1132,85 @@ jobs:
         run: |
           UPDATE_SUFFIX=""
 
-          if [[ "${{ inputs.needs_zebra_state }}" == "true" ]]; then
+          if [[ "${{ inputs.needs_zebra_state }}" == "true" ]] && [[ "${{ inputs.app_name }}" == "zebrad" ]]; then
               UPDATE_SUFFIX="-u"
           fi
 
+          # TODO: find a better logic for the lwd-full-sync case
+          if [[ "${{ inputs.needs_lwd_state }}" == "true" ]] && [[ "${{ inputs.app_name }}" == "lightwalletd" ]] && [[ "${{ inputs.test_id }}" != 'lwd-full-sync' ]]; then
+              UPDATE_SUFFIX="-u"
+          fi
+ 
           # We're going to delete old images after a month, so we don't need the year here
           TIME_SUFFIX=$(date '+%m%d%H%M%S' --utc)
 
           echo "UPDATE_SUFFIX=$UPDATE_SUFFIX" >> $GITHUB_ENV
           echo "TIME_SUFFIX=$TIME_SUFFIX" >> $GITHUB_ENV
 
+      # Get the sync height from the test logs, which is later used as part of the
+      # disk description and labels.
+      #
+      # The regex used to grep the sync height is provided by ${{ inputs.height_grep_text }},
+      # this allows to dynamically change the height as needed by different situations or
+      # based on the logs output from different tests.
+      #
+      # If the sync height is missing from the logs, the job fails.
+      #
+      # Passes the sync height to subsequent steps using $SYNC_HEIGHT env variable.
+      - name: Get sync height from logs
+        run: |
+          SYNC_HEIGHT=$( \
+          gcloud compute ssh \
+          ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          --zone ${{ env.ZONE }} \
+          --quiet \
+          --ssh-flag="-o ServerAliveInterval=5" \
+          --command=" \
+          docker logs ${{ inputs.test_id }} --tail 200 | \
+          tee --output-error=exit /dev/stderr | \
+          grep --extended-regexp --only-matching --color=never \
+          '${{ inputs.height_grep_text }}[0-9]+' | \
+          grep --extended-regexp --only-matching --color=never \
+          '[0-9]+' | \
+          tail -1 \
+          ")
+          
+          if [[ -z "$SYNC_HEIGHT" ]]; then
+              echo "Missing sync height in logs: $SYNC_HEIGHT"
+              # Fail the tests, because Zebra and lightwalletd didn't log their sync heights,
+              # or the CI workflow sync height regex is wrong.
+              false
+          fi
+
+          echo "Found sync height in logs: $SYNC_HEIGHT"
+          echo "SYNC_HEIGHT=$SYNC_HEIGHT" >> $GITHUB_ENV
+
+      # Get the original cached state height from google cloud.
+      #
+      # If the height is missing from the image labels, uses zero instead.
+      # TODO: fail the job if needs_zebra_state but the height is missing
+      #       after all the old images have been deleted, this should happen around 15 September 2022
+      #       we'll also need to do a manual checkpoint rebuild before opening the PR for this change
+      #
+      # Passes the original height to subsequent steps using $ORIGINAL_HEIGHT env variable.
+      - name: Get original cached state height from google cloud
+        run: |
+          ORIGINAL_HEIGHT="0"
+
+          if [[ "${{ inputs.needs_zebra_state }}" == "true" ]]; then
+              ORIGINAL_HEIGHT=$(gcloud compute images list --filter="name=${CACHED_DISK_NAME}" --format="value(labels.height)")
+              echo "$CACHED_DISK_NAME height: $ORIGINAL_HEIGHT"
+          fi
+          
+          echo "ORIGINAL_HEIGHT=$ORIGINAL_HEIGHT" >> $GITHUB_ENV
+          
       # Create an image from the state disk, which will be used for any tests that start
       # after it is created. These tests can be in the same workflow, or in a different PR.
       #
       # Using the newest image makes future jobs faster, because it is closer to the chain tip.
+      #
+      # Skips creating updated images if the original image is less than $CACHED_STATE_UPDATE_LIMIT behind the current tip.
+      # Full sync images are always created.
       #
       # The image can contain:
       # - Zebra cached state, or
@@ -1189,14 +1234,19 @@ jobs:
       # used by the container.
       - name: Create image from state disk
         run: |
-          gcloud compute images create \
-          "${{ inputs.disk_prefix }}-${SHORT_GITHUB_REF}-${{ env.GITHUB_SHA_SHORT }}-v${{ env.STATE_VERSION }}-${{ env.NETWORK }}-${{ inputs.disk_suffix }}${UPDATE_SUFFIX}-${TIME_SUFFIX}" \
-          --force \
-          --source-disk=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} \
-          --source-disk-zone=${{ env.ZONE }} \
-          --storage-location=us \
-          --description="Created from commit ${{ env.GITHUB_SHA_SHORT }} with height ${{ env.SYNC_HEIGHT }}"
-          --labels="height=${{ env.SYNC_HEIGHT }},purpose=${{ inputs.disk_prefix }},commit=${{ env.GITHUB_SHA_SHORT }},state-version=${{ env.STATE_VERSION }},network=${{ env.NETWORK }},target-height=${{ inputs.disk_suffix }},update-flag=${UPDATE_SUFFIX},test-id=${{ inputs.test_id }},app-name=${{ inputs.app_name }}"
+          MINIMUM_UPDATE_HEIGHT=$((ORIGINAL_HEIGHT+CACHED_STATE_UPDATE_LIMIT))
+          if [[ -z "$UPDATE_SUFFIX" ]] || [[ "$SYNC_HEIGHT" -gt "$MINIMUM_UPDATE_HEIGHT" ]]; then
+             gcloud compute images create \
+              "${{ inputs.disk_prefix }}-${SHORT_GITHUB_REF}-${{ env.GITHUB_SHA_SHORT }}-v${{ env.STATE_VERSION }}-${{ env.NETWORK }}-${{ inputs.disk_suffix }}${UPDATE_SUFFIX}-${TIME_SUFFIX}" \
+              --force \
+              --source-disk=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} \
+              --source-disk-zone=${{ env.ZONE }} \
+              --storage-location=us \
+              --description="Created from commit ${{ env.GITHUB_SHA_SHORT }} with height ${{ env.SYNC_HEIGHT }}"
+              --labels="height=${{ env.SYNC_HEIGHT }},purpose=${{ inputs.disk_prefix }},commit=${{ env.GITHUB_SHA_SHORT }},state-version=${{ env.STATE_VERSION }},network=${{ env.NETWORK }},target-height=${{ inputs.disk_suffix }},update-flag=${UPDATE_SUFFIX},updated-from-height=${ORIGINAL_HEIGHT},test-id=${{ inputs.test_id }},app-name=${{ inputs.app_name }}"
+          else
+              echo "Skipped cached state update because the new sync height $SYNC_HEIGHT was less than $CACHED_STATE_UPDATE_LIMIT blocks above the original height $ORIGINAL_HEIGHT"
+          fi          
 
   # delete the Google Cloud instance for this test
   delete-instance:

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1139,7 +1139,7 @@ jobs:
           --zone ${{ env.ZONE }} \
           --quiet \
           --ssh-flag="-o ServerAliveInterval=5" \
-          --command="docker logs ${{ inputs.test_id }} --tail 20")
+          --command="docker logs ${{ inputs.test_id }} --tail 200")
 
           SYNC_HEIGHT=$(echo $DOCKER_LOGS | grep -oE '${{ inputs.height_grep_text }}\([0-9]+\)' | grep -oE '[0-9]+' | tail -1 || [[ $? == 1 ]])
           echo "SYNC_HEIGHT=$SYNC_HEIGHT" >> $GITHUB_ENV

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1141,7 +1141,7 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --command="docker logs ${{ inputs.test_id }} --tail 200")
 
-          SYNC_HEIGHT=$(echo $DOCKER_LOGS | grep -oE '${{ inputs.height_grep_text }}\([0-9]+\)' | grep -oE '[0-9]+' | tail -1 || [[ $? == 1 ]])
+          SYNC_HEIGHT=$(echo $DOCKER_LOGS | grep -oE '${{ inputs.height_grep_text }}[0-9]+' | grep -oE '[0-9]+' | tail -1 || [[ $? == 1 ]])
           echo "SYNC_HEIGHT=$SYNC_HEIGHT" >> $GITHUB_ENV
 
       # Sets the $UPDATE_SUFFIX env var to "-u" if using cached state,
@@ -1196,6 +1196,7 @@ jobs:
           --source-disk-zone=${{ env.ZONE }} \
           --storage-location=us \
           --description="Created from commit ${{ env.GITHUB_SHA_SHORT }} with height ${{ env.SYNC_HEIGHT }}"
+          --labels="height=${{ env.SYNC_HEIGHT }},purpose=${{ inputs.disk_prefix }},commit=${{ env.GITHUB_SHA_SHORT }},state-version=${{ env.STATE_VERSION }},network=${{ env.NETWORK }},target-height=${{ inputs.disk_suffix }},update-flag=${UPDATE_SUFFIX},test-id=${{ inputs.test_id }},app-name=${{ inputs.app_name }}"
 
   # delete the Google Cloud instance for this test
   delete-instance:

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -231,6 +231,8 @@ jobs:
     name: Setup ${{ inputs.test_id }} test
     if: ${{ inputs.needs_zebra_state }}
     runs-on: ubuntu-latest
+    outputs:
+      cached_disk_name: ${{ steps.get-disk-name.outputs.cached_disk_name }}
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -343,6 +345,7 @@ jobs:
           fi
 
           echo "Selected Disk: $CACHED_DISK_NAME"
+          echo "::set-output name=cached_disk_name::$CACHED_DISK_NAME"
 
           echo "STATE_VERSION=$LOCAL_STATE_VERSION" >> $GITHUB_ENV
           echo "CACHED_DISK_NAME=$CACHED_DISK_NAME" >> $GITHUB_ENV
@@ -1068,7 +1071,7 @@ jobs:
   create-state-image:
     name: Create ${{ inputs.test_id }} cached state image
     runs-on: ubuntu-latest
-    needs: [ test-result ]
+    needs: [ test-result, setup-with-cached-state ]
     # We run exactly one of without-cached-state or with-cached-state, and we always skip the other one.
     # Normally, if a job is skipped, all the jobs that depend on it are also skipped.
     # So we need to override the default success() check to make this job run.
@@ -1192,6 +1195,7 @@ jobs:
       # Get the original cached state height from google cloud.
       #
       # If the height is missing from the image labels, uses zero instead.
+      #
       # TODO: fail the job if needs_zebra_state but the height is missing
       #       we can make this change after all the old images have been deleted, this should happen around 15 September 2022
       #       we'll also need to do a manual checkpoint rebuild before opening the PR for this change
@@ -1201,8 +1205,9 @@ jobs:
         run: |
           ORIGINAL_HEIGHT="0"
 
-          if [[ "${{ inputs.needs_zebra_state }}" == "true" ]]; then
-              ORIGINAL_HEIGHT=$(gcloud compute images list --filter="name=${CACHED_DISK_NAME}" --format="value(labels.height)")
+          if [[ -n "${{ format('{0}', needs.setup-with-cached-state.outputs.cached_disk_name) }}" ]]; then
+              ORIGINAL_HEIGHT=$(gcloud compute images list --filter="name=${{ needs.setup-with-cached-state.outputs.cached_disk_name }}" --format="value(labels.height)")
+              ORIGINAL_HEIGHT=${ORIGINAL_HEIGHT:-0}
               echo "$CACHED_DISK_NAME height: $ORIGINAL_HEIGHT"
           fi
           

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1159,21 +1159,25 @@ jobs:
       # Passes the sync height to subsequent steps using $SYNC_HEIGHT env variable.
       - name: Get sync height from logs
         run: |
-          SYNC_HEIGHT=$( \
+          SYNC_HEIGHT=""
+
+          DOCKER_LOGS=$( \
           gcloud compute ssh \
           ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ env.ZONE }} \
           --quiet \
           --ssh-flag="-o ServerAliveInterval=5" \
           --command=" \
-          docker logs ${{ inputs.test_id }} --tail 200 | \
-          tee --output-error=exit /dev/stderr | \
-          grep --extended-regexp --only-matching --color=never \
-          '${{ inputs.height_grep_text }}[0-9]+' | \
-          grep --extended-regexp --only-matching --color=never \
-          '[0-9]+' | \
-          tail -1 \
+          docker logs ${{ inputs.test_id }} --tail 200 \
           ")
+          
+          SYNC_HEIGHT=$( \
+          echo "$DOCKER_LOGS" | \
+          grep --extended-regexp --only-matching '${{ inputs.height_grep_text }}[0-9]+' | \
+          grep --extended-regexp --only-matching  '[0-9]+' | \
+          tail -1 || \
+          [[ $? == 1 ]] \
+          )
           
           if [[ -z "$SYNC_HEIGHT" ]]; then
               echo "Missing sync height in logs: $SYNC_HEIGHT"
@@ -1181,7 +1185,7 @@ jobs:
               # or the CI workflow sync height regex is wrong.
               false
           fi
-
+          
           echo "Found sync height in logs: $SYNC_HEIGHT"
           echo "SYNC_HEIGHT=$SYNC_HEIGHT" >> $GITHUB_ENV
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1195,7 +1195,7 @@ jobs:
           --source-disk=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} \
           --source-disk-zone=${{ env.ZONE }} \
           --storage-location=us \
-          --description="Created from commit ${{ env.GITHUB_SHA_SHORT }} with height ${{ env.SYNC_HEIGHT }}"
+          --description="Created from commit ${{ env.GITHUB_SHA_SHORT }} with height ${{ env.SYNC_HEIGHT }}" \
           --labels="height=${{ env.SYNC_HEIGHT }},purpose=${{ inputs.disk_prefix }},commit=${{ env.GITHUB_SHA_SHORT }},state-version=${{ env.STATE_VERSION }},network=${{ env.NETWORK }},target-height=${{ inputs.disk_suffix }},update-flag=${UPDATE_SUFFIX},test-id=${{ inputs.test_id }},app-name=${{ inputs.app_name }}"
 
   # delete the Google Cloud instance for this test


### PR DESCRIPTION
## Motivation

We've created 400 cached state images over the past week, that's about 40 TB of data.
This is about 25% of our monthly bill.

## Solution

- Skip creating updated cached state images unless the original image is at least 1 day old (1152 blocks)
  - Get the original height from the image labels
  - Fix the update flag calculation
  - Set the zebrad app name in cached state jobs
- Skip creating updated lightwalletd images - they happen right after a full lightwalletd sync
- Make the sync height step fail if there is no sync height (this is either a Zebra, lightwalletd, or CI bug)

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [x] Code makes sense
  - [x] CI passes
  - [x] Some updates get skipped

