### PR TITLE
doc(ci): Fix incorrect docs about Docker build cache order

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -139,9 +139,10 @@ jobs:
           # To improve build speeds, for each branch we push an additional image to the registry,
           # to be used as the caching layer, using the `max` caching mode.
           #
-          # We use multiple cache sources to confirm a cache hit, starting from the `main` branch cache,
-          # and if there's no hit, then continue with a cache scoped per branch.
+          # We use multiple cache sources to confirm a cache hit, starting from a per-branch cache,
+          # and if there's no hit, then continue with the `main` branch. Changes within a PR are usually
+          # small, so this provides the best performance.
           cache-from: |
-            type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:main-cache
             type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache
+            type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:main-cache
           cache-to: type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache,mode=max

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -142,7 +142,9 @@ jobs:
           # We use multiple cache sources to confirm a cache hit, starting from a per-branch cache,
           # and if there's no hit, then continue with the `main` branch. Changes within a PR are usually
           # small, so this provides the best performance.
+          #
+          # The last cache in the list is tried first.
           cache-from: |
-            type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache
             type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:main-cache
+            type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache
           cache-to: type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache,mode=max


### PR DESCRIPTION
## Motivation

We want to use the branch build cache first, because the changes to a PR are usually small.
This is a comment-only PR.

Closes #5186.

### API documentation

The order and failure behaviour of caches is undocumented:
https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#registry-cache

But it seems to be bottom to top, skip on failure.
(This is unusual, typically the order would be top to bottom.)

## Review

This seems to be working in the most efficient way, but the docs are wrong.

### Reviewer Checklist

  - [ ] Docs make sense

