### PR TITLE
fix(ci): Use correct lwd full sync patch job name

### DIFF
--- a/.github/workflows/continous-integration-docker.patch-always.yml
+++ b/.github/workflows/continous-integration-docker.patch-always.yml
@@ -20,7 +20,7 @@ jobs:
       - run: 'echo "No build required"'
 
   lightwalletd-full-sync:
-    name: lightwalletd tip / Run lightwalletd-full-sync test
+    name: lightwalletd tip / Run lwd-full-sync test
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'


### PR DESCRIPTION
## Motivation

We got a workflow patch job name wrong, so Mergify isn't merging PRs.