### PR TITLE
fix(ci): Show logs after each Google Cloud test job

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1105,11 +1105,11 @@ jobs:
         # We always want to show the logs, even if the test failed or was cancelled
         if: ${{ always() }}
         run: |
-          echo "Test stdout:"
-          echo "${{ steps.check-logs.outputs.stdout }}"
+          echo 'Test stdout:'
+          echo '${{ steps.check-logs.outputs.stdout }}'
           echo
-          echo "Test stderr:"
-          echo "${{ steps.check-logs.outputs.stderr }}"
+          echo 'Test stderr:'
+          echo '${{ steps.check-logs.outputs.stderr }}'
 
 
   # create a state image from the instance's state disk, if requested by the caller
@@ -1219,7 +1219,7 @@ jobs:
           SYNC_HEIGHT=""
 
           SYNC_HEIGHT=$( \
-          echo "${{ steps.get-sync-height.outputs.stdout }}" | \
+          echo '${{ steps.get-sync-height.outputs.stdout }}' | \
           grep --extended-regexp --only-matching '${{ inputs.height_grep_text }}[0-9]+' | \
           grep --extended-regexp --only-matching  '[0-9]+' | \
           tail -1 || \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -546,6 +546,8 @@ jobs:
 
       # Wait until Sapling activation (or the test finishes).
       #
+      # Puts the grep result in the `stdout` output, and the last 1 MB of the test logs in the `stderr` output.
+      #
       # The log pipeline ignores the exit status of `sudo docker logs`.
       # It also ignores the expected 'broken pipe' error from `tee`,
       # which happens when `grep` finds a matching output and moves on to the next job.
@@ -563,7 +565,7 @@ jobs:
             --tail all \
             --follow \
             ${{ inputs.test_id }} | \
-            tee --output-error=exit /dev/stderr | \
+            (tee --output-error=exit /dev/stderr | tail -c 1000000) 3>&2 2>&1 1>&3 | \
             grep --max-count=1 --extended-regexp --color=always \
             -e 'estimated progress.*network_upgrade.*=.*Sapling' \
             -e 'estimated progress.*network_upgrade.*=.*Blossom' \
@@ -634,7 +636,7 @@ jobs:
             --tail all \
             --follow \
             ${{ inputs.test_id }} | \
-            tee --output-error=exit /dev/stderr | \
+            (tee --output-error=exit /dev/stderr | tail -c 1000000) 3>&2 2>&1 1>&3 | \
             grep --max-count=1 --extended-regexp --color=always \
             -e 'estimated progress.*network_upgrade.*=.*Canopy' \
             -e 'estimated progress.*network_upgrade.*=.*Nu5' \
@@ -702,7 +704,7 @@ jobs:
             --tail all \
             --follow \
             ${{ inputs.test_id }} | \
-            tee --output-error=exit /dev/stderr | \
+            (tee --output-error=exit /dev/stderr | tail -c 1000000) 3>&2 2>&1 1>&3 | \
             grep --max-count=1 --extended-regexp --color=always \
             -e 'estimated progress.*network_upgrade.*=.*Nu5' \
             -e 'test result:.*finished in'
@@ -772,7 +774,7 @@ jobs:
             --tail all \
             --follow \
             ${{ inputs.test_id }} | \
-            tee --output-error=exit /dev/stderr | \
+            (tee --output-error=exit /dev/stderr | tail -c 1000000) 3>&2 2>&1 1>&3 | \
             grep --max-count=1 --extended-regexp --color=always \
             -e 'estimated progress.*current_height.*=.*17[4-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
             -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
@@ -844,7 +846,7 @@ jobs:
             --tail all \
             --follow \
             ${{ inputs.test_id }} | \
-            tee --output-error=exit /dev/stderr | \
+            (tee --output-error=exit /dev/stderr | tail -c 1000000) 3>&2 2>&1 1>&3 | \
             grep --max-count=1 --extended-regexp --color=always \
             -e 'estimated progress.*current_height.*=.*17[6-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
             -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
@@ -916,7 +918,7 @@ jobs:
             --tail all \
             --follow \
             ${{ inputs.test_id }} | \
-            tee --output-error=exit /dev/stderr | \
+            (tee --output-error=exit /dev/stderr | tail -c 1000000) 3>&2 2>&1 1>&3 | \
             grep --max-count=1 --extended-regexp --color=always \
             -e 'estimated progress.*current_height.*=.*17[8-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
             -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
@@ -989,7 +991,7 @@ jobs:
             --tail all \
             --follow \
             ${{ inputs.test_id }} | \
-            tee --output-error=exit /dev/stderr | \
+            (tee --output-error=exit /dev/stderr | tail -c 1000000) 3>&2 2>&1 1>&3 | \
             grep --max-count=1 --extended-regexp --color=always \
             -e 'estimated progress.*current_height.*=.*179[0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
             -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
@@ -1060,7 +1062,7 @@ jobs:
             --tail ${{ env.EXTRA_LOG_LINES }} \
             --follow \
             ${{ inputs.test_id }} | \
-            tee --output-error=exit /dev/stderr | \
+            (tee --output-error=exit /dev/stderr | tail -c 1000000) 3>&2 2>&1 1>&3 | \
             grep --max-count=1 --extended-regexp --color=always \
             -e 'verified final checkpoint' \
             -e 'test result:.*finished in'
@@ -1127,7 +1129,7 @@ jobs:
             --tail ${{ env.EXTRA_LOG_LINES }} \
             --follow \
             ${{ inputs.test_id }} | \
-            tee --output-error=exit /dev/stderr | \
+            (tee --output-error=exit /dev/stderr | tail -c 1000000) 3>&2 2>&1 1>&3 | \
             grep --max-count=1 --extended-regexp --color=always \
             'test result:.*finished in'
 
@@ -1205,7 +1207,7 @@ jobs:
             sudo docker logs \
             --tail all \
             ${{ inputs.test_id }} | \
-            tee --output-error=exit /dev/stderr | \
+            (tee --output-error=exit /dev/stderr | tail -c 1000000) 3>&2 2>&1 1>&3 | \
             grep --max-count=1 --extended-regexp --color=always \
             "test result: .*ok.* [1-9][0-9]* passed.*finished in"; \
             EXIT_STATUS=$( \
@@ -1313,9 +1315,10 @@ jobs:
           echo "UPDATE_SUFFIX=$UPDATE_SUFFIX" >> $GITHUB_ENV
           echo "TIME_SUFFIX=$TIME_SUFFIX" >> $GITHUB_ENV
 
-      # Get the sync height from the test logs, which is later used as part of the
-      # disk description and labels.
-      - name: Get sync height from logs
+      # Get the last few test log lines, so we can find the sync height.
+      #
+      # Puts the logs in the `stdout` output, limiting the number of log lines and bytes.
+      - name: Get final test logs
         id: get-sync-height
         uses: google-github-actions/ssh-compute@v0.1.2
         with:
@@ -1323,8 +1326,11 @@ jobs:
           zone: ${{ env.ZONE }}
           ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           command: |
-            sudo docker logs ${{ inputs.test_id }} --tail 200
+            sudo docker logs ${{ inputs.test_id }} --tail 200 | tail -c 1000000
 
+      # Get the sync height from the test logs, which is later used as part of the
+      # disk description and labels.
+      #
       # The regex used to grep the sync height is provided by ${{ inputs.height_grep_text }},
       # this allows to dynamically change the height as needed by different situations or
       # based on the logs output from different tests.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1078,7 +1078,7 @@ jobs:
       # with that status.
       # (`docker wait` can also wait for multiple containers, but we only ever wait for a single container.)
       - name: Result of ${{ inputs.test_id }} test
-        id: compute-ssh
+        id: check-logs
         uses: google-github-actions/ssh-compute@v0.1.2
         with:
           instance_name: ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}
@@ -1099,6 +1099,18 @@ jobs:
             ); \
             echo "sudo docker exit status: $EXIT_STATUS"; \
             exit "$EXIT_STATUS"
+
+      # The ssh-compute action doesn't show the SSH output, so we need a separate step for it.
+      - name: Show ${{ inputs.test_id }} test logs
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        run: |
+          echo "Test stdout:"
+          echo "${{ steps.check-logs.outputs.stdout }}"
+          echo
+          echo "Test stderr:"
+          echo "${{ steps.check-logs.outputs.stderr }}"
+
 
   # create a state image from the instance's state disk, if requested by the caller
   create-state-image:

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -544,15 +544,14 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Show all the logs since the container launched,
-      # following until Sapling activation (or the test finishes).
+      # Wait until Sapling activation (or the test finishes).
       #
       # The log pipeline ignores the exit status of `sudo docker logs`.
       # It also ignores the expected 'broken pipe' error from `tee`,
       # which happens when `grep` finds a matching output and moves on to the next job.
       #
       # Errors in the tests are caught by the final test status job.
-      - name: Show logs for ${{ inputs.test_id }} test (sprout)
+      - name: Wait for ${{ inputs.test_id }} test (sprout)
         id: compute-ssh
         uses: google-github-actions/ssh-compute@v0.1.2
         with:
@@ -572,6 +571,17 @@ jobs:
             -e 'estimated progress.*network_upgrade.*=.*Canopy' \
             -e 'estimated progress.*network_upgrade.*=.*Nu5' \
             -e 'test result:.*finished in'
+
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
+      - name: Show ${{ inputs.test_id }} test logs
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        run: |
+          echo 'Test stdout:'
+          echo '${{ steps.compute-ssh.outputs.stdout }}'
+          echo
+          echo 'Test stderr:'
+          echo '${{ steps.compute-ssh.outputs.stderr }}'
 
   # follow the logs of the test we just launched, up to Canopy activation (or the test finishing)
   logs-heartwood:
@@ -609,8 +619,8 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Show recent logs, following until Canopy activation (or the test finishes)
-      - name: Show logs for ${{ inputs.test_id }} test (heartwood)
+      # Wait until Canopy activation (or the test finishes)
+      - name: Wait for ${{ inputs.test_id }} test (heartwood)
         id: compute-ssh
         uses: google-github-actions/ssh-compute@v0.1.2
         with:
@@ -627,6 +637,17 @@ jobs:
             -e 'estimated progress.*network_upgrade.*=.*Canopy' \
             -e 'estimated progress.*network_upgrade.*=.*Nu5' \
             -e 'test result:.*finished in'
+
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
+      - name: Show ${{ inputs.test_id }} test logs
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        run: |
+          echo 'Test stdout:'
+          echo '${{ steps.compute-ssh.outputs.stdout }}'
+          echo
+          echo 'Test stderr:'
+          echo '${{ steps.compute-ssh.outputs.stderr }}'
 
   # follow the logs of the test we just launched, up to NU5 activation (or the test finishing)
   logs-canopy:
@@ -664,8 +685,8 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Show recent logs, following until NU5 activation (or the test finishes)
-      - name: Show logs for ${{ inputs.test_id }} test (canopy)
+      # Wait until NU5 activation (or the test finishes)
+      - name: Wait for ${{ inputs.test_id }} test (canopy)
         id: compute-ssh
         uses: google-github-actions/ssh-compute@v0.1.2
         with:
@@ -681,6 +702,17 @@ jobs:
             grep --max-count=1 --extended-regexp --color=always \
             -e 'estimated progress.*network_upgrade.*=.*Nu5' \
             -e 'test result:.*finished in'
+
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
+      - name: Show ${{ inputs.test_id }} test logs
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        run: |
+          echo 'Test stdout:'
+          echo '${{ steps.compute-ssh.outputs.stdout }}'
+          echo
+          echo 'Test stderr:'
+          echo '${{ steps.compute-ssh.outputs.stderr }}'
 
   # follow the logs of the test we just launched, up to block 1,740,000 or later
   # (or the test finishing)
@@ -721,8 +753,8 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Show recent logs, following until block 1,740,000 (or the test finishes)
-      - name: Show logs for ${{ inputs.test_id }} test (1740k)
+      # Wait until block 1,740,000 (or the test finishes)
+      - name: Wait for ${{ inputs.test_id }} test (1740k)
         id: compute-ssh
         uses: google-github-actions/ssh-compute@v0.1.2
         with:
@@ -740,6 +772,17 @@ jobs:
             -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
             -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
             -e 'test result:.*finished in'
+
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
+      - name: Show ${{ inputs.test_id }} test logs
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        run: |
+          echo 'Test stdout:'
+          echo '${{ steps.compute-ssh.outputs.stdout }}'
+          echo
+          echo 'Test stderr:'
+          echo '${{ steps.compute-ssh.outputs.stderr }}'
 
   # follow the logs of the test we just launched, up to block 1,760,000 or later
   # (or the test finishing)
@@ -780,8 +823,8 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Show recent logs, following until block 1,760,000 (or the test finishes)
-      - name: Show logs for ${{ inputs.test_id }} test (1760k)
+      # Wait until block 1,760,000 (or the test finishes)
+      - name: Wait for ${{ inputs.test_id }} test (1760k)
         id: compute-ssh
         uses: google-github-actions/ssh-compute@v0.1.2
         with:
@@ -799,6 +842,17 @@ jobs:
             -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
             -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
             -e 'test result:.*finished in'
+
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
+      - name: Show ${{ inputs.test_id }} test logs
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        run: |
+          echo 'Test stdout:'
+          echo '${{ steps.compute-ssh.outputs.stdout }}'
+          echo
+          echo 'Test stderr:'
+          echo '${{ steps.compute-ssh.outputs.stderr }}'
 
   # follow the logs of the test we just launched, up to block 1,780,000 or later
   # (or the test finishing)
@@ -839,8 +893,8 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Show recent logs, following until block 1,780,000 (or the test finishes)
-      - name: Show logs for ${{ inputs.test_id }} test (1780k)
+      # Wait until block 1,780,000 (or the test finishes)
+      - name: Wait for ${{ inputs.test_id }} test (1780k)
         id: compute-ssh
         uses: google-github-actions/ssh-compute@v0.1.2
         with:
@@ -858,6 +912,17 @@ jobs:
             -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
             -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
             -e 'test result:.*finished in'
+
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
+      - name: Show ${{ inputs.test_id }} test logs
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        run: |
+          echo 'Test stdout:'
+          echo '${{ steps.compute-ssh.outputs.stdout }}'
+          echo
+          echo 'Test stderr:'
+          echo '${{ steps.compute-ssh.outputs.stderr }}'
 
   # follow the logs of the test we just launched, up to block 1,790,000 or later
   # (or the test finishing)
@@ -899,8 +964,8 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Show recent logs, following until block 1,790,000 (or the test finishes)
-      - name: Show logs for ${{ inputs.test_id }} test (1790k)
+      # Wait until block 1,790,000 (or the test finishes)
+      - name: Wait for ${{ inputs.test_id }} test (1790k)
         id: compute-ssh
         uses: google-github-actions/ssh-compute@v0.1.2
         with:
@@ -918,6 +983,17 @@ jobs:
             -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
             -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
             -e 'test result:.*finished in'
+
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
+      - name: Show ${{ inputs.test_id }} test logs
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        run: |
+          echo 'Test stdout:'
+          echo '${{ steps.compute-ssh.outputs.stdout }}'
+          echo
+          echo 'Test stderr:'
+          echo '${{ steps.compute-ssh.outputs.stderr }}'
 
   # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)
   logs-checkpoint:
@@ -955,10 +1031,10 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Show recent logs, following until the last checkpoint (or the test finishes)
+      # Wait until the last checkpoint (or the test finishes)
       #
       # TODO: when doing obtain/extend tips, log the verifier in use, and check for full verification here
-      - name: Show logs for ${{ inputs.test_id }} test (checkpoint)
+      - name: Wait for ${{ inputs.test_id }} test (checkpoint)
         id: compute-ssh
         uses: google-github-actions/ssh-compute@v0.1.2
         with:
@@ -974,6 +1050,17 @@ jobs:
             grep --max-count=1 --extended-regexp --color=always \
             -e 'verified final checkpoint' \
             -e 'test result:.*finished in'
+
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
+      - name: Show ${{ inputs.test_id }} test logs
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        run: |
+          echo 'Test stdout:'
+          echo '${{ steps.compute-ssh.outputs.stdout }}'
+          echo
+          echo 'Test stderr:'
+          echo '${{ steps.compute-ssh.outputs.stderr }}'
 
   # follow the logs of the test we just launched, until it finishes
   logs-end:
@@ -1011,8 +1098,8 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Show recent logs, following until the test finishes
-      - name: Show logs for ${{ inputs.test_id }} test (end)
+      # Wait until the test finishes
+      - name: Wait for ${{ inputs.test_id }} test (end)
         id: compute-ssh
         uses: google-github-actions/ssh-compute@v0.1.2
         with:
@@ -1027,6 +1114,17 @@ jobs:
             tee --output-error=exit /dev/stderr | \
             grep --max-count=1 --extended-regexp --color=always \
             'test result:.*finished in'
+
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
+      - name: Show ${{ inputs.test_id }} test logs
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        run: |
+          echo 'Test stdout:'
+          echo '${{ steps.compute-ssh.outputs.stdout }}'
+          echo
+          echo 'Test stderr:'
+          echo '${{ steps.compute-ssh.outputs.stderr }}'
 
 
   # check the results of the test, and show all of the test logs
@@ -1078,7 +1176,7 @@ jobs:
       # with that status.
       # (`docker wait` can also wait for multiple containers, but we only ever wait for a single container.)
       - name: Result of ${{ inputs.test_id }} test
-        id: check-logs
+        id: compute-ssh
         uses: google-github-actions/ssh-compute@v0.1.2
         with:
           instance_name: ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}
@@ -1100,16 +1198,16 @@ jobs:
             echo "sudo docker exit status: $EXIT_STATUS"; \
             exit "$EXIT_STATUS"
 
-      # The ssh-compute action doesn't show the SSH output, so we need a separate step for it.
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
       - name: Show ${{ inputs.test_id }} test logs
         # We always want to show the logs, even if the test failed or was cancelled
         if: ${{ always() }}
         run: |
           echo 'Test stdout:'
-          echo '${{ steps.check-logs.outputs.stdout }}'
+          echo '${{ steps.compute-ssh.outputs.stdout }}'
           echo
           echo 'Test stderr:'
-          echo '${{ steps.check-logs.outputs.stderr }}'
+          echo '${{ steps.compute-ssh.outputs.stderr }}'
 
 
   # create a state image from the instance's state disk, if requested by the caller
@@ -1235,6 +1333,17 @@ jobs:
 
           echo "Found sync height in logs: $SYNC_HEIGHT"
           echo "SYNC_HEIGHT=$SYNC_HEIGHT" >> $GITHUB_ENV
+
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
+      - name: Show logs from get sync height ssh
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        run: |
+          echo 'Sync height stdout:'
+          echo '${{ steps.get-sync-height.outputs.stdout }}'
+          echo
+          echo 'Sync height stderr:'
+          echo '${{ steps.get-sync-height.outputs.stderr }}'
 
       # Get the original cached state height from google cloud.
       #

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -576,12 +576,14 @@ jobs:
       - name: Show ${{ inputs.test_id }} test logs
         # We always want to show the logs, even if the test failed or was cancelled
         if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
         run: |
-          echo 'Test stdout:'
-          echo '${{ steps.compute-ssh.outputs.stdout }}'
-          echo
-          echo 'Test stderr:'
-          echo '${{ steps.compute-ssh.outputs.stderr }}'
+          Test stdout:
+          ${{ steps.compute-ssh.outputs.stdout }}
+          
+          Test stderr:
+          ${{ steps.compute-ssh.outputs.stderr }}
 
   # follow the logs of the test we just launched, up to Canopy activation (or the test finishing)
   logs-heartwood:
@@ -642,12 +644,14 @@ jobs:
       - name: Show ${{ inputs.test_id }} test logs
         # We always want to show the logs, even if the test failed or was cancelled
         if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
         run: |
-          echo 'Test stdout:'
-          echo '${{ steps.compute-ssh.outputs.stdout }}'
-          echo
-          echo 'Test stderr:'
-          echo '${{ steps.compute-ssh.outputs.stderr }}'
+          Test stdout:
+          ${{ steps.compute-ssh.outputs.stdout }}
+          
+          Test stderr:
+          ${{ steps.compute-ssh.outputs.stderr }}
 
   # follow the logs of the test we just launched, up to NU5 activation (or the test finishing)
   logs-canopy:
@@ -707,12 +711,14 @@ jobs:
       - name: Show ${{ inputs.test_id }} test logs
         # We always want to show the logs, even if the test failed or was cancelled
         if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
         run: |
-          echo 'Test stdout:'
-          echo '${{ steps.compute-ssh.outputs.stdout }}'
-          echo
-          echo 'Test stderr:'
-          echo '${{ steps.compute-ssh.outputs.stderr }}'
+          Test stdout:
+          ${{ steps.compute-ssh.outputs.stdout }}
+          
+          Test stderr:
+          ${{ steps.compute-ssh.outputs.stderr }}
 
   # follow the logs of the test we just launched, up to block 1,740,000 or later
   # (or the test finishing)
@@ -777,12 +783,14 @@ jobs:
       - name: Show ${{ inputs.test_id }} test logs
         # We always want to show the logs, even if the test failed or was cancelled
         if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
         run: |
-          echo 'Test stdout:'
-          echo '${{ steps.compute-ssh.outputs.stdout }}'
-          echo
-          echo 'Test stderr:'
-          echo '${{ steps.compute-ssh.outputs.stderr }}'
+          Test stdout:
+          ${{ steps.compute-ssh.outputs.stdout }}
+          
+          Test stderr:
+          ${{ steps.compute-ssh.outputs.stderr }}
 
   # follow the logs of the test we just launched, up to block 1,760,000 or later
   # (or the test finishing)
@@ -847,12 +855,14 @@ jobs:
       - name: Show ${{ inputs.test_id }} test logs
         # We always want to show the logs, even if the test failed or was cancelled
         if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
         run: |
-          echo 'Test stdout:'
-          echo '${{ steps.compute-ssh.outputs.stdout }}'
-          echo
-          echo 'Test stderr:'
-          echo '${{ steps.compute-ssh.outputs.stderr }}'
+          Test stdout:
+          ${{ steps.compute-ssh.outputs.stdout }}
+          
+          Test stderr:
+          ${{ steps.compute-ssh.outputs.stderr }}
 
   # follow the logs of the test we just launched, up to block 1,780,000 or later
   # (or the test finishing)
@@ -917,12 +927,14 @@ jobs:
       - name: Show ${{ inputs.test_id }} test logs
         # We always want to show the logs, even if the test failed or was cancelled
         if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
         run: |
-          echo 'Test stdout:'
-          echo '${{ steps.compute-ssh.outputs.stdout }}'
-          echo
-          echo 'Test stderr:'
-          echo '${{ steps.compute-ssh.outputs.stderr }}'
+          Test stdout:
+          ${{ steps.compute-ssh.outputs.stdout }}
+          
+          Test stderr:
+          ${{ steps.compute-ssh.outputs.stderr }}
 
   # follow the logs of the test we just launched, up to block 1,790,000 or later
   # (or the test finishing)
@@ -988,12 +1000,14 @@ jobs:
       - name: Show ${{ inputs.test_id }} test logs
         # We always want to show the logs, even if the test failed or was cancelled
         if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
         run: |
-          echo 'Test stdout:'
-          echo '${{ steps.compute-ssh.outputs.stdout }}'
-          echo
-          echo 'Test stderr:'
-          echo '${{ steps.compute-ssh.outputs.stderr }}'
+          Test stdout:
+          ${{ steps.compute-ssh.outputs.stdout }}
+          
+          Test stderr:
+          ${{ steps.compute-ssh.outputs.stderr }}
 
   # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)
   logs-checkpoint:
@@ -1055,12 +1069,14 @@ jobs:
       - name: Show ${{ inputs.test_id }} test logs
         # We always want to show the logs, even if the test failed or was cancelled
         if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
         run: |
-          echo 'Test stdout:'
-          echo '${{ steps.compute-ssh.outputs.stdout }}'
-          echo
-          echo 'Test stderr:'
-          echo '${{ steps.compute-ssh.outputs.stderr }}'
+          Test stdout:
+          ${{ steps.compute-ssh.outputs.stdout }}
+          
+          Test stderr:
+          ${{ steps.compute-ssh.outputs.stderr }}
 
   # follow the logs of the test we just launched, until it finishes
   logs-end:
@@ -1119,12 +1135,14 @@ jobs:
       - name: Show ${{ inputs.test_id }} test logs
         # We always want to show the logs, even if the test failed or was cancelled
         if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
         run: |
-          echo 'Test stdout:'
-          echo '${{ steps.compute-ssh.outputs.stdout }}'
-          echo
-          echo 'Test stderr:'
-          echo '${{ steps.compute-ssh.outputs.stderr }}'
+          Test stdout:
+          ${{ steps.compute-ssh.outputs.stdout }}
+          
+          Test stderr:
+          ${{ steps.compute-ssh.outputs.stderr }}
 
 
   # check the results of the test, and show all of the test logs
@@ -1202,12 +1220,14 @@ jobs:
       - name: Show ${{ inputs.test_id }} test logs
         # We always want to show the logs, even if the test failed or was cancelled
         if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
         run: |
-          echo 'Test stdout:'
-          echo '${{ steps.compute-ssh.outputs.stdout }}'
-          echo
-          echo 'Test stderr:'
-          echo '${{ steps.compute-ssh.outputs.stderr }}'
+          Test stdout:
+          ${{ steps.compute-ssh.outputs.stdout }}
+          
+          Test stderr:
+          ${{ steps.compute-ssh.outputs.stderr }}
 
 
   # create a state image from the instance's state disk, if requested by the caller
@@ -1338,12 +1358,14 @@ jobs:
       - name: Show logs from get sync height ssh
         # We always want to show the logs, even if the test failed or was cancelled
         if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
         run: |
-          echo 'Sync height stdout:'
-          echo '${{ steps.get-sync-height.outputs.stdout }}'
-          echo
-          echo 'Sync height stderr:'
-          echo '${{ steps.get-sync-height.outputs.stderr }}'
+          Test stdout:
+          ${{ steps.get-sync-height.outputs.stdout }}
+          
+          Test stderr:
+          ${{ steps.get-sync-height.outputs.stderr }}
 
       # Get the original cached state height from google cloud.
       #


### PR DESCRIPTION
## Motivation

PR #5330 stopped showing any test logs in Google Cloud test runs that use the `ssh-compute` action.

But we need those logs to diagnose test failures.

## Solution

Add a step that shows the logs after each time we run `ssh-compute`

## Review

This PR is urgent because we need to be able to diagnose google cloud failures.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

