### PR TITLE
change(zebrad): opens the database in a blocking tokio thread, which allows tokio to run other tasks 

### DIFF
--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -34,7 +34,7 @@ pub use request::{FinalizedBlock, HashOrHeight, PreparedBlock, ReadRequest, Requ
 pub use response::{ReadResponse, Response};
 pub use service::{
     chain_tip::{ChainTipChange, LatestChainTip, TipAction},
-    init, OutputIndex, OutputLocation, TransactionLocation,
+    init, spawn_init, OutputIndex, OutputLocation, TransactionLocation,
 };
 
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1293,7 +1293,6 @@ pub fn init(
 }
 
 /// Calls [`init`] with the provided [`Config`] and [`Network`] from a blocking task.
-/// 
 /// Returns a [`tokio::task::JoinHandle`] with a boxed state service,
 /// a read state service, and receivers for state chain tip updates.
 pub fn spawn_init(

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1292,6 +1292,22 @@ pub fn init(
     )
 }
 
+/// Calls [`init`] with the provided [`Config`] and [`Network`] from a blocking task.
+/// 
+/// Returns a [`tokio::task::JoinHandle`] with a boxed state service,
+/// a read state service, and receivers for state chain tip updates.
+pub fn spawn_init(
+    config: Config,
+    network: Network,
+) -> tokio::task::JoinHandle<(
+    BoxService<Request, Response, BoxError>,
+    ReadStateService,
+    LatestChainTip,
+    ChainTipChange,
+)> {
+    tokio::task::spawn_blocking(move || init(config, network))
+}
+
 /// Returns a [`StateService`] with an ephemeral [`Config`] and a buffer with a single slot.
 ///
 /// This can be used to create a state service for testing.

--- a/zebrad/src/commands/copy_state.rs
+++ b/zebrad/src/commands/copy_state.rs
@@ -117,7 +117,7 @@ impl CopyStateCmd {
             _source_read_only_state_service,
             _source_latest_chain_tip,
             _source_chain_tip_change,
-        ) = old_zs::init(source_config.clone(), network);
+        ) = old_zs::spawn_init(source_config.clone(), network).await?;
 
         let elapsed = source_start_time.elapsed();
         info!(?elapsed, "finished initializing source state service");
@@ -136,7 +136,7 @@ impl CopyStateCmd {
             _target_read_only_state_service,
             _target_latest_chain_tip,
             _target_chain_tip_change,
-        ) = new_zs::init(target_config.clone(), network);
+        ) = new_zs::spawn_init(target_config.clone(), network).await?;
 
         let elapsed = target_start_time.elapsed();
         info!(?elapsed, "finished initializing target state service");

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -103,8 +103,11 @@ impl StartCmd {
         info!(?config);
 
         info!("initializing node state");
+        info!("opening database, this may take a couple minutes");
+
         let (state_service, read_only_state_service, latest_chain_tip, chain_tip_change) =
-            zebra_state::init(config.state.clone(), config.network.network);
+            zebra_state::spawn_init(config.state.clone(), config.network.network).await?;
+
         let state = ServiceBuilder::new()
             .buffer(Self::state_buffer_bound())
             .service(state_service);


### PR DESCRIPTION
## Motivation

To allow tokio to run other tasks while the database is opening and to tell users that it may take a couple minutes

Closes #4821.

## Solution

- Move the initialization of zebra-state and the database to a blocking thread
- Log an info-level message before starting to open the database

## Review

This PR is part of regular scheduled work.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?

## Follow Up Work

- Do the first read in a blocking tokio thread. (Some RocksDB documentation warns that that can also be slow)
