### PR TITLE
change(release): Exclude zebra-dependencies-for-audit.md from release version updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -64,7 +64,7 @@ fastmod --extensions rs,toml,md --fixed-strings '1.0.0-beta.15' '1.0.0-beta.16' 
 fastmod --extensions rs,toml,md --fixed-strings '0.2.30' '0.2.31' tower-batch tower-fallback
 ```
 
-If you use `fastmod`, don't update versions in `CHANGELOG.md`.
+If you use `fastmod`, don't update versions in `CHANGELOG.md` or `zebra-dependencies-for-audit.md`.
 
 ## README
 


### PR DESCRIPTION
## Motivation

We don't want to update the audited dependencies during a release. Instead, we'll check if there are any critical changes, and update it separately.

## Review

This is a routine change.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

