### PR TITLE
fix(ci): Simplify GitHub actions caches

### DIFF
--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -223,7 +223,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
         with:
-          shared-key: "clippy-cargo-lock"
+          # TODO: change to shared-key when we switch to Swatinem/rust-cache@v2
+          sharedKey: "clippy-cargo-lock"
 
       - name: Check Cargo.lock is up to date
         uses: actions-rs/cargo@v1.0.3

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -91,6 +91,19 @@ jobs:
           override: true
 
       - uses: Swatinem/rust-cache@v1
+        # TODO: change Rust cache target directory on Windows,
+        #       or remove this workaround once the build is more efficient (#3005).
+        #with:
+        #  workspaces: ". -> C:\\zebra-target"
+
+      - name: Change target output directory on Windows
+        # Windows doesn't have enough space on the D: drive, so we redirect the build output to the
+        # larger C: drive.
+        # TODO: Remove this workaround once the build is more efficient (#3005).
+        if: matrix.os == 'windows-latest'
+        run: |
+          mkdir C:\zebra-target
+          echo "CARGO_TARGET_DIR=C:\zebra-target" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: cargo fetch
         uses: actions-rs/cargo@v1.0.3
@@ -122,15 +135,6 @@ jobs:
         run: |
           echo "PROPTEST_CASES=1" >> $GITHUB_ENV
           echo "PROPTEST_MAX_SHRINK_ITERS=1024" >> $GITHUB_ENV
-
-      - name: Change target output directory on Windows
-        # Windows doesn't have enough space on the D: drive, so we redirect the build output to the
-        # larger C: drive.
-        # TODO: Remove this workaround once the build is more efficient (#3005).
-        if: matrix.os == 'windows-latest'
-        run: |
-          mkdir C:\zebra-target
-          echo "CARGO_TARGET_DIR=C:\zebra-target" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       # Modified from:
       # https://github.com/zcash/librustzcash/blob/c48bb4def2e122289843ddb3cb2984c325c03ca0/.github/workflows/ci.yml#L20-L33

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -218,6 +218,8 @@ jobs:
           override: true
 
       - uses: Swatinem/rust-cache@v1
+        with:
+          shared-key: "clippy-cargo-lock"
 
       - name: Check Cargo.lock is up to date
         uses: actions-rs/cargo@v1.0.3

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -102,8 +102,8 @@ jobs:
         # TODO: Remove this workaround once the build is more efficient (#3005).
         if: matrix.os == 'windows-latest'
         run: |
-          mkdir C:\zebra-target
-          echo "CARGO_TARGET_DIR=C:\zebra-target" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          mkdir "C:\\zebra-target"
+          echo "CARGO_TARGET_DIR=C:\\zebra-target" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
 
       - name: cargo fetch
         uses: actions-rs/cargo@v1.0.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -83,6 +83,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: Swatinem/rust-cache@v1
+        with:
+          shared-key: "clippy-cargo-lock"
 
       - name: Run clippy action to produce annotations
         uses: actions-rs/clippy-check@v1.0.7
@@ -127,7 +129,9 @@ jobs:
           components: rustfmt
           override: true
 
-      - uses: Swatinem/rust-cache@v1
+      # We don't cache `fmt` outputs because the job is quick,
+      # and we want to use the limited GitHub actions cache space for slower jobs.
+      #- uses: Swatinem/rust-cache@v1
 
       - uses: actions-rs/cargo@v1.0.3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -84,7 +84,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
         with:
-          shared-key: "clippy-cargo-lock"
+          # TODO: change to shared-key when we switch to Swatinem/rust-cache@v2
+          sharedKey: "clippy-cargo-lock"
 
       - name: Run clippy action to produce annotations
         uses: actions-rs/clippy-check@v1.0.7


### PR DESCRIPTION
## Motivation

GitHub actions has a 10 GB cache limit per OS, and we're currently at the limit.

Disabling or merging some caches speeds up builds, and allows more PRs to use cached build files.

### GitHub Actions Reference

## Solution

- Disable `fmt` job Rust cache, it's quick anyway
- Merge the `clippy` and `check-cargo-lock` caches, they are a very similar size and do similar work

Related changes:
- Fix the quoting in the Windows Rust target directory
- Add a TODO for the Windows Rust cache path

## Review

Anyone can review this PR, it might fix the beta Rust out of disk space errors.

### Reviewer Checklist

  - [ ] CI passes

