### PR TITLE
fix(ci): Run GitHub runner tests using release builds

### DIFF
--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Fetch path to Zcash parameters
         working-directory: ./zebra-consensus
         shell: bash
-        run: echo "ZCASH_PARAMS=$(cargo run --example get-params-path)" >> $GITHUB_ENV
+        run: echo "ZCASH_PARAMS=$(cargo run --release --example get-params-path)" >> $GITHUB_ENV
       - name: Cache Zcash parameters
         id: cache-params
         uses: actions/cache@v3
@@ -164,7 +164,7 @@ jobs:
       - name: Fetch Zcash parameters
         if: steps.cache-params.outputs.cache-hit != 'true'
         working-directory: ./zebra-consensus
-        run: cargo run --example download-params
+        run: cargo run --release --example download-params
 
       # Run unit and basic acceptance tests, only showing command output if the test fails.
       #
@@ -173,7 +173,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: ${{ matrix.features }} --verbose --workspace
+          args: ${{ matrix.features }} --release --verbose --workspace
 
       # Explicitly run any tests that are usually #[ignored]
 
@@ -186,7 +186,7 @@ jobs:
         with:
           command: test
           # Note: this only runs the zebrad acceptance tests, because re-running all the test binaries is slow on Windows
-          args: ${{ matrix.features }} --verbose --package zebrad --test acceptance -- --nocapture --include-ignored sync_large_checkpoints_
+          args: ${{ matrix.features }} --release --verbose --package zebrad --test acceptance -- --nocapture --include-ignored sync_large_checkpoints_
 
   # Install Zebra with lockfile dependencies, with no caching and default features
   install-from-lockfile-no-cache:


### PR DESCRIPTION
## Motivation

We're testing with release builds in Docker, but debug builds in GitHub runners. 

Possibly fixes #5570.

## Solution

This might be a disk space error, and release builds are smaller than debug builds.

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

