### PR TITLE
feat(rpc): introduce getblocktemplate rpc call with stub fields

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -35,10 +35,10 @@ use zebra_state::{OutputIndex, OutputLocation, TransactionLocation};
 use crate::queue::Queue;
 
 #[cfg(feature = "getblocktemplate-rpcs")]
-mod get_block_template;
+mod get_block_template_rpcs;
 
 #[cfg(feature = "getblocktemplate-rpcs")]
-pub use get_block_template::{GetBlockTemplateRpc, GetBlockTemplateRpcImpl};
+pub use get_block_template_rpcs::{GetBlockTemplateRpc, GetBlockTemplateRpcImpl};
 
 #[cfg(test)]
 mod tests;

--- a/zebra-rpc/src/methods/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template.rs
@@ -171,7 +171,6 @@ where
                 },
                 transactions: vec![],
                 coinbasetxn: Coinbase {},
-                longpollid: empty_string.clone(),
                 target: empty_string.clone(),
                 mintime: 0,
                 mutable: vec![],
@@ -207,8 +206,6 @@ pub struct GetBlockTemplate {
     pub transactions: Vec<Transaction>,
     /// Add documentation.
     pub coinbasetxn: Coinbase,
-    /// Add documentation.
-    pub longpollid: String,
     /// Add documentation.
     pub target: String,
     /// Add documentation.

--- a/zebra-rpc/src/methods/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template.rs
@@ -35,8 +35,19 @@ pub trait GetBlockTemplateRpc {
     ///
     /// - If `index` is positive then index = block height.
     /// - If `index` is negative then -1 is the last known valid block.
+    /// - This rpc method is available only if zebra is built with `--features getblocktemplate-rpcs`.
     #[rpc(name = "getblockhash")]
     fn get_block_hash(&self, index: i32) -> BoxFuture<Result<GetBlockHash>>;
+
+    /// Documentation to be filled as we go.
+    ///
+    /// zcashd reference: [`getblocktemplate`](https://zcash-rpc.github.io/getblocktemplate.html)
+    ///
+    /// # Notes
+    ///
+    /// - This rpc method is available only if zebra is built with `--features getblocktemplate-rpcs`.
+    #[rpc(name = "getblocktemplate")]
+    fn get_block_template(&self) -> BoxFuture<Result<GetBlockTemplate>>;
 }
 
 /// RPC method implementations.
@@ -139,7 +150,105 @@ where
         }
         .boxed()
     }
+
+    fn get_block_template(&self) -> BoxFuture<Result<GetBlockTemplate>> {
+        async move {
+            let empty_string = String::from("");
+
+            // Returns empty `GetBlockTemplate`
+            Ok(GetBlockTemplate {
+                capabilities: vec![],
+                version: 0,
+                previousblockhash: empty_string.clone(),
+                blockcommitmentshash: empty_string.clone(),
+                lightclientroothash: empty_string.clone(),
+                finalsaplingroothash: empty_string.clone(),
+                defaultroots: DefaultRoots {
+                    merkleroot: empty_string.clone(),
+                    chainhistoryroot: empty_string.clone(),
+                    authdataroot: empty_string.clone(),
+                    blockcommitmentshash: empty_string.clone(),
+                },
+                transactions: vec![],
+                coinbasetxn: Coinbase {},
+                longpollid: empty_string.clone(),
+                target: empty_string.clone(),
+                mintime: 0,
+                mutable: vec![],
+                noncerange: empty_string.clone(),
+                sigoplimit: 0,
+                sizelimit: 0,
+                curtime: 0,
+                bits: empty_string,
+                height: 0,
+            })
+        }
+        .boxed()
+    }
 }
+/// Documentation to be added after we document all the individual fields.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct GetBlockTemplate {
+    /// Add documentation.
+    pub capabilities: Vec<String>,
+    /// Add documentation.
+    pub version: usize,
+    /// Add documentation.
+    pub previousblockhash: String,
+    /// Add documentation.
+    pub blockcommitmentshash: String,
+    /// Add documentation.
+    pub lightclientroothash: String,
+    /// Add documentation.
+    pub finalsaplingroothash: String,
+    /// Add documentation.
+    pub defaultroots: DefaultRoots,
+    /// Add documentation.
+    pub transactions: Vec<Transaction>,
+    /// Add documentation.
+    pub coinbasetxn: Coinbase,
+    /// Add documentation.
+    pub longpollid: String,
+    /// Add documentation.
+    pub target: String,
+    /// Add documentation.
+    pub mintime: u32,
+    /// Add documentation.
+    pub mutable: Vec<String>,
+    /// Add documentation.
+    pub noncerange: String,
+    /// Add documentation.
+    pub sigoplimit: u32,
+    /// Add documentation.
+    pub sizelimit: u32,
+    /// Add documentation.
+    pub curtime: u32,
+    /// Add documentation.
+    pub bits: String,
+    /// Add documentation.
+    pub height: u32,
+}
+
+/// Documentation to be added in #5452 or #5455.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct DefaultRoots {
+    /// Add documentation.
+    pub merkleroot: String,
+    /// Add documentation.
+    pub chainhistoryroot: String,
+    /// Add documentation.
+    pub authdataroot: String,
+    /// Add documentation.
+    pub blockcommitmentshash: String,
+}
+
+/// Documentation and fields to be added in #5454.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Transaction {}
+
+/// documentation and fields to be added in #5453.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Coinbase {}
 
 /// Given a potentially negative index, find the corresponding `Height`.
 ///

--- a/zebra-rpc/src/methods/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template.rs
@@ -159,25 +159,25 @@ where
             Ok(GetBlockTemplate {
                 capabilities: vec![],
                 version: 0,
-                previousblockhash: empty_string.clone(),
-                blockcommitmentshash: empty_string.clone(),
-                lightclientroothash: empty_string.clone(),
-                finalsaplingroothash: empty_string.clone(),
-                defaultroots: DefaultRoots {
-                    merkleroot: empty_string.clone(),
-                    chainhistoryroot: empty_string.clone(),
-                    authdataroot: empty_string.clone(),
-                    blockcommitmentshash: empty_string.clone(),
+                previous_block_hash: empty_string.clone(),
+                block_commitments_hash: empty_string.clone(),
+                light_client_root_hash: empty_string.clone(),
+                final_sapling_root_hash: empty_string.clone(),
+                default_roots: DefaultRoots {
+                    merkle_root: empty_string.clone(),
+                    chain_history_root: empty_string.clone(),
+                    auth_data_root: empty_string.clone(),
+                    block_commitments_hash: empty_string.clone(),
                 },
                 transactions: vec![],
-                coinbasetxn: Coinbase {},
+                coinbase_txn: Coinbase {},
                 target: empty_string.clone(),
-                mintime: 0,
+                min_time: 0,
                 mutable: vec![],
-                noncerange: empty_string.clone(),
-                sigoplimit: 0,
-                sizelimit: 0,
-                curtime: 0,
+                nonce_range: empty_string.clone(),
+                sigop_limit: 0,
+                size_limit: 0,
+                cur_time: 0,
                 bits: empty_string,
                 height: 0,
             })
@@ -193,33 +193,44 @@ pub struct GetBlockTemplate {
     /// Add documentation.
     pub version: usize,
     /// Add documentation.
-    pub previousblockhash: String,
+    #[serde(rename = "previousblockhash")]
+    pub previous_block_hash: String,
     /// Add documentation.
-    pub blockcommitmentshash: String,
+    #[serde(rename = "blockcommitmentshash")]
+    pub block_commitments_hash: String,
     /// Add documentation.
-    pub lightclientroothash: String,
+    #[serde(rename = "lightclientroothash")]
+    pub light_client_root_hash: String,
     /// Add documentation.
-    pub finalsaplingroothash: String,
+    #[serde(rename = "finalsaplingroothash")]
+    pub final_sapling_root_hash: String,
     /// Add documentation.
-    pub defaultroots: DefaultRoots,
+    #[serde(rename = "defaultroots")]
+    pub default_roots: DefaultRoots,
     /// Add documentation.
     pub transactions: Vec<Transaction>,
     /// Add documentation.
-    pub coinbasetxn: Coinbase,
+    #[serde(rename = "coinbasetxn")]
+    pub coinbase_txn: Coinbase,
     /// Add documentation.
     pub target: String,
     /// Add documentation.
-    pub mintime: u32,
+    #[serde(rename = "mintime")]
+    pub min_time: u32,
     /// Add documentation.
     pub mutable: Vec<String>,
     /// Add documentation.
-    pub noncerange: String,
+    #[serde(rename = "noncerange")]
+    pub nonce_range: String,
     /// Add documentation.
-    pub sigoplimit: u32,
+    #[serde(rename = "sigoplimit")]
+    pub sigop_limit: u32,
     /// Add documentation.
-    pub sizelimit: u32,
+    #[serde(rename = "sizelimit")]
+    pub size_limit: u32,
     /// Add documentation.
-    pub curtime: u32,
+    #[serde(rename = "curtime")]
+    pub cur_time: u32,
     /// Add documentation.
     pub bits: String,
     /// Add documentation.
@@ -230,13 +241,17 @@ pub struct GetBlockTemplate {
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct DefaultRoots {
     /// Add documentation.
-    pub merkleroot: String,
+    #[serde(rename = "merkleroot")]
+    pub merkle_root: String,
     /// Add documentation.
-    pub chainhistoryroot: String,
+    #[serde(rename = "chainhistoryroot")]
+    pub chain_history_root: String,
     /// Add documentation.
-    pub authdataroot: String,
+    #[serde(rename = "authdataroot")]
+    pub auth_data_root: String,
     /// Add documentation.
-    pub blockcommitmentshash: String,
+    #[serde(rename = "blockcommitmentshash")]
+    pub block_commitments_hash: String,
 }
 
 /// Documentation and fields to be added in #5454.

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -6,7 +6,14 @@ use jsonrpc_core::{self, BoxFuture, Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use tower::{Service, ServiceExt};
 
-use crate::methods::{GetBlockHash, MISSING_BLOCK_ERROR_CODE};
+pub(crate) mod types;
+
+use crate::methods::{
+    get_block_template_rpcs::types::{
+        coinbase::Coinbase, default_roots::DefaultRoots, get_block_template::GetBlockTemplate,
+    },
+    GetBlockHash, MISSING_BLOCK_ERROR_CODE,
+};
 
 /// getblocktemplate RPC method signatures.
 #[rpc(server)]
@@ -185,82 +192,6 @@ where
         .boxed()
     }
 }
-/// Documentation to be added after we document all the individual fields.
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct GetBlockTemplate {
-    /// Add documentation.
-    pub capabilities: Vec<String>,
-    /// Add documentation.
-    pub version: usize,
-    /// Add documentation.
-    #[serde(rename = "previousblockhash")]
-    pub previous_block_hash: String,
-    /// Add documentation.
-    #[serde(rename = "blockcommitmentshash")]
-    pub block_commitments_hash: String,
-    /// Add documentation.
-    #[serde(rename = "lightclientroothash")]
-    pub light_client_root_hash: String,
-    /// Add documentation.
-    #[serde(rename = "finalsaplingroothash")]
-    pub final_sapling_root_hash: String,
-    /// Add documentation.
-    #[serde(rename = "defaultroots")]
-    pub default_roots: DefaultRoots,
-    /// Add documentation.
-    pub transactions: Vec<Transaction>,
-    /// Add documentation.
-    #[serde(rename = "coinbasetxn")]
-    pub coinbase_txn: Coinbase,
-    /// Add documentation.
-    pub target: String,
-    /// Add documentation.
-    #[serde(rename = "mintime")]
-    pub min_time: u32,
-    /// Add documentation.
-    pub mutable: Vec<String>,
-    /// Add documentation.
-    #[serde(rename = "noncerange")]
-    pub nonce_range: String,
-    /// Add documentation.
-    #[serde(rename = "sigoplimit")]
-    pub sigop_limit: u32,
-    /// Add documentation.
-    #[serde(rename = "sizelimit")]
-    pub size_limit: u32,
-    /// Add documentation.
-    #[serde(rename = "curtime")]
-    pub cur_time: u32,
-    /// Add documentation.
-    pub bits: String,
-    /// Add documentation.
-    pub height: u32,
-}
-
-/// Documentation to be added in #5452 or #5455.
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct DefaultRoots {
-    /// Add documentation.
-    #[serde(rename = "merkleroot")]
-    pub merkle_root: String,
-    /// Add documentation.
-    #[serde(rename = "chainhistoryroot")]
-    pub chain_history_root: String,
-    /// Add documentation.
-    #[serde(rename = "authdataroot")]
-    pub auth_data_root: String,
-    /// Add documentation.
-    #[serde(rename = "blockcommitmentshash")]
-    pub block_commitments_hash: String,
-}
-
-/// Documentation and fields to be added in #5454.
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct Transaction {}
-
-/// documentation and fields to be added in #5453.
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct Coinbase {}
 
 /// Given a potentially negative index, find the corresponding `Height`.
 ///

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types.rs
@@ -1,0 +1,6 @@
+//! Types used in mining RPC methods.
+
+pub(crate) mod coinbase;
+pub(crate) mod default_roots;
+pub(crate) mod get_block_template;
+pub(crate) mod transaction;

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/coinbase.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/coinbase.rs
@@ -1,0 +1,5 @@
+//! The `Coinbase` type is part of the `getblocktemplate` RPC method output.
+
+/// documentation and fields to be added in #5453.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Coinbase {}

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/default_roots.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/default_roots.rs
@@ -1,0 +1,18 @@
+//! The `DefaultRoots` type is part of the `getblocktemplate` RPC method output.
+
+/// Documentation to be added in #5452 or #5455.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct DefaultRoots {
+    /// Add documentation.
+    #[serde(rename = "merkleroot")]
+    pub merkle_root: String,
+    /// Add documentation.
+    #[serde(rename = "chainhistoryroot")]
+    pub chain_history_root: String,
+    /// Add documentation.
+    #[serde(rename = "authdataroot")]
+    pub auth_data_root: String,
+    /// Add documentation.
+    #[serde(rename = "blockcommitmentshash")]
+    pub block_commitments_hash: String,
+}

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
@@ -1,0 +1,57 @@
+//! The `GetBlockTempate` type is the output of the `getblocktemplate` RPC method.
+
+use crate::methods::get_block_template_rpcs::types::{
+    coinbase::Coinbase, default_roots::DefaultRoots, transaction::Transaction,
+};
+
+/// Documentation to be added after we document all the individual fields.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct GetBlockTemplate {
+    /// Add documentation.
+    pub capabilities: Vec<String>,
+    /// Add documentation.
+    pub version: usize,
+    /// Add documentation.
+    #[serde(rename = "previousblockhash")]
+    pub previous_block_hash: String,
+    /// Add documentation.
+    #[serde(rename = "blockcommitmentshash")]
+    pub block_commitments_hash: String,
+    /// Add documentation.
+    #[serde(rename = "lightclientroothash")]
+    pub light_client_root_hash: String,
+    /// Add documentation.
+    #[serde(rename = "finalsaplingroothash")]
+    pub final_sapling_root_hash: String,
+    /// Add documentation.
+    #[serde(rename = "defaultroots")]
+    pub default_roots: DefaultRoots,
+    /// Add documentation.
+    pub transactions: Vec<Transaction>,
+    /// Add documentation.
+    #[serde(rename = "coinbasetxn")]
+    pub coinbase_txn: Coinbase,
+    /// Add documentation.
+    pub target: String,
+    /// Add documentation.
+    #[serde(rename = "mintime")]
+    pub min_time: u32,
+    /// Add documentation.
+    pub mutable: Vec<String>,
+    /// Add documentation.
+    #[serde(rename = "noncerange")]
+    pub nonce_range: String,
+    /// Add documentation.
+    #[serde(rename = "sigoplimit")]
+    pub sigop_limit: u32,
+    /// Add documentation.
+    #[serde(rename = "sizelimit")]
+    pub size_limit: u32,
+    /// Add documentation.
+    #[serde(rename = "curtime")]
+    pub cur_time: u32,
+    /// Add documentation.
+    pub bits: String,
+    /// Add documentation.
+    pub height: u32,
+}

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/transaction.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/transaction.rs
@@ -1,0 +1,5 @@
+//! The `Transaction` type is part of the `getblocktemplate` RPC method output.
+
+/// Documentation and fields to be added in #5454.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Transaction {}

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -191,6 +191,13 @@ async fn test_rpc_response_data_for_network(network: Network) {
             .expect("We should have a GetBlockHash struct");
 
         snapshot_rpc_getblockhash(get_block_hash, &settings);
+
+        // `getblocktemplate`
+        let get_block_template = get_block_template_rpc
+            .get_block_template()
+            .await
+            .expect("We should have a GetBlockTemplate struct");
+        snapshot_rpc_getblocktemplate(get_block_template, &settings);
     }
 }
 
@@ -290,6 +297,15 @@ fn snapshot_rpc_getblockcount(block_count: u32, settings: &insta::Settings) {
 /// Snapshot `getblockhash` response, using `cargo insta` and JSON serialization.
 fn snapshot_rpc_getblockhash(block_hash: GetBlockHash, settings: &insta::Settings) {
     settings.bind(|| insta::assert_json_snapshot!("get_block_hash", block_hash));
+}
+
+#[cfg(feature = "getblocktemplate-rpcs")]
+/// Snapshot `getblocktemplate` response, using `cargo insta` and JSON serialization.
+fn snapshot_rpc_getblocktemplate(
+    block_template: crate::methods::get_block_template::GetBlockTemplate,
+    settings: &insta::Settings,
+) {
+    settings.bind(|| insta::assert_json_snapshot!("get_block_template", block_template));
 }
 
 /// Utility function to convert a `Network` to a lowercase string.

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -302,7 +302,7 @@ fn snapshot_rpc_getblockhash(block_hash: GetBlockHash, settings: &insta::Setting
 #[cfg(feature = "getblocktemplate-rpcs")]
 /// Snapshot `getblocktemplate` response, using `cargo insta` and JSON serialization.
 fn snapshot_rpc_getblocktemplate(
-    block_template: crate::methods::get_block_template::GetBlockTemplate,
+    block_template: crate::methods::get_block_template_rpcs::types::get_block_template::GetBlockTemplate,
     settings: &insta::Settings,
 ) {
     settings.bind(|| insta::assert_json_snapshot!("get_block_template", block_template));

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_template@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_template@mainnet_10.snap
@@ -18,7 +18,6 @@ expression: block_template
   },
   "transactions": [],
   "coinbasetxn": {},
-  "longpollid": "",
   "target": "",
   "mintime": 0,
   "mutable": [],

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_template@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_template@mainnet_10.snap
@@ -1,0 +1,31 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+assertion_line: 308
+expression: block_template
+---
+{
+  "capabilities": [],
+  "version": 0,
+  "previousblockhash": "",
+  "blockcommitmentshash": "",
+  "lightclientroothash": "",
+  "finalsaplingroothash": "",
+  "defaultroots": {
+    "merkleroot": "",
+    "chainhistoryroot": "",
+    "authdataroot": "",
+    "blockcommitmentshash": ""
+  },
+  "transactions": [],
+  "coinbasetxn": {},
+  "longpollid": "",
+  "target": "",
+  "mintime": 0,
+  "mutable": [],
+  "noncerange": "",
+  "sigoplimit": 0,
+  "sizelimit": 0,
+  "curtime": 0,
+  "bits": "",
+  "height": 0
+}

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_template@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_template@testnet_10.snap
@@ -18,7 +18,6 @@ expression: block_template
   },
   "transactions": [],
   "coinbasetxn": {},
-  "longpollid": "",
   "target": "",
   "mintime": 0,
   "mutable": [],

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_template@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_template@testnet_10.snap
@@ -1,0 +1,31 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+assertion_line: 308
+expression: block_template
+---
+{
+  "capabilities": [],
+  "version": 0,
+  "previousblockhash": "",
+  "blockcommitmentshash": "",
+  "lightclientroothash": "",
+  "finalsaplingroothash": "",
+  "defaultroots": {
+    "merkleroot": "",
+    "chainhistoryroot": "",
+    "authdataroot": "",
+    "blockcommitmentshash": ""
+  },
+  "transactions": [],
+  "coinbasetxn": {},
+  "longpollid": "",
+  "target": "",
+  "mintime": 0,
+  "mutable": [],
+  "noncerange": "",
+  "sigoplimit": 0,
+  "sizelimit": 0,
+  "curtime": 0,
+  "bits": "",
+  "height": 0
+}

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -793,29 +793,32 @@ async fn rpc_getblocktemplate() {
 
     assert!(get_block_template.capabilities.is_empty());
     assert_eq!(get_block_template.version, 0);
-    assert!(get_block_template.previousblockhash.is_empty());
-    assert!(get_block_template.blockcommitmentshash.is_empty());
-    assert!(get_block_template.lightclientroothash.is_empty());
-    assert!(get_block_template.finalsaplingroothash.is_empty());
-    assert!(get_block_template.defaultroots.merkleroot.is_empty());
-    assert!(get_block_template.defaultroots.chainhistoryroot.is_empty());
-    assert!(get_block_template.defaultroots.authdataroot.is_empty());
+    assert!(get_block_template.previous_block_hash.is_empty());
+    assert!(get_block_template.block_commitments_hash.is_empty());
+    assert!(get_block_template.light_client_root_hash.is_empty());
+    assert!(get_block_template.final_sapling_root_hash.is_empty());
+    assert!(get_block_template.default_roots.merkle_root.is_empty());
     assert!(get_block_template
-        .defaultroots
-        .blockcommitmentshash
+        .default_roots
+        .chain_history_root
+        .is_empty());
+    assert!(get_block_template.default_roots.auth_data_root.is_empty());
+    assert!(get_block_template
+        .default_roots
+        .block_commitments_hash
         .is_empty());
     assert!(get_block_template.transactions.is_empty());
     assert_eq!(
-        get_block_template.coinbasetxn,
+        get_block_template.coinbase_txn,
         get_block_template::Coinbase {}
     );
     assert!(get_block_template.target.is_empty());
-    assert_eq!(get_block_template.mintime, 0);
+    assert_eq!(get_block_template.min_time, 0);
     assert!(get_block_template.mutable.is_empty());
-    assert!(get_block_template.noncerange.is_empty());
-    assert_eq!(get_block_template.sigoplimit, 0);
-    assert_eq!(get_block_template.sizelimit, 0);
-    assert_eq!(get_block_template.curtime, 0);
+    assert!(get_block_template.nonce_range.is_empty());
+    assert_eq!(get_block_template.sigop_limit, 0);
+    assert_eq!(get_block_template.size_limit, 0);
+    assert_eq!(get_block_template.cur_time, 0);
     assert!(get_block_template.bits.is_empty());
     assert_eq!(get_block_template.height, 0);
 

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -809,7 +809,6 @@ async fn rpc_getblocktemplate() {
         get_block_template.coinbasetxn,
         get_block_template::Coinbase {}
     );
-    assert!(get_block_template.longpollid.is_empty());
     assert!(get_block_template.target.is_empty());
     assert_eq!(get_block_template.mintime, 0);
     assert!(get_block_template.mutable.is_empty());

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -647,7 +647,7 @@ async fn rpc_getblockcount() {
 
     // Init RPC
     let get_block_template_rpc =
-        get_block_template::GetBlockTemplateRpcImpl::new(latest_chain_tip.clone(), read_state);
+        get_block_template_rpcs::GetBlockTemplateRpcImpl::new(latest_chain_tip.clone(), read_state);
 
     // Get the tip height using RPC method `get_block_count`
     let get_block_count = get_block_template_rpc
@@ -686,7 +686,7 @@ async fn rpc_getblockcount_empty_state() {
     );
 
     let get_block_template_rpc =
-        get_block_template::GetBlockTemplateRpcImpl::new(latest_chain_tip.clone(), read_state);
+        get_block_template_rpcs::GetBlockTemplateRpcImpl::new(latest_chain_tip.clone(), read_state);
 
     // Get the tip height using RPC method `get_block_count
     let get_block_count = get_block_template_rpc.get_block_count();
@@ -730,7 +730,7 @@ async fn rpc_getblockhash() {
         latest_chain_tip.clone(),
     );
     let get_block_template_rpc =
-        get_block_template::GetBlockTemplateRpcImpl::new(latest_chain_tip, read_state);
+        get_block_template_rpcs::GetBlockTemplateRpcImpl::new(latest_chain_tip, read_state);
 
     // Query the hashes using positive indexes
     for (i, block) in blocks.iter().enumerate() {
@@ -784,7 +784,7 @@ async fn rpc_getblocktemplate() {
         latest_chain_tip.clone(),
     );
     let get_block_template_rpc =
-        get_block_template::GetBlockTemplateRpcImpl::new(latest_chain_tip, read_state);
+        get_block_template_rpcs::GetBlockTemplateRpcImpl::new(latest_chain_tip, read_state);
 
     let get_block_template = get_block_template_rpc
         .get_block_template()
@@ -810,7 +810,7 @@ async fn rpc_getblocktemplate() {
     assert!(get_block_template.transactions.is_empty());
     assert_eq!(
         get_block_template.coinbase_txn,
-        get_block_template::Coinbase {}
+        get_block_template_rpcs::types::coinbase::Coinbase {}
     );
     assert!(get_block_template.target.is_empty());
     assert_eq!(get_block_template.min_time, 0);


### PR DESCRIPTION
## Motivation

This is pretty much what i have in mind for https://github.com/ZcashFoundation/zebra/issues/5451

It introduces the rpc call and all the fields using mostly strings as placeholders. All data will be filled in the other tickets, this is kind of the skeleton.

This is a draft, feel free to suggest changes. 

## Solution

Introduce `getblocktemplate` rpc methjod, return empty `GetblockTemplate` struct on call.

## Review

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?

## Follow Up Work

- https://github.com/ZcashFoundation/zebra/issues/5452
- https://github.com/ZcashFoundation/zebra/issues/5455
- https://github.com/ZcashFoundation/zebra/issues/5453
- https://github.com/ZcashFoundation/zebra/issues/5454