### PR TITLE
change(state): Write finalized blocks to the state in a separate thread, to avoid network and RPC hangs

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1283,7 +1283,7 @@ fn check_height_range(start: Height, end: Height, chain_height: Height) -> Resul
     }
     if start > chain_height || end > chain_height {
         return Err(Error::invalid_params(format!(
-            "start {start:?} or end {end:?} must both be less than or equal to the chain tip {chain_height:?}"
+            "start {start:?} and end {end:?} must both be less than or equal to the chain tip {chain_height:?}"
         )));
     }
 

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -872,7 +872,7 @@ where
                     hashes
                         .iter()
                         .map(|(tx_loc, tx_id)| {
-                            // TODO: downgrade to debug, because there's nothing the user can do
+                            // Check that the returned transactions are in chain order.
                             assert!(
                                 *tx_loc > last_tx_location,
                                 "Transactions were not in chain order:\n\
@@ -931,7 +931,7 @@ where
                 let satoshis = u64::from(utxo_data.3.value);
 
                 let output_location = *utxo_data.2;
-                // TODO: downgrade to debug, because there's nothing the user can do
+                // Check that the returned UTXOs are in chain order.
                 assert!(
                     output_location > last_output_location,
                     "UTXOs were not in chain order:\n\
@@ -1272,17 +1272,19 @@ impl GetRawTransaction {
 /// Check if provided height range is valid for address indexes.
 fn check_height_range(start: Height, end: Height, chain_height: Height) -> Result<()> {
     if start == Height(0) || end == Height(0) {
-        return Err(Error::invalid_params(
-            "Start and end are expected to be greater than zero",
-        ));
+        return Err(Error::invalid_params(format!(
+            "start {start:?} and end {end:?} must both be greater than zero"
+        )));
     }
-    if end < start {
-        return Err(Error::invalid_params(
-            "End value is expected to be greater than or equal to start",
-        ));
+    if start > end {
+        return Err(Error::invalid_params(format!(
+            "start {start:?} must be less than or equal to end {end:?}"
+        )));
     }
     if start > chain_height || end > chain_height {
-        return Err(Error::invalid_params("Start or end is outside chain range"));
+        return Err(Error::invalid_params(format!(
+            "start {start:?} or end {end:?} must both be less than or equal to the chain tip {chain_height:?}"
+        )));
     }
 
     Ok(())

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -395,7 +395,7 @@ async fn rpc_getaddresstxids_invalid_arguments() {
         .unwrap_err();
     assert_eq!(
         error.message,
-        "End value is expected to be greater than or equal to start".to_string()
+        "start Height(2) must be less than or equal to end Height(1)".to_string()
     );
 
     // call the method with start equal zero
@@ -411,7 +411,7 @@ async fn rpc_getaddresstxids_invalid_arguments() {
         .unwrap_err();
     assert_eq!(
         error.message,
-        "Start and end are expected to be greater than zero".to_string()
+        "start Height(0) and end Height(1) must both be greater than zero".to_string()
     );
 
     // call the method outside the chain tip height
@@ -427,7 +427,7 @@ async fn rpc_getaddresstxids_invalid_arguments() {
         .unwrap_err();
     assert_eq!(
         error.message,
-        "Start or end is outside chain range".to_string()
+        "start Height(1) and end Height(11) must both be less than or equal to the chain tip Height(10)".to_string()
     );
 
     mempool.expect_no_requests().await;

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -17,6 +17,8 @@ use crate::{
 
 /// Mocks computation done during semantic validation
 pub trait Prepare {
+    /// Runs block semantic validation computation, and returns the result.
+    /// Test-only method.
     fn prepare(self) -> PreparedBlock;
 }
 

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -16,7 +16,8 @@
 extern crate tracing;
 
 #[cfg(any(test, feature = "proptest-impl"))]
-mod arbitrary;
+pub mod arbitrary;
+
 mod config;
 pub mod constants;
 mod error;
@@ -39,7 +40,7 @@ pub use service::{
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use service::{
-    arbitrary::populated_state,
+    arbitrary::{populated_state, CHAIN_TIP_UPDATE_WAIT_LIMIT},
     chain_tip::{ChainTipBlock, ChainTipSender},
     init_test, init_test_services,
 };

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -424,8 +424,15 @@ impl StateService {
 
         if self.finalized_block_write_sender.is_some() {
             // We're still committing finalized blocks
-            self.queued_finalized_blocks
-                .insert(queued_prev_hash, queued);
+            if let Some(duplicate_queued) = self
+                .queued_finalized_blocks
+                .insert(queued_prev_hash, queued)
+            {
+                Self::send_finalized_block_error(
+                    duplicate_queued,
+                    "dropping older finalized block: got newer duplicate block",
+                );
+            }
 
             self.drain_queue_and_commit_finalized();
         } else {

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -383,8 +383,9 @@ impl StateService {
             .queued_finalized_blocks
             .remove(&self.last_block_hash_sent)
         {
+            self.last_block_hash_sent = queued_block.0.hash;
+
             if let Ok(finalized) = self.disk.commit_finalized(queued_block) {
-                self.last_block_hash_sent = finalized.hash;
                 highest_queue_commit = Some(finalized);
             } else {
                 // the last block in the queue failed, so we can't commit the next block

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -250,6 +250,8 @@ impl Drop for StateService {
         // so dropping it should shut down everything.
 
         // Close the channels (non-blocking)
+        // This makes the block write thread exit the next time it checks the channels.
+        // We want to do this here so we get any errors or panics from the block write task before it shuts down.
         self.invalid_block_reset_receiver.close();
 
         std::mem::drop(self.finalized_block_write_sender.take());
@@ -465,7 +467,7 @@ impl StateService {
     }
 
     /// Finds queued finalized blocks to be committed to the state in order,
-    /// remove them from the queue, and sends them to the block commit task.
+    /// removes them from the queue, and sends them to the block commit task.
     ///
     /// After queueing a finalized block, this method checks whether the newly
     /// queued block (and any of its descendants) can be committed to the state.

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -222,7 +222,7 @@ pub struct ReadStateService {
 
     // Shared Concurrently Readable State
     //
-    /// A watch channel for a recent [`NonFinalizedState`].
+    /// A watch channel with a cached copy of the [`NonFinalizedState`].
     ///
     /// This state is only updated between requests,
     /// so it might include some block data that is also on `disk`.

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -255,11 +255,6 @@ impl Drop for StateService {
         std::mem::drop(self.finalized_block_write_sender.take());
         std::mem::drop(self.non_finalized_block_write_sender.take());
 
-        //// Shut down the database (blocking):
-        //// - stops the block write task if it is busy writing to the database
-        //// - stops concurrent reads from the database
-        //self.read_service.db.shutdown(true);
-
         // Then drop self.read_service, which checks the block write task for panics,
         // and tries to shut down the database.
     }
@@ -270,16 +265,15 @@ impl Drop for ReadStateService {
         // The read state service shares the state,
         // so dropping it should check if we can shut down.
 
-        // Wait until the block write task finishes, then check for panics (blocking).
-        //
-        // TODO: move this into a function
         if let Some(block_write_task) = self.block_write_task.take() {
             if let Ok(block_write_task_handle) = Arc::try_unwrap(block_write_task) {
-                // We're the last database user, so we can tell it to shut down.
+                // We're the last database user, so we can tell it to shut down (blocking):
+                // - flushes the database to disk, and
+                // - drops the database, which cleans up any database tasks correctly.
                 self.db.shutdown(true);
 
-                // We are the last state with a reference to this thread,
-                // so we can propagate any panics.
+                // We are the last state with a reference to this thread, so we can
+                // wait until the block write task finishes, then check for panics (blocking).
                 // (We'd also like to abort the thread, but std::thread::JoinHandle can't do that.)
                 info!("waiting for the block write task to finish");
                 if let Err(thread_panic) = block_write_task_handle.join() {

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -257,6 +257,8 @@ impl Drop for StateService {
         std::mem::drop(self.finalized_block_write_sender.take());
         std::mem::drop(self.non_finalized_block_write_sender.take());
 
+        self.clear_finalized_block_queue("dropping the state: dropped unused queued block");
+
         // Then drop self.read_service, which checks the block write task for panics,
         // and tries to shut down the database.
     }
@@ -607,7 +609,10 @@ impl StateService {
             std::mem::drop(self.finalized_block_write_sender.take());
 
             // We've finished committing finalized blocks, so drop any repeated queued blocks.
-            self.queued_finalized_blocks.clear();
+            self.clear_finalized_block_queue(
+                "already finished committing finalized blocks: dropped duplicate block, \
+                 block is already committed to the state",
+            );
         }
 
         // TODO: avoid a temporary verification failure that can happen

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -136,7 +136,10 @@ pub(crate) struct StateService {
 
     /// A channel to send blocks to the `block_write_task`,
     /// so they can be written to the [`FinalizedState`].
-    finalized_block_write_sender: tokio::sync::mpsc::UnboundedSender<QueuedFinalized>,
+    ///
+    /// This sender is dropped after the state has finished sending all the checkpointed blocks,
+    /// and the lowest non-finalized block arrives.
+    finalized_block_write_sender: Option<tokio::sync::mpsc::UnboundedSender<QueuedFinalized>>,
 
     /// The [`block::Hash`] of the most recent block sent on
     /// `finalized_block_write_sender` or `non_finalized_block_write_sender`.
@@ -315,7 +318,7 @@ impl StateService {
             mem: non_finalized_state,
             disk: finalized_state,
             _non_finalized_block_write_sender: non_finalized_block_write_sender,
-            finalized_block_write_sender,
+            finalized_block_write_sender: Some(finalized_block_write_sender),
             last_block_hash_sent,
             invalid_block_reset_receiver,
             block_write_task: Some(block_write_task),
@@ -371,11 +374,26 @@ impl StateService {
         let queued_height = finalized.height;
 
         let (rsp_tx, rsp_rx) = oneshot::channel();
-        let queued = (finalized, rsp_tx);
-        self.queued_finalized_blocks
-            .insert(queued_prev_hash, queued);
 
-        self.drain_queue_and_commit_finalized();
+        if self.finalized_block_write_sender.is_some() {
+            // We're still committing finalized blocks
+            let queued = (finalized, rsp_tx);
+            self.queued_finalized_blocks
+                .insert(queued_prev_hash, queued);
+
+            self.drain_queue_and_commit_finalized();
+        } else {
+            // We've finished committing finalized blocks, so drop any repeated queued blocks,
+            // and return an error.
+            self.queued_finalized_blocks.clear();
+
+            // We don't care if this error ever gets received.
+            let _ = rsp_tx.send(Err(
+                "already finished committing finalized blocks: dropped duplicate block, \
+                 block is already committed to the state"
+                    .into(),
+            ));
+        }
 
         if self.queued_finalized_blocks.is_empty() {
             self.max_queued_finalized_height = f64::NAN;
@@ -429,16 +447,20 @@ impl StateService {
         {
             self.last_block_hash_sent = queued_block.0.hash;
 
-            let send_result = self.finalized_block_write_sender.send(queued_block);
+            // If we've finished sending finalized blocks, ignore any repeated blocks.
+            // (Blocks can be repeated after a syncer reset.)
+            if let Some(finalized_block_write_sender) = &self.finalized_block_write_sender {
+                let send_result = finalized_block_write_sender.send(queued_block);
 
-            // If the receiver is closed, we can't send any more blocks.
-            // TODO: also immediately fail the block that we just queued?
-            if let Err(SendError((_finalized, block_result_sender))) = send_result {
-                // If Zebra is shutting down, ignore dropped block result receivers
-                let _ = block_result_sender.send(Err(
-                    "block commit task exited. Is Zebra shutting down?".into(),
-                ));
-            };
+                // If the receiver is closed, we can't send any more blocks.
+                // TODO: also immediately fail the block that we just queued?
+                if let Err(SendError((_finalized, block_result_sender))) = send_result {
+                    // If Zebra is shutting down, ignore dropped block result receivers
+                    let _ = block_result_sender.send(Err(
+                        "block commit task exited. Is Zebra shutting down?".into(),
+                    ));
+                };
+            }
         }
     }
 
@@ -481,6 +503,28 @@ impl StateService {
             self.queued_non_finalized_blocks.queue((prepared, rsp_tx));
             rsp_rx
         };
+
+        // We've finished sending finalized blocks when:
+        // - we've sent the finalized block for the last checkpoint, and
+        // - it has been successfully written to disk.
+        //
+        // We detect the last checkpoint by looking for non-finalized blocks
+        // that are a child of the last block we sent.
+        //
+        // TODO: configure the state with the last checkpoint hash instead?
+        if self.finalized_block_write_sender.is_some()
+            && self
+                .queued_non_finalized_blocks
+                .has_queued_children(self.last_block_hash_sent)
+            && self.disk.db().finalized_tip_hash() == self.last_block_hash_sent
+        {
+            // Tell the block write task to stop committing finalized blocks,
+            // and move on to committing non-finalized blocks.
+            std::mem::drop(self.finalized_block_write_sender.take());
+
+            // We've finished committing finalized blocks, so drop any repeated queued blocks.
+            self.queued_finalized_blocks.clear();
+        }
 
         // TODO: avoid a temporary verification failure that can happen
         //       if the first non-finalized block arrives before the last finalized block is committed

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -132,7 +132,8 @@ pub(crate) struct StateService {
     /// so they can be written to the [`NonFinalizedState`].
     //
     // TODO: actually send blocks on this channel
-    _non_finalized_block_write_sender: tokio::sync::mpsc::UnboundedSender<QueuedNonFinalized>,
+    non_finalized_block_write_sender:
+        Option<tokio::sync::mpsc::UnboundedSender<QueuedNonFinalized>>,
 
     /// A channel to send blocks to the `block_write_task`,
     /// so they can be written to the [`FinalizedState`].
@@ -251,6 +252,53 @@ pub struct ReadStateService {
     block_write_task: Option<Arc<std::thread::JoinHandle<()>>>,
 }
 
+impl Drop for StateService {
+    fn drop(&mut self) {
+        // The state service owns the state, tasks, and channels,
+        // so dropping it should shut down everything.
+
+        // Close the channels (non-blocking)
+        self.invalid_block_reset_receiver.close();
+
+        std::mem::drop(self.finalized_block_write_sender.take());
+        std::mem::drop(self.non_finalized_block_write_sender.take());
+
+        // Shut down the database (blocking):
+        // - stops the block write task if it is busy writing to the database
+        // - stops concurrent reads from the database
+        self.disk.db().clone().shutdown(true);
+
+        // Then drop self.read_service, which checks the block write task for panics.
+    }
+}
+
+impl Drop for ReadStateService {
+    fn drop(&mut self) {
+        // The read state service shares the state,
+        // so dropping it should check if we can shut down.
+
+        // TODO: rename this to try_shutdown()?
+        self.db.shutdown(false);
+
+        // Wait until the block write task finishes, then check for panics (blocking).
+        //
+        // TODO: move this into a function
+        if let Some(block_write_task) = self.block_write_task.take() {
+            if let Ok(block_write_task_handle) = Arc::try_unwrap(block_write_task) {
+                // We are the last state with a reference to this thread,
+                // so we can propagate any panics.
+                // (We'd also like to abort the thread, but std::thread::JoinHandle can't do that.)
+                info!("waiting for the block write task to finish");
+                if let Err(thread_panic) = block_write_task_handle.join() {
+                    std::panic::resume_unwind(thread_panic);
+                } else {
+                    info!("shutting down the state without waiting for the block write task");
+                }
+            }
+        }
+    }
+}
+
 impl StateService {
     const PRUNE_INTERVAL: Duration = Duration::from_secs(30);
 
@@ -317,7 +365,7 @@ impl StateService {
             queued_finalized_blocks: HashMap::new(),
             mem: non_finalized_state,
             disk: finalized_state,
-            _non_finalized_block_write_sender: non_finalized_block_write_sender,
+            non_finalized_block_write_sender: Some(non_finalized_block_write_sender),
             finalized_block_write_sender: Some(finalized_block_write_sender),
             last_block_hash_sent,
             invalid_block_reset_receiver,

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -140,6 +140,14 @@ pub(crate) struct StateService {
     // TODO: actually send blocks on this channel
     _finalized_block_write_sender: tokio::sync::mpsc::UnboundedSender<FinalizedBlock>,
 
+    /// The [`block::Hash`] of the most recent block sent on
+    /// `finalized_block_write_sender` or `non_finalized_block_write_sender`.
+    ///
+    /// On startup, this is:
+    /// - the finalized tip, if there are stored blocks, or
+    /// - the genesis block's parent hash, if the database is empty.
+    last_block_hash_sent: block::Hash,
+
     /// A shared handle to a task that writes blocks to the [`NonFinalizedState`] or [`FinalizedState`],
     /// once the queues have received all their parent blocks.
     ///
@@ -157,7 +165,7 @@ pub(crate) struct StateService {
     /// Instant tracking the last time `pending_utxos` was pruned.
     last_prune: Instant,
 
-    // Concurrently Readable State
+    // Updating Concurrently Readable State
     //
     /// A sender channel used to update the current best chain tip for
     /// [`LatestChainTip`] and [`ChainTipChange`].
@@ -166,6 +174,8 @@ pub(crate) struct StateService {
     /// A sender channel used to update the recent non-finalized state for the [`ReadStateService`].
     non_finalized_state_sender: watch::Sender<NonFinalizedState>,
 
+    // Concurrently Readable State
+    //
     /// A cloneable [`ReadStateService`], used to answer concurrent read requests.
     ///
     /// TODO: move users of read [`Request`]s to [`ReadStateService`], and remove `read_service`.
@@ -276,6 +286,8 @@ impl StateService {
         let queued_non_finalized_blocks = QueuedBlocks::default();
         let pending_utxos = PendingUtxos::default();
 
+        let last_block_hash_sent = finalized_state.db().finalized_tip_hash();
+
         let state = Self {
             network,
             queued_non_finalized_blocks,
@@ -284,6 +296,7 @@ impl StateService {
             disk: finalized_state,
             _non_finalized_block_write_sender: non_finalized_block_write_sender,
             _finalized_block_write_sender: finalized_block_write_sender,
+            last_block_hash_sent,
             _block_write_task: block_write_task,
             pending_utxos,
             last_prune: Instant::now(),
@@ -368,9 +381,10 @@ impl StateService {
 
         while let Some(queued_block) = self
             .queued_finalized_blocks
-            .remove(&self.disk.db().finalized_tip_hash())
+            .remove(&self.last_block_hash_sent)
         {
             if let Ok(finalized) = self.disk.commit_finalized(queued_block) {
+                self.last_block_hash_sent = finalized.hash;
                 highest_queue_commit = Some(finalized);
             } else {
                 // the last block in the queue failed, so we can't commit the next block

--- a/zebra-state/src/service/arbitrary.rs
+++ b/zebra-state/src/service/arbitrary.rs
@@ -217,7 +217,7 @@ pub async fn populated_state(
         // which both happen in a separate thread from this one.
         rsp.expect("unexpected block commit failure");
 
-        // Allow the chain tip update
+        // Wait for the chain tip update
         if let Err(timeout_error) = timeout(
             CHAIN_TIP_UPDATE_WAIT_LIMIT,
             chain_tip_change.wait_for_tip_change(),

--- a/zebra-state/src/service/arbitrary.rs
+++ b/zebra-state/src/service/arbitrary.rs
@@ -1,6 +1,6 @@
 //! Arbitrary data generation and test setup for Zebra's state.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use futures::{stream::FuturesUnordered, StreamExt};
 use proptest::{
@@ -9,11 +9,12 @@ use proptest::{
     strategy::{NewTree, ValueTree},
     test_runner::TestRunner,
 };
+use tokio::time::timeout;
 use tower::{buffer::Buffer, util::BoxService, Service, ServiceExt};
 
 use zebra_chain::{
     block::Block,
-    fmt::SummaryDebug,
+    fmt::{humantime_seconds, SummaryDebug},
     history_tree::HistoryTree,
     parameters::{Network, NetworkUpgrade},
     LedgerState,
@@ -26,6 +27,9 @@ use crate::{
 };
 
 pub use zebra_chain::block::arbitrary::MAX_PARTIAL_CHAIN_BLOCKS;
+
+/// How long we wait for chain tip updates before skipping them.
+pub const CHAIN_TIP_UPDATE_WAIT_LIMIT: Duration = Duration::from_secs(2);
 
 #[derive(Debug)]
 pub struct PreparedChainTree {
@@ -212,10 +216,21 @@ pub async fn populated_state(
         // Wait for the block result and the chain tip update,
         // which both happen in a separate thread from this one.
         rsp.expect("unexpected block commit failure");
-        chain_tip_change
-            .wait_for_tip_change()
-            .await
-            .expect("unexpected chain tip update failure");
+
+        // Allow the chain tip update
+        if let Err(timeout_error) = timeout(
+            CHAIN_TIP_UPDATE_WAIT_LIMIT,
+            chain_tip_change.wait_for_tip_change(),
+        )
+        .await
+        .map(|change_result| change_result.expect("unexpected chain tip update failure"))
+        {
+            info!(
+                timeout = ?humantime_seconds(CHAIN_TIP_UPDATE_WAIT_LIMIT),
+                ?timeout_error,
+                "timeout waiting for chain tip change after committing block"
+            );
+        }
     }
 
     (state, read_state, latest_chain_tip, chain_tip_change)

--- a/zebra-state/src/service/block_iter.rs
+++ b/zebra-state/src/service/block_iter.rs
@@ -49,7 +49,7 @@ impl Iter<'_> {
             IterState::Finished => unreachable!(),
         };
 
-        if let Some(block) = service.disk.db().block(hash_or_height) {
+        if let Some(block) = service.read_service.db.block(hash_or_height) {
             let height = block
                 .coinbase_height()
                 .expect("valid blocks have a coinbase height");

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -45,8 +45,11 @@ pub(super) use zebra_db::ZebraDb;
 /// The finalized part of the chain state, stored in the db.
 ///
 /// `rocksdb` allows concurrent writes through a shared reference,
-/// so finalized state instances are cloneable. When the final clone is dropped,
-/// the database is closed.
+/// so clones of the finalized state represent the same database instance.
+/// When the final clone is dropped, the database is closed.
+///
+/// This is different from `NonFinalizedState::clone()`,
+/// which returns an independent copy of the chains.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FinalizedState {
     // Configuration

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -17,7 +17,6 @@
 
 use std::{
     io::{stderr, stdout, Write},
-    path::Path,
     sync::Arc,
 };
 
@@ -72,7 +71,7 @@ pub struct FinalizedState {
     /// `rocksdb` allows reads and writes via a shared reference,
     /// so this database object can be freely cloned.
     /// The last instance that is dropped will close the underlying database.
-    db: ZebraDb,
+    pub db: ZebraDb,
 }
 
 impl FinalizedState {
@@ -132,17 +131,6 @@ impl FinalizedState {
     /// Returns the configured network for this database.
     pub fn network(&self) -> Network {
         self.network
-    }
-
-    /// Returns the `Path` where the files used by this database are located.
-    #[allow(dead_code)]
-    pub fn path(&self) -> &Path {
-        self.db.path()
-    }
-
-    /// Returns a reference to the inner database instance.
-    pub(crate) fn db(&self) -> &ZebraDb {
-        &self.db
     }
 
     /// Commit a finalized block to the state.

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -135,6 +135,7 @@ impl FinalizedState {
     }
 
     /// Returns the `Path` where the files used by this database are located.
+    #[allow(dead_code)]
     pub fn path(&self) -> &Path {
         self.db.path()
     }

--- a/zebra-state/src/service/finalized_state/arbitrary.rs
+++ b/zebra-state/src/service/finalized_state/arbitrary.rs
@@ -14,7 +14,7 @@ impl Deref for FinalizedState {
     type Target = ZebraDb;
 
     fn deref(&self) -> &Self::Target {
-        self.db()
+        &self.db
     }
 }
 

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -748,7 +748,7 @@ impl DiskDb {
         // but if the race happens, it will only cause database errors during shutdown.
         let clone_prevention_guard = Arc::get_mut(&mut self.db);
 
-        if clone_prevention_guard.is_none() && !force {
+        if clone_prevention_guard.is_none() {
             let path = self.path();
             if force {
                 info!(

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -684,6 +684,12 @@ impl DiskDb {
         self.db.flush().expect("flush is successful");
 
         // But we should call `cancel_all_background_work` before Zebra exits.
+        //
+        // In some tests, we need to drop() the state service before the test function returns,
+        // and sleep() until all the other threads exit.
+        // (This seems to be a bug in RocksDB: cancel_all_background_work() should wait until
+        // all the threads have cleaned up.)
+        //
         // If we don't, we see these kinds of errors:
         // ```
         // pthread lock: Invalid argument

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -30,7 +30,13 @@ mod tests;
 pub(crate) use chain::Chain;
 
 /// The state of the chains in memory, including queued blocks.
-#[derive(Debug, Clone)]
+///
+/// Clones of the non-finalized state contain independent copies of the chains.
+/// This is different from `FinalizedState::clone()`,
+/// which returns a shared reference to the database.
+///
+/// Most chain data is clone-on-write using [`Arc`].
+#[derive(Clone, Debug)]
 pub struct NonFinalizedState {
     /// Verified, non-finalized chains, in ascending order.
     ///

--- a/zebra-state/src/service/pending_utxos.rs
+++ b/zebra-state/src/service/pending_utxos.rs
@@ -1,5 +1,6 @@
-use std::collections::HashMap;
-use std::future::Future;
+//! Pending UTXO tracker for [`AwaitUtxo` requests](crate::Request::AwaitUtxo).
+
+use std::{collections::HashMap, future::Future};
 
 use tokio::sync::broadcast;
 

--- a/zebra-state/src/service/queued_blocks.rs
+++ b/zebra-state/src/service/queued_blocks.rs
@@ -77,6 +77,12 @@ impl QueuedBlocks {
         self.update_metrics();
     }
 
+    /// Returns `true` if there are any queued children of `parent_hash`.
+    #[instrument(skip(self), fields(%parent_hash))]
+    pub fn has_queued_children(&self, parent_hash: block::Hash) -> bool {
+        self.by_parent.contains_key(&parent_hash)
+    }
+
     /// Dequeue and return all blocks that were waiting for the arrival of
     /// `parent`.
     #[instrument(skip(self), fields(%parent_hash))]

--- a/zebra-state/src/service/read/address/balance.rs
+++ b/zebra-state/src/service/read/address/balance.rs
@@ -2,8 +2,9 @@
 //!
 //! In the functions in this module:
 //!
-//! The StateService commits blocks to the finalized state before updating
-//! `chain` from the latest chain. Then it can commit additional blocks to
+//! The block write task commits blocks to the finalized state before updating
+//! `chain` with a cached copy of the best non-finalized chain from
+//! `NonFinalizedState.chain_set`. Then the block commit task can commit additional blocks to
 //! the finalized state after we've cloned the `chain`.
 //!
 //! This means that some blocks can be in both:

--- a/zebra-state/src/service/read/address/tx_id.rs
+++ b/zebra-state/src/service/read/address/tx_id.rs
@@ -2,8 +2,9 @@
 //!
 //! In the functions in this module:
 //!
-//! The StateService commits blocks to the finalized state before updating
-//! `chain` from the latest chain. Then it can commit additional blocks to
+//! The block write task commits blocks to the finalized state before updating
+//! `chain` with a cached copy of the best non-finalized chain from
+//! `NonFinalizedState.chain_set`. Then the block commit task can commit additional blocks to
 //! the finalized state after we've cloned the `chain`.
 //!
 //! This means that some blocks can be in both:

--- a/zebra-state/src/service/read/address/utxo.rs
+++ b/zebra-state/src/service/read/address/utxo.rs
@@ -2,8 +2,9 @@
 //!
 //! In the functions in this module:
 //!
-//! The StateService commits blocks to the finalized state before updating
-//! `chain` from the latest chain. Then it can commit additional blocks to
+//! The block write task commits blocks to the finalized state before updating
+//! `chain` with a cached copy of the best non-finalized chain from
+//! `NonFinalizedState.chain_set`. Then the block commit task can commit additional blocks to
 //! the finalized state after we've cloned the `chain`.
 //!
 //! This means that some blocks can be in both:

--- a/zebra-state/src/service/read/block.rs
+++ b/zebra-state/src/service/read/block.rs
@@ -2,8 +2,9 @@
 //!
 //! In the functions in this module:
 //!
-//! The StateService commits blocks to the finalized state before updating
-//! `chain` or `non_finalized_state` from the latest chains. Then it can
+//! The block write task commits blocks to the finalized state before updating
+//! `chain` or `non_finalized_state` with a cached copy of the non-finalized chains
+//! in `NonFinalizedState.chain_set`. Then the block commit task can
 //! commit additional blocks to the finalized state after we've cloned the
 //! `chain` or `non_finalized_state`.
 //!

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -2,8 +2,9 @@
 //!
 //! In the functions in this module:
 //!
-//! The StateService commits blocks to the finalized state before updating
-//! `chain` from the latest chain. Then it can commit additional blocks to
+//! The block write task commits blocks to the finalized state before updating
+//! `chain` with a cached copy of the best non-finalized chain from
+//! `NonFinalizedState.chain_set`. Then the block commit task can commit additional blocks to
 //! the finalized state after we've cloned the `chain`.
 //!
 //! This means that some blocks can be in both:

--- a/zebra-state/src/service/read/tree.rs
+++ b/zebra-state/src/service/read/tree.rs
@@ -2,8 +2,9 @@
 //!
 //! In the functions in this module:
 //!
-//! The StateService commits blocks to the finalized state before updating
-//! `chain` from the latest chain. Then it can commit additional blocks to
+//! The block write task commits blocks to the finalized state before updating
+//! `chain` with a cached copy of the best non-finalized chain from
+//! `NonFinalizedState.chain_set`. Then the block commit task can commit additional blocks to
 //! the finalized state after we've cloned the `chain`.
 //!
 //! This means that some blocks can be in both:

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -468,10 +468,6 @@ proptest! {
                 expected_transparent_pool
             );
         }
-
-        // Work around a RocksDB shutdown bug, see DiskDb::shutdown() for details.
-        std::mem::drop(state_service);
-        std::thread::sleep(Duration::from_secs(1));
     }
 }
 
@@ -546,10 +542,6 @@ proptest! {
             prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
             prop_assert_eq!(chain_tip_change.last_tip_change(), Some(expected_action));
         }
-
-        // Work around a RocksDB shutdown bug, see DiskDb::shutdown() for details.
-        std::mem::drop(state_service);
-        std::thread::sleep(Duration::from_secs(1));
     }
 }
 

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -468,10 +468,14 @@ proptest! {
                 expected_transparent_pool
             );
         }
+
+        // Work around a RocksDB shutdown bug, see DiskDb::shutdown() for details.
+        std::mem::drop(state_service);
+        std::thread::sleep(Duration::from_secs(1));
     }
 }
 
-// This test sleeps, so we only ever want to run it once
+// This test sleeps for every block, so we only ever want to run it once
 proptest! {
     #![proptest_config(
         proptest::test_runner::Config::with_cases(1)
@@ -542,6 +546,10 @@ proptest! {
             prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
             prop_assert_eq!(chain_tip_change.last_tip_change(), Some(expected_action));
         }
+
+        // Work around a RocksDB shutdown bug, see DiskDb::shutdown() for details.
+        std::mem::drop(state_service);
+        std::thread::sleep(Duration::from_secs(1));
     }
 }
 

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -386,73 +386,6 @@ proptest! {
         prop_assert_eq!(response, Ok(()));
     }
 
-    /// Test that the best tip height is updated accordingly.
-    ///
-    /// 1. Generate a finalized chain and some non-finalized blocks.
-    /// 2. Check that initially the best tip height is empty.
-    /// 3. Commit the finalized blocks and check that the best tip height is updated accordingly.
-    /// 4. Commit the non-finalized blocks and check that the best tip height is also updated
-    ///    accordingly.
-    #[test]
-    fn chain_tip_sender_is_updated(
-        (network, finalized_blocks, non_finalized_blocks)
-            in continuous_empty_blocks_from_test_vectors(),
-    ) {
-        let _init_guard = zebra_test::init();
-
-        let (mut state_service, _read_only_state_service, latest_chain_tip, mut chain_tip_change) = StateService::new(Config::ephemeral(), network);
-
-        prop_assert_eq!(latest_chain_tip.best_tip_height(), None);
-        prop_assert_eq!(chain_tip_change.last_tip_change(), None);
-
-        for block in finalized_blocks {
-            let expected_block = block.clone();
-
-            let expected_action = if expected_block.height <= block::Height(1) {
-                // 0: reset by both initialization and the Genesis network upgrade
-                // 1: reset by the BeforeOverwinter network upgrade
-                TipAction::reset_with(expected_block.clone().into())
-            } else {
-                TipAction::grow_with(expected_block.clone().into())
-            };
-
-            let result_receiver = state_service.queue_and_commit_finalized(block);
-            let result = result_receiver.blocking_recv();
-
-            prop_assert!(result.is_ok(), "unexpected failed finalized block commit: {:?}", result);
-
-            // Wait for the channels to be updated by the block commit task.
-            // (There is no blocking method on ChainTipChange.)
-            std::thread::sleep(Duration::from_secs(1));
-
-            prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
-            prop_assert_eq!(chain_tip_change.last_tip_change(), Some(expected_action));
-        }
-
-        for block in non_finalized_blocks {
-            let expected_block = block.clone();
-
-            let expected_action = if expected_block.height == block::Height(1) {
-                // 1: reset by the BeforeOverwinter network upgrade
-                TipAction::reset_with(expected_block.clone().into())
-            } else {
-                TipAction::grow_with(expected_block.clone().into())
-            };
-
-            let result_receiver = state_service.queue_and_commit_non_finalized(block);
-            let result = result_receiver.blocking_recv();
-
-            prop_assert!(result.is_ok(), "unexpected failed non-finalized block commit: {:?}", result);
-
-            // Wait for the channels to be updated by the block commit task.
-            // (There is no blocking method on ChainTipChange.)
-            std::thread::sleep(Duration::from_secs(1));
-
-            prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
-            prop_assert_eq!(chain_tip_change.last_tip_change(), Some(expected_action));
-        }
-    }
-
     /// Test that the value pool is updated accordingly.
     ///
     /// 1. Generate a finalized chain and some non-finalized blocks.
@@ -534,6 +467,80 @@ proptest! {
                 state_service.mem.best_chain().unwrap().chain_value_pools,
                 expected_transparent_pool
             );
+        }
+    }
+}
+
+// This test sleeps, so we only ever want to run it once
+proptest! {
+    #![proptest_config(
+        proptest::test_runner::Config::with_cases(1)
+    )]
+
+    /// Test that the best tip height is updated accordingly.
+    ///
+    /// 1. Generate a finalized chain and some non-finalized blocks.
+    /// 2. Check that initially the best tip height is empty.
+    /// 3. Commit the finalized blocks and check that the best tip height is updated accordingly.
+    /// 4. Commit the non-finalized blocks and check that the best tip height is also updated
+    ///    accordingly.
+    #[test]
+    fn chain_tip_sender_is_updated(
+        (network, finalized_blocks, non_finalized_blocks)
+            in continuous_empty_blocks_from_test_vectors(),
+    ) {
+        let _init_guard = zebra_test::init();
+
+        let (mut state_service, _read_only_state_service, latest_chain_tip, mut chain_tip_change) = StateService::new(Config::ephemeral(), network);
+
+        prop_assert_eq!(latest_chain_tip.best_tip_height(), None);
+        prop_assert_eq!(chain_tip_change.last_tip_change(), None);
+
+        for block in finalized_blocks {
+            let expected_block = block.clone();
+
+            let expected_action = if expected_block.height <= block::Height(1) {
+                // 0: reset by both initialization and the Genesis network upgrade
+                // 1: reset by the BeforeOverwinter network upgrade
+                TipAction::reset_with(expected_block.clone().into())
+            } else {
+                TipAction::grow_with(expected_block.clone().into())
+            };
+
+            let result_receiver = state_service.queue_and_commit_finalized(block);
+            let result = result_receiver.blocking_recv();
+
+            prop_assert!(result.is_ok(), "unexpected failed finalized block commit: {:?}", result);
+
+            // Wait for the channels to be updated by the block commit task.
+            // TODO: add a blocking method on ChainTipChange
+            std::thread::sleep(Duration::from_secs(1));
+
+            prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
+            prop_assert_eq!(chain_tip_change.last_tip_change(), Some(expected_action));
+        }
+
+        for block in non_finalized_blocks {
+            let expected_block = block.clone();
+
+            let expected_action = if expected_block.height == block::Height(1) {
+                // 1: reset by the BeforeOverwinter network upgrade
+                TipAction::reset_with(expected_block.clone().into())
+            } else {
+                TipAction::grow_with(expected_block.clone().into())
+            };
+
+            let result_receiver = state_service.queue_and_commit_non_finalized(block);
+            let result = result_receiver.blocking_recv();
+
+            prop_assert!(result.is_ok(), "unexpected failed non-finalized block commit: {:?}", result);
+
+            // Wait for the channels to be updated by the block commit task.
+            // TODO: add a blocking method on ChainTipChange
+            std::thread::sleep(Duration::from_secs(1));
+
+            prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
+            prop_assert_eq!(chain_tip_change.last_tip_change(), Some(expected_action));
         }
     }
 }

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -2,7 +2,7 @@
 //!
 //! TODO: move these tests into tests::vectors and tests::prop modules.
 
-use std::{env, sync::Arc};
+use std::{env, sync::Arc, time::Duration};
 
 use tower::{buffer::Buffer, util::BoxService};
 
@@ -416,7 +416,14 @@ proptest! {
                 TipAction::grow_with(expected_block.clone().into())
             };
 
-            state_service.queue_and_commit_finalized(block);
+            let result_receiver = state_service.queue_and_commit_finalized(block);
+            let result = result_receiver.blocking_recv();
+
+            prop_assert!(result.is_ok(), "unexpected failed finalized block commit: {:?}", result);
+
+            // Wait for the channels to be updated by the block commit task.
+            // (There is no blocking method on ChainTipChange.)
+            std::thread::sleep(Duration::from_secs(1));
 
             prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
             prop_assert_eq!(chain_tip_change.last_tip_change(), Some(expected_action));
@@ -432,7 +439,14 @@ proptest! {
                 TipAction::grow_with(expected_block.clone().into())
             };
 
-            state_service.queue_and_commit_non_finalized(block);
+            let result_receiver = state_service.queue_and_commit_non_finalized(block);
+            let result = result_receiver.blocking_recv();
+
+            prop_assert!(result.is_ok(), "unexpected failed non-finalized block commit: {:?}", result);
+
+            // Wait for the channels to be updated by the block commit task.
+            // (There is no blocking method on ChainTipChange.)
+            std::thread::sleep(Duration::from_secs(1));
 
             prop_assert_eq!(latest_chain_tip.best_tip_height(), Some(expected_block.height));
             prop_assert_eq!(chain_tip_change.last_tip_change(), Some(expected_action));
@@ -476,7 +490,10 @@ proptest! {
                 expected_finalized_value_pool += *block_value_pool;
             }
 
-            state_service.queue_and_commit_finalized(block.clone());
+            let result_receiver = state_service.queue_and_commit_finalized(block.clone());
+            let result = result_receiver.blocking_recv();
+
+            prop_assert!(result.is_ok(), "unexpected failed finalized block commit: {:?}", result);
 
             prop_assert_eq!(
                 state_service.disk.finalized_value_pool(),
@@ -499,7 +516,10 @@ proptest! {
             let block_value_pool = &block.block.chain_value_pool_change(&transparent::utxos_from_ordered_utxos(utxos))?;
             expected_non_finalized_value_pool += *block_value_pool;
 
-            state_service.queue_and_commit_non_finalized(block.clone());
+            let result_receiver = state_service.queue_and_commit_non_finalized(block.clone());
+            let result = result_receiver.blocking_recv();
+
+            prop_assert!(result.is_ok(), "unexpected failed non-finalized block commit: {:?}", result);
 
             prop_assert_eq!(
                 state_service.mem.best_chain().unwrap().chain_value_pools,

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -1,21 +1,105 @@
 //! Writing blocks to the finalized and non-finalized states.
 
-use crate::{service::finalized_state::FinalizedState, FinalizedBlock, PreparedBlock};
+use std::sync::{Arc, Mutex};
 
-/// Write blocks to the state,
+use zebra_chain::block::{self, Height};
+
+use crate::service::{
+    finalized_state::FinalizedState,
+    queued_blocks::{QueuedFinalized, QueuedNonFinalized},
+    ChainTipBlock, ChainTipSender,
+};
+
+/// Reads blocks from the channels, write them to the `finalized_state`,
+/// and updates the
 ///
-/// TODO: pass the non-finalized state and associated update channels to this function
+/// TODO: pass the non-finalized state and associated update channel to this function
+#[instrument(skip(
+    finalized_block_write_receiver,
+    non_finalized_block_write_receiver,
+    invalid_block_reset_sender,
+    chain_tip_sender
+))]
 pub fn write_blocks_from_channels(
-    mut finalized_block_write_receiver: tokio::sync::mpsc::UnboundedReceiver<FinalizedBlock>,
-    mut non_finalized_block_write_receiver: tokio::sync::mpsc::UnboundedReceiver<PreparedBlock>,
-    _finalized_state: FinalizedState,
+    mut finalized_block_write_receiver: tokio::sync::mpsc::UnboundedReceiver<QueuedFinalized>,
+    mut non_finalized_block_write_receiver: tokio::sync::mpsc::UnboundedReceiver<
+        QueuedNonFinalized,
+    >,
+    mut finalized_state: FinalizedState,
+    invalid_block_reset_sender: tokio::sync::mpsc::UnboundedSender<block::Hash>,
+    chain_tip_sender: Arc<Mutex<ChainTipSender>>,
 ) {
-    // TODO: actually write blocks here
-    while let Some(_block) = finalized_block_write_receiver.blocking_recv() {
-        error!("handle finalized block writes here");
+    while let Some(ordered_block) = finalized_block_write_receiver.blocking_recv() {
+        // TODO: split these checks into separate functions
+
+        // Discard any children of invalid blocks in the channel
+        let next_valid_height = finalized_state
+            .db()
+            .finalized_tip_height()
+            .map(|height| (height + 1).expect("committed heights are valid"))
+            .unwrap_or(Height(0));
+
+        if ordered_block.0.height > next_valid_height {
+            debug!(
+                ?next_valid_height,
+                invalid_height = ?ordered_block.0.height,
+                invalid_hash = ?ordered_block.0.hash,
+                "got a block that was too high, assuming that a parent block failed, \
+                 and clearing child blocks in the channel",
+            );
+
+            let send_result =
+                invalid_block_reset_sender.send(finalized_state.db().finalized_tip_hash());
+
+            if send_result.is_err() {
+                info!("StateService closed the block reset channel. Is Zebra shutting down?");
+                return;
+            }
+        }
+
+        // Try committing the block
+        match finalized_state.commit_finalized(ordered_block) {
+            Ok(finalized) => {
+                let tip_block = ChainTipBlock::from(finalized);
+
+                // TODO: update the chain tip sender with non-finalized blocks in this function,
+                //       and get rid of the mutex
+                chain_tip_sender
+                    .lock()
+                    .expect("unexpected panic in block commit task or state")
+                    .set_finalized_tip(tip_block);
+            }
+            Err(error) => {
+                let finalized_tip = finalized_state.db().tip();
+
+                // The last block in the queue failed, so we can't commit the next block.
+                // Instead, we need to reset the state queue,
+                // and discard any children of the invalid block in the channel.
+                info!(
+                    ?error,
+                    last_valid_height = ?finalized_tip.map(|tip| tip.0),
+                    last_valid_hash = ?finalized_tip.map(|tip| tip.1),
+                    "committing a block to the finalized state failed, resetting state queue",
+                );
+
+                let send_result =
+                    invalid_block_reset_sender.send(finalized_state.db().finalized_tip_hash());
+
+                if send_result.is_err() {
+                    info!("StateService closed the block reset channel. Is Zebra shutting down?");
+                    return;
+                }
+            }
+        }
     }
 
     while let Some(_block) = non_finalized_block_write_receiver.blocking_recv() {
+        // TODO:
+        // - read from the channel
+        // - commit blocks to the non-finalized state
+        // - commit blocks to the finalized state
+        // - handle errors
+        // - update the chain tip sender and cached non-finalized state
         error!("handle non-finalized block writes here");
     }
 }

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -10,8 +10,8 @@ use crate::service::{
     ChainTipBlock, ChainTipSender,
 };
 
-/// Reads blocks from the channels, write them to the `finalized_state`,
-/// and updates the
+/// Reads blocks from the channels, writes them to the `finalized_state`,
+/// and updates the `chain_tip_sender`.
 ///
 /// TODO: pass the non-finalized state and associated update channel to this function
 #[instrument(skip(

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -91,8 +91,8 @@ pub fn write_blocks_from_channels(
         // TODO:
         // - read from the channel
         // - commit blocks to the non-finalized state
-        // - commit blocks to the finalized state
-        // - handle errors
+        // - if there are any ready, commit blocks to the finalized state
+        // - handle errors by sending a reset with all the block hashes in the non-finalized state, and the finalized tip
         // - update the chain tip sender and cached non-finalized state
         error!("handle non-finalized block writes here");
     }

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -44,17 +44,11 @@ pub fn write_blocks_from_channels(
                 ?next_valid_height,
                 invalid_height = ?ordered_block.0.height,
                 invalid_hash = ?ordered_block.0.hash,
-                "got a block that was too high, assuming that a parent block failed, \
-                 and clearing child blocks in the channel",
+                "got a block that was too high. \
+                 Assuming a parent block failed, and dropping this block",
             );
 
-            let send_result =
-                invalid_block_reset_sender.send(finalized_state.db().finalized_tip_hash());
-
-            if send_result.is_err() {
-                info!("StateService closed the block reset channel. Is Zebra shutting down?");
-                return;
-            }
+            // We don't want to send a reset here, because it could overwrite a valid sent hash
         }
 
         // Try committing the block

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -1,0 +1,21 @@
+//! Writing blocks to the finalized and non-finalized states.
+
+use crate::{service::finalized_state::FinalizedState, FinalizedBlock, PreparedBlock};
+
+/// Write blocks to the state,
+///
+/// TODO: pass the non-finalized state and associated update channels to this function
+pub fn write_blocks_from_channels(
+    mut finalized_block_write_receiver: tokio::sync::mpsc::UnboundedReceiver<FinalizedBlock>,
+    mut non_finalized_block_write_receiver: tokio::sync::mpsc::UnboundedReceiver<PreparedBlock>,
+    _finalized_state: FinalizedState,
+) {
+    // TODO: actually write blocks here
+    while let Some(_block) = finalized_block_write_receiver.blocking_recv() {
+        error!("handle finalized block writes here");
+    }
+
+    while let Some(_block) = non_finalized_block_write_receiver.blocking_recv() {
+        error!("handle non-finalized block writes here");
+    }
+}

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -56,6 +56,8 @@ pub fn write_blocks_from_channels(
             );
 
             // We don't want to send a reset here, because it could overwrite a valid sent hash
+            std::mem::drop(ordered_block);
+            continue;
         }
 
         // Try committing the block

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -40,6 +40,11 @@ pub fn write_blocks_from_channels(
         }
 
         // Discard any children of invalid blocks in the channel
+        //
+        // `commit_finalized()` requires blocks in height order.
+        // So if there has been a block commit error,
+        // we need to drop all the descendants of that block,
+        // until we receive a block at the required next height.
         let next_valid_height = finalized_state
             .db
             .finalized_tip_height()

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -51,12 +51,12 @@ pub fn write_blocks_from_channels(
             .map(|height| (height + 1).expect("committed heights are valid"))
             .unwrap_or(Height(0));
 
-        if ordered_block.0.height > next_valid_height {
+        if ordered_block.0.height != next_valid_height {
             debug!(
                 ?next_valid_height,
                 invalid_height = ?ordered_block.0.height,
                 invalid_hash = ?ordered_block.0.hash,
-                "got a block that was too high. \
+                "got a block that was the wrong height. \
                  Assuming a parent block failed, and dropping this block",
             );
 

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -10,13 +10,14 @@ use std::{
 };
 
 use futures::FutureExt;
-use tokio::{sync::oneshot, task::JoinHandle};
+use tokio::{sync::oneshot, task::JoinHandle, time::timeout};
 use tower::{buffer::Buffer, builder::ServiceBuilder, util::BoxService, Service, ServiceExt};
 use tracing::Span;
 
 use zebra_chain::{
     amount::Amount,
     block::Block,
+    fmt::humantime_seconds,
     parameters::Network::{self, *},
     serialization::ZcashDeserializeInto,
     transaction::{UnminedTx, UnminedTxId, VerifiedUnminedTx},
@@ -24,7 +25,7 @@ use zebra_chain::{
 use zebra_consensus::{error::TransactionError, transaction, Config as ConsensusConfig};
 use zebra_network::{AddressBook, InventoryResponse, Request, Response};
 use zebra_node_services::mempool;
-use zebra_state::Config as StateConfig;
+use zebra_state::{ChainTipChange, Config as StateConfig, CHAIN_TIP_UPDATE_WAIT_LIMIT};
 use zebra_test::mock_service::{MockService, PanicAssertion};
 
 use crate::{
@@ -59,6 +60,7 @@ async fn mempool_requests_for_transactions() {
         _mock_tx_verifier,
         mut peer_set,
         _state_guard,
+        _chain_tip_change,
         sync_gossip_task_handle,
         tx_gossip_task_handle,
     ) = setup(true).await;
@@ -142,6 +144,7 @@ async fn mempool_push_transaction() -> Result<(), crate::BoxError> {
         mut tx_verifier,
         mut peer_set,
         _state_guard,
+        _chain_tip_change,
         sync_gossip_task_handle,
         tx_gossip_task_handle,
     ) = setup(false).await;
@@ -236,6 +239,7 @@ async fn mempool_advertise_transaction_ids() -> Result<(), crate::BoxError> {
         mut tx_verifier,
         mut peer_set,
         _state_guard,
+        _chain_tip_change,
         sync_gossip_task_handle,
         tx_gossip_task_handle,
     ) = setup(false).await;
@@ -342,6 +346,7 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
         mut tx_verifier,
         mut peer_set,
         state_service,
+        _chain_tip_change,
         sync_gossip_task_handle,
         tx_gossip_task_handle,
     ) = setup(false).await;
@@ -638,6 +643,7 @@ async fn inbound_block_height_lookahead_limit() -> Result<(), crate::BoxError> {
         mut tx_verifier,
         mut peer_set,
         state_service,
+        mut chain_tip_change,
         sync_gossip_task_handle,
         tx_gossip_task_handle,
     ) = setup(false).await;
@@ -658,7 +664,20 @@ async fn inbound_block_height_lookahead_limit() -> Result<(), crate::BoxError> {
         .await
         .respond(Response::Blocks(vec![Available(block)]));
 
-    // TODO: check that the block is queued in the checkpoint verifier
+    // Wait for the chain tip update
+    if let Err(timeout_error) = timeout(
+        CHAIN_TIP_UPDATE_WAIT_LIMIT,
+        chain_tip_change.wait_for_tip_change(),
+    )
+    .await
+    .map(|change_result| change_result.expect("unexpected chain tip update failure"))
+    {
+        info!(
+            timeout = ?humantime_seconds(CHAIN_TIP_UPDATE_WAIT_LIMIT),
+            ?timeout_error,
+            "timeout waiting for chain tip change after committing block"
+        );
+    }
 
     // check that nothing unexpected happened
     peer_set.expect_no_requests().await;
@@ -729,6 +748,7 @@ async fn setup(
     MockService<transaction::Request, transaction::Response, PanicAssertion, TransactionError>,
     MockService<Request, Response, PanicAssertion>,
     Buffer<BoxService<zebra_state::Request, zebra_state::Response, BoxError>, zebra_state::Request>,
+    ChainTipChange,
     JoinHandle<Result<(), BlockGossipError>>,
     JoinHandle<Result<(), BoxError>>,
 ) {
@@ -845,7 +865,7 @@ async fn setup(
 
     let sync_gossip_task_handle = tokio::spawn(sync::gossip_best_tip_block_hashes(
         sync_status.clone(),
-        chain_tip_change,
+        chain_tip_change.clone(),
         peer_set.clone(),
     ));
 
@@ -873,6 +893,7 @@ async fn setup(
         mock_tx_verifier,
         peer_set,
         state_service,
+        chain_tip_change,
         sync_gossip_task_handle,
         tx_gossip_task_handle,
     )

--- a/zebrad/tests/common/lightwalletd/send_transaction_test.rs
+++ b/zebrad/tests/common/lightwalletd/send_transaction_test.rs
@@ -176,7 +176,7 @@ pub async fn run() -> Result<()> {
         assert_eq!(response, expected_response);
     }
 
-    // The timing of verification logs are unrealiable, so we've disabled this check for now. 
+    // The timing of verification logs are unrealiable, so we've disabled this check for now.
     //
     // TODO: when lightwalletd starts returning transactions again:
     //       re-enable this check, find a better way to check, or delete this commented-out check

--- a/zebrad/tests/common/lightwalletd/send_transaction_test.rs
+++ b/zebrad/tests/common/lightwalletd/send_transaction_test.rs
@@ -176,8 +176,13 @@ pub async fn run() -> Result<()> {
         assert_eq!(response, expected_response);
     }
 
-    tracing::info!("waiting for mempool to verify some transactions...");
-    zebrad.expect_stdout_line_matches("sending mempool transaction broadcast")?;
+    // The timing of verification logs are unrealiable, so we've disabled this check for now. 
+    //
+    // TODO: when lightwalletd starts returning transactions again:
+    //       re-enable this check, find a better way to check, or delete this commented-out check
+    //
+    //tracing::info!("waiting for mempool to verify some transactions...");
+    //zebrad.expect_stdout_line_matches("sending mempool transaction broadcast")?;
 
     tracing::info!("calling GetMempoolTx gRPC to fetch transactions...");
     let mut transactions_stream = rpc_client


### PR DESCRIPTION
## Motivation

This PR starts moving state block write requests into their own task.
When it is finished, it will make state block writes fully concurrent.

Part of #4937.
Closes #5125.

### Designs

See #4937 and https://docs.google.com/drawings/d/1FXpAUlenDAjl8nkftrypdAPsj0jr-Ut9gZlSP57nuyc/edit

## Solution

Add a block write task:
- Commit finalized blocks to the state in a separate task
- Add last_block_hash_sent to the state service, to avoid database accesses when draining the queue
- Add task handles to check for task exits and panics

Add block write channels:
- Finalized state
- Non-finalized state (not used in this PR)
- Close the finalized block channel when we're finished with it
- Remove a redundant `block_in_place()`

Deal with errors & shutdowns:
- Update last_block_hash_sent regardless of commit errors
- Check for panics in the block write task
- Close state channels and tasks on drop
- Drop channels and check for closed channels in the block commit task
- Work around a RocksDB shutdown bug in the tests, by removing previous code that cancelled RocksDB background work on shutdown
- Drop any leftover queued blocks when finished with the finalized state, and return an error on their channels
- Return an error on the channels of replaced duplicate blocks

Related fixes:
- Wait for the block commit task in tests, and check for errors
- Wait for chain tip updates in the RPC tests
- Improve RPC error logging
- When running a proptest that sleeps a lot, only run it once
- Explain finalized block duplicate handling and consensus rules

Related cleanups:
- Remove some duplicate fields across StateService and ReadStateService
- Rename a field to StateService.max_queued_finalized_height

## Testing

We should run a full sync on this before we merge, and make sure it is not significantly slower than the `main` branch.

## Review

This PR is part of regular scheduled work.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

Handle non-finalized blocks.
Handle task exits and panics correctly.
Testing.