### PR TITLE
3. change(rpc): Add fee and sigops fields to getblocktemplate transactions

### DIFF
--- a/zebra-chain/src/block/merkle.rs
+++ b/zebra-chain/src/block/merkle.rs
@@ -6,7 +6,7 @@ use hex::{FromHex, ToHex};
 
 use crate::{
     serialization::sha256d,
-    transaction::{self, Transaction, UnminedTx, UnminedTxId},
+    transaction::{self, Transaction, UnminedTx, UnminedTxId, VerifiedUnminedTx},
 };
 
 #[cfg(any(any(test, feature = "proptest-impl"), feature = "proptest-impl"))]
@@ -204,6 +204,18 @@ impl std::iter::FromIterator<UnminedTxId> for Root {
     }
 }
 
+impl std::iter::FromIterator<VerifiedUnminedTx> for Root {
+    fn from_iter<I>(transactions: I) -> Self
+    where
+        I: IntoIterator<Item = VerifiedUnminedTx>,
+    {
+        transactions
+            .into_iter()
+            .map(|tx| tx.transaction.id.mined_id())
+            .collect()
+    }
+}
+
 impl std::iter::FromIterator<transaction::Hash> for Root {
     /// # Panics
     ///
@@ -347,6 +359,23 @@ impl std::iter::FromIterator<UnminedTx> for AuthDataRoot {
         transactions
             .into_iter()
             .map(|tx| tx.id.auth_digest().unwrap_or(AUTH_DIGEST_PLACEHOLDER))
+            .collect()
+    }
+}
+
+impl std::iter::FromIterator<VerifiedUnminedTx> for AuthDataRoot {
+    fn from_iter<I>(transactions: I) -> Self
+    where
+        I: IntoIterator<Item = VerifiedUnminedTx>,
+    {
+        transactions
+            .into_iter()
+            .map(|tx| {
+                tx.transaction
+                    .id
+                    .auth_digest()
+                    .unwrap_or(AUTH_DIGEST_PLACEHOLDER)
+            })
             .collect()
     }
 }

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -284,6 +284,10 @@ pub struct VerifiedUnminedTx {
 
     /// The transaction fee for this unmined transaction.
     pub miner_fee: Amount<NonNegative>,
+
+    /// The number of legacy signature operations in this transaction's
+    /// transparent inputs and outputs.
+    pub legacy_sigop_count: u64,
 }
 
 impl fmt::Display for VerifiedUnminedTx {
@@ -291,16 +295,22 @@ impl fmt::Display for VerifiedUnminedTx {
         f.debug_struct("VerifiedUnminedTx")
             .field("transaction", &self.transaction)
             .field("miner_fee", &self.miner_fee)
+            .field("legacy_sigop_count", &self.legacy_sigop_count)
             .finish()
     }
 }
 
 impl VerifiedUnminedTx {
     /// Create a new verified unmined transaction from a transaction and its fee.
-    pub fn new(transaction: UnminedTx, miner_fee: Amount<NonNegative>) -> Self {
+    pub fn new(
+        transaction: UnminedTx,
+        miner_fee: Amount<NonNegative>,
+        legacy_sigop_count: u64,
+    ) -> Self {
         Self {
             transaction,
             miner_fee,
+            legacy_sigop_count,
         }
     }
 

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -301,7 +301,7 @@ impl fmt::Display for VerifiedUnminedTx {
 }
 
 impl VerifiedUnminedTx {
-    /// Create a new verified unmined transaction from a transaction and its fee.
+    /// Create a new verified unmined transaction from a transaction, its fee and the legacy sigop count.
     pub fn new(
         transaction: UnminedTx,
         miner_fee: Amount<NonNegative>,

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -229,9 +229,7 @@ where
                     response
                 );
 
-                legacy_sigop_count += response
-                    .legacy_sigop_count()
-                    .expect("block transaction responses must have a legacy sigop count");
+                legacy_sigop_count += response.legacy_sigop_count();
 
                 // Coinbase transactions consume the miner fee,
                 // so they don't add any value to the block's total miner fee.

--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -4,7 +4,10 @@
 
 use std::collections::HashSet;
 
-use zebra_chain::transaction::{Hash, UnminedTx, UnminedTxId};
+use zebra_chain::transaction::{self, UnminedTx, UnminedTxId};
+
+#[cfg(feature = "getblocktemplate-rpcs")]
+use zebra_chain::transaction::VerifiedUnminedTx;
 
 use crate::BoxError;
 
@@ -22,24 +25,28 @@ pub use self::gossip::Gossip;
 /// because all mempool transactions must be verified.
 #[derive(Debug, Eq, PartialEq)]
 pub enum Request {
-    /// Query all transaction IDs in the mempool.
+    /// Query all [`UnminedTxId`]s in the mempool.
     TransactionIds,
 
-    /// Query matching  transactions in the mempool,
+    /// Query matching [`UnminedTx`] in the mempool,
     /// using a unique set of [`UnminedTxId`]s.
     TransactionsById(HashSet<UnminedTxId>),
 
-    /// Query matching  transactions in the mempool,
-    /// using a unique set of [`struct@Hash`]s. Pre-V5 transactions are matched
+    /// Query matching [`UnminedTx`] in the mempool,
+    /// using a unique set of [`transaction::Hash`]es. Pre-V5 transactions are matched
     /// directly; V5 transaction are matched just by the Hash, disregarding
     /// the [`AuthDigest`](zebra_chain::transaction::AuthDigest).
-    TransactionsByMinedId(HashSet<Hash>),
+    TransactionsByMinedId(HashSet<transaction::Hash>),
 
-    /// Get all the transactions in the mempool.
+    /// Get all the [`VerifiedUnminedTx`] in the mempool.
     ///
-    /// Equivalent to `TransactionsById(TransactionIds)`.
+    /// Equivalent to `TransactionsById(TransactionIds)`,
+    /// but each transaction also includes the `miner_fee` and `legacy_sigop_count` fields.
+    //
+    // TODO: make the Transactions response return VerifiedUnminedTx,
+    //       and remove the FullTransactions variant
     #[cfg(feature = "getblocktemplate-rpcs")]
-    Transactions,
+    FullTransactions,
 
     /// Query matching cached rejected transaction IDs in the mempool,
     /// using a unique set of [`UnminedTxId`]s.
@@ -80,10 +87,10 @@ pub enum Request {
 /// confirm that the mempool has been checked for newly verified transactions.
 #[derive(Debug)]
 pub enum Response {
-    /// Returns all transaction IDs from the mempool.
+    /// Returns all [`UnminedTxId`]s from the mempool.
     TransactionIds(HashSet<UnminedTxId>),
 
-    /// Returns matching transactions from the mempool.
+    /// Returns matching [`UnminedTx`] from the mempool.
     ///
     /// Since the [`Request::TransactionsById`] request is unique,
     /// the response transactions are also unique. The same applies to
@@ -91,7 +98,14 @@ pub enum Response {
     /// different transactions with different mined IDs.
     Transactions(Vec<UnminedTx>),
 
-    /// Returns matching cached rejected transaction IDs from the mempool,
+    /// Returns all [`VerifiedUnminedTx`] in the mempool.
+    //
+    // TODO: make the Transactions response return VerifiedUnminedTx,
+    //       and remove the FullTransactions variant
+    #[cfg(feature = "getblocktemplate-rpcs")]
+    FullTransactions(Vec<VerifiedUnminedTx>),
+
+    /// Returns matching cached rejected [`UnminedTxId`]s from the mempool,
     RejectedTransactionIds(HashSet<UnminedTxId>),
 
     /// Returns a list of queue results.

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -214,18 +214,18 @@ where
         // Since this is a very large RPC, we use separate functions for each group of fields.
         async move {
             // TODO: put this in a separate get_mempool_transactions() function
-            let request = mempool::Request::Transactions;
+            let request = mempool::Request::FullTransactions;
             let response = mempool.oneshot(request).await.map_err(|error| Error {
                 code: ErrorCode::ServerError(0),
                 message: error.to_string(),
                 data: None,
             })?;
 
-            let transactions = if let mempool::Response::Transactions(transactions) = response {
+            let transactions = if let mempool::Response::FullTransactions(transactions) = response {
                 // TODO: select transactions according to ZIP-317 (#5473)
                 transactions
             } else {
-                unreachable!("unmatched response to a mempool::Transactions request");
+                unreachable!("unmatched response to a mempool::FullTransactions request");
             };
 
             let merkle_root;

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -128,7 +128,7 @@ async fn test_rpc_response_data_for_network(network: Network) {
     // - as we have the mempool mocked we need to expect a request and wait for a response,
     // which will be an empty mempool in this case.
     let mempool_req = mempool
-        .expect_request_that(|_request| true)
+        .expect_request_that(|request| matches!(request, mempool::Request::TransactionIds))
         .map(|responder| {
             responder.respond(mempool::Response::TransactionIds(
                 std::collections::HashSet::new(),
@@ -152,9 +152,11 @@ async fn test_rpc_response_data_for_network(network: Network) {
     // `getrawtransaction`
     //
     // - similar to `getrawmempool` described above, a mempool request will be made to get the requested
-    // transaction from the mempoo, response will be empty as we have this transaction in state
+    // transaction from the mempool, response will be empty as we have this transaction in state
     let mempool_req = mempool
-        .expect_request_that(|_request| true)
+        .expect_request_that(|request| {
+            matches!(request, mempool::Request::TransactionsByMinedId(_))
+        })
         .map(|responder| {
             responder.respond(mempool::Response::Transactions(vec![]));
         });

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -61,9 +61,9 @@ pub async fn test_responses<State>(
     let get_block_template = tokio::spawn(get_block_template_rpc.get_block_template());
 
     mempool
-        .expect_request(mempool::Request::Transactions)
+        .expect_request(mempool::Request::FullTransactions)
         .await
-        .respond(mempool::Response::Transactions(vec![]));
+        .respond(mempool::Response::FullTransactions(vec![]));
 
     let get_block_template = get_block_template
         .await

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -758,9 +758,9 @@ async fn rpc_getblocktemplate() {
     let get_block_template = tokio::spawn(get_block_template_rpc.get_block_template());
 
     mempool
-        .expect_request(mempool::Request::Transactions)
+        .expect_request(mempool::Request::FullTransactions)
         .await
-        .respond(mempool::Response::Transactions(vec![]));
+        .respond(mempool::Response::FullTransactions(vec![]));
 
     let get_block_template = get_block_template
         .await

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -166,10 +166,11 @@ async fn mempool_push_transaction() -> Result<(), crate::BoxError> {
             .into_mempool_transaction()
             .expect("unexpected non-mempool request");
 
-        // Set a dummy fee.
+        // Set a dummy fee and sigops.
         responder.respond(transaction::Response::from(VerifiedUnminedTx::new(
             transaction,
             Amount::zero(),
+            0,
         )));
     });
 
@@ -269,10 +270,11 @@ async fn mempool_advertise_transaction_ids() -> Result<(), crate::BoxError> {
             .into_mempool_transaction()
             .expect("unexpected non-mempool request");
 
-        // Set a dummy fee.
+        // Set a dummy fee and sigops.
         responder.respond(transaction::Response::from(VerifiedUnminedTx::new(
             transaction,
             Amount::zero(),
+            0,
         )));
     });
 
@@ -369,10 +371,11 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
             .into_mempool_transaction()
             .expect("unexpected non-mempool request");
 
-        // Set a dummy fee.
+        // Set a dummy fee and sigops.
         responder.respond(transaction::Response::from(VerifiedUnminedTx::new(
             transaction,
             Amount::zero(),
+            0,
         )));
     });
 
@@ -502,10 +505,11 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
             .into_mempool_transaction()
             .expect("unexpected non-mempool request");
 
-        // Set a dummy fee.
+        // Set a dummy fee and sigops.
         responder.respond(transaction::Response::from(VerifiedUnminedTx::new(
             transaction,
             Amount::zero(),
+            0,
         )));
     });
 

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -446,15 +446,16 @@ impl Service<Request> for Mempool {
 
                     async move { Ok(Response::Transactions(res)) }.boxed()
                 }
+
                 #[cfg(feature = "getblocktemplate-rpcs")]
-                Request::Transactions => {
+                Request::FullTransactions => {
                     trace!(?req, "got mempool request");
 
-                    let res: Vec<_> = storage.transactions().cloned().collect();
+                    let res: Vec<_> = storage.full_transactions().cloned().collect();
 
                     trace!(?req, res_count = ?res.len(), "answered mempool request");
 
-                    async move { Ok(Response::Transactions(res)) }.boxed()
+                    async move { Ok(Response::FullTransactions(res)) }.boxed()
                 }
 
                 Request::RejectedTransactionIds(ref ids) => {
@@ -501,19 +502,19 @@ impl Service<Request> for Mempool {
                 // by the peer connection handler. Therefore, return successful
                 // empty responses.
                 let resp = match req {
-                    // Empty Queries
+                    // Return empty responses for queries.
                     Request::TransactionIds => Response::TransactionIds(Default::default()),
 
                     Request::TransactionsById(_) => Response::Transactions(Default::default()),
                     Request::TransactionsByMinedId(_) => Response::Transactions(Default::default()),
                     #[cfg(feature = "getblocktemplate-rpcs")]
-                    Request::Transactions => Response::Transactions(Default::default()),
+                    Request::FullTransactions => Response::FullTransactions(Default::default()),
 
                     Request::RejectedTransactionIds(_) => {
                         Response::RejectedTransactionIds(Default::default())
                     }
 
-                    // Don't queue mempool candidates
+                    // Don't queue mempool candidates, because there is no queue.
                     Request::Queue(gossiped_txs) => Response::Queued(
                         // Special case; we can signal the error inside the response,
                         // because the inbound service ignores inner errors.

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -410,9 +410,21 @@ impl Storage {
         self.verified.transactions().map(|tx| tx.id)
     }
 
-    /// Returns the set of [`UnminedTx`]s in the mempool.
+    /// Returns an iterator over the [`UnminedTx`]s in the mempool.
+    //
+    // TODO: make the transactions() method return VerifiedUnminedTx,
+    //       and remove the full_transactions() method
     pub fn transactions(&self) -> impl Iterator<Item = &UnminedTx> {
         self.verified.transactions()
+    }
+
+    /// Returns an iterator over the [`VerifiedUnminedTx`] in the set.
+    ///
+    /// Each [`VerifiedUnminedTx`] contains an [`UnminedTx`],
+    /// and adds extra fields from the transaction verifier result.
+    #[allow(dead_code)]
+    pub fn full_transactions(&self) -> impl Iterator<Item = &VerifiedUnminedTx> + '_ {
+        self.verified.full_transactions()
     }
 
     /// Returns the number of transactions in the mempool.

--- a/zebrad/src/components/mempool/storage/tests.rs
+++ b/zebrad/src/components/mempool/storage/tests.rs
@@ -1,3 +1,5 @@
+//! Tests and test utility functions for mempool storage.
+
 use std::ops::RangeBounds;
 
 use zebra_chain::{
@@ -30,9 +32,10 @@ pub fn unmined_transactions_in_blocks(
         });
 
     // Extract the transactions from the blocks and wrap each one as an unmined transaction.
-    // Use a fake zero miner fee, because we don't have the UTXOs to calculate the correct fee.
+    // Use a fake zero miner fee and sigops, because we don't have the UTXOs to calculate
+    // the correct fee.
     selected_blocks
         .flat_map(|block| block.transactions)
         .map(UnminedTx::from)
-        .map(|transaction| VerifiedUnminedTx::new(transaction, Amount::zero()))
+        .map(|transaction| VerifiedUnminedTx::new(transaction, Amount::zero(), 0))
 }

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashSet, convert::TryFrom, env, fmt::Debug, thread, time::Duration};
+//! Randomised property tests for mempool storage.
+
+use std::{collections::HashSet, env, fmt::Debug, thread, time::Duration};
 
 use proptest::{collection::vec, prelude::*};
 use proptest_derive::Arbitrary;
@@ -473,8 +475,8 @@ impl SpendConflictTestInput {
         };
 
         (
-            VerifiedUnminedTx::new(first.0.into(), Amount::zero()),
-            VerifiedUnminedTx::new(second.0.into(), Amount::zero()),
+            VerifiedUnminedTx::new(first.0.into(), Amount::zero(), 0),
+            VerifiedUnminedTx::new(second.0.into(), Amount::zero(), 0),
         )
     }
 
@@ -491,8 +493,8 @@ impl SpendConflictTestInput {
         Self::remove_orchard_conflicts(&mut first, &mut second);
 
         (
-            VerifiedUnminedTx::new(first.0.into(), Amount::zero()),
-            VerifiedUnminedTx::new(second.0.into(), Amount::zero()),
+            VerifiedUnminedTx::new(first.0.into(), Amount::zero(), 0),
+            VerifiedUnminedTx::new(second.0.into(), Amount::zero(), 0),
         )
     }
 

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -1,3 +1,5 @@
+//! Fixed test vectors for mempool storage.
+
 use std::iter;
 
 use color_eyre::eyre::Result;
@@ -269,8 +271,8 @@ fn mempool_expired_basic_for_network(network: Network) -> Result<()> {
 
     let tx_id = tx.unmined_id();
 
-    // Insert the transaction into the mempool, with a fake zero miner fee
-    storage.insert(VerifiedUnminedTx::new(tx.into(), Amount::zero()))?;
+    // Insert the transaction into the mempool, with a fake zero miner fee and sigops
+    storage.insert(VerifiedUnminedTx::new(tx.into(), Amount::zero(), 0))?;
 
     assert_eq!(storage.transaction_count(), 1);
 

--- a/zebrad/src/components/mempool/storage/verified_set.rs
+++ b/zebrad/src/components/mempool/storage/verified_set.rs
@@ -54,9 +54,20 @@ impl Drop for VerifiedSet {
 }
 
 impl VerifiedSet {
-    /// Returns an iterator over the transactions in the set.
+    /// Returns an iterator over the [`UnminedTx`] in the set.
+    //
+    // TODO: make the transactions() method return VerifiedUnminedTx,
+    //       and remove the full_transactions() method
     pub fn transactions(&self) -> impl Iterator<Item = &UnminedTx> + '_ {
         self.transactions.iter().map(|tx| &tx.transaction)
+    }
+
+    /// Returns an iterator over the [`VerifiedUnminedTx`] in the set.
+    ///
+    /// Each [`VerifiedUnminedTx`] contains an [`UnminedTx`],
+    /// and adds extra fields from the transaction verifier result.
+    pub fn full_transactions(&self) -> impl Iterator<Item = &VerifiedUnminedTx> + '_ {
+        self.transactions.iter()
     }
 
     /// Returns the number of verified transactions in the set.


### PR DESCRIPTION
## Motivation

We need to add a mempool query to get the `fee` and `sigops` fields for the `getblocktemplate` RPC.

Closes #5454 
Depends-On: #5496

### Specifications

https://zcash.github.io/rpc/getblocktemplate.html

And whatever `zcashd` does.

## Solution

- Add a new `FullTransactions` mempool request
- Return `VerifiedUnminedTx` with a new `legacy_sigop_count` field
- Add the `fee` and `sigops` fields to the transaction templates
- Add conversions from `VerifiedUnminedTx` to the block header roots
- Update tests for the new API

## Review

I think @oxarbitrage is reviewing this PR series, but anyone else can review it as well.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?

## Follow Up Work

The rest of the `getblocktemplate` RPC, probably the coinbase transaction or state request next