### PR TITLE
fix(consensus): Refactor block subsidy to handle Height::MAX without panicking

### DIFF
--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -1,7 +1,8 @@
 //! Consensus check functions
 
-use chrono::{DateTime, Utc};
 use std::{collections::HashSet, sync::Arc};
+
+use chrono::{DateTime, Utc};
 
 use zebra_chain::{
     amount::{Amount, Error as AmountError, NonNegative},
@@ -126,7 +127,11 @@ pub fn subsidy_is_valid(block: &Block, network: Network) -> Result<(), BlockErro
     let coinbase = block.transactions.get(0).ok_or(SubsidyError::NoCoinbase)?;
 
     // Validate funding streams
-    let halving_div = subsidy::general::halving_divisor(height, network);
+    let Some(halving_div) = subsidy::general::halving_divisor(height, network) else {
+        // Far future halving, with no founders reward or funding streams
+        return Ok(());
+    };
+
     let canopy_activation_height = NetworkUpgrade::Canopy
         .activation_height(network)
         .expect("Canopy activation height is known");

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -1,7 +1,8 @@
 //! Constants for Block Subsidy and Funding Streams
 
-use lazy_static::lazy_static;
 use std::collections::HashMap;
+
+use lazy_static::lazy_static;
 
 use zebra_chain::{amount::COIN, block::Height, parameters::Network};
 
@@ -27,7 +28,7 @@ pub const MAX_BLOCK_SUBSIDY: u64 = ((25 * COIN) / 2) as u64;
 ///
 /// Calculated as `PRE_BLOSSOM_POW_TARGET_SPACING / POST_BLOSSOM_POW_TARGET_SPACING`
 /// in the Zcash specification.
-pub const BLOSSOM_POW_TARGET_SPACING_RATIO: u64 = 2;
+pub const BLOSSOM_POW_TARGET_SPACING_RATIO: u32 = 2;
 
 /// Halving is at about every 4 years, before Blossom block time is 150 seconds.
 ///
@@ -36,7 +37,7 @@ pub const PRE_BLOSSOM_HALVING_INTERVAL: Height = Height(840_000);
 
 /// After Blossom the block time is reduced to 75 seconds but halving period should remain around 4 years.
 pub const POST_BLOSSOM_HALVING_INTERVAL: Height =
-    Height((PRE_BLOSSOM_HALVING_INTERVAL.0 as u64 * BLOSSOM_POW_TARGET_SPACING_RATIO) as u32);
+    Height(PRE_BLOSSOM_HALVING_INTERVAL.0 * BLOSSOM_POW_TARGET_SPACING_RATIO);
 
 /// The first halving height in the testnet is at block height `1_116_000`
 /// as specified in [protocol specification §7.10.1][7.10.1]


### PR DESCRIPTION
## Motivation

Zebra panics when doing the block subsidy calculations for `Height::MAX`.

This is unlikely to ever happen on mainnet, because it only happens when block subsidies are all zero zats. But it's good to clean it up anyway, to avoid future changes causing actual panics in production.

### Specifications

<img width="758" alt="Screen Shot 2022-12-05 at 18 25 28" src="https://user-images.githubusercontent.com/8951843/205589098-262b04d6-24bf-45fc-8b68-ac531f08d013.png">

https://zips.z.cash/protocol/protocol.pdf#subsidies

### Designs

Use `Option<u64>` internally whenever 2<sup>Halving(height)</sup> would overflow a `u64`.

## Solution

Refactor the halving divisor to avoid overflows and panics.

Add tests for `Height::MAX` and other large values.

## Review

This is a routine consensus rule fix, it would be good to get two people to review it.

This doesn't need to be included in the audit, because it only happens with very large heights.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?


