### PR TITLE
fix(ci): Allow extra lookahead in the verifier, state, and block commit queues

### DIFF
--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -49,7 +49,7 @@ type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// the rest of the capacity is reserved for the other queues.
 /// There is no reserved capacity for the syncer queue:
 /// if the other queues stay full, the syncer will eventually time out and reset.
-pub const VERIFICATION_PIPELINE_SCALING_MULTIPLIER: usize = 4;
+pub const VERIFICATION_PIPELINE_SCALING_MULTIPLIER: usize = 5;
 
 #[derive(Copy, Clone, Debug)]
 pub(super) struct AlwaysHedge;


### PR DESCRIPTION
## Motivation

PR #5465 didn't entirely fix #5420, maybe we need to allow a few hundred more blocks.

This increases memory usage, but speeds up syncs.

Longer term, we might want to do something like #5101, or make the lookahead smaller above the height where the large blocks start.

## Review

@arya2 knows what's going on here, but anyone can review.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

