### PR TITLE
fix(cd): allow deploying instance templates without disk errors

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -116,6 +116,8 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1.0.1
 
+      # TODO we should implement the fixes from https://github.com/ZcashFoundation/zebra/pull/5670 here
+      # but the implementation is failing as it's requiring the disk names, contrary to what is stated in the official documentation
       - name: Create instance template
         run: |
           gcloud compute instance-templates create-with-container zebrad-${{ needs.versioning.outputs.major_version || env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
@@ -123,8 +125,8 @@ jobs:
           --image-project=cos-cloud \
           --image-family=cos-stable \
           --container-image ${{ env.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
-          --create-disk=auto-delete=yes,size=300GB,type=pd-ssd \
-          --container-mount-disk=mount-path="/zebrad-cache" \
+          --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }},auto-delete=yes,size=300GB,type=pd-ssd \
+          --container-mount-disk mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --scopes cloud-platform \
           --tags zebrad
@@ -146,7 +148,7 @@ jobs:
           --health-check zebrad-tracing-filter \
           --initial-delay 30 \
           --region "${{ env.REGION }}" \
-          --size 2
+          --size 1
 
       # Rolls out update to existing group using the new instance template
       - name: Update managed instance group

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -126,7 +126,7 @@ jobs:
           --image-family=cos-stable \
           --container-image ${{ env.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
           --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }},auto-delete=yes,size=300GB,type=pd-ssd \
-          --container-mount-disk mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
+          --container-mount-disk=mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --scopes cloud-platform \
           --tags zebrad


### PR DESCRIPTION
## Motivation:

PR #5670 failed in `main` as it was tested with `gcloud compute instances create-with-container` and even the manual deployment uses `instances`, and it works.

But the one that failed uses `gcloud compute instance-templates create-with-container` using `instance-template` and it's complaining with: `When attaching or creating a disk that is also being mounted to a container, must specify the disk name`

Based on the documentation, the name is optional when using `create-with-container`, for both `instances` and `instance-templates`

Source: https://cloud.google.com/sdk/gcloud/reference/compute/instance-templates/create-with-container#--container-mount-disk

This partially reverts: #5670

## Solution:

Revert this specific job as how it was, and do not scale the instances above 1, as this would cause the following error:
`Instance template specifies a disk with a custom name. This will cause instance group not to scale beyond 1 instance per zone.`

## Review

@teor2345 reviewed the previous one

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?
