### PR TITLE
fix(build): Prefer the PR cache for docker images

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -140,11 +140,13 @@ jobs:
           # to be used as the caching layer, using the `max` caching mode.
           #
           # We use multiple cache sources to confirm a cache hit, starting from a per-branch cache,
-          # and if there's no hit, then continue with the `main` branch. Changes within a PR are usually
-          # small, so this provides the best performance.
+          # and if there's no hit, then continue with the `main` branch. When changes are added to a PR,
+          # they are usually smaller than the diff between the PR and `main` branch. So this provides the
+          # best performance.
           #
-          # The last cache in the list is tried first.
+          # The caches are tried in top-down order, the first available cache is used:
+          # https://github.com/moby/moby/pull/26839#issuecomment-277383550
           cache-from: |
-            type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:main-cache
             type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache
+            type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:main-cache
           cache-to: type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache,mode=max


### PR DESCRIPTION
## Motivation

The PR cache is likely to be newer and have a smaller diff than `main`.

## Review

@gustavovalverde found out how this works.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

