### PR TITLE
fix(rust): Make Zebra build with the latest nightly Rust

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -151,6 +151,7 @@ impl Block {
     pub fn orchard_nullifiers(&self) -> impl Iterator<Item = &orchard::Nullifier> {
         // Work around a compiler panic (ICE) with flat_map():
         // https://github.com/rust-lang/rust/issues/105044
+        #[allow(clippy::needless_collect)]
         let nullifiers: Vec<_> = self
             .transactions
             .iter()

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -149,9 +149,15 @@ impl Block {
 
     /// Access the [`orchard::Nullifier`]s from all transactions in this block.
     pub fn orchard_nullifiers(&self) -> impl Iterator<Item = &orchard::Nullifier> {
-        self.transactions
+        // Work around a compiler panic (ICE) with flat_map():
+        // https://github.com/rust-lang/rust/issues/105044
+        let nullifiers: Vec<_> = self
+            .transactions
             .iter()
             .flat_map(|transaction| transaction.orchard_nullifiers())
+            .collect();
+
+        nullifiers.into_iter()
     }
 
     /// Count how many Sapling transactions exist in a block,

--- a/zebra-network/src/isolated/tests/vectors.rs
+++ b/zebra-network/src/isolated/tests/vectors.rs
@@ -120,7 +120,6 @@ async fn connect_isolated_sends_anonymised_version_message_mem_net(network: Netw
 
 /// Wait to receive a version message on `inbound_stream`,
 /// then check that it is correctly anonymised.
-#[track_caller]
 async fn check_version_message<PeerTransport>(
     network: Network,
     inbound_stream: &mut Framed<PeerTransport, Codec>,

--- a/zebra-network/src/peer/client/tests.rs
+++ b/zebra-network/src/peer/client/tests.rs
@@ -90,10 +90,12 @@ impl ClientTestHarness {
 
     /// Drops the mocked heartbeat shutdown receiver endpoint.
     pub fn drop_heartbeat_shutdown_receiver(&mut self) {
-        let _ = self
+        let hearbeat_future = self
             .shutdown_receiver
             .take()
-            .expect("heartbeat shutdown receiver endpoint has already been dropped");
+            .expect("unexpected test failure: heartbeat shutdown receiver endpoint has already been dropped");
+
+        std::mem::drop(hearbeat_future);
     }
 
     /// Closes the receiver endpoint of [`ClientRequest`]s that are supposed to be sent to the

--- a/zebra-network/src/peer_set/set/tests/prop.rs
+++ b/zebra-network/src/peer_set/set/tests/prop.rs
@@ -145,7 +145,8 @@ proptest! {
             }
 
             // Send a request to all peers
-            let _ = peer_set.route_broadcast(Request::AdvertiseBlock(block_hash));
+            let response_future = peer_set.route_broadcast(Request::AdvertiseBlock(block_hash));
+            std::mem::drop(response_future);
 
             // Check how many peers received the request
             let mut received = 0;
@@ -213,7 +214,8 @@ proptest! {
                 let number_of_peers_to_broadcast = peer_set.number_of_peers_to_broadcast();
 
                 // Send a request to all peers we have now
-                let _ = peer_set.route_broadcast(Request::AdvertiseBlock(block_hash));
+                let response_future = peer_set.route_broadcast(Request::AdvertiseBlock(block_hash));
+                std::mem::drop(response_future);
 
                 // Check how many peers received the request
                 let mut received = 0;
@@ -273,7 +275,8 @@ proptest! {
             }
 
             // this will panic as expected
-            let _ = peer_set.route_broadcast(Request::AdvertiseBlock(block_hash));
+            let response_future = peer_set.route_broadcast(Request::AdvertiseBlock(block_hash));
+            std::mem::drop(response_future);
 
             Ok::<_, TestCaseError>(())
         })?;

--- a/zebra-state/src/service/finalized_state/zebra_db/metrics.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/metrics.rs
@@ -38,7 +38,7 @@ pub(crate) fn block_precommit_metrics(block: &Block, hash: block::Hash, height: 
     let orchard_nullifier_count: usize = block
         .transactions
         .iter()
-        .map(|t| t.orchard_nullifiers().into_iter().count())
+        .map(|t| t.orchard_nullifiers().count())
         .sum();
 
     tracing::debug!(

--- a/zebra-state/src/service/finalized_state/zebra_db/metrics.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/metrics.rs
@@ -33,11 +33,13 @@ pub(crate) fn block_precommit_metrics(block: &Block, hash: block::Hash, height: 
         .flat_map(|t| t.sapling_nullifiers())
         .count();
 
-    let orchard_nullifier_count = block
+    // Work around a compiler panic (ICE) with flat_map():
+    // https://github.com/rust-lang/rust/issues/105044
+    let orchard_nullifier_count: usize = block
         .transactions
         .iter()
-        .flat_map(|t| t.orchard_nullifiers())
-        .count();
+        .map(|t| t.orchard_nullifiers().into_iter().count())
+        .sum();
 
     tracing::debug!(
         ?hash,


### PR DESCRIPTION
## Motivation

Zebra doesn't build on the latest nightly Rust due to a compiler bug:
https://github.com/rust-lang/rust/issues/105044

## Solution

It seems like it's going to be tricky to diagnose the bug, so I rewrote the code to avoid it.

I also dealt with some new clippy lints and compiler warnings.

## Review

Anyone can review this fix. It's not urgent.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

