### PR TITLE
fix(lint): Fix result_large_err lint by making errors smaller, improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5481,6 +5481,8 @@ dependencies = [
  "displaydoc",
  "hex",
  "lazy_static",
+ "proptest",
+ "proptest-derive",
  "thiserror",
  "zcash_script",
  "zebra-chain",

--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -18,6 +18,9 @@ use byteorder::{ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod arbitrary;
 
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
 #[cfg(test)]
 mod tests;
 
@@ -411,6 +414,7 @@ where
 
 #[derive(thiserror::Error, Debug, displaydoc::Display, Clone, PartialEq, Eq)]
 #[allow(missing_docs)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 /// Errors that can be returned when validating `Amount`s
 pub enum Error {
     /// input {value} is outside of valid range for zatoshi Amount, valid_range={range:?}
@@ -420,6 +424,7 @@ pub enum Error {
     },
 
     /// {value} could not be converted to an i64 Amount
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     Convert {
         value: i128,
         source: std::num::TryFromIntError,

--- a/zebra-chain/src/block/commitment.rs
+++ b/zebra-chain/src/block/commitment.rs
@@ -9,6 +9,9 @@ use crate::{
     sapling,
 };
 
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
 /// Zcash blocks contain different kinds of commitments to their contents,
 /// depending on the network and height.
 ///
@@ -333,6 +336,7 @@ impl FromHex for ChainHistoryBlockTxAuthCommitmentHash {
 /// for a non-enumerated reason.
 #[allow(missing_docs)]
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum CommitmentError {
     #[error(
         "invalid final sapling root: expected {:?}, actual: {:?}",

--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -89,13 +89,17 @@ pub struct Header {
 #[allow(missing_docs)]
 #[derive(Error, Debug)]
 pub enum BlockTimeError {
-    #[error("invalid time {0:?} in block header {1:?} {2:?}: block time is more than 2 hours in the future ({3:?}). Hint: check your machine's date, time, and time zone.")]
-    InvalidBlockTime(
-        DateTime<Utc>,
-        crate::block::Height,
-        crate::block::Hash,
-        DateTime<Utc>,
-    ),
+    #[error(
+        "invalid time {invalid_time:?} in block header {block_height:?} {block_hash:?}: \
+         block time is more than 2 hours in the future (more than {max_valid_time:?}). \
+         Hint: check your machine's date, time, and time zone."
+    )]
+    InvalidBlockTime {
+        block_hash: Hash,
+        invalid_time: DateTime<Utc>,
+        max_valid_time: DateTime<Utc>,
+        block_height: Height,
+    },
 }
 
 impl Header {
@@ -114,12 +118,12 @@ impl Header {
         if self.time <= two_hours_in_the_future {
             Ok(())
         } else {
-            Err(BlockTimeError::InvalidBlockTime(
-                self.time,
-                *height,
-                *hash,
-                two_hours_in_the_future,
-            ))?
+            Err(BlockTimeError::InvalidBlockTime {
+                invalid_time: self.time,
+                block_height: *height,
+                block_hash: *hash,
+                max_valid_time: two_hours_in_the_future,
+            })?
         }
     }
 }

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -33,6 +33,9 @@ use crate::serialization::{
     serde_helpers, ReadZcashExt, SerializationError, ZcashDeserialize, ZcashSerialize,
 };
 
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
 /// The type that is used to update the note commitment tree.
 ///
 /// Unfortunately, this is not the same as `orchard::NoteCommitment`.
@@ -254,6 +257,7 @@ impl<'de> serde::Deserialize<'de> for Node {
 
 #[derive(Error, Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[allow(missing_docs)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum NoteCommitmentTreeError {
     #[error("The note commitment tree is full")]
     FullTree,

--- a/zebra-chain/src/parallel/tree.rs
+++ b/zebra-chain/src/parallel/tree.rs
@@ -9,6 +9,9 @@ use crate::{
     orchard, sapling, sprout,
 };
 
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
 /// An argument wrapper struct for note commitment trees.
 #[derive(Clone, Debug)]
 pub struct NoteCommitmentTrees {
@@ -24,6 +27,7 @@ pub struct NoteCommitmentTrees {
 
 /// Note commitment tree errors.
 #[derive(Error, Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum NoteCommitmentTreeError {
     /// A sprout tree error
     #[error("sprout error: {0}")]

--- a/zebra-chain/src/primitives/redpallas/error.rs
+++ b/zebra-chain/src/primitives/redpallas/error.rs
@@ -1,6 +1,12 @@
+//! Errors for redpallas operations.
+
 use thiserror::Error;
 
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
 #[derive(Error, Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum Error {
     #[error("Malformed signing key encoding.")]
     MalformedSigningKey,

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -19,13 +19,11 @@ use std::{
 };
 
 use bitvec::prelude::*;
-
 use incrementalmerkletree::{
     bridgetree::{self, Leaf},
     Frontier,
 };
 use lazy_static::lazy_static;
-
 use thiserror::Error;
 use zcash_encoding::{Optional, Vector};
 use zcash_primitives::merkle_tree::{self, Hashable};
@@ -35,6 +33,9 @@ use super::commitment::pedersen_hashes::pedersen_hash;
 use crate::serialization::{
     serde_helpers, ReadZcashExt, SerializationError, ZcashDeserialize, ZcashSerialize,
 };
+
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
 
 /// The type that is used to update the note commitment tree.
 ///
@@ -257,6 +258,7 @@ impl<'de> serde::Deserialize<'de> for Node {
 
 #[derive(Error, Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[allow(missing_docs)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum NoteCommitmentTreeError {
     #[error("The note commitment tree is full")]
     FullTree,

--- a/zebra-chain/src/sprout/tree.rs
+++ b/zebra-chain/src/sprout/tree.rs
@@ -15,13 +15,13 @@ use std::{fmt, ops::Deref};
 use byteorder::{BigEndian, ByteOrder};
 use incrementalmerkletree::{bridgetree, Frontier};
 use lazy_static::lazy_static;
+use sha2::digest::generic_array::GenericArray;
 use thiserror::Error;
 
 use super::commitment::NoteCommitment;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
-use sha2::digest::generic_array::GenericArray;
 
 /// Sprout note commitment trees have a max depth of 29.
 ///
@@ -182,6 +182,7 @@ impl<'de> serde::Deserialize<'de> for Node {
 
 #[derive(Error, Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[allow(missing_docs)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum NoteCommitmentTreeError {
     #[error("the note commitment tree is full")]
     FullTree,

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -59,8 +59,6 @@ use crate::{
 /// activation, we do not validate any pre-Sapling transaction types.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Serialize))]
-// XXX consider boxing the Optional fields of V4 and V5 txs
-#[allow(clippy::large_enum_variant)]
 pub enum Transaction {
     /// A fully transparent transaction (`version = 1`).
     V1 {

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -14,6 +14,9 @@ use crate::{amount::MAX_MONEY, transaction::Transaction};
 #[cfg(any(test, feature = "proptest-impl"))]
 mod arbitrary;
 
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
 #[cfg(test)]
 mod tests;
 
@@ -385,8 +388,9 @@ impl ValueBalance<NonNegative> {
     }
 }
 
-#[derive(thiserror::Error, Debug, displaydoc::Display, Clone, PartialEq, Eq)]
 /// Errors that can be returned when validating a [`ValueBalance`]
+#[derive(thiserror::Error, Debug, displaydoc::Display, Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum ValueBalanceError {
     /// transparent amount error {0}
     Transparent(amount::Error),

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -7,8 +7,20 @@ edition = "2021"
 
 [features]
 default = []
+
+# Production features that activate extra dependencies, or extra features in dependencies
+
+# Experimental mining RPC support
 getblocktemplate-rpcs = []
-proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl", "zebra-state/proptest-impl"]
+
+# Test-only features
+proptest-impl = [
+    "proptest",
+    "proptest-derive",
+    "zebra-script/proptest-impl",
+    "zebra-state/proptest-impl",
+    "zebra-chain/proptest-impl"
+]
 
 [dependencies]
 blake2b_simd = "1.0.0"

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -53,7 +53,7 @@ pub struct BlockVerifier<S, V> {
 #[derive(Debug, Error)]
 pub enum VerifyBlockError {
     #[error("unable to verify depth for block {hash} from chain state during block verification")]
-    Depth { source: BoxError, hash: block::Hash },
+    Depth { hash: block::Hash, source: BoxError },
 
     #[error(transparent)]
     Block {
@@ -157,7 +157,10 @@ where
             // Zebra does not support heights greater than
             // [`block::Height::MAX`].
             if height > block::Height::MAX {
-                Err(BlockError::MaxHeight(height, hash, block::Height::MAX))?;
+                Err(BlockError::MaxHeight {
+                    invalid_height: height,
+                    block_hash: hash,
+                })?;
             }
 
             // Do the difficulty checks first, to raise the threshold for

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -77,6 +77,17 @@ pub enum VerifyBlockError {
     Transaction(#[from] TransactionError),
 }
 
+impl VerifyBlockError {
+    /// Returns `true` if this is definitely a duplicate request.
+    /// Some duplicate requests might not be detected, and therefore return `false`.
+    pub fn is_duplicate_request(&self) -> bool {
+        match self {
+            VerifyBlockError::Block { source, .. } => source.is_duplicate_request(),
+            _ => false,
+        }
+    }
+}
+
 /// The maximum allowed number of legacy signature check operations in a block.
 ///
 /// This consensus rule is not documented, so Zebra follows the `zcashd` implementation.

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -859,8 +859,8 @@ pub enum VerifyCheckpointError {
     },
     #[error("rejected older of duplicate verification requests for block at {height:?} {hash:?}")]
     NewerRequest {
-        height: block::Height,
         hash: block::Hash,
+        height: block::Height,
     },
     #[error("the block {hash:?} does not have a coinbase height")]
     CoinbaseHeight { hash: block::Hash },

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -25,6 +25,7 @@ proptest-impl = [
     "proptest",
     "proptest-derive",
     "zebra-consensus/proptest-impl",
+    "zebra-script/proptest-impl",
     "zebra-state/proptest-impl",
     "zebra-chain/proptest-impl",
 ]

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -5,7 +5,15 @@ authors = ["Zcash Foundation <zebra@zfnd.org>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
+
+# Test-only features
+proptest-impl = [
+    "proptest",
+    "proptest-derive",
+    "zebra-chain/proptest-impl"
+]
 
 [dependencies]
 zcash_script = "0.1.8"
@@ -15,7 +23,15 @@ zebra-chain = { path = "../zebra-chain" }
 thiserror = "1.0.37"
 displaydoc = "0.2.3"
 
+# Test-only feature proptest-impl
+proptest = { version = "0.10.1", optional = true }
+proptest-derive = { version = "0.3.0", optional = true }
+
 [dev-dependencies]
 hex = "0.4.3"
 lazy_static = "1.4.0"
+
+proptest = "0.10.1"
+proptest-derive = "0.3.0"
+
 zebra-test = { path = "../zebra-test" }

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -22,8 +22,12 @@ use zebra_chain::{
     transparent,
 };
 
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
 #[derive(Copy, Clone, Debug, Display, Error, PartialEq, Eq)]
 #[non_exhaustive]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 /// An Error type representing the error codes returned from zcash_script.
 pub enum Error {
     /// script failed to verify

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [features]
+default = []
 
 # Production features that activate extra dependencies, or extra features in dependencies
 
@@ -47,6 +48,8 @@ tower = { version = "0.4.13", features = ["buffer", "util"] }
 tracing = "0.1.37"
 
 zebra-chain = { path = "../zebra-chain" }
+
+# Test-only feature proptest-impl
 zebra-test = { path = "../zebra-test/", optional = true }
 
 proptest = { version = "0.10.1", optional = true }

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -167,10 +167,10 @@ pub enum ValidateContextError {
     )]
     #[non_exhaustive]
     NegativeRemainingTransactionValue {
-        amount_error: amount::Error,
-        height: block::Height,
-        tx_index_in_block: usize,
         transaction_hash: transaction::Hash,
+        amount_error: amount::Error,
+        tx_index_in_block: usize,
+        height: block::Height,
     },
 
     #[error(
@@ -180,10 +180,10 @@ pub enum ValidateContextError {
     )]
     #[non_exhaustive]
     CalculateRemainingTransactionValue {
-        amount_error: amount::Error,
-        height: block::Height,
-        tx_index_in_block: usize,
         transaction_hash: transaction::Hash,
+        amount_error: amount::Error,
+        tx_index_in_block: usize,
+        height: block::Height,
     },
 
     #[error(
@@ -193,10 +193,10 @@ pub enum ValidateContextError {
     )]
     #[non_exhaustive]
     CalculateTransactionValueBalances {
-        value_balance_error: ValueBalanceError,
-        height: block::Height,
-        tx_index_in_block: usize,
         transaction_hash: transaction::Hash,
+        value_balance_error: ValueBalanceError,
+        tx_index_in_block: usize,
+        height: block::Height,
     },
 
     #[error(
@@ -207,11 +207,11 @@ pub enum ValidateContextError {
     )]
     #[non_exhaustive]
     CalculateBlockChainValueChange {
-        value_balance_error: ValueBalanceError,
-        height: block::Height,
         block_hash: block::Hash,
+        value_balance_error: ValueBalanceError,
         transaction_count: usize,
         spent_utxo_count: usize,
+        height: block::Height,
     },
 
     #[error(
@@ -223,9 +223,9 @@ pub enum ValidateContextError {
     )]
     #[non_exhaustive]
     AddValuePool {
-        value_balance_error: ValueBalanceError,
         chain_value_pools: ValueBalance<NonNegative>,
         block_value_pool_change: ValueBalance<NegativeAllowed>,
+        value_balance_error: ValueBalanceError,
         height: Option<block::Height>,
     },
 
@@ -245,10 +245,10 @@ pub enum ValidateContextError {
     )]
     #[non_exhaustive]
     UnknownSproutAnchor {
-        anchor: sprout::tree::Root,
-        height: Option<block::Height>,
-        tx_index_in_block: Option<usize>,
         transaction_hash: transaction::Hash,
+        anchor: sprout::tree::Root,
+        tx_index_in_block: Option<usize>,
+        height: Option<block::Height>,
     },
 
     #[error(
@@ -257,10 +257,10 @@ pub enum ValidateContextError {
     )]
     #[non_exhaustive]
     UnknownSaplingAnchor {
-        anchor: sapling::tree::Root,
-        height: Option<block::Height>,
-        tx_index_in_block: Option<usize>,
         transaction_hash: transaction::Hash,
+        anchor: sapling::tree::Root,
+        tx_index_in_block: Option<usize>,
+        height: Option<block::Height>,
     },
 
     #[error(
@@ -269,10 +269,10 @@ pub enum ValidateContextError {
     )]
     #[non_exhaustive]
     UnknownOrchardAnchor {
-        anchor: orchard::tree::Root,
-        height: Option<block::Height>,
-        tx_index_in_block: Option<usize>,
         transaction_hash: transaction::Hash,
+        anchor: orchard::tree::Root,
+        tx_index_in_block: Option<usize>,
+        height: Option<block::Height>,
     },
 }
 

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -16,6 +16,9 @@ use zebra_chain::{
 
 use crate::constants::MIN_TRANSPARENT_COINBASE_MATURITY;
 
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
 /// A wrapper for type erased errors that is itself clonable and implements the
 /// Error trait
 #[derive(Debug, Error, Clone)]
@@ -44,12 +47,14 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// An error describing the reason a block could not be committed to the state.
 #[derive(Debug, Error, PartialEq, Eq)]
 #[error("block is not contextually valid")]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct CommitBlockError(#[from] ValidateContextError);
 
 /// An error describing why a block failed contextual validation.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 #[allow(missing_docs)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum ValidateContextError {
     #[error("block parent not found in any chain")]
     #[non_exhaustive]
@@ -71,6 +76,7 @@ pub enum ValidateContextError {
 
     #[error("block time {candidate_time:?} is less than or equal to the median-time-past for the block {median_time_past:?}")]
     #[non_exhaustive]
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     TimeTooEarly {
         candidate_time: DateTime<Utc>,
         median_time_past: DateTime<Utc>,
@@ -78,6 +84,7 @@ pub enum ValidateContextError {
 
     #[error("block time {candidate_time:?} is greater than the median-time-past for the block plus 90 minutes {block_time_max:?}")]
     #[non_exhaustive]
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     TimeTooLate {
         candidate_time: DateTime<Utc>,
         block_time_max: DateTime<Utc>,
@@ -92,6 +99,7 @@ pub enum ValidateContextError {
 
     #[error("transparent double-spend: {outpoint:?} is spent twice in {location:?}")]
     #[non_exhaustive]
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     DuplicateTransparentSpend {
         outpoint: transparent::OutPoint,
         location: &'static str,
@@ -99,6 +107,7 @@ pub enum ValidateContextError {
 
     #[error("missing transparent output: possible double-spend of {outpoint:?} in {location:?}")]
     #[non_exhaustive]
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     MissingTransparentOutput {
         outpoint: transparent::OutPoint,
         location: &'static str,
@@ -224,7 +233,8 @@ pub enum ValidateContextError {
     NoteCommitmentTreeError(#[from] zebra_chain::parallel::tree::NoteCommitmentTreeError),
 
     #[error("error building the history tree")]
-    HistoryTreeError(#[from] Arc<HistoryTreeError>),
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
+    HistoryTreeError(#[from] HistoryTreeError),
 
     #[error("block contains an invalid commitment")]
     InvalidBlockCommitment(#[from] block::CommitmentError),

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -410,14 +410,12 @@ impl Chain {
                 .expect("Orchard anchors must exist for pre-fork blocks");
 
             let history_tree_mut = Arc::make_mut(&mut self.history_tree);
-            history_tree_mut
-                .push(
-                    self.network,
-                    block.block.clone(),
-                    *sapling_root,
-                    *orchard_root,
-                )
-                .map_err(Arc::new)?;
+            history_tree_mut.push(
+                self.network,
+                block.block.clone(),
+                *sapling_root,
+                *orchard_root,
+            )?;
         }
 
         Ok(())
@@ -911,14 +909,12 @@ impl Chain {
 
         // TODO: update the history trees in a rayon thread, if they show up in CPU profiles
         let history_tree_mut = Arc::make_mut(&mut self.history_tree);
-        history_tree_mut
-            .push(
-                self.network,
-                contextually_valid.block.clone(),
-                sapling_root,
-                orchard_root,
-            )
-            .map_err(Arc::new)?;
+        history_tree_mut.push(
+            self.network,
+            contextually_valid.block.clone(),
+            sapling_root,
+            orchard_root,
+        )?;
 
         self.history_trees_by_height
             .insert(height, self.history_tree.clone());

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -80,6 +80,8 @@ type InboundTxDownloads = TxDownloads<Timeout<Outbound>, Timeout<TxVerifier>, St
 ///
 /// Indicates whether it is enabled or disabled and, if enabled, contains
 /// the necessary data to run it.
+//
+// Zebra only has one mempool, so the enum variant size difference doesn't matter.
 #[allow(clippy::large_enum_variant)]
 enum ActiveState {
     /// The Mempool is disabled.

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -19,9 +19,6 @@ use zebra_chain::{
     chain_tip::ChainTip,
     parameters::genesis_hash,
 };
-use zebra_consensus::{
-    chain::VerifyChainError, BlockError, VerifyBlockError, VerifyCheckpointError,
-};
 use zebra_network as zn;
 use zebra_state as zs;
 
@@ -1008,7 +1005,6 @@ where
     ///
     /// See [`Self::handle_response`] for more details.
     #[allow(unknown_lints)]
-    #[allow(clippy::result_large_err)]
     fn handle_block_response(
         &mut self,
         response: Result<(Height, block::Hash), BlockDownloadVerifyError>,
@@ -1027,7 +1023,6 @@ where
     ///
     /// See [`Self::handle_response`] for more details.
     #[allow(unknown_lints)]
-    #[allow(clippy::result_large_err)]
     fn handle_hash_response(
         response: Result<IndexSet<block::Hash>, BlockDownloadVerifyError>,
     ) -> Result<IndexSet<block::Hash>, BlockDownloadVerifyError> {
@@ -1044,7 +1039,6 @@ where
     ///
     /// Returns `Err` if an unexpected error occurred, to force the synchronizer to restart.
     #[allow(unknown_lints)]
-    #[allow(clippy::result_large_err)]
     fn handle_response<T>(
         response: Result<T, BlockDownloadVerifyError>,
     ) -> Result<(), BlockDownloadVerifyError> {
@@ -1098,21 +1092,8 @@ where
     fn should_restart_sync(e: &BlockDownloadVerifyError) -> bool {
         match e {
             // Structural matches: downcasts
-            BlockDownloadVerifyError::Invalid {
-                error: VerifyChainError::Checkpoint(VerifyCheckpointError::AlreadyVerified { .. }),
-                ..
-            } => {
+            BlockDownloadVerifyError::Invalid { error, .. } if error.is_duplicate_request() => {
                 debug!(error = ?e, "block was already verified, possibly from a previous sync run, continuing");
-                false
-            }
-            BlockDownloadVerifyError::Invalid {
-                error:
-                    VerifyChainError::Block(VerifyBlockError::Block {
-                        source: BlockError::AlreadyInChain(_, _),
-                    }),
-                ..
-            } => {
-                debug!(error = ?e, "block is already in chain, possibly from a previous sync run, continuing");
                 false
             }
 
@@ -1140,12 +1121,15 @@ where
             }
 
             // String matches
-            BlockDownloadVerifyError::Invalid {
-                error: VerifyChainError::Block(VerifyBlockError::Commit(ref source)),
-                ..
-            } if format!("{source:?}").contains("block is already committed to the state")
-                || format!("{source:?}")
-                    .contains("block has already been sent to be committed to the state") =>
+            //
+            // We want to match VerifyChainError::Block(VerifyBlockError::Commit(ref source)),
+            // but that type is boxed.
+            // TODO:
+            // - turn this check into a function on VerifyChainError, like is_duplicate_request()
+            BlockDownloadVerifyError::Invalid { error, .. }
+                if format!("{error:?}").contains("block is already committed to the state")
+                    || format!("{error:?}")
+                        .contains("block has already been sent to be committed to the state") =>
             {
                 // TODO: improve this by checking the type (#2908)
                 debug!(error = ?e, "block is already committed or pending a commit, possibly from a previous sync run, continuing");

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -91,9 +91,9 @@ pub enum BlockDownloadVerifyError {
 
     #[error("error downloading block: {error:?} {hash:?}")]
     DownloadFailed {
+        hash: block::Hash,
         #[source]
         error: BoxError,
-        hash: block::Hash,
     },
 
     /// A downloaded block was a long way ahead of the state chain tip.
@@ -106,14 +106,14 @@ pub enum BlockDownloadVerifyError {
     /// chain, or blocks far ahead of the current state tip.
     #[error("downloaded block was too far ahead of the chain tip: {height:?} {hash:?}")]
     AboveLookaheadHeightLimit {
-        height: block::Height,
         hash: block::Hash,
+        height: block::Height,
     },
 
     #[error("downloaded block was too far behind the chain tip: {height:?} {hash:?}")]
     BehindTipHeightLimit {
-        height: block::Height,
         hash: block::Hash,
+        height: block::Height,
     },
 
     #[error("downloaded block had an invalid height: {hash:?}")]
@@ -121,18 +121,18 @@ pub enum BlockDownloadVerifyError {
 
     #[error("block failed consensus validation: {error:?} {height:?} {hash:?}")]
     Invalid {
+        hash: block::Hash,
         #[source]
         error: zebra_consensus::chain::VerifyChainError,
         height: block::Height,
-        hash: block::Hash,
     },
 
     #[error("block validation request failed: {error:?} {height:?} {hash:?}")]
     ValidationRequestError {
+        hash: block::Hash,
         #[source]
         error: BoxError,
         height: block::Height,
-        hash: block::Hash,
     },
 
     #[error("block download & verification was cancelled during download: {hash:?}")]
@@ -143,16 +143,16 @@ pub enum BlockDownloadVerifyError {
          to become ready: {height:?} {hash:?}"
     )]
     CancelledAwaitingVerifierReadiness {
-        height: block::Height,
         hash: block::Hash,
+        height: block::Height,
     },
 
     #[error(
         "block download & verification was cancelled during verification: {height:?} {hash:?}"
     )]
     CancelledDuringVerification {
-        height: block::Height,
         hash: block::Hash,
+        height: block::Height,
     },
 }
 


### PR DESCRIPTION
## Motivation

1. There are a lot more result_large_err lints on nightly, so we should probably actually fix them
2. We don't derive Arbitrary consistently for our error types
3. Some errors are boxed when they don't need to be

## Solution

- Reorder error fields so smaller fields are last, to remove padding
- Box very large (128-140 byte) error types, adding accessor methods as needed
- Make Arbitrary derives work for more errors

## Review

I'm opening this PR so we have a record of the changes for ticket #2908. Then I'm going to minimise it to what's needed for the lint.