### PR TITLE
refactor(config): Move configs to components

### DIFF
--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -120,7 +120,8 @@ where
 /// Transactions sent over this connection can be linked to the sending and receiving IP address
 /// by passive internet observers.
 ///
-/// Prefer [`connect_isolated_tor`](tor::connect_isolated_tor) if available.
+///
+/// Prefer `connect_isolated_tor` if available.
 pub fn connect_isolated_tcp_direct(
     network: Network,
     addr: SocketAddr,

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -69,7 +69,7 @@ test_sync_past_mandatory_checkpoint_testnet = []
 
 [dependencies]
 zebra-chain = { path = "../zebra-chain" }
-zebra-consensus = { path = "../zebra-consensus/" }
+zebra-consensus = { path = "../zebra-consensus" }
 zebra-network = { path = "../zebra-network" }
 zebra-node-services = { path = "../zebra-node-services" }
 zebra-rpc = { path = "../zebra-rpc" }
@@ -176,7 +176,7 @@ proptest-derive = "0.3.0"
 color-eyre = { version = "0.6.2", features = ["issue-url"] }
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus/", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", features = ["proptest-impl"] }
 zebra-network = { path = "../zebra-network", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test" }

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -386,6 +386,7 @@ impl Application for ZebradApp {
 
         // Ignore the configured tracing filter for short-lived utility commands
         let mut tracing_config = cfg_ref.tracing.clone();
+        let metrics_config = cfg_ref.metrics.clone();
         if is_server {
             // Override the default tracing filter based on the command-line verbosity.
             tracing_config.filter = tracing_config
@@ -426,7 +427,7 @@ impl Application for ZebradApp {
         if is_server {
             components.push(Box::new(TokioComponent::new()?));
             components.push(Box::new(TracingEndpoint::new(cfg_ref)?));
-            components.push(Box::new(MetricsEndpoint::new(cfg_ref)?));
+            components.push(Box::new(MetricsEndpoint::new(&metrics_config)?));
         }
 
         self.state.components.register(components)

--- a/zebrad/src/components/metrics.rs
+++ b/zebrad/src/components/metrics.rs
@@ -13,7 +13,7 @@ impl MetricsEndpoint {
     /// Create the component.
     #[cfg(feature = "prometheus")]
     pub fn new(config: &Config) -> Result<Self, FrameworkError> {
-        if let Some(addr) = config.metrics.endpoint_addr {
+        if let Some(addr) = config.endpoint_addr {
             info!("Trying to open metrics endpoint at {}...", addr);
 
             let endpoint_result = metrics_exporter_prometheus::PrometheusBuilder::new()

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -7,6 +7,7 @@ use std::{cmp::max, collections::HashSet, pin::Pin, sync::Arc, task::Poll, time:
 use color_eyre::eyre::{eyre, Report};
 use futures::stream::{FuturesUnordered, StreamExt};
 use indexmap::IndexSet;
+use serde::{Deserialize, Serialize};
 use tokio::time::sleep;
 use tower::{
     builder::ServiceBuilder, hedge::Hedge, limit::ConcurrencyLimit, retry::Retry, timeout::Timeout,
@@ -203,6 +204,83 @@ const SYNC_RESTART_DELAY: Duration = Duration::from_secs(67);
 /// to download and verify the genesis block from its peers. This can cause
 /// a denial of service on those peers.
 const GENESIS_TIMEOUT_RETRY: Duration = Duration::from_secs(5);
+
+/// Sync configuration section.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Config {
+    /// The number of parallel block download requests.
+    ///
+    /// This is set to a low value by default, to avoid task and
+    /// network contention. Increasing this value may improve
+    /// performance on machines with a fast network connection.
+    #[serde(alias = "max_concurrent_block_requests")]
+    pub download_concurrency_limit: usize,
+
+    /// The number of blocks submitted in parallel to the checkpoint verifier.
+    ///
+    /// Increasing this limit increases the buffer size, so it reduces
+    /// the impact of an individual block request failing. However, it
+    /// also increases memory and CPU usage if block validation stalls,
+    /// or there are some large blocks in the pipeline.
+    ///
+    /// The block size limit is 2MB, so in theory, this could represent multiple
+    /// gigabytes of data, if we downloaded arbitrary blocks. However,
+    /// because we randomly load balance outbound requests, and separate
+    /// block download from obtaining block hashes, an adversary would
+    /// have to control a significant fraction of our peers to lead us
+    /// astray.
+    ///
+    /// For reliable checkpoint syncing, Zebra enforces a
+    /// [`MIN_CHECKPOINT_CONCURRENCY_LIMIT`](MIN_CHECKPOINT_CONCURRENCY_LIMIT).
+    ///
+    /// This is set to a high value by default, to avoid verification pipeline stalls.
+    /// Decreasing this value reduces RAM usage.
+    #[serde(alias = "lookahead_limit")]
+    pub checkpoint_verify_concurrency_limit: usize,
+
+    /// The number of blocks submitted in parallel to the full verifier.
+    ///
+    /// This is set to a low value by default, to avoid verification timeouts on large blocks.
+    /// Increasing this value may improve performance on machines with many cores.
+    pub full_verify_concurrency_limit: usize,
+
+    /// The number of threads used to verify signatures, proofs, and other CPU-intensive code.
+    ///
+    /// Set to `0` by default, which uses one thread per available CPU core.
+    /// For details, see [the `rayon` documentation](https://docs.rs/rayon/latest/rayon/struct.ThreadPoolBuilder.html#method.num_threads).
+    pub parallel_cpu_threads: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            // 2/3 of the default outbound peer limit.
+            download_concurrency_limit: 50,
+
+            // A few max-length checkpoints.
+            checkpoint_verify_concurrency_limit: DEFAULT_CHECKPOINT_CONCURRENCY_LIMIT,
+
+            // This default is deliberately very low, so Zebra can verify a few large blocks in under 60 seconds,
+            // even on machines with only a few cores.
+            //
+            // This lets users see the committed block height changing in every progress log,
+            // and avoids hangs due to out-of-order verifications flooding the CPUs.
+            //
+            // TODO:
+            // - limit full verification concurrency based on block transaction counts?
+            // - move more disk work to blocking tokio threads,
+            //   and CPU work to the rayon thread pool inside blocking tokio threads
+            full_verify_concurrency_limit: 20,
+
+            // Use one thread per CPU.
+            //
+            // If this causes tokio executor starvation, move CPU-intensive tasks to rayon threads,
+            // or reserve a few cores for tokio threads, based on `num_cpus()`.
+            parallel_cpu_threads: 0,
+        }
+    }
+}
 
 /// Helps work around defects in the bitcoin protocol by checking whether
 /// the returned hashes actually extend a chain tip.

--- a/zebrad/src/components/tracing.rs
+++ b/zebrad/src/components/tracing.rs
@@ -1,5 +1,9 @@
 //! Tracing and logging infrastructure for Zebra.
 
+use std::{net::SocketAddr, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+
 mod component;
 mod endpoint;
 
@@ -11,3 +15,109 @@ pub use endpoint::TracingEndpoint;
 
 #[cfg(feature = "flamegraph")]
 pub use flame::{layer, Grapher};
+
+/// Tracing configuration section.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Config {
+    /// Whether to use colored terminal output, if available.
+    ///
+    /// Colored terminal output is automatically disabled if an output stream
+    /// is connected to a file. (Or another non-terminal device.)
+    ///
+    /// Defaults to `true`, which automatically enables colored output to
+    /// terminals.
+    pub use_color: bool,
+
+    /// Whether to force the use of colored terminal output, even if it's not available.
+    ///
+    /// Will force Zebra to use colored terminal output even if it does not detect that the output
+    /// is a terminal that supports colors.
+    ///
+    /// Defaults to `false`, which keeps the behavior of `use_color`.
+    pub force_use_color: bool,
+
+    /// The filter used for tracing events.
+    ///
+    /// The filter is used to create a `tracing-subscriber`
+    /// [`EnvFilter`](https://docs.rs/tracing-subscriber/0.2.10/tracing_subscriber/filter/struct.EnvFilter.html#directives),
+    /// and more details on the syntax can be found there or in the examples
+    /// below.
+    ///
+    /// If no filter is specified (`None`), the filter is set to `info` if the
+    /// `-v` flag is given and `warn` if it is not given.
+    ///
+    /// # Examples
+    ///
+    /// `warn,zebrad=info,zebra_network=debug` sets a global `warn` level, an
+    /// `info` level for the `zebrad` crate, and a `debug` level for the
+    /// `zebra_network` crate.
+    ///
+    /// ```ascii,no_run
+    /// [block_verify{height=Some\(block::Height\(.*000\)\)}]=trace
+    /// ```
+    /// sets `trace` level for all events occurring in the context of a
+    /// `block_verify` span whose `height` field ends in `000`, i.e., traces the
+    /// verification of every 1000th block.
+    pub filter: Option<String>,
+
+    /// The buffer_limit size sets the number of log lines that can be queued by the tracing subscriber
+    /// to be written to stdout before logs are dropped.
+    ///
+    /// Defaults to 128,000 with a minimum of 100.
+    pub buffer_limit: usize,
+
+    /// The address used for an ad-hoc RPC endpoint allowing dynamic control of the tracing filter.
+    ///
+    /// Install Zebra using `cargo install --features=filter-reload` to enable this config.
+    ///
+    /// If this is set to None, the endpoint is disabled.
+    pub endpoint_addr: Option<SocketAddr>,
+
+    /// Controls whether to write a flamegraph of tracing spans.
+    ///
+    /// Install Zebra using `cargo install --features=flamegraph` to enable this config.
+    ///
+    /// If this is set to None, flamegraphs are disabled. Otherwise, it specifies
+    /// an output file path, as described below.
+    ///
+    /// This path is not used verbatim when writing out the flamegraph. This is
+    /// because the flamegraph is written out as two parts. First the flamegraph
+    /// is constantly persisted to the disk in a "folded" representation that
+    /// records collapsed stack traces of the tracing spans that are active.
+    /// Then, when the application is finished running the destructor will flush
+    /// the flamegraph output to the folded file and then read that file and
+    /// generate the final flamegraph from it as an SVG.
+    ///
+    /// The need to create two files means that we will slightly manipulate the
+    /// path given to us to create the two representations.
+    ///
+    /// # Example
+    ///
+    /// Given `flamegraph = "flamegraph"` we will generate a `flamegraph.svg` and
+    /// a `flamegraph.folded` file in the current directory.
+    ///
+    /// If you provide a path with an extension the extension will be ignored and
+    /// replaced with `.folded` and `.svg` for the respective files.
+    pub flamegraph: Option<PathBuf>,
+
+    /// The use_journald flag sends tracing events to systemd-journald, on Linux
+    /// distributions that use systemd.
+    ///
+    /// Install Zebra using `cargo install --features=journald` to enable this config.
+    pub use_journald: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            use_color: true,
+            force_use_color: false,
+            filter: None,
+            buffer_limit: 128_000,
+            endpoint_addr: None,
+            flamegraph: None,
+            use_journald: false,
+        }
+    }
+}

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::{
 
 use tracing_appender::non_blocking::{NonBlocking, NonBlockingBuilder, WorkerGuard};
 
-use crate::{application::app_version, config::TracingSection};
+use crate::{application::app_version, components::tracing::Config};
 
 #[cfg(feature = "flamegraph")]
 use super::flame;
@@ -43,7 +43,7 @@ pub struct Tracing {
 
 impl Tracing {
     /// Try to create a new [`Tracing`] component with the given `filter`.
-    pub fn new(config: TracingSection) -> Result<Self, FrameworkError> {
+    pub fn new(config: Config) -> Result<Self, FrameworkError> {
         let filter = config.filter.unwrap_or_default();
         let flame_root = &config.flamegraph;
 

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -4,16 +4,7 @@
 //! application's configuration file and/or command-line options
 //! for specifying it.
 
-use std::{net::SocketAddr, path::PathBuf};
-
 use serde::{Deserialize, Serialize};
-
-use zebra_consensus::Config as ConsensusSection;
-use zebra_network::Config as NetworkSection;
-use zebra_rpc::config::Config as RpcSection;
-use zebra_state::Config as StateSection;
-
-use crate::components::{mempool::Config as MempoolSection, sync};
 
 /// Configuration for `zebrad`.
 ///
@@ -24,232 +15,26 @@ use crate::components::{mempool::Config as MempoolSection, sync};
 #[serde(deny_unknown_fields, default)]
 pub struct ZebradConfig {
     /// Consensus configuration
-    pub consensus: ConsensusSection,
+    pub consensus: zebra_consensus::Config,
 
     /// Metrics configuration
-    pub metrics: MetricsSection,
+    pub metrics: crate::components::metrics::Config,
 
     /// Networking configuration
-    pub network: NetworkSection,
+    pub network: zebra_network::Config,
 
     /// State configuration
-    pub state: StateSection,
+    pub state: zebra_state::Config,
 
     /// Tracing configuration
-    pub tracing: TracingSection,
+    pub tracing: crate::components::tracing::Config,
 
     /// Sync configuration
-    pub sync: SyncSection,
+    pub sync: crate::components::sync::Config,
 
     /// Mempool configuration
-    pub mempool: MempoolSection,
+    pub mempool: crate::components::mempool::Config,
 
     /// RPC configuration
-    pub rpc: RpcSection,
-}
-
-/// Tracing configuration section.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields, default)]
-pub struct TracingSection {
-    /// Whether to use colored terminal output, if available.
-    ///
-    /// Colored terminal output is automatically disabled if an output stream
-    /// is connected to a file. (Or another non-terminal device.)
-    ///
-    /// Defaults to `true`, which automatically enables colored output to
-    /// terminals.
-    pub use_color: bool,
-
-    /// Whether to force the use of colored terminal output, even if it's not available.
-    ///
-    /// Will force Zebra to use colored terminal output even if it does not detect that the output
-    /// is a terminal that supports colors.
-    ///
-    /// Defaults to `false`, which keeps the behavior of `use_color`.
-    pub force_use_color: bool,
-
-    /// The filter used for tracing events.
-    ///
-    /// The filter is used to create a `tracing-subscriber`
-    /// [`EnvFilter`](https://docs.rs/tracing-subscriber/0.2.10/tracing_subscriber/filter/struct.EnvFilter.html#directives),
-    /// and more details on the syntax can be found there or in the examples
-    /// below.
-    ///
-    /// If no filter is specified (`None`), the filter is set to `info` if the
-    /// `-v` flag is given and `warn` if it is not given.
-    ///
-    /// # Examples
-    ///
-    /// `warn,zebrad=info,zebra_network=debug` sets a global `warn` level, an
-    /// `info` level for the `zebrad` crate, and a `debug` level for the
-    /// `zebra_network` crate.
-    ///
-    /// ```ascii,no_run
-    /// [block_verify{height=Some\(block::Height\(.*000\)\)}]=trace
-    /// ```
-    /// sets `trace` level for all events occurring in the context of a
-    /// `block_verify` span whose `height` field ends in `000`, i.e., traces the
-    /// verification of every 1000th block.
-    pub filter: Option<String>,
-
-    /// The buffer_limit size sets the number of log lines that can be queued by the tracing subscriber
-    /// to be written to stdout before logs are dropped.
-    ///
-    /// Defaults to 128,000 with a minimum of 100.
-    pub buffer_limit: usize,
-
-    /// The address used for an ad-hoc RPC endpoint allowing dynamic control of the tracing filter.
-    ///
-    /// Install Zebra using `cargo install --features=filter-reload` to enable this config.
-    ///
-    /// If this is set to None, the endpoint is disabled.
-    pub endpoint_addr: Option<SocketAddr>,
-
-    /// Controls whether to write a flamegraph of tracing spans.
-    ///
-    /// Install Zebra using `cargo install --features=flamegraph` to enable this config.
-    ///
-    /// If this is set to None, flamegraphs are disabled. Otherwise, it specifies
-    /// an output file path, as described below.
-    ///
-    /// This path is not used verbatim when writing out the flamegraph. This is
-    /// because the flamegraph is written out as two parts. First the flamegraph
-    /// is constantly persisted to the disk in a "folded" representation that
-    /// records collapsed stack traces of the tracing spans that are active.
-    /// Then, when the application is finished running the destructor will flush
-    /// the flamegraph output to the folded file and then read that file and
-    /// generate the final flamegraph from it as an SVG.
-    ///
-    /// The need to create two files means that we will slightly manipulate the
-    /// path given to us to create the two representations.
-    ///
-    /// # Example
-    ///
-    /// Given `flamegraph = "flamegraph"` we will generate a `flamegraph.svg` and
-    /// a `flamegraph.folded` file in the current directory.
-    ///
-    /// If you provide a path with an extension the extension will be ignored and
-    /// replaced with `.folded` and `.svg` for the respective files.
-    pub flamegraph: Option<PathBuf>,
-
-    /// The use_journald flag sends tracing events to systemd-journald, on Linux
-    /// distributions that use systemd.
-    ///
-    /// Install Zebra using `cargo install --features=journald` to enable this config.
-    pub use_journald: bool,
-}
-
-impl Default for TracingSection {
-    fn default() -> Self {
-        Self {
-            use_color: true,
-            force_use_color: false,
-            filter: None,
-            buffer_limit: 128_000,
-            endpoint_addr: None,
-            flamegraph: None,
-            use_journald: false,
-        }
-    }
-}
-
-/// Metrics configuration section.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields, default)]
-pub struct MetricsSection {
-    /// The address used for the Prometheus metrics endpoint.
-    ///
-    /// Install Zebra using `cargo install --features=prometheus` to enable this config.
-    ///
-    /// The endpoint is disabled if this is set to `None`.
-    pub endpoint_addr: Option<SocketAddr>,
-}
-
-// we like our default configs to be explicit
-#[allow(unknown_lints)]
-#[allow(clippy::derivable_impls)]
-impl Default for MetricsSection {
-    fn default() -> Self {
-        Self {
-            endpoint_addr: None,
-        }
-    }
-}
-
-/// Sync configuration section.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields, default)]
-pub struct SyncSection {
-    /// The number of parallel block download requests.
-    ///
-    /// This is set to a low value by default, to avoid task and
-    /// network contention. Increasing this value may improve
-    /// performance on machines with a fast network connection.
-    #[serde(alias = "max_concurrent_block_requests")]
-    pub download_concurrency_limit: usize,
-
-    /// The number of blocks submitted in parallel to the checkpoint verifier.
-    ///
-    /// Increasing this limit increases the buffer size, so it reduces
-    /// the impact of an individual block request failing. However, it
-    /// also increases memory and CPU usage if block validation stalls,
-    /// or there are some large blocks in the pipeline.
-    ///
-    /// The block size limit is 2MB, so in theory, this could represent multiple
-    /// gigabytes of data, if we downloaded arbitrary blocks. However,
-    /// because we randomly load balance outbound requests, and separate
-    /// block download from obtaining block hashes, an adversary would
-    /// have to control a significant fraction of our peers to lead us
-    /// astray.
-    ///
-    /// For reliable checkpoint syncing, Zebra enforces a
-    /// [`MIN_CHECKPOINT_CONCURRENCY_LIMIT`](sync::MIN_CHECKPOINT_CONCURRENCY_LIMIT).
-    ///
-    /// This is set to a high value by default, to avoid verification pipeline stalls.
-    /// Decreasing this value reduces RAM usage.
-    #[serde(alias = "lookahead_limit")]
-    pub checkpoint_verify_concurrency_limit: usize,
-
-    /// The number of blocks submitted in parallel to the full verifier.
-    ///
-    /// This is set to a low value by default, to avoid verification timeouts on large blocks.
-    /// Increasing this value may improve performance on machines with many cores.
-    pub full_verify_concurrency_limit: usize,
-
-    /// The number of threads used to verify signatures, proofs, and other CPU-intensive code.
-    ///
-    /// Set to `0` by default, which uses one thread per available CPU core.
-    /// For details, see [the `rayon` documentation](https://docs.rs/rayon/latest/rayon/struct.ThreadPoolBuilder.html#method.num_threads).
-    pub parallel_cpu_threads: usize,
-}
-
-impl Default for SyncSection {
-    fn default() -> Self {
-        Self {
-            // 2/3 of the default outbound peer limit.
-            download_concurrency_limit: 50,
-
-            // A few max-length checkpoints.
-            checkpoint_verify_concurrency_limit: sync::DEFAULT_CHECKPOINT_CONCURRENCY_LIMIT,
-
-            // This default is deliberately very low, so Zebra can verify a few large blocks in under 60 seconds,
-            // even on machines with only a few cores.
-            //
-            // This lets users see the committed block height changing in every progress log,
-            // and avoids hangs due to out-of-order verifications flooding the CPUs.
-            //
-            // TODO:
-            // - limit full verification concurrency based on block transaction counts?
-            // - move more disk work to blocking tokio threads,
-            //   and CPU work to the rayon thread pool inside blocking tokio threads
-            full_verify_concurrency_limit: 20,
-
-            // Use one thread per CPU.
-            //
-            // If this causes tokio executor starvation, move CPU-intensive tasks to rayon threads,
-            // or reserve a few cores for tokio threads, based on `num_cpus()`.
-            parallel_cpu_threads: 0,
-        }
-    }
+    pub rpc: zebra_rpc::config::Config,
 }

--- a/zebrad/tests/common/config.rs
+++ b/zebrad/tests/common/config.rs
@@ -15,8 +15,8 @@ use color_eyre::eyre::Result;
 use tempfile::TempDir;
 
 use zebrad::{
-    components::{mempool, sync},
-    config::{SyncSection, TracingSection, ZebradConfig},
+    components::{mempool, sync, tracing},
+    config::ZebradConfig,
 };
 
 /// Returns a config with:
@@ -34,10 +34,10 @@ pub fn default_test_config() -> Result<ZebradConfig> {
         ..zebra_network::Config::default()
     };
 
-    let sync = SyncSection {
+    let sync = sync::Config {
         // Avoid downloading unnecessary blocks.
         checkpoint_verify_concurrency_limit: sync::MIN_CHECKPOINT_CONCURRENCY_LIMIT,
-        ..SyncSection::default()
+        ..sync::Config::default()
     };
 
     let mempool = mempool::Config {
@@ -54,9 +54,9 @@ pub fn default_test_config() -> Result<ZebradConfig> {
         env::var("ZEBRA_FORCE_USE_COLOR"),
         Err(env::VarError::NotPresent)
     );
-    let tracing = TracingSection {
+    let tracing = tracing::Config {
         force_use_color,
-        ..TracingSection::default()
+        ..tracing::Config::default()
     };
 
     let config = ZebradConfig {


### PR DESCRIPTION
## Motivation

This was inspired by https://github.com/ZcashFoundation/zebra/issues/5436 where there is a broken link and we don't know why. 

I am not sure if this will fix the link issue but in my opinion the docs about the config and also the code will be a bit more clear if each `Config` is where it needs to be.

![config](https://user-images.githubusercontent.com/21685097/197290941-3b08e33e-5e23-4df6-9e29-2998f302e3f2.png)


## Solution

- Move the config code to each component (https://github.com/ZcashFoundation/zebra/commit/c21d0be05848ce1437f0c93a2a50506c135d3b04) and make needed fixes to make them work that way.
- Remove trailing slash from zebrad Cargo.toml when importing consensus (https://github.com/ZcashFoundation/zebra/commit/68a681ee904ee5db26b1f2cff9f7f09dc2ee92d2)
- Remove a doc warning that will be visible when running `cargo doc`. This is because the code the link is pointing to is behind a rust feature, so i prefer to just remove the link in those cases (https://github.com/ZcashFoundation/zebra/commit/5572f748efea36091438217984b2e1d4d73e2b1e)

## Review

I think anyone can review. In regards to the priority i think it can depend, we could want to add it to the new audit tag we are going to do. If so the priority can be medium, low otherwise.


### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

