### PR TITLE
change(consensus) verify that mempool transaction UTXOs are in the best chain

### DIFF
--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -178,8 +178,8 @@ pub enum TransactionError {
     #[error("must have at least one active orchard flag")]
     NotEnoughFlags,
 
-    #[error("could not find an input UTXO in best chain")]
-    InputNotFound,
+    #[error("could not find a mempool transaction input UTXO in the best chain")]
+    TransparentInputNotFound,
 }
 
 impl From<BoxError> for TransactionError {

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -177,6 +177,9 @@ pub enum TransactionError {
 
     #[error("must have at least one active orchard flag")]
     NotEnoughFlags,
+
+    #[error("could not find an input UTXO in best chain")]
+    InputNotFound,
 }
 
 impl From<BoxError> for TransactionError {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -488,7 +488,7 @@ where
                 } else if is_mempool {
                     let query = state.clone().oneshot(zs::Request::BestChainUtxo(*outpoint));
                     if let zebra_state::Response::BestChainUtxo(utxo) = query.await? {
-                        utxo.ok_or(TransactionError::InputNotFound)?
+                        utxo.ok_or(TransactionError::TransparentInputNotFound)?
                     } else {
                         unreachable!("BestChainUtxo always responds with Option<Utxo>")
                     }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -486,11 +486,13 @@ where
                     tracing::trace!("UXTO in known_utxos, discarding query");
                     output.utxo.clone()
                 } else if is_mempool {
-                    let query = state.clone().oneshot(zs::Request::BestChainUtxo(*outpoint));
-                    if let zebra_state::Response::BestChainUtxo(utxo) = query.await? {
+                    let query = state
+                        .clone()
+                        .oneshot(zs::Request::UnspentBestChainUtxo(*outpoint));
+                    if let zebra_state::Response::UnspentBestChainUtxo(utxo) = query.await? {
                         utxo.ok_or(TransactionError::TransparentInputNotFound)?
                     } else {
-                        unreachable!("BestChainUtxo always responds with Option<Utxo>")
+                        unreachable!("UnspentBestChainUtxo always responds with Option<Utxo>")
                     }
                 } else {
                     let query = state

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -480,6 +480,8 @@ where
         for input in inputs {
             if let transparent::Input::PrevOut { outpoint, .. } = input {
                 tracing::trace!("awaiting outpoint lookup");
+                // Currently, Zebra only supports known UTXOs in block transactions.
+                // But it might support them in the mempool in future.
                 let utxo = if let Some(output) = known_utxos.get(outpoint) {
                     tracing::trace!("UXTO in known_utxos, discarding query");
                     output.utxo.clone()

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -189,7 +189,7 @@ async fn mempool_request_with_missing_input_is_rejected() {
         .find(|(_, tx)| !(tx.is_coinbase() || tx.inputs().is_empty()))
         .expect("At least one non-coinbase transaction with transparent inputs in test vectors");
 
-    let expected_state_request = zebra_state::Request::BestChainUtxo(match tx.inputs()[0] {
+    let expected_state_request = zebra_state::Request::UnspentBestChainUtxo(match tx.inputs()[0] {
         transparent::Input::PrevOut { outpoint, .. } => outpoint,
         transparent::Input::Coinbase { .. } => panic!("requires a non-coinbase transaction"),
     });
@@ -199,7 +199,7 @@ async fn mempool_request_with_missing_input_is_rejected() {
             .expect_request(expected_state_request)
             .await
             .expect("verifier should call mock state service")
-            .respond(zebra_state::Response::BestChainUtxo(None));
+            .respond(zebra_state::Response::UnspentBestChainUtxo(None));
     });
 
     let verifier_response = verifier

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -209,7 +209,10 @@ async fn mempool_request_with_missing_input_is_rejected() {
         })
         .await;
 
-    assert_eq!(verifier_response, Err(TransactionError::InputNotFound));
+    assert_eq!(
+        verifier_response,
+        Err(TransactionError::TransparentInputNotFound)
+    );
 }
 
 #[test]

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -462,10 +462,7 @@ pub enum Request {
     /// returning `None` immediately if it is unknown.
     ///
     /// Checks verified blocks in the finalized chain and the _best_ non-finalized chain.
-    ///
-    /// This request is purely informational, there is no guarantee that
-    /// the UTXO remains unspent in the best chain.
-    BestChainUtxo(transparent::OutPoint),
+    UnspentBestChainUtxo(transparent::OutPoint),
 
     /// Looks up a block by hash or height in the current best chain.
     ///
@@ -554,7 +551,7 @@ impl Request {
             Request::Tip => "tip",
             Request::BlockLocator => "block_locator",
             Request::Transaction(_) => "transaction",
-            Request::BestChainUtxo { .. } => "best_chain_utxo",
+            Request::UnspentBestChainUtxo { .. } => "unspent_best_chain_utxo",
             Request::Block(_) => "block",
             Request::FindBlockHashes { .. } => "find_block_hashes",
             Request::FindBlockHeaders { .. } => "find_block_headers",
@@ -623,10 +620,7 @@ pub enum ReadRequest {
     /// returning `None` immediately if it is unknown.
     ///
     /// Checks verified blocks in the finalized chain and the _best_ non-finalized chain.
-    ///
-    /// This request is purely informational, there is no guarantee that
-    /// the UTXO remains unspent in the best chain.
-    BestChainUtxo(transparent::OutPoint),
+    UnspentBestChainUtxo(transparent::OutPoint),
 
     /// Looks up a UTXO identified by the given [`OutPoint`](transparent::OutPoint),
     /// returning `None` immediately if it is unknown.
@@ -760,7 +754,7 @@ impl ReadRequest {
             ReadRequest::Block(_) => "block",
             ReadRequest::Transaction(_) => "transaction",
             ReadRequest::TransactionIdsForBlock(_) => "transaction_ids_for_block",
-            ReadRequest::BestChainUtxo { .. } => "best_chain_utxo",
+            ReadRequest::UnspentBestChainUtxo { .. } => "unspent_best_chain_utxo",
             ReadRequest::AnyChainUtxo { .. } => "any_chain_utxo",
             ReadRequest::BlockLocator => "block_locator",
             ReadRequest::FindBlockHashes { .. } => "find_block_hashes",
@@ -799,7 +793,9 @@ impl TryFrom<Request> for ReadRequest {
 
             Request::Block(hash_or_height) => Ok(ReadRequest::Block(hash_or_height)),
             Request::Transaction(tx_hash) => Ok(ReadRequest::Transaction(tx_hash)),
-            Request::BestChainUtxo(outpoint) => Ok(ReadRequest::BestChainUtxo(outpoint)),
+            Request::UnspentBestChainUtxo(outpoint) => {
+                Ok(ReadRequest::UnspentBestChainUtxo(outpoint))
+            }
 
             Request::BlockLocator => Ok(ReadRequest::BlockLocator),
             Request::FindBlockHashes { known_blocks, stop } => {

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -458,6 +458,15 @@ pub enum Request {
     /// * [`Response::Transaction(None)`](Response::Transaction) otherwise.
     Transaction(transaction::Hash),
 
+    /// Looks up a UTXO identified by the given [`OutPoint`](transparent::OutPoint),
+    /// returning `None` immediately if it is unknown.
+    ///
+    /// Checks verified blocks in the finalized chain and the _best_ non-finalized chain.
+    ///
+    /// This request is purely informational, there is no guarantee that
+    /// the UTXO remains unspent in the best chain.
+    BestChainUtxo(transparent::OutPoint),
+
     /// Looks up a block by hash or height in the current best chain.
     ///
     /// Returns
@@ -545,6 +554,7 @@ impl Request {
             Request::Tip => "tip",
             Request::BlockLocator => "block_locator",
             Request::Transaction(_) => "transaction",
+            Request::BestChainUtxo { .. } => "best_chain_utxo",
             Request::Block(_) => "block",
             Request::FindBlockHashes { .. } => "find_block_hashes",
             Request::FindBlockHeaders { .. } => "find_block_headers",
@@ -789,6 +799,7 @@ impl TryFrom<Request> for ReadRequest {
 
             Request::Block(hash_or_height) => Ok(ReadRequest::Block(hash_or_height)),
             Request::Transaction(tx_hash) => Ok(ReadRequest::Transaction(tx_hash)),
+            Request::BestChainUtxo(outpoint) => Ok(ReadRequest::BestChainUtxo(outpoint)),
 
             Request::BlockLocator => Ok(ReadRequest::BlockLocator),
             Request::FindBlockHashes { known_blocks, stop } => {

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -36,8 +36,8 @@ pub enum Response {
     /// Response to [`Request::Transaction`] with the specified transaction.
     Transaction(Option<Arc<Transaction>>),
 
-    /// Response to [`Request::BestChainUtxo`] with the UTXO
-    BestChainUtxo(Option<transparent::Utxo>),
+    /// Response to [`Request::UnspentBestChainUtxo`] with the UTXO
+    UnspentBestChainUtxo(Option<transparent::Utxo>),
 
     /// Response to [`Request::Block`] with the specified block.
     Block(Option<Arc<Block>>),
@@ -84,12 +84,9 @@ pub enum ReadResponse {
     /// The response to a `FindBlockHeaders` request.
     BlockHeaders(Vec<block::CountedHeader>),
 
-    /// The response to a `BestChainUtxo` request, from verified blocks in the
+    /// The response to a `UnspentBestChainUtxo` request, from verified blocks in the
     /// _best_ non-finalized chain, or the finalized chain.
-    ///
-    /// This response is purely informational, there is no guarantee that
-    /// the UTXO remains unspent in the best chain.
-    BestChainUtxo(Option<transparent::Utxo>),
+    UnspentBestChainUtxo(Option<transparent::Utxo>),
 
     /// The response to an `AnyChainUtxo` request, from verified blocks in
     /// _any_ non-finalized chain, or the finalized chain.
@@ -135,7 +132,7 @@ impl TryFrom<ReadResponse> for Response {
             ReadResponse::Transaction(tx_and_height) => {
                 Ok(Response::Transaction(tx_and_height.map(|(tx, _height)| tx)))
             }
-            ReadResponse::BestChainUtxo(utxo) => Ok(Response::BestChainUtxo(utxo)),
+            ReadResponse::UnspentBestChainUtxo(utxo) => Ok(Response::UnspentBestChainUtxo(utxo)),
 
 
             ReadResponse::AnyChainUtxo(_) => Err("ReadService does not track pending UTXOs. \

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -36,6 +36,9 @@ pub enum Response {
     /// Response to [`Request::Transaction`] with the specified transaction.
     Transaction(Option<Arc<Transaction>>),
 
+    /// Response to [`Request::BestChainUtxo`] with the UTXO
+    BestChainUtxo(Option<transparent::Utxo>),
+
     /// Response to [`Request::Block`] with the specified block.
     Block(Option<Arc<Block>>),
 
@@ -132,6 +135,8 @@ impl TryFrom<ReadResponse> for Response {
             ReadResponse::Transaction(tx_and_height) => {
                 Ok(Response::Transaction(tx_and_height.map(|(tx, _height)| tx)))
             }
+            ReadResponse::BestChainUtxo(utxo) => Ok(Response::BestChainUtxo(utxo)),
+
 
             ReadResponse::AnyChainUtxo(_) => Err("ReadService does not track pending UTXOs. \
                                                   Manually unwrap the response, and handle pending UTXOs."),
@@ -141,7 +146,6 @@ impl TryFrom<ReadResponse> for Response {
             ReadResponse::BlockHeaders(headers) => Ok(Response::BlockHeaders(headers)),
 
             ReadResponse::TransactionIdsForBlock(_)
-            | ReadResponse::BestChainUtxo(_)
             | ReadResponse::SaplingTree(_)
             | ReadResponse::OrchardTree(_)
             | ReadResponse::AddressBalance(_)

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1021,6 +1021,7 @@ impl Service<Request> for StateService {
             | Request::Tip
             | Request::BlockLocator
             | Request::Transaction(_)
+            | Request::BestChainUtxo(_)
             | Request::Block(_)
             | Request::FindBlockHashes { .. }
             | Request::FindBlockHeaders { .. } => {

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -28,7 +28,9 @@ pub use address::{
     utxo::{address_utxos, AddressUtxos, ADDRESS_HEIGHTS_FULL_RANGE},
 };
 
-pub use block::{any_utxo, block, block_header, transaction, transaction_hashes_for_block, utxo};
+pub use block::{
+    any_utxo, block, block_header, transaction, transaction_hashes_for_block, unspent_utxo, utxo,
+};
 
 #[cfg(feature = "getblocktemplate-rpcs")]
 pub use block::hash;

--- a/zebra-state/src/service/read/block.rs
+++ b/zebra-state/src/service/read/block.rs
@@ -141,6 +141,22 @@ where
         .or_else(|| db.utxo(&outpoint).map(|utxo| utxo.utxo))
 }
 
+/// Returns the [`Utxo`] for [`transparent::OutPoint`], if it exists and is unspent in the
+/// non-finalized `chain` or finalized `db`.
+pub fn unspent_utxo<C>(
+    chain: Option<C>,
+    db: &ZebraDb,
+    outpoint: transparent::OutPoint,
+) -> Option<Utxo>
+where
+    C: AsRef<Chain>,
+{
+    match chain {
+        Some(chain) if chain.as_ref().spent_utxos.contains(&outpoint) => None,
+        chain => utxo(chain, db, outpoint),
+    }
+}
+
 /// Returns the [`Utxo`] for [`transparent::OutPoint`], if it exists in any chain
 /// in the `non_finalized_state`, or in the finalized `db`.
 ///


### PR DESCRIPTION
## Motivation

The transaction verifier currently checks that spent UTXOs of mempool transactions are in the state queue or on any chain, but it needs to verify that those spent UTXOs are on the best chain so that mined blocks including those transactions will be contextually valid.

Closes #5386 

## Solution

- Call state service with `BestChainUtxo` request instead of `AwaitUtxo` when verifying mempool transactions.
- Add `InputNotFound` variant to `TransactionError` for when the spent UTXOs are not present on the best chain.

## Review

This PR is part of regular scheduled work.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?

## Follow Up Work

- Add a `retry_list` in the mempool storage for transactions that weren't verified with `InputNotFound`?