### PR TITLE
fix(release): Fix the config for `release-drafter`

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -126,8 +126,9 @@ categories:
 # and minor versions for less significant breaking changes.
 version-resolver:
   major:
+    # We increment the major release version manually
     labels:
-      # We increment the major release version manually
+      - ""
   minor:
     labels:
       - 'C-feature'


### PR DESCRIPTION
## Motivation

PR #5203 introduced an erroneous config for https://github.com/marketplace/actions/release-drafter. The error is reported in this output https://github.com/ZcashFoundation/zebra/actions/runs/3135690088/jobs/5091669854. It seems to be related to `version-resolver.major.labels`.

## Solution

This PR specifies the value for the key `labels` in `version-resolver.major` to be a list with the empty string.

## Review

The reason why this bug went to `main` in the first place is that there's probably no way to test the config before merging it to `main`. I think the same applies to this fix. I assume we'll see if it works after we merge it.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR say?
