### PR TITLE
build(deps): bump zcash_proofs from 0.8.0 to 0.9.0 and zcash_primitives from 0.8.1 to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5218,15 +5218,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "zcash_proofs"
-version = "0.8.0"
+name = "zcash_primitives"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b5cdd6f43c8b56449e52f760d71241b8490530dc10a88d990e8dcf0c435a957"
+checksum = "f7e33ec9068388e8de106a78268f90487d6975b171ee197aef16cc64c093486d"
+dependencies = [
+ "aes",
+ "bip0039",
+ "bitvec",
+ "blake2b_simd",
+ "blake2s_simd",
+ "bls12_381",
+ "byteorder",
+ "equihash",
+ "ff",
+ "fpe",
+ "group",
+ "hdwallet",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "orchard",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "ripemd",
+ "secp256k1",
+ "sha2",
+ "subtle",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_note_encryption",
+]
+
+[[package]]
+name = "zcash_proofs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77381adc72286874e563ee36ba99953946abcbd195ada45440a2754ca823d407"
 dependencies = [
  "bellman",
  "blake2b_simd",
  "bls12_381",
- "byteorder",
  "directories",
  "group",
  "jubjub",
@@ -5235,7 +5270,7 @@ dependencies = [
  "rand_core 0.6.4",
  "redjubjub",
  "tracing",
- "zcash_primitives",
+ "zcash_primitives 0.9.0",
 ]
 
 [[package]]
@@ -5257,7 +5292,7 @@ dependencies = [
  "tracing",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_primitives",
+ "zcash_primitives 0.8.1",
 ]
 
 [[package]]
@@ -5315,7 +5350,7 @@ dependencies = [
  "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives",
+ "zcash_primitives 0.9.0",
  "zebra-test",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -52,6 +52,9 @@ skip-tree = [
 
     # ECC crates
 
+    # wait for zcash_script to upgrade
+    { name = "zcash_primitives", version = "=0.8.1" },
+
     # wait for zcash_primitives to remove duplicated dependencies
     { name = "block-buffer", version = "=0.7.3" },
     { name = "block-buffer", version = "=0.9.0" },

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -61,7 +61,7 @@ orchard = "0.3.0"
 zcash_encoding = "0.2.0"
 zcash_history = "0.3.0"
 zcash_note_encryption = "0.2.0"
-zcash_primitives = { version = "0.8.1", features = ["transparent-inputs"] }
+zcash_primitives = { version = "0.9.0", features = ["transparent-inputs"] }
 
 # Time
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "serde"] }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -37,7 +37,7 @@ tracing-futures = "0.2.5"
 
 orchard = "0.3.0"
 
-zcash_proofs = { version = "0.8.0", features = ["local-prover", "multicore", "download-params"] }
+zcash_proofs = { version = "0.9.0", features = ["local-prover", "multicore", "download-params"] }
 
 tower-fallback = { path = "../tower-fallback/" }
 tower-batch = { path = "../tower-batch/" }


### PR DESCRIPTION
## Motivation

We want to update these at the same time.

Replaces https://github.com/ZcashFoundation/zebra/pull/5627 and https://github.com/ZcashFoundation/zebra/pull/5628

## Review

Anyone can review

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?
