### PR TITLE
fix(docs): Enable all cargo features in Zebra's deployed docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Build external docs
         run: |
           # Exclude zebra-utils, it is not for library or app users
-          cargo doc --no-deps --workspace --exclude zebra-utils
+          cargo doc --no-deps --workspace --all-features --exclude zebra-utils
         env:
           RUSTDOCFLAGS: '--html-in-header katex-header.html'
 
@@ -96,7 +96,7 @@ jobs:
 
       - name: Build internal docs
         run: |
-          cargo doc --no-deps --document-private-items
+          cargo doc --no-deps --workspace --all-features --document-private-items
         env:
           RUSTDOCFLAGS: '--html-in-header katex-header.html'
 


### PR DESCRIPTION
## Motivation

We're not building our docs with all features enabled, so some doc links produce warnings.
We might also be skipping some optional modules *in* the docs, I'm not sure.

## Review

This is a routine fix.

### Reviewer Checklist

  - [x] CI passes

