### PR TITLE
fix(ci): Allow full sync tests to take 42 hours

### DIFF
--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -74,7 +74,7 @@ pub const FINISH_PARTIAL_SYNC_TIMEOUT: Duration = Duration::from_secs(11 * 60 * 
 
 /// The maximum time to wait for Zebrad to synchronize up to the chain tip starting from the
 /// genesis block.
-pub const FINISH_FULL_SYNC_TIMEOUT: Duration = Duration::from_secs(36 * 60 * 60);
+pub const FINISH_FULL_SYNC_TIMEOUT: Duration = Duration::from_secs(42 * 60 * 60);
 
 /// The test sync height where we switch to using the default lookahead limit.
 ///


### PR DESCRIPTION
## Motivation

Full sync tests are taking slightly longer than expected.

We could fix bugs around block validation timeouts to speed this up, but they aren't a priority at the moment.

## Solution

Increase the full sync timeout to take 42 hours

## Review

This is urgent to fix full syncs on `main`.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- #5709

Make block commits more efficient:
- #5425

