### PR TITLE
tests(config): Upgrade config file tests 

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -652,7 +652,11 @@ fn last_config_is_stored() -> Result<()> {
             return Ok(());
         }
     }
-    Err(eyre!("last config is not stored"))
+    Err(eyre!(
+        "latest zebrad config is not being tested for compatibility.\n\
+        Run `zebrad generate -o zebrad/tests/common/configs/<next-release-tag>.toml`\n\
+        and commit the latest config to Zebra's git repository"
+    ))
 }
 
 /// Checks that Zebra prints an informative message when it cannot parse the

--- a/zebrad/tests/common/config.rs
+++ b/zebrad/tests/common/config.rs
@@ -85,7 +85,13 @@ pub fn testdir() -> Result<TempDir> {
         .map_err(Into::into)
 }
 
-/// Get stored config path
-pub fn stored_config_path() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/common/config.toml")
+/// Get the directory where we have different config files.
+pub fn configs_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/common/configs")
+}
+
+/// Given a config file name, return full path to it.
+pub fn config_file_full_path(config_file: PathBuf) -> PathBuf {
+    let path = configs_dir().join(config_file);
+    Path::new(&path).into()
 }

--- a/zebrad/tests/common/configs/v1.0.0-beta.12.toml
+++ b/zebrad/tests/common/configs/v1.0.0-beta.12.toml
@@ -50,7 +50,7 @@ peerset_initial_target_size = 25
 [rpc]
 
 [state]
-cache_dir = '/home/oxarbitrage/.cache/zebra'
+cache_dir = 'cache_dir'
 delete_old_database = true
 ephemeral = false
 

--- a/zebrad/tests/common/configs/v1.0.0-beta.12.toml
+++ b/zebrad/tests/common/configs/v1.0.0-beta.12.toml
@@ -50,13 +50,13 @@ peerset_initial_target_size = 25
 [rpc]
 
 [state]
-cache_dir = 'cache_dir'
+cache_dir = '/home/oxarbitrage/.cache/zebra'
 delete_old_database = true
 ephemeral = false
 
 [sync]
-lookahead_limit = 400
-max_concurrent_block_requests = 25
+lookahead_limit = 1200
+max_concurrent_block_requests = 40
 
 [tracing]
 force_use_color = false

--- a/zebrad/tests/common/configs/v1.0.0-beta.13.toml
+++ b/zebrad/tests/common/configs/v1.0.0-beta.13.toml
@@ -1,0 +1,66 @@
+# Default configuration for zebrad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zebrad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+#
+# zebrad attempts to load configs in the following order:
+#
+# 1. The -c flag on the command line, e.g., `zebrad -c myconfig.toml start`;
+# 2. The file `zebrad.toml` in the users's preference directory (platform-dependent);
+# 3. The default config.
+
+[consensus]
+checkpoint_sync = true
+debug_skip_parameter_preload = false
+
+[mempool]
+eviction_memory_time = '1h'
+tx_cost_limit = 80000000
+
+[metrics]
+
+[network]
+crawl_new_peer_interval = '1m 1s'
+initial_mainnet_peers = [
+    'dnsseed.z.cash:8233',
+    'dnsseed.str4d.xyz:8233',
+    'mainnet.seeder.zfnd.org:8233',
+    'mainnet.is.yolo.money:8233',
+]
+initial_testnet_peers = [
+    'dnsseed.testnet.z.cash:18233',
+    'testnet.seeder.zfnd.org:18233',
+    'testnet.is.yolo.money:18233',
+]
+listen_addr = '0.0.0.0:8233'
+network = 'Mainnet'
+peerset_initial_target_size = 25
+
+[rpc]
+
+[state]
+cache_dir = '/home/oxarbitrage/.cache/zebra'
+delete_old_database = true
+ephemeral = false
+
+[sync]
+checkpoint_verify_concurrency_limit = 1200
+download_concurrency_limit = 50
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+
+[tracing]
+force_use_color = false
+use_color = true
+use_journald = false

--- a/zebrad/tests/common/configs/v1.0.0-beta.13.toml
+++ b/zebrad/tests/common/configs/v1.0.0-beta.13.toml
@@ -50,7 +50,7 @@ peerset_initial_target_size = 25
 [rpc]
 
 [state]
-cache_dir = '/home/oxarbitrage/.cache/zebra'
+cache_dir = 'cache_dir'
 delete_old_database = true
 ephemeral = false
 

--- a/zebrad/tests/common/configs/v1.0.0-beta.14.toml
+++ b/zebrad/tests/common/configs/v1.0.0-beta.14.toml
@@ -1,0 +1,66 @@
+# Default configuration for zebrad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zebrad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+#
+# zebrad attempts to load configs in the following order:
+#
+# 1. The -c flag on the command line, e.g., `zebrad -c myconfig.toml start`;
+# 2. The file `zebrad.toml` in the users's preference directory (platform-dependent);
+# 3. The default config.
+
+[consensus]
+checkpoint_sync = true
+debug_skip_parameter_preload = false
+
+[mempool]
+eviction_memory_time = '1h'
+tx_cost_limit = 80000000
+
+[metrics]
+
+[network]
+crawl_new_peer_interval = '1m 1s'
+initial_mainnet_peers = [
+    'dnsseed.z.cash:8233',
+    'dnsseed.str4d.xyz:8233',
+    'mainnet.seeder.zfnd.org:8233',
+    'mainnet.is.yolo.money:8233',
+]
+initial_testnet_peers = [
+    'dnsseed.testnet.z.cash:18233',
+    'testnet.seeder.zfnd.org:18233',
+    'testnet.is.yolo.money:18233',
+]
+listen_addr = '0.0.0.0:8233'
+network = 'Mainnet'
+peerset_initial_target_size = 25
+
+[rpc]
+
+[state]
+cache_dir = '/home/oxarbitrage/.cache/zebra'
+delete_old_database = true
+ephemeral = false
+
+[sync]
+checkpoint_verify_concurrency_limit = 1200
+download_concurrency_limit = 50
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+
+[tracing]
+force_use_color = false
+use_color = true
+use_journald = false

--- a/zebrad/tests/common/configs/v1.0.0-beta.14.toml
+++ b/zebrad/tests/common/configs/v1.0.0-beta.14.toml
@@ -50,7 +50,7 @@ peerset_initial_target_size = 25
 [rpc]
 
 [state]
-cache_dir = '/home/oxarbitrage/.cache/zebra'
+cache_dir = 'cache_dir'
 delete_old_database = true
 ephemeral = false
 

--- a/zebrad/tests/common/configs/v1.0.0-beta.15.toml
+++ b/zebrad/tests/common/configs/v1.0.0-beta.15.toml
@@ -48,6 +48,8 @@ network = 'Mainnet'
 peerset_initial_target_size = 25
 
 [rpc]
+debug_force_finished_sync = false
+parallel_cpu_threads = 1
 
 [state]
 cache_dir = 'cache_dir'
@@ -61,6 +63,7 @@ full_verify_concurrency_limit = 20
 parallel_cpu_threads = 0
 
 [tracing]
+buffer_limit = 128000
 force_use_color = false
 use_color = true
 use_journald = false


### PR DESCRIPTION
## Motivation

Currently zebra has only one old config file stored to do compatibility checks. We want to have more config versions and test against them. Closes https://github.com/ZcashFoundation/zebra/issues/4684 

## Solution

Add a folder with different config versions and make sure zebra can start with any of them. In this PR i am including configs for v1.0.0-beta.12, v1.0.0-beta.12 and v1.0.0-beta.14. Before that (at v1.0.0-beta.11) the config don't work. This is because we changed the type of time fields to human readable form. It will not worth to remain compatible with that now but we might want to remain compatible in the future if we need to implement field type changes

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] New test is good enough and pass.
