### PR TITLE
fix(ci): Stop using multiple jobs for quick Google Cloud tests

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -332,7 +332,7 @@ jobs:
     # because we might never get a finished sync.
     #
     # See the concurrency comment on the zebrad test-full-sync job for details.
-    concurrency: 
+    concurrency:
       group: ${{ github.workflow }}−${{ github.ref }}-regenerate-stateful-disks
       cancel-in-progress: false
 
@@ -387,7 +387,7 @@ jobs:
     # We want to prevent multiple full zebrad syncs running at the same time,
     # but we don't want to cancel running syncs on `main` if a new PR gets merged,
     # because we might never get a finished sync.
-    # 
+    #
     # Instead, we let the first sync complete, then queue the latest pending sync, cancelling any syncs in between.
     # (As the general workflow concurrency group just gets matched in Pull Requests,
     # it has no impact on this job.)
@@ -395,7 +395,7 @@ jobs:
     # TODO:
     # - allow multiple manual syncs on a branch, and isolate manual syncs from automatic syncs, by adding '-${{ github.run_id }}' when github.event.inputs.run-full-sync is true
     # - stop multiple automatic full syncs across different PRs by removing '−${{ github.ref }}' when needs.get-available-disks.outputs.zebra_tip_disk is true
-    concurrency: 
+    concurrency:
       group: ${{ github.workflow }}−${{ github.ref }}-test-full-sync
       cancel-in-progress: false
 
@@ -462,7 +462,7 @@ jobs:
     # because we might never get a finished sync.
     #
     # See the concurrency comment on the zebrad test-full-sync job for details.
-    concurrency: 
+    concurrency:
       group: ${{ github.workflow }}−${{ github.ref }}-lightwalletd-full-sync
       cancel-in-progress: false
 
@@ -548,7 +548,7 @@ jobs:
     # because we might never get a finished test.
     #
     # See the concurrency comment on the zebrad test-full-sync job for details.
-    concurrency: 
+    concurrency:
       group: ${{ github.workflow }}−${{ github.ref }}-lightwalletd-transactions-test
       cancel-in-progress: false
 

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -378,6 +378,8 @@ jobs:
       test_id: full-sync-to-tip
       test_description: Test a full sync up to the tip
       test_variables: '-e TEST_FULL_SYNC=1 -e ZEBRA_FORCE_USE_COLOR=1 -e FULL_SYNC_MAINNET_TIMEOUT_MINUTES=600'
+      # This test runs for longer than 6 hours, so it needs multiple jobs
+      is_long_test: true
       needs_zebra_state: false
       saves_to_disk: true
       disk_suffix: tip

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -125,11 +125,6 @@ jobs:
         with:
           short-length: 7
 
-      - name: Downcase network name for disks
-        run: |
-          NETWORK_CAPS=${{ inputs.network }}
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
-
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
@@ -198,11 +193,6 @@ jobs:
         uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
-
-      - name: Downcase network name for disks
-        run: |
-          NETWORK_CAPS=${{ inputs.network }}
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
@@ -421,11 +411,6 @@ jobs:
         with:
           short-length: 7
 
-      - name: Downcase network name for disks
-        run: |
-          NETWORK_CAPS=${{ inputs.network }}
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
-
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
@@ -553,11 +538,6 @@ jobs:
         with:
           short-length: 7
 
-      - name: Downcase network name for disks
-        run: |
-          NETWORK_CAPS=${{ inputs.network }}
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
-
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
@@ -622,11 +602,6 @@ jobs:
         with:
           short-length: 7
 
-      - name: Downcase network name for disks
-        run: |
-          NETWORK_CAPS=${{ inputs.network }}
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
-
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
@@ -680,11 +655,6 @@ jobs:
         uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
-
-      - name: Downcase network name for disks
-        run: |
-          NETWORK_CAPS=${{ inputs.network }}
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
@@ -741,11 +711,6 @@ jobs:
         uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
-
-      - name: Downcase network name for disks
-        run: |
-          NETWORK_CAPS=${{ inputs.network }}
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
@@ -805,11 +770,6 @@ jobs:
         with:
           short-length: 7
 
-      - name: Downcase network name for disks
-        run: |
-          NETWORK_CAPS=${{ inputs.network }}
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
-
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
@@ -867,11 +827,6 @@ jobs:
         uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
-
-      - name: Downcase network name for disks
-        run: |
-          NETWORK_CAPS=${{ inputs.network }}
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
@@ -932,11 +887,6 @@ jobs:
         with:
           short-length: 7
 
-      - name: Downcase network name for disks
-        run: |
-          NETWORK_CAPS=${{ inputs.network }}
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
-
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
@@ -995,11 +945,6 @@ jobs:
         with:
           short-length: 7
 
-      - name: Downcase network name for disks
-        run: |
-          NETWORK_CAPS=${{ inputs.network }}
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
-
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
@@ -1054,11 +999,6 @@ jobs:
         uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
-
-      - name: Downcase network name for disks
-        run: |
-          NETWORK_CAPS=${{ inputs.network }}
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
@@ -1121,11 +1061,6 @@ jobs:
         uses: rlespinasse/github-slug-action@v4
         with:
           short-length: 7
-
-      - name: Downcase network name for disks
-        run: |
-          NETWORK_CAPS=${{ inputs.network }}
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1041,7 +1041,6 @@ jobs:
   # If `inputs.is_long_test` is `false`, the Rust test harness mostly runs in this job.
   # Otherwise, it mostly runs in the "logs" jobs.
   test-result:
-    # TODO: update the job name here, and in the branch protection rules
     name: Run ${{ inputs.test_id }} test
     needs: [ logs-checkpoint ]
     # If the previous job fails, we also want to run and fail this job,
@@ -1095,6 +1094,7 @@ jobs:
           set -e;
           sudo docker logs \
           --tail all \
+          --follow \
           ${{ inputs.test_id }} | \
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -12,6 +12,11 @@ on:
         required: true
         type: string
         description: 'Explains what the test does'
+      height_grep_text:
+        required: false
+        type: string
+        description: 'Regular expression to find the tip height in test logs, and add it to newly created cached state image metadata'
+
       # Test selection and parameters
       test_variables:
         required: true
@@ -22,6 +27,12 @@ on:
         type: string
         default: Mainnet
         description: 'Zcash network to test against'
+      is_long_test:
+        required: false
+        type: boolean
+        default: false
+        description: 'Does this test need multiple run jobs? (Does it run longer than 6 hours?)'
+
       # Cached state
       #
       # TODO: find a better name
@@ -69,11 +80,6 @@ on:
         required: true
         type: boolean
         description: 'Does the test create a new cached state disk?'
-      # Metadata
-      height_grep_text:
-        required: false
-        type: string
-        description: 'Regular expression to find the tip height in test logs, and add it to newly created cached state image metadata'
       app_name:
         required: false
         type: string
@@ -524,12 +530,14 @@ jobs:
 
 
   # follow the logs of the test we just launched, up to Sapling activation (or the test finishing)
+  #
+  # If `inputs.is_long_test` is `false`, this job is skipped.
   logs-sprout:
     name: Log ${{ inputs.test_id }} test (sprout)
     # We run exactly one of without-cached-state or with-cached-state, and we always skip the other one.
     needs: [ launch-with-cached-state, launch-without-cached-state ]
     # If the previous job fails, we still want to show the logs.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -598,7 +606,7 @@ jobs:
     name: Log ${{ inputs.test_id }} test (heartwood)
     needs: [ logs-sprout ]
     # If the previous job fails, we still want to show the logs.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -657,7 +665,7 @@ jobs:
     name: Log ${{ inputs.test_id }} test (canopy)
     needs: [ logs-heartwood ]
     # If the previous job fails, we still want to show the logs.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -718,7 +726,7 @@ jobs:
     name: Log ${{ inputs.test_id }} test (1740k)
     needs: [ logs-canopy ]
     # If the previous job fails, we still want to show the logs.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -781,7 +789,7 @@ jobs:
     name: Log ${{ inputs.test_id }} test (1760k)
     needs: [ logs-1740k ]
     # If the previous job fails, we still want to show the logs.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -844,7 +852,7 @@ jobs:
     name: Log ${{ inputs.test_id }} test (1780k)
     needs: [ logs-1760k ]
     # If the previous job fails, we still want to show the logs.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -908,7 +916,7 @@ jobs:
     name: Log ${{ inputs.test_id }} test (1800k)
     needs: [ logs-1780k ]
     # If the previous job fails, we still want to show the logs.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -971,7 +979,7 @@ jobs:
     name: Log ${{ inputs.test_id }} test (1820k)
     needs: [ logs-1800k ]
     # If the previous job fails, we still want to show the logs.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -1031,7 +1039,7 @@ jobs:
     name: Log ${{ inputs.test_id }} test (checkpoint)
     needs: [ logs-1820k ]
     # If the previous job fails, we still want to show the logs.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -1086,69 +1094,16 @@ jobs:
           -e 'test result:.*finished in' \
           "
 
-  # follow the logs of the test we just launched, until it finishes
-  logs-end:
-    name: Log ${{ inputs.test_id }} test (end)
-    needs: [ logs-checkpoint ]
-    # If the previous job fails, we still want to show the logs.
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - uses: actions/checkout@v3.1.0
-        with:
-          persist-credentials: false
-          fetch-depth: '2'
 
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
-        with:
-          short-length: 7
-
-      - name: Downcase network name for disks
-        run: |
-          NETWORK_CAPS=${{ inputs.network }}
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
-
-      # Setup gcloud CLI
-      - name: Authenticate to Google Cloud
-        id: auth
-        uses: google-github-actions/auth@v0.8.3
-        with:
-          retries: '3'
-          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
-          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
-          token_format: 'access_token'
-
-      # Show recent logs, following until the test finishes
-      - name: Show logs for ${{ inputs.test_id }} test (end)
-        run: |
-          gcloud compute ssh \
-          github-service-account@${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
-          --zone ${{ env.ZONE }} \
-          --quiet \
-          --ssh-flag="-o ServerAliveInterval=5" \
-          --ssh-flag="-o ConnectionAttempts=20" \
-          --ssh-flag="-o ConnectTimeout=5" \
-          --command \
-          "\
-          sudo docker logs \
-          --tail ${{ env.EXTRA_LOG_LINES }} \
-          --follow \
-          ${{ inputs.test_id }} | \
-          tee --output-error=exit /dev/stderr | \
-          grep --max-count=1 --extended-regexp --color=always \
-          'test result:.*finished in' \
-          "
-
-
-  # check the results of the test, and show all of the test logs
+  # Show all the test logs, then follow the logs of the test we just launched, until it finishes.
+  # Then check the result of the test.
+  #
+  # If `inputs.is_long_test` is `false`, the Rust test harness mostly runs in this job.
+  # Otherwise, it mostly runs in the "logs" jobs.
   test-result:
     # TODO: update the job name here, and in the branch protection rules
     name: Run ${{ inputs.test_id }} test
-    needs: [ logs-end ]
+    needs: [ logs-checkpoint ]
     # If the previous job fails, we also want to run and fail this job,
     # so that the branch protection rule fails in Mergify and GitHub.
     if: ${{ !cancelled() }}


### PR DESCRIPTION
## Motivation

This PR only uses multiple CI jobs for the full sync tests.
All the other test run in a single "Run" job.

If the SSH errors in these tickets are related to the number of `ssh` connections we make, this should reduce our CI error rates due to:
- #5494 
- #5069
- and possibly #5366

But it doesn't actually fix these bugs. (Unless the cause is an undocumented Google Cloud inbound SSH connection rate-limit.)

## Solution

- Add a new parameter for long tests, and only enable it for the full sync test
- Remove a job that's a duplicate of the "Run" job
- Remove unused steps and whitespace

## Review

@gustavovalverde might be the best person to review this PR.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

