### PR TITLE
build(deps): Remove `arrayvec` and `itoa` from `skip-tree`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -85,10 +85,6 @@ skip-tree = [
 
     # Optional dependencies
 
-    # wait for inferno -> num-format to upgrade
-    { name = "arrayvec", version = "=0.4.12" },
-    { name = "itoa", version = "=0.4.8" },
-
     # upgrade abscissa (required dependency) and arti (optional dependency)
     { name = "darling", version = "=0.10.2" },
     { name = "darling", version = "=0.12.4" },


### PR DESCRIPTION
## Motivation

We recently updated `inferno`, which depends on `num_format`, which depends on `arrayvec` and `itoa`, and running
```bash
cargo deny --all-features check bans
```
started producing the following warnings:
```
   ┌─ .../zebra/deny.toml:89:5
   │
89 │     { name = "arrayvec", version = "=0.4.12" },
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no crate matched these criteria

warning[B010]: skip tree root was not found in the dependency graph
   ┌─ .../zebra/deny.toml:90:5
   │
90 │     { name = "itoa", version = "=0.4.8" },
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no crate matched these criteria

bans ok
```

## Solution

The warning means we don't need to list the `arrayvec` and `itoa` dependencies in the `skip-tree` section, so this PR removes them.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?