### PR TITLE
build(deps): upgrade ed5519-zebra from 3.0.0 to 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,16 +1467,16 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403ef3e961ab98f0ba902771d29f842058578bb1ce7e3c59dad5a6a93e784c69"
+checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
  "curve25519-dalek",
+ "hashbrown 0.12.1",
  "hex",
  "rand_core 0.6.4",
  "serde",
  "sha2",
- "thiserror",
  "zeroize",
 ]
 

--- a/tower-batch/Cargo.toml
+++ b/tower-batch/Cargo.toml
@@ -22,7 +22,7 @@ color-eyre = "0.6.2"
 # Enable a feature that makes tinyvec compile much faster.
 tinyvec = { version = "1.6.0", features = ["rustc_1_55"] }
 
-ed25519-zebra = "3.0.0"
+ed25519-zebra = "3.1.0"
 rand = { version = "0.8.5", package = "rand" }
 
 tokio = { version = "1.21.2", features = ["full", "tracing", "test-util"] }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -70,7 +70,7 @@ itertools = "0.10.5"
 rayon = "1.5.3"
 
 # ZF deps
-ed25519-zebra = "3.0.0"
+ed25519-zebra = "3.1.0"
 redjubjub = "0.5.0"
 
 # Optional testing dependencies


### PR DESCRIPTION
## Motivation

We want to get the no_std support in the latest ed25519-zebra release audited.

Closes #5484.

## Solution

Bumps the `ed25519-zebra` version in `zebra-chain` and `tower-batch`

## Review

Anyone can review

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?
