### PR TITLE
fix(zebrad) print usage info for --help flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ There are a few bugs in Zebra that we're still working on fixing:
 - Experimental Tor support is disabled until [`arti-client` upgrades to `x25519-dalek` 2.0.0 or later](https://github.com/ZcashFoundation/zebra/issues/5492)
   - This happens due to a Rust dependency conflict, which can only be resolved by changing the dependencies of `x25519-dalek`
 
+- Output of `help`, `--help` flag, and usage of invalid commands or options are inconsistent.
+
 ## Future Work
 
 Performance and Reliability:

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ There are a few bugs in Zebra that we're still working on fixing:
 - Experimental Tor support is disabled until [`arti-client` upgrades to `x25519-dalek` 2.0.0 or later](https://github.com/ZcashFoundation/zebra/issues/5492)
   - This happens due to a Rust dependency conflict, which can only be resolved by changing the dependencies of `x25519-dalek`
 
-- Output of `help`, `--help` flag, and usage of invalid commands or options are inconsistent. Reports of this issues can be found [here](https://github.com/ZcashFoundation/zebra/issues/5502) and are planned to be fixed in the context of [upgrading Abscissa](https://github.com/ZcashFoundation/zebra/issues/5502).
+- Output of `help`, `--help` flag, and usage of invalid commands or options are inconsistent. Reports of these issues can be found [here](https://github.com/ZcashFoundation/zebra/issues/5502) and are planned to be fixed in the context of [upgrading Abscissa](https://github.com/ZcashFoundation/zebra/issues/5502).
 
 ## Future Work
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ There are a few bugs in Zebra that we're still working on fixing:
 - Experimental Tor support is disabled until [`arti-client` upgrades to `x25519-dalek` 2.0.0 or later](https://github.com/ZcashFoundation/zebra/issues/5492)
   - This happens due to a Rust dependency conflict, which can only be resolved by changing the dependencies of `x25519-dalek`
 
-- Output of `help`, `--help` flag, and usage of invalid commands or options are inconsistent.
+- Output of `help`, `--help` flag, and usage of invalid commands or options are inconsistent. Reports of this issues can be found [here](https://github.com/ZcashFoundation/zebra/issues/5502) and are planned to be fixed in the context of [upgrading Abscissa](https://github.com/ZcashFoundation/zebra/issues/5502).
 
 ## Future Work
 

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -376,7 +376,7 @@ impl Application for ZebradApp {
         let default_filter = command
             .command
             .as_ref()
-            .map(|zcmd| zcmd.default_tracing_filter(command.verbose))
+            .map(|zcmd| zcmd.default_tracing_filter(command.verbose, command.help))
             .unwrap_or("warn");
         let is_server = command
             .command

--- a/zebrad/src/application/entry_point.rs
+++ b/zebrad/src/application/entry_point.rs
@@ -42,6 +42,13 @@ pub struct EntryPoint {
 impl EntryPoint {
     /// Borrow the underlying command type
     fn command(&self) -> &ZebradCmd {
+        if self.help {
+            let _ = Usage::for_command::<EntryPoint>().print_info();
+            let _ = Usage::for_command::<EntryPoint>().print_usage();
+            let _ = Usage::for_command::<ZebradCmd>().print_usage();
+            std::process::exit(0);
+        }
+
         self.command
             .as_ref()
             .expect("Some(ZebradCmd::Start(StartCmd::default()) as default value")

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -78,7 +78,7 @@ impl ZebradCmd {
     /// Returns the default log level for this command, based on the `verbose` command line flag.
     ///
     /// Some commands need to be quiet by default.
-    pub(crate) fn default_tracing_filter(&self, verbose: bool) -> &'static str {
+    pub(crate) fn default_tracing_filter(&self, verbose: bool, help: bool) -> &'static str {
         let only_show_warnings = match self {
             // Commands that generate quiet output by default.
             // This output:
@@ -90,7 +90,8 @@ impl ZebradCmd {
             CopyState(_) | Download(_) | Start(_) => false,
         };
 
-        if only_show_warnings && !verbose {
+        // set to warn so that usage info is printed without info-level logs from component registration
+        if help || (only_show_warnings && !verbose) {
             "warn"
         } else if only_show_warnings || !verbose {
             "info"

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -42,7 +42,9 @@ pub enum ZebradCmd {
     Generate(GenerateCmd),
 
     /// The `help` subcommand
-    #[options(help = "get usage information")]
+    #[options(help = "get usage information, \
+        use help <subcommand> for subcommand usage information, \
+        or --help flag to see top-level options")]
     Help(Help<Self>),
 
     /// The `start` subcommand


### PR DESCRIPTION
## Motivation

The `zebrad --help` currently runs the process and does not print usage info.

Related to #5624

## Solution

- Print usage info and exit the process if the `--help` flag is set.
- Set tracing filter to "warn" if the `--help` flag is set to avoid info-level logs from component registration
- Update help text for `help` command to mention top-level and subcommand options

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- Print the same for invalid commands and options
- Print the same for the `help` command
