### PR TITLE
ci(getblocktemplate): run getblocktemplate-rpcs feature tests in CI

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -180,7 +180,7 @@ jobs:
   # Run all the zebra tests, including tests that are ignored by default.
   # Skips tests that need a cached state disk or a lightwalletd binary.
   #
-  # - We run all the tests behind the `getblocktemplate-rpcs` feature.
+  # - We run all the tests behind the `getblocktemplate-rpcs` feature as a separated step.
   # - We activate the gRPC feature to avoid recompiling `zebrad`, but we don't actually run any gRPC tests.
   test-all:
     name: Test all
@@ -196,7 +196,13 @@ jobs:
       - name: Run all zebrad tests
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
+          docker run --name zebrad-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features "lightwalletd-grpc-tests" --workspace -- --nocapture --include-ignored
+
+      - name: Run all zebrad tests with getblocktemplate-rpcs feature
+        run: |
+          docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
           docker run --name zebrad-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features "lightwalletd-grpc-tests getblocktemplate-rpcs" --workspace -- --nocapture --include-ignored
+
 
   # Run state tests with fake activation heights.
   #

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -198,11 +198,24 @@ jobs:
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
           docker run --name zebrad-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features "lightwalletd-grpc-tests" --workspace -- --nocapture --include-ignored
 
-      - name: Run all zebrad tests with getblocktemplate-rpcs feature
+  # zebrad tests without cached state with `getblocktemplate-rpcs` feature
+
+  # Same as above but we run all the tests behind the `getblocktemplate-rpcs` feature.
+  test-all-getblocktemplate-rpcs:
+    name: Test all with getblocktemplate-rpcs feature
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
+    steps:
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
+      - name: Run all zebrad tests
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
           docker run --name zebrad-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features "lightwalletd-grpc-tests getblocktemplate-rpcs" --workspace -- --nocapture --include-ignored
-
 
   # Run state tests with fake activation heights.
   #

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -180,7 +180,8 @@ jobs:
   # Run all the zebra tests, including tests that are ignored by default.
   # Skips tests that need a cached state disk or a lightwalletd binary.
   #
-  # (We activate the gRPC feature to avoid recompiling `zebrad`, but we don't actually run any gRPC tests.)
+  # - We run all the tests behind the `getblocktemplate-rpcs` feature.
+  # - We activate the gRPC feature to avoid recompiling `zebrad`, but we don't actually run any gRPC tests.
   test-all:
     name: Test all
     runs-on: ubuntu-latest
@@ -195,7 +196,7 @@ jobs:
       - name: Run all zebrad tests
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run --name zebrad-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features lightwalletd-grpc-tests --workspace -- --nocapture --include-ignored
+          docker run --name zebrad-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features "lightwalletd-grpc-tests getblocktemplate-rpcs" --workspace -- --nocapture --include-ignored
 
   # Run state tests with fake activation heights.
   #

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -57,8 +57,7 @@ jobs:
     # The large timeout is to accommodate:
     # - Windows builds (75 minutes, typically 30-50 minutes), and
     # - parameter downloads (an extra 90 minutes, but only when the cache expires)
-    # - all features enabled (extra 10-15 mins)
-    timeout-minutes: 180
+    timeout-minutes: 165
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -166,7 +165,13 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --all-features --verbose --workspace -- --nocapture
+          args: --verbose --workspace -- --nocapture
+
+      - name: Run tests with getblocktemplate-rpcs feature
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+          args: --features getblocktemplate-rpcs --verbose --workspace -- --nocapture
 
       # Explicitly run any tests that are usually #[ignored]
 

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -165,7 +165,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --verbose --workspace -- --nocapture
+          args: --all-features --verbose --workspace -- --nocapture
 
       # Explicitly run any tests that are usually #[ignored]
 

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -57,7 +57,8 @@ jobs:
     # The large timeout is to accommodate:
     # - Windows builds (75 minutes, typically 30-50 minutes), and
     # - parameter downloads (an extra 90 minutes, but only when the cache expires)
-    timeout-minutes: 165
+    # - all features enabled (extra 10-15 mins)
+    timeout-minutes: 180
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Motivation

One option for https://github.com/ZcashFoundation/zebra/issues/5405 is to run a new test task with the getblocktemplate-rpcs feature enabled.

## Solution

Run a new task with `getblocktemplate-rpc` feature enabled. This will run the tests with and without the feature in a separated task for each case. I think is what we want to make sure everything pass when the feature is enabled/disabled in addition to run extra tests when enabled.

New tests can be seen in the logs at: 
https://github.com/ZcashFoundation/zebra/actions/runs/3291277916/jobs/5425229470#step:15:4896
https://github.com/ZcashFoundation/zebra/actions/runs/3291277916/jobs/5425229470#step:15:4912

## Review



### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
