### PR TITLE
fix(clippy): Fix a new nightly clippy "unwrap_or_else uses default" lint

### DIFF
--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -463,7 +463,7 @@ where
             tx
         });
         let nonces = Arc::new(futures::lock::Mutex::new(HashSet::new()));
-        let user_agent = self.user_agent.unwrap_or_else(|| "".to_string());
+        let user_agent = self.user_agent.unwrap_or_default();
         let our_services = self.our_services.unwrap_or_else(PeerServices::empty);
         let relay = self.relay.unwrap_or(false);
         let network = config.network;

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -44,7 +44,7 @@ pub struct Tracing {
 impl Tracing {
     /// Try to create a new [`Tracing`] component with the given `filter`.
     pub fn new(config: TracingSection) -> Result<Self, FrameworkError> {
-        let filter = config.filter.unwrap_or_else(|| "".to_string());
+        let filter = config.filter.unwrap_or_default();
         let flame_root = &config.flamegraph;
 
         // Builds a lossy NonBlocking logger with a default line limit of 128_000 or an explicit buffer_limit.


### PR DESCRIPTION
## Motivation

There's a new clippy lint on nightly Rust.

## Review

Anyone can review this PR, it's not urgent.

### Reviewer Checklist

  - [ ] CI passes

