### PR TITLE
change(ci): Run Zcash parameter downloads with trace logging

### DIFF
--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -158,6 +158,9 @@ jobs:
       - name: Fetch Zcash parameters
         if: steps.cache-params.outputs.cache-hit != 'true'
         working-directory: ./zebra-consensus
+        # Temporarily run with trace logging, until the hangs in #5091 are fixed
+        env:
+          RUST_LOG: trace
         run: cargo run --example download-params
 
       - name: Run tests

--- a/docker/zcash-params/Dockerfile
+++ b/docker/zcash-params/Dockerfile
@@ -25,6 +25,10 @@ ENV CARGO_HOME /opt/zebrad/.cargo/
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook --release --features sentry --package zebrad --recipe-path recipe.json
 
+# Temporarily run with trace logging, until the hangs in #5091 are fixed
+ARG RUST_LOG
+ENV RUST_LOG ${RUST_LOG:-trace}
+
 ARG RUST_BACKTRACE=0
 ENV RUST_BACKTRACE ${RUST_BACKTRACE}
 


### PR DESCRIPTION
## Motivation

We don't know why Zcash parameter downloads are failing, so we need to log more diagnostic info.

Diagnostics for #5091.

## Solution

- Run GitHub Runner Zcash parameter downloads with trace logging
- Run Docker Zcash parameter downloads with trace logging
  - We might need to use `--no-default-features` or run `cargo run --example download-params` to make this work

## Review

This is important but not critical.

### Before Approving the PR

Does trace logging actually work in GitHub Runners and Docker?

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Look at the diagnostics to help fix the bug.