### PR TITLE
change(rpc): Adds ignored jsonrequestobject argument to the getblocktemplate RPC

### DIFF
--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -318,6 +318,14 @@ where
                         data: None,
                     })
                 }
+
+                if options.longpollid.is_some() {
+                    return Err(Error {
+                        code: ErrorCode::InvalidParams,
+                        message: "long polling is currently unsupported by Zebra".to_string(),
+                        data: None,
+                    })
+                }
             }
 
             let miner_address = miner_address.ok_or_else(|| Error {

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -113,7 +113,10 @@ pub trait GetBlockTemplateRpc {
     ///
     /// This rpc method is available only if zebra is built with `--features getblocktemplate-rpcs`.
     #[rpc(name = "getblocktemplate")]
-    fn get_block_template(&self) -> BoxFuture<Result<GetBlockTemplate>>;
+    fn get_block_template(
+        &self,
+        _options: Option<types::get_block_template::JsonParameters>,
+    ) -> BoxFuture<Result<GetBlockTemplate>>;
 
     /// Submits block to the node to be validated and committed.
     /// Returns the [`submit_block::Response`] for the operation, as a JSON string.
@@ -292,7 +295,10 @@ where
         .boxed()
     }
 
-    fn get_block_template(&self) -> BoxFuture<Result<GetBlockTemplate>> {
+    fn get_block_template(
+        &self,
+        _options: Option<types::get_block_template::JsonParameters>,
+    ) -> BoxFuture<Result<GetBlockTemplate>> {
         let network = self.network;
         let miner_address = self.miner_address;
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types.rs
@@ -1,7 +1,8 @@
 //! Types used in mining RPC methods.
 
-pub(crate) mod default_roots;
-pub(crate) mod get_block_template;
-pub(crate) mod hex_data;
-pub(crate) mod submit_block;
-pub(crate) mod transaction;
+pub mod default_roots;
+pub mod get_block_template;
+pub mod get_block_template_opts;
+pub mod hex_data;
+pub mod submit_block;
+pub mod transaction;

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
@@ -9,6 +9,40 @@ use crate::methods::{
     GetBlockHash,
 };
 
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GetBlockTemplateRequestMode {
+    Template,
+    Proposal,
+}
+
+impl Default for GetBlockTemplateRequestMode {
+    fn default() -> Self {
+        Self::Template
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GetBlockTemplateCapability {
+    LongPoll,
+    CoinbaseTxn,
+    CoinbaseValue,
+    Proposal,
+    ServerList,
+    WorkId,
+}
+
+/// Optional `jsonparametersobject` argument
+#[derive(Debug, serde::Deserialize)]
+pub struct JsonParameters {
+    #[serde(default)]
+    pub mode: GetBlockTemplateRequestMode,
+    #[serde(default)]
+    pub capabilities: Vec<GetBlockTemplateCapability>,
+    pub longpollid: Option<String>,
+}
+
 /// Documentation to be added after we document all the individual fields.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct GetBlockTemplate {

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
@@ -9,40 +9,6 @@ use crate::methods::{
     GetBlockHash,
 };
 
-#[derive(Debug, serde::Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum GetBlockTemplateRequestMode {
-    Template,
-    Proposal,
-}
-
-impl Default for GetBlockTemplateRequestMode {
-    fn default() -> Self {
-        Self::Template
-    }
-}
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum GetBlockTemplateCapability {
-    LongPoll,
-    CoinbaseTxn,
-    CoinbaseValue,
-    Proposal,
-    ServerList,
-    WorkId,
-}
-
-/// Optional `jsonparametersobject` argument
-#[derive(Debug, serde::Deserialize)]
-pub struct JsonParameters {
-    #[serde(default)]
-    pub mode: GetBlockTemplateRequestMode,
-    #[serde(default)]
-    pub capabilities: Vec<GetBlockTemplateCapability>,
-    pub longpollid: Option<String>,
-}
-
 /// Documentation to be added after we document all the individual fields.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct GetBlockTemplate {

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
@@ -24,7 +24,6 @@ impl Default for GetBlockTemplateRequestMode {
 /// Valid `capabilities` values that indicate client-side support.
 #[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-#[allow(dead_code)]
 pub enum GetBlockTemplateCapability {
     /// Long Polling support.
     /// Currently ignored by zebra.

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
@@ -79,5 +79,7 @@ pub struct JsonParameters {
     /// An id to wait for, in zcashd this is the tip hash and an internal counter.
     ///
     /// If provided, the RPC response is delayed until the mempool or chain tip block changes.
+    ///
+    /// Currently unsupported and ignored by Zebra.
     pub longpollid: Option<String>,
 }

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
@@ -51,9 +51,10 @@ pub enum GetBlockTemplateCapability {
     /// Currently ignored by zcashd and zebra.
     WorkId,
 
-    /// Mutations
+    /// Unknown capability to fill in for mutations.
     // TODO: Fill out valid mutations capabilities.
-    UnknownCapability(String),
+    #[serde(other)]
+    UnknownCapability,
 }
 
 /// Optional argument `jsonrequestobject` for `getblocktemplate` RPC request.
@@ -80,7 +81,7 @@ pub struct JsonParameters {
     /// A list of client-side supported capability features
     // TODO: Fill out valid mutations capabilities.
     #[serde(default)]
-    pub capabilities: Vec<String>,
+    pub capabilities: Vec<GetBlockTemplateCapability>,
 
     /// An id to wait for, in zcashd this is the tip hash and an internal counter.
     ///

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
@@ -22,7 +22,7 @@ impl Default for GetBlockTemplateRequestMode {
 }
 
 /// Valid `capabilities` values that indicate client-side support.
-#[derive(Debug, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 #[allow(dead_code)]
 pub enum GetBlockTemplateCapability {

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
@@ -21,39 +21,40 @@ impl Default for GetBlockTemplateRequestMode {
     }
 }
 
-// /// Valid `capabilities` values that indicate client-side support.
-// #[derive(Debug, serde::Deserialize)]
-// #[serde(rename_all = "lowercase")]
-// pub enum GetBlockTemplateCapability {
-//     /// Long Polling support.
-//     /// Currently ignored by zebra.
-//     LongPoll,
+/// Valid `capabilities` values that indicate client-side support.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[allow(dead_code)]
+pub enum GetBlockTemplateCapability {
+    /// Long Polling support.
+    /// Currently ignored by zebra.
+    LongPoll,
 
-//     /// Information for coinbase transaction, default template data with the `coinbasetxn` field.
-//     /// Currently ignored by zebra.
-//     CoinbaseTxn,
+    /// Information for coinbase transaction, default template data with the `coinbasetxn` field.
+    /// Currently ignored by zebra.
+    CoinbaseTxn,
 
-//     /// Coinbase value, template response provides a `coinbasevalue` field and omits `coinbasetxn` field.
-//     /// Currently ignored by zebra.
-//     CoinbaseValue,
+    /// Coinbase value, template response provides a `coinbasevalue` field and omits `coinbasetxn` field.
+    /// Currently ignored by zebra.
+    CoinbaseValue,
 
-//     /// Components of the coinbase transaction.
-//     /// Currently ignored by zebra.
-//     CoinbaseAux,
+    /// Components of the coinbase transaction.
+    /// Currently ignored by zebra.
+    CoinbaseAux,
 
-//     /// Currently ignored by zcashd and zebra.
-//     Proposal,
+    /// Currently ignored by zcashd and zebra.
+    Proposal,
 
-//     /// Currently ignored by zcashd and zebra.
-//     ServerList,
+    /// Currently ignored by zcashd and zebra.
+    ServerList,
 
-//     /// Currently ignored by zcashd and zebra.
-//     WorkId,
+    /// Currently ignored by zcashd and zebra.
+    WorkId,
 
-//     /// Mutations
-//     // TODO: Fill out valid mutations capabilities.
-//     UnknownCapability(String),
-// }
+    /// Mutations
+    // TODO: Fill out valid mutations capabilities.
+    UnknownCapability(String),
+}
 
 /// Optional argument `jsonrequestobject` for `getblocktemplate` RPC request.
 ///

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
@@ -1,0 +1,83 @@
+//! Parameter types for the `getblocktemplate` RPC.
+
+use super::hex_data::HexData;
+
+/// Defines whether the RPC method should generate a block template or attempt to validate a block proposal.
+/// `Proposal` mode is currently unsupported and will return an error.
+#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum GetBlockTemplateRequestMode {
+    /// Indicates a request for a block template.
+    Template,
+
+    /// Indicates a request to validate block data.
+    /// Currently unsupported and will return an error.
+    Proposal,
+}
+
+impl Default for GetBlockTemplateRequestMode {
+    fn default() -> Self {
+        Self::Template
+    }
+}
+
+/// Valid `capabilities` values that indicate client-side support.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GetBlockTemplateCapability {
+    /// Long Polling support.
+    /// Currently ignored by zebra.
+    LongPoll,
+
+    /// Information for coinbase transaction, default template data with the `coinbasetxn` field.
+    /// Currently ignored by zebra.
+    CoinbaseTxn,
+
+    /// Coinbase value, template response provides a `coinbasevalue` field and omits `coinbasetxn` field.
+    /// Currently ignored by zebra.
+    CoinbaseValue,
+
+    /// Components of the coinbase transaction.
+    /// Currently ignored by zebra.
+    CoinbaseAux,
+
+    /// Currently ignored by zcashd and zebra.
+    Proposal,
+
+    /// Currently ignored by zcashd and zebra.
+    ServerList,
+
+    /// Currently ignored by zcashd and zebra.
+    WorkId,
+}
+
+/// Optional argument `jsonrequestobject` for `getblocktemplate` RPC request.
+///
+/// The `data` field must be provided in `proposal` mode, and must be omitted in `template` mode.
+/// All other fields are optional.
+#[derive(Debug, serde::Deserialize, Default)]
+pub struct JsonParameters {
+    /// Must be set to "template" or omitted, as "proposal" mode is currently unsupported.
+    ///
+    /// Defines whether the RPC method should generate a block template or attempt to
+    /// validate block data, checking against all of the server's usual acceptance rules
+    /// (excluding the check for a valid proof-of-work).
+    // TODO: Support `proposal` mode.
+    #[serde(default)]
+    pub mode: GetBlockTemplateRequestMode,
+
+    /// Must be ommitted as "proposal" mode is currently unsupported.
+    ///
+    /// Hex-encoded block data to be validated and checked against the server's usual acceptance rules
+    /// (excluding the check for a valid proof-of-work) when `mode` is set to `proposal`.
+    pub data: Option<HexData>,
+
+    /// A list of client-side supported capability features
+    #[serde(default)]
+    pub capabilities: Vec<GetBlockTemplateCapability>,
+
+    /// An id to wait for, in zcashd this is the tip hash and an internal counter.
+    ///
+    /// If provided, the RPC response is delayed until the mempool or chain tip block changes.
+    pub longpollid: Option<String>,
+}

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
@@ -4,7 +4,7 @@ use super::hex_data::HexData;
 
 /// Defines whether the RPC method should generate a block template or attempt to validate a block proposal.
 /// `Proposal` mode is currently unsupported and will return an error.
-#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum GetBlockTemplateRequestMode {
     /// Indicates a request for a block template.
@@ -61,7 +61,7 @@ pub enum GetBlockTemplateCapability {
 ///
 /// The `data` field must be provided in `proposal` mode, and must be omitted in `template` mode.
 /// All other fields are optional.
-#[derive(Debug, serde::Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, Default)]
 pub struct JsonParameters {
     /// Must be set to "template" or omitted, as "proposal" mode is currently unsupported.
     ///

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
@@ -70,7 +70,7 @@ pub struct JsonParameters {
     #[serde(default)]
     pub mode: GetBlockTemplateRequestMode,
 
-    /// Must be ommitted as "proposal" mode is currently unsupported.
+    /// Must be omitted as "proposal" mode is currently unsupported.
     ///
     /// Hex-encoded block data to be validated and checked against the server's usual acceptance rules
     /// (excluding the check for a valid proof-of-work) when `mode` is set to `proposal`.

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
@@ -21,35 +21,39 @@ impl Default for GetBlockTemplateRequestMode {
     }
 }
 
-/// Valid `capabilities` values that indicate client-side support.
-#[derive(Debug, serde::Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum GetBlockTemplateCapability {
-    /// Long Polling support.
-    /// Currently ignored by zebra.
-    LongPoll,
+// /// Valid `capabilities` values that indicate client-side support.
+// #[derive(Debug, serde::Deserialize)]
+// #[serde(rename_all = "lowercase")]
+// pub enum GetBlockTemplateCapability {
+//     /// Long Polling support.
+//     /// Currently ignored by zebra.
+//     LongPoll,
 
-    /// Information for coinbase transaction, default template data with the `coinbasetxn` field.
-    /// Currently ignored by zebra.
-    CoinbaseTxn,
+//     /// Information for coinbase transaction, default template data with the `coinbasetxn` field.
+//     /// Currently ignored by zebra.
+//     CoinbaseTxn,
 
-    /// Coinbase value, template response provides a `coinbasevalue` field and omits `coinbasetxn` field.
-    /// Currently ignored by zebra.
-    CoinbaseValue,
+//     /// Coinbase value, template response provides a `coinbasevalue` field and omits `coinbasetxn` field.
+//     /// Currently ignored by zebra.
+//     CoinbaseValue,
 
-    /// Components of the coinbase transaction.
-    /// Currently ignored by zebra.
-    CoinbaseAux,
+//     /// Components of the coinbase transaction.
+//     /// Currently ignored by zebra.
+//     CoinbaseAux,
 
-    /// Currently ignored by zcashd and zebra.
-    Proposal,
+//     /// Currently ignored by zcashd and zebra.
+//     Proposal,
 
-    /// Currently ignored by zcashd and zebra.
-    ServerList,
+//     /// Currently ignored by zcashd and zebra.
+//     ServerList,
 
-    /// Currently ignored by zcashd and zebra.
-    WorkId,
-}
+//     /// Currently ignored by zcashd and zebra.
+//     WorkId,
+
+//     /// Mutations
+//     // TODO: Fill out valid mutations capabilities.
+//     UnknownCapability(String),
+// }
 
 /// Optional argument `jsonrequestobject` for `getblocktemplate` RPC request.
 ///
@@ -73,8 +77,9 @@ pub struct JsonParameters {
     pub data: Option<HexData>,
 
     /// A list of client-side supported capability features
+    // TODO: Fill out valid mutations capabilities.
     #[serde(default)]
-    pub capabilities: Vec<GetBlockTemplateCapability>,
+    pub capabilities: Vec<String>,
 
     /// An id to wait for, in zcashd this is the tip hash and an internal counter.
     ///

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/hex_data.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/hex_data.rs
@@ -2,5 +2,5 @@
 //! for the `submitblock` RPC method.
 
 /// Deserialize hex-encoded strings to bytes.
-#[derive(Debug, PartialEq, Eq, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize)]
 pub struct HexData(#[serde(with = "hex")] pub Vec<u8>);

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/submit_block.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/submit_block.rs
@@ -9,7 +9,21 @@ use crate::methods::get_block_template_rpcs::GetBlockTemplateRpc;
 /// See notes for [`GetBlockTemplateRpc::submit_block`] method
 #[derive(Debug, serde::Deserialize)]
 pub struct JsonParameters {
-    pub(crate) _work_id: Option<String>,
+    /// The workid for the block template.
+    ///
+    /// > If the server provided a workid, it MUST be included with submissions,
+    /// currently unused.
+    ///
+    /// Rationale:
+    ///
+    /// > If servers allow all mutations, it may be hard to identify which job it is based on.
+    /// > While it may be possible to verify the submission by its content, it is much easier
+    /// > to compare it to the job issued. It is very easy for the miner to keep track of this.
+    /// > Therefore, using a "workid" is a very cheap solution to enable more mutations.
+    ///
+    /// <https://en.bitcoin.it/wiki/BIP_0022#Rationale>
+    #[serde(rename = "workid")]
+    pub _work_id: Option<String>,
 }
 
 /// Response to a `submitblock` RPC request.

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/submit_block.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/submit_block.rs
@@ -7,7 +7,7 @@ use crate::methods::get_block_template_rpcs::GetBlockTemplateRpc;
 /// Optional argument `jsonparametersobject` for `submitblock` RPC request
 ///
 /// See notes for [`GetBlockTemplateRpc::submit_block`] method
-#[derive(Debug, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize)]
 pub struct JsonParameters {
     /// The workid for the block template.
     ///

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -163,7 +163,7 @@ pub async fn test_responses<State, ReadState>(
             })));
     });
 
-    let get_block_template = tokio::spawn(get_block_template_rpc.get_block_template());
+    let get_block_template = tokio::spawn(get_block_template_rpc.get_block_template(None));
 
     mempool
         .expect_request(mempool::Request::FullTransactions)

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -865,7 +865,7 @@ async fn rpc_getblocktemplate() {
             })));
     });
 
-    let get_block_template = tokio::spawn(get_block_template_rpc.get_block_template());
+    let get_block_template = tokio::spawn(get_block_template_rpc.get_block_template(None));
 
     mempool
         .expect_request(mempool::Request::FullTransactions)
@@ -921,7 +921,7 @@ async fn rpc_getblocktemplate() {
 
     mock_chain_tip_sender.send_estimated_distance_to_network_chain_tip(Some(200));
     let get_block_template_sync_error = get_block_template_rpc
-        .get_block_template()
+        .get_block_template(None)
         .await
         .expect_err("needs an error when estimated distance to network chain tip is far");
 

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -865,8 +865,7 @@ async fn rpc_getblocktemplate() {
             })));
     });
 
-    let get_block_template =
-        tokio::spawn(get_block_template_rpc.get_block_template(Some(Default::default())));
+    let get_block_template = tokio::spawn(get_block_template_rpc.get_block_template(None));
 
     mempool
         .expect_request(mempool::Request::FullTransactions)
@@ -968,7 +967,6 @@ async fn rpc_getblocktemplate() {
         .get_block_template(Some(
             get_block_template_rpcs::types::get_block_template_opts::JsonParameters {
                 data: Some(get_block_template_rpcs::types::hex_data::HexData("".into())),
-                capabilities: vec![get_block_template_rpcs::types::get_block_template_opts::GetBlockTemplateCapability::UnknownCapability],
                 ..Default::default()
             },
         ))

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -967,6 +967,18 @@ async fn rpc_getblocktemplate() {
     let get_block_template_sync_error = get_block_template_rpc
         .get_block_template(Some(
             get_block_template_rpcs::types::get_block_template_opts::JsonParameters {
+                data: Some(get_block_template_rpcs::types::hex_data::HexData("".into())),
+                ..Default::default()
+            },
+        ))
+        .await
+        .expect_err("needs an error when passing in block data");
+
+    assert_eq!(get_block_template_sync_error.code, ErrorCode::InvalidParams);
+
+    let get_block_template_sync_error = get_block_template_rpc
+        .get_block_template(Some(
+            get_block_template_rpcs::types::get_block_template_opts::JsonParameters {
                 longpollid: Some("".to_string()),
                 ..Default::default()
             },

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -968,6 +968,7 @@ async fn rpc_getblocktemplate() {
         .get_block_template(Some(
             get_block_template_rpcs::types::get_block_template_opts::JsonParameters {
                 data: Some(get_block_template_rpcs::types::hex_data::HexData("".into())),
+                capabilities: vec![get_block_template_rpcs::types::get_block_template_opts::GetBlockTemplateCapability::UnknownCapability],
                 ..Default::default()
             },
         ))

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -865,7 +865,8 @@ async fn rpc_getblocktemplate() {
             })));
     });
 
-    let get_block_template = tokio::spawn(get_block_template_rpc.get_block_template(None));
+    let get_block_template =
+        tokio::spawn(get_block_template_rpc.get_block_template(Some(Default::default())));
 
     mempool
         .expect_request(mempool::Request::FullTransactions)
@@ -934,7 +935,7 @@ async fn rpc_getblocktemplate() {
 
     mock_chain_tip_sender.send_estimated_distance_to_network_chain_tip(Some(0));
     let get_block_template_sync_error = get_block_template_rpc
-        .get_block_template()
+        .get_block_template(None)
         .await
         .expect_err("needs an error when syncer is not close to tip");
 
@@ -945,7 +946,7 @@ async fn rpc_getblocktemplate() {
 
     mock_chain_tip_sender.send_estimated_distance_to_network_chain_tip(Some(200));
     let get_block_template_sync_error = get_block_template_rpc
-        .get_block_template()
+        .get_block_template(None)
         .await
         .expect_err("needs an error when syncer is not close to tip or estimated distance to network chain tip is far");
 
@@ -953,6 +954,15 @@ async fn rpc_getblocktemplate() {
         get_block_template_sync_error.code,
         ErrorCode::ServerError(-10)
     );
+    let get_block_template_sync_error = get_block_template_rpc
+        .get_block_template(Some(get_block_template_rpcs::types::get_block_template_opts::JsonParameters {
+            mode: get_block_template_rpcs::types::get_block_template_opts::GetBlockTemplateRequestMode::Proposal,
+            ..Default::default()
+        }))
+        .await
+        .expect_err("needs an error when using unsupported mode");
+
+    assert_eq!(get_block_template_sync_error.code, ErrorCode::InvalidParams);
 }
 
 #[cfg(feature = "getblocktemplate-rpcs")]

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -963,6 +963,18 @@ async fn rpc_getblocktemplate() {
         .expect_err("needs an error when using unsupported mode");
 
     assert_eq!(get_block_template_sync_error.code, ErrorCode::InvalidParams);
+
+    let get_block_template_sync_error = get_block_template_rpc
+        .get_block_template(Some(
+            get_block_template_rpcs::types::get_block_template_opts::JsonParameters {
+                longpollid: Some("".to_string()),
+                ..Default::default()
+            },
+        ))
+        .await
+        .expect_err("needs an error when using unsupported option");
+
+    assert_eq!(get_block_template_sync_error.code, ErrorCode::InvalidParams);
 }
 
 #[cfg(feature = "getblocktemplate-rpcs")]

--- a/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
@@ -63,7 +63,11 @@ pub(crate) async fn run() -> Result<()> {
          with a mempool that is likely empty...",
     );
     let getblocktemplate_response = RPCRequestClient::new(rpc_address)
-        .call("getblocktemplate", "[]".to_string())
+        .call(
+            "getblocktemplate",
+            // test that unknown capabilities are parsed as valid input
+            "[{\"capabilities\": [\"generation\"]}]".to_string(),
+        )
         .await?;
 
     let is_response_success = getblocktemplate_response.status().is_success();


### PR DESCRIPTION
## Motivation

We want to accept and ignore an optional jsonrequestobject in the getblocktemplate RPC.

Closes #5495.

## Solution

- Add an optional argument to the `getblocktemplate` method.

## Review

Part of regular scheduled work.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

