### PR TITLE
fix(ci): Make checkpoint disk image names short enough for Google Cloud

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1096,7 +1096,7 @@ jobs:
       # uses sentence case, so we need to downcase ${{ inputs.network }}.
       #
       # Disk image names in GCP are limited to 63 characters, so we need to limit
-      # branch names to 13 characters.
+      # branch names to 12 characters.
       #
       # Passes ${{ inputs.network }} to subsequent steps using $NETWORK env variable.
       # Passes ${{ env.GITHUB_REF_SLUG_URL }} to subsequent steps using $SHORT_GITHUB_REF env variable.
@@ -1105,7 +1105,7 @@ jobs:
           NETWORK_CAPS=${{ inputs.network }}
           echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
           LONG_GITHUB_REF=${{ env.GITHUB_REF_SLUG_URL }}
-          echo "SHORT_GITHUB_REF=${LONG_GITHUB_REF:0:13}" >> $GITHUB_ENV
+          echo "SHORT_GITHUB_REF=${LONG_GITHUB_REF:0:12}" >> $GITHUB_ENV
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
@@ -1126,7 +1126,7 @@ jobs:
           echo "STATE_VERSION: $LOCAL_STATE_VERSION"
 
           echo "STATE_VERSION=$LOCAL_STATE_VERSION" >> $GITHUB_ENV
-          
+
       # Sets the $UPDATE_SUFFIX env var to "-u" if updating a previous cached state,
       # and the empty string otherwise.
       #
@@ -1143,9 +1143,9 @@ jobs:
           if [[ "${{ inputs.needs_lwd_state }}" == "true" ]] && [[ "${{ inputs.app_name }}" == "lightwalletd" ]] && [[ "${{ inputs.test_id }}" != 'lwd-full-sync' ]]; then
               UPDATE_SUFFIX="-u"
           fi
- 
-          # We're going to delete old images after a month, so we don't need the year here
-          TIME_SUFFIX=$(date '+%m%d%H%M%S' --utc)
+
+          # We're going to delete old images after a few days, so we only need the time here
+          TIME_SUFFIX=$(date '+%H%M%S' --utc)
 
           echo "UPDATE_SUFFIX=$UPDATE_SUFFIX" >> $GITHUB_ENV
           echo "TIME_SUFFIX=$TIME_SUFFIX" >> $GITHUB_ENV
@@ -1173,7 +1173,7 @@ jobs:
           --command=" \
           docker logs ${{ inputs.test_id }} --tail 200 \
           ")
-          
+
           SYNC_HEIGHT=$( \
           echo "$DOCKER_LOGS" | \
           grep --extended-regexp --only-matching '${{ inputs.height_grep_text }}[0-9]+' | \
@@ -1181,14 +1181,14 @@ jobs:
           tail -1 || \
           [[ $? == 1 ]] \
           )
-          
+
           if [[ -z "$SYNC_HEIGHT" ]]; then
               echo "Missing sync height in logs: $SYNC_HEIGHT"
               # Fail the tests, because Zebra and lightwalletd didn't log their sync heights,
               # or the CI workflow sync height regex is wrong.
               false
           fi
-          
+
           echo "Found sync height in logs: $SYNC_HEIGHT"
           echo "SYNC_HEIGHT=$SYNC_HEIGHT" >> $GITHUB_ENV
 
@@ -1210,9 +1210,9 @@ jobs:
               ORIGINAL_HEIGHT=${ORIGINAL_HEIGHT:-0}
               echo "$CACHED_DISK_NAME height: $ORIGINAL_HEIGHT"
           fi
-          
+
           echo "ORIGINAL_HEIGHT=$ORIGINAL_HEIGHT" >> $GITHUB_ENV
-          
+
       # Create an image from the state disk, which will be used for any tests that start
       # after it is created. These tests can be in the same workflow, or in a different PR.
       #


### PR DESCRIPTION
## Motivation

Checkpoint disk image creation is failing with:

> Run gcloud compute images create \
> ERROR: (gcloud.compute.images.create) Could not fetch resource:
> - Invalid value for field 'resource.name': 'zebrad-cache-state-commit--cb0b6b2-v25-mainnet-checkpoint-0909004002'. > Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'

https://github.com/ZcashFoundation/zebra/runs/8261380408?check_suite_focus=true

I thought we were within the limit in my last PR about this, but I must have calculated it wrong.

## Solution

- Remove the month and day from the date - we're deleting images after 2 days now
- Make the branch name slightly shorter

## Testing

I'll post a checkpoint sync link in the comments.

## Review

This is urgent because CI is failing.
Anyone can review this PR.

### Reviewer Checklist

  - [ ] Checkpoint sync passes

