### PR TITLE
change(doc): Update release, ticket, and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -23,11 +23,17 @@ If this changes network behaviour, quote and link to the Bitcoin network referen
 https://developer.bitcoin.org/reference/p2p_networking.html
 -->
 
-### Designs
+### Complex Code or Requirements
 
 <!--
-If this change is part of a Zebra design, quote and link to the RFC:
-https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
+Does this PR change concurrency, unsafe code, or complex consensus rules?
+If it does, explain how we will implement, review, and test it.
+-->
+
+### Testing
+
+<!--
+How can we check that this change does what we want it to do?
 -->
 
 ## Related Work

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -89,7 +89,7 @@ We use [the Release Drafter workflow](https://github.com/marketplace/actions/rel
 We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 
 To create the final change log:
-- [ ] Copy the draft changelog into `CHANGELOG.md`
+- [ ] Copy the **latest** draft changelog into `CHANGELOG.md` (there can be multiple draft releases)
 - [ ] Delete any trivial changes. Keep the list of those, to include in the PR
 - [ ] Combine duplicate changes
 - [ ] Edit change descriptions so they are consistent, and make sense to non-developers
@@ -141,6 +141,7 @@ After you have the version increments, the updated checkpoints and the updated c
       the previous release.
 - [ ] Mark the release as 'pre-release', until it has been built and tested
 - [ ] Publish the pre-release to GitHub using "Publish Release"
+- [ ] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)
 
 ## Binary Testing
 

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -125,6 +125,8 @@ After you have the version increments, the updated checkpoints and the updated c
 - [ ] Turn on [Merge Freeze](https://www.mergefreeze.com/installations/3676/branches).
 - [ ] Once the PR is ready to be merged, unfreeze it [here](https://www.mergefreeze.com/installations/3676/branches).
       Do not unfreeze the whole repository.
+- [ ] Update the PR to the latest `main` branch using `@mergifyio update`. Then Mergify should merge it in-place.
+      If it makes a merge PR instead, that PR will get cancelled by the merge freeze. So just merge the changelog PR manually.
 
 ### Create the Release
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,11 +14,11 @@ If this PR changes network behaviour, quote and link to the Bitcoin network refe
 https://developer.bitcoin.org/reference/p2p_networking.html
 -->
 
-### Designs
+### Complex Code or Requirements
 
 <!--
-If this PR implements a Zebra design, quote and link to the RFC:
-https://github.com/ZcashFoundation/zebra/tree/main/book/src/dev/rfcs/
+Does this PR change concurrency, unsafe code, or complex consensus rules?
+If it does, ask for multiple reviewers on this PR.
 -->
 
 ## Solution
@@ -32,7 +32,7 @@ Does it close any issues?
 
 <!--
 Is this PR blocking any other work?
-If you want a specific reviewer for this PR, tag them here.
+If you want specific reviewers for this PR, tag them here.
 -->
 
 ### Reviewer Checklist
@@ -41,6 +41,7 @@ If you want a specific reviewer for this PR, tag them here.
     - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
   - [ ] Are the PR labels correct?
   - [ ] Does the code do what the ticket and PR says?
+    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
   - [ ] How do you know it works? Does it have tests?
 
 ## Follow Up Work


### PR DESCRIPTION
## Motivation

We discussed some changes to the templates in the retrospective.

## Solution

Ticket Template:
- Add complex code or requirements section
- Add testing section
- Remove unused design section, we can use the "complex requirements" section instead

PR Template
- Add complex code or requirements section
    - Also add it to the review checklist 
- Remove unused design section, we can use the "complex requirements" section instead

Release checklist:
- Use the release notes from the latest draft release
- Delete all draft releases after releasing
- Update the changelog PR for an in-place merge, or merge it manually

## Review

Is this what we wanted out of the retrospective?

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

