### PR TITLE
change(state): Check block and transaction Sprout anchors in parallel

### DIFF
--- a/zebra-state/src/service/check/anchors.rs
+++ b/zebra-state/src/service/check/anchors.rs
@@ -333,12 +333,8 @@ pub(crate) fn block_sapling_orchard_anchors_refer_to_final_treestates(
     parent_chain: &Arc<Chain>,
     prepared: &PreparedBlock,
 ) -> Result<(), ValidateContextError> {
-    prepared
-        .block
-        .transactions
-        .par_iter()
-        .enumerate()
-        .try_for_each(|(tx_index_in_block, transaction)| {
+    prepared.block.transactions.iter().enumerate().try_for_each(
+        |(tx_index_in_block, transaction)| {
             sapling_orchard_anchors_refer_to_final_treestates(
                 finalized_state,
                 Some(parent_chain),
@@ -347,7 +343,8 @@ pub(crate) fn block_sapling_orchard_anchors_refer_to_final_treestates(
                 Some(tx_index_in_block),
                 Some(prepared.height),
             )
-        })
+        },
+    )
 }
 
 /// Accepts a [`ZebraDb`], [`Arc<Chain>`](Chain), and [`PreparedBlock`].

--- a/zebra-state/src/service/check/anchors.rs
+++ b/zebra-state/src/service/check/anchors.rs
@@ -454,39 +454,67 @@ pub(crate) fn tx_anchors_refer_to_final_treestates(
     parent_chain: Option<&Arc<Chain>>,
     unmined_tx: &UnminedTx,
 ) -> Result<(), ValidateContextError> {
-    sapling_orchard_anchors_refer_to_final_treestates(
-        finalized_state,
-        parent_chain,
-        &unmined_tx.transaction,
-        unmined_tx.id.mined_id(),
-        None,
-        None,
-    )?;
+    if unmined_tx.transaction.has_sprout_joinsplit_data() {
+        let mut sprout_anchors_result = None;
+        let mut sapling_orchard_anchors_result = None;
+        rayon::in_place_scope_fifo(|s| {
+            // This check is expensive, because it updates a note commitment tree for each sprout JoinSplit.
+            // Since we could be processing attacker-controlled mempool transactions, we need to run each one
+            // in its own thread, separately from tokio's blocking I/O threads. And if we are under heavy load,
+            // we want verification to finish in order, so that later transactions can't delay earlier ones.
+            s.spawn_fifo(|_s| {
+                let mut sprout_final_treestates = HashMap::new();
 
-    let mut sprout_final_treestates = HashMap::new();
+                fetch_sprout_final_treestates(
+                    &mut sprout_final_treestates,
+                    finalized_state,
+                    parent_chain,
+                    &unmined_tx.transaction,
+                    None,
+                    None,
+                );
 
-    fetch_sprout_final_treestates(
-        &mut sprout_final_treestates,
-        finalized_state,
-        parent_chain,
-        &unmined_tx.transaction,
-        None,
-        None,
-    );
+                tracing::trace!(
+                    sprout_final_treestate_count = ?sprout_final_treestates.len(),
+                    ?sprout_final_treestates,
+                    "received sprout final treestate anchors",
+                );
 
-    tracing::trace!(
-        sprout_final_treestate_count = ?sprout_final_treestates.len(),
-        ?sprout_final_treestates,
-        "received sprout final treestate anchors",
-    );
+                sprout_anchors_result = Some(sprout_anchors_refer_to_treestates(
+                    &sprout_final_treestates,
+                    &unmined_tx.transaction,
+                    unmined_tx.id.mined_id(),
+                    None,
+                    None,
+                ));
+            });
 
-    sprout_anchors_refer_to_treestates(
-        &sprout_final_treestates,
-        &unmined_tx.transaction,
-        unmined_tx.id.mined_id(),
-        None,
-        None,
-    )?;
+            s.spawn_fifo(|_s| {
+                sapling_orchard_anchors_result =
+                    Some(sapling_orchard_anchors_refer_to_final_treestates(
+                        finalized_state,
+                        parent_chain,
+                        &unmined_tx.transaction,
+                        unmined_tx.id.mined_id(),
+                        None,
+                        None,
+                    ));
+            });
+        });
+
+        sprout_anchors_result.expect("scope has finished")?;
+        sapling_orchard_anchors_result.expect("scope has finished")?;
+    } else {
+        // If there are no sprout transactions in the block, avoid running a rayon scope
+        sapling_orchard_anchors_refer_to_final_treestates(
+            finalized_state,
+            parent_chain,
+            &unmined_tx.transaction,
+            unmined_tx.id.mined_id(),
+            None,
+            None,
+        )?;
+    }
 
     Ok(())
 }

--- a/zebra-state/src/service/check/anchors.rs
+++ b/zebra-state/src/service/check/anchors.rs
@@ -451,26 +451,35 @@ pub(crate) fn tx_anchors_refer_to_final_treestates(
     parent_chain: Option<&Arc<Chain>>,
     unmined_tx: &UnminedTx,
 ) -> Result<(), ValidateContextError> {
+    sapling_orchard_anchors_refer_to_final_treestates(
+        finalized_state,
+        parent_chain,
+        &unmined_tx.transaction,
+        unmined_tx.id.mined_id(),
+        None,
+        None,
+    )?;
+
+    // If there are no sprout transactions in the block, avoid running a rayon scope
     if unmined_tx.transaction.has_sprout_joinsplit_data() {
+        let mut sprout_final_treestates = HashMap::new();
+
+        fetch_sprout_final_treestates(
+            &mut sprout_final_treestates,
+            finalized_state,
+            parent_chain,
+            &unmined_tx.transaction,
+            None,
+            None,
+        );
+
         let mut sprout_anchors_result = None;
-        let mut sapling_orchard_anchors_result = None;
         rayon::in_place_scope_fifo(|s| {
             // This check is expensive, because it updates a note commitment tree for each sprout JoinSplit.
             // Since we could be processing attacker-controlled mempool transactions, we need to run each one
             // in its own thread, separately from tokio's blocking I/O threads. And if we are under heavy load,
             // we want verification to finish in order, so that later transactions can't delay earlier ones.
             s.spawn_fifo(|_s| {
-                let mut sprout_final_treestates = HashMap::new();
-
-                fetch_sprout_final_treestates(
-                    &mut sprout_final_treestates,
-                    finalized_state,
-                    parent_chain,
-                    &unmined_tx.transaction,
-                    None,
-                    None,
-                );
-
                 tracing::trace!(
                     sprout_final_treestate_count = ?sprout_final_treestates.len(),
                     ?sprout_final_treestates,
@@ -485,32 +494,9 @@ pub(crate) fn tx_anchors_refer_to_final_treestates(
                     None,
                 ));
             });
-
-            s.spawn_fifo(|_s| {
-                sapling_orchard_anchors_result =
-                    Some(sapling_orchard_anchors_refer_to_final_treestates(
-                        finalized_state,
-                        parent_chain,
-                        &unmined_tx.transaction,
-                        unmined_tx.id.mined_id(),
-                        None,
-                        None,
-                    ));
-            });
         });
 
         sprout_anchors_result.expect("scope has finished")?;
-        sapling_orchard_anchors_result.expect("scope has finished")?;
-    } else {
-        // If there are no sprout transactions in the block, avoid running a rayon scope
-        sapling_orchard_anchors_refer_to_final_treestates(
-            finalized_state,
-            parent_chain,
-            &unmined_tx.transaction,
-            unmined_tx.id.mined_id(),
-            None,
-            None,
-        )?;
     }
 
     Ok(())


### PR DESCRIPTION
## Motivation

We want to run these anchor verifications on a CPU-bound thread pool.

## Solution

- Use a parallel iterator when checking `sprout_anchors_refer_to_treestates(..)` for a block if `sprout_final_treestates` is not empty.
- Use `in_place_scope_fifo` for running sprout anchors checks on an `UnminedTx` if the transaction has sprout `joinsplit_data`
 
## Review

Anyone can review.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [x] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?
