### PR TITLE
fix(ci): Increase the Google Cloud instance sshd connection limit

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -185,7 +185,7 @@ jobs:
             echo 'Modified config:'
             sudo cat /etc/ssh/sshd_config
             echo
-            sudo sh /etc/init.d/ssh reload
+            sudo systemctl reload sshd.service
             echo
             ps auxwww | grep sshd
 
@@ -456,7 +456,7 @@ jobs:
             echo 'Modified config:'
             sudo cat /etc/ssh/sshd_config
             echo
-            sudo sh /etc/init.d/ssh reload
+            sudo systemctl reload sshd.service
             echo
             ps auxwww | grep sshd
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -172,13 +172,13 @@ jobs:
             ps auxwww | grep sshd
             sudo grep MaxStartups /etc/ssh/sshd_config
             sudo cat /etc/ssh/sshd_config
-            sudo sed --in-place=.bak 's/MaxStartups .*/MaxStartups 500/g' /etc/ssh/sshd_config \
+            echo 'MaxStartups 500' | sudo tee --append /etc/ssh/sshd_config \
             || \
             (echo "updating instance sshd config failed: failing test"; exit 1)
             sudo grep MaxStartups /etc/ssh/sshd_config
             sudo cat /etc/ssh/sshd_config
-            !sudo killall --user root -HUP sshd \
-            || \
+            sudo killall --user root -HUP sshd \
+            && \
             (echo "activating new sshd config failed: failing test"; exit 1)
             ps auxwww | grep sshd
 
@@ -439,13 +439,13 @@ jobs:
             ps auxwww | grep sshd
             sudo grep MaxStartups /etc/ssh/sshd_config
             sudo cat /etc/ssh/sshd_config
-            sudo sed --in-place=.bak 's/MaxStartups .*/MaxStartups 500/g' /etc/ssh/sshd_config \
+            echo 'MaxStartups 500' | sudo tee --append /etc/ssh/sshd_config \
             || \
             (echo "updating instance sshd config failed: failing test"; exit 1)
             sudo grep MaxStartups /etc/ssh/sshd_config
             sudo cat /etc/ssh/sshd_config
-            !sudo killall --user root -HUP sshd \
-            || \
+            sudo killall --user root -HUP sshd \
+            && \
             (echo "activating new sshd config failed: failing test"; exit 1)
             ps auxwww | grep sshd
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -170,16 +170,20 @@ jobs:
           ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           command: |
             ps auxwww | grep sshd
+            echo
             sudo grep MaxStartups /etc/ssh/sshd_config
+            echo 'Original config:'
             sudo cat /etc/ssh/sshd_config
+            echo
             echo 'MaxStartups 500' | sudo tee --append /etc/ssh/sshd_config \
             || \
             (echo "updating instance sshd config failed: failing test"; exit 1)
             sudo grep MaxStartups /etc/ssh/sshd_config
+            echo 'Modified config:'
             sudo cat /etc/ssh/sshd_config
-            sudo killall --user root -HUP sshd \
-            && \
-            (echo "activating new sshd config failed: failing test"; exit 1)
+            echo
+            sudo /etc/init.d/ssh reload
+            echo
             ps auxwww | grep sshd
 
       # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
@@ -425,9 +429,6 @@ jobs:
       #
       # SSH into the just created VM, modify the sshd MaxStartups connection option, and restart sshd.
       # Restarting sshd will terminate the SSH connection.
-      #
-      # TODO: adjust the config file in the instance Docker image, before the instance starts
-      #       (Note: the instance Docker image is different from the test Docker image)
       - name: Fix sshd on ${{ inputs.test_id }} instance
         id: compute-ssh-sshd
         uses: google-github-actions/ssh-compute@v0.1.2
@@ -437,16 +438,20 @@ jobs:
           ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           command: |
             ps auxwww | grep sshd
+            echo
             sudo grep MaxStartups /etc/ssh/sshd_config
+            echo 'Original config:'
             sudo cat /etc/ssh/sshd_config
+            echo
             echo 'MaxStartups 500' | sudo tee --append /etc/ssh/sshd_config \
             || \
             (echo "updating instance sshd config failed: failing test"; exit 1)
             sudo grep MaxStartups /etc/ssh/sshd_config
+            echo 'Modified config:'
             sudo cat /etc/ssh/sshd_config
-            sudo killall --user root -HUP sshd \
-            && \
-            (echo "activating new sshd config failed: failing test"; exit 1)
+            echo
+            sudo /etc/init.d/ssh reload
+            echo
             ps auxwww | grep sshd
 
       # The ssh-compute action doesn't show the SSH output, so that needs a separate step.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -156,8 +156,7 @@ jobs:
 
       # Adjust sshd config on the newly created VM, to avoid connection errors.
       #
-      # SSH into the just created VM, modify the sshd MaxStartups connection option, and restart sshd.
-      # Restarting sshd will terminate the SSH connection.
+      # SSH into the just created VM, modify the sshd MaxStartups connection option, and reload the sshd config.
       #
       # TODO: adjust the config file in the instance Docker image, before the instance starts
       #       (Note: the instance Docker image is different from the test Docker image)
@@ -211,7 +210,6 @@ jobs:
           zone: ${{ env.ZONE }}
           ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           command: |
-            ps auxwww | grep sshd
             sudo mkfs.ext4 -v /dev/sdb \
             && \
             sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
@@ -428,8 +426,7 @@ jobs:
 
       # Adjust sshd config on the newly created VM, to avoid connection errors.
       #
-      # SSH into the just created VM, modify the sshd MaxStartups connection option, and restart sshd.
-      # Restarting sshd will terminate the SSH connection.
+      # SSH into the just created VM, modify the sshd MaxStartups connection option, and reload the sshd config.
       - name: Fix sshd on ${{ inputs.test_id }} instance
         id: compute-ssh-sshd
         uses: google-github-actions/ssh-compute@v0.1.2
@@ -483,7 +480,6 @@ jobs:
           zone: ${{ env.ZONE }}
           ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           command: |
-            ps auxwww | grep sshd
             sudo e2fsck -v -f -p /dev/sdb \
             && \
             sudo resize2fs -p /dev/sdb \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -182,6 +182,19 @@ jobs:
             (echo "activating new sshd config failed: failing test"; exit 1)
             ps auxwww | grep sshd
 
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
+      - name: Show sshd ${{ inputs.test_id }} adjustment logs
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
+        run: |
+          sshd adjustment stdout:
+          ${{ steps.compute-ssh-sshd.outputs.stdout }}
+          
+          sshd adjustment stderr:
+          ${{ steps.compute-ssh-sshd.outputs.stderr }}
+
       # Create a docker volume with the new disk we just created.
       #
       # SSH into the just created VM, and create a docker volume with the newly created disk.
@@ -198,6 +211,19 @@ jobs:
             && \
             sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
             ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}
+
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
+      - name: Show docker ${{ inputs.test_id }} volume logs
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
+        run: |
+          Docker volume stdout:
+          ${{ steps.compute-ssh.outputs.stdout }}
+          
+          Docker volume stderr:
+          ${{ steps.compute-ssh.outputs.stderr }}
 
   # launch the test, if it doesn't use any cached state
   launch-without-cached-state:
@@ -423,6 +449,19 @@ jobs:
             (echo "activating new sshd config failed: failing test"; exit 1)
             ps auxwww | grep sshd
 
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
+      - name: Show sshd ${{ inputs.test_id }} adjustment logs
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
+        run: |
+          sshd adjustment stdout:
+          ${{ steps.compute-ssh-sshd.outputs.stdout }}
+          
+          sshd adjustment stderr:
+          ${{ steps.compute-ssh-sshd.outputs.stderr }}
+
       # Create a docker volume with the selected cached state.
       #
       # SSH into the just created VM, expand the partition and filesystem to fill the entire disk,
@@ -444,6 +483,20 @@ jobs:
             && \
             sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
             ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}
+
+      # The ssh-compute action doesn't show the SSH output, so that needs a separate step.
+      - name: Show docker ${{ inputs.test_id }} volume logs
+        # We always want to show the logs, even if the test failed or was cancelled
+        if: ${{ always() }}
+        # Ignore shell metacharacters like ' and $
+        shell: cat {0}
+        run: |
+          Docker volume stdout:
+          ${{ steps.compute-ssh.outputs.stdout }}
+          
+          Docker volume stderr:
+          ${{ steps.compute-ssh.outputs.stderr }}
+
 
   # launch the test, if it uses cached state
   launch-with-cached-state:

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -169,8 +169,6 @@ jobs:
           zone: ${{ env.ZONE }}
           ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           command: |
-            echo 'sudo permissions:'
-            sudo cat /etc/sudoers
             ps auxwww | grep sshd
             echo
             sudo grep MaxStartups /etc/ssh/sshd_config
@@ -440,8 +438,6 @@ jobs:
           zone: ${{ env.ZONE }}
           ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           command: |
-            echo 'sudo permissions:'
-            sudo cat /etc/sudoers
             ps auxwww | grep sshd
             echo
             sudo grep MaxStartups /etc/ssh/sshd_config

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -169,12 +169,15 @@ jobs:
           zone: ${{ env.ZONE }}
           ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           command: |
+            echo 'sudo permissions:'
+            sudo cat /etc/sudoers
             ps auxwww | grep sshd
             echo
             sudo grep MaxStartups /etc/ssh/sshd_config
             echo 'Original config:'
             sudo cat /etc/ssh/sshd_config
             echo
+            echo 'Modifying config:'
             echo 'MaxStartups 500' | sudo tee --append /etc/ssh/sshd_config \
             || \
             (echo "updating instance sshd config failed: failing test"; exit 1)
@@ -182,7 +185,7 @@ jobs:
             echo 'Modified config:'
             sudo cat /etc/ssh/sshd_config
             echo
-            sudo /etc/init.d/ssh reload
+            sudo sh /etc/init.d/ssh reload
             echo
             ps auxwww | grep sshd
 
@@ -437,12 +440,15 @@ jobs:
           zone: ${{ env.ZONE }}
           ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           command: |
+            echo 'sudo permissions:'
+            sudo cat /etc/sudoers
             ps auxwww | grep sshd
             echo
             sudo grep MaxStartups /etc/ssh/sshd_config
             echo 'Original config:'
             sudo cat /etc/ssh/sshd_config
             echo
+            echo 'Modifying config:'
             echo 'MaxStartups 500' | sudo tee --append /etc/ssh/sshd_config \
             || \
             (echo "updating instance sshd config failed: failing test"; exit 1)
@@ -450,7 +456,7 @@ jobs:
             echo 'Modified config:'
             sudo cat /etc/ssh/sshd_config
             echo
-            sudo /etc/init.d/ssh reload
+            sudo sh /etc/init.d/ssh reload
             echo
             ps auxwww | grep sshd
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -145,7 +145,7 @@ jobs:
           --boot-disk-size 200GB \
           --boot-disk-type pd-ssd \
           --create-disk name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=200GB,type=pd-ssd \
-          --container-image debian:buster \
+          --container-image debian:bullseye \
           --container-restart-policy=never \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --scopes cloud-platform \
@@ -153,6 +153,34 @@ jobs:
           --tags ${{ inputs.app_name }} \
           --zone ${{ env.ZONE }}
           sleep 60
+
+      # Adjust sshd config on the newly created VM, to avoid connection errors.
+      #
+      # SSH into the just created VM, modify the sshd MaxStartups connection option, and restart sshd.
+      # Restarting sshd will terminate the SSH connection.
+      #
+      # TODO: adjust the config file in the instance Docker image, before the instance starts
+      #       (Note: the instance Docker image is different from the test Docker image)
+      - name: Fix sshd on ${{ inputs.test_id }} instance
+        id: compute-ssh-sshd
+        uses: google-github-actions/ssh-compute@v0.1.2
+        with:
+          instance_name: ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}
+          zone: ${{ env.ZONE }}
+          ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          command: |
+            ps auxwww | grep sshd
+            sudo grep MaxStartups /etc/ssh/sshd_config
+            sudo cat /etc/ssh/sshd_config
+            sudo sed --in-place=.bak 's/MaxStartups .*/MaxStartups 500/g' /etc/ssh/sshd_config \
+            || \
+            (echo "updating instance sshd config failed: failing test"; exit 1)
+            sudo grep MaxStartups /etc/ssh/sshd_config
+            sudo cat /etc/ssh/sshd_config
+            !sudo killall --user root -HUP sshd \
+            || \
+            (echo "activating new sshd config failed: failing test"; exit 1)
+            ps auxwww | grep sshd
 
       # Create a docker volume with the new disk we just created.
       #
@@ -165,6 +193,7 @@ jobs:
           zone: ${{ env.ZONE }}
           ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           command: |
+            ps auxwww | grep sshd
             sudo mkfs.ext4 -v /dev/sdb \
             && \
             sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
@@ -357,7 +386,7 @@ jobs:
           --boot-disk-size 200GB \
           --boot-disk-type pd-ssd \
           --create-disk image=${{ env.CACHED_DISK_NAME }},name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=200GB,type=pd-ssd \
-          --container-image debian:buster \
+          --container-image debian:bullseye \
           --container-restart-policy=never \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --scopes cloud-platform \
@@ -365,6 +394,34 @@ jobs:
           --tags ${{ inputs.app_name }} \
           --zone ${{ env.ZONE }}
           sleep 60
+
+      # Adjust sshd config on the newly created VM, to avoid connection errors.
+      #
+      # SSH into the just created VM, modify the sshd MaxStartups connection option, and restart sshd.
+      # Restarting sshd will terminate the SSH connection.
+      #
+      # TODO: adjust the config file in the instance Docker image, before the instance starts
+      #       (Note: the instance Docker image is different from the test Docker image)
+      - name: Fix sshd on ${{ inputs.test_id }} instance
+        id: compute-ssh-sshd
+        uses: google-github-actions/ssh-compute@v0.1.2
+        with:
+          instance_name: ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}
+          zone: ${{ env.ZONE }}
+          ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          command: |
+            ps auxwww | grep sshd
+            sudo grep MaxStartups /etc/ssh/sshd_config
+            sudo cat /etc/ssh/sshd_config
+            sudo sed --in-place=.bak 's/MaxStartups .*/MaxStartups 500/g' /etc/ssh/sshd_config \
+            || \
+            (echo "updating instance sshd config failed: failing test"; exit 1)
+            sudo grep MaxStartups /etc/ssh/sshd_config
+            sudo cat /etc/ssh/sshd_config
+            !sudo killall --user root -HUP sshd \
+            || \
+            (echo "activating new sshd config failed: failing test"; exit 1)
+            ps auxwww | grep sshd
 
       # Create a docker volume with the selected cached state.
       #
@@ -380,6 +437,7 @@ jobs:
           zone: ${{ env.ZONE }}
           ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           command: |
+            ps auxwww | grep sshd
             sudo e2fsck -v -f -p /dev/sdb \
             && \
             sudo resize2fs -p /dev/sdb \


### PR DESCRIPTION
## Motivation

SSH connections to Google Cloud test instances are failing with:
> ERROR: (gcloud.compute.start-iap-tunnel) Error while connecting [4010: 'destination read failed'].
> kex_exchange_identification: Connection closed by remote host

https://github.com/ZcashFoundation/zebra/actions/runs/3203311358/jobs/5234000346#step:6:106

Closes #5362

### Reference

> Weirdly, none actually try to authenticate to open a session.
>
> Some spiders and services like [Shodan](https://www.shodan.io/) scans public ipv4 addresses for open services, e.g. salt masters, ftp servers, RDPs, and also SSH services. These spiders usually only connect to the services without doing any valid authentication steps.

https://serverfault.com/questions/1015547/what-causes-ssh-error-kex-exchange-identification-connection-closed-by-remote/1015554#1015554

> I got this error when using docker command with remote host
> docker -H ssh://user@server compose up
> after some digging i found on my remote server in auth logs (/var/log/auth.log) this:
> Aug  8 14:51:46 user sshd[1341]: error: beginning MaxStartups throttling
> Aug  8 14:51:46 user sshd[1341]: drop connection #10 from [some_ip]:32992 on [some_ip]:22 past MaxStartups

https://stackoverflow.com/questions/67000681/kex-exchange-identification-connection-closed-by-remote-host/73292521#73292521

> MaxStartups
> Specifies the maximum number of concurrent unauthenticated connections to the SSH daemon.
> Additional connections will be dropped until authentication succeeds or the LoginGraceTime
> expires for a connection.

https://man7.org/linux/man-pages/man5/sshd_config.5.html

## Solution

Allow up to 500 unauthenticated connections to Google Cloud instances.
This tolerates a larger number of port scanning bots.

## Review

These errors are blocking most other PR merges.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

If this change works, we should:
- revert the change to the `ssh-compute` action in PRs #5330, #5358, and #5365, because they make test logging much worse
- modify the debian Docker image we use for Google Cloud instances, rather than editing the file after the instance has started using a SSH connection