### PR TITLE
change(rpc): Adds `getmininginfo`, `getnetworksolps` and `getnetworkhashps` methods

### DIFF
--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -505,6 +505,13 @@ impl std::ops::Add for Work {
 /// Partial work used to track relative work in non-finalized chains
 pub struct PartialCumulativeWork(u128);
 
+impl PartialCumulativeWork {
+    /// Return the inner `u128` value.
+    pub fn as_u128(self) -> u128 {
+        self.0
+    }
+}
+
 impl From<Work> for PartialCumulativeWork {
     fn from(work: Work) -> Self {
         PartialCumulativeWork(work.0)
@@ -545,13 +552,5 @@ impl std::ops::Sub<Work> for PartialCumulativeWork {
 impl std::ops::SubAssign<Work> for PartialCumulativeWork {
     fn sub_assign(&mut self, rhs: Work) {
         *self = *self - rhs;
-    }
-}
-
-impl std::ops::Deref for PartialCumulativeWork {
-    type Target = u128;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -547,3 +547,11 @@ impl std::ops::SubAssign<Work> for PartialCumulativeWork {
         *self = *self - rhs;
     }
 }
+
+impl std::ops::Deref for PartialCumulativeWork {
+    type Target = u128;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -43,7 +43,7 @@ jsonrpc-http-server = "18.0.0"
 num_cpus = "1.14.0"
 
 # zebra-rpc needs the preserve_order feature in serde_json, which is a dependency of jsonrpc-core
-serde_json = { version = "1.0.89", features = ["preserve_order"] }
+serde_json = { version = "1.0.89", features = ["preserve_order", "arbitrary_precision"] }
 indexmap = { version = "1.9.2", features = ["serde"] }
 
 tokio = { version = "1.23.0", features = ["time", "rt-multi-thread", "macros", "tracing"] }

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -140,7 +140,9 @@ pub trait GetBlockTemplateRpc {
     #[rpc(name = "getmininginfo")]
     fn get_mining_info(&self) -> BoxFuture<Result<types::get_mining_info::Response>>;
 
-    /// Returns the estimated network solutions per second based on the last n blocks.
+    /// Returns the estimated network solutions per second based on the last `num_blocks` before `height`.
+    /// If `num_blocks` is not supplied, uses 120 blocks.
+    /// If `height` is not supplied or is 0, uses the tip height.
     ///
     /// zcashd reference: [`getnetworksolps`](https://zcash.github.io/rpc/getnetworksolps.html)
     #[rpc(name = "getnetworksolps")]
@@ -150,7 +152,9 @@ pub trait GetBlockTemplateRpc {
         height: Option<i32>,
     ) -> BoxFuture<Result<u128>>;
 
-    /// Returns the estimated network solutions per second based on the last n blocks.
+    /// Returns the estimated network solutions per second based on the last `num_blocks` before `height`.
+    /// If `num_blocks` is not supplied, uses 120 blocks.
+    /// If `height` is not supplied or is 0, uses the tip height.
     ///
     /// zcashd reference: [`getnetworkhashps`](https://zcash.github.io/rpc/getnetworkhashps.html)
     #[rpc(name = "getnetworkhashps")]

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -53,6 +53,11 @@ pub(crate) mod zip317;
 /// > and clock time varies between nodes.
 const MAX_ESTIMATED_DISTANCE_TO_NETWORK_CHAIN_TIP: i32 = 100;
 
+/// The default window size specifying how many blocks to check when estimating the chain's solution rate.
+///
+/// Based on default value in zcashd.
+const DEFAULT_SOLUTION_RATE_WINDOW_SIZE: usize = 120;
+
 /// The RPC error code used by `zcashd` for when it's still downloading initial blocks.
 ///
 /// `s-nomp` mining pool expects error code `-10` when the node is not synced:
@@ -579,7 +584,9 @@ where
         num_blocks: Option<usize>,
         height: Option<i32>,
     ) -> BoxFuture<Result<u128>> {
-        let num_blocks = num_blocks.map(|num_blocks| num_blocks.max(1));
+        let num_blocks = num_blocks
+            .map(|num_blocks| num_blocks.max(1))
+            .unwrap_or(DEFAULT_SOLUTION_RATE_WINDOW_SIZE);
         let height = height.and_then(|height| (height > 1).then_some(Height(height as u32)));
         let mut state = self.state.clone();
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -139,6 +139,28 @@ pub trait GetBlockTemplateRpc {
     /// zcashd reference: [`getmininginfo`](https://zcash.github.io/rpc/getmininginfo.html)
     #[rpc(name = "getmininginfo")]
     fn get_mining_info(&self) -> BoxFuture<Result<types::get_mining_info::Response>>;
+
+    /// Returns the estimated network solutions per second based on the last n blocks.
+    ///
+    /// zcashd reference: [`getnetworksolps`](https://zcash.github.io/rpc/getnetworksolps.html)
+    #[rpc(name = "getnetworksolps")]
+    fn get_network_sol_ps(
+        &self,
+        num_blocks: Option<usize>,
+        height: Option<i32>,
+    ) -> BoxFuture<Result<u128>>;
+
+    /// Returns the estimated network solutions per second based on the last n blocks.
+    ///
+    /// zcashd reference: [`getnetworkhashps`](https://zcash.github.io/rpc/getnetworkhashps.html)
+    #[rpc(name = "getnetworkhashps")]
+    fn get_network_hash_ps(
+        &self,
+        num_blocks: Option<usize>,
+        height: Option<i32>,
+    ) -> BoxFuture<Result<u128>> {
+        self.get_network_sol_ps(num_blocks, height)
+    }
 }
 
 /// RPC method implementations.
@@ -538,7 +560,50 @@ where
 
     fn get_mining_info(&self) -> BoxFuture<Result<types::get_mining_info::Response>> {
         let network = self.network;
-        async move { Ok(types::get_mining_info::Response::new(network, 0)) }.boxed()
+        let solution_rate_fut = self.get_network_sol_ps(None, None);
+        async move {
+            Ok(types::get_mining_info::Response::new(
+                network,
+                solution_rate_fut.await?,
+            ))
+        }
+        .boxed()
+    }
+
+    fn get_network_sol_ps(
+        &self,
+        num_blocks: Option<usize>,
+        height: Option<i32>,
+    ) -> BoxFuture<Result<u128>> {
+        let num_blocks = num_blocks.map(|num_blocks| num_blocks.max(1));
+        let height = height.and_then(|height| (height > 1).then_some(Height(height as u32)));
+        let mut state = self.state.clone();
+
+        async move {
+            let request = ReadRequest::SolutionRate { num_blocks, height };
+
+            let response = state
+                .ready()
+                .and_then(|service| service.call(request))
+                .await
+                .map_err(|error| Error {
+                    code: ErrorCode::ServerError(0),
+                    message: error.to_string(),
+                    data: None,
+                })?;
+
+            let solution_rate = match response {
+                ReadResponse::SolutionRate(solution_rate) => solution_rate.ok_or(Error {
+                    code: ErrorCode::ServerError(0),
+                    message: "No blocks in state".to_string(),
+                    data: None,
+                })?,
+                _ => unreachable!("unmatched response to a solution rate request"),
+            };
+
+            Ok(solution_rate)
+        }
+        .boxed()
     }
 }
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -133,6 +133,12 @@ pub trait GetBlockTemplateRpc {
         hex_data: HexData,
         _options: Option<submit_block::JsonParameters>,
     ) -> BoxFuture<Result<submit_block::Response>>;
+
+    /// Returns mining-related information.
+    ///
+    /// zcashd reference: [`getmininginfo`](https://zcash.github.io/rpc/getmininginfo.html)
+    #[rpc(name = "getmininginfo")]
+    fn get_mining_info(&self) -> BoxFuture<Result<types::get_mining_info::Response>>;
 }
 
 /// RPC method implementations.
@@ -528,6 +534,11 @@ where
             .into())
         }
         .boxed()
+    }
+
+    fn get_mining_info(&self) -> BoxFuture<Result<types::get_mining_info::Response>> {
+        let network = self.network;
+        async move { Ok(types::get_mining_info::Response::new(network, 0)) }.boxed()
     }
 }
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types.rs
@@ -3,6 +3,7 @@
 pub mod default_roots;
 pub mod get_block_template;
 pub mod get_block_template_opts;
+pub mod get_mining_info;
 pub mod hex_data;
 pub mod submit_block;
 pub mod transaction;

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
@@ -1,0 +1,26 @@
+//! Response type for the `getmininginfo` RPC.
+
+use zebra_chain::parameters::Network;
+
+/// Response to a `getmininginfo` RPC request.
+#[derive(Debug, PartialEq, Eq, serde::Serialize)]
+pub struct Response {
+    /// The estimated network solution rate in Sol/s.
+    networksolps: u128,
+
+    /// The estimated network solution rate in Sol/s.
+    networkhashps: u128,
+
+    /// Current network name as defined in BIP70 (main, test, regtest)/
+    chain: Network,
+}
+
+impl Response {
+    pub fn new(chain: Network, networksolps: u128) -> Self {
+        Self {
+            networksolps,
+            networkhashps: networksolps,
+            chain,
+        }
+    }
+}

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
@@ -16,6 +16,7 @@ pub struct Response {
 }
 
 impl Response {
+    /// Creates a new `getmininginfo` response
     pub fn new(chain: Network, networksolps: u128) -> Self {
         Self {
             networksolps,

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
@@ -12,7 +12,7 @@ pub struct Response {
     networkhashps: u128,
 
     /// Current network name as defined in BIP70 (main, test, regtest)
-    chain: Network,
+    chain: String,
 
     /// If using testnet or not
     testnet: bool,
@@ -20,12 +20,12 @@ pub struct Response {
 
 impl Response {
     /// Creates a new `getmininginfo` response
-    pub fn new(chain: Network, networksolps: u128) -> Self {
+    pub fn new(network: Network, networksolps: u128) -> Self {
         Self {
             networksolps,
             networkhashps: networksolps,
-            chain,
-            testnet: chain == Network::Testnet,
+            chain: network.bip70_network_name(),
+            testnet: network == Network::Testnet,
         }
     }
 }

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
@@ -11,7 +11,7 @@ pub struct Response {
     /// The estimated network solution rate in Sol/s.
     networkhashps: u128,
 
-    /// Current network name as defined in BIP70 (main, test, regtest)/
+    /// Current network name as defined in BIP70 (main, test, regtest)
     chain: Network,
 }
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
@@ -13,6 +13,9 @@ pub struct Response {
 
     /// Current network name as defined in BIP70 (main, test, regtest)
     chain: Network,
+
+    /// If using testnet or not
+    testnet: bool,
 }
 
 impl Response {
@@ -22,6 +25,7 @@ impl Response {
             networksolps,
             networkhashps: networksolps,
             chain,
+            testnet: chain == Network::Testnet,
         }
     }
 }

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -29,7 +29,9 @@ use zebra_test::mock_service::{MockService, PanicAssertion};
 use crate::methods::{
     get_block_template_rpcs::{
         self,
-        types::{get_block_template::GetBlockTemplate, hex_data::HexData, submit_block},
+        types::{
+            get_block_template::GetBlockTemplate, get_mining_info, hex_data::HexData, submit_block,
+        },
     },
     tests::utils::fake_history_tree,
     GetBlockHash, GetBlockTemplateRpc, GetBlockTemplateRpcImpl,
@@ -194,6 +196,20 @@ pub async fn test_responses<State, ReadState>(
         .expect("unexpected error in submitblock RPC call");
 
     snapshot_rpc_submit_block_invalid(submit_block, &settings);
+
+    // `getmininginfo`
+    let get_mining_info = get_block_template_rpc
+        .get_mining_info()
+        .await
+        .expect("We should have a success response");
+    snapshot_rpc_getmininginfo(get_mining_info, &settings);
+
+    // `getnetworksolps` (and `getnetworkhashps`)
+    let get_network_sol_ps = get_block_template_rpc
+        .get_network_sol_ps(None, None)
+        .await
+        .expect("We should have a success response");
+    snapshot_rpc_getnetworksolps(get_network_sol_ps, &settings);
 }
 
 /// Snapshot `getblockcount` response, using `cargo insta` and JSON serialization.
@@ -224,4 +240,17 @@ fn snapshot_rpc_submit_block_invalid(
     settings.bind(|| {
         insta::assert_json_snapshot!("snapshot_rpc_submit_block_invalid", submit_block_response)
     });
+}
+
+/// Snapshot `getmininginfo` response, using `cargo insta` and JSON serialization.
+fn snapshot_rpc_getmininginfo(
+    get_mining_info: get_mining_info::Response,
+    settings: &insta::Settings,
+) {
+    settings.bind(|| insta::assert_json_snapshot!("get_mining_info", get_mining_info));
+}
+
+/// Snapshot `getnetworksolps` response, using `cargo insta` and JSON serialization.
+fn snapshot_rpc_getnetworksolps(get_network_sol_ps: u128, settings: &insta::Settings) {
+    settings.bind(|| insta::assert_json_snapshot!("get_network_sol_ps", get_network_sol_ps));
 }

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -129,8 +129,21 @@ pub async fn test_responses<State, ReadState>(
         .get_block_hash(BLOCK_HEIGHT10)
         .await
         .expect("We should have a GetBlockHash struct");
-
     snapshot_rpc_getblockhash(get_block_hash, &settings);
+
+    // `getmininginfo`
+    let get_mining_info = get_block_template_rpc
+        .get_mining_info()
+        .await
+        .expect("We should have a success response");
+    snapshot_rpc_getmininginfo(get_mining_info, &settings);
+
+    // `getnetworksolps` (and `getnetworkhashps`)
+    let get_network_sol_ps = get_block_template_rpc
+        .get_network_sol_ps(None, None)
+        .await
+        .expect("We should have a success response");
+    snapshot_rpc_getnetworksolps(get_network_sol_ps, &settings);
 
     // get a new empty state
     let new_read_state = MockService::build().for_unit_tests();
@@ -196,20 +209,6 @@ pub async fn test_responses<State, ReadState>(
         .expect("unexpected error in submitblock RPC call");
 
     snapshot_rpc_submit_block_invalid(submit_block, &settings);
-
-    // `getmininginfo`
-    let get_mining_info = get_block_template_rpc
-        .get_mining_info()
-        .await
-        .expect("We should have a success response");
-    snapshot_rpc_getmininginfo(get_mining_info, &settings);
-
-    // `getnetworksolps` (and `getnetworkhashps`)
-    let get_network_sol_ps = get_block_template_rpc
-        .get_network_sol_ps(None, None)
-        .await
-        .expect("We should have a success response");
-    snapshot_rpc_getnetworksolps(get_network_sol_ps, &settings);
 }
 
 /// Snapshot `getblockcount` response, using `cargo insta` and JSON serialization.

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_mining_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_mining_info@mainnet_10.snap
@@ -5,5 +5,6 @@ expression: get_mining_info
 {
   "networksolps": 2,
   "networkhashps": 2,
-  "chain": "Mainnet"
+  "chain": "main",
+  "testnet": false
 }

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_mining_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_mining_info@mainnet_10.snap
@@ -1,0 +1,9 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+expression: get_mining_info
+---
+{
+  "networksolps": 2,
+  "networkhashps": 2,
+  "chain": "Mainnet"
+}

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_mining_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_mining_info@testnet_10.snap
@@ -5,5 +5,6 @@ expression: get_mining_info
 {
   "networksolps": 0,
   "networkhashps": 0,
-  "chain": "Testnet"
+  "chain": "test",
+  "testnet": true
 }

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_mining_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_mining_info@testnet_10.snap
@@ -1,0 +1,9 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+expression: get_mining_info
+---
+{
+  "networksolps": 0,
+  "networkhashps": 0,
+  "chain": "Testnet"
+}

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_network_sol_ps@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_network_sol_ps@mainnet_10.snap
@@ -1,0 +1,5 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+expression: get_network_sol_ps
+---
+2

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_network_sol_ps@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_network_sol_ps@testnet_10.snap
@@ -1,0 +1,5 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+expression: get_network_sol_ps
+---
+0

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -786,7 +786,7 @@ pub enum ReadRequest {
     /// Returns [`ReadResponse::SolutionRate`]
     SolutionRate {
         /// Specifies over difficulty averaging window.
-        num_blocks: Option<usize>,
+        num_blocks: usize,
         /// Optionally estimate the network speed at the time when a certain block was found
         height: Option<block::Height>,
     },

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -779,6 +779,17 @@ pub enum ReadRequest {
     /// [`zebra-state::GetBlockTemplateChainInfo`](zebra-state::GetBlockTemplateChainInfo)` structure containing
     /// best chain state information.
     ChainInfo,
+
+    #[cfg(feature = "getblocktemplate-rpcs")]
+    /// Get the average solution rate in the best chain.
+    ///
+    /// Returns [`ReadResponse::SolutionRate`]
+    SolutionRate {
+        /// Specifies over difficulty averaging window.
+        num_blocks: Option<usize>,
+        /// Optionally estimate the network speed at the time when a certain block was found
+        height: Option<block::Height>,
+    },
 }
 
 impl ReadRequest {
@@ -806,6 +817,8 @@ impl ReadRequest {
             ReadRequest::BestChainBlockHash(_) => "best_chain_block_hash",
             #[cfg(feature = "getblocktemplate-rpcs")]
             ReadRequest::ChainInfo => "chain_info",
+            #[cfg(feature = "getblocktemplate-rpcs")]
+            ReadRequest::SolutionRate { .. } => "solution_rate",
         }
     }
 

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -135,7 +135,7 @@ pub enum ReadResponse {
     ChainInfo(GetBlockTemplateChainInfo),
 
     #[cfg(feature = "getblocktemplate-rpcs")]
-    /// Response to [`ReadRequest::ChainSolutionRate`](crate::ReadRequest::ChainSolutionRate)
+    /// Response to [`ReadRequest::SolutionRate`](crate::ReadRequest::SolutionRate)
     SolutionRate(Option<u128>),
 }
 

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -133,6 +133,10 @@ pub enum ReadResponse {
     /// Response to [`ReadRequest::ChainInfo`](crate::ReadRequest::ChainInfo) with the state
     /// information needed by the `getblocktemplate` RPC method.
     ChainInfo(GetBlockTemplateChainInfo),
+
+    #[cfg(feature = "getblocktemplate-rpcs")]
+    /// Response to [`ReadRequest::ChainSolutionRate`](crate::ReadRequest::ChainSolutionRate)
+    SolutionRate(Option<u128>),
 }
 
 #[cfg(feature = "getblocktemplate-rpcs")]
@@ -204,7 +208,7 @@ impl TryFrom<ReadResponse> for Response {
                 Err("there is no corresponding Response for this ReadResponse")
             }
             #[cfg(feature = "getblocktemplate-rpcs")]
-            ReadResponse::ChainInfo(_) => {
+            ReadResponse::ChainInfo(_) | ReadResponse::SolutionRate(_) => {
                 Err("there is no corresponding Response for this ReadResponse")
             }
         }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1637,6 +1637,13 @@ impl Service<ReadRequest> for ReadStateService {
                 tokio::task::spawn_blocking(move || {
                     span.in_scope(move || {
                         let latest_non_finalized_state = state.latest_non_finalized_state();
+                        // # Correctness
+                        //
+                        // It is ok to do these lookups using multiple database calls. Finalized state updates
+                        // can only add overlapping blocks, and block hashes are unique across all chain forks.
+                        //
+                        // The worst that can happen here is that the default `start_hash` will be below
+                        // the chain tip.
                         let (tip_height, tip_hash) =
                             match read::tip(latest_non_finalized_state.best_chain(), &state.db) {
                                 Some(tip_hash) => tip_hash,

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1622,6 +1622,55 @@ impl Service<ReadRequest> for ReadStateService {
                 .map(|join_result| join_result.expect("panic in ReadRequest::ChainInfo"))
                 .boxed()
             }
+
+            // Used by getmininginfo, getnetworksolps, and getnetworkhashps RPCs.
+            #[cfg(feature = "getblocktemplate-rpcs")]
+            ReadRequest::SolutionRate { num_blocks, height } => {
+                let timer = CodeTimer::start();
+
+                let state = self.clone();
+
+                // # Performance
+                //
+                // Allow other async tasks to make progress while concurrently reading blocks from disk.
+                let span = Span::current();
+                tokio::task::spawn_blocking(move || {
+                    span.in_scope(move || {
+                        let latest_non_finalized_state = state.latest_non_finalized_state();
+                        let (tip_height, tip_hash) =
+                            match read::tip(latest_non_finalized_state.best_chain(), &state.db) {
+                                Some(tip_hash) => tip_hash,
+                                None => return Ok(ReadResponse::SolutionRate(None)),
+                            };
+
+                        let start_hash = match height {
+                            Some(height) if height < tip_height => read::hash_by_height(
+                                latest_non_finalized_state.best_chain(),
+                                &state.db,
+                                height,
+                            ),
+                            // use the chain tip hash if height is above it or not provided.
+                            _ => Some(tip_hash),
+                        };
+
+                        let solution_rate = start_hash.and_then(|start_hash| {
+                            read::difficulty::solution_rate(
+                                &latest_non_finalized_state,
+                                &state.db,
+                                num_blocks,
+                                start_hash,
+                            )
+                        });
+
+                        // The work is done in the future.
+                        timer.finish(module_path!(), line!(), "ReadRequest::ChainInfo");
+
+                        Ok(ReadResponse::SolutionRate(solution_rate))
+                    })
+                })
+                .map(|join_result| join_result.expect("panic in ReadRequest::ChainInfo"))
+                .boxed()
+            }
         }
     }
 }

--- a/zebra-state/src/service/read/difficulty.rs
+++ b/zebra-state/src/service/read/difficulty.rs
@@ -77,6 +77,8 @@ pub fn solution_rate(
     num_blocks: usize,
     start_hash: Hash,
 ) -> Option<u128> {
+    // Take 1 extra block for calculating the number of seconds between when mining on the first block likely started.
+    // The work for the last block in this iterator is not added to `total_work`.
     let mut block_iter = any_ancestor_blocks(non_finalized_state, db, start_hash)
         .take(num_blocks.checked_add(1).unwrap_or(num_blocks))
         .peekable();

--- a/zebra-state/src/service/read/difficulty.rs
+++ b/zebra-state/src/service/read/difficulty.rs
@@ -63,27 +63,21 @@ pub fn get_block_template_chain_info(
     ))
 }
 
-/// The default window size specifying how many blocks to check when estimating the chain's solution rate
-/// Based on default value in zcashd.
-const DEFAULT_SOLUTION_RATE_WINDOW_SIZE: usize = 120;
-
 /// Accepts a `non_finalized_state`, [`ZebraDb`], `num_blocks`, and a block hash to start at.
 ///
-/// Iterates over up to the last `num_blocks` or [`DEFAULT_SOLUTION_RATE_WINDOW_SIZE`] blocks, summing up
-/// their total work. Divides that total by the number of seconds between the timestamp of the
+/// Iterates over up to the last `num_blocks` blocks, summing up their total work.
+/// Divides that total by the number of seconds between the timestamp of the
 /// first block in the iteration and 1 block below the last block.
 ///
-/// Returns the solution rate per second for the current best chain, or `None` if the `start_hash` and
-/// at least 1 block below it are not found in the chain.
+/// Returns the solution rate per second for the current best chain, or `None` if
+/// the `start_hash` and at least 1 block below it are not found in the chain.
 pub fn solution_rate(
     non_finalized_state: &NonFinalizedState,
     db: &ZebraDb,
-    num_blocks: Option<usize>,
+    num_blocks: usize,
     start_hash: Hash,
 ) -> Option<u128> {
     let mut total_work: u128 = 0;
-    let num_blocks = num_blocks.unwrap_or(DEFAULT_SOLUTION_RATE_WINDOW_SIZE);
-
     let mut block_iter = any_ancestor_blocks(non_finalized_state, db, start_hash)
         .take(num_blocks.checked_add(1).unwrap_or(num_blocks))
         .peekable();

--- a/zebra-state/src/service/read/difficulty.rs
+++ b/zebra-state/src/service/read/difficulty.rs
@@ -108,7 +108,9 @@ pub fn solution_rate(
         } else {
             let first_block_time = block.header.time;
             let duration_between_first_and_last_block = last_block_time - first_block_time;
-            return Some(*total_work / duration_between_first_and_last_block.num_seconds() as u128);
+            return Some(
+                total_work.as_u128() / duration_between_first_and_last_block.num_seconds() as u128,
+            );
         }
     }
 }

--- a/zebra-state/src/service/read/difficulty.rs
+++ b/zebra-state/src/service/read/difficulty.rs
@@ -102,6 +102,8 @@ pub fn solution_rate(
 
         if block_iter.peek().is_some() {
             // Add the block's work to `total_work` if it's not the last item in the iterator.
+            // The last item in the iterator is only used to estimate when mining on the first block
+            // in the window of `num_blocks` likely started.
             total_work += get_work(block);
         } else {
             let first_block_time = block.header.time;


### PR DESCRIPTION
## Motivation

We want to support the `getnetworksolps`, `getnetworkhashps`, and `getmininginfo` RPCs.

- Closes #5721
- Closes #5468

## Solution

- Adds a state request for getting the chain solution rate
  - Sums up total work for a range of blocks
  - Divides it by number of seconds elapsed between the first and last block in the range
- Adds RPC `getmininginfo`, `getnetworksolps` and `getnetworkhashps` RPCs

## Review

Part of regular scheduled work.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- Populate other fields for the `getmininginfo` response