### PR TITLE
change(ci): Fail CI if there are doc warnings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -36,10 +36,9 @@ rustflags = [
     "-Wclippy::unnecessary_cast",
 
     # Incomplete code
-    "-Wmissing_docs",
     "-Wclippy::dbg_macro",
     "-Wclippy::todo",
-
+    
     # Manual debugging output.
     # Use tracing::trace!() or tracing::debug!() instead.
     "-Wclippy::print_stdout",
@@ -49,12 +48,18 @@ rustflags = [
     # Code styles we want to accept
     "-Aclippy::try_err",
 
-    # Links in public docs can point to private items.
-    "-Arustdoc::private_intra_doc_links",
-
     # Panics
     "-Wclippy::fallible_impl_from",
     "-Wclippy::unwrap_in_result",
+    
+    # Documentation
+    "-Wmissing_docs",
+
+    # These rustdoc -A and -W settings must be the same as the RUSTDOCFLAGS in:
+    # https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/lint.yml#L152
+    
+    # Links in public docs can point to private items.
+    "-Arustdoc::private_intra_doc_links",
 
     # TODOs:
     # `cargo fix` might help do these fixes,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -144,9 +144,10 @@ jobs:
     needs: changed-files
     if: ${{ needs.changed-files.outputs.rust == 'true' }}
     # cargo doc doesn't support '--  -D warnings', so we have to add it here
+    # https://github.com/rust-lang/cargo/issues/8424#issuecomment-774662296
     env:
       RUSTDOCFLAGS: -D warnings
-      
+
     steps:
       - uses: actions/checkout@v3.1.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -164,7 +164,7 @@ jobs:
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: doc
-          args: --no-deps --document-private-items --all-features -- -D warnings
+          args: --no-deps --document-private-items --all-features -D warnings
 
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -164,7 +164,7 @@ jobs:
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: doc
-          args: --no-deps --document-private-items --all-features
+          args: --no-deps --document-private-items --all-features -- -D warnings
 
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -143,7 +143,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed-files
     if: ${{ needs.changed-files.outputs.rust == 'true' }}
-
+    # cargo doc doesn't support '--  -D warnings', so we have to add it here
+    env:
+      RUSTDOCFLAGS: -D warnings
+      
     steps:
       - uses: actions/checkout@v3.1.0
         with:
@@ -164,7 +167,7 @@ jobs:
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: doc
-          args: --no-deps --document-private-items --all-features -D warnings
+          args: --no-deps --document-private-items --all-features
 
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -145,8 +145,11 @@ jobs:
     if: ${{ needs.changed-files.outputs.rust == 'true' }}
     # cargo doc doesn't support '--  -D warnings', so we have to add it here
     # https://github.com/rust-lang/cargo/issues/8424#issuecomment-774662296
+    #
+    # These -A and -W settings must be the same as the rustdoc settings in:
+    # https://github.com/ZcashFoundation/zebra/blob/main/.cargo/config.toml#L53
     env:
-      RUSTDOCFLAGS: -D warnings
+      RUSTDOCFLAGS: -D warnings -A rustdoc::private_intra_doc_links
 
     steps:
       - uses: actions/checkout@v3.1.0


### PR DESCRIPTION
## Motivation

Alfredo and I were talking about doc warnings in PRs. We realised we could merge a PR with doc warnings.

But if we do that, the warnings appear in every new PR until they are fixed.

Instead, we can stop PRs from merging until doc warnings are fixed.

## Solution

Make doc warnings into CI errors.

## Review

@gustavovalverde does this need to wait until CI is working again?
I don't want to break anything accidentally.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?


