### PR TITLE
change(rpc): check contextual validity of getblocktemplate response

### DIFF
--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -32,6 +32,13 @@ pub(crate) const SOLUTION_SIZE: usize = 1344;
 #[derive(Deserialize, Serialize)]
 pub struct Solution(#[serde(with = "BigArray")] pub [u8; SOLUTION_SIZE]);
 
+#[cfg(feature = "getblocktemplate-rpcs")]
+impl Default for Solution {
+    fn default() -> Self {
+        Self([0; SOLUTION_SIZE])
+    }
+}
+
 impl Solution {
     /// The length of the portion of the header used as input when verifying
     /// equihash solutions, in bytes.

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -744,6 +744,12 @@ pub enum ReadRequest {
     /// * [`ReadResponse::BlockHash(Some(hash))`](ReadResponse::BlockHash) if the block is in the best chain;
     /// * [`ReadResponse::BlockHash(None)`](ReadResponse::BlockHash) otherwise.
     BestChainBlockHash(block::Height),
+
+    #[cfg(feature = "getblocktemplate-rpcs")]
+    /// Performs contextual validation of the given block
+    ///
+    /// Returns [`ReadResponse::Validated`] when successful or a validation error
+    CheckContextualValidity(PreparedBlock),
 }
 
 impl ReadRequest {
@@ -766,6 +772,8 @@ impl ReadRequest {
             ReadRequest::UtxosByAddresses(_) => "utxos_by_addesses",
             #[cfg(feature = "getblocktemplate-rpcs")]
             ReadRequest::BestChainBlockHash(_) => "best_chain_block_hash",
+            #[cfg(feature = "getblocktemplate-rpcs")]
+            ReadRequest::CheckContextualValidity(_) => "check_contextual_validity",
         }
     }
 

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -115,6 +115,10 @@ pub enum ReadResponse {
     /// Response to [`ReadRequest::BestChainBlockHash`](crate::ReadRequest::BestChainBlockHash) with the
     /// specified block hash.
     BlockHash(Option<block::Hash>),
+
+    #[cfg(feature = "getblocktemplate-rpcs")]
+    /// Response to [`ReadRequest::CheckContextualValidity`]
+    Validated,
 }
 
 /// Conversion from read-only [`ReadResponse`]s to read-write [`Response`]s.
@@ -152,7 +156,7 @@ impl TryFrom<ReadResponse> for Response {
             }
 
             #[cfg(feature = "getblocktemplate-rpcs")]
-            ReadResponse::BlockHash(_) => {
+            ReadResponse::BlockHash(_) | ReadResponse::Validated => {
                 Err("there is no corresponding Response for this ReadResponse")
             }
         }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -853,6 +853,9 @@ impl ReadStateService {
             block_commitment_result.expect("scope has finished")?;
             sprout_anchor_result.expect("scope has finished")?;
         } else {
+            // Not currently used by the getblocktemplate rpc method because it requires
+            // a low estimated distance to the network chain tip that means it would return
+            // an error before reaching this when the non-finalized state is empty anyways
             let next_valid_height = self
                 .db
                 .finalized_tip_height()

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -78,7 +78,6 @@ impl NonFinalizedStateBuilder {
     }
 }
 
-#[cfg(feature = "getblocktemplate-rpcs")]
 impl NonFinalizedState {
     /// Returns a new non-finalized state for `network`.
     pub fn new(network: Network) -> NonFinalizedState {

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -49,10 +49,49 @@ pub struct NonFinalizedState {
     pub network: Network,
 }
 
+/// Builder for NonFinalizedState
+#[derive(Clone, Debug)]
+#[cfg(feature = "getblocktemplate-rpcs")]
+pub struct NonFinalizedStateBuilder {
+    /// Verified, non-finalized chains, in ascending order
+    pub chain_set: BTreeSet<Arc<Chain>>,
+
+    /// The configured Zcash network.
+    pub network: Network,
+}
+
+#[cfg(feature = "getblocktemplate-rpcs")]
+impl NonFinalizedStateBuilder {
+    /// Add a chain to be included in the built NonFinalizedState
+    /// Returns the builder
+    pub fn insert_chain(mut self, chain: Arc<Chain>) -> Self {
+        self.chain_set.insert(chain);
+        self
+    }
+
+    /// Consumes the builder and returns the NonFinalizedState
+    pub fn finish(self) -> NonFinalizedState {
+        NonFinalizedState {
+            chain_set: self.chain_set,
+            network: self.network,
+        }
+    }
+}
+
+#[cfg(feature = "getblocktemplate-rpcs")]
 impl NonFinalizedState {
     /// Returns a new non-finalized state for `network`.
     pub fn new(network: Network) -> NonFinalizedState {
         NonFinalizedState {
+            chain_set: Default::default(),
+            network,
+        }
+    }
+
+    /// Returns a new NonFinalizedStateBuilder for creating a non-finalized state for `network`.
+    #[cfg(feature = "getblocktemplate-rpcs")]
+    pub fn build(network: Network) -> NonFinalizedStateBuilder {
+        NonFinalizedStateBuilder {
             chain_set: Default::default(),
             network,
         }

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -40,7 +40,12 @@ pub(crate) fn validate_and_commit_non_finalized(
     non_finalized_state: &mut NonFinalizedState,
     prepared: PreparedBlock,
 ) -> Result<(), CommitBlockError> {
-    check::initial_contextual_validity(finalized_state, non_finalized_state, &prepared)?;
+    check::initial_contextual_validity(
+        finalized_state.network(),
+        &finalized_state.db,
+        non_finalized_state,
+        &prepared,
+    )?;
     let parent_hash = prepared.block.header.previous_block_hash;
 
     if finalized_state.db.finalized_tip_hash() == parent_hash {


### PR DESCRIPTION
## Motivation

The getblocktemplate response must be contextually valid based on the best tip in the state.

Needs other getblocktemplate fields for testing the success case.

Closes #5376

## Solution

- Add a new state request for checking the contextual validity of a prepared block without committing it.
- Make a prepared block with default `nonce` and `solution` fields to use the new state request.
- Update vectors and snapshot tests to use a MockService that returns a `Validated` response.

## Review

This PR is part of regular scheduled work.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?
