### PR TITLE
change(log): Log loaded config path when Zebra starts up

### DIFF
--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -216,10 +216,7 @@ impl Application for ZebradApp {
         // report an error to the terminal if it occurs.
         let config = match command.config_path() {
             Some(path) => match self.load_config(&path) {
-                Ok(config) => {
-                    info!(config_path = ?path, ?config, "loaded zebrad config");
-                    config
-                }
+                Ok(config) => config,
                 Err(e) => {
                     status_err!("Zebra could not parse the provided config file. This might mean you are using a deprecated format of the file. You can generate a valid config by running \"zebrad generate\", and diff it against yours to examine any format inconsistencies.");
                     return Err(e);
@@ -405,6 +402,7 @@ impl Application for ZebradApp {
         // Log git metadata and platform info when zebrad starts up
         if is_server {
             tracing::info!("Diagnostic {}", metadata_section);
+            info!(config_path = ?command.config_path(), ?config, "loaded zebrad config");
         }
 
         // Activate the global span, so it's visible when we load the other

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -216,7 +216,10 @@ impl Application for ZebradApp {
         // report an error to the terminal if it occurs.
         let config = match command.config_path() {
             Some(path) => match self.load_config(&path) {
-                Ok(config) => config,
+                Ok(config) => {
+                    info!(config_path = ?path, ?config, "loaded zebrad config");
+                    config
+                }
                 Err(e) => {
                     status_err!("Zebra could not parse the provided config file. This might mean you are using a deprecated format of the file. You can generate a valid config by running \"zebrad generate\", and diff it against yours to examine any format inconsistencies.");
                     return Err(e);

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -402,7 +402,7 @@ impl Application for ZebradApp {
         // Log git metadata and platform info when zebrad starts up
         if is_server {
             tracing::info!("Diagnostic {}", metadata_section);
-            info!(config_path = ?command.config_path(), ?config, "loaded zebrad config");
+            info!(config_path = ?command.config_path(), config = ?cfg_ref, "loaded zebrad config");
         }
 
         // Activate the global span, so it's visible when we load the other

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -100,7 +100,6 @@ pub struct StartCmd {
 impl StartCmd {
     async fn start(&self) -> Result<(), Report> {
         let config = app_config().clone();
-        info!(?config);
 
         info!("initializing node state");
         let (_, max_checkpoint_height) = zebra_consensus::chain::init_checkpoint_list(


### PR DESCRIPTION
## Motivation

1. We need to check the correct Docker config is loaded in ticket #5168
2. Users need to know what config they are loading so they can debug config issues

## Solution

- Log the config path and fields for all Zebra server commands
- Remove a duplicate config fields log for the start command

## Review

Anyone can review this routine PR.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Testing in #5168 