### PR TITLE
suggestion: Use the same ChainVerifier for downloaded and submitted blocks

### DIFF
--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -39,7 +39,6 @@ mod subsidy;
 mod tests;
 
 /// Asynchronous block verification.
-#[cfg_attr(feature = "getblocktemplate-rpcs", derive(Clone))]
 #[derive(Debug)]
 pub struct BlockVerifier<S, V> {
     /// The network to be verified.

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -56,7 +56,7 @@ mod tests;
 ///
 /// We deliberately add extra slots, because they only cost a small amount of
 /// memory, but missing slots can significantly slow down Zebra.
-pub const VERIFIER_BUFFER_BOUND: usize = 5;
+const VERIFIER_BUFFER_BOUND: usize = 5;
 
 /// The chain verifier routes requests to either the checkpoint verifier or the
 /// block verifier, depending on the maximum checkpoint height.

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -47,6 +47,7 @@ pub mod chain;
 pub mod error;
 
 pub use block::VerifyBlockError;
+pub use chain::VerifyChainError;
 pub use checkpoint::{
     CheckpointList, VerifyCheckpointError, MAX_CHECKPOINT_BYTE_COUNT, MAX_CHECKPOINT_HEIGHT_GAP,
 };

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -57,8 +57,3 @@ pub use primitives::{ed25519, groth16, halo2, redjubjub, redpallas};
 
 /// A boxed [`std::error::Error`].
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
-
-#[cfg(feature = "getblocktemplate-rpcs")]
-pub use block::BlockVerifier;
-#[cfg(feature = "getblocktemplate-rpcs")]
-pub use transaction::Verifier as TransactionVerifier;

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -41,7 +41,7 @@ proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 
 zebra-chain = { path = "../zebra-chain" }
-zebra-consensus = { path = "../zebra-consensus", optional = true }
+zebra-consensus = { path = "../zebra-consensus" }
 zebra-network = { path = "../zebra-network" }
 zebra-node-services = { path = "../zebra-node-services" }
 zebra-state = { path = "../zebra-state" }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -9,8 +9,10 @@ edition = "2021"
 
 [features]
 default = []
-proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl", "zebra-state/proptest-impl"]
 getblocktemplate-rpcs = ["zebra-state/getblocktemplate-rpcs", "zebra-consensus/getblocktemplate-rpcs"]
+
+# Test-only features
+proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl", "zebra-state/proptest-impl"]
 
 [dependencies]
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std"] }

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -68,7 +68,7 @@ pub trait GetBlockTemplateRpc {
     fn get_block_template(&self) -> BoxFuture<Result<GetBlockTemplate>>;
 
     /// Submits block to the node to be validated and committed.
-    /// Returns the [`SentTransactionHash`] for the transaction, as a JSON string.
+    /// Returns the [`submit_block::Response`] for the transaction, as a JSON string.
     ///
     /// zcashd reference: [`submitblock`](https://zcash.github.io/rpc/submitblock.html)
     ///

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -340,7 +340,10 @@ where
                 // might require architectural changes to Zebra, so we should only do it
                 // if mining pools really need it.
                 Ok(_verify_chain_error) => Ok(submit_block::Response::Rejected),
-                Err(_boxed_string_error) => Ok(submit_block::Response::Rejected),
+
+                // This match arm is currently unreachable, but if future changes add extra error types,
+                // we want to turn them into `Rejected`.
+                Err(_unknown_error_type) => Ok(submit_block::Response::Rejected),
             }
         }
         .boxed()

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/submit_block.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/submit_block.rs
@@ -9,7 +9,7 @@ use crate::methods::get_block_template_rpcs::GetBlockTemplateRpc;
 /// See notes for [`GetBlockTemplateRpc::submit_block`] method
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct JsonParameters {
-    pub(crate) work_id: String,
+    pub(crate) work_id: Option<String>,
 }
 
 /// Response to a `submitblock` RPC request.

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/submit_block.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/submit_block.rs
@@ -1,12 +1,20 @@
+//! Parameter and response types for the `submitblock` RPC.
+
+// Allow doc links to these imports.
+#[allow(unused_imports)]
+use crate::methods::get_block_template_rpcs::GetBlockTemplateRpc;
+
 /// Optional argument `jsonparametersobject` for `submitblock` RPC request
 ///
-/// See notes for [`Rpc::submit_block`] method
+/// See notes for [`GetBlockTemplateRpc::submit_block`] method
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct JsonParameters {
     pub(crate) work_id: String,
 }
 
-/// Response to a `submitblock` RPC request
+/// Response to a `submitblock` RPC request.
+///
+/// Zebra never returns "duplicate-invalid", because it does not store invalid blocks.
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Response {

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -57,6 +57,7 @@ async fn test_rpc_response_data_for_network(network: Network) {
     // Test getblocktemplate-rpcs snapshots
     #[cfg(feature = "getblocktemplate-rpcs")]
     get_block_template_rpcs::test_responses(
+        network,
         mempool.clone(),
         state,
         read_state.clone(),

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -46,6 +46,7 @@ async fn test_rpc_response_data_for_network(network: Network) {
     let mut mempool: MockService<_, _, _, zebra_node_services::BoxError> =
         MockService::build().for_unit_tests();
     // Create a populated state service
+    #[allow(unused_variables)]
     let (state, read_state, latest_chain_tip, _chain_tip_change) =
         zebra_state::populated_state(blocks.clone(), network).await;
 
@@ -57,7 +58,7 @@ async fn test_rpc_response_data_for_network(network: Network) {
     #[cfg(feature = "getblocktemplate-rpcs")]
     get_block_template_rpcs::test_responses(
         mempool.clone(),
-        state.clone(),
+        state,
         read_state.clone(),
         latest_chain_tip.clone(),
         settings.clone(),

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -5,9 +5,6 @@ use std::{ops::RangeInclusive, sync::Arc};
 use jsonrpc_core::ErrorCode;
 use tower::buffer::Buffer;
 
-#[cfg(feature = "getblocktemplate-rpcs")]
-use tower::util::BoxService;
-
 use zebra_chain::{
     block::Block,
     chain_tip::NoChainTip,
@@ -20,9 +17,6 @@ use zebra_network::constants::USER_AGENT;
 use zebra_node_services::BoxError;
 
 use zebra_test::mock_service::MockService;
-
-#[cfg(feature = "getblocktemplate-rpcs")]
-use zebra_consensus::{chain::VERIFIER_BUFFER_BOUND, BlockVerifier, TransactionVerifier};
 
 use super::super::*;
 
@@ -641,15 +635,25 @@ async fn rpc_getblockcount() {
     let (state, read_state, latest_chain_tip, _chain_tip_change) =
         zebra_state::populated_state(blocks.clone(), Mainnet).await;
 
+    let (
+        block_verifier,
+        _transaction_verifier,
+        _parameter_download_task_handle,
+        _max_checkpoint_height,
+    ) = zebra_consensus::chain::init(
+        zebra_consensus::Config::default(),
+        Mainnet,
+        state.clone(),
+        true,
+    )
+    .await;
+
     // Init RPC
-    let tx_verifier = TransactionVerifier::new(Mainnet, state.clone());
-    let tx_verifier = Buffer::new(BoxService::new(tx_verifier), VERIFIER_BUFFER_BOUND);
-    let block_verifier = BlockVerifier::new(Mainnet, state, tx_verifier);
     let get_block_template_rpc = get_block_template_rpcs::GetBlockTemplateRpcImpl::new(
         Buffer::new(mempool.clone(), 1),
         read_state,
         latest_chain_tip.clone(),
-        tower::ServiceBuilder::new().service(block_verifier),
+        block_verifier,
     );
 
     // Get the tip height using RPC method `get_block_count`
@@ -674,10 +678,20 @@ async fn rpc_getblockcount_empty_state() {
     let (state, read_state, latest_chain_tip, _chain_tip_change) =
         zebra_state::init_test_services(Mainnet);
 
+    let (
+        block_verifier,
+        _transaction_verifier,
+        _parameter_download_task_handle,
+        _max_checkpoint_height,
+    ) = zebra_consensus::chain::init(
+        zebra_consensus::Config::default(),
+        Mainnet,
+        state.clone(),
+        true,
+    )
+    .await;
+
     // Init RPC
-    let tx_verifier = TransactionVerifier::new(Mainnet, state.clone());
-    let tx_verifier = Buffer::new(BoxService::new(tx_verifier), VERIFIER_BUFFER_BOUND);
-    let block_verifier = BlockVerifier::new(Mainnet, state, tx_verifier);
     let get_block_template_rpc = get_block_template_rpcs::GetBlockTemplateRpcImpl::new(
         Buffer::new(mempool.clone(), 1),
         read_state,
@@ -713,10 +727,20 @@ async fn rpc_getblockhash() {
     let (state, read_state, latest_chain_tip, _chain_tip_change) =
         zebra_state::populated_state(blocks.clone(), Mainnet).await;
 
+    let (
+        block_verifier,
+        _transaction_verifier,
+        _parameter_download_task_handle,
+        _max_checkpoint_height,
+    ) = zebra_consensus::chain::init(
+        zebra_consensus::Config::default(),
+        Mainnet,
+        state.clone(),
+        true,
+    )
+    .await;
+
     // Init RPC
-    let tx_verifier = TransactionVerifier::new(Mainnet, state.clone());
-    let tx_verifier = Buffer::new(BoxService::new(tx_verifier), VERIFIER_BUFFER_BOUND);
-    let block_verifier = BlockVerifier::new(Mainnet, state, tx_verifier);
     let get_block_template_rpc = get_block_template_rpcs::GetBlockTemplateRpcImpl::new(
         Buffer::new(mempool.clone(), 1),
         read_state,
@@ -766,10 +790,20 @@ async fn rpc_getblocktemplate() {
     let (state, read_state, latest_chain_tip, _chain_tip_change) =
         zebra_state::populated_state(blocks.clone(), Mainnet).await;
 
+    let (
+        block_verifier,
+        _transaction_verifier,
+        _parameter_download_task_handle,
+        _max_checkpoint_height,
+    ) = zebra_consensus::chain::init(
+        zebra_consensus::Config::default(),
+        Mainnet,
+        state.clone(),
+        true,
+    )
+    .await;
+
     // Init RPC
-    let tx_verifier = TransactionVerifier::new(Mainnet, state.clone());
-    let tx_verifier = Buffer::new(BoxService::new(tx_verifier), VERIFIER_BUFFER_BOUND);
-    let block_verifier = BlockVerifier::new(Mainnet, state, tx_verifier);
     let get_block_template_rpc = get_block_template_rpcs::GetBlockTemplateRpcImpl::new(
         Buffer::new(mempool.clone(), 1),
         read_state,
@@ -842,10 +876,20 @@ async fn rpc_submitblock_errors() {
         latest_chain_tip.clone(),
     );
 
+    let (
+        block_verifier,
+        _transaction_verifier,
+        _parameter_download_task_handle,
+        _max_checkpoint_height,
+    ) = zebra_consensus::chain::init(
+        zebra_consensus::Config::default(),
+        Mainnet,
+        state.clone(),
+        true,
+    )
+    .await;
+
     // Init RPC
-    let tx_verifier = TransactionVerifier::new(Mainnet, state.clone());
-    let tx_verifier = Buffer::new(BoxService::new(tx_verifier), VERIFIER_BUFFER_BOUND);
-    let block_verifier = BlockVerifier::new(Mainnet, state, tx_verifier);
     let get_block_template_rpc = get_block_template_rpcs::GetBlockTemplateRpcImpl::new(
         Buffer::new(mempool.clone(), 1),
         read_state,

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -46,6 +46,8 @@ fn rpc_server_spawn(parallel_cpu_threads: bool) {
     rt.block_on(async {
         let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
         let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+        let mut block_verifier: MockService<_, _, _, BoxError> =
+            MockService::build().for_unit_tests();
 
         info!("spawning RPC server...");
 
@@ -54,8 +56,7 @@ fn rpc_server_spawn(parallel_cpu_threads: bool) {
             "RPC server test",
             Buffer::new(mempool.clone(), 1),
             Buffer::new(state.clone(), 1),
-            #[cfg(feature = "getblocktemplate-rpcs")]
-            None,
+            Buffer::new(block_verifier.clone(), 1),
             NoChainTip,
             Mainnet,
         );
@@ -64,6 +65,7 @@ fn rpc_server_spawn(parallel_cpu_threads: bool) {
 
         mempool.expect_no_requests().await;
         state.expect_no_requests().await;
+        block_verifier.expect_no_requests().await;
 
         // The server and queue tasks should continue without errors or panics
         let rpc_server_task_result = rpc_server_task_handle.now_or_never();
@@ -115,6 +117,8 @@ fn rpc_server_spawn_unallocated_port(parallel_cpu_threads: bool) {
     rt.block_on(async {
         let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
         let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+        let mut block_verifier: MockService<_, _, _, BoxError> =
+            MockService::build().for_unit_tests();
 
         info!("spawning RPC server...");
 
@@ -123,8 +127,7 @@ fn rpc_server_spawn_unallocated_port(parallel_cpu_threads: bool) {
             "RPC server test",
             Buffer::new(mempool.clone(), 1),
             Buffer::new(state.clone(), 1),
-            #[cfg(feature = "getblocktemplate-rpcs")]
-            None,
+            Buffer::new(block_verifier.clone(), 1),
             NoChainTip,
             Mainnet,
         );
@@ -133,6 +136,7 @@ fn rpc_server_spawn_unallocated_port(parallel_cpu_threads: bool) {
 
         mempool.expect_no_requests().await;
         state.expect_no_requests().await;
+        block_verifier.expect_no_requests().await;
 
         // The server and queue tasks should continue without errors or panics
         let rpc_server_task_result = rpc_server_task_handle.now_or_never();
@@ -171,6 +175,8 @@ fn rpc_server_spawn_port_conflict() {
     let test_task_handle = rt.spawn(async {
         let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
         let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+        let mut block_verifier: MockService<_, _, _, BoxError> =
+            MockService::build().for_unit_tests();
 
         info!("spawning RPC server 1...");
 
@@ -179,8 +185,7 @@ fn rpc_server_spawn_port_conflict() {
             "RPC server 1 test",
             Buffer::new(mempool.clone(), 1),
             Buffer::new(state.clone(), 1),
-            #[cfg(feature = "getblocktemplate-rpcs")]
-            None,
+            Buffer::new(block_verifier.clone(), 1),
             NoChainTip,
             Mainnet,
         );
@@ -194,8 +199,7 @@ fn rpc_server_spawn_port_conflict() {
             "RPC server 2 conflict test",
             Buffer::new(mempool.clone(), 1),
             Buffer::new(state.clone(), 1),
-            #[cfg(feature = "getblocktemplate-rpcs")]
-            None,
+            Buffer::new(block_verifier.clone(), 1),
             NoChainTip,
             Mainnet,
         );
@@ -204,6 +208,7 @@ fn rpc_server_spawn_port_conflict() {
 
         mempool.expect_no_requests().await;
         state.expect_no_requests().await;
+        block_verifier.expect_no_requests().await;
 
         // Because there is a panic inside a multi-threaded executor,
         // we can't depend on the exact behaviour of the other tasks,
@@ -271,6 +276,8 @@ fn rpc_server_spawn_port_conflict_parallel_auto() {
     let test_task_handle = rt.spawn(async {
         let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
         let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+        let mut block_verifier: MockService<_, _, _, BoxError> =
+            MockService::build().for_unit_tests();
 
         info!("spawning parallel RPC server 1...");
 
@@ -279,8 +286,7 @@ fn rpc_server_spawn_port_conflict_parallel_auto() {
             "RPC server 1 test",
             Buffer::new(mempool.clone(), 1),
             Buffer::new(state.clone(), 1),
-            #[cfg(feature = "getblocktemplate-rpcs")]
-            None,
+            Buffer::new(block_verifier.clone(), 1),
             NoChainTip,
             Mainnet,
         );
@@ -294,8 +300,7 @@ fn rpc_server_spawn_port_conflict_parallel_auto() {
             "RPC server 2 conflict test",
             Buffer::new(mempool.clone(), 1),
             Buffer::new(state.clone(), 1),
-            #[cfg(feature = "getblocktemplate-rpcs")]
-            None,
+            Buffer::new(block_verifier.clone(), 1),
             NoChainTip,
             Mainnet,
         );
@@ -304,6 +309,7 @@ fn rpc_server_spawn_port_conflict_parallel_auto() {
 
         mempool.expect_no_requests().await;
         state.expect_no_requests().await;
+        block_verifier.expect_no_requests().await;
 
         // Because there might be a panic inside a multi-threaded executor,
         // we can't depend on the exact behaviour of the other tasks,

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -73,8 +73,7 @@ use futures::FutureExt;
 use tokio::{pin, select, sync::oneshot};
 use tower::{builder::ServiceBuilder, util::BoxService};
 use tracing_futures::Instrument;
-#[cfg(feature = "getblocktemplate-rpcs")]
-use zebra_consensus::BlockVerifier;
+
 use zebra_rpc::server::RpcServer;
 
 use crate::{
@@ -151,10 +150,6 @@ impl StartCmd {
             )
             .await;
 
-        #[cfg(feature = "getblocktemplate-rpcs")]
-        let block_verifier =
-            BlockVerifier::new(config.network.network, state.clone(), tx_verifier.clone());
-
         info!("initializing syncer");
         let (syncer, sync_status) = ChainSync::new(
             &config,
@@ -186,8 +181,7 @@ impl StartCmd {
             app_version(),
             mempool.clone(),
             read_only_state_service,
-            #[cfg(feature = "getblocktemplate-rpcs")]
-            Some(block_verifier),
+            chain_verifier.clone(),
             latest_chain_tip.clone(),
             config.network.network,
         );


### PR DESCRIPTION
## Motivation

Zebra isn't really designed to use multiple instances of the same verifiers. It might work, but it is easier to design, test, and maintain if we just have one running verifier of each kind.

This is a suggestion for PR #5526.

## Solution

See the explanations I'm going to post on each part of the PR.

## Review

@arya2 wrote the original PR.

I'm happy to revert any of these changes that aren't needed - let me know what you think!

### Reviewer Checklist

  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

