### PR TITLE
fix(ci): Add missing getblocktemplate-rpcs feature dependencies

### DIFF
--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -9,7 +9,23 @@ edition = "2021"
 
 [features]
 default = []
-proptest-impl = ["proptest", "proptest-derive", "zebra-test", "rand", "rand_chacha", "tokio"]
+
+# Production features that activate extra functionality
+
+# Experimental mining RPC support
+getblocktemplate-rpcs = []
+
+# Test-only features
+
+proptest-impl = [
+    "proptest",
+    "proptest-derive",
+    "rand",
+    "rand_chacha",
+    "tokio",
+    "zebra-test",
+]
+
 bench = ["zebra-test"]
 
 [dependencies]

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -8,7 +8,13 @@ repository = "https://github.com/ZcashFoundation/zebra"
 
 [features]
 default = []
-getblocktemplate-rpcs = []
+
+# Production features that activate extra dependencies, or extra features in dependencies
+
+# Experimental mining RPC support
+getblocktemplate-rpcs = [
+    "zebra-chain/getblocktemplate-rpcs",
+]
 
 [dependencies]
 zebra-chain = { path = "../zebra-chain" }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -9,10 +9,25 @@ edition = "2021"
 
 [features]
 default = []
-getblocktemplate-rpcs = ["zebra-state/getblocktemplate-rpcs", "zebra-node-services/getblocktemplate-rpcs", "zebra-consensus/getblocktemplate-rpcs"]
+
+# Production features that activate extra dependencies, or extra features in dependencies
+
+# Experimental mining RPC support
+getblocktemplate-rpcs = [
+    "zebra-consensus/getblocktemplate-rpcs",
+    "zebra-state/getblocktemplate-rpcs",
+    "zebra-node-services/getblocktemplate-rpcs",
+    "zebra-chain/getblocktemplate-rpcs",
+]
 
 # Test-only features
-proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl", "zebra-state/proptest-impl"]
+proptest-impl = [
+    "proptest",
+    "proptest-derive",
+    "zebra-consensus/proptest-impl",
+    "zebra-state/proptest-impl",
+    "zebra-chain/proptest-impl",
+]
 
 [dependencies]
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std"] }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -6,8 +6,21 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [features]
-proptest-impl = ["proptest", "proptest-derive", "zebra-test", "zebra-chain/proptest-impl"]
-getblocktemplate-rpcs = []
+
+# Production features that activate extra dependencies, or extra features in dependencies
+
+# Experimental mining RPC support
+getblocktemplate-rpcs = [
+    "zebra-chain/getblocktemplate-rpcs",
+]
+
+# Test-only features
+proptest-impl = [
+    "proptest",
+    "proptest-derive",
+    "zebra-test",
+    "zebra-chain/proptest-impl"
+]
 
 [dependencies]
 bincode = "1.3.3"

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -21,8 +21,10 @@ default = ["release_max_level_info"]
 # Experimental mining RPC support
 getblocktemplate-rpcs = [
     "zebra-rpc/getblocktemplate-rpcs",
+    "zebra-consensus/getblocktemplate-rpcs",
     "zebra-state/getblocktemplate-rpcs",
     "zebra-node-services/getblocktemplate-rpcs",
+    "zebra-chain/getblocktemplate-rpcs",
 ]
 
 sentry = ["dep:sentry", "sentry-tracing"]
@@ -50,7 +52,14 @@ max_level_info = ["tracing/max_level_info", "log/max_level_info"]
 max_level_debug = ["tracing/max_level_debug", "log/max_level_debug"]
 
 # Testing features that activate extra dependencies
-proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl", "zebra-state/proptest-impl", "zebra-consensus/proptest-impl", "zebra-network/proptest-impl"]
+proptest-impl = [
+    "proptest",
+    "proptest-derive",
+    "zebra-consensus/proptest-impl",
+    "zebra-state/proptest-impl",
+    "zebra-network/proptest-impl",
+    "zebra-chain/proptest-impl",
+]
 
 # The gRPC tests also need an installed lightwalletd binary
 lightwalletd-grpc-tests = ["tonic-build"]


### PR DESCRIPTION
## Motivation

Zebra is missing some `getblocktemplate-rpcs` feature dependencies.
This might be causing build bugs like #5570.

## Solution

- Add missing `getblocktemplate-rpcs` feature dependencies between Zebra crates
- Add a `getblocktemplate-rpcs` feature to `zebra-chain` (needed for ticket #5453)

## Review

This is urgent because these failures are blocking other PRs merging.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

