### PR TITLE
change(doc): Use HTTP to clone Zebra in Docker documentation

### DIFF
--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -17,7 +17,7 @@ docker run --detach zfnd/zebra:1.0.0-rc.1
 ### Build it locally
 
 ```shell
-git clone --depth 1 --branch v1.0.0-rc.1 git@github.com:ZcashFoundation/zebra.git
+git clone --depth 1 --branch v1.0.0-rc.1 https://github.com/ZcashFoundation/zebra.git
 docker build --file docker/Dockerfile --target runtime --tag zebra:local
 docker run --detach zebra:local
 ```


### PR DESCRIPTION
## Motivation

Git clones over HTTP are usually more reliable than SSH, because some users don't have SSH installed, or it doesn't work from their network.

## Review

Anyone can review this PR, but @gustavovalverde wrote the original docs.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

