### PR TITLE
fix(ci): Increase full sync time to 32 hours

### DIFF
--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -76,7 +76,7 @@ pub const FINISH_PARTIAL_SYNC_TIMEOUT: Duration = Duration::from_secs(11 * 60 * 
 
 /// The maximum time to wait for Zebrad to synchronize up to the chain tip starting from the
 /// genesis block.
-pub const FINISH_FULL_SYNC_TIMEOUT: Duration = Duration::from_secs(28 * 60 * 60);
+pub const FINISH_FULL_SYNC_TIMEOUT: Duration = Duration::from_secs(32 * 60 * 60);
 
 /// The test sync height where we switch to using the default lookahead limit.
 ///


### PR DESCRIPTION
## Motivation

I just saw a full sync take 27 hours, so it looks like we might need to allow a bit of extra time.

## Review

This isn't failing anything yet, but we should try to merge it soon.

