### PR TITLE
change(docs): Fix typos in Zebra book treestate RFC draft

### DIFF
--- a/book/src/dev/rfcs/drafts/0005-treestate.md
+++ b/book/src/dev/rfcs/drafts/0005-treestate.md
@@ -118,7 +118,7 @@ treestate anchor of previous `JoinSplit` in this transaction, and we have to wai
 for that one to be parsed and its root computed to check that ours is
 valid. Luckily, it can only be a previous `JoinSplit` in this transaction, and is
 [usually the immediately previous one](zcashd), so the set of candidate anchors
-is smaller for earlier `JoinSplit`s in a transcation, but larger for the later
+is smaller for earlier `JoinSplit`s in a transaction, but larger for the later
 ones. For these `JoinSplit`s, they can be validated independently of their
 anchor's finalization status as long as the final check of the anchor is done,
 when available, such as at the Transaction level after all the `JoinSplit`s have
@@ -146,7 +146,7 @@ order and if they have `Spend`s and/or `Output`s, we update our Nullifer set for
 the block as nullifiers are revealed in `Spend` descriptions, and update our note
 commitment tree as `NoteCommitment`s are revealed in `Output` descriptions, adding
 them as leaves in positions according to their order as they appear transaction
-to transction, output to output, in the block. This can be done independent of
+to transaction, output to output, in the block. This can be done independent of
 the transaction validations. When the Sapling transactions are all validated,
 the `NoteCommitmentTree` root should be computed: this is the anchor for this
 block. For Sapling and Blossom blocks, we need to check that this root matches

--- a/zebrad/tests/common/lightwalletd/wallet_grpc_test.rs
+++ b/zebrad/tests/common/lightwalletd/wallet_grpc_test.rs
@@ -196,7 +196,7 @@ pub async fn run() -> Result<()> {
         counter += 1;
     }
 
-    // Get the first transction of the first block in the mainnet
+    // Get the first transaction of the first block in the mainnet
     let hash = zebra_test::vectors::BLOCK_MAINNET_1_BYTES
         .zcash_deserialize_into::<Block>()
         .expect("block should deserialize")


### PR DESCRIPTION
## Motivation

Fixes typos in treestate RFC draft and a test comment.

Credit to @rex4539 who originally authored the change in https://github.com/ZcashFoundation/zebra/pull/5727.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?
