### PR TITLE
feat(gcp): add label to instances for cost and logs grouping

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -127,7 +127,7 @@ jobs:
           --container-mount-disk mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --scopes cloud-platform \
-          --labels=app=zebrad,environment=prod,github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zebrad,environment=prod,network=${{env.NETWORK}},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zebrad
 
       # Check if our destination instance group exists already
@@ -208,5 +208,5 @@ jobs:
           --container-mount-disk mount-path='/zebrad-cache',name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --zone ${{ env.ZONE }} \
-          --labels=app=zebrad,environment=qa,github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zebrad,environment=qa,network=${{env.NETWORK}},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zebrad

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -127,7 +127,7 @@ jobs:
           --container-mount-disk mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --scopes cloud-platform \
-          --labels=app=zebrad,environment=prod,network=${{env.NETWORK}},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zebrad,environment=prod,github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zebrad
 
       # Check if our destination instance group exists already
@@ -208,5 +208,5 @@ jobs:
           --container-mount-disk mount-path='/zebrad-cache',name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --zone ${{ env.ZONE }} \
-          --labels=app=zebrad,environment=qa,network=${{env.NETWORK}},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zebrad,environment=qa,github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zebrad

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -127,6 +127,7 @@ jobs:
           --container-mount-disk mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --scopes cloud-platform \
+          --labels=app=zebrad,environment=prod,github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zebrad
 
       # Check if our destination instance group exists already
@@ -207,4 +208,5 @@ jobs:
           --container-mount-disk mount-path='/zebrad-cache',name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --zone ${{ env.ZONE }} \
+          --labels=app=zebrad,environment=qa,github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zebrad

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -163,7 +163,7 @@ jobs:
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \
           --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
-          --labels=app=${{ inputs.app_name }},environment=test,network=${{ inputs.network }},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
+          --labels=app=${{ inputs.app_name }},environment=test,github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ env.ZONE }}
           sleep 60
@@ -404,7 +404,7 @@ jobs:
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \
           --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
-          --labels=app=${{ inputs.app_name }},environment=test,network=${{ inputs.network }},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
+          --labels=app=${{ inputs.app_name }},environment=test,github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ env.ZONE }}
           sleep 60

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -163,6 +163,7 @@ jobs:
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \
           --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
+          --labels=app=${{ inputs.app_name }},environment=test,github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ env.ZONE }}
           sleep 60
@@ -403,6 +404,7 @@ jobs:
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \
           --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
+          --labels=app=${{ inputs.app_name }},environment=test,github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ env.ZONE }}
           sleep 60

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -163,7 +163,7 @@ jobs:
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \
           --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
-          --labels=app=${{ inputs.app_name }},environment=test,github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
+          --labels=app=${{ inputs.app_name }},environment=test,network=${{ inputs.network }},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ env.ZONE }}
           sleep 60
@@ -404,7 +404,7 @@ jobs:
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \
           --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
-          --labels=app=${{ inputs.app_name }},environment=test,github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
+          --labels=app=${{ inputs.app_name }},environment=test,network=${{ inputs.network }},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ env.ZONE }}
           sleep 60

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -64,7 +64,7 @@ jobs:
           --machine-type ${{ env.MACHINE_TYPE }} \
           --service-account ${{ env.DEPLOY_SA }} \
           --scopes cloud-platform \
-          --labels=app=zcashd,environment=qa,github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zcashd,environment=qa,network=${{ github.event.inputs.network }},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zcashd
 
       # Check if our destination instance group exists already

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -64,7 +64,7 @@ jobs:
           --machine-type ${{ env.MACHINE_TYPE }} \
           --service-account ${{ env.DEPLOY_SA }} \
           --scopes cloud-platform \
-          --labels=app=zcashd,environment=qa,network=${{ github.event.inputs.network }},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zcashd,environment=qa,github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zcashd
 
       # Check if our destination instance group exists already

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -64,7 +64,7 @@ jobs:
           --machine-type ${{ env.MACHINE_TYPE }} \
           --service-account ${{ env.DEPLOY_SA }} \
           --scopes cloud-platform \
-          --labels=app=zcashd,environment=qa,github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zcashd,environment=prod,github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zcashd
 
       # Check if our destination instance group exists already

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -64,6 +64,7 @@ jobs:
           --machine-type ${{ env.MACHINE_TYPE }} \
           --service-account ${{ env.DEPLOY_SA }} \
           --scopes cloud-platform \
+          --labels=app=zcashd,environment=qa,github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zcashd
 
       # Check if our destination instance group exists already


### PR DESCRIPTION
## Previous behavior:
We couldn't search GCP logs using the instance name if that instance was already deleted. And if we want to know how we're spending our budget its also difficult to know if specific tests or type of instances are the one responsible for a certain % of the costs

Fixes #5153
Fixes #5543

## Expected behavior:
Be able to search logs using the test ID or at least the GitHub reference, and be able to group GCP costs by labels

## Solution:
- Add labels to instances

## Review

Anyone can review this

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?
