### PR TITLE
Revert "build(deps): bump codecov/codecov-action from 3.1.0 to 3.1.1"

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -109,4 +109,4 @@ jobs:
         run: cargo llvm-cov --lcov --no-run --output-path lcov.info
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v3.1.0


### PR DESCRIPTION
## Motivation

After we merged this change, coverage builds started hanging during the download of the Zcash parameters.

We should try reverting it, and clearing the GitHub Actions caches. (The hang only seems to happen on the second run.)

## Solution

Reverts ZcashFoundation/zebra#5205