### PR TITLE
fix(test): Allow more time between thread CPU slices in db_init_outside_future_executor

### DIFF
--- a/zebra-test/src/mock_service.rs
+++ b/zebra-test/src/mock_service.rs
@@ -76,7 +76,7 @@ const DEFAULT_PROXY_CHANNEL_SIZE: usize = 100;
 ///
 /// Note that if a test checks that no requests are received, each check has to wait for this
 /// amount of time, so this may affect the test execution time.
-const DEFAULT_MAX_REQUEST_DELAY: Duration = Duration::from_millis(25);
+pub const DEFAULT_MAX_REQUEST_DELAY: Duration = Duration::from_millis(25);
 
 /// An internal type representing the item that's sent in the [`broadcast`] channel.
 ///

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -113,7 +113,12 @@
 //! export TMPDIR=/path/to/disk/directory
 //! ```
 
-use std::{collections::HashSet, env, fs, panic, path::PathBuf, time::Duration};
+use std::{
+    collections::HashSet,
+    env, fs, panic,
+    path::PathBuf,
+    time::{Duration, Instant},
+};
 
 use color_eyre::{
     eyre::{eyre, Result, WrapErr},
@@ -151,6 +156,13 @@ use common::{
         TINY_CHECKPOINT_TEST_HEIGHT, TINY_CHECKPOINT_TIMEOUT,
     },
 };
+
+/// The maximum amount of time that we allow the creation of a future to block the `tokio` executor.
+///
+/// This should be larger than the amount of time between thread time slices on a busy test VM.
+///
+/// This limit only applies to some tests.
+pub const MAX_ASYNC_BLOCKING_TIME: Duration = zebra_test::mock_service::DEFAULT_MAX_REQUEST_DELAY;
 
 #[test]
 fn generate_no_args() -> Result<()> {
@@ -315,8 +327,6 @@ fn start_args() -> Result<()> {
 
 #[tokio::test]
 async fn db_init_outside_future_executor() -> Result<()> {
-    use std::time::{Duration, Instant};
-
     let _init_guard = zebra_test::init();
     let config = default_test_config()?;
 
@@ -328,7 +338,7 @@ async fn db_init_outside_future_executor() -> Result<()> {
     // will wait indefinitely for blocking operation to finish once started
     let block_duration = start.elapsed();
     assert!(
-        block_duration < Duration::from_millis(5),
+        block_duration <= MAX_ASYNC_BLOCKING_TIME,
         "futures executor was blocked longer than expected ({:?})",
         block_duration,
     );


### PR DESCRIPTION
## Motivation

The `db_init_outside_future_executor` test is failing because its timeout is too short.

Closes #5295.

## Review

@arya2 wrote the original test.

This seems like a high priority because it is causing CI failures.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?
