### PR TITLE
fix(build): Disable new Rust 1.65 lints and fix some test errors

### DIFF
--- a/.github/workflows/continous-integration-os.patch.yml
+++ b/.github/workflows/continous-integration-os.patch.yml
@@ -15,16 +15,18 @@ on:
 
 jobs:
   test:
-    name: Test ${{ matrix.rust }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Test ${{ matrix.rust }} on ${{ matrix.os }}${{ matrix.features }}
     strategy:
       matrix:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
         os: [ubuntu-latest, macos-latest]
         rust: [stable, beta]
+        features: ["", " --features getblocktemplate-rpcs"]
         exclude:
           - os: macos-latest
             rust: beta
+          - os: macos-latest
+            features: " --features getblocktemplate-rpcs"
 
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -53,7 +53,7 @@ env:
 
 jobs:
   test:
-    name: Test ${{ matrix.rust }} on ${{ matrix.os }}
+    name: Test ${{ matrix.rust }} on ${{ matrix.os }}${{ matrix.features }}
     # The large timeout is to accommodate:
     # - Windows builds (75 minutes, typically 30-50 minutes), and
     # - parameter downloads (an extra 90 minutes, but only when the cache expires)
@@ -65,6 +65,7 @@ jobs:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
         os: [ubuntu-latest, macos-latest]
         rust: [stable, beta]
+        features: ["", " --features getblocktemplate-rpcs"]
         exclude:
         # We're excluding macOS for the following reasons:
         # - the concurrent macOS runner limit is much lower than the Linux limit
@@ -72,6 +73,8 @@ jobs:
         # - macOS is a second-tier Zebra support platform
           - os: macos-latest
             rust: beta
+          - os: macos-latest
+            features: " --features getblocktemplate-rpcs"
 
     steps:
       - uses: actions/checkout@v3.1.0
@@ -139,9 +142,11 @@ jobs:
       # Modified from:
       # https://github.com/zcash/librustzcash/blob/c48bb4def2e122289843ddb3cb2984c325c03ca0/.github/workflows/ci.yml#L20-L33
       #
-      # TODO: split get-params-path and download-params examples into their own crate,
-      #       to speed up compilation
-      #       compile examples in release mode, to speed up downloads
+      # TODO:
+      # - split Fetch/Cache Zcash parameters into their own job,
+      #   and use `concurrency:` to limit it to one job per OS
+      # - split get-params-path and download-params examples into their own crate,
+      #   to speed up compilation
       - name: Fetch path to Zcash parameters
         working-directory: ./zebra-consensus
         shell: bash
@@ -157,28 +162,24 @@ jobs:
         working-directory: ./zebra-consensus
         run: cargo run --example download-params
 
-      - name: Run tests
+      - name: Run tests${{ matrix.features }}
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --verbose --workspace -- --nocapture
-
-      - name: Run tests with getblocktemplate-rpcs feature
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: test
-          args: --features getblocktemplate-rpcs --verbose --workspace -- --nocapture
+          args: ${{ matrix.features }} --verbose --workspace -- --nocapture
 
       # Explicitly run any tests that are usually #[ignored]
 
-      - name: Run zebrad large sync tests
+      - name: Run zebrad large sync tests${{ matrix.features }}
         # Skip the entire step on Ubuntu and Windows, because the test would be skipped anyway due to ZEBRA_SKIP_NETWORK_TESTS
+        # Currently, this also skips large sync with `getblocktemplate-rpcs`,
+        # but that is already covered by the Docker tests.
         if: matrix.os == 'macos-latest'
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
           # Note: this only runs the zebrad acceptance tests, because re-running all the test binaries is slow on Windows
-          args: --verbose --package zebrad --test acceptance -- --nocapture --include-ignored sync_large_checkpoints_
+          args: ${{ matrix.features }} --verbose --package zebrad --test acceptance -- --nocapture --include-ignored sync_large_checkpoints_
 
   # Install Zebra with lockfile dependencies, with no caching and default features
   install-from-lockfile-no-cache:

--- a/zebra-test/src/mock_service.rs
+++ b/zebra-test/src/mock_service.rs
@@ -76,7 +76,9 @@ const DEFAULT_PROXY_CHANNEL_SIZE: usize = 100;
 ///
 /// Note that if a test checks that no requests are received, each check has to wait for this
 /// amount of time, so this may affect the test execution time.
-pub const DEFAULT_MAX_REQUEST_DELAY: Duration = Duration::from_millis(25);
+///
+/// We've seen delays up to 67ms on busy Linux and macOS machines.
+pub const DEFAULT_MAX_REQUEST_DELAY: Duration = Duration::from_millis(150);
 
 /// An internal type representing the item that's sent in the [`broadcast`] channel.
 ///

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -990,6 +990,7 @@ where
     /// Handles a response for a requested block.
     ///
     /// See [`Self::handle_response`] for more details.
+    #[allow(unknown_lints)]
     #[allow(clippy::result_large_err)]
     fn handle_block_response(
         &mut self,
@@ -1008,6 +1009,7 @@ where
     /// Handles a response to block hash submission, passing through any extra hashes.
     ///
     /// See [`Self::handle_response`] for more details.
+    #[allow(unknown_lints)]
     #[allow(clippy::result_large_err)]
     fn handle_hash_response(
         response: Result<IndexSet<block::Hash>, BlockDownloadVerifyError>,
@@ -1024,6 +1026,7 @@ where
     /// so that the synchronization can continue normally.
     ///
     /// Returns `Err` if an unexpected error occurred, to force the synchronizer to restart.
+    #[allow(unknown_lints)]
     #[allow(clippy::result_large_err)]
     fn handle_response<T>(
         response: Result<T, BlockDownloadVerifyError>,

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -990,6 +990,7 @@ where
     /// Handles a response for a requested block.
     ///
     /// See [`Self::handle_response`] for more details.
+    #[allow(clippy::result_large_err)]
     fn handle_block_response(
         &mut self,
         response: Result<(Height, block::Hash), BlockDownloadVerifyError>,
@@ -1007,6 +1008,7 @@ where
     /// Handles a response to block hash submission, passing through any extra hashes.
     ///
     /// See [`Self::handle_response`] for more details.
+    #[allow(clippy::result_large_err)]
     fn handle_hash_response(
         response: Result<IndexSet<block::Hash>, BlockDownloadVerifyError>,
     ) -> Result<IndexSet<block::Hash>, BlockDownloadVerifyError> {
@@ -1022,6 +1024,7 @@ where
     /// so that the synchronization can continue normally.
     ///
     /// Returns `Err` if an unexpected error occurred, to force the synchronizer to restart.
+    #[allow(clippy::result_large_err)]
     fn handle_response<T>(
         response: Result<T, BlockDownloadVerifyError>,
     ) -> Result<(), BlockDownloadVerifyError> {


### PR DESCRIPTION
## Motivation

The following errors are happening on the `main` branch, some are related to the Rust 1.65 release:
1. clippy::result_large_err lints
2. timeout in db_init_outside_future_executor test
3. build failure in `--features getblocktemplate-rpcs` tests
    - we've seen this failure before, it might be related to a full disk, or to compiling with and without the feature

Closes #5547

## Solution

1. Disable the lint
2. Increase the timeout
3. Split the test jobs so `--features getblocktemplate-rpcs` gets a separate job, and add patch jobs

## Review

@arya2 reported these errors, but @oxarbitrage is on `main` branch failures this week.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- [ ] Add the new `--features getblocktemplate-rpcs` to the `main` branch protection rules (needs admin)