### PR TITLE
ci(lint): fetch with depth for `tj-actions/changed-files` on push

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Rust files
         id: changed-files-rust


### PR DESCRIPTION
## Previous behavior:
The `tj-actions/changed-files` crashed when making pushes to main, as no
fetch depth was defined on the previous checkout action. Which is now r
required after https://github.com/ZcashFoundation/zebra/commit/b216561b5bda1f515d1c5a2ba13d16d56855bbca

Example case: https://github.com/ZcashFoundation/zebra/runs/8203778954?check_suite_focus=true

## Expected behavior:
Do not fail with this new requirement

## Solution:
Change the chekout action `fetch-depth` to 2, allowing to compare with
the previous commit

## Review

Anyone can review this
