### PR TITLE
change(ci): Add patch jobs for lightwalletd build and getblocktemplate-rpcs tests

### DIFF
--- a/.github/workflows/continous-integration-docker.patch.yml
+++ b/.github/workflows/continous-integration-docker.patch.yml
@@ -42,6 +42,12 @@ jobs:
     steps:
       - run: 'echo "No build required"'
 
+  test-all-getblocktemplate-rpcs:
+    name: Test all with getblocktemplate-rpcs feature
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
   test-fake-activation-heights:
     name: Test with fake activation heights
     runs-on: ubuntu-latest

--- a/.github/workflows/zcash-lightwalletd.patch.yml
+++ b/.github/workflows/zcash-lightwalletd.patch.yml
@@ -1,0 +1,22 @@
+name: zcash-lightwalletd
+
+# When the real job doesn't run because the files aren't changed,
+# run a fake CI job to satisfy the branch protection rules.
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'zebra-rpc/**'
+      - 'zebrad/tests/acceptance.rs'
+      - 'zebrad/src/config.rs'
+      - 'zebrad/src/commands/start.rs'
+      - 'docker/zcash-lightwalletd/Dockerfile'
+      - '.github/workflows/zcash-lightwalletd.yml'
+
+jobs:
+  build:
+    name: Build images
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -1,5 +1,14 @@
 name: zcash-lightwalletd
 
+# Ensures that only one workflow task will run at a time. Previous builds, if
+# already in process, will get cancelled. Only the latest commit will be allowed
+# to run, cancelling any workflows in between
+#
+# Cancelling old jobs is the most efficient approach, because the workflow is quick.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
## Motivation

We want to add patch jobs so we can require the lightwalletd build and getblocktemplate-rpcs tests to succeed in CI, before merging PRs.

This is a follow-up to PR #5435.
It also closes ticket #4882.

## Solution

- Add the patch jobs
- Add a missing lightwalletd build concurrency rule

## Review

@oxarbitrage created PR #5435, but @gustavovalverde is more familiar with how patch jobs work.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- [ ] After this PR merges, add the two jobs to the branch protection rules (requires admin access)