### PR TITLE
fix(build): restore Rust stable in builds and beta for CI

### DIFF
--- a/.github/workflows/continous-integration-os.patch.yml
+++ b/.github/workflows/continous-integration-os.patch.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
         os: [ubuntu-latest, macos-latest]
-        rust: [1.63, beta]
+        rust: [stable, beta]
         exclude:
           - os: macos-latest
             rust: beta

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -66,9 +66,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         rust: [stable, beta]
         exclude:
-        # TODO: re-enable beta Rust tests on ubuntu (#4929)
-          - os: ubuntu-latest
-            rust: beta
         # We're excluding macOS for the following reasons:
         # - the concurrent macOS runner limit is much lower than the Linux limit
         # - macOS is slower than Linux, and shouldn't have a build or test difference with Linux

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -64,8 +64,7 @@ jobs:
       matrix:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
         os: [ubuntu-latest, macos-latest]
-        # Rust 1.64 hangs when downloading the Zcash Parameters on GitHub Actions runners
-        rust: [1.63, beta]
+        rust: [stable, beta]
         exclude:
         # TODO: re-enable beta Rust tests on ubuntu (#4929)
           - os: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,8 +61,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1.0.7
         with:
-          # Rust 1.64 hangs when downloading the Zcash Parameters on GitHub Actions runners
-          toolchain: 1.63
+          toolchain: stable
           override: true
           profile: minimal
           components: llvm-tools-preview

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 - [Contents](#contents)
 - [About](#about)
   - [Using Zebra](#using-zebra)
-- [Beta Releases](#beta-releases)
+- [Release Candidates](#release-candidates)
 - [Getting Started](#getting-started)
-  - [Build and Run Instructions](#build-and-run-instructions)
+  - [Build Instructions](#build-instructions)
   - [Configuring JSON-RPC for lightwalletd](#configuring-json-rpc-for-lightwalletd)
   - [Optional Features](#optional-features)
   - [System Requirements](#system-requirements)
@@ -88,9 +88,10 @@ To run `zebrad`, follow the instructions to compile `zebrad`
 for your platform:
 
 1. Install [`cargo` and `rustc`](https://www.rust-lang.org/tools/install).
-   - Zebra requires Rust 1.63, due to [a compiler performance regression in Rust 1.64](https://github.com/ZcashFoundation/zebra/issues/5091).
-     Zebra is also tested with the latest `stable` Rust version.
-     Earlier versions are not supported or tested. Any Zebra release can remove support for older Rust versions, without any notice.
+   - Zebra is tested with the latest `stable` Rust version.
+     Earlier versions are not supported or tested.
+     Any Zebra release can remove support for older Rust versions, without any notice.
+     (Rust 1.59 and earlier are definitely not supported, due to missing features.)
 2. Install Zebra's build dependencies:
    - **libclang:** the `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` packages, depending on your package manager
    - **clang** or another C++ compiler: `g++`, `Xcode`, or `MSVC`
@@ -231,8 +232,7 @@ There are a few bugs in Zebra that we're still working on fixing:
     for a short period of time because Zebra will quickly find out that it's
     still not close to the tip.
 
-- Zebra requires Rust 1.63, due to [a compiler performance regression in Rust 1.64](https://github.com/ZcashFoundation/zebra/issues/5091)
-  - If Zebra fails downloading the Zcash parameters, use [the Zcash parameters download script](https://github.com/zcash/zcash/blob/master/zcutil/fetch-params.sh) instead. This script might be needed on macOS, even with Rust 1.63.
+- If Zebra fails downloading the Zcash parameters, use [the Zcash parameters download script](https://github.com/zcash/zcash/blob/master/zcutil/fetch-params.sh) instead. This script might be needed on macOS, even with Rust stable.
 - No Windows support [#3801](https://github.com/ZcashFoundation/zebra/issues/3801)
   - We used to test with Windows Server 2019, but not anymore; see issue for details
   

--- a/book/src/user/supported-platforms.md
+++ b/book/src/user/supported-platforms.md
@@ -17,15 +17,6 @@ For the full requirements, see [Tier 1 platform policy](platform-tier-policy.md#
 
 | platform | os | notes | rust | artifacts
 | -------|-------|-------|-------|-------
-| `x86_64-unknown-linux-gnu` | [Debian 11](https://www.debian.org/releases/bullseye/) | 64-bit | [1.63](https://github.com/rust-lang/rust/releases) | Docker
-
-### Temporarily Unsupported
-
-Zcash parameter downloads currently [hang when built with Rust 1.64 and later](https://github.com/ZcashFoundation/zebra/issues/5091).
-Those Rust versions are unsupported until that bug is fixed.
-
-| platform | os | notes | rust | artifacts
-| -------|-------|-------|-------|-------
 | `x86_64-unknown-linux-gnu` | [Debian 11](https://www.debian.org/releases/bullseye/) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | Docker
 
 ## Tier 2

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@
 # - runtime: is our runtime environment
 #
 # This stage implements cargo-chef for docker layer caching
-FROM rust:1.63-bullseye as chef
+FROM rust:bullseye as chef
 RUN cargo install cargo-chef --locked
 WORKDIR /opt/zebrad
 

--- a/docker/zcash-params/Dockerfile
+++ b/docker/zcash-params/Dockerfile
@@ -1,6 +1,6 @@
 # This steps implement cargo-chef for docker layer caching
 # This image is for caching Zcash Sprout and Sapling parameters
-FROM rust:1.63-bullseye as chef
+FROM rust:bullseye as chef
 RUN cargo install cargo-chef --locked
 WORKDIR /opt/zebrad
 


### PR DESCRIPTION
This reverts commits 9cb6c559f4611432ece85ef66aa3c0ee3b8b4093 ee0edef8571d3ed82848303b142c7ae72e7135fc e650d6770b57cfe64171626cef096c9b44e842f9

## Motivation

In PR #5090 we disabled beta Rust tests because multiple bugs happened:
- disk filled up during builds with beta Rust
- the beta Rust (1.64) builds hung when downloading Zcash parameters

Rust was not fixed before the Rust stable release on 23 September 2022, so we were using Rust 1.63; now this issues are fixed and we can re-add Rust `stable` and Rust `beta` channels to our CI, and build our images using Rust stable again.

Fixes #5091

## Solution

- Make GitHub Actions builds use Rust stable in:
    - https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/continous-integration-os.yml
    - https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/continous-integration-os.patch.yml
- Make Docker builds use Rust stable in:
    - https://github.com/ZcashFoundation/zebra/blob/main/docker/Dockerfile
    - https://github.com/ZcashFoundation/zebra/blob/main/docker/zcash-params/Dockerfile
- Re-enable beta Rust on Ubuntu in:
    - https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/continous-integration-os.yml

## Review

Reviewer should ping an admin after approving, to update branch protection rules https://github.com/ZcashFoundation/zebra/settings/branches

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

