### PR TITLE
fix(test): resolve a timing issue in mempool test

### DIFF
--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -417,6 +417,21 @@ async fn mempool_cancel_mined() -> Result<(), Report> {
         .await
         .unwrap();
 
+    // Wait for the chain tip update
+    if let Err(timeout_error) = timeout(
+        CHAIN_TIP_UPDATE_WAIT_LIMIT,
+        chain_tip_change.wait_for_tip_change(),
+    )
+    .await
+    .map(|change_result| change_result.expect("unexpected chain tip update failure"))
+    {
+        info!(
+            timeout = ?humantime_seconds(CHAIN_TIP_UPDATE_WAIT_LIMIT),
+            ?timeout_error,
+            "timeout waiting for chain tip change after committing block"
+        );
+    }
+
     // Query the mempool to make it poll chain_tip_change
     mempool.dummy_call().await;
 
@@ -430,6 +445,21 @@ async fn mempool_cancel_mined() -> Result<(), Report> {
         ))
         .await
         .unwrap();
+
+    // Wait for the chain tip update
+    if let Err(timeout_error) = timeout(
+        CHAIN_TIP_UPDATE_WAIT_LIMIT,
+        chain_tip_change.wait_for_tip_change(),
+    )
+    .await
+    .map(|change_result| change_result.expect("unexpected chain tip update failure"))
+    {
+        info!(
+            timeout = ?humantime_seconds(CHAIN_TIP_UPDATE_WAIT_LIMIT),
+            ?timeout_error,
+            "timeout waiting for chain tip change after committing block"
+        );
+    }
 
     // Query the mempool to make it poll chain_tip_change
     mempool.dummy_call().await;


### PR DESCRIPTION
## Motivation

To fix a mempool test that's failing occasionally.

The prior `mempool.dummy_call`s should also see the chain tip changes, and it's possible for the wait_for_tip_change call after the third block commit in this test to see the tip change from the first or second block commits.

See https://github.com/ZcashFoundation/zebra/pull/5322, closes https://github.com/ZcashFoundation/zebra/issues/5301

## Solution

Await `wait_for_tip_change` after every block commit.

## Review

Part of regular scheduled work.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?
