### PR TITLE
change(rpc): Provide and parse a long poll ID, but don't use it yet

### DIFF
--- a/zebra-rpc/src/config.rs
+++ b/zebra-rpc/src/config.rs
@@ -55,6 +55,8 @@ pub struct Config {
     pub debug_force_finished_sync: bool,
 }
 
+// This impl isn't derivable because it depends on features.
+#[allow(clippy::derivable_impls)]
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -62,7 +64,12 @@ impl Default for Config {
             listen_addr: None,
 
             // Use a single thread, so we can detect RPC port conflicts.
+            #[cfg(not(feature = "getblocktemplate-rpcs"))]
             parallel_cpu_threads: 1,
+
+            // Use multiple threads, because we pause requests during getblocktemplate long polling
+            #[cfg(feature = "getblocktemplate-rpcs")]
+            parallel_cpu_threads: 0,
 
             // Debug options are always off by default.
             debug_force_finished_sync: false,

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -355,7 +355,7 @@ where
 
             // The tip estimate may not be the same as the one coming from the state
             // but this is ok for an estimate
-            let (estimated_distance_to_chain_tip, estimated_tip_height) = latest_chain_tip
+            let (estimated_distance_to_chain_tip, local_tip_height) = latest_chain_tip
                 .estimate_distance_to_network_chain_tip(network)
                 .ok_or_else(|| Error {
                     code: ErrorCode::ServerError(0),
@@ -366,7 +366,7 @@ where
             if !sync_status.is_close_to_tip() || estimated_distance_to_chain_tip > MAX_ESTIMATED_DISTANCE_TO_NETWORK_CHAIN_TIP {
                 tracing::info!(
                     estimated_distance_to_chain_tip,
-                    ?estimated_tip_height,
+                    ?local_tip_height,
                     "Zebra has not synced to the chain tip"
                 );
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -343,14 +343,6 @@ where
                         data: None,
                     })
                 }
-
-                if options.longpollid.is_some() {
-                    return Err(Error {
-                        code: ErrorCode::InvalidParams,
-                        message: "long polling is currently unsupported by Zebra".to_string(),
-                        data: None,
-                    })
-                }
             }
 
             let miner_address = miner_address.ok_or_else(|| Error {

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -424,8 +424,8 @@ where
             // TODO: use the entire mempool content via a watch channel,
             //       rather than the randomly selected transactions
             let long_poll_id = LongPollInput::new(
-                tip_height,
-                tip_hash,
+                chain_info.tip_height,
+                chain_info.tip_hash,
                 chain_info.max_time,
                 mempool_txs.iter().map(|tx| tx.transaction.id),
             ).into();

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -422,7 +422,7 @@ where
             );
 
             // TODO: use the entire mempool content via a watch channel,
-            //       rather than the randomly selected transactions
+            //       rather than just the randomly selected transactions
             let long_poll_id = LongPollInput::new(
                 chain_info.tip_height,
                 chain_info.tip_hash,

--- a/zebra-rpc/src/methods/get_block_template_rpcs/constants.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/constants.rs
@@ -14,12 +14,8 @@ pub const GET_BLOCK_TEMPLATE_MUTABLE_FIELD: &[&str] = &[
 ];
 
 /// A hardcoded list of Zebra's getblocktemplate RPC capabilities.
-pub const GET_BLOCK_TEMPLATE_CAPABILITIES_FIELD: &[&str] = &[
-    // > miners which support long polling SHOULD provide a list including the String "longpoll"
-    //
-    // https://en.bitcoin.it/wiki/BIP_0022#Optional:_Long_Polling
-    "longpoll",
-];
+/// Currently empty.
+pub const GET_BLOCK_TEMPLATE_CAPABILITIES_FIELD: &[&str] = &[];
 
 /// The max estimated distance to the chain tip for the getblocktemplate method.
 ///

--- a/zebra-rpc/src/methods/get_block_template_rpcs/constants.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/constants.rs
@@ -1,7 +1,41 @@
 //! Constant values used in mining rpcs methods.
 
-/// A range of valid nonces that goes from `u32::MIN` to `u32::MAX` as a string.
+use jsonrpc_core::ErrorCode;
+
+/// A range of valid block template nonces, that goes from `u32::MIN` to `u32::MAX` as a string.
 pub const GET_BLOCK_TEMPLATE_NONCE_RANGE_FIELD: &str = "00000000ffffffff";
 
-/// A hardcoded list of fields that the miner can change from the block.
-pub const GET_BLOCK_TEMPLATE_MUTABLE_FIELD: &[&str] = &["time", "transactions", "prevblock"];
+/// A hardcoded list of fields that the miner can change from the block template.
+pub const GET_BLOCK_TEMPLATE_MUTABLE_FIELD: &[&str] = &[
+    // Standard mutations, copied from zcashd
+    "time",
+    "transactions",
+    "prevblock",
+];
+
+/// A hardcoded list of Zebra's getblocktemplate RPC capabilities.
+pub const GET_BLOCK_TEMPLATE_CAPABILITIES_FIELD: &[&str] = &[
+    // > miners which support long polling SHOULD provide a list including the String "longpoll"
+    //
+    // https://en.bitcoin.it/wiki/BIP_0022#Optional:_Long_Polling
+    "longpoll",
+];
+
+/// The max estimated distance to the chain tip for the getblocktemplate method.
+///
+/// Allows the same clock skew as the Zcash network, which is 100 blocks, based on the standard rule:
+/// > A full validator MUST NOT accept blocks with nTime more than two hours in the future
+/// > according to its clock. This is not strictly a consensus rule because it is nondeterministic,
+/// > and clock time varies between nodes.
+pub const MAX_ESTIMATED_DISTANCE_TO_NETWORK_CHAIN_TIP: i32 = 100;
+
+/// The RPC error code used by `zcashd` for when it's still downloading initial blocks.
+///
+/// `s-nomp` mining pool expects error code `-10` when the node is not synced:
+/// <https://github.com/s-nomp/node-stratum-pool/blob/d86ae73f8ff968d9355bb61aac05e0ebef36ccb5/lib/pool.js#L142>
+pub const NOT_SYNCED_ERROR_CODE: ErrorCode = ErrorCode::ServerError(-10);
+
+/// The default window size specifying how many blocks to check when estimating the chain's solution rate.
+///
+/// Based on default value in zcashd.
+pub const DEFAULT_SOLUTION_RATE_WINDOW_SIZE: usize = 120;

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types.rs
@@ -5,5 +5,6 @@ pub mod get_block_template;
 pub mod get_block_template_opts;
 pub mod get_mining_info;
 pub mod hex_data;
+pub mod long_poll;
 pub mod submit_block;
 pub mod transaction;

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
@@ -4,7 +4,7 @@ use zebra_chain::{amount, block::ChainHistoryBlockTxAuthCommitmentHash};
 
 use crate::methods::{
     get_block_template_rpcs::types::{
-        default_roots::DefaultRoots, transaction::TransactionTemplate,
+        default_roots::DefaultRoots, long_poll::LongPollId, transaction::TransactionTemplate,
     },
     GetBlockHash,
 };
@@ -66,6 +66,10 @@ pub struct GetBlockTemplate {
     /// The coinbase transaction generated from `transactions` and `height`.
     #[serde(rename = "coinbasetxn")]
     pub coinbase_txn: TransactionTemplate<amount::NegativeOrZero>,
+
+    /// An ID that represents the chain tip and mempool contents for this template.
+    #[serde(rename = "longpollid")]
+    pub long_poll_id: LongPollId,
 
     /// The expected difficulty for the new block displayed in expanded form.
     // TODO: use ExpandedDifficulty type.

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template_opts.rs
@@ -1,6 +1,6 @@
 //! Parameter types for the `getblocktemplate` RPC.
 
-use super::hex_data::HexData;
+use super::{hex_data::HexData, long_poll::LongPollId};
 
 /// Defines whether the RPC method should generate a block template or attempt to validate a block proposal.
 /// `Proposal` mode is currently unsupported and will return an error.
@@ -82,10 +82,8 @@ pub struct JsonParameters {
     #[serde(default)]
     pub capabilities: Vec<GetBlockTemplateCapability>,
 
-    /// An id to wait for, in zcashd this is the tip hash and an internal counter.
+    /// An ID that delays the RPC response until the template changes.
     ///
-    /// If provided, the RPC response is delayed until the mempool or chain tip block changes.
-    ///
-    /// Currently unsupported and ignored by Zebra.
-    pub longpollid: Option<String>,
+    /// In Zebra, the ID represents the chain tip, max time, and mempool contents.
+    pub longpollid: Option<LongPollId>,
 }

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/long_poll.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/long_poll.rs
@@ -194,6 +194,9 @@ impl From<LongPollInput> for LongPollId {
 fn update_checksum(checksum: &mut u32, item: [u8; 32]) {
     for chunk in item.chunks(4) {
         let chunk = chunk.try_into().expect("chunk is u32 size");
+
+        // The endianness of this conversion doesn't matter,
+        // so we make it efficient on the most common platforms.
         let chunk = u32::from_le_bytes(chunk);
 
         // It's ok to use xor here, because long polling checks are probabilistic,

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/long_poll.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/long_poll.rs
@@ -1,0 +1,140 @@
+//! Long polling support for the `getblocktemplate` RPC.
+//!
+//! These implementation details are private, and should not be relied upon by miners.
+//! They are also different from the `zcashd` implementation of long polling.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+
+use zebra_chain::{
+    block::{self, Height},
+    transaction,
+};
+
+/// The inputs to the long polling check.
+///
+/// If these inputs change, Zebra should return a response to any open long polls.
+pub struct LongPollInput {
+    // Fields that invalidate old work:
+    //
+    /// If the tip block height changes, a new template must be provided.
+    /// Old work is no longer valid.
+    ///
+    /// We use the height as well as the hash, to reduce the probability of a missed tip change.
+    pub tip_block_height: Height,
+
+    /// If the tip block hash changes, a new template must be provided.
+    /// Old work is no longer valid.
+    pub tip_block_hash: block::Hash,
+
+    /// If the max time is reached, a new template must be provided.
+    /// Old work is no longer valid.
+    ///
+    /// Ideally, a new template should be provided at least one target block interval before
+    /// the max time. This avoids wasted work.
+    pub max_time: DateTime<Utc>,
+
+    // Fields that allow old work:
+    //
+    /// If the mempool transactions change, a new template might be provided.
+    /// Old work is still valid.
+    ///
+    /// We ignore changes to authorizing data.
+    pub mempool_transaction_mined_ids: Arc<[transaction::Hash]>,
+}
+
+/// The encoded long poll ID, generated from the [`LongPollInput`].
+///
+/// `zcashd` IDs are currently 69 hex digits long.
+/// If Zebra's IDs are less than that, we should have good compatibility with mining pools.
+pub struct LongPollId {
+    // Fields that invalidate old work:
+    //
+    /// If the tip block height changes, a new template must be provided.
+    /// Old work is no longer valid.
+    ///
+    /// We use the height as well as the hash, to reduce the probability of a missed tip change.
+    pub tip_block_height: u32,
+
+    /// If the tip block changes, a new template must be provided.
+    /// Old work is no longer valid.
+    /// This checksum is not cryptographically secure.
+    ///
+    /// It's ok to do a probabilistic check here,
+    /// so we choose a 1 in 2^64 chance of missing a block change.
+    pub tip_block_checksum: u64,
+
+    /// If the max time is reached, a new template must be provided.
+    /// Old work is no longer valid.
+    ///
+    /// Ideally, a new template should be provided at least one target block interval before
+    /// the max time. This avoids wasted work.
+    ///
+    /// Zcash times are limited to 32 bits by the consensus rules.
+    pub max_timestamp: u32,
+
+    // Fields that allow old work:
+    //
+    /// If the number of mempool transactions changes, a new template might be provided.
+    /// Old work is still valid.
+    ///
+    /// The number of transactions is limited by the mempool DoS limit.
+    pub mempool_transaction_count: u32,
+
+    /// If the content of the mempool changes, a new template might be provided.
+    /// Old work is still valid.
+    /// This checksum is not cryptographically secure.
+    ///
+    /// We ignore changes to authorizing data.
+    ///
+    /// It's ok to do a probabilistic check here,
+    /// so we choose a 1 in 2^32 chance of missing a transaction change.
+    pub mempool_transaction_content_checksum: u32,
+}
+
+impl From<LongPollInput> for LongPollId {
+    fn from(input: LongPollInput) -> Self {
+        // TODO: make a generic checksum function?
+        let mut tip_block_checksum = 0;
+        for chunk in input.tip_block_hash.0.chunks(8) {
+            let chunk = chunk.try_into().expect("chunk is u64 size");
+            let chunk = u64::from_le_bytes(chunk);
+
+            // This checksum is not cryptographically secure.
+            // But it's ok to use xor here, because long polling checks are probabilistic,
+            // and the height, time, and transaction count fields will detect most changes.
+            //
+            // Without those fields, miners could game the xor-ed block hash,
+            // and hide block changes from other miners, gaining an advantage.
+            // But this would reduce their profit under proof of work,
+            // because the first valid block hash a miner generates will pay
+            // a significant block subsidy.
+            tip_block_checksum ^= chunk;
+        }
+
+        let mut mempool_transaction_content_checksum: u32 = 0;
+        for tx_mined_id in input.mempool_transaction_mined_ids.iter() {
+            for chunk in tx_mined_id.0.chunks(4) {
+                let chunk = chunk.try_into().expect("chunk is u32 size");
+                let chunk = u32::from_le_bytes(chunk);
+
+                mempool_transaction_content_checksum ^= chunk;
+            }
+        }
+
+        Self {
+            tip_block_height: input.tip_block_height.0,
+
+            tip_block_checksum,
+
+            // It's ok to do wrapping conversions here,
+            // because long polling checks are probabilistic.
+            max_timestamp: input.max_time.timestamp() as u32,
+
+            mempool_transaction_count: input.mempool_transaction_mined_ids.len() as u32,
+
+            mempool_transaction_content_checksum,
+        }
+    }
+}

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template@mainnet_10.snap
@@ -27,6 +27,7 @@ expression: block_template
     "sigops": 0,
     "required": true
   },
+  "longpollid": "00016871043eab7f731654008728000000000000000000",
   "target": "0000000000000000000000000000000000000000000000000000000000000001",
   "mintime": 1654008606,
   "mutable": [

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template@mainnet_10.snap
@@ -3,9 +3,7 @@ source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
 expression: block_template
 ---
 {
-  "capabilities": [
-    "longpoll"
-  ],
+  "capabilities": [],
   "version": 4,
   "previousblockhash": "0000000000d723156d9b65ffcf4984da7a19675ed7e2f06d9e5d5188af087bf8",
   "blockcommitmentshash": "fe03d8236b0835c758f59d279230ebaee2128754413103b9edb17c07451c2c82",

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template@mainnet_10.snap
@@ -3,7 +3,9 @@ source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
 expression: block_template
 ---
 {
-  "capabilities": [],
+  "capabilities": [
+    "longpoll"
+  ],
   "version": 4,
   "previousblockhash": "0000000000d723156d9b65ffcf4984da7a19675ed7e2f06d9e5d5188af087bf8",
   "blockcommitmentshash": "fe03d8236b0835c758f59d279230ebaee2128754413103b9edb17c07451c2c82",

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template@testnet_10.snap
@@ -27,6 +27,7 @@ expression: block_template
     "sigops": 0,
     "required": true
   },
+  "longpollid": "00018424203eab7f731654008728000000000000000000",
   "target": "0000000000000000000000000000000000000000000000000000000000000001",
   "mintime": 1654008606,
   "mutable": [

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template@testnet_10.snap
@@ -3,7 +3,9 @@ source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
 expression: block_template
 ---
 {
-  "capabilities": [],
+  "capabilities": [
+    "longpoll"
+  ],
   "version": 4,
   "previousblockhash": "0000000000d723156d9b65ffcf4984da7a19675ed7e2f06d9e5d5188af087bf8",
   "blockcommitmentshash": "cb1f1c6a5ad5ff9c4a170e3b747a24f3aec79817adba9a9451f19914481bb422",

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template@testnet_10.snap
@@ -3,9 +3,7 @@ source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
 expression: block_template
 ---
 {
-  "capabilities": [
-    "longpoll"
-  ],
+  "capabilities": [],
   "version": 4,
   "previousblockhash": "0000000000d723156d9b65ffcf4984da7a19675ed7e2f06d9e5d5188af087bf8",
   "blockcommitmentshash": "cb1f1c6a5ad5ff9c4a170e3b747a24f3aec79817adba9a9451f19914481bb422",

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -881,12 +881,6 @@ async fn rpc_getblocktemplate() {
 
     use chrono::{TimeZone, Utc};
 
-    use crate::methods::{
-        get_block_template_rpcs::constants::{
-            GET_BLOCK_TEMPLATE_MUTABLE_FIELD, GET_BLOCK_TEMPLATE_NONCE_RANGE_FIELD,
-        },
-        tests::utils::fake_history_tree,
-    };
     use zebra_chain::{
         amount::{Amount, NonNegative},
         block::{Hash, MAX_BLOCK_BYTES, ZCASH_BLOCK_VERSION},
@@ -894,8 +888,15 @@ async fn rpc_getblocktemplate() {
         work::difficulty::{CompactDifficulty, ExpandedDifficulty, U256},
     };
     use zebra_consensus::MAX_BLOCK_SIGOPS;
-
     use zebra_state::{GetBlockTemplateChainInfo, ReadRequest, ReadResponse};
+
+    use crate::methods::{
+        get_block_template_rpcs::constants::{
+            GET_BLOCK_TEMPLATE_CAPABILITIES_FIELD, GET_BLOCK_TEMPLATE_MUTABLE_FIELD,
+            GET_BLOCK_TEMPLATE_NONCE_RANGE_FIELD,
+        },
+        tests::utils::fake_history_tree,
+    };
 
     let _init_guard = zebra_test::init();
 
@@ -973,7 +974,10 @@ async fn rpc_getblocktemplate() {
         })
         .expect("unexpected error in getblocktemplate RPC call");
 
-    assert_eq!(get_block_template.capabilities, Vec::<String>::new());
+    assert_eq!(
+        get_block_template.capabilities,
+        GET_BLOCK_TEMPLATE_CAPABILITIES_FIELD.to_vec()
+    );
     assert_eq!(get_block_template.version, ZCASH_BLOCK_VERSION);
     assert!(get_block_template.transactions.is_empty());
     assert_eq!(

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1073,7 +1073,9 @@ async fn rpc_getblocktemplate() {
     let get_block_template_sync_error = get_block_template_rpc
         .get_block_template(Some(
             get_block_template_rpcs::types::get_block_template_opts::JsonParameters {
-                longpollid: Some("".to_string()),
+                // This must parse as a LongPollId.
+                // It must be the correct length and have hex/decimal digits.
+                longpollid: Some("0".repeat(46).parse().expect("invalid LongPollId")),
                 ..Default::default()
             },
         ))

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -891,9 +891,12 @@ async fn rpc_getblocktemplate() {
     use zebra_state::{GetBlockTemplateChainInfo, ReadRequest, ReadResponse};
 
     use crate::methods::{
-        get_block_template_rpcs::constants::{
-            GET_BLOCK_TEMPLATE_CAPABILITIES_FIELD, GET_BLOCK_TEMPLATE_MUTABLE_FIELD,
-            GET_BLOCK_TEMPLATE_NONCE_RANGE_FIELD,
+        get_block_template_rpcs::{
+            constants::{
+                GET_BLOCK_TEMPLATE_CAPABILITIES_FIELD, GET_BLOCK_TEMPLATE_MUTABLE_FIELD,
+                GET_BLOCK_TEMPLATE_NONCE_RANGE_FIELD,
+            },
+            types::long_poll::LONG_POLL_ID_LENGTH,
         },
         tests::utils::fake_history_tree,
     };
@@ -1075,7 +1078,11 @@ async fn rpc_getblocktemplate() {
             get_block_template_rpcs::types::get_block_template_opts::JsonParameters {
                 // This must parse as a LongPollId.
                 // It must be the correct length and have hex/decimal digits.
-                longpollid: Some("0".repeat(46).parse().expect("invalid LongPollId")),
+                longpollid: Some(
+                    "0".repeat(LONG_POLL_ID_LENGTH)
+                        .parse()
+                        .expect("invalid LongPollId"),
+                ),
                 ..Default::default()
             },
         ))

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -896,10 +896,7 @@ async fn rpc_getblocktemplate() {
                 GET_BLOCK_TEMPLATE_CAPABILITIES_FIELD, GET_BLOCK_TEMPLATE_MUTABLE_FIELD,
                 GET_BLOCK_TEMPLATE_NONCE_RANGE_FIELD,
             },
-            types::{
-                get_block_template_opts::GetBlockTemplateRequestMode,
-                long_poll::LONG_POLL_ID_LENGTH,
-            },
+            types::long_poll::LONG_POLL_ID_LENGTH,
         },
         tests::utils::fake_history_tree,
     };
@@ -1074,18 +1071,6 @@ async fn rpc_getblocktemplate() {
         ))
         .await
         .expect_err("needs an error when passing in block data");
-
-    assert_eq!(get_block_template_sync_error.code, ErrorCode::InvalidParams);
-
-    let get_block_template_sync_error = get_block_template_rpc
-        .get_block_template(Some(
-            get_block_template_rpcs::types::get_block_template_opts::JsonParameters {
-                mode: GetBlockTemplateRequestMode::Proposal,
-                ..Default::default()
-            },
-        ))
-        .await
-        .expect_err("needs an error when the mode is unsupported");
 
     assert_eq!(get_block_template_sync_error.code, ErrorCode::InvalidParams);
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -656,6 +656,7 @@ fn valid_generated_config(command: &str, expect_stdout_line_contains: &str) -> R
 
 /// Check if the config produced by current zebrad is stored.
 #[tracing::instrument]
+#[allow(clippy::print_stdout)]
 fn last_config_is_stored() -> Result<()> {
     let _init_guard = zebra_test::init();
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -711,14 +711,30 @@ fn last_config_is_stored() -> Result<()> {
         }
     }
 
+    println!(
+        "\n\
+         Here is the missing config file: \n\
+         \n\
+         {processed_generated_content}\n"
+    );
+
     Err(eyre!(
-        "latest zebrad config is not being tested for compatibility.\n\
-         Run: \n\
+        "latest zebrad config is not being tested for compatibility. \n\
+         \n\
+         Take the missing config file logged above, \n\
+         and commit it to Zebra's git repository as:\n\
+         zebrad/tests/common/configs/{}<next-release-tag>.toml \n\
+         \n\
+         Or run: \n\
          cargo build {}--bin zebrad && \n\
          zebrad generate | \n\
          sed \"s/cache_dir = '.*'/cache_dir = 'cache_dir'/\" > \n\
-         zebrad/tests/common/configs/{}<next-release-tag>.toml \n\
-         and commit the latest config to Zebra's git repository",
+         zebrad/tests/common/configs/{}<next-release-tag>.toml",
+        if cfg!(feature = "getblocktemplate-rpcs") {
+            GET_BLOCK_TEMPLATE_CONFIG_PREFIX
+        } else {
+            ""
+        },
         if cfg!(feature = "getblocktemplate-rpcs") {
             "--features=getblocktemplate-rpcs "
         } else {

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -575,6 +575,7 @@ fn config_tests() -> Result<()> {
 }
 
 /// Test that `zebrad` runs the start command with no args
+#[tracing::instrument]
 fn app_no_args() -> Result<()> {
     let _init_guard = zebra_test::init();
 
@@ -654,6 +655,7 @@ fn valid_generated_config(command: &str, expect_stdout_line_contains: &str) -> R
 }
 
 /// Check if the config produced by current zebrad is stored.
+#[tracing::instrument]
 fn last_config_is_stored() -> Result<()> {
     let _init_guard = zebra_test::init();
 
@@ -732,6 +734,7 @@ fn last_config_is_stored() -> Result<()> {
 
 /// Checks that Zebra prints an informative message when it cannot parse the
 /// config file.
+#[tracing::instrument]
 fn invalid_generated_config() -> Result<()> {
     let _init_guard = zebra_test::init();
 
@@ -804,6 +807,7 @@ fn invalid_generated_config() -> Result<()> {
 }
 
 /// Test all versions of `zebrad.toml` we have stored can be parsed by the latest `zebrad`.
+#[tracing::instrument]
 fn stored_configs_works() -> Result<()> {
     let old_configs_dir = configs_dir();
 

--- a/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.3.toml
+++ b/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.3.toml
@@ -1,0 +1,72 @@
+# Default configuration for zebrad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zebrad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+#
+# zebrad attempts to load configs in the following order:
+#
+# 1. The -c flag on the command line, e.g., `zebrad -c myconfig.toml start`;
+# 2. The file `zebrad.toml` in the users's preference directory (platform-dependent);
+# 3. The default config.
+
+[consensus]
+checkpoint_sync = true
+debug_skip_parameter_preload = false
+
+[mempool]
+eviction_memory_time = '1h'
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+
+[network]
+crawl_new_peer_interval = '1m 1s'
+initial_mainnet_peers = [
+    'dnsseed.z.cash:8233',
+    'dnsseed.str4d.xyz:8233',
+    'mainnet.seeder.zfnd.org:8233',
+    'mainnet.is.yolo.money:8233',
+]
+initial_testnet_peers = [
+    'dnsseed.testnet.z.cash:18233',
+    'testnet.seeder.zfnd.org:18233',
+    'testnet.is.yolo.money:18233',
+]
+listen_addr = '0.0.0.0:8233'
+network = 'Mainnet'
+peerset_initial_target_size = 25
+
+[rpc]
+debug_force_finished_sync = false
+parallel_cpu_threads = 1
+
+[state]
+cache_dir = 'cache_dir'
+delete_old_database = true
+ephemeral = false
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 50
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false
+

--- a/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.3.toml
+++ b/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.3.toml
@@ -51,7 +51,7 @@ peerset_initial_target_size = 25
 
 [rpc]
 debug_force_finished_sync = false
-parallel_cpu_threads = 1
+parallel_cpu_threads = 0
 
 [state]
 cache_dir = 'cache_dir'


### PR DESCRIPTION
## Motivation

We want to implement long polling support in Zebra.

Depends-On: #5772

### Specifications

getblocktemplate request:
> capabilities: miners which support long polling SHOULD provide a list including the String "longpoll"
> longpollid: "longpollid" of job to monitor for expiration; required and valid only for long poll requests

getblocktemplate response:
> longpollid: identifier for long poll request; MUST be omitted if the server does not support long polling

https://en.bitcoin.it/wiki/BIP_0022#Optional:_Long_Polling

### Designs

Add a `LongPollInput` type which contains all the data long polling can depend on.
Lossily convert it into a `LongPollId` type, which almost always changes when the `LongPollInput` changes.
Convert the `LongPollId` type to and from a string in the `getblocktemplate` RPC.

## Solution

RPC request:
- Declare longpoll support in the getblocktemplate RPC capabilities
- Provide a longpollid field in the RPC response, which represents the contents of the tip and mempool used to create the response.
- Accept a longpollid parameter to the RPC request, but don't implement long polling yet.

RPC server:
- Increase the default number of RPC threads when the getblocktemplate-rpcs feature is on, because every long polling client could use one thread.

This is part of #5720.

## Review

I'd like an initial review of the design and the data we're using, before I add long polling waits and tests in the next PR.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- Actually wait when long polling
- Add the `submit_old` field
- Check if `jsonrpc_core` blocks when a RPC waits
- Add tests