### PR TITLE
change(mempool): Contextually validates mempool transactions in best chain

### DIFF
--- a/zebra-chain/src/block/commitment.rs
+++ b/zebra-chain/src/block/commitment.rs
@@ -332,7 +332,7 @@ impl FromHex for ChainHistoryBlockTxAuthCommitmentHash {
 /// implement, and ensures that we don't reject blocks or transactions
 /// for a non-enumerated reason.
 #[allow(missing_docs)]
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum CommitmentError {
     #[error(
         "invalid final sapling root: expected {:?}, actual: {:?}",

--- a/zebra-chain/src/history_tree.rs
+++ b/zebra-chain/src/history_tree.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 /// An error describing why a history tree operation failed.
-#[derive(Debug, Error, Clone)]
+#[derive(Debug, Error)]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum HistoryTreeError {
@@ -31,7 +31,7 @@ pub enum HistoryTreeError {
     InnerError { inner: zcash_history::Error },
 
     #[error("I/O error")]
-    IOError(#[from] Arc<io::Error>),
+    IOError(#[from] io::Error),
 }
 
 impl PartialEq for HistoryTreeError {
@@ -99,8 +99,7 @@ impl NonEmptyHistoryTree {
                     size,
                     &peaks,
                     &Default::default(),
-                )
-                .map_err(Arc::new)?;
+                )?;
                 InnerHistoryTree::PreOrchard(tree)
             }
             NetworkUpgrade::Nu5 => {
@@ -110,8 +109,7 @@ impl NonEmptyHistoryTree {
                     size,
                     &peaks,
                     &Default::default(),
-                )
-                .map_err(Arc::new)?;
+                )?;
                 InnerHistoryTree::OrchardOnward(tree)
             }
         };
@@ -155,8 +153,7 @@ impl NonEmptyHistoryTree {
                     block,
                     sapling_root,
                     &Default::default(),
-                )
-                .map_err(Arc::new)?;
+                )?;
                 (InnerHistoryTree::PreOrchard(tree), entry)
             }
             NetworkUpgrade::Nu5 => {
@@ -165,8 +162,7 @@ impl NonEmptyHistoryTree {
                     block,
                     sapling_root,
                     orchard_root,
-                )
-                .map_err(Arc::new)?;
+                )?;
                 (InnerHistoryTree::OrchardOnward(tree), entry)
             }
         };
@@ -236,7 +232,7 @@ impl NonEmptyHistoryTree {
             self.peaks.insert(self.size, entry);
             self.size += 1;
         }
-        self.prune().map_err(Arc::new)?;
+        self.prune()?;
         self.current_height = height;
         Ok(())
     }

--- a/zebra-chain/src/history_tree.rs
+++ b/zebra-chain/src/history_tree.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 /// An error describing why a history tree operation failed.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone)]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum HistoryTreeError {
@@ -31,7 +31,7 @@ pub enum HistoryTreeError {
     InnerError { inner: zcash_history::Error },
 
     #[error("I/O error")]
-    IOError(#[from] io::Error),
+    IOError(#[from] Arc<io::Error>),
 }
 
 impl PartialEq for HistoryTreeError {
@@ -99,7 +99,8 @@ impl NonEmptyHistoryTree {
                     size,
                     &peaks,
                     &Default::default(),
-                )?;
+                )
+                .map_err(Arc::new)?;
                 InnerHistoryTree::PreOrchard(tree)
             }
             NetworkUpgrade::Nu5 => {
@@ -109,7 +110,8 @@ impl NonEmptyHistoryTree {
                     size,
                     &peaks,
                     &Default::default(),
-                )?;
+                )
+                .map_err(Arc::new)?;
                 InnerHistoryTree::OrchardOnward(tree)
             }
         };
@@ -153,7 +155,8 @@ impl NonEmptyHistoryTree {
                     block,
                     sapling_root,
                     &Default::default(),
-                )?;
+                )
+                .map_err(Arc::new)?;
                 (InnerHistoryTree::PreOrchard(tree), entry)
             }
             NetworkUpgrade::Nu5 => {
@@ -162,7 +165,8 @@ impl NonEmptyHistoryTree {
                     block,
                     sapling_root,
                     orchard_root,
-                )?;
+                )
+                .map_err(Arc::new)?;
                 (InnerHistoryTree::OrchardOnward(tree), entry)
             }
         };
@@ -232,7 +236,7 @@ impl NonEmptyHistoryTree {
             self.peaks.insert(self.size, entry);
             self.size += 1;
         }
-        self.prune()?;
+        self.prune().map_err(Arc::new)?;
         self.current_height = height;
         Ok(())
     }

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -5,8 +5,6 @@
 //! implement, and ensures that we don't reject blocks or transactions
 //! for a non-enumerated reason.
 
-use std::sync::Arc;
-
 use chrono::{DateTime, Utc};
 use thiserror::Error;
 
@@ -186,7 +184,7 @@ pub enum TransactionError {
 
     #[error("could not validate nullifiers and anchors on best chain")]
     #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
-    ValidateNullifiersAndAnchorsError(#[from] Arc<ValidateContextError>),
+    ValidateNullifiersAndAnchorsError(#[from] ValidateContextError),
 }
 
 impl From<BoxError> for TransactionError {
@@ -198,7 +196,7 @@ impl From<BoxError> for TransactionError {
         }
 
         match err.downcast::<ValidateContextError>() {
-            Ok(e) => return Arc::new(*e).into(),
+            Ok(e) => return (*e).into(),
             Err(e) => err = e,
         }
 

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Utc};
 use thiserror::Error;
 
 use zebra_chain::{amount, block, orchard, sapling, sprout, transparent};
+use zebra_state::ValidateContextError;
 
 use crate::{block::MAX_BLOCK_SIGOPS, BoxError};
 
@@ -33,7 +34,7 @@ pub enum SubsidyError {
     SumOverflow,
 }
 
-#[derive(Error, Clone, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum TransactionError {
     #[error("first transaction must be coinbase")]
@@ -180,6 +181,10 @@ pub enum TransactionError {
 
     #[error("could not find a mempool transaction input UTXO in the best chain")]
     TransparentInputNotFound,
+
+    #[error("could not validate nullifiers and anchors on best chain")]
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
+    ValidateNullifiersAndAnchorsError(#[from] ValidateContextError),
 }
 
 impl From<BoxError> for TransactionError {
@@ -209,7 +214,7 @@ impl From<SubsidyError> for BlockError {
     }
 }
 
-#[derive(Error, Clone, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum BlockError {
     #[error("block contains invalid transactions")]
     Transaction(#[from] TransactionError),

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -195,6 +195,11 @@ impl From<BoxError> for TransactionError {
             Err(e) => err = e,
         }
 
+        match err.downcast::<ValidateContextError>() {
+            Ok(e) => return (*e).into(),
+            Err(e) => err = e,
+        }
+
         // buffered transaction verifier service error
         match err.downcast::<TransactionError>() {
             Ok(e) => return *e,

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -219,7 +219,7 @@ impl From<SubsidyError> for BlockError {
     }
 }
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum BlockError {
     #[error("block contains invalid transactions")]
     Transaction(#[from] TransactionError),

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -347,7 +347,7 @@ where
             if req.is_mempool() {
                 let check_anchors_and_revealed_nullifiers_query = state
                     .clone()
-                    .oneshot(zs::Request::TransactionContextualValidity(
+                    .oneshot(zs::Request::CheckBestChainTipShieldedSpends(
                         req.transaction(),
                     ));
 

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -343,6 +343,15 @@ where
 
             check::spend_conflicts(&tx)?;
 
+
+            let check_anchors_and_revealed_nullifiers_query = state
+                .clone()
+                .oneshot(zs::Request::TransactionContextualValidity(
+                    req.transaction(),
+                ));
+
+            check_anchors_and_revealed_nullifiers_query.await?;
+
             tracing::trace!(?tx_id, "passed quick checks");
 
             // "The consensus rules applied to valueBalance, vShieldedOutput, and bindingSig

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -410,7 +410,7 @@ where
                                 .expect("CheckBestChainTipNullifiersAndAnchors error must be a ValidateContextError");
                             err.into()
                         });
-                        assert!(res? == zs::Response::ValidBestChainTipNullifiersAndAnchors);
+                        assert!(res? == zs::Response::ValidBestChainTipNullifiersAndAnchors, "unexpected response to CheckBestChainTipNullifiersAndAnchors request");
                         Ok(())
                     }
                 );

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -351,7 +351,7 @@ where
                         req.transaction(),
                     ));
 
-                check_anchors_and_revealed_nullifiers_query.await?;
+                assert!(check_anchors_and_revealed_nullifiers_query.await? == zs::Response::ValidBestChainTipShieldedSpends);
             }
 
             tracing::trace!(?tx_id, "passed quick checks");

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -175,10 +175,10 @@ impl Request {
     }
 
     /// The unverified mempool transaction, if this is a mempool request.
-    pub fn into_mempool_transaction(self) -> Option<UnminedTx> {
+    pub fn mempool_transaction(&self) -> Option<UnminedTx> {
         match self {
             Request::Block { .. } => None,
-            Request::Mempool { transaction, .. } => Some(transaction),
+            Request::Mempool { transaction, .. } => Some(transaction.clone()),
         }
     }
 
@@ -397,11 +397,11 @@ where
                 )?,
             };
 
-            if req.is_mempool() {
+            if let Some(unmined_tx) = req.mempool_transaction() {
                 let check_anchors_and_revealed_nullifiers_query = state
                     .clone()
                     .oneshot(zs::Request::CheckBestChainTipShieldedSpends(
-                        req.transaction(),
+                        unmined_tx,
                     ))
                     .map(|res| {
                         assert!(res? == zs::Response::ValidBestChainTipShieldedSpends);

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -31,6 +31,7 @@ use zebra_chain::{
 
 use zebra_script::CachedFfiTransaction;
 use zebra_state as zs;
+use zs::ValidateContextError;
 
 use crate::{error::TransactionError, groth16::DescriptionWrapper, primitives, script, BoxError};
 
@@ -404,6 +405,11 @@ where
                         unmined_tx,
                     ))
                     .map(|res| {
+                        let res: Result<zs::Response, TransactionError> = res.map_err(|err| {
+                            let err: ValidateContextError = *err.downcast()
+                                .expect("CheckBestChainTipNullifiersAndAnchors error must be a ValidateContextError");
+                            err.into()
+                        });
                         assert!(res? == zs::Response::ValidBestChainTipNullifiersAndAnchors);
                         Ok(())
                     }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -357,9 +357,9 @@ where
 
             // Load spent UTXOs from state.
             // TODO: Make this a method of `Request` and replace `tx.clone()` with `self.transaction()`?
-            let check_spent_utxos =
+            let load_spent_utxos_fut =
                 Self::spent_utxos(tx.clone(), req.known_utxos(), req.is_mempool(), state.clone());
-            let (spent_utxos, spent_outputs) = check_spent_utxos.await?;
+            let (spent_utxos, spent_outputs) = load_spent_utxos_fut.await?;
 
             let cached_ffi_transaction =
                 Arc::new(CachedFfiTransaction::new(tx.clone(), spent_outputs));

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -31,7 +31,6 @@ use zebra_chain::{
 
 use zebra_script::CachedFfiTransaction;
 use zebra_state as zs;
-use zs::ValidateContextError;
 
 use crate::{error::TransactionError, groth16::DescriptionWrapper, primitives, script, BoxError};
 
@@ -405,11 +404,6 @@ where
                         unmined_tx,
                     ))
                     .map(|res| {
-                        let res: Result<zs::Response, TransactionError> = res.map_err(|err| {
-                            let err: ValidateContextError = *err.downcast()
-                                .expect("CheckBestChainTipNullifiersAndAnchors error must be a ValidateContextError");
-                            err.into()
-                        });
                         assert!(res? == zs::Response::ValidBestChainTipNullifiersAndAnchors, "unexpected response to CheckBestChainTipNullifiersAndAnchors request");
                         Ok(())
                     }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -400,11 +400,11 @@ where
             if let Some(unmined_tx) = req.mempool_transaction() {
                 let check_anchors_and_revealed_nullifiers_query = state
                     .clone()
-                    .oneshot(zs::Request::CheckBestChainTipShieldedSpends(
+                    .oneshot(zs::Request::CheckBestChainTipNullifiersAndAnchors(
                         unmined_tx,
                     ))
                     .map(|res| {
-                        assert!(res? == zs::Response::ValidBestChainTipShieldedSpends);
+                        assert!(res? == zs::Response::ValidBestChainTipNullifiersAndAnchors);
                         Ok(())
                     }
                 );

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -344,13 +344,15 @@ where
             check::spend_conflicts(&tx)?;
 
 
-            let check_anchors_and_revealed_nullifiers_query = state
-                .clone()
-                .oneshot(zs::Request::TransactionContextualValidity(
-                    req.transaction(),
-                ));
+            if req.is_mempool() {
+                let check_anchors_and_revealed_nullifiers_query = state
+                    .clone()
+                    .oneshot(zs::Request::TransactionContextualValidity(
+                        req.transaction(),
+                    ));
 
-            check_anchors_and_revealed_nullifiers_query.await?;
+                check_anchors_and_revealed_nullifiers_query.await?;
+            }
 
             tracing::trace!(?tx_id, "passed quick checks");
 

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -199,12 +199,12 @@ async fn mempool_request_with_missing_input_is_rejected() {
             .expect_request_that(|req| {
                 matches!(
                     req,
-                    zebra_state::Request::CheckBestChainTipShieldedSpends(_)
+                    zebra_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
                 )
             })
             .await
             .expect("verifier should call mock state service")
-            .respond(zebra_state::Response::ValidBestChainTipShieldedSpends);
+            .respond(zebra_state::Response::ValidBestChainTipNullifiersAndAnchors);
 
         state
             .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
@@ -257,12 +257,12 @@ async fn mempool_request_with_present_input_is_accepted() {
             .expect_request_that(|req| {
                 matches!(
                     req,
-                    zebra_state::Request::CheckBestChainTipShieldedSpends(_)
+                    zebra_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
                 )
             })
             .await
             .expect("verifier should call mock state service")
-            .respond(zebra_state::Response::ValidBestChainTipShieldedSpends);
+            .respond(zebra_state::Response::ValidBestChainTipNullifiersAndAnchors);
 
         state
             .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -196,6 +196,12 @@ async fn mempool_request_with_missing_input_is_rejected() {
 
     tokio::spawn(async move {
         state
+            .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
+            .await
+            .expect("verifier should call mock state service")
+            .respond(zebra_state::Response::UnspentBestChainUtxo(None));
+
+        state
             .expect_request_that(|req| {
                 matches!(
                     req,
@@ -205,12 +211,6 @@ async fn mempool_request_with_missing_input_is_rejected() {
             .await
             .expect("verifier should call mock state service")
             .respond(zebra_state::Response::ValidBestChainTipNullifiersAndAnchors);
-
-        state
-            .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
-            .await
-            .expect("verifier should call mock state service")
-            .respond(zebra_state::Response::UnspentBestChainUtxo(None));
     });
 
     let verifier_response = verifier
@@ -254,6 +254,16 @@ async fn mempool_request_with_present_input_is_accepted() {
 
     tokio::spawn(async move {
         state
+            .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
+            .await
+            .expect("verifier should call mock state service")
+            .respond(zebra_state::Response::UnspentBestChainUtxo(
+                known_utxos
+                    .get(&input_outpoint)
+                    .map(|utxo| utxo.utxo.clone()),
+            ));
+
+        state
             .expect_request_that(|req| {
                 matches!(
                     req,
@@ -263,16 +273,6 @@ async fn mempool_request_with_present_input_is_accepted() {
             .await
             .expect("verifier should call mock state service")
             .respond(zebra_state::Response::ValidBestChainTipNullifiersAndAnchors);
-
-        state
-            .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
-            .await
-            .expect("verifier should call mock state service")
-            .respond(zebra_state::Response::UnspentBestChainUtxo(
-                known_utxos
-                    .get(&input_outpoint)
-                    .map(|utxo| utxo.utxo.clone()),
-            ));
     });
 
     let verifier_response = verifier

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -197,11 +197,14 @@ async fn mempool_request_with_missing_input_is_rejected() {
     tokio::spawn(async move {
         state
             .expect_request_that(|req| {
-                matches!(req, zebra_state::Request::TransactionContextualValidity(_))
+                matches!(
+                    req,
+                    zebra_state::Request::CheckBestChainTipShieldedSpends(_)
+                )
             })
             .await
             .expect("verifier should call mock state service")
-            .respond(zebra_state::Response::ContextuallyValid);
+            .respond(zebra_state::Response::ValidBestChainTipShieldedSpends);
 
         state
             .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
@@ -235,7 +238,10 @@ async fn mempool_request_with_invalid_input_is_rejected() {
     tokio::spawn(async move {
         state
             .expect_request_that(|req| {
-                matches!(req, zebra_state::Request::TransactionContextualValidity(_))
+                matches!(
+                    req,
+                    zebra_state::Request::CheckBestChainTipShieldedSpends(_)
+                )
             })
             .await
             .expect("verifier should call mock state service")
@@ -284,11 +290,14 @@ async fn mempool_request_with_present_input_is_accepted() {
     tokio::spawn(async move {
         state
             .expect_request_that(|req| {
-                matches!(req, zebra_state::Request::TransactionContextualValidity(_))
+                matches!(
+                    req,
+                    zebra_state::Request::CheckBestChainTipShieldedSpends(_)
+                )
             })
             .await
             .expect("verifier should call mock state service")
-            .respond(zebra_state::Response::ContextuallyValid);
+            .respond(zebra_state::Response::ValidBestChainTipShieldedSpends);
 
         state
             .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -189,17 +189,57 @@ async fn mempool_request_with_missing_input_is_rejected() {
         .find(|(_, tx)| !(tx.is_coinbase() || tx.inputs().is_empty()))
         .expect("At least one non-coinbase transaction with transparent inputs in test vectors");
 
-    let expected_state_request = zebra_state::Request::UnspentBestChainUtxo(match tx.inputs()[0] {
+    let input_outpoint = match tx.inputs()[0] {
         transparent::Input::PrevOut { outpoint, .. } => outpoint,
         transparent::Input::Coinbase { .. } => panic!("requires a non-coinbase transaction"),
-    });
+    };
 
     tokio::spawn(async move {
         state
-            .expect_request(expected_state_request)
+            .expect_request_that(|req| {
+                matches!(req, zebra_state::Request::TransactionContextualValidity(_))
+            })
+            .await
+            .expect("verifier should call mock state service")
+            .respond(zebra_state::Response::ContextuallyValid);
+
+        state
+            .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
             .await
             .expect("verifier should call mock state service")
             .respond(zebra_state::Response::UnspentBestChainUtxo(None));
+    });
+
+    let verifier_response = verifier
+        .oneshot(Request::Mempool {
+            transaction: tx.into(),
+            height,
+        })
+        .await;
+
+    assert_eq!(
+        verifier_response,
+        Err(TransactionError::TransparentInputNotFound)
+    );
+}
+
+#[tokio::test]
+async fn mempool_request_with_invalid_input_is_rejected() {
+    let mut state: MockService<_, _, _, _> = MockService::build().for_prop_tests();
+    let verifier = Verifier::new(Network::Mainnet, state.clone());
+
+    let (height, tx) = transactions_from_blocks(zebra_test::vectors::MAINNET_BLOCKS.iter())
+        .find(|(_, tx)| !(tx.is_coinbase() || tx.inputs().is_empty()))
+        .expect("At least one non-coinbase transaction with transparent inputs in test vectors");
+
+    tokio::spawn(async move {
+        state
+            .expect_request_that(|req| {
+                matches!(req, zebra_state::Request::TransactionContextualValidity(_))
+            })
+            .await
+            .expect("verifier should call mock state service")
+            .respond(Err("duplicate nullifier or invalid anchor"));
     });
 
     let verifier_response = verifier
@@ -242,6 +282,14 @@ async fn mempool_request_with_present_input_is_accepted() {
     };
 
     tokio::spawn(async move {
+        state
+            .expect_request_that(|req| {
+                matches!(req, zebra_state::Request::TransactionContextualValidity(_))
+            })
+            .await
+            .expect("verifier should call mock state service")
+            .respond(zebra_state::Response::ContextuallyValid);
+
         state
             .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
             .await

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -224,7 +224,7 @@ pub enum ValidateContextError {
     NoteCommitmentTreeError(#[from] zebra_chain::parallel::tree::NoteCommitmentTreeError),
 
     #[error("error building the history tree")]
-    HistoryTreeError(#[from] HistoryTreeError),
+    HistoryTreeError(#[from] Arc<HistoryTreeError>),
 
     #[error("block contains an invalid commitment")]
     InvalidBlockCommitment(#[from] block::CommitmentError),

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -47,7 +47,7 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub struct CommitBlockError(#[from] ValidateContextError);
 
 /// An error describing why a block failed contextual validation.
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum ValidateContextError {

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -236,8 +236,8 @@ pub enum ValidateContextError {
     #[non_exhaustive]
     UnknownSproutAnchor {
         anchor: sprout::tree::Root,
-        height: block::Height,
-        tx_index_in_block: usize,
+        height: Option<block::Height>,
+        tx_index_in_block: Option<usize>,
         transaction_hash: transaction::Hash,
     },
 
@@ -248,8 +248,8 @@ pub enum ValidateContextError {
     #[non_exhaustive]
     UnknownSaplingAnchor {
         anchor: sapling::tree::Root,
-        height: block::Height,
-        tx_index_in_block: usize,
+        height: Option<block::Height>,
+        tx_index_in_block: Option<usize>,
         transaction_hash: transaction::Hash,
     },
 
@@ -260,8 +260,8 @@ pub enum ValidateContextError {
     #[non_exhaustive]
     UnknownOrchardAnchor {
         anchor: orchard::tree::Root,
-        height: block::Height,
-        tx_index_in_block: usize,
+        height: Option<block::Height>,
+        tx_index_in_block: Option<usize>,
         transaction_hash: transaction::Hash,
     },
 }

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -543,7 +543,7 @@ pub enum Request {
 
     /// Contextually validates anchors and nullifiers of a transaction on the best chain
     ///
-    /// Returns [`Response::ValidBestChainTipNullifiersAndAnchors`] or a [`ValidateContextError`](crate::ValidateContextError)
+    /// Returns [`Response::ValidBestChainTipNullifiersAndAnchors`]
     CheckBestChainTipNullifiersAndAnchors(UnminedTx),
 }
 

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -543,7 +543,7 @@ pub enum Request {
 
     /// Contextually validates anchors and nullifiers of a transaction on the best chain
     ///
-    /// Returns [`Response::ValidBestChainTipNullifiersAndAnchors`].
+    /// Returns [`Response::ValidBestChainTipNullifiersAndAnchors`] or a [`ValidateContextError`](crate::ValidateContextError)
     CheckBestChainTipNullifiersAndAnchors(UnminedTx),
 }
 

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -15,7 +15,7 @@ use zebra_chain::{
     sapling,
     serialization::SerializationError,
     sprout,
-    transaction::{self, Transaction},
+    transaction::{self, UnminedTx},
     transparent::{self, utxos_from_ordered_utxos},
     value_balance::{ValueBalance, ValueBalanceError},
 };
@@ -544,7 +544,7 @@ pub enum Request {
     /// Contextually validates anchors and nullifiers of a transaction on the best chain
     ///
     /// Returns [`Response::ValidBestChainTipShieldedSpends`].
-    CheckBestChainTipShieldedSpends(Arc<Transaction>),
+    CheckBestChainTipShieldedSpends(UnminedTx),
 }
 
 impl Request {
@@ -746,7 +746,7 @@ pub enum ReadRequest {
     /// Contextually validates anchors and nullifiers of a transaction on the best chain
     ///
     /// Returns [`ReadResponse::ValidBestChainTipShieldedSpends`].
-    CheckBestChainTipShieldedSpends(Arc<Transaction>),
+    CheckBestChainTipShieldedSpends(UnminedTx),
 
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Looks up a block hash by height in the current best chain.

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -561,7 +561,9 @@ impl Request {
             Request::Block(_) => "block",
             Request::FindBlockHashes { .. } => "find_block_hashes",
             Request::FindBlockHeaders { .. } => "find_block_headers",
-            Request::CheckBestChainTipNullifiersAndAnchors(_) => "best_chain_tip_nullifiers_anchors",
+            Request::CheckBestChainTipNullifiersAndAnchors(_) => {
+                "best_chain_tip_nullifiers_anchors"
+            }
         }
     }
 

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -543,7 +543,7 @@ pub enum Request {
 
     /// Contextually validates anchors and nullifiers of a transaction on the best chain
     ///
-    /// Returns [`Response::Valid`].
+    /// Returns [`Response::ContextuallyValid`].
     TransactionContextualValidity(Arc<Transaction>),
 }
 
@@ -745,7 +745,7 @@ pub enum ReadRequest {
 
     /// Contextually validates anchors and nullifiers of a transaction on the best chain
     ///
-    /// Returns [`ReadResponse::Valid`].
+    /// Returns [`ReadResponse::ContextuallyValid`].
     TransactionContextualValidity(Arc<Transaction>),
 
     #[cfg(feature = "getblocktemplate-rpcs")]

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -543,8 +543,8 @@ pub enum Request {
 
     /// Contextually validates anchors and nullifiers of a transaction on the best chain
     ///
-    /// Returns [`Response::ContextuallyValid`].
-    TransactionContextualValidity(Arc<Transaction>),
+    /// Returns [`Response::ValidBestChainTipShieldedSpends`].
+    CheckBestChainTipShieldedSpends(Arc<Transaction>),
 }
 
 impl Request {
@@ -561,7 +561,7 @@ impl Request {
             Request::Block(_) => "block",
             Request::FindBlockHashes { .. } => "find_block_hashes",
             Request::FindBlockHeaders { .. } => "find_block_headers",
-            Request::TransactionContextualValidity(_) => "transaction_contextual_validity",
+            Request::CheckBestChainTipShieldedSpends(_) => "transaction_contextual_validity",
         }
     }
 
@@ -745,8 +745,8 @@ pub enum ReadRequest {
 
     /// Contextually validates anchors and nullifiers of a transaction on the best chain
     ///
-    /// Returns [`ReadResponse::ContextuallyValid`].
-    TransactionContextualValidity(Arc<Transaction>),
+    /// Returns [`ReadResponse::ValidBestChainTipShieldedSpends`].
+    CheckBestChainTipShieldedSpends(Arc<Transaction>),
 
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Looks up a block hash by height in the current best chain.
@@ -776,7 +776,7 @@ impl ReadRequest {
             ReadRequest::AddressBalance { .. } => "address_balance",
             ReadRequest::TransactionIdsByAddresses { .. } => "transaction_ids_by_addesses",
             ReadRequest::UtxosByAddresses(_) => "utxos_by_addesses",
-            ReadRequest::TransactionContextualValidity(_) => "transaction_contextual_validity",
+            ReadRequest::CheckBestChainTipShieldedSpends(_) => "transaction_contextual_validity",
             #[cfg(feature = "getblocktemplate-rpcs")]
             ReadRequest::BestChainBlockHash(_) => "best_chain_block_hash",
         }
@@ -818,8 +818,8 @@ impl TryFrom<Request> for ReadRequest {
                 Ok(ReadRequest::FindBlockHeaders { known_blocks, stop })
             }
 
-            Request::TransactionContextualValidity(tx) => {
-                Ok(ReadRequest::TransactionContextualValidity(tx))
+            Request::CheckBestChainTipShieldedSpends(tx) => {
+                Ok(ReadRequest::CheckBestChainTipShieldedSpends(tx))
             }
 
             Request::CommitBlock(_) | Request::CommitFinalizedBlock(_) => {

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -561,7 +561,7 @@ impl Request {
             Request::Block(_) => "block",
             Request::FindBlockHashes { .. } => "find_block_hashes",
             Request::FindBlockHeaders { .. } => "find_block_headers",
-            Request::CheckBestChainTipNullifiersAndAnchors(_) => "transaction_contextual_validity",
+            Request::CheckBestChainTipNullifiersAndAnchors(_) => "best_chain_tip_nullifiers_anchors",
         }
     }
 
@@ -777,7 +777,7 @@ impl ReadRequest {
             ReadRequest::TransactionIdsByAddresses { .. } => "transaction_ids_by_addesses",
             ReadRequest::UtxosByAddresses(_) => "utxos_by_addesses",
             ReadRequest::CheckBestChainTipNullifiersAndAnchors(_) => {
-                "transaction_contextual_validity"
+                "best_chain_tip_nullifiers_anchors"
             }
             #[cfg(feature = "getblocktemplate-rpcs")]
             ReadRequest::BestChainBlockHash(_) => "best_chain_block_hash",

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -543,8 +543,8 @@ pub enum Request {
 
     /// Contextually validates anchors and nullifiers of a transaction on the best chain
     ///
-    /// Returns [`Response::ValidBestChainTipShieldedSpends`].
-    CheckBestChainTipShieldedSpends(UnminedTx),
+    /// Returns [`Response::ValidBestChainTipNullifiersAndAnchors`].
+    CheckBestChainTipNullifiersAndAnchors(UnminedTx),
 }
 
 impl Request {
@@ -561,7 +561,7 @@ impl Request {
             Request::Block(_) => "block",
             Request::FindBlockHashes { .. } => "find_block_hashes",
             Request::FindBlockHeaders { .. } => "find_block_headers",
-            Request::CheckBestChainTipShieldedSpends(_) => "transaction_contextual_validity",
+            Request::CheckBestChainTipNullifiersAndAnchors(_) => "transaction_contextual_validity",
         }
     }
 
@@ -745,8 +745,8 @@ pub enum ReadRequest {
 
     /// Contextually validates anchors and nullifiers of a transaction on the best chain
     ///
-    /// Returns [`ReadResponse::ValidBestChainTipShieldedSpends`].
-    CheckBestChainTipShieldedSpends(UnminedTx),
+    /// Returns [`ReadResponse::ValidBestChainTipNullifiersAndAnchors`].
+    CheckBestChainTipNullifiersAndAnchors(UnminedTx),
 
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Looks up a block hash by height in the current best chain.
@@ -776,7 +776,9 @@ impl ReadRequest {
             ReadRequest::AddressBalance { .. } => "address_balance",
             ReadRequest::TransactionIdsByAddresses { .. } => "transaction_ids_by_addesses",
             ReadRequest::UtxosByAddresses(_) => "utxos_by_addesses",
-            ReadRequest::CheckBestChainTipShieldedSpends(_) => "transaction_contextual_validity",
+            ReadRequest::CheckBestChainTipNullifiersAndAnchors(_) => {
+                "transaction_contextual_validity"
+            }
             #[cfg(feature = "getblocktemplate-rpcs")]
             ReadRequest::BestChainBlockHash(_) => "best_chain_block_hash",
         }
@@ -818,8 +820,8 @@ impl TryFrom<Request> for ReadRequest {
                 Ok(ReadRequest::FindBlockHeaders { known_blocks, stop })
             }
 
-            Request::CheckBestChainTipShieldedSpends(tx) => {
-                Ok(ReadRequest::CheckBestChainTipShieldedSpends(tx))
+            Request::CheckBestChainTipNullifiersAndAnchors(tx) => {
+                Ok(ReadRequest::CheckBestChainTipNullifiersAndAnchors(tx))
             }
 
             Request::CommitBlock(_) | Request::CommitFinalizedBlock(_) => {

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -51,6 +51,9 @@ pub enum Response {
 
     /// The response to a `FindBlockHeaders` request.
     BlockHeaders(Vec<block::CountedHeader>),
+
+    /// Response to [`Request::TransactionContextualValidity`].
+    ContextuallyValid,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -111,6 +114,9 @@ pub enum ReadResponse {
     /// Response to [`ReadRequest::UtxosByAddresses`] with found utxos and transaction data.
     AddressUtxos(AddressUtxos),
 
+    /// Response to [`ReadRequest::TransactionContextualValidity`].
+    ContextuallyValid,
+
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Response to [`ReadRequest::BestChainBlockHash`](crate::ReadRequest::BestChainBlockHash) with the
     /// specified block hash.
@@ -141,6 +147,8 @@ impl TryFrom<ReadResponse> for Response {
             ReadResponse::BlockLocator(hashes) => Ok(Response::BlockLocator(hashes)),
             ReadResponse::BlockHashes(hashes) => Ok(Response::BlockHashes(hashes)),
             ReadResponse::BlockHeaders(headers) => Ok(Response::BlockHeaders(headers)),
+
+            ReadResponse::ContextuallyValid => Ok(Response::ContextuallyValid),
 
             ReadResponse::TransactionIdsForBlock(_)
             | ReadResponse::SaplingTree(_)

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -53,6 +53,8 @@ pub enum Response {
     BlockHeaders(Vec<block::CountedHeader>),
 
     /// Response to [`Request::TransactionContextualValidity`].
+    ///
+    /// Does not check transparent UTXO inputs
     ContextuallyValid,
 }
 
@@ -115,6 +117,8 @@ pub enum ReadResponse {
     AddressUtxos(AddressUtxos),
 
     /// Response to [`ReadRequest::TransactionContextualValidity`].
+    ///
+    /// Does not check transparent UTXO inputs
     ContextuallyValid,
 
     #[cfg(feature = "getblocktemplate-rpcs")]

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -52,10 +52,10 @@ pub enum Response {
     /// The response to a `FindBlockHeaders` request.
     BlockHeaders(Vec<block::CountedHeader>),
 
-    /// Response to [`Request::CheckBestChainTipShieldedSpends`].
+    /// Response to [`Request::CheckBestChainTipNullifiersAndAnchors`].
     ///
     /// Does not check transparent UTXO inputs
-    ValidBestChainTipShieldedSpends,
+    ValidBestChainTipNullifiersAndAnchors,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -116,10 +116,10 @@ pub enum ReadResponse {
     /// Response to [`ReadRequest::UtxosByAddresses`] with found utxos and transaction data.
     AddressUtxos(AddressUtxos),
 
-    /// Response to [`ReadRequest::CheckBestChainTipShieldedSpends`].
+    /// Response to [`ReadRequest::CheckBestChainTipNullifiersAndAnchors`].
     ///
     /// Does not check transparent UTXO inputs
-    ValidBestChainTipShieldedSpends,
+    ValidBestChainTipNullifiersAndAnchors,
 
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Response to [`ReadRequest::BestChainBlockHash`](crate::ReadRequest::BestChainBlockHash) with the
@@ -152,7 +152,7 @@ impl TryFrom<ReadResponse> for Response {
             ReadResponse::BlockHashes(hashes) => Ok(Response::BlockHashes(hashes)),
             ReadResponse::BlockHeaders(headers) => Ok(Response::BlockHeaders(headers)),
 
-            ReadResponse::ValidBestChainTipShieldedSpends => Ok(Response::ValidBestChainTipShieldedSpends),
+            ReadResponse::ValidBestChainTipNullifiersAndAnchors => Ok(Response::ValidBestChainTipNullifiersAndAnchors),
 
             ReadResponse::TransactionIdsForBlock(_)
             | ReadResponse::SaplingTree(_)

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -52,10 +52,10 @@ pub enum Response {
     /// The response to a `FindBlockHeaders` request.
     BlockHeaders(Vec<block::CountedHeader>),
 
-    /// Response to [`Request::TransactionContextualValidity`].
+    /// Response to [`Request::CheckBestChainTipShieldedSpends`].
     ///
     /// Does not check transparent UTXO inputs
-    ContextuallyValid,
+    ValidBestChainTipShieldedSpends,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -116,10 +116,10 @@ pub enum ReadResponse {
     /// Response to [`ReadRequest::UtxosByAddresses`] with found utxos and transaction data.
     AddressUtxos(AddressUtxos),
 
-    /// Response to [`ReadRequest::TransactionContextualValidity`].
+    /// Response to [`ReadRequest::CheckBestChainTipShieldedSpends`].
     ///
     /// Does not check transparent UTXO inputs
-    ContextuallyValid,
+    ValidBestChainTipShieldedSpends,
 
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Response to [`ReadRequest::BestChainBlockHash`](crate::ReadRequest::BestChainBlockHash) with the
@@ -152,7 +152,7 @@ impl TryFrom<ReadResponse> for Response {
             ReadResponse::BlockHashes(hashes) => Ok(Response::BlockHashes(hashes)),
             ReadResponse::BlockHeaders(headers) => Ok(Response::BlockHeaders(headers)),
 
-            ReadResponse::ContextuallyValid => Ok(Response::ContextuallyValid),
+            ReadResponse::ValidBestChainTipShieldedSpends => Ok(Response::ValidBestChainTipShieldedSpends),
 
             ReadResponse::TransactionIdsForBlock(_)
             | ReadResponse::SaplingTree(_)

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1519,7 +1519,7 @@ impl Service<ReadRequest> for ReadStateService {
                 .boxed()
             }
 
-            ReadRequest::CheckBestChainTipShieldedSpends(transaction) => {
+            ReadRequest::CheckBestChainTipShieldedSpends(unmined_tx) => {
                 let timer = CodeTimer::start();
 
                 let state = self.clone();
@@ -1533,13 +1533,13 @@ impl Service<ReadRequest> for ReadStateService {
                         check::nullifier::tx_no_duplicates_in_chain(
                             &state.db,
                             latest_non_finalized_best_chain.as_ref(),
-                            &transaction,
+                            &unmined_tx.transaction,
                         )?;
 
                         check::anchors::tx_anchors_refer_to_final_treestates(
                             &state.db,
                             latest_non_finalized_best_chain.as_ref(),
-                            &transaction,
+                            &unmined_tx,
                         )?;
 
                         // The work is done in the future.

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1025,7 +1025,7 @@ impl Service<Request> for StateService {
             | Request::Block(_)
             | Request::FindBlockHashes { .. }
             | Request::FindBlockHeaders { .. }
-            | Request::CheckBestChainTipShieldedSpends(_) => {
+            | Request::CheckBestChainTipNullifiersAndAnchors(_) => {
                 // Redirect the request to the concurrent ReadStateService
                 let read_service = self.read_service.clone();
 
@@ -1519,7 +1519,7 @@ impl Service<ReadRequest> for ReadStateService {
                 .boxed()
             }
 
-            ReadRequest::CheckBestChainTipShieldedSpends(unmined_tx) => {
+            ReadRequest::CheckBestChainTipNullifiersAndAnchors(unmined_tx) => {
                 let timer = CodeTimer::start();
 
                 let state = self.clone();
@@ -1545,7 +1545,7 @@ impl Service<ReadRequest> for ReadStateService {
                         // The work is done in the future.
                         timer.finish(module_path!(), line!(), "ReadRequest::UnspentBestChainUtxo");
 
-                        Ok(ReadResponse::ValidBestChainTipShieldedSpends)
+                        Ok(ReadResponse::ValidBestChainTipNullifiersAndAnchors)
                     })
                 })
                 .map(|join_result| join_result.expect("panic in ReadRequest::UnspentBestChainUtxo"))

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1536,10 +1536,25 @@ impl Service<ReadRequest> for ReadStateService {
                             &transaction,
                         )?;
 
-                        check::anchors::tx_sapling_orchard_anchors_refer_to_final_treestates(
+                        check::anchors::sapling_orchard_anchors_refer_to_final_treestates(
                             &state.db,
                             latest_non_finalized_best_chain.as_ref(),
                             std::iter::once(&transaction),
+                            None,
+                        )?;
+
+                        // Reads from disk
+                        let sprout_final_treestates = check::anchors::fetch_sprout_final_treestates(
+                            &state.db,
+                            latest_non_finalized_best_chain.as_ref(),
+                            std::iter::once(&transaction),
+                            None,
+                        );
+
+                        check::anchors::sprout_anchors_refer_to_treestates(
+                            sprout_final_treestates,
+                            std::iter::once(&transaction),
+                            None,
                         )?;
 
                         // The work is done in the future.

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1519,8 +1519,6 @@ impl Service<ReadRequest> for ReadStateService {
                 .boxed()
             }
 
-            // Transaction Verifier expects errors from this request to be the ValidateContextError type
-            // and will panic if returned a different type of error.
             ReadRequest::CheckBestChainTipNullifiersAndAnchors(unmined_tx) => {
                 let timer = CodeTimer::start();
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1024,7 +1024,8 @@ impl Service<Request> for StateService {
             | Request::UnspentBestChainUtxo(_)
             | Request::Block(_)
             | Request::FindBlockHashes { .. }
-            | Request::FindBlockHeaders { .. } => {
+            | Request::FindBlockHeaders { .. }
+            | Request::TransactionContextualValidity(_) => {
                 // Redirect the request to the concurrent ReadStateService
                 let read_service = self.read_service.clone();
 
@@ -1217,7 +1218,6 @@ impl Service<ReadRequest> for ReadStateService {
                 .boxed()
             }
 
-            // Currently unused.
             ReadRequest::UnspentBestChainUtxo(outpoint) => {
                 let timer = CodeTimer::start();
 
@@ -1516,6 +1516,39 @@ impl Service<ReadRequest> for ReadStateService {
                     })
                 })
                 .map(|join_result| join_result.expect("panic in ReadRequest::UtxosByAddresses"))
+                .boxed()
+            }
+
+            ReadRequest::TransactionContextualValidity(transaction) => {
+                let timer = CodeTimer::start();
+
+                let state = self.clone();
+
+                let span = Span::current();
+                tokio::task::spawn_blocking(move || {
+                    span.in_scope(move || {
+                        let latest_non_finalized_best_chain =
+                            state.latest_non_finalized_state().best_chain().cloned();
+
+                        check::nullifier::tx_no_duplicates_in_chain(
+                            latest_non_finalized_best_chain.as_ref(),
+                            &state.db,
+                            &transaction,
+                        )?;
+
+                        check::anchors::tx_sapling_orchard_anchors_refer_to_final_treestates(
+                            &state.db,
+                            latest_non_finalized_best_chain.as_ref(),
+                            std::iter::once(&transaction),
+                        )?;
+
+                        // The work is done in the future.
+                        timer.finish(module_path!(), line!(), "ReadRequest::UnspentBestChainUtxo");
+
+                        Ok(ReadResponse::ContextuallyValid)
+                    })
+                })
+                .map(|join_result| join_result.expect("panic in ReadRequest::UnspentBestChainUtxo"))
                 .boxed()
             }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1025,7 +1025,7 @@ impl Service<Request> for StateService {
             | Request::Block(_)
             | Request::FindBlockHashes { .. }
             | Request::FindBlockHeaders { .. }
-            | Request::TransactionContextualValidity(_) => {
+            | Request::CheckBestChainTipShieldedSpends(_) => {
                 // Redirect the request to the concurrent ReadStateService
                 let read_service = self.read_service.clone();
 
@@ -1519,7 +1519,7 @@ impl Service<ReadRequest> for ReadStateService {
                 .boxed()
             }
 
-            ReadRequest::TransactionContextualValidity(transaction) => {
+            ReadRequest::CheckBestChainTipShieldedSpends(transaction) => {
                 let timer = CodeTimer::start();
 
                 let state = self.clone();
@@ -1560,7 +1560,7 @@ impl Service<ReadRequest> for ReadStateService {
                         // The work is done in the future.
                         timer.finish(module_path!(), line!(), "ReadRequest::UnspentBestChainUtxo");
 
-                        Ok(ReadResponse::ContextuallyValid)
+                        Ok(ReadResponse::ValidBestChainTipShieldedSpends)
                     })
                 })
                 .map(|join_result| join_result.expect("panic in ReadRequest::UnspentBestChainUtxo"))

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1531,30 +1531,15 @@ impl Service<ReadRequest> for ReadStateService {
                             state.latest_non_finalized_state().best_chain().cloned();
 
                         check::nullifier::tx_no_duplicates_in_chain(
-                            latest_non_finalized_best_chain.as_ref(),
                             &state.db,
+                            latest_non_finalized_best_chain.as_ref(),
                             &transaction,
                         )?;
 
-                        check::anchors::sapling_orchard_anchors_refer_to_final_treestates(
+                        check::anchors::tx_anchors_refer_to_final_treestates(
                             &state.db,
                             latest_non_finalized_best_chain.as_ref(),
-                            std::iter::once(&transaction),
-                            None,
-                        )?;
-
-                        // Reads from disk
-                        let sprout_final_treestates = check::anchors::fetch_sprout_final_treestates(
-                            &state.db,
-                            latest_non_finalized_best_chain.as_ref(),
-                            std::iter::once(&transaction),
-                            None,
-                        );
-
-                        check::anchors::sprout_anchors_refer_to_treestates(
-                            sprout_final_treestates,
-                            std::iter::once(&transaction),
-                            None,
+                            &transaction,
                         )?;
 
                         // The work is done in the future.

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1519,6 +1519,8 @@ impl Service<ReadRequest> for ReadStateService {
                 .boxed()
             }
 
+            // Transaction Verifier expects errors from this request to be the ValidateContextError type
+            // and will panic if returned a different type of error.
             ReadRequest::CheckBestChainTipNullifiersAndAnchors(unmined_tx) => {
                 let timer = CodeTimer::start();
 

--- a/zebra-state/src/service/check/anchors.rs
+++ b/zebra-state/src/service/check/anchors.rs
@@ -3,8 +3,6 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use rayon::prelude::*;
-
 use zebra_chain::{
     block::{Block, Height},
     sprout,
@@ -333,12 +331,8 @@ pub(crate) fn block_sapling_orchard_anchors_refer_to_final_treestates(
     parent_chain: &Arc<Chain>,
     prepared: &PreparedBlock,
 ) -> Result<(), ValidateContextError> {
-    prepared
-        .block
-        .transactions
-        .par_iter()
-        .enumerate()
-        .try_for_each(|(tx_index_in_block, transaction)| {
+    prepared.block.transactions.iter().enumerate().try_for_each(
+        |(tx_index_in_block, transaction)| {
             sapling_orchard_anchors_refer_to_final_treestates(
                 finalized_state,
                 Some(parent_chain),
@@ -347,7 +341,8 @@ pub(crate) fn block_sapling_orchard_anchors_refer_to_final_treestates(
                 Some(tx_index_in_block),
                 Some(prepared.height),
             )
-        })
+        },
+    )
 }
 
 /// Accepts a [`ZebraDb`], [`Arc<Chain>`](Chain), and [`PreparedBlock`].
@@ -413,7 +408,7 @@ pub(crate) fn block_sprout_anchors_refer_to_treestates(
 
     block
         .transactions
-        .par_iter()
+        .iter()
         .enumerate()
         .try_for_each(|(tx_index_in_block, transaction)| {
             sprout_anchors_refer_to_treestates(

--- a/zebra-state/src/service/check/anchors.rs
+++ b/zebra-state/src/service/check/anchors.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, sync::Arc};
 use zebra_chain::{
     block::{Block, Height},
     sprout,
-    transaction::Transaction,
+    transaction::{Hash as TransactionHash, Transaction, UnminedTx},
 };
 
 use crate::{
@@ -19,108 +19,104 @@ use crate::{
 /// This method checks for anchors computed from the final treestate of each block in
 /// the `parent_chain` or `finalized_state`.
 #[tracing::instrument(skip_all)]
-fn sapling_orchard_anchors_refer_to_final_treestates<
-    'a,
-    TransactionsIter: Iterator<Item = &'a Arc<Transaction>>,
->(
+fn sapling_orchard_anchors_refer_to_final_treestates(
     finalized_state: &ZebraDb,
     parent_chain: Option<&Arc<Chain>>,
-    transactions: TransactionsIter,
+    transaction: &Arc<Transaction>,
+    transaction_hash: TransactionHash,
+    tx_index_in_block: Option<usize>,
     height: Option<Height>,
 ) -> Result<(), ValidateContextError> {
-    for (tx_index_in_block, transaction) in transactions.enumerate() {
-        let tx_index_in_block = height.map(|_| tx_index_in_block);
-        // Sapling Spends
-        //
-        // MUST refer to some earlier block’s final Sapling treestate.
-        //
-        // # Consensus
-        //
-        // > The anchor of each Spend description MUST refer to some earlier
-        // > block’s final Sapling treestate. The anchor is encoded separately
-        // > in each Spend description for v4 transactions, or encoded once and
-        // > shared between all Spend descriptions in a v5 transaction.
-        //
-        // <https://zips.z.cash/protocol/protocol.pdf#spendsandoutputs>
-        //
-        // This rule is also implemented in
-        // [`zebra_chain::sapling::shielded_data`].
-        //
-        // The "earlier treestate" check is implemented here.
-        for (anchor_index_in_tx, anchor) in transaction.sapling_anchors().enumerate() {
-            tracing::debug!(
-                ?anchor,
-                ?anchor_index_in_tx,
-                ?tx_index_in_block,
-                ?height,
-                "observed sapling anchor",
-            );
+    // Sapling Spends
+    //
+    // MUST refer to some earlier block’s final Sapling treestate.
+    //
+    // # Consensus
+    //
+    // > The anchor of each Spend description MUST refer to some earlier
+    // > block’s final Sapling treestate. The anchor is encoded separately
+    // > in each Spend description for v4 transactions, or encoded once and
+    // > shared between all Spend descriptions in a v5 transaction.
+    //
+    // <https://zips.z.cash/protocol/protocol.pdf#spendsandoutputs>
+    //
+    // This rule is also implemented in
+    // [`zebra_chain::sapling::shielded_data`].
+    //
+    // The "earlier treestate" check is implemented here.
+    for (anchor_index_in_tx, anchor) in transaction.sapling_anchors().enumerate() {
+        tracing::debug!(
+            ?anchor,
+            ?anchor_index_in_tx,
+            ?tx_index_in_block,
+            ?height,
+            "observed sapling anchor",
+        );
 
-            if !parent_chain
-                .map(|chain| chain.sapling_anchors.contains(&anchor))
-                .unwrap_or(false)
-                && !finalized_state.contains_sapling_anchor(&anchor)
-            {
-                return Err(ValidateContextError::UnknownSaplingAnchor {
-                    anchor,
-                    height,
-                    tx_index_in_block,
-                    transaction_hash: transaction.hash(),
-                });
-            }
-
-            tracing::debug!(
-                ?anchor,
-                ?anchor_index_in_tx,
-                ?tx_index_in_block,
-                ?height,
-                "validated sapling anchor",
-            );
+        if !parent_chain
+            .map(|chain| chain.sapling_anchors.contains(&anchor))
+            .unwrap_or(false)
+            && !finalized_state.contains_sapling_anchor(&anchor)
+        {
+            return Err(ValidateContextError::UnknownSaplingAnchor {
+                anchor,
+                height,
+                tx_index_in_block,
+                transaction_hash,
+            });
         }
 
-        // Orchard Actions
-        //
-        // MUST refer to some earlier block’s final Orchard treestate.
-        //
-        // # Consensus
-        //
-        // > The anchorOrchard field of the transaction, whenever it exists
-        // > (i.e. when there are any Action descriptions), MUST refer to some
-        // > earlier block’s final Orchard treestate.
-        //
-        // <https://zips.z.cash/protocol/protocol.pdf#actions>
-        if let Some(orchard_shielded_data) = transaction.orchard_shielded_data() {
-            tracing::debug!(
-                ?orchard_shielded_data.shared_anchor,
-                ?tx_index_in_block,
-                ?height,
-                "observed orchard anchor",
-            );
+        tracing::debug!(
+            ?anchor,
+            ?anchor_index_in_tx,
+            ?tx_index_in_block,
+            ?height,
+            "validated sapling anchor",
+        );
+    }
 
-            if !parent_chain
-                .map(|chain| {
-                    chain
-                        .orchard_anchors
-                        .contains(&orchard_shielded_data.shared_anchor)
-                })
-                .unwrap_or(false)
-                && !finalized_state.contains_orchard_anchor(&orchard_shielded_data.shared_anchor)
-            {
-                return Err(ValidateContextError::UnknownOrchardAnchor {
-                    anchor: orchard_shielded_data.shared_anchor,
-                    height: None,
-                    tx_index_in_block: None,
-                    transaction_hash: transaction.hash(),
-                });
-            }
+    // Orchard Actions
+    //
+    // MUST refer to some earlier block’s final Orchard treestate.
+    //
+    // # Consensus
+    //
+    // > The anchorOrchard field of the transaction, whenever it exists
+    // > (i.e. when there are any Action descriptions), MUST refer to some
+    // > earlier block’s final Orchard treestate.
+    //
+    // <https://zips.z.cash/protocol/protocol.pdf#actions>
+    if let Some(orchard_shielded_data) = transaction.orchard_shielded_data() {
+        tracing::debug!(
+            ?orchard_shielded_data.shared_anchor,
+            ?tx_index_in_block,
+            ?height,
+            "observed orchard anchor",
+        );
 
-            tracing::debug!(
-                ?orchard_shielded_data.shared_anchor,
-                ?tx_index_in_block,
-                ?height,
-                "validated orchard anchor",
-            );
+        if !parent_chain
+            .map(|chain| {
+                chain
+                    .orchard_anchors
+                    .contains(&orchard_shielded_data.shared_anchor)
+            })
+            .unwrap_or(false)
+            && !finalized_state.contains_orchard_anchor(&orchard_shielded_data.shared_anchor)
+        {
+            return Err(ValidateContextError::UnknownOrchardAnchor {
+                anchor: orchard_shielded_data.shared_anchor,
+                height,
+                tx_index_in_block,
+                transaction_hash,
+            });
         }
+
+        tracing::debug!(
+            ?orchard_shielded_data.shared_anchor,
+            ?tx_index_in_block,
+            ?height,
+            "validated orchard anchor",
+        );
     }
 
     Ok(())
@@ -134,60 +130,55 @@ fn sapling_orchard_anchors_refer_to_final_treestates<
 /// `JoinSplit` _within the same transaction_; these are created on the fly
 /// in [`sprout_anchors_refer_to_treestates()`].
 #[tracing::instrument(skip_all)]
-fn fetch_sprout_final_treestates<'a, TransactionsIter: Iterator<Item = &'a Arc<Transaction>>>(
+fn fetch_sprout_final_treestates(
+    sprout_final_treestates: &mut HashMap<
+        sprout::tree::Root,
+        Arc<sprout::tree::NoteCommitmentTree>,
+    >,
     finalized_state: &ZebraDb,
     parent_chain: Option<&Arc<Chain>>,
-    transactions: TransactionsIter,
+    transaction: &Arc<Transaction>,
+    tx_index_in_block: Option<usize>,
     height: Option<Height>,
-) -> HashMap<sprout::tree::Root, Arc<sprout::tree::NoteCommitmentTree>> {
-    let mut sprout_final_treestates = HashMap::new();
+) {
+    // Fetch and return Sprout JoinSplit final treestates
+    for (joinsplit_index_in_tx, joinsplit) in transaction.sprout_groth16_joinsplits().enumerate() {
+        // Avoid duplicate fetches
+        if sprout_final_treestates.contains_key(&joinsplit.anchor) {
+            continue;
+        }
 
-    for (tx_index_in_block, transaction) in transactions.enumerate() {
-        let tx_index_in_block = height.map(|_| tx_index_in_block);
+        let input_tree = parent_chain
+            .and_then(|chain| chain.sprout_trees_by_anchor.get(&joinsplit.anchor).cloned())
+            .or_else(|| finalized_state.sprout_note_commitment_tree_by_anchor(&joinsplit.anchor));
 
-        // Fetch and return Sprout JoinSplit final treestates
-        for (joinsplit_index_in_tx, joinsplit) in
-            transaction.sprout_groth16_joinsplits().enumerate()
-        {
-            // Avoid duplicate fetches
-            if sprout_final_treestates.contains_key(&joinsplit.anchor) {
-                continue;
-            }
+        if let Some(input_tree) = input_tree {
+            /* TODO:
+                 - fix tests that generate incorrect root data
+                 - assert that roots match the fetched tree during tests
+                 - move this CPU-intensive check to sprout_anchors_refer_to_treestates()
 
-            let input_tree = parent_chain
-                .and_then(|chain| chain.sprout_trees_by_anchor.get(&joinsplit.anchor).cloned())
-                .or_else(|| {
-                    finalized_state.sprout_note_commitment_tree_by_anchor(&joinsplit.anchor)
-                });
+            assert_eq!(
+                input_tree.root(),
+                joinsplit.anchor,
+                "anchor and fetched input tree root did not match:\n\
+                 anchor: {anchor:?},\n\
+                 input tree root: {input_tree_root:?},\n\
+                 input_tree: {input_tree:?}",
+                anchor = joinsplit.anchor
+            );
+             */
 
-            if let Some(input_tree) = input_tree {
-                /* TODO:
-                     - fix tests that generate incorrect root data
-                     - assert that roots match the fetched tree during tests
-                     - move this CPU-intensive check to sprout_anchors_refer_to_treestates()
+            sprout_final_treestates.insert(joinsplit.anchor, input_tree);
 
-                assert_eq!(
-                    input_tree.root(),
-                    joinsplit.anchor,
-                    "anchor and fetched input tree root did not match:\n\
-                     anchor: {anchor:?},\n\
-                     input tree root: {input_tree_root:?},\n\
-                     input_tree: {input_tree:?}",
-                    anchor = joinsplit.anchor
-                );
-                 */
-
-                sprout_final_treestates.insert(joinsplit.anchor, input_tree);
-
-                tracing::debug!(
-                    sprout_final_treestate_count = ?sprout_final_treestates.len(),
-                    ?joinsplit.anchor,
-                    ?joinsplit_index_in_tx,
-                    ?tx_index_in_block,
-                    ?height,
-                    "observed sprout final treestate anchor",
-                );
-            }
+            tracing::debug!(
+                sprout_final_treestate_count = ?sprout_final_treestates.len(),
+                ?joinsplit.anchor,
+                ?joinsplit_index_in_tx,
+                ?tx_index_in_block,
+                ?height,
+                "observed sprout final treestate anchor",
+            );
         }
     }
 
@@ -197,8 +188,6 @@ fn fetch_sprout_final_treestates<'a, TransactionsIter: Iterator<Item = &'a Arc<T
         ?height,
         "returning sprout final treestate anchors",
     );
-
-    sprout_final_treestates
 }
 
 /// Checks the Sprout anchors specified by `transactions`.
@@ -211,135 +200,121 @@ fn fetch_sprout_final_treestates<'a, TransactionsIter: Iterator<Item = &'a Arc<T
 /// (which must be populated with all treestates pointed to in the `prepared` block;
 /// see [`fetch_sprout_final_treestates()`]); or in the interstitial
 /// treestates which are computed on the fly in this function.
-#[tracing::instrument(skip(sprout_final_treestates, transactions))]
-fn sprout_anchors_refer_to_treestates<
-    'a,
-    TransactionsIter: Iterator<Item = &'a Arc<Transaction>>,
->(
-    sprout_final_treestates: HashMap<sprout::tree::Root, Arc<sprout::tree::NoteCommitmentTree>>,
-    transactions: TransactionsIter,
+#[tracing::instrument(skip(sprout_final_treestates, transaction, transaction_hash))]
+fn sprout_anchors_refer_to_treestates(
+    sprout_final_treestates: &HashMap<sprout::tree::Root, Arc<sprout::tree::NoteCommitmentTree>>,
+    transaction: &Arc<Transaction>,
     // Only used for debugging
+    transaction_hash: TransactionHash,
+    tx_index_in_block: Option<usize>,
     height: Option<Height>,
 ) -> Result<(), ValidateContextError> {
-    tracing::trace!(
-        sprout_final_treestate_count = ?sprout_final_treestates.len(),
-        ?sprout_final_treestates,
-        ?height,
-        "received sprout final treestate anchors",
-    );
+    // Sprout JoinSplits, with interstitial treestates to check as well.
+    let mut interstitial_trees: HashMap<sprout::tree::Root, Arc<sprout::tree::NoteCommitmentTree>> =
+        HashMap::new();
 
-    for (tx_index_in_block, transaction) in transactions.enumerate() {
-        // Sprout JoinSplits, with interstitial treestates to check as well.
-        let mut interstitial_trees: HashMap<
-            sprout::tree::Root,
-            Arc<sprout::tree::NoteCommitmentTree>,
-        > = HashMap::new();
+    let joinsplit_count = transaction.sprout_groth16_joinsplits().count();
 
-        let joinsplit_count = transaction.sprout_groth16_joinsplits().count();
+    for (joinsplit_index_in_tx, joinsplit) in transaction.sprout_groth16_joinsplits().enumerate() {
+        // Check all anchor sets, including the one for interstitial
+        // anchors.
+        //
+        // The anchor is checked and the matching tree is obtained,
+        // which is used to create the interstitial tree state for this
+        // JoinSplit:
+        //
+        // > For each JoinSplit description in a transaction, an
+        // > interstitial output treestate is constructed which adds the
+        // > note commitments and nullifiers specified in that JoinSplit
+        // > description to the input treestate referred to by its
+        // > anchor. This interstitial output treestate is available for
+        // > use as the anchor of subsequent JoinSplit descriptions in
+        // > the same transaction.
+        //
+        // <https://zips.z.cash/protocol/protocol.pdf#joinsplit>
+        //
+        // # Consensus
+        //
+        // > The anchor of each JoinSplit description in a transaction
+        // > MUST refer to either some earlier block’s final Sprout
+        // > treestate, or to the interstitial output treestate of any
+        // > prior JoinSplit description in the same transaction.
+        //
+        // > For the first JoinSplit description of a transaction, the
+        // > anchor MUST be the output Sprout treestate of a previous
+        // > block.
+        //
+        // <https://zips.z.cash/protocol/protocol.pdf#joinsplit>
+        //
+        // Note that in order to satisfy the latter consensus rule above,
+        // [`interstitial_trees`] is always empty in the first iteration
+        // of the loop.
+        let input_tree = interstitial_trees
+            .get(&joinsplit.anchor)
+            .cloned()
+            .or_else(|| sprout_final_treestates.get(&joinsplit.anchor).cloned());
 
-        for (joinsplit_index_in_tx, joinsplit) in
-            transaction.sprout_groth16_joinsplits().enumerate()
-        {
-            // Check all anchor sets, including the one for interstitial
-            // anchors.
-            //
-            // The anchor is checked and the matching tree is obtained,
-            // which is used to create the interstitial tree state for this
-            // JoinSplit:
-            //
-            // > For each JoinSplit description in a transaction, an
-            // > interstitial output treestate is constructed which adds the
-            // > note commitments and nullifiers specified in that JoinSplit
-            // > description to the input treestate referred to by its
-            // > anchor. This interstitial output treestate is available for
-            // > use as the anchor of subsequent JoinSplit descriptions in
-            // > the same transaction.
-            //
-            // <https://zips.z.cash/protocol/protocol.pdf#joinsplit>
-            //
-            // # Consensus
-            //
-            // > The anchor of each JoinSplit description in a transaction
-            // > MUST refer to either some earlier block’s final Sprout
-            // > treestate, or to the interstitial output treestate of any
-            // > prior JoinSplit description in the same transaction.
-            //
-            // > For the first JoinSplit description of a transaction, the
-            // > anchor MUST be the output Sprout treestate of a previous
-            // > block.
-            //
-            // <https://zips.z.cash/protocol/protocol.pdf#joinsplit>
-            //
-            // Note that in order to satisfy the latter consensus rule above,
-            // [`interstitial_trees`] is always empty in the first iteration
-            // of the loop.
-            let input_tree = interstitial_trees
-                .get(&joinsplit.anchor)
-                .cloned()
-                .or_else(|| sprout_final_treestates.get(&joinsplit.anchor).cloned());
+        tracing::trace!(
+            ?input_tree,
+            final_lookup = ?sprout_final_treestates.get(&joinsplit.anchor),
+            interstitial_lookup = ?interstitial_trees.get(&joinsplit.anchor),
+            interstitial_tree_count = ?interstitial_trees.len(),
+            ?interstitial_trees,
+            ?height,
+            "looked up sprout treestate anchor",
+        );
 
-            tracing::trace!(
-                ?input_tree,
-                final_lookup = ?sprout_final_treestates.get(&joinsplit.anchor),
-                interstitial_lookup = ?interstitial_trees.get(&joinsplit.anchor),
-                interstitial_tree_count = ?interstitial_trees.len(),
-                ?interstitial_trees,
-                ?height,
-                "looked up sprout treestate anchor",
-            );
-
-            let mut input_tree = match input_tree {
-                Some(tree) => tree,
-                None => {
-                    tracing::debug!(
-                        ?joinsplit.anchor,
-                        ?joinsplit_index_in_tx,
-                        ?tx_index_in_block,
-                        ?height,
-                        "failed to find sprout anchor",
-                    );
-                    return Err(ValidateContextError::UnknownSproutAnchor {
-                        anchor: joinsplit.anchor,
-                        height,
-                        tx_index_in_block: Some(tx_index_in_block),
-                        transaction_hash: transaction.hash(),
-                    });
-                }
-            };
-
-            tracing::debug!(
-                ?joinsplit.anchor,
-                ?joinsplit_index_in_tx,
-                ?tx_index_in_block,
-                ?height,
-                "validated sprout anchor",
-            );
-
-            // The last interstitial treestate in a transaction can never be used,
-            // so we avoid generating it.
-            if joinsplit_index_in_tx == joinsplit_count - 1 {
-                continue;
+        let mut input_tree = match input_tree {
+            Some(tree) => tree,
+            None => {
+                tracing::debug!(
+                    ?joinsplit.anchor,
+                    ?joinsplit_index_in_tx,
+                    ?tx_index_in_block,
+                    ?height,
+                    "failed to find sprout anchor",
+                );
+                return Err(ValidateContextError::UnknownSproutAnchor {
+                    anchor: joinsplit.anchor,
+                    height,
+                    tx_index_in_block,
+                    transaction_hash,
+                });
             }
+        };
 
-            let input_tree_inner = Arc::make_mut(&mut input_tree);
+        tracing::debug!(
+            ?joinsplit.anchor,
+            ?joinsplit_index_in_tx,
+            ?tx_index_in_block,
+            ?height,
+            "validated sprout anchor",
+        );
 
-            // Add new anchors to the interstitial note commitment tree.
-            for cm in joinsplit.commitments {
-                input_tree_inner
-                    .append(cm)
-                    .expect("note commitment should be appendable to the tree");
-            }
-
-            interstitial_trees.insert(input_tree.root(), input_tree);
-
-            tracing::debug!(
-                ?joinsplit.anchor,
-                ?joinsplit_index_in_tx,
-                ?tx_index_in_block,
-                ?height,
-                "observed sprout interstitial anchor",
-            );
+        // The last interstitial treestate in a transaction can never be used,
+        // so we avoid generating it.
+        if joinsplit_index_in_tx == joinsplit_count - 1 {
+            continue;
         }
+
+        let input_tree_inner = Arc::make_mut(&mut input_tree);
+
+        // Add new anchors to the interstitial note commitment tree.
+        for cm in joinsplit.commitments {
+            input_tree_inner
+                .append(cm)
+                .expect("note commitment should be appendable to the tree");
+        }
+
+        interstitial_trees.insert(input_tree.root(), input_tree);
+
+        tracing::debug!(
+            ?joinsplit.anchor,
+            ?joinsplit_index_in_tx,
+            ?tx_index_in_block,
+            ?height,
+            "observed sprout interstitial anchor",
+        );
     }
 
     Ok(())
@@ -356,12 +331,18 @@ pub(crate) fn block_sapling_orchard_anchors_refer_to_final_treestates(
     parent_chain: &Arc<Chain>,
     prepared: &PreparedBlock,
 ) -> Result<(), ValidateContextError> {
-    sapling_orchard_anchors_refer_to_final_treestates(
-        finalized_state,
-        Some(parent_chain),
-        prepared.block.transactions.iter(),
-        Some(prepared.height),
-    )
+    for (tx_index_in_block, transaction) in prepared.block.transactions.iter().enumerate() {
+        sapling_orchard_anchors_refer_to_final_treestates(
+            finalized_state,
+            Some(parent_chain),
+            transaction,
+            prepared.transaction_hashes[tx_index_in_block],
+            Some(tx_index_in_block),
+            Some(prepared.height),
+        )?;
+    }
+
+    Ok(())
 }
 
 /// This function fetches and returns the Sprout final treestates from the state,
@@ -377,12 +358,20 @@ pub(crate) fn block_fetch_sprout_final_treestates(
     parent_chain: &Arc<Chain>,
     prepared: &PreparedBlock,
 ) -> HashMap<sprout::tree::Root, Arc<sprout::tree::NoteCommitmentTree>> {
-    fetch_sprout_final_treestates(
-        finalized_state,
-        Some(parent_chain),
-        prepared.block.transactions.iter(),
-        Some(prepared.height),
-    )
+    let mut sprout_final_treestates = HashMap::new();
+
+    for (tx_index_in_block, transaction) in prepared.block.transactions.iter().enumerate() {
+        fetch_sprout_final_treestates(
+            &mut sprout_final_treestates,
+            finalized_state,
+            Some(parent_chain),
+            transaction,
+            Some(tx_index_in_block),
+            Some(prepared.height),
+        );
+    }
+
+    sprout_final_treestates
 }
 
 /// Checks the Sprout anchors specified by transactions in `block`.
@@ -400,13 +389,27 @@ pub(crate) fn block_sprout_anchors_refer_to_treestates(
     sprout_final_treestates: HashMap<sprout::tree::Root, Arc<sprout::tree::NoteCommitmentTree>>,
     block: Arc<Block>,
     // Only used for debugging
+    transaction_hashes: Arc<[TransactionHash]>,
     height: Height,
 ) -> Result<(), ValidateContextError> {
-    sprout_anchors_refer_to_treestates(
-        sprout_final_treestates,
-        block.transactions.iter(),
-        Some(height),
-    )
+    tracing::trace!(
+        sprout_final_treestate_count = ?sprout_final_treestates.len(),
+        ?sprout_final_treestates,
+        ?height,
+        "received sprout final treestate anchors",
+    );
+
+    for (tx_index_in_block, transaction) in block.transactions.iter().enumerate() {
+        sprout_anchors_refer_to_treestates(
+            &sprout_final_treestates,
+            transaction,
+            transaction_hashes[tx_index_in_block],
+            Some(tx_index_in_block),
+            Some(height),
+        )?;
+    }
+
+    Ok(())
 }
 
 /// Checks the final Sprout, Sapling and Orchard anchors specified by `transaction`
@@ -417,26 +420,39 @@ pub(crate) fn block_sprout_anchors_refer_to_treestates(
 pub(crate) fn tx_anchors_refer_to_final_treestates(
     finalized_state: &ZebraDb,
     parent_chain: Option<&Arc<Chain>>,
-    transaction: &Arc<Transaction>,
+    unmined_tx: &UnminedTx,
 ) -> Result<(), ValidateContextError> {
     sapling_orchard_anchors_refer_to_final_treestates(
         finalized_state,
         parent_chain,
-        std::iter::once(transaction),
+        &unmined_tx.transaction,
+        unmined_tx.id.mined_id(),
+        None,
         None,
     )?;
 
-    // Reads from disk
-    let sprout_final_treestates = fetch_sprout_final_treestates(
+    let mut sprout_final_treestates = HashMap::new();
+
+    fetch_sprout_final_treestates(
+        &mut sprout_final_treestates,
         finalized_state,
         parent_chain,
-        std::iter::once(transaction),
+        &unmined_tx.transaction,
+        None,
         None,
     );
 
+    tracing::trace!(
+        sprout_final_treestate_count = ?sprout_final_treestates.len(),
+        ?sprout_final_treestates,
+        "received sprout final treestate anchors",
+    );
+
     sprout_anchors_refer_to_treestates(
-        sprout_final_treestates,
-        std::iter::once(transaction),
+        &sprout_final_treestates,
+        &unmined_tx.transaction,
+        unmined_tx.id.mined_id(),
+        None,
         None,
     )?;
 

--- a/zebra-state/src/service/check/anchors.rs
+++ b/zebra-state/src/service/check/anchors.rs
@@ -206,7 +206,6 @@ fn fetch_sprout_final_treestates(
 fn sprout_anchors_refer_to_treestates(
     sprout_final_treestates: &HashMap<sprout::tree::Root, Arc<sprout::tree::NoteCommitmentTree>>,
     transaction: &Arc<Transaction>,
-    // Only used for debugging
     transaction_hash: TransactionHash,
     tx_index_in_block: Option<usize>,
     height: Option<Height>,
@@ -322,8 +321,9 @@ fn sprout_anchors_refer_to_treestates(
     Ok(())
 }
 
-/// Checks the final Sapling and Orchard anchors specified by transactions in this
-/// `prepared` block.
+/// Accepts a [`ZebraDb`], [`Chain`], and [`PreparedBlock`].
+///
+/// Iterates over the transactions in the [`PreparedBlock`] checking the final Sapling and Orchard anchors.
 ///
 /// This method checks for anchors computed from the final treestate of each block in
 /// the `parent_chain` or `finalized_state`.
@@ -346,15 +346,17 @@ pub(crate) fn block_sapling_orchard_anchors_refer_to_final_treestates(
                 prepared.transaction_hashes[tx_index_in_block],
                 Some(tx_index_in_block),
                 Some(prepared.height),
-            )?;
-
-            Ok(())
+            )
         })
 }
 
-/// This function fetches and returns the Sprout final treestates from the state,
-/// so [`sprout_anchors_refer_to_treestates()`] can check Sprout final and interstitial treestates,
-/// without accessing the disk.
+/// Accepts a [`ZebraDb`], [`Chain`], and [`PreparedBlock`].
+///
+/// Iterates over the transactions in the [`PreparedBlock`], and fetches the Sprout final treestates
+/// from the state.
+///
+/// Returns a `HashMap` of the Sprout final treestates from the state for [`sprout_anchors_refer_to_treestates()`]
+/// to check Sprout final and interstitial treestates without accessing the disk.
 ///
 /// Sprout anchors may also refer to the interstitial output treestate of any prior
 /// `JoinSplit` _within the same transaction_; these are created on the fly
@@ -381,7 +383,10 @@ pub(crate) fn block_fetch_sprout_final_treestates(
     sprout_final_treestates
 }
 
-/// Checks the Sprout anchors specified by transactions in `block`.
+/// Accepts a [`ZebraDb`], [`Chain`], [`Block`], and a slice of [`transaction::Hash`](`TransactionHash`)es
+/// corresponding to the transactions in [`Block`]
+///
+/// Iterates over the transactions in the [`Block`] checking the final Sprout anchors.
 ///
 /// Sprout anchors may refer to some earlier block's final treestate (like
 /// Sapling and Orchard do exclusively) _or_ to the interstitial output
@@ -423,7 +428,9 @@ pub(crate) fn block_sprout_anchors_refer_to_treestates(
         })
 }
 
-/// Checks the final Sprout, Sapling and Orchard anchors specified by `transaction`
+/// Accepts a [`ZebraDb`], an optional [`Chain`], and an [`UnminedTx`].
+///
+/// Checks the final Sprout, Sapling and Orchard anchors specified in the [`UnminedTx`].
 ///
 /// This method checks for anchors computed from the final treestate of each block in
 /// the `parent_chain` or `finalized_state`.

--- a/zebra-state/src/service/check/anchors.rs
+++ b/zebra-state/src/service/check/anchors.rs
@@ -20,7 +20,7 @@ use crate::{
 ///
 /// This method checks for anchors computed from the final treestate of each block in
 /// the `parent_chain` or `finalized_state`.
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(skip(finalized_state, parent_chain, transaction))]
 fn sapling_orchard_anchors_refer_to_final_treestates(
     finalized_state: &ZebraDb,
     parent_chain: Option<&Arc<Chain>>,
@@ -131,7 +131,7 @@ fn sapling_orchard_anchors_refer_to_final_treestates(
 /// Sprout anchors may also refer to the interstitial output treestate of any prior
 /// `JoinSplit` _within the same transaction_; these are created on the fly
 /// in [`sprout_anchors_refer_to_treestates()`].
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(skip(sprout_final_treestates, finalized_state, parent_chain, transaction))]
 fn fetch_sprout_final_treestates(
     sprout_final_treestates: &mut HashMap<
         sprout::tree::Root,
@@ -202,7 +202,7 @@ fn fetch_sprout_final_treestates(
 /// (which must be populated with all treestates pointed to in the `prepared` block;
 /// see [`fetch_sprout_final_treestates()`]); or in the interstitial
 /// treestates which are computed on the fly in this function.
-#[tracing::instrument(skip(sprout_final_treestates, transaction, transaction_hash))]
+#[tracing::instrument(skip(sprout_final_treestates, transaction))]
 fn sprout_anchors_refer_to_treestates(
     sprout_final_treestates: &HashMap<sprout::tree::Root, Arc<sprout::tree::NoteCommitmentTree>>,
     transaction: &Arc<Transaction>,
@@ -396,7 +396,7 @@ pub(crate) fn block_fetch_sprout_final_treestates(
 /// (which must be populated with all treestates pointed to in the `prepared` block;
 /// see [`fetch_sprout_final_treestates()`]); or in the interstitial
 /// treestates which are computed on the fly in this function.
-#[tracing::instrument(skip(sprout_final_treestates, block))]
+#[tracing::instrument(skip(sprout_final_treestates, block, transaction_hashes))]
 pub(crate) fn block_sprout_anchors_refer_to_treestates(
     sprout_final_treestates: HashMap<sprout::tree::Root, Arc<sprout::tree::NoteCommitmentTree>>,
     block: Arc<Block>,

--- a/zebra-state/src/service/check/anchors.rs
+++ b/zebra-state/src/service/check/anchors.rs
@@ -350,7 +350,7 @@ pub(crate) fn block_sapling_orchard_anchors_refer_to_final_treestates(
         })
 }
 
-/// Accepts a [`ZebraDb`], [`Chain`], and [`PreparedBlock`].
+/// Accepts a [`ZebraDb`], [`Arc<Chain>`](Chain), and [`PreparedBlock`].
 ///
 /// Iterates over the transactions in the [`PreparedBlock`], and fetches the Sprout final treestates
 /// from the state.
@@ -383,8 +383,8 @@ pub(crate) fn block_fetch_sprout_final_treestates(
     sprout_final_treestates
 }
 
-/// Accepts a [`ZebraDb`], [`Chain`], [`Block`], and a slice of [`transaction::Hash`](`TransactionHash`)es
-/// corresponding to the transactions in [`Block`]
+/// Accepts a [`ZebraDb`], [`Arc<Chain>`](Chain), [`Arc<Block>`](Block), and an
+/// [`Arc<[transaction::Hash]>`](TransactionHash) of hashes corresponding to the transactions in [`Block`]
 ///
 /// Iterates over the transactions in the [`Block`] checking the final Sprout anchors.
 ///
@@ -428,7 +428,7 @@ pub(crate) fn block_sprout_anchors_refer_to_treestates(
         })
 }
 
-/// Accepts a [`ZebraDb`], an optional [`Chain`], and an [`UnminedTx`].
+/// Accepts a [`ZebraDb`], an optional [`Option<Arc<Chain>>`](Chain), and an [`UnminedTx`].
 ///
 /// Checks the final Sprout, Sapling and Orchard anchors specified in the [`UnminedTx`].
 ///

--- a/zebra-state/src/service/check/anchors.rs
+++ b/zebra-state/src/service/check/anchors.rs
@@ -15,6 +15,7 @@ use crate::{
 ///
 /// This method checks for anchors computed from the final treestate of each block in
 /// the `parent_chain` or `finalized_state`.
+#[tracing::instrument(skip_all)]
 pub(crate) fn sapling_orchard_anchors_refer_to_final_treestates<
     'a,
     TransactionsIter: Iterator<Item = &'a Arc<Transaction>>,

--- a/zebra-state/src/service/check/nullifier.rs
+++ b/zebra-state/src/service/check/nullifier.rs
@@ -68,10 +68,12 @@ pub(crate) fn no_duplicates_in_finalized_chain(
 /// > even if they have the same bit pattern.
 ///
 /// <https://zips.z.cash/protocol/protocol.pdf#nullifierset>
+// TODO: impl nullifier getters for a trait and use a generic type to unify
+//       this fn with the one for `PreparedBlock`
 #[tracing::instrument(skip_all)]
 fn tx_no_duplicates_in_finalized_chain(
     finalized_chain: &ZebraDb,
-    transaction: Arc<Transaction>,
+    transaction: &Arc<Transaction>,
 ) -> Result<(), ValidateContextError> {
     for nullifier in transaction.sprout_nullifiers() {
         if finalized_chain.contains_sprout_nullifier(nullifier) {
@@ -110,7 +112,7 @@ fn tx_no_duplicates_in_finalized_chain(
 pub(crate) fn tx_no_duplicates_in_chain(
     non_finalized_chain: Option<&Arc<Chain>>,
     finalized_chain: &ZebraDb,
-    transaction: Arc<Transaction>,
+    transaction: &Arc<Transaction>,
 ) -> Result<(), ValidateContextError> {
     let non_finalized_chain = match non_finalized_chain {
         None => return tx_no_duplicates_in_finalized_chain(finalized_chain, transaction),

--- a/zebra-state/src/service/check/nullifier.rs
+++ b/zebra-state/src/service/check/nullifier.rs
@@ -56,8 +56,8 @@ pub(crate) fn no_duplicates_in_finalized_chain(
     Ok(())
 }
 
-/// Returns a Ok(()) if the predicate(s) return false for every revealed nullifier
-/// Returns Err(DuplicateNullifierError) for the first nullifier that matches the predicate(s)
+/// Returns `Err(DuplicateNullifierError)` if any of the `revealed_nullifiers` are found in the non-finalized or finalized chains.
+/// Returns `Ok(())` if all the `revealed_nullifiers` have not been seen in either chain.
 fn find_duplicate_nullifier<'a, NullifierT, FinalizedStateContainsFn, NonFinalizedStateContainsFn>(
     revealed_nullifiers: impl IntoIterator<Item = &'a NullifierT>,
     finalized_state_contains: FinalizedStateContainsFn,

--- a/zebra-state/src/service/check/nullifier.rs
+++ b/zebra-state/src/service/check/nullifier.rs
@@ -98,8 +98,8 @@ where
 /// <https://zips.z.cash/protocol/protocol.pdf#nullifierset>
 #[tracing::instrument(skip_all)]
 pub(crate) fn tx_no_duplicates_in_chain(
-    non_finalized_chain: Option<&Arc<Chain>>,
     finalized_chain: &ZebraDb,
+    non_finalized_chain: Option<&Arc<Chain>>,
     transaction: &Arc<Transaction>,
 ) -> Result<(), ValidateContextError> {
     find_duplicate_nullifier(

--- a/zebra-state/src/service/check/tests/nullifier.rs
+++ b/zebra-state/src/service/check/tests/nullifier.rs
@@ -73,7 +73,7 @@ proptest! {
 
         block1.transactions.push(transaction.into());
 
-    let (mut finalized_state, mut non_finalized_state, _genesis) = new_state_with_mainnet_genesis();
+        let (mut finalized_state, mut non_finalized_state, _genesis) = new_state_with_mainnet_genesis();
 
         // Allows anchor checks to pass
         finalized_state.populate_with_anchors(&block1);
@@ -214,7 +214,9 @@ proptest! {
         let block1 = Arc::new(block1).prepare();
         let commit_result = validate_and_commit_non_finalized(
             &finalized_state,
-            &mut non_finalized_state,  block1);
+            &mut non_finalized_state,
+            block1
+        );
 
         prop_assert_eq!(
             commit_result,

--- a/zebra-state/src/service/check/tests/nullifier.rs
+++ b/zebra-state/src/service/check/tests/nullifier.rs
@@ -19,7 +19,9 @@ use zebra_chain::{
 
 use crate::{
     arbitrary::Prepare,
-    service::{read, write::validate_and_commit_non_finalized},
+    service::{
+        check::nullifier::tx_no_duplicates_in_chain, read, write::validate_and_commit_non_finalized,
+    },
     tests::setup::{new_state_with_mainnet_genesis, transaction_v4_from_coinbase},
     FinalizedBlock,
     ValidateContextError::{
@@ -102,7 +104,7 @@ proptest! {
             let commit_result = validate_and_commit_non_finalized(
                 &finalized_state,
                 &mut non_finalized_state,
-                 block1.clone()
+                block1.clone()
             );
 
             // the block was committed
@@ -155,7 +157,9 @@ proptest! {
         let block1 = Arc::new(block1).prepare();
         let commit_result = validate_and_commit_non_finalized(
             &finalized_state,
-            &mut non_finalized_state,  block1);
+            &mut non_finalized_state,
+            block1
+        );
 
         // if the random proptest data produces other errors,
         // we might need to just check `is_err()` here
@@ -320,22 +324,27 @@ proptest! {
         let duplicate_nullifier = joinsplit1.nullifiers[0];
         joinsplit2.nullifiers[0] = duplicate_nullifier;
 
-        let transaction1 = transaction_v4_with_joinsplit_data(joinsplit_data1.0, [joinsplit1.0]);
+        let transaction1 = Arc::new(transaction_v4_with_joinsplit_data(joinsplit_data1.0, [joinsplit1.0]));
         let transaction2 = transaction_v4_with_joinsplit_data(joinsplit_data2.0, [joinsplit2.0]);
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
         block2.transactions[0] = transaction_v4_from_coinbase(&block2.transactions[0]).into();
 
-        block1.transactions.push(transaction1.into());
+        block1.transactions.push(transaction1.clone());
         block2.transactions.push(transaction2.into());
 
-    let (mut finalized_state, mut non_finalized_state, _genesis) = new_state_with_mainnet_genesis();
+        let (mut finalized_state, mut non_finalized_state, _genesis) = new_state_with_mainnet_genesis();
 
         // Allows anchor checks to pass
         finalized_state.populate_with_anchors(&block1);
         finalized_state.populate_with_anchors(&block2);
 
         let mut previous_mem = non_finalized_state.clone();
+
+        // makes sure there are no spurious rejections that might hide bugs in `tx_no_duplicates_in_chain`
+        let check_tx_no_duplicates_in_chain =
+            tx_no_duplicates_in_chain(&finalized_state.db, non_finalized_state.best_chain(), &transaction1);
+        prop_assert!(check_tx_no_duplicates_in_chain.is_ok());
 
         let block1_hash;
         // randomly choose to commit the next block to the finalized or non-finalized state
@@ -355,8 +364,10 @@ proptest! {
         } else {
             let block1 = Arc::new(block1).prepare();
             let commit_result = validate_and_commit_non_finalized(
-            &finalized_state,
-            &mut non_finalized_state,  block1.clone());
+                &finalized_state,
+                &mut non_finalized_state,
+                block1.clone()
+            );
 
             prop_assert_eq!(commit_result, Ok(()));
             prop_assert_eq!(Some((Height(1), block1.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
@@ -373,7 +384,9 @@ proptest! {
         let block2 = Arc::new(block2).prepare();
         let commit_result = validate_and_commit_non_finalized(
             &finalized_state,
-            &mut non_finalized_state,  block2);
+            &mut non_finalized_state,
+            block2
+        );
 
         prop_assert_eq!(
             commit_result,
@@ -383,6 +396,18 @@ proptest! {
             }
             .into())
         );
+
+        let check_tx_no_duplicates_in_chain =
+            tx_no_duplicates_in_chain(&finalized_state.db, non_finalized_state.best_chain(), &transaction1);
+
+        prop_assert_eq!(
+            check_tx_no_duplicates_in_chain,
+            Err(DuplicateSproutNullifier {
+                nullifier: duplicate_nullifier,
+                in_finalized_state: duplicate_in_finalized_state,
+            })
+        );
+
         prop_assert_eq!(Some((Height(1), block1_hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
     }
@@ -415,7 +440,7 @@ proptest! {
 
         block1.transactions.push(transaction.into());
 
-    let (mut finalized_state, mut non_finalized_state, _genesis) = new_state_with_mainnet_genesis();
+        let (mut finalized_state, mut non_finalized_state, _genesis) = new_state_with_mainnet_genesis();
 
         // Allows anchor checks to pass
         finalized_state.populate_with_anchors(&block1);
@@ -526,7 +551,7 @@ proptest! {
             .transactions
             .extend([transaction1.into(), transaction2.into()]);
 
-            let (finalized_state, mut non_finalized_state, genesis) = new_state_with_mainnet_genesis();
+        let (finalized_state, mut non_finalized_state, genesis) = new_state_with_mainnet_genesis();
 
         // Allows anchor checks to pass
         finalized_state.populate_with_anchors(&block1);
@@ -536,7 +561,9 @@ proptest! {
         let block1 = Arc::new(block1).prepare();
         let commit_result = validate_and_commit_non_finalized(
             &finalized_state,
-            &mut non_finalized_state,  block1);
+            &mut non_finalized_state,
+            block1
+        );
 
         prop_assert_eq!(
             commit_result,
@@ -574,23 +601,28 @@ proptest! {
         spend2.nullifier = duplicate_nullifier;
 
         let transaction1 =
-            transaction_v4_with_sapling_shielded_data(sapling_shielded_data1.0, [spend1.0]);
+            Arc::new(transaction_v4_with_sapling_shielded_data(sapling_shielded_data1.0, [spend1.0]));
         let transaction2 =
             transaction_v4_with_sapling_shielded_data(sapling_shielded_data2.0, [spend2.0]);
 
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
         block2.transactions[0] = transaction_v4_from_coinbase(&block2.transactions[0]).into();
 
-        block1.transactions.push(transaction1.into());
+        block1.transactions.push(transaction1.clone());
         block2.transactions.push(transaction2.into());
 
-    let (mut finalized_state, mut non_finalized_state, _genesis) = new_state_with_mainnet_genesis();
+        let (mut finalized_state, mut non_finalized_state, _genesis) = new_state_with_mainnet_genesis();
 
         // Allows anchor checks to pass
         finalized_state.populate_with_anchors(&block1);
         finalized_state.populate_with_anchors(&block2);
 
         let mut previous_mem = non_finalized_state.clone();
+
+        // makes sure there are no spurious rejections that might hide bugs in `tx_no_duplicates_in_chain`
+        let check_tx_no_duplicates_in_chain =
+            tx_no_duplicates_in_chain(&finalized_state.db, non_finalized_state.best_chain(), &transaction1);
+        prop_assert!(check_tx_no_duplicates_in_chain.is_ok());
 
         let block1_hash;
         // randomly choose to commit the next block to the finalized or non-finalized state
@@ -634,6 +666,18 @@ proptest! {
             }
             .into())
         );
+
+        let check_tx_no_duplicates_in_chain =
+            tx_no_duplicates_in_chain(&finalized_state.db, non_finalized_state.best_chain(), &transaction1);
+
+        prop_assert_eq!(
+            check_tx_no_duplicates_in_chain,
+            Err(DuplicateSaplingNullifier {
+                nullifier: duplicate_nullifier,
+                in_finalized_state: duplicate_in_finalized_state,
+            })
+        );
+
         prop_assert_eq!(Some((Height(1), block1_hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
     }
@@ -831,10 +875,10 @@ proptest! {
         let duplicate_nullifier = authorized_action1.action.nullifier;
         authorized_action2.action.nullifier = duplicate_nullifier;
 
-        let transaction1 = transaction_v5_with_orchard_shielded_data(
+        let transaction1 = Arc::new(transaction_v5_with_orchard_shielded_data(
             orchard_shielded_data1.0,
             [authorized_action1.0],
-        );
+        ));
         let transaction2 = transaction_v5_with_orchard_shielded_data(
             orchard_shielded_data2.0,
             [authorized_action2.0],
@@ -843,7 +887,7 @@ proptest! {
         block1.transactions[0] = transaction_v4_from_coinbase(&block1.transactions[0]).into();
         block2.transactions[0] = transaction_v4_from_coinbase(&block2.transactions[0]).into();
 
-        block1.transactions.push(transaction1.into());
+        block1.transactions.push(transaction1.clone());
         block2.transactions.push(transaction2.into());
 
     let (mut finalized_state, mut non_finalized_state, _genesis) = new_state_with_mainnet_genesis();
@@ -853,6 +897,11 @@ proptest! {
         finalized_state.populate_with_anchors(&block2);
 
         let mut previous_mem = non_finalized_state.clone();
+
+        // makes sure there are no spurious rejections that might hide bugs in `tx_no_duplicates_in_chain`
+        let check_tx_no_duplicates_in_chain =
+            tx_no_duplicates_in_chain(&finalized_state.db, non_finalized_state.best_chain(), &transaction1);
+        prop_assert!(check_tx_no_duplicates_in_chain.is_ok());
 
         let block1_hash;
         // randomly choose to commit the next block to the finalized or non-finalized state
@@ -895,6 +944,18 @@ proptest! {
             }
             .into())
         );
+
+        let check_tx_no_duplicates_in_chain =
+            tx_no_duplicates_in_chain(&finalized_state.db, non_finalized_state.best_chain(), &transaction1);
+
+        prop_assert_eq!(
+            check_tx_no_duplicates_in_chain,
+            Err(DuplicateOrchardNullifier {
+                nullifier: duplicate_nullifier,
+                in_finalized_state: duplicate_in_finalized_state,
+            })
+        );
+
         prop_assert_eq!(Some((Height(1), block1_hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
     }

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -276,6 +276,7 @@ impl NonFinalizedState {
 
         let block2 = contextual.block.clone();
         let height = contextual.height;
+        let transaction_hashes = contextual.transaction_hashes.clone();
 
         rayon::in_place_scope_fifo(|scope| {
             scope.spawn_fifo(|_scope| {
@@ -291,6 +292,7 @@ impl NonFinalizedState {
                     Some(check::anchors::block_sprout_anchors_refer_to_treestates(
                         sprout_final_treestates,
                         block2,
+                        transaction_hashes,
                         height,
                     ));
             });

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -226,19 +226,17 @@ impl NonFinalizedState {
         )?;
 
         // Reads from disk
-        check::anchors::sapling_orchard_anchors_refer_to_final_treestates(
+        check::anchors::block_sapling_orchard_anchors_refer_to_final_treestates(
             finalized_state,
-            Some(&new_chain),
-            prepared.block.transactions.iter(),
-            Some(prepared.height),
+            &new_chain,
+            &prepared,
         )?;
 
         // Reads from disk
-        let sprout_final_treestates = check::anchors::fetch_sprout_final_treestates(
+        let sprout_final_treestates = check::anchors::block_fetch_sprout_final_treestates(
             finalized_state,
-            Some(&new_chain),
-            prepared.block.transactions.iter(),
-            Some(prepared.height),
+            &new_chain,
+            &prepared,
         );
 
         // Quick check that doesn't read from disk
@@ -289,11 +287,12 @@ impl NonFinalizedState {
             });
 
             scope.spawn_fifo(|_scope| {
-                sprout_anchor_result = Some(check::anchors::sprout_anchors_refer_to_treestates(
-                    sprout_final_treestates,
-                    block2.transactions.iter(),
-                    Some(height),
-                ));
+                sprout_anchor_result =
+                    Some(check::anchors::block_sprout_anchors_refer_to_treestates(
+                        sprout_final_treestates,
+                        block2,
+                        height,
+                    ));
             });
 
             // We're pretty sure the new block is valid,

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -105,11 +105,11 @@ pub struct Chain {
     pub(crate) orchard_anchors_by_height: BTreeMap<block::Height, orchard::tree::Root>,
 
     /// The Sprout nullifiers revealed by `blocks`.
-    pub(super) sprout_nullifiers: HashSet<sprout::Nullifier>,
+    pub(crate) sprout_nullifiers: HashSet<sprout::Nullifier>,
     /// The Sapling nullifiers revealed by `blocks`.
-    pub(super) sapling_nullifiers: HashSet<sapling::Nullifier>,
+    pub(crate) sapling_nullifiers: HashSet<sapling::Nullifier>,
     /// The Orchard nullifiers revealed by `blocks`.
-    pub(super) orchard_nullifiers: HashSet<orchard::Nullifier>,
+    pub(crate) orchard_nullifiers: HashSet<orchard::Nullifier>,
 
     /// Partial transparent address index data from `blocks`.
     pub(super) partial_transparent_transfers: HashMap<transparent::Address, TransparentTransfers>,

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -410,12 +410,14 @@ impl Chain {
                 .expect("Orchard anchors must exist for pre-fork blocks");
 
             let history_tree_mut = Arc::make_mut(&mut self.history_tree);
-            history_tree_mut.push(
-                self.network,
-                block.block.clone(),
-                *sapling_root,
-                *orchard_root,
-            )?;
+            history_tree_mut
+                .push(
+                    self.network,
+                    block.block.clone(),
+                    *sapling_root,
+                    *orchard_root,
+                )
+                .map_err(Arc::new)?;
         }
 
         Ok(())
@@ -909,12 +911,14 @@ impl Chain {
 
         // TODO: update the history trees in a rayon thread, if they show up in CPU profiles
         let history_tree_mut = Arc::make_mut(&mut self.history_tree);
-        history_tree_mut.push(
-            self.network,
-            contextually_valid.block.clone(),
-            sapling_root,
-            orchard_root,
-        )?;
+        history_tree_mut
+            .push(
+                self.network,
+                contextually_valid.block.clone(),
+                sapling_root,
+                orchard_root,
+            )
+            .map_err(Arc::new)?;
 
         self.history_trees_by_height
             .insert(height, self.history_tree.clone());

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -163,7 +163,7 @@ async fn mempool_push_transaction() -> Result<(), crate::BoxError> {
         let transaction = responder
             .request()
             .clone()
-            .into_mempool_transaction()
+            .mempool_transaction()
             .expect("unexpected non-mempool request");
 
         // Set a dummy fee and sigops.
@@ -267,7 +267,7 @@ async fn mempool_advertise_transaction_ids() -> Result<(), crate::BoxError> {
         let transaction = responder
             .request()
             .clone()
-            .into_mempool_transaction()
+            .mempool_transaction()
             .expect("unexpected non-mempool request");
 
         // Set a dummy fee and sigops.
@@ -368,7 +368,7 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
         let transaction = responder
             .request()
             .clone()
-            .into_mempool_transaction()
+            .mempool_transaction()
             .expect("unexpected non-mempool request");
 
         // Set a dummy fee and sigops.
@@ -502,7 +502,7 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
         let transaction = responder
             .request()
             .clone()
-            .into_mempool_transaction()
+            .mempool_transaction()
             .expect("unexpected non-mempool request");
 
         // Set a dummy fee and sigops.

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -271,10 +271,10 @@ where
         let mut state = self.state.clone();
 
         let fut = async move {
-            // Don't download/verify if the transaction is already in the state.
+            // Don't download/verify if the transaction is already in the best chain.
             Self::transaction_in_state(&mut state, txid).await?;
 
-            trace!(?txid, "transaction is not in state");
+            trace!(?txid, "transaction is not in best chain");
 
             let next_height = match state.oneshot(zs::Request::Tip).await {
                 Ok(zs::Response::Tip(None)) => Ok(Height(0)),
@@ -442,12 +442,11 @@ where
         self.pending.len()
     }
 
-    /// Check if transaction is already in the state.
+    /// Check if transaction is already in the best chain.
     async fn transaction_in_state(
         state: &mut ZS,
         txid: UnminedTxId,
     ) -> Result<(), TransactionDownloadVerifyError> {
-        // Check if the transaction is already in the state.
         match state
             .ready()
             .await

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -272,7 +272,7 @@ where
 
         let fut = async move {
             // Don't download/verify if the transaction is already in the best chain.
-            Self::transaction_in_chain(&mut state, txid).await?;
+            Self::transaction_in_best_chain(&mut state, txid).await?;
 
             trace!(?txid, "transaction is not in best chain");
 

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -272,7 +272,7 @@ where
 
         let fut = async move {
             // Don't download/verify if the transaction is already in the best chain.
-            Self::transaction_in_state(&mut state, txid).await?;
+            Self::transaction_in_chain(&mut state, txid).await?;
 
             trace!(?txid, "transaction is not in best chain");
 
@@ -443,7 +443,7 @@ where
     }
 
     /// Check if transaction is already in the best chain.
-    async fn transaction_in_state(
+    async fn transaction_in_chain(
         state: &mut ZS,
         txid: UnminedTxId,
     ) -> Result<(), TransactionDownloadVerifyError> {

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -443,7 +443,7 @@ where
     }
 
     /// Check if transaction is already in the best chain.
-    async fn transaction_in_chain(
+    async fn transaction_in_best_chain(
         state: &mut ZS,
         txid: UnminedTxId,
     ) -> Result<(), TransactionDownloadVerifyError> {


### PR DESCRIPTION
## Motivation

Mempool transactions collected into a block template need to be contextually valid in the best chain to produce a block template that's contextually valid on the best chain.

Closes #5376 

## Solution

- Add `check::nullifiers::no_duplicates_in_chain` that searches the non-finalized state as well as the finalized state for duplicate nullifiers
- Update `check::anchors` fns and errors accommodate transactions without a `PreparedBlock`
- Add new state request to check that the anchors and nullifiers of a transaction are valid on the best chain
- Use the new state request in the transactions' verifier for mempool transactions

## Review

This PR is part of regular scheduled work.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?
