### PR TITLE
ci(sync): increase the height of blocks for some full sync jobs

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -968,10 +968,74 @@ jobs:
           -e 'test result:.*finished in' \
           "
 
+  # follow the logs of the test we just launched, up to block 1,810,000 or later
+  # (or the test finishing)
+  #
+  # We chose this height because it was about 20 hours into the NU5 sync, in October 2022.
+  # (These blocks seem to be larger than the previous ones.)
+  logs-1810k:
+    name: Log ${{ inputs.test_id }} test (1810k)
+    needs: [ logs-1790k ]
+    # If the previous job fails, we still want to show the logs.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with:
+          persist-credentials: false
+          fetch-depth: '2'
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
+      - name: Downcase network name for disks
+        run: |
+          NETWORK_CAPS=${{ inputs.network }}
+          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+
+      # Setup gcloud CLI
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.8.1
+        with:
+          retries: '3'
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
+
+      # Show recent logs, following until block 1,810,000 (or the test finishes)
+      - name: Show logs for ${{ inputs.test_id }} test (1810k)
+        run: |
+          gcloud compute ssh \
+          github-service-account@${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          --zone ${{ env.ZONE }} \
+          --quiet \
+          --ssh-flag="-o ServerAliveInterval=5" \
+          --ssh-flag="-o ConnectionAttempts=20" \
+          --ssh-flag="-o ConnectTimeout=5" \
+          --command \
+          "\
+          sudo docker logs \
+          --tail all \
+          --follow \
+          ${{ inputs.test_id }} | \
+          tee --output-error=exit /dev/stderr | \
+          grep --max-count=1 --extended-regexp --color=always \
+          -e 'estimated progress.*current_height.*=.*181[0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*1[8-9][1-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'test result:.*finished in' \
+          "
+
   # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)
   logs-checkpoint:
     name: Log ${{ inputs.test_id }} test (checkpoint)
-    needs: [ logs-1790k ]
+    needs: [ logs-1810k ]
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -904,13 +904,13 @@ jobs:
           -e 'test result:.*finished in' \
           "
 
-  # follow the logs of the test we just launched, up to block 1,790,000 or later
+  # follow the logs of the test we just launched, up to block 1,800,000 or later
   # (or the test finishing)
   #
-  # We chose this height because it was about 16 hours into the NU5 sync, in September 2022.
+  # We chose this height because it was about 20 hours into the NU5 sync, in October 2022.
   # (These blocks seem to be larger than the previous ones.)
-  logs-1790k:
-    name: Log ${{ inputs.test_id }} test (1790k)
+  logs-1800k:
+    name: Log ${{ inputs.test_id }} test (1800k)
     needs: [ logs-1780k ]
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() }}
@@ -944,8 +944,8 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Show recent logs, following until block 1,790,000 (or the test finishes)
-      - name: Show logs for ${{ inputs.test_id }} test (1790k)
+      # Show recent logs, following until block 1,800,000 (or the test finishes)
+      - name: Show logs for ${{ inputs.test_id }} test (1800k)
         run: |
           gcloud compute ssh \
           github-service-account@${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
@@ -962,20 +962,20 @@ jobs:
           ${{ inputs.test_id }} | \
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          -e 'estimated progress.*current_height.*=.*179[0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*180[0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'test result:.*finished in' \
           "
 
-  # follow the logs of the test we just launched, up to block 1,810,000 or later
+  # follow the logs of the test we just launched, up to block 1,820,000 or later
   # (or the test finishing)
   #
-  # We chose this height because it was about 20 hours into the NU5 sync, in October 2022.
+  # We chose this height because it was about 24 hours into the NU5 sync, in October 2022.
   # (These blocks seem to be larger than the previous ones.)
-  logs-1810k:
-    name: Log ${{ inputs.test_id }} test (1810k)
-    needs: [ logs-1790k ]
+  logs-1820k:
+    name: Log ${{ inputs.test_id }} test (1820k)
+    needs: [ logs-1800k ]
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
@@ -1008,8 +1008,8 @@ jobs:
           service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
           token_format: 'access_token'
 
-      # Show recent logs, following until block 1,810,000 (or the test finishes)
-      - name: Show logs for ${{ inputs.test_id }} test (1810k)
+      # Show recent logs, following until block 1,820,000 (or the test finishes)
+      - name: Show logs for ${{ inputs.test_id }} test (1820k)
         run: |
           gcloud compute ssh \
           github-service-account@${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
@@ -1026,8 +1026,8 @@ jobs:
           ${{ inputs.test_id }} | \
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          -e 'estimated progress.*current_height.*=.*181[0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
-          -e 'estimated progress.*current_height.*=.*1[8-9][1-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*182[0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*1[8-9][2-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'test result:.*finished in' \
           "
@@ -1035,7 +1035,7 @@ jobs:
   # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)
   logs-checkpoint:
     name: Log ${{ inputs.test_id }} test (checkpoint)
-    needs: [ logs-1810k ]
+    needs: [ logs-1820k ]
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1026,8 +1026,8 @@ jobs:
           ${{ inputs.test_id }} | \
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          -e 'estimated progress.*current_height.*=.*182[0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
-          -e 'estimated progress.*current_height.*=.*1[8-9][2-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*18[2-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*19[0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'test result:.*finished in' \
           "

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -962,7 +962,6 @@ jobs:
           ${{ inputs.test_id }} | \
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          -e 'estimated progress.*current_height.*=.*180[0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'test result:.*finished in' \


### PR DESCRIPTION
## Motivation

This is the standard fix for when a full sync job runs too long (`logs-checkpoint` needs to sync ~45k blocks as of the latest checkpoint update).

## Solution

- Replace full sync job for 1790k blocks with one for 1800k blocks
- Add full sync job for 1820k blocks

See [fixing-ci-sync-timeouts](https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/continuous-integration.md#fixing-ci-sync-timeouts)

## Review

Anyone can review.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?
