### PR TITLE
fix(ci): update fake_peer_set test to avoid spurious failures

### DIFF
--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -78,13 +78,11 @@ async fn mempool_requests_for_transactions() {
         .await;
     match response {
         Ok(Response::TransactionIds(response)) => assert_eq!(response, added_transaction_ids),
-        Ok(Response::Nil) => if !added_transaction_ids.is_empty() {
-            info!(
-                "response {response:?} to `MempoolTransactionIds` request \
-                 should match added_transaction_ids {added_transaction_ids:?}, \
-                 ignoring test failure because this test is unreliable due to timing issues",
-            );
-        }
+        Ok(Response::Nil) => assert!(
+            added_transaction_ids.is_empty(),
+            "`MempoolTransactionIds` request should match added_transaction_ids {:?}, got Ok(Nil)",
+            added_transaction_ids
+        ),
         _ => unreachable!(
             "`MempoolTransactionIds` requests should always respond `Ok(Vec<UnminedTxId> | Nil)`, got {:?}",
             response
@@ -869,9 +867,6 @@ async fn setup(
         chain_tip_change.clone(),
     );
 
-    // Enable the mempool
-    mempool_service.enable(&mut recent_syncs).await;
-
     let sync_gossip_task_handle = tokio::spawn(sync::gossip_best_tip_block_hashes(
         sync_status.clone(),
         chain_tip_change.clone(),
@@ -893,6 +888,13 @@ async fn setup(
             .await
             .respond(Response::Nil);
     }
+
+    // Enable the mempool
+    // Note: this needs to be done after the mock peer set service has received the AdvertiseBlock
+    // request to ensure that the call to `last_tip_change` returns the chain tip block for block_one
+    // and not the genesis block, or else the transactions from the genesis block will be added to
+    // the mempool storage's rejection list and tests will fail.
+    mempool_service.enable(&mut recent_syncs).await;
 
     // Add transactions to the mempool, skipping verification and broadcast
     let mut added_transactions = Vec::new();

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -855,7 +855,8 @@ async fn setup(
         .unwrap();
     committed_blocks.push(block_one);
 
-    // Don't wait for the chain tip update here, we wait for AdvertiseBlock below.
+    // Don't wait for the chain tip update here, we wait for expect_request(AdvertiseBlock) below,
+    // which is called by the gossip_best_tip_block_hashes task once the chain tip changes.
 
     let (mut mempool_service, transaction_receiver) = Mempool::new(
         &MempoolConfig::default(),
@@ -866,6 +867,9 @@ async fn setup(
         latest_chain_tip.clone(),
         chain_tip_change.clone(),
     );
+
+    // Pretend we're close to tip
+    SyncStatus::sync_close_to_tip(&mut recent_syncs);
 
     let sync_gossip_task_handle = tokio::spawn(sync::gossip_best_tip_block_hashes(
         sync_status.clone(),


### PR DESCRIPTION
## Motivation

This test may still be unreliable due to timing issues if the transactions are being rejected because there is a second request in the `mempool_requests_for_transactions` for the same data that might also receive `Nil`.

Related to #5384.

## Solution

- Move `mempool.enable()` below `peer_set.expect_request().await` to wait for the second chain tip change

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?
