### PR TITLE
2. change(state): Run AwaitUtxo read requests without shared mutable chain state

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -916,7 +916,7 @@ where
                     data: None,
                 })?;
             let utxos = match response {
-                zebra_state::ReadResponse::Utxos(utxos) => utxos,
+                zebra_state::ReadResponse::AddressUtxos(utxos) => utxos,
                 _ => unreachable!("unmatched response to a UtxosByAddresses request"),
             };
 

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -549,11 +549,20 @@ pub enum ReadRequest {
     /// Looks up a UTXO identified by the given [`OutPoint`](transparent::OutPoint),
     /// returning `None` immediately if it is unknown.
     ///
-    /// Checks verified blocks in the finalized chain and non-finalized chain.
+    /// Checks verified blocks in the finalized chain and the _best_ non-finalized chain.
     ///
     /// This request is purely informational, there is no guarantee that
     /// the UTXO remains unspent in the best chain.
     BestChainUtxo(transparent::OutPoint),
+
+    /// Looks up a UTXO identified by the given [`OutPoint`](transparent::OutPoint),
+    /// returning `None` immediately if it is unknown.
+    ///
+    /// Checks verified blocks in the finalized chain and _all_ non-finalized chains.
+    ///
+    /// This request is purely informational, there is no guarantee that
+    /// the UTXO remains unspent in the best chain.
+    AnyChainUtxo(transparent::OutPoint),
 
     /// Computes a block locator object based on the current best chain.
     ///
@@ -687,10 +696,9 @@ impl TryFrom<Request> for ReadRequest {
                 Err("ReadService does not write blocks")
             }
 
-            Request::AwaitUtxo(_) => {
-                Err("ReadService does not track pending UTXOs. \
-                     Manually convert the request to ReadRequest::ChainUtxo, and handle pending UTXOs.")
-            }
+            Request::AwaitUtxo(_) => Err("ReadService does not track pending UTXOs. \
+                     Manually convert the request to ReadRequest::AnyChainUtxo, \
+                     and handle pending UTXOs"),
         }
     }
 }

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -448,7 +448,7 @@ pub enum Request {
     /// Request a UTXO identified by the given [`OutPoint`](transparent::OutPoint),
     /// waiting until it becomes available if it is unknown.
     ///
-    /// Checks the finalized chain, non-finalized chain, queued unverified blocks,
+    /// Checks the finalized chain, all non-finalized chains, queued unverified blocks,
     /// and any blocks that arrive at the state after the request future has been created.
     ///
     /// This request is purely informational, and there are no guarantees about

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -553,7 +553,7 @@ pub enum ReadRequest {
     ///
     /// This request is purely informational, there is no guarantee that
     /// the UTXO remains unspent in the best chain.
-    ChainUtxo(transparent::OutPoint),
+    BestChainUtxo(transparent::OutPoint),
 
     /// Computes a block locator object based on the current best chain.
     ///

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -76,12 +76,12 @@ pub enum ReadResponse {
     /// The response to a `FindBlockHeaders` request.
     BlockHeaders(Vec<block::CountedHeader>),
 
-    /// The response to a `ChainUtxo` request, from verified blocks in the
+    /// The response to a `BestChainUtxo` request, from verified blocks in the
     /// non-finalized chain or finalized chain.
     ///
     /// This response is purely informational, there is no guarantee that
     /// the UTXO remains unspent in the best chain.
-    ChainUtxo(Option<transparent::Utxo>),
+    BestChainUtxo(Option<transparent::Utxo>),
 
     /// Response to [`ReadRequest::SaplingTree`] with the specified Sapling note commitment tree.
     SaplingTree(Option<Arc<sapling::tree::NoteCommitmentTree>>),

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -39,7 +39,7 @@ pub enum Response {
     /// Response to [`Request::Block`] with the specified block.
     Block(Option<Arc<Block>>),
 
-    /// The response to a `AwaitUtxo` request, from the non-finalized chain, finalized chain,
+    /// The response to a `AwaitUtxo` request, from any non-finalized chains, finalized chain,
     /// pending unverified blocks, or blocks received after the request was sent.
     Utxo(transparent::Utxo),
 

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -89,7 +89,7 @@ pub enum ReadResponse {
     AddressesTransactionIds(BTreeMap<TransactionLocation, transaction::Hash>),
 
     /// Response to [`ReadRequest::UtxosByAddresses`] with found utxos and transaction data.
-    Utxos(AddressUtxos),
+    AddressUtxos(AddressUtxos),
 }
 
 /// Conversion from read-only [`ReadResponse`]s to read-write [`Response`]s.
@@ -117,8 +117,7 @@ impl TryFrom<ReadResponse> for Response {
 
             ReadResponse::AddressBalance(_) => unimplemented!(),
             ReadResponse::AddressesTransactionIds(_) => unimplemented!(),
-            // TODO: Rename to AddressUtxos
-            ReadResponse::Utxos(_) => unimplemented!(),
+            ReadResponse::AddressUtxos(_) => unimplemented!(),
         }
     }
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -68,10 +68,6 @@ mod tests;
 
 pub use finalized_state::{OutputIndex, OutputLocation, TransactionLocation};
 
-pub type QueuedBlock = (
-    PreparedBlock,
-    oneshot::Sender<Result<block::Hash, BoxError>>,
-);
 pub type QueuedFinalized = (
     FinalizedBlock,
     oneshot::Sender<Result<block::Hash, BoxError>>,
@@ -110,9 +106,10 @@ pub(crate) struct StateService {
     /// The non-finalized chain state, including its in-memory chain forks.
     mem: NonFinalizedState,
 
-    // Queued Non-Finalized Blocks
+    // Queued Blocks
     //
-    /// Blocks awaiting their parent blocks for contextual verification.
+    /// Blocks for the [`NonFinalizedState`], which are awaiting their parent blocks
+    /// before they can do contextual verification.
     queued_blocks: QueuedBlocks,
 
     // Pending UTXO Request Tracking

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1309,7 +1309,7 @@ impl Service<ReadRequest> for ReadStateService {
                         // The work is done in the future.
                         timer.finish(module_path!(), line!(), "ReadRequest::UtxosByAddresses");
 
-                        utxos.map(ReadResponse::Utxos)
+                        utxos.map(ReadResponse::AddressUtxos)
                     })
                 })
                 .map(|join_result| join_result.expect("panic in ReadRequest::UtxosByAddresses"))

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1,13 +1,12 @@
 //! [`tower::Service`]s for Zebra's cached chain state.
 //!
 //! Zebra provides cached state access via two main services:
-//! - [`StateService`]: a read-write service that waits for queued blocks.
+//! - [`StateService`]: a read-write service that writes blocks to the state,
+//!   and redirects most read requests to the [`ReadStateService`].
 //! - [`ReadStateService`]: a read-only service that answers from the most
 //!   recent committed block.
 //!
-//! Most users should prefer [`ReadStateService`], unless they need to wait for
-//! verified blocks to be committed. (For example, the syncer and mempool
-//! tasks.)
+//! Most users should prefer [`ReadStateService`], unless they need to write blocks to the state.
 //!
 //! Zebra also provides access to the best chain tip via:
 //! - [`LatestChainTip`]: a read-only channel that contains the latest committed

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -315,6 +315,9 @@ impl StateService {
             rsp_rx
         };
 
+        // TODO: avoid a temporary verification failure that can happen
+        //       if the first non-finalized block arrives before the last finalized block is committed
+        //       (#5125)
         if !self.can_fork_chain_at(&parent_hash) {
             tracing::trace!("unready to verify, returning early");
             return rsp_rx;

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -137,7 +137,7 @@ pub(crate) struct StateService {
 
     /// A cloneable [`ReadStateService`], used to answer concurrent read requests.
     ///
-    /// TODO: move concurrent read requests to [`ReadRequest`], and remove `read_service`.
+    /// TODO: move users of read [`Request`]s to [`ReadStateService`], and remove `read_service`.
     read_service: ReadStateService,
 }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1072,7 +1072,7 @@ impl Service<ReadRequest> for ReadStateService {
             }
 
             // Currently unused.
-            ReadRequest::ChainUtxo(outpoint) => {
+            ReadRequest::BestChainUtxo(outpoint) => {
                 metrics::counter!(
                     "state.requests",
                     1,
@@ -1094,12 +1094,12 @@ impl Service<ReadRequest> for ReadStateService {
                         );
 
                         // The work is done in the future.
-                        timer.finish(module_path!(), line!(), "ReadRequest::ChainUtxo");
+                        timer.finish(module_path!(), line!(), "ReadRequest::BestChainUtxo");
 
-                        Ok(ReadResponse::ChainUtxo(utxo))
+                        Ok(ReadResponse::BestChainUtxo(utxo))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::ChainUtxo"))
+                .map(|join_result| join_result.expect("panic in ReadRequest::BestChainUtxo"))
                 .boxed()
             }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1303,7 +1303,7 @@ impl Service<ReadRequest> for ReadStateService {
                 tokio::task::spawn_blocking(move || {
                     span.in_scope(move || {
                         let utxos = state.best_chain_receiver.with_watch_data(|best_chain| {
-                            read::transparent_utxos(state.network, best_chain, &state.db, addresses)
+                            read::address_utxos(state.network, best_chain, &state.db, addresses)
                         });
 
                         // The work is done in the future.

--- a/zebra-state/src/service/check/nullifier.rs
+++ b/zebra-state/src/service/check/nullifier.rs
@@ -9,9 +9,13 @@ use crate::{
     ValidateContextError,
 };
 
+// Tidy up some doc links
+#[allow(unused_imports)]
+use crate::service;
+
 /// Reject double-spends of nullifers:
 /// - one from this [`PreparedBlock`], and the other already committed to the
-///   [`FinalizedState`](super::super::FinalizedState).
+///   [`FinalizedState`](service::FinalizedState).
 ///
 /// (Duplicate non-finalized nullifiers are rejected during the chain update,
 /// see [`add_to_non_finalized_chain_unique`] for details.)
@@ -80,7 +84,7 @@ pub(crate) fn no_duplicates_in_finalized_chain(
 /// [2]: zebra_chain::sapling::Spend
 /// [3]: zebra_chain::orchard::Action
 /// [4]: zebra_chain::block::Block
-/// [5]: super::super::Chain
+/// [5]: service::non_finalized_state::Chain
 #[tracing::instrument(skip(chain_nullifiers, shielded_data_nullifiers))]
 pub(crate) fn add_to_non_finalized_chain_unique<'block, NullifierT>(
     chain_nullifiers: &mut HashSet<NullifierT>,
@@ -124,7 +128,7 @@ where
 /// [`add_to_non_finalized_chain_unique`], so this shielded data should be the
 /// only shielded data that added this nullifier to this [`Chain`][1].
 ///
-/// [1]: super::super::Chain
+/// [1]: service::non_finalized_state::Chain
 #[tracing::instrument(skip(chain_nullifiers, shielded_data_nullifiers))]
 pub(crate) fn remove_from_non_finalized_chain<'block, NullifierT>(
     chain_nullifiers: &mut HashSet<NullifierT>,

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -313,7 +313,7 @@ impl ZebraDb {
     ///
     /// Specifically, a block in the partial chain must be a child block of the finalized tip.
     /// (But the child block does not have to be the partial chain root.)
-    pub fn partial_finalized_transparent_utxos(
+    pub fn partial_finalized_address_utxos(
         &self,
         addresses: &HashSet<transparent::Address>,
     ) -> BTreeMap<OutputLocation, transparent::Output> {

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -340,14 +340,13 @@ impl NonFinalizedState {
 
     /// Returns the [`transparent::Utxo`] pointed to by the given
     /// [`transparent::OutPoint`] if it is present in any chain.
+    ///
+    /// UTXOs are returned regardless of whether they have been spent.
     pub fn any_utxo(&self, outpoint: &transparent::OutPoint) -> Option<transparent::Utxo> {
-        for chain in self.chain_set.iter().rev() {
-            if let Some(utxo) = chain.created_utxos.get(outpoint) {
-                return Some(utxo.utxo.clone());
-            }
-        }
-
-        None
+        self.chain_set
+            .iter()
+            .rev()
+            .find_map(|chain| chain.created_utxo(outpoint))
     }
 
     /// Returns the `block` with the given hash in any chain.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -651,6 +651,18 @@ impl Chain {
         unspent_utxos
     }
 
+    /// Returns the [`transparent::Utxo`] pointed to by the given
+    /// [`transparent::OutPoint`] if it was created by this chain.
+    ///
+    /// UTXOs are returned regardless of whether they have been spent.
+    pub fn created_utxo(&self, outpoint: &transparent::OutPoint) -> Option<transparent::Utxo> {
+        if let Some(utxo) = self.created_utxos.get(outpoint) {
+            return Some(utxo.utxo.clone());
+        }
+
+        None
+    }
+
     // Address index queries
 
     /// Returns the transparent transfers for `addresses` in this non-finalized chain.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -646,7 +646,7 @@ impl Chain {
     /// and removed from the relevant chain(s).
     pub fn unspent_utxos(&self) -> HashMap<transparent::OutPoint, transparent::OrderedUtxo> {
         let mut unspent_utxos = self.created_utxos.clone();
-        unspent_utxos.retain(|out_point, _utxo| !self.spent_utxos.contains(out_point));
+        unspent_utxos.retain(|outpoint, _utxo| !self.spent_utxos.contains(outpoint));
 
         unspent_utxos
     }

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -4,11 +4,15 @@
 //! best [`Chain`][5] in the [`NonFinalizedState`][3], and the database in the
 //! [`FinalizedState`][4].
 //!
-//! [1]: super::StateService
-//! [2]: super::ReadStateService
-//! [3]: super::non_finalized_state::NonFinalizedState
-//! [4]: super::finalized_state::FinalizedState
-//! [5]: super::Chain
+//! [1]: service::StateService
+//! [2]: service::ReadStateService
+//! [3]: service::non_finalized_state::NonFinalizedState
+//! [4]: service::finalized_state::FinalizedState
+//! [5]: service::non_finalized_state::Chain
+
+// Tidy up some doc links
+#[allow(unused_imports)]
+use crate::service;
 
 pub mod address;
 pub mod block;
@@ -23,7 +27,7 @@ pub use address::{
     tx_id::transparent_tx_ids,
     utxo::{address_utxos, AddressUtxos, ADDRESS_HEIGHTS_FULL_RANGE},
 };
-pub use block::{block, block_header, transaction, utxo};
+pub use block::{any_utxo, block, block_header, transaction, utxo};
 pub use find::{
     block_locator, chain_contains_hash, depth, find_chain_hashes, find_chain_headers,
     hash_by_height, height_by_hash, tip, tip_height,

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -23,7 +23,7 @@ pub use address::{
     tx_id::transparent_tx_ids,
     utxo::{address_utxos, AddressUtxos, ADDRESS_HEIGHTS_FULL_RANGE},
 };
-pub use block::{block, block_header, transaction};
+pub use block::{block, block_header, transaction, utxo};
 pub use find::{
     block_locator, chain_contains_hash, depth, find_chain_hashes, find_chain_headers,
     hash_by_height, height_by_hash, tip, tip_height,

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -21,7 +21,7 @@ mod tests;
 pub use address::{
     balance::transparent_balance,
     tx_id::transparent_tx_ids,
-    utxo::{transparent_utxos, AddressUtxos, ADDRESS_HEIGHTS_FULL_RANGE},
+    utxo::{address_utxos, AddressUtxos, ADDRESS_HEIGHTS_FULL_RANGE},
 };
 pub use block::{block, block_header, transaction};
 pub use find::{

--- a/zebra-state/src/service/read/address/balance.rs
+++ b/zebra-state/src/service/read/address/balance.rs
@@ -1,4 +1,14 @@
 //! Reading address balances.
+//!
+//! In the functions in this module:
+//!
+//! The StateService commits blocks to the finalized state before updating
+//! `chain` from the latest chain. Then it can commit additional blocks to
+//! the finalized state after we've cloned the `chain`.
+//!
+//! This means that some blocks can be in both:
+//! - the cached [`Chain`], and
+//! - the shared finalized [`ZebraDb`] reference.
 
 use std::{collections::HashSet, sync::Arc};
 
@@ -91,8 +101,7 @@ fn chain_transparent_balance_change(
 ) -> Amount<NegativeAllowed> {
     // # Correctness
     //
-    // The StateService commits blocks to the finalized state before updating the latest chain,
-    // and it can commit additional blocks after we've cloned this `chain` variable.
+    // Find the balance adjustment that corrects for overlapping finalized and non-finalized blocks.
 
     // Check if the finalized and non-finalized states match
     let required_chain_root = finalized_tip

--- a/zebra-state/src/service/read/address/tx_id.rs
+++ b/zebra-state/src/service/read/address/tx_id.rs
@@ -1,4 +1,14 @@
 //! Reading address transaction IDs.
+//!
+//! In the functions in this module:
+//!
+//! The StateService commits blocks to the finalized state before updating
+//! `chain` from the latest chain. Then it can commit additional blocks to
+//! the finalized state after we've cloned the `chain`.
+//!
+//! This means that some blocks can be in both:
+//! - the cached [`Chain`], and
+//! - the shared finalized [`ZebraDb`] reference.
 
 use std::{
     collections::{BTreeMap, HashSet},
@@ -134,10 +144,7 @@ where
 
     // # Correctness
     //
-    // The StateService commits blocks to the finalized state before updating the latest chain,
-    // and it can commit additional blocks after we've cloned this `chain` variable.
-    //
-    // But we can compensate for addresses with mismatching blocks,
+    // We can compensate for addresses with mismatching blocks,
     // by adding the overlapping non-finalized transaction IDs.
     //
     // If there is only one address, mismatches aren't possible,

--- a/zebra-state/src/service/read/address/utxo.rs
+++ b/zebra-state/src/service/read/address/utxo.rs
@@ -83,7 +83,7 @@ impl AddressUtxos {
 ///
 /// If the addresses do not exist in the non-finalized `chain` or finalized `db`,
 /// returns an empty list.
-pub fn transparent_utxos<C>(
+pub fn address_utxos<C>(
     network: Network,
     chain: Option<C>,
     db: &ZebraDb,
@@ -100,7 +100,7 @@ where
     for attempt in 0..=FINALIZED_ADDRESS_INDEX_RETRIES {
         debug!(?attempt, ?address_count, "starting address UTXO query");
 
-        let (finalized_utxos, finalized_tip_range) = finalized_transparent_utxos(db, &addresses);
+        let (finalized_utxos, finalized_tip_range) = finalized_address_utxos(db, &addresses);
 
         debug!(
             finalized_utxo_count = ?finalized_utxos.len(),
@@ -162,7 +162,7 @@ where
 /// If the addresses do not exist in the finalized `db`, returns an empty list.
 //
 // TODO: turn the return type into a struct?
-fn finalized_transparent_utxos(
+fn finalized_address_utxos(
     db: &ZebraDb,
     addresses: &HashSet<transparent::Address>,
 ) -> (
@@ -176,7 +176,7 @@ fn finalized_transparent_utxos(
     // Check if the finalized state changed while we were querying it
     let start_finalized_tip = db.finalized_tip_height();
 
-    let finalized_utxos = db.partial_finalized_transparent_utxos(addresses);
+    let finalized_utxos = db.partial_finalized_address_utxos(addresses);
 
     let end_finalized_tip = db.finalized_tip_height();
 

--- a/zebra-state/src/service/read/address/utxo.rs
+++ b/zebra-state/src/service/read/address/utxo.rs
@@ -1,4 +1,14 @@
 //! Transparent address index UTXO queries.
+//!
+//! In the functions in this module:
+//!
+//! The StateService commits blocks to the finalized state before updating
+//! `chain` from the latest chain. Then it can commit additional blocks to
+//! the finalized state after we've cloned the `chain`.
+//!
+//! This means that some blocks can be in both:
+//! - the cached [`Chain`], and
+//! - the shared finalized [`ZebraDb`] reference.
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
@@ -234,10 +244,7 @@ where
 
     // # Correctness
     //
-    // The StateService commits blocks to the finalized state before updating the latest chain,
-    // and it can commit additional blocks after we've cloned this `chain` variable.
-    //
-    // But we can compensate for deleted UTXOs by applying the overlapping non-finalized UTXO changes.
+    // We can compensate for deleted UTXOs by applying the overlapping non-finalized UTXO changes.
 
     // Check if the finalized and non-finalized states match or overlap
     let required_min_non_finalized_root = finalized_tip_range.start().0 + 1;

--- a/zebra-state/src/service/read/block.rs
+++ b/zebra-state/src/service/read/block.rs
@@ -96,7 +96,12 @@ where
 /// Returns the [`Utxo`] for [`transparent::OutPoint`], if it exists in the
 /// non-finalized `chain` or finalized `db`.
 ///
-/// UTXOs may be returned regardless of whether they have been spent.
+/// Non-finalized UTXOs are returned regardless of whether they have been spent.
+///
+/// Finalized UTXOs are only returned if they are unspent in the finalized chain.
+/// They may have been spent in the non-finalized chain,
+/// but this function returns them without checking for non-finalized spends,
+/// because we don't know which non-finalized chain will be committed to the finalized state.
 pub fn utxo<C>(chain: Option<C>, db: &ZebraDb, outpoint: transparent::OutPoint) -> Option<Utxo>
 where
     C: AsRef<Chain>,
@@ -115,10 +120,18 @@ where
         .or_else(|| db.utxo(&outpoint).map(|utxo| utxo.utxo))
 }
 
-/// Returns the [`Utxo`] for [`transparent::OutPoint`], if it exists in the
-/// `non_finalized_state` or finalized `db`.
+/// Returns the [`Utxo`] for [`transparent::OutPoint`], if it exists in any chain
+/// in the `non_finalized_state`, or in the finalized `db`.
 ///
-/// UTXOs may be returned regardless of whether they have been spent.
+/// Non-finalized UTXOs are returned regardless of whether they have been spent.
+///
+/// Finalized UTXOs are only returned if they are unspent in the finalized chain.
+/// They may have been spent in one or more non-finalized chains,
+/// but this function returns them without checking for non-finalized spends,
+/// because we don't know which non-finalized chain the request belongs to.
+///
+/// UTXO spends are checked once the block reaches the non-finalized state,
+/// by [`check::utxo::transparent_spend()`](crate::service::check::utxo::transparent_spend).
 pub fn any_utxo(
     non_finalized_state: NonFinalizedState,
     db: &ZebraDb,

--- a/zebra-state/src/service/read/block.rs
+++ b/zebra-state/src/service/read/block.rs
@@ -1,4 +1,15 @@
 //! Shared block, header, and transaction reading code.
+//!
+//! In the functions in this module:
+//!
+//! The StateService commits blocks to the finalized state before updating
+//! `chain` or `non_finalized_state` from the latest chains. Then it can
+//! commit additional blocks to the finalized state after we've cloned the
+//! `chain` or `non_finalized_state`.
+//!
+//! This means that some blocks can be in both:
+//! - the cached [`Chain`] or [`NonFinalizedState`], and
+//! - the shared finalized [`ZebraDb`] reference.
 
 use std::sync::Arc;
 
@@ -24,10 +35,6 @@ where
 {
     // # Correctness
     //
-    // The StateService commits blocks to the finalized state before updating
-    // the latest chain, and it can commit additional blocks after we've cloned
-    // this `chain` variable.
-    //
     // Since blocks are the same in the finalized and non-finalized state, we
     // check the most efficient alternative first. (`chain` is always in memory,
     // but `db` stores blocks on disk, with a memory cache.)
@@ -50,10 +57,6 @@ where
 {
     // # Correctness
     //
-    // The StateService commits blocks to the finalized state before updating
-    // the latest chain, and it can commit additional blocks after we've cloned
-    // this `chain` variable.
-    //
     // Since blocks are the same in the finalized and non-finalized state, we
     // check the most efficient alternative first. (`chain` is always in memory,
     // but `db` stores blocks on disk, with a memory cache.)
@@ -75,10 +78,6 @@ where
     C: AsRef<Chain>,
 {
     // # Correctness
-    //
-    // The StateService commits blocks to the finalized state before updating
-    // the latest chain, and it can commit additional blocks after we've cloned
-    // this `chain` variable.
     //
     // Since transactions are the same in the finalized and non-finalized state,
     // we check the most efficient alternative first. (`chain` is always in
@@ -108,10 +107,6 @@ where
 {
     // # Correctness
     //
-    // The StateService commits blocks to the finalized state before updating
-    // the latest chain, and it can commit additional blocks after we've cloned
-    // this `chain` variable.
-    //
     // Since UTXOs are the same in the finalized and non-finalized state,
     // we check the most efficient alternative first. (`chain` is always in
     // memory, but `db` stores transactions on disk, with a memory cache.)
@@ -138,10 +133,6 @@ pub fn any_utxo(
     outpoint: transparent::OutPoint,
 ) -> Option<Utxo> {
     // # Correctness
-    //
-    // The StateService commits blocks to the finalized state before updating
-    // the latest chain, and it can commit additional blocks after we've cloned
-    // the `non_finalized_state`.
     //
     // Since UTXOs are the same in the finalized and non-finalized state,
     // we check the most efficient alternative first. (`non_finalized_state` is always in

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -1,4 +1,14 @@
 //! Finding and reading block hashes and headers, in response to peer requests.
+//!
+//! In the functions in this module:
+//!
+//! The StateService commits blocks to the finalized state before updating
+//! `chain` from the latest chain. Then it can commit additional blocks to
+//! the finalized state after we've cloned the `chain`.
+//!
+//! This means that some blocks can be in both:
+//! - the cached [`Chain`], and
+//! - the shared finalized [`ZebraDb`] reference.
 
 use std::{
     iter,
@@ -23,10 +33,6 @@ where
     C: AsRef<Chain>,
 {
     // # Correctness
-    //
-    // The StateService commits blocks to the finalized state before updating
-    // the latest chain, and it can commit additional blocks after we've cloned
-    // this `chain` variable.
     //
     // If there is an overlap between the non-finalized and finalized states,
     // where the finalized tip is above the non-finalized tip,
@@ -66,10 +72,6 @@ where
 
     // # Correctness
     //
-    // The StateService commits blocks to the finalized state before updating
-    // the latest chain, and it can commit additional blocks after we've cloned
-    // this `chain` variable.
-    //
     // It is ok to do this lookup in two different calls. Finalized state updates
     // can only add overlapping blocks, and hashes are unique.
 
@@ -86,10 +88,6 @@ where
 {
     // # Correctness
     //
-    // The StateService commits blocks to the finalized state before updating
-    // the latest chain, and it can commit additional blocks after we've cloned
-    // this `chain` variable.
-    //
     // Finalized state updates can only add overlapping blocks, and hashes are unique.
 
     chain
@@ -103,10 +101,6 @@ where
     C: AsRef<Chain>,
 {
     // # Correctness
-    //
-    // The StateService commits blocks to the finalized state before updating
-    // the latest chain, and it can commit additional blocks after we've cloned
-    // this `chain` variable.
     //
     // Finalized state updates can only add overlapping blocks, and heights are unique
     // in the current `chain`.
@@ -127,10 +121,6 @@ where
     C: AsRef<Chain>,
 {
     // # Correctness
-    //
-    // The StateService commits blocks to the finalized state before updating
-    // the latest chain, and it can commit additional blocks after we've cloned
-    // this `chain` variable.
     //
     // Finalized state updates can only add overlapping blocks, and hashes are unique.
     //
@@ -157,10 +147,6 @@ where
     let chain = chain.as_ref();
 
     // # Correctness
-    //
-    // The StateService commits blocks to the finalized state before updating
-    // the latest chain, and it can commit additional blocks after we've cloned
-    // this `chain` variable.
     //
     // It is ok to do these lookups using multiple database calls. Finalized state updates
     // can only add overlapping blocks, and hashes are unique.

--- a/zebra-state/src/service/read/tree.rs
+++ b/zebra-state/src/service/read/tree.rs
@@ -1,4 +1,14 @@
 //! Reading note commitment trees.
+//!
+//! In the functions in this module:
+//!
+//! The StateService commits blocks to the finalized state before updating
+//! `chain` from the latest chain. Then it can commit additional blocks to
+//! the finalized state after we've cloned the `chain`.
+//!
+//! This means that some blocks can be in both:
+//! - the cached [`Chain`], and
+//! - the shared finalized [`ZebraDb`] reference.
 
 use std::sync::Arc;
 
@@ -22,10 +32,6 @@ where
 {
     // # Correctness
     //
-    // The StateService commits blocks to the finalized state before updating
-    // the latest chain, and it can commit additional blocks after we've cloned
-    // this `chain` variable.
-    //
     // Since sapling treestates are the same in the finalized and non-finalized
     // state, we check the most efficient alternative first. (`chain` is always
     // in memory, but `db` stores blocks on disk, with a memory cache.)
@@ -46,10 +52,6 @@ where
     C: AsRef<Chain>,
 {
     // # Correctness
-    //
-    // The StateService commits blocks to the finalized state before updating
-    // the latest chain, and it can commit additional blocks after we've cloned
-    // this `chain` variable.
     //
     // Since orchard treestates are the same in the finalized and non-finalized
     // state, we check the most efficient alternative first. (`chain` is always


### PR DESCRIPTION
## Motivation

This PR runs `StateService::AwaitUtxo` read requests without accessing shared mutable chain state.
As a useful side-effect, this makes all `StateService` read requests concurrent.

Closes #5102.

### Designs

See #4937 and https://docs.google.com/drawings/d/1FXpAUlenDAjl8nkftrypdAPsj0jr-Ut9gZlSP57nuyc/edit

## Solution

Don't access shared mutable chain state in `StateService` read requests:
- Re-Implement `AwaitUtxo` without accessing shared mutable chain state, using `StateService.pending_utxos` and `ReadStateService::AnyUtxo`
  - Send the whole `NonFinalizedState` to the `ReadStateService`
  - Rename the `ChainUtxo` request to `BestChainUtxo`
  - Add an `AnyChainUtxo` request

Related documentation:
- Update the state service module documentation
- Explain how spent UTXOs are treated by the state
- Clarify how cached Chains impact state read requests

Related Cleanups:
- Move `AwaitUtxos` next to the other shared writeable state requests
- Rename `ReadResponse::Utxos` to `ReadResponse::AddressUtxos`
- Rename an `out_point` variable to `outpoint` for consistency
- Rename `transparent_utxos` to `address_utxos`
- Move the `QueuedBlock` type into the `queued_blocks` module

## Testing

We should run a full sync on this before we merge, and make sure it is not significantly slower than the `main` branch.

## Review

This PR is part of regular scheduled work.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Actually create a separate task to commit blocks to the state.