### PR TITLE
fix(ci): Allow extra lookahead blocks in the verifier, state, and block commit task queues

### DIFF
--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -33,12 +33,13 @@ use crate::components::sync::{
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// A multiplier used to calculate the extra number of blocks we allow in the
-/// verifier and state pipelines, on top of the lookahead limit.
+/// verifier, state, and block commit pipelines, on top of the lookahead limit.
 ///
 /// The extra number of blocks is calculated using
 /// `lookahead_limit * VERIFICATION_PIPELINE_SCALING_MULTIPLIER`.
 ///
-/// This allows the verifier and state queues to hold a few extra tips responses worth of blocks,
+/// This allows the verifier and state queues, and the block commit channel,
+/// to hold a few extra tips responses worth of blocks,
 /// even if the syncer queue is full. Any unused capacity is shared between both queues.
 ///
 /// If this capacity is exceeded, the downloader will start failing download blocks with
@@ -48,7 +49,7 @@ type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// the rest of the capacity is reserved for the other queues.
 /// There is no reserved capacity for the syncer queue:
 /// if the other queues stay full, the syncer will eventually time out and reset.
-pub const VERIFICATION_PIPELINE_SCALING_MULTIPLIER: usize = 3;
+pub const VERIFICATION_PIPELINE_SCALING_MULTIPLIER: usize = 4;
 
 #[derive(Copy, Clone, Debug)]
 pub(super) struct AlwaysHedge;


### PR DESCRIPTION
## Motivation

Full syncs are timing out on the `main` branch, with a lot of "synced block height too far ahead of the tip: dropped downloaded block" errors:
https://github.com/ZcashFoundation/zebra/actions/runs/3300574887/jobs/5458683486

Close #5420.

## Solution

- Allow extra capacity in the verifier queue, state queue, or block commit task channel

This will increase Zebra's memory usage, users can reduce memory usage by reducing the configured lookahead limit.

## Review

We can only test this change by merging it to `main`.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

