### PR TITLE
fix(ci): Delete Google Cloud test instances after 3 days

### DIFF
--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -47,13 +47,14 @@ jobs:
       - name: Delete old instances
         run: |
           DELETE_BEFORE_DATE=$(date --date="$DELETE_INSTANCE_DAYS days ago" '+%Y%m%d')
-          IFS=$'\n'
 
+          IFS=$'\n'
           INSTANCES=$(gcloud compute instances list --sort-by=creationTimestamp --filter="name~-[0-9a-f]{7,}$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME,ZONE)' | \
                       sed 's/\(.*\)\t\(.*\)/\1 --zone=\2/')
 
           for INSTANCE_AND_ZONE in $INSTANCES
           do
+            IFS=$' '
             gcloud compute instances delete --verbosity=info ${INSTANCE_AND_ZONE} --delete-disks=all || continue
           done
 
@@ -74,23 +75,27 @@ jobs:
       - name: Delete old disks
         run: |
           DELETE_BEFORE_DATE=$(date --date="$DELETE_AGE_DAYS days ago" '+%Y%m%d')
-          IFS=$'\n'
 
+          IFS=$'\n'
           # Disks created by PR jobs, and other jobs that use a commit hash
           COMMIT_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp --filter="name~-[0-9a-f]{7,}$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME,LOCATION,LOCATION_SCOPE)' | \
                          sed 's/\(.*\)\t\(.*\)\t\(.*\)/\1 --\3=\2/')
 
           for DISK_AND_LOCATION in $COMMIT_DISKS
           do
+            IFS=$' '
             gcloud compute disks delete --verbosity=info ${DISK_AND_LOCATION} || continue
           done
           
+          IFS=$'\n'
           # Disks created by managed instance groups, and other jobs that start with "zebrad-"
-          ZEBRAD_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp --filter="name~^zebrad- AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          ZEBRAD_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp --filter="name~^zebrad- AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME,LOCATION,LOCATION_SCOPE)' | \
+                         sed 's/\(.*\)\t\(.*\)\t\(.*\)/\1 --\3=\2/')
 
-          for DISK in $ZEBRAD_DISKS
+          for DISK_AND_LOCATION in $ZEBRAD_DISKS
           do
-            gcloud compute disks delete --verbosity=info "${DISK}" || continue
+            IFS=$' '
+            gcloud compute disks delete --verbosity=info ${DISK_AND_LOCATION} || continue
           done
 
       # Deletes cache images older than $DELETE_AGE_DAYS days.

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -52,9 +52,9 @@ jobs:
           INSTANCES=$(gcloud compute instances list --sort-by=creationTimestamp --filter="name~-[0-9a-f]{7,}$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME,ZONE)' | \
                       sed 's/\(.*\)\t\(.*\)/\1 --zone=\2/')
 
-          for INSTANCE in $INSTANCES
+          for INSTANCE_AND_ZONE in $INSTANCES
           do
-            gcloud compute instances delete --verbosity=info ${INSTANCE} --delete-disks=all || continue
+            gcloud compute instances delete --verbosity=info ${INSTANCE_AND_ZONE} --delete-disks=all || continue
           done
 
       # Deletes all the instance templates older than $DELETE_AGE_DAYS days.
@@ -80,9 +80,9 @@ jobs:
           COMMIT_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp --filter="name~-[0-9a-f]{7,}$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME,LOCATION,LOCATION_SCOPE)' | \
                          sed 's/\(.*\)\t\(.*\)\t\(.*\)/\1 --\3=\2/')
 
-          for DISK in $COMMIT_DISKS
+          for DISK_AND_LOCATION in $COMMIT_DISKS
           do
-            gcloud compute disks delete --verbosity=info "${DISK}" || continue
+            gcloud compute disks delete --verbosity=info ${DISK_AND_LOCATION} || continue
           done
           
           # Disks created by managed instance groups, and other jobs that start with "zebrad-"

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -44,6 +44,10 @@ jobs:
       #
       # We only delete instances that end in 7 or more hex characters,
       # to avoid deleting managed instance groups and manually created instances.
+      #
+      # ${INSTANCE_AND_ZONE} expands to:
+      # <instance-name> --zone=<zone-name>
+      # so it can't be shell-quoted.
       - name: Delete old instances
         run: |
           DELETE_BEFORE_DATE=$(date --date="$DELETE_INSTANCE_DAYS days ago" '+%Y%m%d')
@@ -72,7 +76,11 @@ jobs:
 
       # Deletes all the disks older than $DELETE_AGE_DAYS days.
       #
-      # Disks that are attached to an instance template can't be deleted, so it is safe to delete all disks here.
+      # Disks that are attached to an instance template can't be deleted, so it is safe to try to delete all disks here.
+      #
+      # ${DISK_AND_LOCATION} expands to:
+      # <disk-name> --[zone|region]=<location-name>
+      # so it can't be shell-quoted.
       - name: Delete old disks
         run: |
           DELETE_BEFORE_DATE=$(date --date="$DELETE_AGE_DAYS days ago" '+%Y%m%d')

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -56,6 +56,7 @@ jobs:
           do
             IFS=$' '
             gcloud compute instances delete --verbosity=info ${INSTANCE_AND_ZONE} --delete-disks=all || continue
+            IFS=$'\n'
           done
 
       # Deletes all the instance templates older than $DELETE_AGE_DAYS days.
@@ -85,6 +86,7 @@ jobs:
           do
             IFS=$' '
             gcloud compute disks delete --verbosity=info ${DISK_AND_LOCATION} || continue
+            IFS=$'\n'
           done
           
           IFS=$'\n'
@@ -96,6 +98,7 @@ jobs:
           do
             IFS=$' '
             gcloud compute disks delete --verbosity=info ${DISK_AND_LOCATION} || continue
+            IFS=$'\n'
           done
 
       # Deletes cache images older than $DELETE_AGE_DAYS days.

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -8,7 +8,10 @@ on:
   workflow_dispatch:
 
 env:
-  # Delete all resources created before $DELETE_AGE_DAYS days ago.
+  # Delete all resources created before $DELETE_INSTANCE_DAYS days ago.
+  # We keep this short to reduce CPU, RAM, and storage costs.
+  DELETE_INSTANCE_DAYS: 3
+  # Delete all other resources created before $DELETE_AGE_DAYS days ago.
   # We keep this short to reduce storage costs.
   DELETE_AGE_DAYS: 2
   # But keep the latest $KEEP_LATEST_IMAGE_COUNT images of each type.
@@ -37,11 +40,25 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
+      # Deletes all instances older than $DELETE_INSTANCE_DAYS days.
+      #
+      # We only delete instances that end in 7 or more hex characters,
+      # to avoid deleting managed instance groups and manually created instances.
+      - name: Delete old instances
+        run: |
+          DELETE_BEFORE_DATE=$(date --date="$DELETE_INSTANCE_DAYS days ago" '+%Y%m%d')
+          INSTANCES=$(gcloud compute instances list --sort-by=creationTimestamp --filter="name~-[0-9a-f]{7,}$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+
+          for INSTANCE in $INSTANCES
+          do
+            gcloud compute instance delete ${INSTANCE} --delete-disks=all || continue
+          done
+
       # Deletes all the instance templates older than $DELETE_AGE_DAYS days.
       - name: Delete old instance templates
         run: |
           DELETE_BEFORE_DATE=$(date --date="$DELETE_AGE_DAYS days ago" '+%Y%m%d')
-          TEMPLATES=$(gcloud compute instance-templates list --sort-by=creationTimestamp  --filter="name~-[0-9a-f]+$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          TEMPLATES=$(gcloud compute instance-templates list --sort-by=creationTimestamp --filter="name~-[0-9a-f]{7,}$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
 
           for TEMPLATE in $TEMPLATES
           do
@@ -56,7 +73,7 @@ jobs:
           DELETE_BEFORE_DATE=$(date --date="$DELETE_AGE_DAYS days ago" '+%Y%m%d')
 
           # Disks created by PR jobs, and other jobs that use a commit hash
-          COMMIT_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp  --filter="name~-[0-9a-f]+$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          COMMIT_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp --filter="name~-[0-9a-f]{7,}$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
 
           for DISK in $COMMIT_DISKS
           do
@@ -64,7 +81,7 @@ jobs:
           done
           
           # Disks created by managed instance groups, and other jobs that start with "zebrad-"
-          ZEBRAD_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp  --filter="name~^zebrad- AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          ZEBRAD_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp --filter="name~^zebrad- AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
 
           for DISK in $ZEBRAD_DISKS
           do

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -47,11 +47,14 @@ jobs:
       - name: Delete old instances
         run: |
           DELETE_BEFORE_DATE=$(date --date="$DELETE_INSTANCE_DAYS days ago" '+%Y%m%d')
-          INSTANCES=$(gcloud compute instances list --sort-by=creationTimestamp --filter="name~-[0-9a-f]{7,}$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          IFS=$'\n'
+
+          INSTANCES=$(gcloud compute instances list --sort-by=creationTimestamp --filter="name~-[0-9a-f]{7,}$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME,ZONE)' | \
+                      sed 's/\(.*\)\t\(.*\)/\1 --zone=\2/')
 
           for INSTANCE in $INSTANCES
           do
-            gcloud compute instances delete --verbosity=info "${INSTANCE}" --delete-disks=all || continue
+            gcloud compute instances delete --verbosity=info ${INSTANCE} --delete-disks=all || continue
           done
 
       # Deletes all the instance templates older than $DELETE_AGE_DAYS days.
@@ -71,9 +74,11 @@ jobs:
       - name: Delete old disks
         run: |
           DELETE_BEFORE_DATE=$(date --date="$DELETE_AGE_DAYS days ago" '+%Y%m%d')
+          IFS=$'\n'
 
           # Disks created by PR jobs, and other jobs that use a commit hash
-          COMMIT_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp --filter="name~-[0-9a-f]{7,}$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          COMMIT_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp --filter="name~-[0-9a-f]{7,}$ AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME,LOCATION,LOCATION_SCOPE)' | \
+                         sed 's/\(.*\)\t\(.*\)\t\(.*\)/\1 --\3=\2/')
 
           for DISK in $COMMIT_DISKS
           do

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -51,7 +51,7 @@ jobs:
 
           for INSTANCE in $INSTANCES
           do
-            gcloud compute instance delete ${INSTANCE} --delete-disks=all || continue
+            gcloud compute instances delete --verbosity=info "${INSTANCE}" --delete-disks=all || continue
           done
 
       # Deletes all the instance templates older than $DELETE_AGE_DAYS days.
@@ -62,7 +62,7 @@ jobs:
 
           for TEMPLATE in $TEMPLATES
           do
-            gcloud compute instance-templates delete ${TEMPLATE} || continue
+            gcloud compute instance-templates delete "${TEMPLATE}" || continue
           done
 
       # Deletes all the disks older than $DELETE_AGE_DAYS days.
@@ -77,7 +77,7 @@ jobs:
 
           for DISK in $COMMIT_DISKS
           do
-            gcloud compute disks delete --verbosity=info ${DISK} || continue
+            gcloud compute disks delete --verbosity=info "${DISK}" || continue
           done
           
           # Disks created by managed instance groups, and other jobs that start with "zebrad-"
@@ -85,7 +85,7 @@ jobs:
 
           for DISK in $ZEBRAD_DISKS
           do
-            gcloud compute disks delete --verbosity=info ${DISK} || continue
+            gcloud compute disks delete --verbosity=info "${DISK}" || continue
           done
 
       # Deletes cache images older than $DELETE_AGE_DAYS days.
@@ -115,7 +115,7 @@ jobs:
               continue
             fi
             
-            gcloud compute images delete ${IMAGE} || continue
+            gcloud compute images delete "${IMAGE}" || continue
           done
 
           ZEBRAD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*net-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
@@ -129,7 +129,7 @@ jobs:
               continue
             fi
             
-            gcloud compute images delete ${IMAGE} || continue
+            gcloud compute images delete "${IMAGE}" || continue
           done
           
           LWD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^lwd-cache-.*net-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
@@ -143,5 +143,5 @@ jobs:
               continue
             fi
             
-            gcloud compute images delete ${IMAGE} || continue
+            gcloud compute images delete "${IMAGE}" || continue
           done

--- a/book/src/dev/continuous-integration.md
+++ b/book/src/dev/continuous-integration.md
@@ -47,16 +47,13 @@ Please shut down large instances when they are not being used.
 ### Automated Deletion
 
 The [Delete GCP Resources](https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/delete-gcp-resources.yml)
-workflow automatically deletes instance templates, disks, and images older than a few days.
+workflow automatically deletes test instances, instance templates, disks, and images older than a few days.
 
-Running instances and their disks are protected from deletion.
-
-If you want to keep instance templates, disks, or images in Google Cloud, name them so they don't match the automated names:
-- deleted instance templates and disks end in a commit hash, so use a name ending in `-` or `-[^0-9a-f]+`
+If you want to keep instances, instance templates, disks, or images in Google Cloud, name them so they don't match the automated names:
+- deleted instance templates and disks end in a commit hash, so use a name that doesn't end in `-[0-9a-f]{7,}`
 - deleted images start with `zebrad-cache` or `lwd-cache`, so use a name starting with anything else
 
-Our other Google Cloud projects don't have automated deletion, so you can also use them for experiments or production deployments.
-
+Our production Google Cloud project doesn't have automated deletion.
 
 ## Troubleshooting
 

--- a/book/src/dev/continuous-integration.md
+++ b/book/src/dev/continuous-integration.md
@@ -50,8 +50,8 @@ The [Delete GCP Resources](https://github.com/ZcashFoundation/zebra/blob/main/.g
 workflow automatically deletes test instances, instance templates, disks, and images older than a few days.
 
 If you want to keep instances, instance templates, disks, or images in Google Cloud, name them so they don't match the automated names:
-- deleted instance templates and disks end in a commit hash, so use a name that doesn't end in `-[0-9a-f]{7,}`
-- deleted images start with `zebrad-cache` or `lwd-cache`, so use a name starting with anything else
+- deleted instances, instance templates and disks end in a commit hash, so use a name that doesn't end in `-[0-9a-f]{7,}`
+- deleted disks and images start with `zebrad-` or `lwd-`, so use a name starting with anything else
 
 Our production Google Cloud project doesn't have automated deletion.
 


### PR DESCRIPTION
## Motivation

Sometimes Google Cloud instances don't get deleted when the test finishes or fails. This can be expensive.

Closes #5187.

### Specifications

https://cloud.google.com/sdk/gcloud/reference/compute/instances/delete

## Solution

- Delete instances and their disks after 3 days
- Make test instance template and disk search more specific - require at least 7 hex characters for the commit tag
- Provide locations for instances and disks
- Fix shell quoting

## Review

This isn't urgent, but we want to merge it to reduce costs.

### Reviewer Checklist

  - [x] CI passes
  - [ ] Manual run deletes what we expect

