### PR TITLE
fix(test): Move test-only code to test-only modules

### DIFF
--- a/zebra-chain/src/chain_sync_status.rs
+++ b/zebra-chain/src/chain_sync_status.rs
@@ -1,32 +1,13 @@
 //! Defines method signatures for checking if the synchronizer is likely close to the network chain tip.
 
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+#[cfg(any(test, feature = "proptest-impl"))]
+pub mod mock;
+
+#[cfg(any(test, feature = "proptest-impl"))]
+pub use mock::MockSyncStatus;
 
 /// An interface for checking if the synchronization is likely close to the network chain tip.
 pub trait ChainSyncStatus {
     /// Check if the synchronization is likely close to the network chain tip.
     fn is_close_to_tip(&self) -> bool;
-}
-
-/// A mock [`ChainSyncStatus`] implementation that allows setting the status externally.
-#[derive(Clone, Default)]
-pub struct MockSyncStatus {
-    is_close_to_tip: Arc<AtomicBool>,
-}
-
-impl MockSyncStatus {
-    /// Sets mock sync status determining the return value of `is_close_to_tip()`
-    pub fn set_is_close_to_tip(&mut self, is_close_to_tip: bool) {
-        self.is_close_to_tip
-            .store(is_close_to_tip, Ordering::SeqCst);
-    }
-}
-
-impl ChainSyncStatus for MockSyncStatus {
-    fn is_close_to_tip(&self) -> bool {
-        self.is_close_to_tip.load(Ordering::SeqCst)
-    }
 }

--- a/zebra-chain/src/chain_sync_status/mock.rs
+++ b/zebra-chain/src/chain_sync_status/mock.rs
@@ -1,0 +1,28 @@
+//! Test-only mocks for [`ChainSyncStatus`].
+
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+use super::ChainSyncStatus;
+
+/// A mock [`ChainSyncStatus`] implementation that allows setting the status externally.
+#[derive(Clone, Default)]
+pub struct MockSyncStatus {
+    is_close_to_tip: Arc<AtomicBool>,
+}
+
+impl MockSyncStatus {
+    /// Sets mock sync status determining the return value of `is_close_to_tip()`
+    pub fn set_is_close_to_tip(&mut self, is_close_to_tip: bool) {
+        self.is_close_to_tip
+            .store(is_close_to_tip, Ordering::SeqCst);
+    }
+}
+
+impl ChainSyncStatus for MockSyncStatus {
+    fn is_close_to_tip(&self) -> bool {
+        self.is_close_to_tip.load(Ordering::SeqCst)
+    }
+}

--- a/zebra-chain/src/chain_tip.rs
+++ b/zebra-chain/src/chain_tip.rs
@@ -4,14 +4,19 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 
-use self::network_chain_tip_height_estimator::NetworkChainTipHeightEstimator;
 use crate::{block, parameters::Network, transaction};
+
+mod network_chain_tip_height_estimator;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod mock;
-mod network_chain_tip_height_estimator;
 #[cfg(test)]
 mod tests;
+
+use network_chain_tip_height_estimator::NetworkChainTipHeightEstimator;
+
+#[cfg(any(test, feature = "proptest-impl"))]
+pub use mock::NoChainTip;
 
 /// An interface for querying the chain tip.
 ///
@@ -79,35 +84,5 @@ pub trait ChainTip {
             estimator.estimate_height_at(Utc::now()) - current_height,
             current_height,
         ))
-    }
-}
-
-/// A chain tip that is always empty.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct NoChainTip;
-
-impl ChainTip for NoChainTip {
-    fn best_tip_height(&self) -> Option<block::Height> {
-        None
-    }
-
-    fn best_tip_hash(&self) -> Option<block::Hash> {
-        None
-    }
-
-    fn best_tip_height_and_hash(&self) -> Option<(block::Height, block::Hash)> {
-        None
-    }
-
-    fn best_tip_block_time(&self) -> Option<DateTime<Utc>> {
-        None
-    }
-
-    fn best_tip_height_and_block_time(&self) -> Option<(block::Height, DateTime<Utc>)> {
-        None
-    }
-
-    fn best_tip_mined_transaction_ids(&self) -> Arc<[transaction::Hash]> {
-        Arc::new([])
     }
 }

--- a/zebra-chain/src/chain_tip.rs
+++ b/zebra-chain/src/chain_tip.rs
@@ -15,9 +15,6 @@ mod tests;
 
 use network_chain_tip_height_estimator::NetworkChainTipHeightEstimator;
 
-#[cfg(any(test, feature = "proptest-impl"))]
-pub use mock::NoChainTip;
-
 /// An interface for querying the chain tip.
 ///
 /// This trait helps avoid dependencies between:
@@ -84,5 +81,38 @@ pub trait ChainTip {
             estimator.estimate_height_at(Utc::now()) - current_height,
             current_height,
         ))
+    }
+}
+
+/// A chain tip that is always empty.
+///
+/// Used in production for isolated network connections,
+/// and as a mock chain tip in tests.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct NoChainTip;
+
+impl ChainTip for NoChainTip {
+    fn best_tip_height(&self) -> Option<block::Height> {
+        None
+    }
+
+    fn best_tip_hash(&self) -> Option<block::Hash> {
+        None
+    }
+
+    fn best_tip_height_and_hash(&self) -> Option<(block::Height, block::Hash)> {
+        None
+    }
+
+    fn best_tip_block_time(&self) -> Option<DateTime<Utc>> {
+        None
+    }
+
+    fn best_tip_height_and_block_time(&self) -> Option<(block::Height, DateTime<Utc>)> {
+        None
+    }
+
+    fn best_tip_mined_transaction_ids(&self) -> Arc<[transaction::Hash]> {
+        Arc::new([])
     }
 }

--- a/zebra-chain/src/chain_tip/mock.rs
+++ b/zebra-chain/src/chain_tip/mock.rs
@@ -143,3 +143,33 @@ impl MockChainTipSender {
             .expect("attempt to send a best tip height to a dropped `MockChainTip`");
     }
 }
+
+/// A chain tip that is always empty.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct NoChainTip;
+
+impl ChainTip for NoChainTip {
+    fn best_tip_height(&self) -> Option<block::Height> {
+        None
+    }
+
+    fn best_tip_hash(&self) -> Option<block::Hash> {
+        None
+    }
+
+    fn best_tip_height_and_hash(&self) -> Option<(block::Height, block::Hash)> {
+        None
+    }
+
+    fn best_tip_block_time(&self) -> Option<DateTime<Utc>> {
+        None
+    }
+
+    fn best_tip_height_and_block_time(&self) -> Option<(block::Height, DateTime<Utc>)> {
+        None
+    }
+
+    fn best_tip_mined_transaction_ids(&self) -> Arc<[transaction::Hash]> {
+        Arc::new([])
+    }
+}

--- a/zebra-chain/src/chain_tip/mock.rs
+++ b/zebra-chain/src/chain_tip/mock.rs
@@ -143,33 +143,3 @@ impl MockChainTipSender {
             .expect("attempt to send a best tip height to a dropped `MockChainTip`");
     }
 }
-
-/// A chain tip that is always empty.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct NoChainTip;
-
-impl ChainTip for NoChainTip {
-    fn best_tip_height(&self) -> Option<block::Height> {
-        None
-    }
-
-    fn best_tip_hash(&self) -> Option<block::Hash> {
-        None
-    }
-
-    fn best_tip_height_and_hash(&self) -> Option<(block::Height, block::Hash)> {
-        None
-    }
-
-    fn best_tip_block_time(&self) -> Option<DateTime<Utc>> {
-        None
-    }
-
-    fn best_tip_height_and_block_time(&self) -> Option<(block::Height, DateTime<Utc>)> {
-        None
-    }
-
-    fn best_tip_mined_transaction_ids(&self) -> Arc<[transaction::Hash]> {
-        Arc::new([])
-    }
-}

--- a/zebrad/src/components/sync/status.rs
+++ b/zebrad/src/components/sync/status.rs
@@ -1,8 +1,12 @@
+//! Syncer chain tip status, based on recent block locator responses from peers.
+
 use tokio::sync::watch;
 use zebra_chain::chain_sync_status::ChainSyncStatus;
 
 use super::RecentSyncLengths;
 
+#[cfg(any(test, feature = "proptest-impl"))]
+pub mod mock;
 #[cfg(test)]
 mod tests;
 
@@ -42,24 +46,6 @@ impl SyncStatus {
         }
 
         Ok(())
-    }
-
-    /// Feed the given [`RecentSyncLengths`] it order to make the matching
-    /// [`SyncStatus`] report that it's close to the tip.
-    #[cfg(test)]
-    pub(crate) fn sync_close_to_tip(recent_syncs: &mut RecentSyncLengths) {
-        for _ in 0..RecentSyncLengths::MAX_RECENT_LENGTHS {
-            recent_syncs.push_extend_tips_length(1);
-        }
-    }
-
-    /// Feed the given [`RecentSyncLengths`] it order to make the matching
-    /// [`SyncStatus`] report that it's not close to the tip.
-    #[cfg(test)]
-    pub(crate) fn sync_far_from_tip(recent_syncs: &mut RecentSyncLengths) {
-        for _ in 0..RecentSyncLengths::MAX_RECENT_LENGTHS {
-            recent_syncs.push_extend_tips_length(Self::MIN_DIST_FROM_TIP * 10);
-        }
     }
 }
 

--- a/zebrad/src/components/sync/status/mock.rs
+++ b/zebrad/src/components/sync/status/mock.rs
@@ -1,5 +1,8 @@
 //! Test-only mocking code for [`SyncStatus`].
 
+// This code is currently unused with some feature combinations.
+#![allow(dead_code)]
+
 use crate::components::sync::RecentSyncLengths;
 
 use super::SyncStatus;

--- a/zebrad/src/components/sync/status/mock.rs
+++ b/zebrad/src/components/sync/status/mock.rs
@@ -1,0 +1,24 @@
+//! Test-only mocking code for [`SyncStatus`].
+
+use crate::components::sync::RecentSyncLengths;
+
+use super::SyncStatus;
+
+// TODO: move these methods to RecentSyncLengths
+impl SyncStatus {
+    /// Feed the given [`RecentSyncLengths`] it order to make the matching
+    /// [`SyncStatus`] report that it's close to the tip.
+    pub(crate) fn sync_close_to_tip(recent_syncs: &mut RecentSyncLengths) {
+        for _ in 0..RecentSyncLengths::MAX_RECENT_LENGTHS {
+            recent_syncs.push_extend_tips_length(1);
+        }
+    }
+
+    /// Feed the given [`RecentSyncLengths`] it order to make the matching
+    /// [`SyncStatus`] report that it's not close to the tip.
+    pub(crate) fn sync_far_from_tip(recent_syncs: &mut RecentSyncLengths) {
+        for _ in 0..RecentSyncLengths::MAX_RECENT_LENGTHS {
+            recent_syncs.push_extend_tips_length(Self::MIN_DIST_FROM_TIP * 10);
+        }
+    }
+}

--- a/zebrad/src/components/sync/status/tests.rs
+++ b/zebrad/src/components/sync/status/tests.rs
@@ -1,3 +1,5 @@
+//! Tests for syncer status.
+
 use std::{env, sync::Arc, time::Duration};
 
 use futures::{select, FutureExt};


### PR DESCRIPTION
## Motivation

We want to make sure test-only code isn't used in production.

This is mainly a cleanup on PR #5769.

## Solution

- ~~Move `NoChainTip` into a test-only module~~ - actually, we can't do this, it is used for isolated network connections
- Move `MockSyncStatus` into a test-only module
- Move the mocking methods on `SyncStatus` into a test-only module

## Review

@arya2 will probably want to review this.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
  - [x] How do you know it works? Does it have tests?

