### PR TITLE
fix(ci): Build zebrad with Rust 1.63 to avoid Zcash parameter download hangs

### DIFF
--- a/.github/workflows/continous-integration-os.patch.yml
+++ b/.github/workflows/continous-integration-os.patch.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
         os: [ubuntu-latest, macos-latest]
-        rust: [stable, beta]
+        rust: [1.63, beta]
         exclude:
           - os: macos-latest
             rust: beta

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -64,7 +64,8 @@ jobs:
       matrix:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
         os: [ubuntu-latest, macos-latest]
-        rust: [stable, beta]
+        # Rust 1.64 hangs when downloading the Zcash Parameters on GitHub Actions runners
+        rust: [1.63, beta]
         exclude:
         # TODO: re-enable beta Rust tests on ubuntu (#4929)
           - os: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,7 +61,8 @@ jobs:
 
       - uses: actions-rs/toolchain@v1.0.7
         with:
-          toolchain: stable
+          # Rust 1.64 hangs when downloading the Zcash Parameters on GitHub Actions runners
+          toolchain: 1.63
           override: true
           profile: minimal
           components: llvm-tools-preview

--- a/book/src/user/supported-platforms.md
+++ b/book/src/user/supported-platforms.md
@@ -17,6 +17,15 @@ For the full requirements, see [Tier 1 platform policy](platform-tier-policy.md#
 
 | platform | os | notes | rust | artifacts
 | -------|-------|-------|-------|-------
+| `x86_64-unknown-linux-gnu` | [Debian 11](https://www.debian.org/releases/bullseye/) | 64-bit | [1.63](https://github.com/rust-lang/rust/releases) | Docker
+
+### Temporarily Unsupported
+
+Zcash parameter downloads currently [hang when built with Rust 1.64 and later](https://github.com/ZcashFoundation/zebra/issues/5091).
+Those Rust versions are unsupported until that bug is fixed.
+
+| platform | os | notes | rust | artifacts
+| -------|-------|-------|-------|-------
 | `x86_64-unknown-linux-gnu` | [Debian 11](https://www.debian.org/releases/bullseye/) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | Docker
 
 ## Tier 2

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@
 # - runtime: is our runtime environment
 #
 # This stage implements cargo-chef for docker layer caching
-FROM rust:bullseye as chef
+FROM rust:1.63-bullseye as chef
 RUN cargo install cargo-chef --locked
 WORKDIR /opt/zebrad
 

--- a/docker/zcash-params/Dockerfile
+++ b/docker/zcash-params/Dockerfile
@@ -1,6 +1,6 @@
 # This steps implement cargo-chef for docker layer caching
 # This image is for caching Zcash Sprout and Sapling parameters
-FROM rust:bullseye as chef
+FROM rust:1.63-bullseye as chef
 RUN cargo install cargo-chef --locked
 WORKDIR /opt/zebrad
 


### PR DESCRIPTION
## Motivation

Zcash parameter downloads hang when built with Rust 1.64.

## Solution

- Use Rust 1.63 instead of Rust stable in the zebrad GitHub Actions workflows and Dockerfiles
- Change the branch protection rules to require 1.63 instead of stable

## Review

This is urgent because it blocks merging everything else.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [x] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?

