### PR TITLE
change(dev): Add CHANGELOG checks to PR review template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,9 +37,11 @@ If you want a specific reviewer for this PR, tag them here.
 
 ### Reviewer Checklist
 
-  - [ ] Code implements Specs and Designs
-  - [ ] Tests for Expected Behaviour
-  - [ ] Tests for Errors
+  - [ ] Will the PR name make sense to users?
+    - [ ] Does it need a CHANGELOG intro? (new features, breaking changes, large changes)
+  - [ ] Are the PR labels correct?
+  - [ ] Does the code do what the ticket and PR says?
+  - [ ] How do you know it works? Does it have tests?
 
 ## Follow Up Work
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,7 +38,7 @@ If you want a specific reviewer for this PR, tag them here.
 ### Reviewer Checklist
 
   - [ ] Will the PR name make sense to users?
-    - [ ] Does it need a CHANGELOG intro? (new features, breaking changes, large changes)
+    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
   - [ ] Are the PR labels correct?
   - [ ] Does the code do what the ticket and PR says?
   - [ ] How do you know it works? Does it have tests?


### PR DESCRIPTION
## Motivation

We want to check CHANGELOG entries as part of PR reviews.

## Solution

- Check PR name that is used for release drafter entries
- Check labels that will be used for release drafter categories
- Check extra info in CHANGELOG for breaking changes, new features, large changes

## Review

This is urgent because we want to check these things in new PRs, so making releases is easier.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need a CHANGELOG intro? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
