### PR TITLE
change(ci): Combine high and low Mergify queues into a batched queue

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,8 @@
+# Automatic merging of approved PRs for Zebra
+#
+# This file can be edited and validated using:
+# https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/config-editor
+
 queue_rules:
   - name: urgent
     # Allow to update/rebase the original pull request if possible to check its mergeability,

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,5 +1,5 @@
 queue_rules:
-  - name: hotfix
+  - name: urgent
     # Allow to update/rebase the original pull request if possible to check its mergeability,
     # and it does not create a draft PR if not needed
     allow_inplace_checks: True
@@ -14,28 +14,18 @@ queue_rules:
       # https://docs.mergify.com/conditions/#about-branch-protection
       - base=main
 
-  - name: high
+  - name: batched
     allow_inplace_checks: True
     allow_checks_interruption: True
     speculative_checks: 1
     batch_size: 20
-    # Wait for a few minutes to embark high priority tickets together in a merge train
-    batch_max_wait_time: "10 minutes"
-    conditions:
-      - base=main
-
-  - name: low
-    allow_inplace_checks: True
-    allow_checks_interruption: True
-    speculative_checks: 1
-    batch_size: 20
-    # Wait a bit longer to embark low priority tickets together in a merge train
+    # Wait for about 10% of the time it takes Rust PRs to run CI (3h)
     batch_max_wait_time: "20 minutes"
     conditions:
       - base=main
 
 pull_request_rules:
-  - name: move to hotfix queue when CI passes with 1 review and not WIP targeting main
+  - name: move to urgent queue when CI passes with 1 review and not WIP targeting main
     conditions:
       # This queue handles a PR if:
       # - it targets main
@@ -48,41 +38,24 @@ pull_request_rules:
       - 'label~=^P-Critical'
     actions:
       queue:
-        name: hotfix
+        name: urgent
         method: squash
 
-  - name: move to high queue when CI passes with 1 review and not WIP targeting main
+  - name: move to batched queue when CI passes with 1 review and not WIP targeting main
     conditions:
       # This queue handles a PR if:
       # - it targets main
       # - is not in draft
       # - does not include the do-not-merge label
-      # - is labeled with High or Medium priority
-      - base=main
-      - -draft
-      - label!=do-not-merge
-      - or:
-          - 'label~=^P-High'
-          - 'label~=^P-Medium'
-    actions:
-      queue:
-        name: high
-        method: squash
-
-  - name: move to low queue when CI passes with 1 review and not WIP targeting main
-    conditions:
-      # We don't need to check priority labels here, because the rules are evaluated in order:
-      # https://docs.mergify.com/configuration/#pull-request-rules
-      #
-      # This queue handles a PR if:
-      # - it targets main
-      # - is not in draft
-      # - is labeled with Low or Optional priority, or does not have a priority label,
+      # - is labeled with any other priority except Critical, or does not have a priority label,
       #   including automated dependabot PRs.
+      #
+      # We don't need to check priority labels here, because the rules are evaluated in order:
+      # https://docs.mergify.com/configuration/#pull-request-rules      
       - base=main
       - -draft
       - label!=do-not-merge
     actions:
       queue:
-        name: low
+        name: batched
         method: squash


### PR DESCRIPTION
## Motivation

This PR combines the `high` and `low` queues into a single `batched` queue.
The `urgent` queue remains the same.

This reduces Google Cloud costs.

## Review

This PR is not urgent, but we should merge it soon anyway, to increase CI speed.

We will need to merge this PR manually, Mergify doesn't automatically merge changes to its own configs.

### Reviewer Checklist

  - [ ] CI passes
  - [ ] Config format is correct
