### PR TITLE
fix(deps): Update yanked versions of cpufeatures (orchard/aes), ed25519 (tor), and quick-xml (flamegraph)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,9 +985,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -1452,9 +1452,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.4.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed12bbf7b5312f8da1c2722bc06d8c6b12c2d86a7fb35a194c7f3e6fc2bbe39"
+checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
  "signature",
 ]
@@ -3672,9 +3672,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9279fbdacaad3baf559d8cabe0acc3d06e30ea14931af31af79578ac0946decc"
+checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
## Motivation

Some of Zebra's transitive dependencies have been yanked (unpublished on crates.io).

The latest versions fix a miscompile that causes crashes in cryptographic code, and other bugs.

This fixes compilation warnings like:
> Warning: warning: package `ed25519 v1.4.0` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked

https://github.com/ZcashFoundation/zebra/actions/runs/3150408776/jobs/5123159992#step:4:18

https://github.com/ZcashFoundation/zebra/actions/runs/3170245187

## Solution

Use `cargo update -p <crate-name>` to update each of these dependencies to the latest version in `Cargo.lock`.

(We don't depend on them directly, so we can't update `Cargo.toml` to fix them.)

## Review

This is a high priority because it might be a cause of #5091.

(These dependencies are not used by the download code, but they are in the same crate. So it's unlikely but possible.)

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

