### PR TITLE
feat(logs): prints git metadata and platform info when zebrad starts up

### DIFF
--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -400,7 +400,7 @@ impl Application for ZebradApp {
 
         // Log git metadata and platform info when zebrad starts up
         if is_server {
-            tracing::info!("{}", metadata_section);
+            tracing::info!("Diagnostic {}", metadata_section);
         }
 
         // Activate the global span, so it's visible when we load the other

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -286,7 +286,7 @@ impl Application for ZebradApp {
 
         builder = builder
             .theme(theme)
-            .panic_section(metadata_section)
+            .panic_section(metadata_section.clone())
             .issue_url(concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/new"))
             .issue_filter(|kind| match kind {
                 color_eyre::ErrorKind::NonRecoverable(error) => {
@@ -397,6 +397,11 @@ impl Application for ZebradApp {
             tracing_config.flamegraph = None;
         }
         components.push(Box::new(Tracing::new(tracing_config)?));
+
+        // Log git metadata and platform info when zebrad starts up
+        if is_server {
+            tracing::info!("{}", metadata_section);
+        }
 
         // Activate the global span, so it's visible when we load the other
         // components. Space is at a premium here, so we use an empty message,


### PR DESCRIPTION
## Motivation

To make it easier for user to find git metadata and platform info for their bug reports.

Closes #3111

## Solution

Logs the panic metadata at info level when starting a zebrad server 

## Review

Anyone can review this PR

### Reviewer Checklist

  - [x] Logs git and build metadata when running zebrad start or copy-state commands