### PR TITLE
1. fix(rpc): Fix slow getblock RPC (verbose=1) using transaction ID index

### DIFF
--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -597,6 +597,18 @@ pub enum ReadRequest {
     /// * [`ReadResponse::Transaction(None)`](ReadResponse::Transaction) otherwise.
     Transaction(transaction::Hash),
 
+    /// Looks up the transaction IDs for a block, using a block hash or height.
+    ///
+    /// Returns
+    ///
+    /// * An ordered list of transaction hashes, or
+    /// * `None` if the block was not found.
+    ///
+    /// Note: Each block has at least one transaction: the coinbase transaction.
+    ///
+    /// Returned txids are in the order they appear in the block.
+    TransactionIdsForBlock(HashOrHeight),
+
     /// Looks up a UTXO identified by the given [`OutPoint`](transparent::OutPoint),
     /// returning `None` immediately if it is unknown.
     ///
@@ -728,6 +740,7 @@ impl ReadRequest {
             ReadRequest::Depth(_) => "depth",
             ReadRequest::Block(_) => "block",
             ReadRequest::Transaction(_) => "transaction",
+            ReadRequest::TransactionIdsForBlock(_) => "transaction_ids_for_block",
             ReadRequest::BestChainUtxo { .. } => "best_chain_utxo",
             ReadRequest::AnyChainUtxo { .. } => "any_chain_utxo",
             ReadRequest::BlockLocator => "block_locator",

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -67,6 +67,11 @@ pub enum ReadResponse {
     /// Response to [`ReadRequest::Transaction`] with the specified transaction.
     Transaction(Option<(Arc<Transaction>, block::Height)>),
 
+    /// Response to [`ReadRequest::TransactionIdsForBlock`],
+    /// with an list of transaction hashes in block order,
+    /// or `None` if the block was not found.
+    TransactionIdsForBlock(Option<Arc<[transaction::Hash]>>),
+
     /// Response to [`ReadRequest::BlockLocator`] with a block locator object.
     BlockLocator(Vec<block::Hash>),
 
@@ -130,7 +135,8 @@ impl TryFrom<ReadResponse> for Response {
             ReadResponse::BlockHashes(hashes) => Ok(Response::BlockHashes(hashes)),
             ReadResponse::BlockHeaders(headers) => Ok(Response::BlockHeaders(headers)),
 
-            ReadResponse::BestChainUtxo(_)
+            ReadResponse::TransactionIdsForBlock(_)
+            | ReadResponse::BestChainUtxo(_)
             | ReadResponse::SaplingTree(_)
             | ReadResponse::OrchardTree(_)
             | ReadResponse::AddressBalance(_)

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1173,7 +1173,7 @@ impl Service<ReadRequest> for ReadStateService {
                 .boxed()
             }
 
-            // Used by get_block RPC and the StateService.
+            // Used by the get_block (raw) RPC and the StateService.
             ReadRequest::Block(hash_or_height) => {
                 let timer = CodeTimer::start();
 
@@ -1224,6 +1224,39 @@ impl Service<ReadRequest> for ReadStateService {
                     })
                 })
                 .map(|join_result| join_result.expect("panic in ReadRequest::Transaction"))
+                .boxed()
+            }
+
+            // Used by the getblock (verbose) RPC.
+            ReadRequest::TransactionIdsForBlock(hash_or_height) => {
+                let timer = CodeTimer::start();
+
+                let state = self.clone();
+
+                let span = Span::current();
+                tokio::task::spawn_blocking(move || {
+                    span.in_scope(move || {
+                        let transaction_ids = state.non_finalized_state_receiver.with_watch_data(
+                            |non_finalized_state| {
+                                read::transaction_hashes_for_block(
+                                    non_finalized_state.best_chain(),
+                                    &state.db,
+                                    hash_or_height,
+                                )
+                            },
+                        );
+
+                        // The work is done in the future.
+                        timer.finish(
+                            module_path!(),
+                            line!(),
+                            "ReadRequest::TransactionIdsForBlock",
+                        );
+
+                        Ok(ReadResponse::TransactionIdsForBlock(transaction_ids))
+                    })
+                })
+                .map(|join_result| join_result.expect("panic in ReadRequest::Block"))
                 .boxed()
             }
 

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -226,6 +226,39 @@ impl ZebraDb {
             .map(|tx| (tx, transaction_location.height))
     }
 
+    /// Returns the [`transaction::Hash`]es in the block with `hash_or_height`,
+    /// if it exists in this chain.
+    ///
+    /// Hashes are returned in block order.
+    ///
+    /// Returns `None` if the block is not found.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn transaction_hashes_for_block(
+        &self,
+        hash_or_height: HashOrHeight,
+    ) -> Option<Arc<[transaction::Hash]>> {
+        // Block
+        let height = hash_or_height.height_or_else(|hash| self.height(hash))?;
+
+        // Transaction hashes
+        let hash_by_tx_loc = self.db.cf_handle("hash_by_tx_loc").unwrap();
+
+        // Manually fetch the entire block's transaction hashes
+        let mut transaction_hashes = Vec::new();
+
+        for tx_index in 0..=Transaction::max_allocation() {
+            let tx_loc = TransactionLocation::from_u64(height, tx_index);
+
+            if let Some(tx_hash) = self.db.zs_get(&hash_by_tx_loc, &tx_loc) {
+                transaction_hashes.push(tx_hash);
+            } else {
+                break;
+            }
+        }
+
+        Some(transaction_hashes.into())
+    }
+
     // Write block methods
 
     /// Write `finalized` to the finalized state.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -471,6 +471,21 @@ impl Chain {
             .get(tx_loc.index.as_usize())
     }
 
+    /// Returns the [`transaction::Hash`]es in the block with `hash_or_height`,
+    /// if it exists in this chain.
+    ///
+    /// Hashes are returned in block order.
+    ///
+    /// Returns `None` if the block is not found.
+    pub fn transaction_hashes_for_block(
+        &self,
+        hash_or_height: HashOrHeight,
+    ) -> Option<Arc<[transaction::Hash]>> {
+        let transaction_hashes = self.block(hash_or_height)?.transaction_hashes.clone();
+
+        Some(transaction_hashes)
+    }
+
     /// Returns the [`block::Hash`] for `height`, if it exists in this chain.
     pub fn hash_by_height(&self, height: Height) -> Option<block::Hash> {
         let hash = self.blocks.get(&height)?.hash;

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -27,7 +27,7 @@ pub use address::{
     tx_id::transparent_tx_ids,
     utxo::{address_utxos, AddressUtxos, ADDRESS_HEIGHTS_FULL_RANGE},
 };
-pub use block::{any_utxo, block, block_header, transaction, utxo};
+pub use block::{any_utxo, block, block_header, transaction, transaction_hashes_for_block, utxo};
 pub use find::{
     block_locator, chain_contains_hash, depth, find_chain_hashes, find_chain_headers,
     hash_by_height, height_by_hash, tip, tip_height,

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -89,10 +89,12 @@ echo "$@"
 echo
 
 echo "Querying $ZEBRAD $ZEBRAD_NET chain at height >=$ZEBRAD_HEIGHT..."
-$ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" "$@" > "$ZEBRAD_RESPONSE"
+time $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" "$@" > "$ZEBRAD_RESPONSE"
+echo
 
 echo "Querying $ZCASHD $ZCASHD_NET chain at height >=$ZCASHD_HEIGHT..."
-$ZCASH_CLI "$@" > "$ZCASHD_RESPONSE"
+time $ZCASH_CLI "$@" > "$ZCASHD_RESPONSE"
+echo
 
 echo
 


### PR DESCRIPTION
## Motivation

Zebra's `lightwalletd` sync takes a lot longer than `zcashd`'s (7h vs 5h).

Fixes #5298.

## Solution

Use the transaction ID index for verbose `getblock` RPC requests, rather than deserializing the entire block, then hashing all the transactions in the block.

Also add timing output to `zcash-rpc-diff`.

## Review

This is a routine fix.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [x] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?

