### PR TITLE
Suggestion: use closures for finding duplicate nullifiers with/without non-finalized state

### DIFF
--- a/zebra-state/src/service/check/nullifier.rs
+++ b/zebra-state/src/service/check/nullifier.rs
@@ -56,8 +56,8 @@ pub(crate) fn no_duplicates_in_finalized_chain(
     Ok(())
 }
 
-/// Returns a Ok(()) if the predicate(s) return false for every revealed nullifier
-/// Returns Err(DuplicateNullifierError) for the first nullifier that matches the predicate(s)
+/// Returns `Err(DuplicateNullifierError)` if any of the `revealed_nullifiers` are found in the non-finalized or finalized chains.
+/// Returns `Ok(())` if all the `revealed_nullifiers` have not been seen in either chain.
 fn find_duplicate_nullifier<'a, NullifierT, FinalizedStateContainsFn, NonFinalizedStateContainsFn>(
     revealed_nullifiers: impl IntoIterator<Item = &'a NullifierT>,
     finalized_state_contains: FinalizedStateContainsFn,


### PR DESCRIPTION
## Motivation

I'm not sure if this is any better than what's there now but this is related to the new `no_duplicate_nullifiers` fn in https://github.com/ZcashFoundation/zebra/pull/5716. 

I'm open to other suggestions.

## Review

Reviewers of https://github.com/ZcashFoundation/zebra/pull/5716 can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?
