### PR TITLE
fix(ci): Split out getblocktemplate-rpcs GitHub Actions cache

### DIFF
--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -98,6 +98,10 @@ jobs:
         #       or remove this workaround once the build is more efficient (#3005).
         #with:
         #  workspaces: ". -> C:\\zebra-target"
+        with:
+          # Split the getblocktemplate-rpcs cache from the regular cache, to avoid linker errors.
+          # (These might be "disk full" errors, or they might be dependency resolution issues.)
+          key: ${{ matrix.features }}
 
       - name: Change target output directory on Windows
         # Windows doesn't have enough space on the D: drive, so we redirect the build output to the


### PR DESCRIPTION
## Motivation

We're getting linker errors while building Zebra in GitHub Actions. These errors are difficult to diagnose, because the actual linker error log isn't shown by `cargo`.

Closes #5570.

## Solution

- Have different caches for `--features getblocktemplate-rpcs` and regular builds

We'll need to clear the caches manually after this PR merges to `main`:
https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/continuous-integration.md#fixing-disk-full-errors-and-zcash-parameter-errors

## Review

This is urgent, it's blocking a few different PRs.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

