### PR TITLE
fix(ci): Remove failing arm64 lightwalletd builds

### DIFF
--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -91,12 +91,14 @@ jobs:
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v2
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: all
+      # Currently failing with:
+      # Error response from daemon: Head "https://registry-1.docker.io/v2/tonistiigi/binfmt/manifests/latest": received unexpected HTTP status: 503 Service Unavailable
+      #- name: Set up QEMU
+      #  id: qemu
+      #  uses: docker/setup-qemu-action@v2
+      #  with:
+      #    image: tonistiigi/binfmt:latest
+      #    platforms: all
 
       # Setup Docker Buildx to allow use of docker cache layers from GH
       - name: Set up Docker Buildx
@@ -133,7 +135,8 @@ jobs:
           file: ./zebra/docker/zcash-lightwalletd/Dockerfile
           platforms: |
             linux/amd64
-            linux/arm64
+          # Disabled due to QEMU docker image failure
+          # linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true


### PR DESCRIPTION
## Motivation

The QEMU install step is currently failing in an unrelated PR:
> Error response from daemon: Head "https://registry-1.docker.io/v2/tonistiigi/binfmt/manifests/latest": received unexpected HTTP status: 503 Service Unavailable

https://github.com/ZcashFoundation/zebra/actions/runs/3569163606/jobs/5998829876#step:6:142

## Solution

We don't support arm64 or use it in our tests, so we can just remove it for now.

## Review

This is failing all CI, so it is critical.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

