### PR TITLE
fix(ci): Run required jobs on dependent PRs

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -65,6 +65,7 @@ jobs:
   #
   # The image will be commonly named `zebrad:<short-hash | github-ref | semver>`
   build:
+    name: Build CD Docker
     uses: ./.github/workflows/build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile

--- a/.github/workflows/continous-integration-docker.patch.yml
+++ b/.github/workflows/continous-integration-docker.patch.yml
@@ -31,7 +31,7 @@ jobs:
       - run: 'echo "No build required"'
 
   build:
-    name: Build / Build images
+    name: Build CI Docker / Build images
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -165,7 +165,7 @@ jobs:
           fi
 
   build:
-    name: Build
+    name: Build CI Docker
     uses: ./.github/workflows/build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -28,7 +28,7 @@ on:
       - '.cargo/config.toml'
       - '**/clippy.toml'
       # workflow definitions
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/continous-integration-os.yml'
   pull_request:
     paths:
       # code and tests

--- a/.github/workflows/lint.patch.yml
+++ b/.github/workflows/lint.patch.yml
@@ -2,8 +2,6 @@ name: Lint
 
 on:
   pull_request:
-    branches:
-      - 'main'
 
 jobs:
   clippy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - 'main'
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -20,6 +20,7 @@ jobs:
   #
   # The image will be named `zebrad:<semver>`
   build:
+    name: Build Release Docker
     uses: ./.github/workflows/build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile

--- a/.github/workflows/zcash-lightwalletd.patch.yml
+++ b/.github/workflows/zcash-lightwalletd.patch.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    name: Build images
+    name: Build lightwalletd Docker
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/zcash-lightwalletd.patch.yml
+++ b/.github/workflows/zcash-lightwalletd.patch.yml
@@ -4,8 +4,6 @@ name: zcash-lightwalletd
 # run a fake CI job to satisfy the branch protection rules.
 on:
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - 'zebra-rpc/**'
       - 'zebrad/tests/acceptance.rs'

--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -31,8 +31,6 @@ on:
 
   # Update the lightwalletd image when each related PR changes
   pull_request:
-    branches:
-      - main
     paths:
       # rebuild lightwalletd whenever the related Zebra code changes
       # (this code isn't actually compiled in this docker image)

--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -48,7 +48,7 @@ env:
 
 jobs:
   build:
-    name: Build images
+    name: Build lightwalletd Docker
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'

--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   build:
+    name: Build Zcash Params Docker
     uses: ./.github/workflows/build-docker-image.yml
     with:
       dockerfile_path: ./docker/zcash-params/Dockerfile


### PR DESCRIPTION
## Motivation

1. Some required CI jobs don't run on dependent PRs, stopping them from merging after the original PR merges
2. Some CI jobs have confusingly similar (or identical) names

## Solution

1. Make all required CI jobs run on every PR
2. Rename jobs based on the workflow name

After it has been reviewed, an admin will need to update these job names in the `main` branch protection rules:
- [x] Build CI Docker / Build images
- [x] Build lightwalletd Docker

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

