### PR TITLE
fix(ci): Add a missing runs-on field to a patch workflow

### DIFF
--- a/.github/workflows/continous-integration-os.patch.yml
+++ b/.github/workflows/continous-integration-os.patch.yml
@@ -16,6 +16,9 @@ on:
 jobs:
   test:
     name: Test ${{ matrix.rust }} on ${{ matrix.os }}${{ matrix.features }}
+    # We're just doing this job for the name, the platform doesn't matter.
+    # So we use the platform with the most concurrent instances.
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801


### PR DESCRIPTION
## Motivation

This is a critical fix on PR #5550, which prevents CI hangs and failures.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?
