### PR TITLE
cleanup(deps): Remove unused `fpe` dependency and cleanup references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5241,7 +5241,6 @@ dependencies = [
  "displaydoc",
  "ed25519-zebra",
  "equihash",
- "fpe",
  "futures",
  "group",
  "halo2_proofs",

--- a/book/src/dev/zebra-dependencies-for-audit.md
+++ b/book/src/dev/zebra-dependencies-for-audit.md
@@ -88,7 +88,6 @@ Click the triangle for details:
 | [ripemd](https://github.com/RustCrypto/hashes) | 0.1.3 | no audits, but seems widely used
 | [secp256k1](https://github.com/rust-bitcoin/rust-secp256k1/) | 0.21.3 | no audits, but seems widely used
 | [subtle](https://github.com/dalek-cryptography/subtle) | [2.4.1](https://github.com/dalek-cryptography/subtle/releases/tag/2.4.1) | no audits, but seems widely used
-| [fpe](https://github.com/str4d/fpe) | 0.5.1 |  I think it's not being used yet
 | [group](https://github.com/zkcrypto/group) | [0.12.0](https://github.com/zkcrypto/group/releases/tag/0.12.0) | no audits but it's just traits, seems widely used
 | [x25519-dalek](https://github.com/dalek-cryptography/x25519-dalek) | [1.2.0](https://github.com/dalek-cryptography/x25519-dalek/releases/tag/1.2.0) | no audits, but seems widely used
 | [jubjub](https://github.com/zkcrypto/jubjub) | [0.9.0](https://github.com/zkcrypto/jubjub/releases/tag/0.9.0) | not sure if were covered by ECC audits. Seem widely used.

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -25,7 +25,6 @@ bls12_381 = "0.7.0"
 bs58 = { version = "0.4.0", features = ["check"] }
 byteorder = "1.4.3"
 equihash = "0.2.0"
-fpe = "0.5.1"
 group = "0.12.0"
 incrementalmerkletree = "0.3.0"
 jubjub = "0.9.0"


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->
When we removed unused orchard code we also remove our use of the `fpe` crate. However, we forgot to also remove this from `Cargo.toml`

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
-->

This change removes `fpe` from `Cargo.toml` and also from the list of dependencies that should not be audited

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?
