### PR TITLE
fix(ci): Revert "bump tj-actions/changed-files from 29.0.7 to 31.0.1" to fix workflow configuration errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Rust files
         id: changed-files-rust
-        uses: tj-actions/changed-files@v31.0.1
+        uses: tj-actions/changed-files@v29.0.7
         with:
           files: |
             **/*.rs
@@ -51,7 +51,7 @@ jobs:
 
       - name: Workflow files
         id: changed-files-workflows
-        uses: tj-actions/changed-files@v31.0.1
+        uses: tj-actions/changed-files@v29.0.7
         with:
           files: |
             .github/workflows/*.yml


### PR DESCRIPTION
## Motivation

This version bump causes errors like:
>  Error: Unable to locate the previous sha: ec115e930fe600c6e9c76143bfbb3089ab852b23
>  Error: You seem to be missing 'fetch-depth: 0' or 'fetch-depth: 2'. See https://github.com/tj-actions/changed-files#usage
>  Error: Process completed with exit code 1.

https://github.com/ZcashFoundation/zebra/actions/runs/3132588752/jobs/5085079053#step:3:93

## Solution

Reverts ZcashFoundation/zebra#5254

## Related Changes

Fix the error and re-update in #5265