### PR TITLE
add(devops): Allow manual Release Drafter workflow runs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,18 +1,22 @@
+# Creates a draft release with all the PR names since the last release.
+# https://github.com/ZcashFoundation/zebra/releases
 name: Release Drafter
 
 on:
+  # Automatically update the draft release every time a PR merges to `main`
   push:
     branches:
       - main
+  # Manually update the draft release without waiting for a PR to merge
+  workflow_dispatch:
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into main
+      # Drafts your next Release notes
       - uses: release-drafter/release-drafter@v5
         with:
-          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
           config-name: release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

Sometimes we want to update the draft release without having to merge a PR.

## Solution

- Allow manual Release Drafter workflow runs
- Update workflow comments

## Review

This blocks #5011, so it's a bit urgent.

### Reviewer Checklist

  - [ ] Changes make sense

