### PR TITLE
fix(build): a path must exist before creating a file in it

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -139,14 +139,21 @@ RUN apt-get update && \
 ARG CHECKPOINT_SYNC=true
 ARG NETWORK=Mainnet
 
-# Use a configurable path for the zebrad configuration file
-ARG ZEBRA_CONF_PATH=/etc/zebra/zebrad.toml
+# Use a configurable dir and file for the zebrad configuration file
+ARG ZEBRA_CONF_PATH=/etc/zebra
 ENV ZEBRA_CONF_PATH ${ZEBRA_CONF_PATH}
 
+ARG ZEBRA_CONF_FILE=zebrad.toml
+ENV ZEBRA_CONF_FILE ${ZEBRA_CONF_FILE}
+
 # Build the `zebrad.toml` before starting the container, using the arguments from build
-# time, or using the default values set just above. And create the file path if it does
-# not exist
-RUN mkdir -p ${ZEBRA_CONF_PATH}
+# time, or using the default values set just above. And create the conf path and file if
+# it does not exist
+#
+# TODO: move this file creation to an entrypoint as we can use default values at runtime,
+# and modify those as needed when starting the container (at runtime and not at build time)
+RUN mkdir -p ${ZEBRA_CONF_PATH} \
+    && touch ${ZEBRA_CONF_PATH}/${ZEBRA_CONF_FILE}
 RUN set -ex; \
   { \
     echo "[consensus]"; \
@@ -159,7 +166,7 @@ RUN set -ex; \
     echo "cache_dir = '/zebrad-cache'"; \
     echo "[tracing]"; \
     echo "endpoint_addr = '0.0.0.0:3000'"; \
-  } > "${ZEBRA_CONF_PATH}"
+  } > "${ZEBRA_CONF_PATH}/${ZEBRA_CONF_FILE}"
 
 EXPOSE 3000 8233 18233
 
@@ -169,4 +176,5 @@ ENV SHORT_SHA $SHORT_SHA
 ARG SENTRY_DSN
 ENV SENTRY_DSN ${SENTRY_DSN}
 
-CMD [ "zebrad", "-c", "${ZEBRA_CONF_PATH}", "start" ]
+# TODO: remove the specified config file location and use the default expected by zebrad
+CMD [ "zebrad", "-c", "${ZEBRA_CONF_FILE}/${ZEBRA_CONF_FILE}", "start" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -177,4 +177,4 @@ ARG SENTRY_DSN
 ENV SENTRY_DSN ${SENTRY_DSN}
 
 # TODO: remove the specified config file location and use the default expected by zebrad
-CMD [ "zebrad", "-c", "${ZEBRA_CONF_FILE}/${ZEBRA_CONF_FILE}", "start" ]
+CMD [ "zebrad", "-c", "${ZEBRA_CONF_PATH}/${ZEBRA_CONF_FILE}", "start" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -139,11 +139,14 @@ RUN apt-get update && \
 ARG CHECKPOINT_SYNC=true
 ARG NETWORK=Mainnet
 
+# Use a configurable path for the zebrad configuration file
 ARG ZEBRA_CONF_PATH=/etc/zebra/zebrad.toml
 ENV ZEBRA_CONF_PATH ${ZEBRA_CONF_PATH}
 
 # Build the `zebrad.toml` before starting the container, using the arguments from build
-# time, or using the default values set just above.
+# time, or using the default values set just above. And create the file path if it does
+# not exist
+RUN mkdir -p ${ZEBRA_CONF_PATH}
 RUN set -ex; \
   { \
     echo "[consensus]"; \


### PR DESCRIPTION


## Motivation

Builds in the main branch are failing

## Solution

Other directories in the Dockerfile were automatically created with the `WORKDIR` and  `COPY` commands. In this case it has to be explicitly created 

## Review

Anyone can review this, and it's urgently needed
