### PR TITLE
change(rpc): Return an error from getblocktemplate RPC if Zebra is still syncing lots of blocks

### DIFF
--- a/zebra-chain/src/chain_sync_status.rs
+++ b/zebra-chain/src/chain_sync_status.rs
@@ -1,5 +1,10 @@
 //! Defines method signatures for checking if the synchronizer is likely close to the network chain tip.
 
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
 /// An interface for checking if the synchronization is likely close to the network chain tip.
 pub trait ChainSyncStatus {
     /// Check if the synchronization is likely close to the network chain tip.
@@ -9,18 +14,19 @@ pub trait ChainSyncStatus {
 /// A mock [`ChainSyncStatus`] implementation that allows setting the status externally.
 #[derive(Clone, Default)]
 pub struct MockSyncStatus {
-    is_close_to_tip: bool,
+    is_close_to_tip: Arc<AtomicBool>,
 }
 
 impl MockSyncStatus {
     /// Sets mock sync status determining the return value of `is_close_to_tip()`
     pub fn set_is_close_to_tip(&mut self, is_close_to_tip: bool) {
-        self.is_close_to_tip = is_close_to_tip;
+        self.is_close_to_tip
+            .store(is_close_to_tip, Ordering::Release);
     }
 }
 
 impl ChainSyncStatus for MockSyncStatus {
     fn is_close_to_tip(&self) -> bool {
-        self.is_close_to_tip
+        self.is_close_to_tip.load(Ordering::Acquire)
     }
 }

--- a/zebra-chain/src/chain_sync_status.rs
+++ b/zebra-chain/src/chain_sync_status.rs
@@ -5,3 +5,22 @@ pub trait ChainSyncStatus {
     /// Check if the synchronization is likely close to the network chain tip.
     fn is_close_to_tip(&self) -> bool;
 }
+
+/// A mock [`ChainSyncStatus`] implementation that allows setting the status externally.
+#[derive(Clone, Default)]
+pub struct MockSyncStatus {
+    is_close_to_tip: bool,
+}
+
+impl MockSyncStatus {
+    /// Sets mock sync status determining the return value of `is_close_to_tip()`
+    pub fn set_is_close_to_tip(&mut self, is_close_to_tip: bool) {
+        self.is_close_to_tip = is_close_to_tip;
+    }
+}
+
+impl ChainSyncStatus for MockSyncStatus {
+    fn is_close_to_tip(&self) -> bool {
+        self.is_close_to_tip
+    }
+}

--- a/zebra-chain/src/chain_sync_status.rs
+++ b/zebra-chain/src/chain_sync_status.rs
@@ -1,0 +1,7 @@
+//! Defines method signatures for checking if the synchronizer is likely close to the network chain tip.
+
+/// An interface for checking if the synchronization is likely close to the network chain tip.
+pub trait ChainSyncStatus {
+    /// Check if the synchronization is likely close to the network chain tip.
+    fn is_close_to_tip(&self) -> bool;
+}

--- a/zebra-chain/src/chain_sync_status.rs
+++ b/zebra-chain/src/chain_sync_status.rs
@@ -21,12 +21,12 @@ impl MockSyncStatus {
     /// Sets mock sync status determining the return value of `is_close_to_tip()`
     pub fn set_is_close_to_tip(&mut self, is_close_to_tip: bool) {
         self.is_close_to_tip
-            .store(is_close_to_tip, Ordering::Release);
+            .store(is_close_to_tip, Ordering::SeqCst);
     }
 }
 
 impl ChainSyncStatus for MockSyncStatus {
     fn is_close_to_tip(&self) -> bool {
-        self.is_close_to_tip.load(Ordering::Acquire)
+        self.is_close_to_tip.load(Ordering::SeqCst)
     }
 }

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -20,6 +20,7 @@ extern crate tracing;
 
 pub mod amount;
 pub mod block;
+pub mod chain_sync_status;
 pub mod chain_tip;
 pub mod diagnostic;
 pub mod fmt;

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -42,10 +42,13 @@ pub mod config;
 pub mod constants;
 pub(crate) mod types;
 
-/// The max estimated distance to the chain tip for the getblocktemplate method
-// Set to 30 in case the local time is a little ahead.
-// TODO: Replace this with SyncStatus
-const MAX_ESTIMATED_DISTANCE_TO_NETWORK_CHAIN_TIP: i32 = 30;
+/// The max estimated distance to the chain tip for the getblocktemplate method.
+///
+/// Allows the same clock skew as the Zcash network, which is 100 blocks, based on the standard rule:
+/// > A full validator MUST NOT accept blocks with nTime more than two hours in the future
+/// > according to its clock. This is not strictly a consensus rule because it is nondeterministic,
+/// > and clock time varies between nodes.
+const MAX_ESTIMATED_DISTANCE_TO_NETWORK_CHAIN_TIP: i32 = 100;
 
 /// getblocktemplate RPC method signatures.
 #[rpc(server)]

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -290,8 +290,8 @@ where
 
         let mempool = self.mempool.clone();
         let latest_chain_tip = self.latest_chain_tip.clone();
+        let sync_status = self.sync_status.clone();
         let mut state = self.state.clone();
-        let is_zebra_close_to_network_tip = self.sync_status.is_close_to_tip();
 
         // Since this is a very large RPC, we use separate functions for each group of fields.
         async move {
@@ -313,7 +313,7 @@ where
                     data: None,
                 })?;
 
-            if !is_zebra_close_to_network_tip || estimated_distance_to_chain_tip > MAX_ESTIMATED_DISTANCE_TO_NETWORK_CHAIN_TIP {
+            if !sync_status.is_close_to_tip() || estimated_distance_to_chain_tip > MAX_ESTIMATED_DISTANCE_TO_NETWORK_CHAIN_TIP {
                 tracing::info!(
                     estimated_distance_to_chain_tip,
                     ?tip_height,

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -51,6 +51,12 @@ pub(crate) mod types;
 /// > and clock time varies between nodes.
 const MAX_ESTIMATED_DISTANCE_TO_NETWORK_CHAIN_TIP: i32 = 100;
 
+/// The RPC error code used by `zcashd` for when it's still downloading initial blocks.
+///
+/// `s-nomp` mining pool expects error code `-10` when the node is not synced:
+/// <https://github.com/s-nomp/node-stratum-pool/blob/d86ae73f8ff968d9355bb61aac05e0ebef36ccb5/lib/pool.js#L142>
+pub const NOT_SYNCED_ERROR_CODE: ErrorCode = ErrorCode::ServerError(-10);
+
 /// getblocktemplate RPC method signatures.
 #[rpc(server)]
 pub trait GetBlockTemplateRpc {
@@ -321,9 +327,7 @@ where
                 );
 
                 return Err(Error {
-                    // Return error code -10 (https://github.com/s-nomp/node-stratum-pool/blob/d86ae73f8ff968d9355bb61aac05e0ebef36ccb5/lib/pool.js#L140)
-                    // TODO: Confirm that this is the expected error code for !synced
-                    code: ErrorCode::ServerError(-10),
+                    code: NOT_SYNCED_ERROR_CODE,
                     message: format!("Zebra has not synced to the chain tip, estimated distance: {estimated_distance_to_chain_tip}"),
                     data: None,
                 });

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -12,6 +12,7 @@ use tower::{buffer::Buffer, Service};
 
 use zebra_chain::{
     block::Hash,
+    chain_sync_status::MockSyncStatus,
     chain_tip::mock::MockChainTip,
     parameters::{Network, NetworkUpgrade},
     serialization::ZcashDeserializeInto,
@@ -77,6 +78,9 @@ pub async fn test_responses<State, ReadState>(
     )
     .await;
 
+    let mut mock_sync_status = MockSyncStatus::default();
+    mock_sync_status.set_is_close_to_tip(true);
+
     let mining_config = get_block_template_rpcs::config::Config {
         miner_address: Some(transparent::Address::from_script_hash(network, [0xad; 20])),
     };
@@ -107,6 +111,7 @@ pub async fn test_responses<State, ReadState>(
         read_state,
         mock_chain_tip.clone(),
         chain_verifier.clone(),
+        mock_sync_status.clone(),
     );
 
     // `getblockcount`
@@ -138,6 +143,7 @@ pub async fn test_responses<State, ReadState>(
         new_read_state.clone(),
         mock_chain_tip,
         chain_verifier,
+        mock_sync_status,
     );
 
     // `getblocktemplate`

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -8,7 +8,6 @@ use tower::buffer::Buffer;
 use zebra_chain::{
     amount::Amount,
     block::Block,
-    chain_sync_status::MockSyncStatus,
     chain_tip::NoChainTip,
     parameters::Network::*,
     serialization::{ZcashDeserializeInto, ZcashSerialize},
@@ -21,6 +20,9 @@ use zebra_node_services::BoxError;
 use zebra_test::mock_service::MockService;
 
 use super::super::*;
+
+#[cfg(feature = "getblocktemplate-rpcs")]
+use zebra_chain::chain_sync_status::MockSyncStatus;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_getinfo() {

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -936,7 +936,7 @@ async fn rpc_getblocktemplate() {
     let get_block_template_sync_error = get_block_template_rpc
         .get_block_template()
         .await
-        .expect_err("needs an error when syncer is not close to tip or estimated distance to network chain tip is far");
+        .expect_err("needs an error when syncer is not close to tip");
 
     assert_eq!(
         get_block_template_sync_error.code,

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -8,7 +8,9 @@ use std::{
 use futures::FutureExt;
 use tower::buffer::Buffer;
 
-use zebra_chain::{chain_tip::NoChainTip, parameters::Network::*};
+use zebra_chain::{
+    chain_sync_status::MockSyncStatus, chain_tip::NoChainTip, parameters::Network::*,
+};
 use zebra_node_services::BoxError;
 
 use zebra_test::mock_service::MockService;
@@ -58,6 +60,7 @@ fn rpc_server_spawn(parallel_cpu_threads: bool) {
             Buffer::new(mempool.clone(), 1),
             Buffer::new(state.clone(), 1),
             Buffer::new(chain_verifier.clone(), 1),
+            MockSyncStatus::default(),
             NoChainTip,
             Mainnet,
         );
@@ -142,6 +145,7 @@ fn rpc_server_spawn_unallocated_port(parallel_cpu_threads: bool, do_shutdown: bo
             Buffer::new(mempool.clone(), 1),
             Buffer::new(state.clone(), 1),
             Buffer::new(chain_verifier.clone(), 1),
+            MockSyncStatus::default(),
             NoChainTip,
             Mainnet,
         );
@@ -220,6 +224,7 @@ fn rpc_server_spawn_port_conflict() {
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
                 Buffer::new(chain_verifier.clone(), 1),
+                MockSyncStatus::default(),
                 NoChainTip,
                 Mainnet,
             );
@@ -235,6 +240,7 @@ fn rpc_server_spawn_port_conflict() {
             Buffer::new(mempool.clone(), 1),
             Buffer::new(state.clone(), 1),
             Buffer::new(chain_verifier.clone(), 1),
+            MockSyncStatus::default(),
             NoChainTip,
             Mainnet,
         );
@@ -324,6 +330,7 @@ fn rpc_server_spawn_port_conflict_parallel_auto() {
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
                 Buffer::new(chain_verifier.clone(), 1),
+                MockSyncStatus::default(),
                 NoChainTip,
                 Mainnet,
             );
@@ -339,6 +346,7 @@ fn rpc_server_spawn_port_conflict_parallel_auto() {
             Buffer::new(mempool.clone(), 1),
             Buffer::new(state.clone(), 1),
             Buffer::new(chain_verifier.clone(), 1),
+            MockSyncStatus::default(),
             NoChainTip,
             Mainnet,
         );

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -185,6 +185,7 @@ impl StartCmd {
             mempool.clone(),
             read_only_state_service,
             chain_verifier.clone(),
+            sync_status.clone(),
             latest_chain_tip.clone(),
             config.network.network,
         );

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -30,7 +30,10 @@ use futures::{future::FutureExt, stream::Stream};
 use tokio::sync::watch;
 use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, Service};
 
-use zebra_chain::{block::Height, chain_tip::ChainTip, transaction::UnminedTxId};
+use zebra_chain::{
+    block::Height, chain_sync_status::ChainSyncStatus, chain_tip::ChainTip,
+    transaction::UnminedTxId,
+};
 use zebra_consensus::{error::TransactionError, transaction};
 use zebra_network as zn;
 use zebra_node_services::mempool::{Request, Response};

--- a/zebrad/src/components/mempool/crawler/tests/prop.rs
+++ b/zebrad/src/components/mempool/crawler/tests/prop.rs
@@ -8,7 +8,9 @@ use proptest::{
 };
 use tokio::time;
 
-use zebra_chain::{parameters::Network, transaction::UnminedTxId};
+use zebra_chain::{
+    chain_sync_status::ChainSyncStatus, parameters::Network, transaction::UnminedTxId,
+};
 use zebra_network as zn;
 use zebra_node_services::mempool::Gossip;
 use zebra_state::ChainTipSender;

--- a/zebrad/src/components/sync/progress.rs
+++ b/zebrad/src/components/sync/progress.rs
@@ -7,6 +7,7 @@ use num_integer::div_ceil;
 
 use zebra_chain::{
     block::Height,
+    chain_sync_status::ChainSyncStatus,
     chain_tip::ChainTip,
     fmt::humantime_seconds,
     parameters::{Network, NetworkUpgrade, POST_BLOSSOM_POW_TARGET_SPACING},

--- a/zebrad/src/components/sync/status/tests.rs
+++ b/zebrad/src/components/sync/status/tests.rs
@@ -3,6 +3,7 @@ use std::{env, sync::Arc, time::Duration};
 use futures::{select, FutureExt};
 use proptest::prelude::*;
 use tokio::{sync::Semaphore, time::timeout};
+use zebra_chain::chain_sync_status::ChainSyncStatus;
 
 use super::{super::RecentSyncLengths, SyncStatus};
 


### PR DESCRIPTION
## Motivation

Mining pools may use `getblocktemplate` RPC method to check if the node is synced to the tip so we want to check that Zebra is likely close to the network chain tip before responding with a block template.

Closes #5675.

## Solution

- Add a `ChainSyncStatus` trait to zebra-chain.
- Add `sync_status` field to `GetBlockTemplateRpcsImpl`.
- Return an error from `get_block_template` method if `!sync_status.is_close_to_tip()`.
- Add a `MockSyncStatus` for tests.

## Review

Part of regular scheduled work.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- Hide `MockSyncStatus` and other test-only code behind `#[cfg(test)]`?