### PR TITLE
suggestion: Avoid new uses of lazy_static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5384,7 +5384,6 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-derive",
  "jsonrpc-http-server",
- "lazy_static",
  "num_cpus",
  "proptest",
  "proptest-derive",

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -37,7 +37,6 @@ tracing = "0.1.37"
 tracing-futures = "0.2.5"
 
 hex = { version = "0.4.3", features = ["serde"] }
-lazy_static = "1.4.0"
 serde = { version = "1.0.147", features = ["serde_derive"] }
 
 proptest = { version = "0.10.1", optional = true }

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -329,7 +329,10 @@ where
                 min_time: 0,
 
                 // Hardcoded list of block fields the miner is allowed to change.
-                mutable: constants::GET_BLOCK_TEMPLATE_MUTABLE_FIELD.to_vec(),
+                mutable: constants::GET_BLOCK_TEMPLATE_MUTABLE_FIELD
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
 
                 // A range of valid nonces that goes from `u32::MIN` to `u32::MAX`.
                 nonce_range: constants::GET_BLOCK_TEMPLATE_NONCE_RANGE_FIELD.to_string(),

--- a/zebra-rpc/src/methods/get_block_template_rpcs/constants.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/constants.rs
@@ -1,15 +1,7 @@
 //! Constant values used in mining rpcs methods.
 
-use lazy_static::lazy_static;
-
 /// A range of valid nonces that goes from `u32::MIN` to `u32::MAX` as a string.
 pub const GET_BLOCK_TEMPLATE_NONCE_RANGE_FIELD: &str = "00000000ffffffff";
 
-lazy_static! {
-    /// A hardcoded list of fields that the miner can change from the block.
-    pub static ref GET_BLOCK_TEMPLATE_MUTABLE_FIELD: Vec<String> = vec![
-        "time".to_string(),
-        "transactions".to_string(),
-        "prevblock".to_string()
-    ];
-}
+/// A hardcoded list of fields that the miner can change from the block.
+pub const GET_BLOCK_TEMPLATE_MUTABLE_FIELD: &[&str] = &["time", "transactions", "prevblock"];

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/default_roots.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/default_roots.rs
@@ -5,7 +5,10 @@ use zebra_chain::block::{
     ChainHistoryBlockTxAuthCommitmentHash, ChainHistoryMmrRootHash,
 };
 
-/// Documentation to be added in #5452 or #5455.
+/// The block header roots for [`GetBlockTemplate.transactions`].
+///
+/// If the transactions in the block template are modified, these roots must be recalculated
+/// [according to the specification](https://zcash.github.io/rpc/getblocktemplate.html).
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct DefaultRoots {
     /// The merkle root of the transaction IDs in the block.

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
@@ -12,35 +12,47 @@ use crate::methods::{
 /// Documentation to be added after we document all the individual fields.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct GetBlockTemplate {
-    /// Add documentation.
+    /// The getblocktemplate RPC capabilities supported by Zebra.
+    ///
+    /// At the moment, Zebra does not support any of the extra capabilities from the specification:
+    /// - `proposal`: <https://en.bitcoin.it/wiki/BIP_0023#Block_Proposal>
+    /// - `longpoll`: <https://en.bitcoin.it/wiki/BIP_0022#Optional:_Long_Polling>
+    /// - `serverlist`: <https://en.bitcoin.it/wiki/BIP_0023#Logical_Services>
     pub capabilities: Vec<String>,
 
     /// The version of the block format.
     /// Always 4 for new Zcash blocks.
-    //
-    // TODO: add a default block version constant to zebra-chain.
     pub version: u32,
 
-    /// Add documentation.
+    /// The hash of the previous block.
     #[serde(rename = "previousblockhash")]
     pub previous_block_hash: GetBlockHash,
 
-    /// Add documentation.
+    /// The block commitment for the new block's header.
+    ///
+    /// Same as [`DefaultRoots.block_commitments_hash`], see that field for details.
     #[serde(rename = "blockcommitmentshash")]
     #[serde(with = "hex")]
     pub block_commitments_hash: ChainHistoryBlockTxAuthCommitmentHash,
 
-    /// Add documentation.
+    /// Legacy backwards-compatibility header root field.
+    ///
+    /// Same as [`DefaultRoots.block_commitments_hash`], see that field for details.
     #[serde(rename = "lightclientroothash")]
     #[serde(with = "hex")]
     pub light_client_root_hash: ChainHistoryBlockTxAuthCommitmentHash,
 
-    /// Add documentation.
+    /// Legacy backwards-compatibility header root field.
+    ///
+    /// Same as [`DefaultRoots.block_commitments_hash`], see that field for details.
     #[serde(rename = "finalsaplingroothash")]
     #[serde(with = "hex")]
     pub final_sapling_root_hash: ChainHistoryBlockTxAuthCommitmentHash,
 
-    /// Add documentation.
+    /// The block header roots for [`GetBlockTemplate.transactions`].
+    ///
+    /// If the transactions in the block template are modified, these roots must be recalculated
+    /// [according to the specification](https://zcash.github.io/rpc/getblocktemplate.html).
     #[serde(rename = "defaultroots")]
     pub default_roots: DefaultRoots,
 


### PR DESCRIPTION
## Motivation

This is a suggestion on PR #5558.

It removes a new use of `lazy_static`, and adds some missing documentation.