### PR TITLE
ci(docs): update our Docker Hub documentation with our README

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,30 @@
+name: Update Docker Hub Description
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - README.md
+      - .github/workflows/dockerhub-description.yml
+
+jobs:
+  dockerHubDescription:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with:
+          persist-credentials: false
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v3.1.2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: zfnd/zebra
+          short-description: ${{ github.event.repository.description }}


### PR DESCRIPTION
## Previous behavior

Our Docker Hub is missing the documentation we use in the Zebra repository

Fixes #5542 

## Expected behavior

Each time we change our README.md, or on demand, update the documentation on Docker Hub with it. Also update the short description using our repository description.

## Solution

Implement https://github.com/peter-evans/dockerhub-description

## Review

Anyone can review this

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [x] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?
