### PR TITLE
fix(log): reduce verbose logs for block commits

### DIFF
--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -61,7 +61,7 @@ pub(crate) fn validate_and_commit_non_finalized(
 /// # Panics
 ///
 /// If the `non_finalized_state` is empty.
-#[instrument(level = "debug", skip(chain_tip_sender))]
+#[instrument(level = "debug", skip(chain_tip_sender, non_finalized_state_sender))]
 fn update_latest_chain_channels(
     non_finalized_state: &NonFinalizedState,
     chain_tip_sender: &mut ChainTipSender,
@@ -94,7 +94,8 @@ fn update_latest_chain_channels(
     finalized_block_write_receiver,
     non_finalized_block_write_receiver,
     invalid_block_reset_sender,
-    chain_tip_sender
+    chain_tip_sender,
+    non_finalized_state_sender,
 ))]
 pub fn write_blocks_from_channels(
     mut finalized_block_write_receiver: UnboundedReceiver<QueuedFinalized>,

--- a/zebrad/src/components/tracing/endpoint.rs
+++ b/zebrad/src/components/tracing/endpoint.rs
@@ -37,7 +37,7 @@ async fn read_filter(req: Request<Body>) -> Result<String, String> {
 impl TracingEndpoint {
     /// Create the component.
     pub fn new(config: &ZebradConfig) -> Result<Self, FrameworkError> {
-        if !cfg!(feature = "filter-reload") {
+        if config.tracing.endpoint_addr.is_some() && !cfg!(feature = "filter-reload") {
             warn!(addr = ?config.tracing.endpoint_addr,
                   "unable to activate configured tracing filter endpoint: \
                    enable the 'filter-reload' feature when compiling zebrad",


### PR DESCRIPTION
## Motivation

Some of the block commit logs are very long.

This is not a release blocker.

Depends-On: #5257

## Solution

- Skip some verbose fields when instrumenting block writes

Related fixes:
- Use CloneError rather than formatting an error 
- Only warn about the tracing endpoint when it's actually set

## Review

Anyone can review this PR, it can merge after PR #5257.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

