### PR TITLE
fix(ci): adds full sync jobs for 1800k, 1810k, and 1820k blocks

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -919,10 +919,182 @@ jobs:
             -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
             -e 'test result:.*finished in'
 
+  # follow the logs of the test we just launched, up to block 1,800,000 or later
+  # (or the test finishing)
+  logs-1800k:
+    name: Log ${{ inputs.test_id }} test (1800k)
+    needs: [ logs-1790k ]
+    # If the previous job fails, we still want to show the logs.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with:
+          persist-credentials: false
+          fetch-depth: '2'
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
+      - name: Downcase network name for disks
+        run: |
+          NETWORK_CAPS=${{ inputs.network }}
+          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+
+      # Setup gcloud CLI
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.8.1
+        with:
+          retries: '3'
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
+
+      # Show recent logs, following until block 1,800,000 (or the test finishes)
+      - name: Show logs for ${{ inputs.test_id }} test (1800k)
+        id: compute-ssh
+        uses: google-github-actions/ssh-compute@v0.1.2
+        with:
+          instance_name: ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}
+          zone: ${{ env.ZONE }}
+          ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          command: |
+            sudo docker logs \
+            --tail all \
+            --follow \
+            ${{ inputs.test_id }} | \
+            tee --output-error=exit /dev/stderr | \
+            grep --max-count=1 --extended-regexp --color=always \
+            -e 'estimated progress.*current_height.*=.*180[0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+            -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+            -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+            -e 'test result:.*finished in'
+
+
+  # follow the logs of the test we just launched, up to block 1,810,000 or later
+  # (or the test finishing)
+  logs-1810k:
+    name: Log ${{ inputs.test_id }} test (1810k)
+    needs: [ logs-1800k ]
+    # If the previous job fails, we still want to show the logs.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with:
+          persist-credentials: false
+          fetch-depth: '2'
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
+      - name: Downcase network name for disks
+        run: |
+          NETWORK_CAPS=${{ inputs.network }}
+          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+
+      # Setup gcloud CLI
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.8.1
+        with:
+          retries: '3'
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
+
+      # Show recent logs, following until block 1,810,000 (or the test finishes)
+      - name: Show logs for ${{ inputs.test_id }} test (1810k)
+        id: compute-ssh
+        uses: google-github-actions/ssh-compute@v0.1.2
+        with:
+          instance_name: ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}
+          zone: ${{ env.ZONE }}
+          ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          command: |
+            sudo docker logs \
+            --tail all \
+            --follow \
+            ${{ inputs.test_id }} | \
+            tee --output-error=exit /dev/stderr | \
+            grep --max-count=1 --extended-regexp --color=always \
+            -e 'estimated progress.*current_height.*=.*181[0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+            -e 'estimated progress.*current_height.*=.*1[8-9][1-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+            -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+            -e 'test result:.*finished in'
+
+  # follow the logs of the test we just launched, up to block 1,820,000 or later
+  # (or the test finishing)
+  logs-1820k:
+    name: Log ${{ inputs.test_id }} test (1820k)
+    needs: [ logs-1810k ]
+    # If the previous job fails, we still want to show the logs.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with:
+          persist-credentials: false
+          fetch-depth: '2'
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
+      - name: Downcase network name for disks
+        run: |
+          NETWORK_CAPS=${{ inputs.network }}
+          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+
+      # Setup gcloud CLI
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.8.1
+        with:
+          retries: '3'
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
+
+      # Show recent logs, following until block 1,820,000 (or the test finishes)
+      - name: Show logs for ${{ inputs.test_id }} test (1820k)
+        id: compute-ssh
+        uses: google-github-actions/ssh-compute@v0.1.2
+        with:
+          instance_name: ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}
+          zone: ${{ env.ZONE }}
+          ssh_private_key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          command: |
+            sudo docker logs \
+            --tail all \
+            --follow \
+            ${{ inputs.test_id }} | \
+            tee --output-error=exit /dev/stderr | \
+            grep --max-count=1 --extended-regexp --color=always \
+            -e 'estimated progress.*current_height.*=.*182[0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+            -e 'estimated progress.*current_height.*=.*1[8-9][2-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+            -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+            -e 'test result:.*finished in'
+
   # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)
   logs-checkpoint:
     name: Log ${{ inputs.test_id }} test (checkpoint)
-    needs: [ logs-1790k ]
+    needs: [ logs-1820k ]
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

This is the standard fix for when the full sync job runs too long.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

## Solution

Add full sync jobs for 1800k, 1810k, and 1820k blocks

## Review

Anyone can review

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?
