### PR TITLE
fix(clippy): Allow a clippy::bool_to_int_with_if

### DIFF
--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -102,6 +102,7 @@ fn rpc_server_spawn_unallocated_port(parallel_cpu_threads: bool) {
     let port = zebra_test::net::random_unallocated_port();
     let config = Config {
         listen_addr: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port).into()),
+        #[allow(unknown-lints)]
         #[allow(clippy::bool_to_int_with_if)]
         parallel_cpu_threads: if parallel_cpu_threads { 0 } else { 1 },
         debug_force_finished_sync: false,

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -102,7 +102,7 @@ fn rpc_server_spawn_unallocated_port(parallel_cpu_threads: bool) {
     let port = zebra_test::net::random_unallocated_port();
     let config = Config {
         listen_addr: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port).into()),
-        #[allow(unknown-lints)]
+        #[allow(unknown_lints)]
         #[allow(clippy::bool_to_int_with_if)]
         parallel_cpu_threads: if parallel_cpu_threads { 0 } else { 1 },
         debug_force_finished_sync: false,

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -102,6 +102,7 @@ fn rpc_server_spawn_unallocated_port(parallel_cpu_threads: bool) {
     let port = zebra_test::net::random_unallocated_port();
     let config = Config {
         listen_addr: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port).into()),
+        #[allow(clippy::bool_to_int_with_if)]
         parallel_cpu_threads: if parallel_cpu_threads { 0 } else { 1 },
         debug_force_finished_sync: false,
     };


### PR DESCRIPTION
## Motivation

We fix clippy warnings on nightly, so they don't cause CI failures when they reach stable.