### PR TITLE
fix(sync): Make the syncer ignore some new block verification errors

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -609,14 +609,17 @@ impl StateService {
             .contains(&prepared.hash)
         {
             let (rsp_tx, rsp_rx) = oneshot::channel();
-            let _ = rsp_tx.send(Err("block has already been sent to be committed to the state".into()));
+            let _ = rsp_tx.send(Err(
+                "block has already been sent to be committed to the state".into(),
+            ));
             return rsp_rx;
         }
 
         if self.read_service.db.contains_height(prepared.height) {
             let (rsp_tx, rsp_rx) = oneshot::channel();
             let _ = rsp_tx.send(Err(
-                "block height is in the finalized state: block is already committed to the state".into(),
+                "block height is in the finalized state: block is already committed to the state"
+                    .into(),
             ));
             return rsp_rx;
         }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -609,14 +609,14 @@ impl StateService {
             .contains(&prepared.hash)
         {
             let (rsp_tx, rsp_rx) = oneshot::channel();
-            let _ = rsp_tx.send(Err("block already sent to be committed to the state".into()));
+            let _ = rsp_tx.send(Err("block has already been sent to be committed to the state".into()));
             return rsp_rx;
         }
 
         if self.read_service.db.contains_height(prepared.height) {
             let (rsp_tx, rsp_rx) = oneshot::channel();
             let _ = rsp_tx.send(Err(
-                "block height is already committed to the finalized state".into(),
+                "block height is in the finalized state: block is already committed to the state".into(),
             ));
             return rsp_rx;
         }

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1120,8 +1120,10 @@ where
             BlockDownloadVerifyError::Invalid {
                 error: VerifyChainError::Block(VerifyBlockError::Commit(ref source)),
                 ..
-            } if format!("{source:?}").contains("block is already committed to the state") ||
-                 format!("{source:?}").contains("block has already been sent to be committed to the state") => {
+            } if format!("{source:?}").contains("block is already committed to the state")
+                || format!("{source:?}")
+                    .contains("block has already been sent to be committed to the state") =>
+            {
                 // TODO: improve this by checking the type (#2908)
                 debug!(error = ?e, "block is already committed or pending a commit, possibly from a previous sync run, continuing");
                 false

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1120,9 +1120,10 @@ where
             BlockDownloadVerifyError::Invalid {
                 error: VerifyChainError::Block(VerifyBlockError::Commit(ref source)),
                 ..
-            } if format!("{source:?}").contains("block is already committed to the state") => {
+            } if format!("{source:?}").contains("block is already committed to the state") ||
+                 format!("{source:?}").contains("block has already been sent to be committed to the state") => {
                 // TODO: improve this by checking the type (#2908)
-                debug!(error = ?e, "block is already committed, possibly from a previous sync run, continuing");
+                debug!(error = ?e, "block is already committed or pending a commit, possibly from a previous sync run, continuing");
                 false
             }
             BlockDownloadVerifyError::DownloadFailed { ref error, .. }
@@ -1152,6 +1153,7 @@ where
                 if err_str.contains("AlreadyVerified")
                     || err_str.contains("AlreadyInChain")
                     || err_str.contains("block is already committed to the state")
+                    || err_str.contains("block has already been sent to be committed to the state")
                     || err_str.contains("NotFound")
                 {
                     error!(?e,


### PR DESCRIPTION
## Motivation

The syncer skips some duplicate block errors, but we added new duplicate block errors in #4937.

This might fix the full sync errors on the `main` branch.

## Solution

- Ignore "block has already been sent to be committed to the state" errors
- Make a finalized state error into "block has already been committed to the state"

## Review

I talked through this with @arya2 already.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?

## Follow Up Work

We should fix these permanently using typed errors, so we don't introduce this sort of bug again:
- #2908