### PR TITLE
ci: use Container-Optimized OS public image on the VM

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -120,6 +120,8 @@ jobs:
         run: |
           gcloud compute instance-templates create-with-container zebrad-${{ needs.versioning.outputs.major_version || env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --boot-disk-type=pd-ssd \
+          --image-project=debian-cloud \
+          --image-family=debian-11 \
           --container-image ${{ env.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
           --create-disk name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }},auto-delete=yes,size=300GB,type=pd-ssd \
           --container-mount-disk mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
@@ -196,6 +198,8 @@ jobs:
           gcloud compute instances create-with-container "zebrad-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 300GB \
           --boot-disk-type=pd-ssd \
+          --image-project=debian-cloud \
+          --image-family=debian-11 \
           --container-stdin \
           --container-tty \
           --container-image ${{ env.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -120,8 +120,8 @@ jobs:
         run: |
           gcloud compute instance-templates create-with-container zebrad-${{ needs.versioning.outputs.major_version || env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --boot-disk-type=pd-ssd \
-          --image-project=debian-cloud \
-          --image-family=debian-11 \
+          --image-project=cos-cloud \
+          --image-family=cos-stable \
           --container-image ${{ env.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
           --create-disk name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }},auto-delete=yes,size=300GB,type=pd-ssd \
           --container-mount-disk mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
@@ -198,8 +198,8 @@ jobs:
           gcloud compute instances create-with-container "zebrad-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 300GB \
           --boot-disk-type=pd-ssd \
-          --image-project=debian-cloud \
-          --image-family=debian-11 \
+          --image-project=cos-cloud \
+          --image-family=cos-stable \
           --container-stdin \
           --container-tty \
           --container-image ${{ env.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -144,9 +144,10 @@ jobs:
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 300GB \
           --boot-disk-type pd-ssd \
+          --image-project=debian-cloud \
+          --image-family=debian-11 \
           --create-disk name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=300GB,type=pd-ssd \
-          --container-image debian-11 \
-          --container-restart-policy=never \
+          --container-image=gcr.io/google-containers/busybox \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=true,google-logging-enabled=true \
@@ -365,9 +366,10 @@ jobs:
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 300GB \
           --boot-disk-type pd-ssd \
+          --image-project=debian-cloud \
+          --image-family=debian-11 \
           --create-disk image=${{ env.CACHED_DISK_NAME }},name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=300GB,type=pd-ssd \
-          --container-image debian-11 \
-          --container-restart-policy=never \
+          --container-image=gcr.io/google-containers/busybox \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=true,google-logging-enabled=true \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1247,7 +1247,7 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command=" \
-          docker logs ${{ inputs.test_id }} --tail 200 \
+          sudo docker logs ${{ inputs.test_id }} --tail 200 \
           ")
 
           SYNC_HEIGHT=$( \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -144,8 +144,8 @@ jobs:
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 300GB \
           --boot-disk-type pd-ssd \
-          --image-project=debian-cloud \
-          --image-family=debian-11 \
+          --image-project=cos-cloud \
+          --image-family=cos-stable \
           --create-disk name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=300GB,type=pd-ssd \
           --container-image=gcr.io/google-containers/busybox \
           --machine-type ${{ env.MACHINE_TYPE }} \
@@ -366,8 +366,8 @@ jobs:
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 300GB \
           --boot-disk-type pd-ssd \
-          --image-project=debian-cloud \
-          --image-family=debian-11 \
+          --image-project=cos-cloud \
+          --image-family=cos-stable \
           --create-disk image=${{ env.CACHED_DISK_NAME }},name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=300GB,type=pd-ssd \
           --container-image=gcr.io/google-containers/busybox \
           --machine-type ${{ env.MACHINE_TYPE }} \

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -55,8 +55,8 @@ jobs:
           gcloud compute instance-templates create-with-container zcashd-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --boot-disk-size 10GB \
           --boot-disk-type=pd-ssd \
-          --image-project=debian-cloud \
-          --image-family=debian-11 \
+          --image-project=cos-cloud \
+          --image-family=cos-stable \
           --container-stdin \
           --container-tty \
           --container-image electriccoinco/zcashd \

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -55,6 +55,8 @@ jobs:
           gcloud compute instance-templates create-with-container zcashd-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --boot-disk-size 10GB \
           --boot-disk-type=pd-ssd \
+          --image-project=debian-cloud \
+          --image-family=debian-11 \
           --container-stdin \
           --container-tty \
           --container-image electriccoinco/zcashd \


### PR DESCRIPTION
## Previous behavior:

We were pulling the debian image the wrong way, as this was being used as a container but it was meant to be the VM image

The image being pulled to create the internal container has been causing crashes as this images do not exists on Google's container repositories

Fixes #5618

## Expected behavior:

Use a public image as ~debian-11~ `cos-stable`  to get multiple benefits from it, as being able to use machine-images (#5615) ~and automatic disk resizing (which is now possible as we're using COS images, but those are more restrictive)~. We would have preferred `debian-11` but the host image does not include Docker. 

## Solution

Add `--image-project=cos-cloud` and `--image-family=cos-stable` as stated in the official documentation: https://cloud.google.com/sdk/gcloud/reference/compute/instances/create-with-container#--image-project

More info: https://cloud.google.com/compute/docs/images/os-details#import

## Review

Anyone from @ZcashFoundation/devops-reviewers 

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

This might reduce some error's we've been having with GCP