### PR TITLE
fix(ci): Disable beta Rust tests

### DIFF
--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -66,6 +66,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         rust: [stable, beta]
         exclude:
+        # TODO: re-enable beta Rust tests on ubuntu (#4929)
+          - os: ubuntu-latest
+            rust: beta
         # We're excluding macOS for the following reasons:
         # - the concurrent macOS runner limit is much lower than the Linux limit
         # - macOS is slower than Linux, and shouldn't have a build or test difference with Linux


### PR DESCRIPTION
## Motivation

Beta Rust builds are failing with:
> warning: libgit2/src/util/tsort.c:382:1: fatal error: error writing to /tmp/ccFhppqU.s: No space left on device

https://github.com/ZcashFoundation/zebra/runs/8195908267?check_suite_focus=true#step:13:493

## Changes

Reverts ZcashFoundation/zebra#5024.

We don't need to disable any branch protection rules, because they weren't re-enabled when we did ticket #4929.