### PR TITLE
fix(ci): Reduce false positives for the `C-trivial` label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -55,7 +55,6 @@ autolabeler:
       - 'CHANGELOG.md'
       - 'zebra-consensus/src/checkpoint/*-checkpoints.txt'
       # Developer-only changes
-      - 'only zebra-utils'
       - '.gitignore'
       # Test-only changes
       - 'zebra-test'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -55,7 +55,7 @@ autolabeler:
       - 'CHANGELOG.md'
       - 'zebra-consensus/src/checkpoint/*-checkpoints.txt'
       # Developer-only changes
-      - 'zebra-utils'
+      - 'only zebra-utils'
       - '.gitignore'
       # Test-only changes
       - 'zebra-test'


### PR DESCRIPTION
## Motivation

`release-drafter` erroneously labeled PR #5164 as `C-trivial`. It did so because the PR edited the file `zcash-rpc-diff` in `zebra-utils`.

## Solution

This PR deletes `zebra-utils` from the confing file for `release-drafter`.

## Review

We can't test this PR until we merge it to `main`.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?