### PR TITLE
build(deps): bump inferno from 0.11.12 to 0.11.13, and allow a duplicate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,19 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.8",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+dependencies = [
+ "cfg-if 1.0.0",
+ "getrandom 0.2.8",
  "once_cell",
  "version_check",
 ]
@@ -1518,13 +1530,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1673,7 +1685,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -1951,11 +1963,11 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2fa5a9ad16dedcfabbc87f048ee6dd40d4944736fe4c5d362fb01df1209de1"
+checksum = "d7207d75fcf6c1868f1390fc1c610431fe66328e9ee6813330a041ef6879eca1"
 dependencies = [
- "ahash",
+ "ahash 0.8.2",
  "atty",
  "itoa",
  "log",
@@ -2307,7 +2319,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "metrics-macros",
  "portable-atomic",
 ]
@@ -3157,9 +3169,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.23.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
  "memchr",
 ]
@@ -3270,7 +3282,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -3371,7 +3383,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.8",
  "redox_syscall",
 ]
 
@@ -3770,7 +3782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc95faa4078768a6bf8df45e2b894bbf372b3dbbfb364e9429c1c58ab7545c6"
 dependencies = [
  "debugid",
- "getrandom 0.2.5",
+ "getrandom 0.2.8",
  "hex",
  "serde",
  "serde_json",
@@ -4777,7 +4789,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93bbc61e655a4833cf400d0d15bf3649313422fa7572886ad6dab16d79886365"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.8",
  "serde",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -35,9 +35,6 @@ skip = [
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [
-    # Wait until `orchard` updates `aes`, which depends on `cipher`
-    { name = "cipher", version = "=0.3.0" },
-
     # ticket #3000: upgrade tower-fallback dependencies
     { name = "pin-project", version = "=0.4.30" },
 
@@ -50,10 +47,21 @@ skip-tree = [
     # wait for primitive-types to upgrade
     { name = "proc-macro-crate", version = "=0.1.5" },
 
-    # ECC crates
+    # ZF crates
 
     # wait for zcash_script to upgrade
+    # https://github.com/ZcashFoundation/zcash_script/pulls
     { name = "zcash_primitives", version = "=0.8.1" },
+
+    # wait for ed25519-zebra, indexmap, metrics-util, and metrics to upgrade
+    # ed25519-zebra/hashbrown: https://github.com/ZcashFoundation/ed25519-zebra/pull/63
+    { name = "ahash", version = "=0.7.6" },
+
+    # ECC crates
+
+    # Wait until `orchard` updates `aes`, which depends on `cipher`
+    { name = "cipher", version = "=0.3.0" },
+
 
     # wait for zcash_primitives to remove duplicated dependencies
     { name = "block-buffer", version = "=0.7.3" },

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -134,7 +134,7 @@ sentry = { version = "0.29.1", default-features = false, features = ["backtrace"
 
 # prod feature flamegraph
 tracing-flame = { version = "0.2.0", optional = true }
-inferno = { version = "0.11.12", default-features = false, optional = true }
+inferno = { version = "0.11.13", default-features = false, optional = true }
 
 # prod feature journald
 tracing-journald = { version = "0.3.0", optional = true }


### PR DESCRIPTION
## Motivation

This is a routine dependency update, it just needs a duplicate dependency exception.