### PR TITLE
fix(docker): Add edge tag to Docker images, document when latest tag will appear

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -88,7 +88,7 @@ jobs:
             type=sha
             # edge is the latest commit on the default branch.
             # We only have edge builds for `us-docker.pkg.dev`, because DockerHub doesn't keep up with every `main` branch commit.
-            type=edge,enable=${{ !env.USE_DOCKERHUB && is_default_branch }}
+            type=edge,enable=${{ !env.USE_DOCKERHUB && {{is_default_branch}} }}
 
       # Setup Docker Buildx to allow use of docker cache layers from GH
       - name: Set up Docker Buildx

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -78,17 +78,14 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
+            # semver and ref,tag automatically add a "latest" tag, but only on stable releases
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=ref,event=tag
             type=ref,event=branch
             type=ref,event=pr
-            type=ref,event=tag
             type=sha
-            # set latest and edge tags for the default branch.
-            # latest is the most recently published image on the main branch.
-            # It is the default tag that Docker fetches.
-            type=raw,value=latest,enable={{is_default_branch}}
             # edge is the latest commit on the default branch.
             # We only have edge builds for `us-docker.pkg.dev`, because DockerHub doesn't keep up with every `main` branch commit.
             type=edge,enable=${{ !env.USE_DOCKERHUB && is_default_branch }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -42,6 +42,9 @@ on:
         description: 'The image digest to be used on a caller workflow'
         value: ${{ jobs.build.outputs.image_digest }}
 
+env:
+  USE_DOCKERHUB: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
+
 jobs:
   build:
     name: Build images
@@ -71,7 +74,7 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}
-            zfnd/zebra,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            zfnd/zebra,enable=${{ env.USE_DOCKERHUB }}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
@@ -80,7 +83,15 @@ jobs:
             type=semver,pattern={{major}}
             type=ref,event=branch
             type=ref,event=pr
+            type=ref,event=tag
             type=sha
+            # set latest and edge tags for the default branch.
+            # latest is the most recently published image on the main branch.
+            # It is the default tag that Docker fetches.
+            type=raw,value=latest,enable={{is_default_branch}}
+            # edge is the latest commit on the default branch.
+            # We only have edge builds for `us-docker.pkg.dev`, because DockerHub doesn't keep up with every `main` branch commit.
+            type=edge,enable=${{ !env.USE_DOCKERHUB && is_default_branch }}
 
       # Setup Docker Buildx to allow use of docker cache layers from GH
       - name: Set up Docker Buildx
@@ -110,7 +121,7 @@ jobs:
       - name: Login to DockerHub
         # We only publish images to DockerHub if a release is not a pre-release
         # Ref: https://github.com/orgs/community/discussions/26281#discussioncomment-3251177
-        if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
+        if: ${{ env.USE_DOCKERHUB }}
         uses: docker/login-action@v2.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -88,7 +88,7 @@ jobs:
             type=sha
             # edge is the latest commit on the default branch.
             # We only have edge builds for `us-docker.pkg.dev`, because DockerHub doesn't keep up with every `main` branch commit.
-            type=edge,enable=${{ !env.USE_DOCKERHUB && {{is_default_branch}} }}
+            type=edge,enable=${{ !env.USE_DOCKERHUB }} && {{is_default_branch}}
 
       # Setup Docker Buildx to allow use of docker cache layers from GH
       - name: Set up Docker Buildx

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -88,7 +88,7 @@ jobs:
             type=sha
             # edge is the latest commit on the default branch.
             # We only have edge builds for `us-docker.pkg.dev`, because DockerHub doesn't keep up with every `main` branch commit.
-            type=edge,enable=${{ !env.USE_DOCKERHUB }} && {{is_default_branch}}
+            type=edge,enable=${{ !env.USE_DOCKERHUB }},enable={{is_default_branch}}
 
       # Setup Docker Buildx to allow use of docker cache layers from GH
       - name: Set up Docker Buildx

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -42,9 +42,6 @@ on:
         description: 'The image digest to be used on a caller workflow'
         value: ${{ jobs.build.outputs.image_digest }}
 
-env:
-  USE_DOCKERHUB: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
-
 jobs:
   build:
     name: Build images
@@ -74,7 +71,7 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}
-            zfnd/zebra,enable=${{ env.USE_DOCKERHUB }}
+            zfnd/zebra,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
@@ -87,8 +84,8 @@ jobs:
             type=ref,event=pr
             type=sha
             # edge is the latest commit on the default branch.
-            # We only have edge builds for `us-docker.pkg.dev`, because DockerHub doesn't keep up with every `main` branch commit.
-            type=edge,enable=${{ !env.USE_DOCKERHUB }},enable={{is_default_branch}}
+            # TODO: We only want edge builds for `us-docker.pkg.dev`, because DockerHub doesn't keep up with every `main` branch commit.
+            type=edge,enable={{is_default_branch}}
 
       # Setup Docker Buildx to allow use of docker cache layers from GH
       - name: Set up Docker Buildx
@@ -118,7 +115,7 @@ jobs:
       - name: Login to DockerHub
         # We only publish images to DockerHub if a release is not a pre-release
         # Ref: https://github.com/orgs/community/discussions/26281#discussioncomment-3251177
-        if: ${{ env.USE_DOCKERHUB }}
+        if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
         uses: docker/login-action@v2.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Motivation

`latest` is the default Docker tag, but it's missing from published Zebra images:
https://hub.docker.com/r/zfnd/zebra/tags

This makes typical Docker commands fail:
```sh
$ docker run zfnd/zebra
Unable to find image 'zfnd/zebra:latest' locally
docker: Error response from daemon: manifest for zfnd/zebra:latest not found: manifest unknown: manifest unknown.
See 'docker run --help'.
```

### Specifications

https://github.com/docker/metadata-action#latest-tag

## Solution

- Add `edge` tag to published Docker images
- Document when latest tag will appear

## Review

Anyone can review this PR.

It is only a release blocker if we want users to be able to easily use Docker images.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

