### PR TITLE
fix(ci): Comment out empty major version list in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -125,10 +125,11 @@ categories:
 # In Zebra, we use major versions for mainnet network upgrades,
 # and minor versions for less significant breaking changes.
 version-resolver:
-  major:
-    # We increment the major release version manually
-    labels:
-      - ""
+  # We increment the major release version manually
+  #major:
+  #  labels:
+  #labels can not be an empty list, or empty strings
+  #    - # network upgrade release PRs
   minor:
     labels:
       - 'C-feature'


### PR DESCRIPTION
## Motivation

The release drafter config has a syntax issue.