### PR TITLE
fix(test): Add a timeout to the non_blocking_logger test

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1353,8 +1353,10 @@ fn non_blocking_logger() -> Result<()> {
         let zebra_rpc_address = config.rpc.listen_addr.unwrap();
 
         let dir = testdir()?.with_config(&mut config)?;
-        let mut child = dir.spawn_child(args!["start"])?.with_timeout(TINY_CHECKPOINT_TIMEOUT);
-        
+        let mut child = dir
+            .spawn_child(args!["start"])?
+            .with_timeout(TINY_CHECKPOINT_TIMEOUT);
+
         // Wait until port is open.
         child.expect_stdout_line_matches(
             format!("Opened RPC endpoint at {}", config.rpc.listen_addr.unwrap()).as_str(),

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1353,7 +1353,8 @@ fn non_blocking_logger() -> Result<()> {
         let zebra_rpc_address = config.rpc.listen_addr.unwrap();
 
         let dir = testdir()?.with_config(&mut config)?;
-        let mut child = dir.spawn_child(args!["start"])?;
+        let mut child = dir.spawn_child(args!["start"])?.with_timeout(TINY_CHECKPOINT_TIMEOUT);
+        
         // Wait until port is open.
         child.expect_stdout_line_matches(
             format!("Opened RPC endpoint at {}", config.rpc.listen_addr.unwrap()).as_str(),


### PR DESCRIPTION
## Motivation

The non_blocking_logger test timed out on PR #5164 and produced 3 GB of logs:
https://github.com/ZcashFoundation/zebra/actions/runs/3177218716/jobs/5177415689

If that happens again, we want to end the test sooner, so the bug is easier to diagnose.

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?

