### PR TITLE
fix(docker): Use correct TOML syntax in Docker zebrad.toml

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -150,6 +150,9 @@ ENV ZEBRA_CONF_FILE ${ZEBRA_CONF_FILE}
 # time, or using the default values set just above. And create the conf path and file if
 # it does not exist.
 #
+# We disable most ports by default, so the default config is secure.
+# Users have to opt-in to additional functionality by editing `zebrad.toml`.
+#
 # It is safe to use multiple RPC threads in Docker, because we know we are the only running
 # `zebrad` or `zcashd` process in the container.
 #
@@ -168,12 +171,12 @@ RUN set -ex; \
     echo "[state]"; \
     echo "cache_dir = '/zebrad-cache'"; \
     echo "[rpc]"; \
-    echo "listen_addr = None"; \
+    echo "#listen_addr = '127.0.0.1:8232'"; \
     echo "parallel_cpu_threads = 0"; \
     echo "[metrics]"; \
-    echo "endpoint_addr = None"; \
+    echo "#endpoint_addr = '127.0.0.1:9999'"; \
     echo "[tracing]"; \
-    echo "endpoint_addr = None"; \
+    echo "#endpoint_addr = '127.0.0.1:3000'"; \
   } > "${ZEBRA_CONF_PATH}/${ZEBRA_CONF_FILE}"
 
 EXPOSE 8233 18233


### PR DESCRIPTION
## Motivation

The TOML syntax is still wrong in the Dockerfile.

(This time I'll leave the PR in draft until I've tested it.)

## Solution

Comment out the disabled ports.

### Testing

We need to run these commands in Google Cloud shell after the image has been built for this branch:
```sh
gcloud auth configure-docker us-docker.pkg.dev
docker run us-docker.pkg.dev/zealous-zebra/zebra/zebrad-test:sha-9023e17
```

Here is a full list of available images:
https://console.cloud.google.com/artifacts/docker/zealous-zebra/us/zebra/zebrad?project=zealous-zebra

## Review

Anyone can review this PR, but @gustavovalverde reviewed the last one.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

