### PR TITLE
ci(lint): do not fail linter on `push` events

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,6 +41,7 @@ jobs:
         id: changed-files-rust
         uses: tj-actions/changed-files@v29.0.7
         with:
+          fetch-depth: 2
           files: |
             **/*.rs
             **/Cargo.toml
@@ -53,6 +54,7 @@ jobs:
         id: changed-files-workflows
         uses: tj-actions/changed-files@v29.0.7
         with:
+          fetch-depth: 2
           files: |
             .github/workflows/*.yml
 


### PR DESCRIPTION
## Previous behavior
The following error was causing an exit 1 in GitHub Actions when a pushing to the `main` branch

```
Error: Similar commit hashes detected: previous sha is equivalent to the
current sha
```

## Expected behavior
Allow the linter to run sucesfully even if the previous SHA has no files changed

## Solution:
Add `fetch-depth: 2` to retrieve the preceding commit

## Review
Anyone can review this

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

