### PR TITLE
fix(docker): Make default command work in docker images, disable optional listener ports

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -148,27 +148,35 @@ ENV ZEBRA_CONF_FILE ${ZEBRA_CONF_FILE}
 
 # Build the `zebrad.toml` before starting the container, using the arguments from build
 # time, or using the default values set just above. And create the conf path and file if
-# it does not exist
+# it does not exist.
 #
-# TODO: move this file creation to an entrypoint as we can use default values at runtime,
-# and modify those as needed when starting the container (at runtime and not at build time)
+# It is safe to use multiple RPC threads in Docker, because we know we are the only running
+# `zebrad` or `zcashd` process in the container.
+#
+# TODO:
+#  - move this file creation to an entrypoint as we can use default values at runtime,
+#    and modify those as needed when starting the container (at runtime and not at build time)
+#  - make `cache_dir`, `rpc.listen_addr`, `metrics.endpoint_addr`, and `tracing.endpoint_addr` into Docker arguments
 RUN mkdir -p ${ZEBRA_CONF_PATH} \
     && touch ${ZEBRA_CONF_PATH}/${ZEBRA_CONF_FILE}
 RUN set -ex; \
   { \
-    echo "[consensus]"; \
-    echo "checkpoint_sync = ${CHECKPOINT_SYNC}"; \
-    echo "[metrics]"; \
-    echo "endpoint_addr = '0.0.0.0:9999'"; \
     echo "[network]"; \
     echo "network = '${NETWORK}'"; \
+    echo "[consensus]"; \
+    echo "checkpoint_sync = ${CHECKPOINT_SYNC}"; \
     echo "[state]"; \
     echo "cache_dir = '/zebrad-cache'"; \
+    echo "[rpc]"; \
+    echo "listen_addr = None"; \
+    echo "parallel_cpu_threads = 0"; \
+    echo "[metrics]"; \
+    echo "endpoint_addr = None"; \
     echo "[tracing]"; \
-    echo "endpoint_addr = '0.0.0.0:3000'"; \
+    echo "endpoint_addr = None"; \
   } > "${ZEBRA_CONF_PATH}/${ZEBRA_CONF_FILE}"
 
-EXPOSE 3000 8233 18233
+EXPOSE 8233 18233
 
 ARG SHORT_SHA
 ENV SHORT_SHA $SHORT_SHA

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -109,8 +109,8 @@ COPY ./docker/entrypoint.sh /
 RUN chmod u+x /entrypoint.sh
 
 # By default, runs the entrypoint tests specified by the environmental variables (if any are set)
-ENTRYPOINT ["/entrypoint.sh"]
-CMD [ "cargo"]
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "cargo" ]
 
 # In this stage we build a release (generate the zebrad binary)
 #
@@ -185,4 +185,4 @@ ARG SENTRY_DSN
 ENV SENTRY_DSN ${SENTRY_DSN}
 
 # TODO: remove the specified config file location and use the default expected by zebrad
-CMD [ "zebrad", "-c", "${ZEBRA_CONF_PATH}/${ZEBRA_CONF_FILE}", "start" ]
+CMD zebrad -c "${ZEBRA_CONF_PATH}/${ZEBRA_CONF_FILE}" start


### PR DESCRIPTION
## Motivation

1. The default Zebra docker command fails because the path variables are not substituted
2. The Zebra docker image opens world-readable metrics and logging ports by default, this is insecure

### Specifications

The variable substitution is undocumented:
https://docs.docker.com/engine/reference/run/#cmd-default-command-or-options

But there is some advice here:
https://stackoverflow.com/questions/39989045/dockerfile-cmd-not-accepting-variables-for-substitution/39989087#39989087

## Solution

- Use raw strings rather than a JSON array
- Disable optional ports

## Review

This is important because it is a security issue in a released Docker image.

We need to manually test the image created by this PR before merging:
```sh
docker run us-docker.pkg.dev/zealous-zebra/zebra:{commit-hash}
```

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

