### PR TITLE
fix(ci): Fix network parameter in continous-delivery.yml, and add network labels to GCP jobs

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Downcase network name for labels
         run: |
           NETWORK_CAPS="${{ inputs.network || 'Mainnet' }}"
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+          echo "NETWORK=${NETWORK_CAPS,,}" >> "$GITHUB_ENV"
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -112,7 +112,7 @@ jobs:
       # Passes the lowercase network to subsequent steps using $NETWORK env variable.
       - name: Downcase network name for labels
         run: |
-          NETWORK_CAPS=${{ inputs.network || env.DEFAULT_NETWORK }}
+          NETWORK_CAPS="${{ inputs.network || env.DEFAULT_NETWORK }}"
           echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
 
       # Setup gcloud CLI

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -129,7 +129,7 @@ jobs:
           --container-mount-disk=mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --scopes cloud-platform \
-          --labels=app=zebrad,environment=prod,github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zebrad,environment=prod,network=${{env.NETWORK}},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zebrad
 
       # Check if our destination instance group exists already
@@ -210,5 +210,5 @@ jobs:
           --container-mount-disk=mount-path='/zebrad-cache' \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --zone ${{ env.ZONE }} \
-          --labels=app=zebrad,environment=qa,github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zebrad,environment=qa,network=${{env.NETWORK}},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zebrad

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -71,7 +71,7 @@ jobs:
       dockerfile_target: runtime
       image_name: zebrad
       # We need to hard-code Mainnet here, because env is not allowed in this context
-      network: ${{ inputs.network || Mainnet }}
+      network: ${{ inputs.network || 'Mainnet' }}
       checkpoint_sync: true
       rust_backtrace: '1'
       zebra_skip_ipv6_tests: '1'
@@ -89,7 +89,7 @@ jobs:
   # - on every push/merge to the `main` branch
   # - on every release, when it's published
   deploy-nodes:
-    name: Deploy ${{ inputs.network || Mainnet }} nodes
+    name: Deploy ${{ inputs.network || 'Mainnet' }} nodes
     needs: [ build, versioning ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -107,12 +107,12 @@ jobs:
       # Makes the Zcash network name lowercase.
       #
       # Labels in GCP are required to be in lowercase, but the blockchain network
-      # uses sentence case, so we need to downcase ${{ inputs.network || Mainnet }}.
+      # uses sentence case, so we need to downcase ${{ inputs.network || 'Mainnet' }}.
       #
       # Passes the lowercase network to subsequent steps using $NETWORK env variable.
       - name: Downcase network name for labels
         run: |
-          NETWORK_CAPS="${{ inputs.network || Mainnet }}"
+          NETWORK_CAPS="${{ inputs.network || 'Mainnet' }}"
           echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
 
       # Setup gcloud CLI

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -40,7 +40,7 @@ jobs:
   # - If our semver is `v1.3.0` the resulting output from this job would be `v1`
   #
   # Note: We just use the first part of the version to replace old instances, and change
-  # it when a major version is released, to keep a segregation between new and old 
+  # it when a major version is released, to keep a segregation between new and old
   # versions.
   versioning:
     name: Versioning
@@ -104,6 +104,17 @@ jobs:
         with:
           short-length: 7
 
+      # Makes the Zcash network name lowercase.
+      #
+      # Labels in GCP are required to be in lowercase, but the blockchain network
+      # uses sentence case, so we need to downcase ${{ inputs.network || env.DEFAULT_NETWORK }}.
+      #
+      # Passes the lowercase network to subsequent steps using $NETWORK env variable.
+      - name: Downcase network name for labels
+        run: |
+          NETWORK_CAPS=${{ inputs.network || env.DEFAULT_NETWORK }}
+          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
@@ -129,7 +140,7 @@ jobs:
           --container-mount-disk=mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --scopes cloud-platform \
-          --labels=app=zebrad,environment=prod,network=${{ inputs.network || env.DEFAULT_NETWORK }},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zebrad,environment=prod,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zebrad
 
       # Check if our destination instance group exists already
@@ -210,5 +221,5 @@ jobs:
           --container-mount-disk=mount-path='/zebrad-cache' \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --zone ${{ env.ZONE }} \
-          --labels=app=zebrad,environment=qa,network=${{ inputs.network || env.DEFAULT_NETWORK }},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zebrad,environment=qa,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zebrad

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -26,7 +26,7 @@ on:
       - published
 
 env:
-  NETWORK: Mainnet
+  DEFAULT_NETWORK: Mainnet
   GAR_BASE: us-docker.pkg.dev/zealous-zebra/zebra
   REGION: us-central1
   ZONE: us-central1-a
@@ -71,7 +71,7 @@ jobs:
       dockerfile_path: ./docker/Dockerfile
       dockerfile_target: runtime
       image_name: zebrad
-      network: Mainnet
+      network: ${{ inputs.network || env.DEFAULT_NETWORK }}
       checkpoint_sync: true
       rust_backtrace: '1'
       zebra_skip_ipv6_tests: '1'
@@ -89,7 +89,7 @@ jobs:
   # - on every push/merge to the `main` branch
   # - on every release, when it's published
   deploy-nodes:
-    name: Deploy Mainnet nodes
+    name: Deploy ${{ inputs.network || env.DEFAULT_NETWORK }} nodes
     needs: [ build, versioning ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -129,7 +129,7 @@ jobs:
           --container-mount-disk=mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --scopes cloud-platform \
-          --labels=app=zebrad,environment=prod,network=${{env.NETWORK}},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zebrad,environment=prod,network=${{ inputs.network || env.DEFAULT_NETWORK }},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zebrad
 
       # Check if our destination instance group exists already
@@ -210,5 +210,5 @@ jobs:
           --container-mount-disk=mount-path='/zebrad-cache' \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --zone ${{ env.ZONE }} \
-          --labels=app=zebrad,environment=qa,network=${{env.NETWORK}},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zebrad,environment=qa,network=${{ inputs.network || env.DEFAULT_NETWORK }},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zebrad

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -26,7 +26,6 @@ on:
       - published
 
 env:
-  DEFAULT_NETWORK: Mainnet
   GAR_BASE: us-docker.pkg.dev/zealous-zebra/zebra
   REGION: us-central1
   ZONE: us-central1-a
@@ -71,7 +70,8 @@ jobs:
       dockerfile_path: ./docker/Dockerfile
       dockerfile_target: runtime
       image_name: zebrad
-      network: ${{ inputs.network || env.DEFAULT_NETWORK }}
+      # We need to hard-code Mainnet here, because env is not allowed in this context
+      network: ${{ inputs.network || Mainnet }}
       checkpoint_sync: true
       rust_backtrace: '1'
       zebra_skip_ipv6_tests: '1'
@@ -89,7 +89,7 @@ jobs:
   # - on every push/merge to the `main` branch
   # - on every release, when it's published
   deploy-nodes:
-    name: Deploy ${{ inputs.network || env.DEFAULT_NETWORK }} nodes
+    name: Deploy ${{ inputs.network || Mainnet }} nodes
     needs: [ build, versioning ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -107,12 +107,12 @@ jobs:
       # Makes the Zcash network name lowercase.
       #
       # Labels in GCP are required to be in lowercase, but the blockchain network
-      # uses sentence case, so we need to downcase ${{ inputs.network || env.DEFAULT_NETWORK }}.
+      # uses sentence case, so we need to downcase ${{ inputs.network || Mainnet }}.
       #
       # Passes the lowercase network to subsequent steps using $NETWORK env variable.
       - name: Downcase network name for labels
         run: |
-          NETWORK_CAPS="${{ inputs.network || env.DEFAULT_NETWORK }}"
+          NETWORK_CAPS="${{ inputs.network || Mainnet }}"
           echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
 
       # Setup gcloud CLI

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -133,7 +133,7 @@ jobs:
       # Passes ${{ inputs.network }} to subsequent steps using $NETWORK env variable.
       - name: Downcase network name for labels
         run: |
-          NETWORK_CAPS=${{ inputs.network }}
+          NETWORK_CAPS="${{ inputs.network }}"
           echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
 
       # Install our SSH secret
@@ -285,7 +285,7 @@ jobs:
 
       - name: Downcase network name for disks and labels
         run: |
-          NETWORK_CAPS=${{ inputs.network }}
+          NETWORK_CAPS="${{ inputs.network }}"
           echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
 
       # Install our SSH secret
@@ -1311,9 +1311,9 @@ jobs:
       # Passes ${{ env.GITHUB_REF_SLUG_URL }} to subsequent steps using $SHORT_GITHUB_REF env variable.
       - name: Format network name and branch name for disks
         run: |
-          NETWORK_CAPS=${{ inputs.network }}
+          NETWORK_CAPS="${{ inputs.network }}"
           echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
-          LONG_GITHUB_REF=${{ env.GITHUB_REF_SLUG_URL }}
+          LONG_GITHUB_REF="${{ env.GITHUB_REF_SLUG_URL }}"
           echo "SHORT_GITHUB_REF=${LONG_GITHUB_REF:0:12}" >> $GITHUB_ENV
 
       # Install our SSH secret

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -163,7 +163,7 @@ jobs:
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \
           --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
-          --labels=app=${{ inputs.app_name }},environment=test,github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
+          --labels=app=${{ inputs.app_name }},environment=test,network=${{ inputs.network }},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ env.ZONE }}
           sleep 60
@@ -404,7 +404,7 @@ jobs:
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \
           --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
-          --labels=app=${{ inputs.app_name }},environment=test,github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
+          --labels=app=${{ inputs.app_name }},environment=test,network=${{ inputs.network }},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ env.ZONE }}
           sleep 60

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Downcase network name for labels
         run: |
           NETWORK_CAPS="${{ inputs.network }}"
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+          echo "NETWORK=${NETWORK_CAPS,,}" >> "$GITHUB_ENV"
 
       # Install our SSH secret
       - name: Install private SSH key
@@ -286,7 +286,7 @@ jobs:
       - name: Downcase network name for disks and labels
         run: |
           NETWORK_CAPS="${{ inputs.network }}"
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+          echo "NETWORK=${NETWORK_CAPS,,}" >> "$GITHUB_ENV"
 
       # Install our SSH secret
       - name: Install private SSH key
@@ -396,8 +396,8 @@ jobs:
           echo "Selected Disk: $CACHED_DISK_NAME"
           echo "::set-output name=cached_disk_name::$CACHED_DISK_NAME"
 
-          echo "STATE_VERSION=$LOCAL_STATE_VERSION" >> $GITHUB_ENV
-          echo "CACHED_DISK_NAME=$CACHED_DISK_NAME" >> $GITHUB_ENV
+          echo "STATE_VERSION=$LOCAL_STATE_VERSION" >> "$GITHUB_ENV"
+          echo "CACHED_DISK_NAME=$CACHED_DISK_NAME" >> "$GITHUB_ENV"
 
       # Create a Compute Engine virtual machine and attach a cached state disk using the
       # $CACHED_DISK_NAME variable as the source image to populate the disk cached state
@@ -1312,9 +1312,9 @@ jobs:
       - name: Format network name and branch name for disks
         run: |
           NETWORK_CAPS="${{ inputs.network }}"
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+          echo "NETWORK=${NETWORK_CAPS,,}" >> "$GITHUB_ENV"
           LONG_GITHUB_REF="${{ env.GITHUB_REF_SLUG_URL }}"
-          echo "SHORT_GITHUB_REF=${LONG_GITHUB_REF:0:12}" >> $GITHUB_ENV
+          echo "SHORT_GITHUB_REF=${LONG_GITHUB_REF:0:12}" >> "$GITHUB_ENV"
 
       # Install our SSH secret
       - name: Install private SSH key
@@ -1347,7 +1347,7 @@ jobs:
           LOCAL_STATE_VERSION=$(grep -oE "DATABASE_FORMAT_VERSION: .* [0-9]+" $GITHUB_WORKSPACE/zebra-state/src/constants.rs | grep -oE "[0-9]+" | tail -n1)
           echo "STATE_VERSION: $LOCAL_STATE_VERSION"
 
-          echo "STATE_VERSION=$LOCAL_STATE_VERSION" >> $GITHUB_ENV
+          echo "STATE_VERSION=$LOCAL_STATE_VERSION" >> "$GITHUB_ENV"
 
       # Sets the $UPDATE_SUFFIX env var to "-u" if updating a previous cached state,
       # and the empty string otherwise.
@@ -1369,8 +1369,8 @@ jobs:
           # We're going to delete old images after a few days, so we only need the time here
           TIME_SUFFIX=$(date '+%H%M%S' --utc)
 
-          echo "UPDATE_SUFFIX=$UPDATE_SUFFIX" >> $GITHUB_ENV
-          echo "TIME_SUFFIX=$TIME_SUFFIX" >> $GITHUB_ENV
+          echo "UPDATE_SUFFIX=$UPDATE_SUFFIX" >> "$GITHUB_ENV"
+          echo "TIME_SUFFIX=$TIME_SUFFIX" >> "$GITHUB_ENV"
 
       # Get the sync height from the test logs, which is later used as part of the
       # disk description and labels.
@@ -1412,7 +1412,7 @@ jobs:
           fi
 
           echo "Found sync height in logs: $SYNC_HEIGHT"
-          echo "SYNC_HEIGHT=$SYNC_HEIGHT" >> $GITHUB_ENV
+          echo "SYNC_HEIGHT=$SYNC_HEIGHT" >> "$GITHUB_ENV"
 
       # Get the original cached state height from google cloud.
       #
@@ -1433,7 +1433,7 @@ jobs:
               echo "$CACHED_DISK_NAME height: $ORIGINAL_HEIGHT"
           fi
 
-          echo "ORIGINAL_HEIGHT=$ORIGINAL_HEIGHT" >> $GITHUB_ENV
+          echo "ORIGINAL_HEIGHT=$ORIGINAL_HEIGHT" >> "$GITHUB_ENV"
 
       # Create an image from the state disk, which will be used for any tests that start
       # after it is created. These tests can be in the same workflow, or in a different PR.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -125,6 +125,17 @@ jobs:
         with:
           short-length: 7
 
+      # Makes the Zcash network name lowercase.
+      #
+      # Labels in GCP are required to be in lowercase, but the blockchain network
+      # uses sentence case, so we need to downcase ${{ inputs.network }}.
+      #
+      # Passes ${{ inputs.network }} to subsequent steps using $NETWORK env variable.
+      - name: Downcase network name for labels
+        run: |
+          NETWORK_CAPS=${{ inputs.network }}
+          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+
       # Install our SSH secret
       - name: Install private SSH key
         uses: shimataro/ssh-key-action@v2.4.0
@@ -163,7 +174,7 @@ jobs:
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \
           --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
-          --labels=app=${{ inputs.app_name }},environment=test,network=${{ inputs.network }},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
+          --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ env.ZONE }}
           sleep 60
@@ -272,7 +283,7 @@ jobs:
         with:
           short-length: 7
 
-      - name: Downcase network name for disks
+      - name: Downcase network name for disks and labels
         run: |
           NETWORK_CAPS=${{ inputs.network }}
           echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
@@ -404,7 +415,7 @@ jobs:
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \
           --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
-          --labels=app=${{ inputs.app_name }},environment=test,network=${{ inputs.network }},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
+          --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ env.ZONE }}
           sleep 60

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Format network name for labels
         run: |
           NETWORK_CAPS="${{ inputs.network }}"
-          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+          echo "NETWORK=${NETWORK_CAPS,,}" >> "$GITHUB_ENV"
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -60,7 +60,7 @@ jobs:
           --container-stdin \
           --container-tty \
           --container-image electriccoinco/zcashd \
-          --container-env ZCASHD_NETWORK="${{ github.event.inputs.network }}" \
+          --container-env ZCASHD_NETWORK="${{ inputs.network }}" \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --service-account ${{ env.DEPLOY_SA }} \
           --scopes cloud-platform \
@@ -72,14 +72,14 @@ jobs:
         id: does-group-exist
         continue-on-error: true
         run: |
-          gcloud compute instance-groups list | grep "zcashd-${{ env.GITHUB_REF_SLUG_URL }}-${{ github.event.inputs.network }}" | grep "${{ env.REGION }}"
+          gcloud compute instance-groups list | grep "zcashd-${{ env.GITHUB_REF_SLUG_URL }}-${{ inputs.network }}" | grep "${{ env.REGION }}"
 
       # Deploy new managed instance group using the new instance template
       - name: Create managed instance group
         if: steps.does-group-exist.outcome == 'failure'
         run: |
           gcloud compute instance-groups managed create \
-          "zcashd-${{ env.GITHUB_REF_SLUG_URL }}-${{ github.event.inputs.network }}" \
+          "zcashd-${{ env.GITHUB_REF_SLUG_URL }}-${{ inputs.network }}" \
           --template "zcashd-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --region "${{ env.REGION }}" \
           --size "${{ github.event.inputs.size }}"
@@ -89,6 +89,6 @@ jobs:
         if: steps.does-group-exist.outcome == 'success'
         run: |
           gcloud compute instance-groups managed rolling-action start-update \
-          "zcashd-${{ env.GITHUB_REF_SLUG_URL }}-${{ github.event.inputs.network }}" \
+          "zcashd-${{ env.GITHUB_REF_SLUG_URL }}-${{ inputs.network }}" \
           --version template="zcashd-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --region "${{ env.REGION }}"

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -64,7 +64,7 @@ jobs:
           --machine-type ${{ env.MACHINE_TYPE }} \
           --service-account ${{ env.DEPLOY_SA }} \
           --scopes cloud-platform \
-          --labels=app=zcashd,environment=prod,github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zcashd,environment=prod,network=${{ inputs.network }},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zcashd
 
       # Check if our destination instance group exists already

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -45,7 +45,7 @@ jobs:
       # Passes ${{ inputs.network }} to subsequent steps using $NETWORK env variable.
       - name: Format network name for labels
         run: |
-          NETWORK_CAPS=${{ inputs.network }}
+          NETWORK_CAPS="${{ inputs.network }}"
           echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
 
       # Setup gcloud CLI

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -37,6 +37,17 @@ jobs:
         with:
           short-length: 7
 
+      # Performs formatting on the Zcash network name.
+      #
+      # Labels in GCP are required to be in lowercase, but the blockchain network
+      # uses sentence case, so we need to downcase ${{ inputs.network }}.
+      #
+      # Passes ${{ inputs.network }} to subsequent steps using $NETWORK env variable.
+      - name: Format network name for labels
+        run: |
+          NETWORK_CAPS=${{ inputs.network }}
+          echo "NETWORK=${NETWORK_CAPS,,}" >> $GITHUB_ENV
+
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
@@ -64,7 +75,7 @@ jobs:
           --machine-type ${{ env.MACHINE_TYPE }} \
           --service-account ${{ env.DEPLOY_SA }} \
           --scopes cloud-platform \
-          --labels=app=zcashd,environment=prod,network=${{ inputs.network }},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
+          --labels=app=zcashd,environment=prod,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zcashd
 
       # Check if our destination instance group exists already

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -37,13 +37,13 @@ jobs:
         with:
           short-length: 7
 
-      # Performs formatting on the Zcash network name.
+      # Makes the Zcash network name lowercase.
       #
       # Labels in GCP are required to be in lowercase, but the blockchain network
       # uses sentence case, so we need to downcase ${{ inputs.network }}.
       #
       # Passes ${{ inputs.network }} to subsequent steps using $NETWORK env variable.
-      - name: Format network name for labels
+      - name: Downcase network name for labels
         run: |
           NETWORK_CAPS="${{ inputs.network }}"
           echo "NETWORK=${NETWORK_CAPS,,}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Motivation

We want to add the Zcash network as a GCP label. We need to lowercase the network to do that.

This also fixes a workflow input handling bug in continous-delivery.yml, which made it impossible to correctly implement a network label in PR #5693.

## Solution

- fix network parameter in continous-delivery.yml
- standardise network usage in zcashd-manual-deploy
- add Network as a label
- use lowercase network labels 

This PR also fixes some shellcheck errors using search and replace, including scripts in the unchanged parts of these workflows.

## Review

This is a routine change.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?
