### PR TITLE
chore(build): allow a custom `zebrad` config file path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -139,7 +139,7 @@ RUN apt-get update && \
 ARG CHECKPOINT_SYNC=true
 ARG NETWORK=Mainnet
 
-ARG ZEBRA_CONF_PATH=/etc/zebrad/zebrad.toml
+ARG ZEBRA_CONF_PATH=/etc/zebra/zebrad.toml
 ENV ZEBRA_CONF_PATH ${ZEBRA_CONF_PATH}
 
 # Build the `zebrad.toml` before starting the container, using the arguments from build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -139,6 +139,9 @@ RUN apt-get update && \
 ARG CHECKPOINT_SYNC=true
 ARG NETWORK=Mainnet
 
+ARG ZEBRA_CONF_PATH=/etc/zebrad/zebrad.toml
+ENV ZEBRA_CONF_PATH ${ZEBRA_CONF_PATH}
+
 # Build the `zebrad.toml` before starting the container, using the arguments from build
 # time, or using the default values set just above.
 RUN set -ex; \
@@ -153,7 +156,7 @@ RUN set -ex; \
     echo "cache_dir = '/zebrad-cache'"; \
     echo "[tracing]"; \
     echo "endpoint_addr = '0.0.0.0:3000'"; \
-  } > "zebrad.toml"
+  } > "${ZEBRA_CONF_PATH}"
 
 EXPOSE 3000 8233 18233
 
@@ -163,4 +166,4 @@ ENV SHORT_SHA $SHORT_SHA
 ARG SENTRY_DSN
 ENV SENTRY_DSN ${SENTRY_DSN}
 
-CMD [ "zebrad", "-c", "zebrad.toml", "start" ]
+CMD [ "zebrad", "-c", "${ZEBRA_CONF_PATH}", "start" ]


### PR DESCRIPTION
## Previous behavior:
The zebrad config file was hardcoded into the Dockerfile, allowing to change specific values, but not the config file as a whole

## Expected behavior:
Allow the user to specify the config file themselves, for example with the nginx image you can pass -v /host/path/nginx.conf:/etc/nginx/nginx.conf:ro

## Solution:
Use and ARG, with a default value, to allow the user to change the location of the zebrad configuration file. This also sets the location under /etc, honoring The Filesystem Hierarchy Standard (FHS) for linux

## Review

Anyone can review this, but @conradoplg proposed the change.

### Reviewer Checklist

  - [ ] CI passes
  - [ ] Tests for Expected Behavior
