### PR TITLE
fix(README): Clarify alternate dependency names

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ for your platform:
      Any Zebra release can remove support for older Rust versions, without any notice.
      (Rust 1.59 and earlier are definitely not supported, due to missing features.)
 2. Install Zebra's build dependencies:
-   - **libclang:** the `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` packages, depending on your package manager
-   - **clang** or another C++ compiler: `g++`, `Xcode`, or `MSVC`
+   - **libclang:** the `libclang`, `libclang-dev`, `llvm`, or `llvm-dev` packages
+     (these packages will have different names depending on your package manager)
+   - **clang** or another C++ compiler: `g++` (all platforms) or `Xcode` (macOS)
 3. Run `cargo install --locked --git https://github.com/ZcashFoundation/zebra --tag v1.0.0-rc.0 zebrad`
 4. Run `zebrad start` (see [Running Zebra](https://zebra.zfnd.org/user/run.html) for more information)
 


### PR DESCRIPTION
## Motivation

This clarifies that the `clang` dependency can have different names for different package managers.

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

