### PR TITLE
fix(ci): Run basic and ignored unit tests at the same time, speeding up CI by half an hour

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -205,18 +205,13 @@ jobs:
         with:
           short-length: 7
 
-      # Run unit and basic acceptance tests, only showing command output if the test fails.
+      # Run unit, basic acceptance tests, and ignored tests, only showing command output if the test fails.
       #
       # If some tests hang, add "-- --nocapture" for just that test, or for all the tests.
-      - name: Run basic zebrad tests
+      - name: Run zebrad tests
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run --name zebrad-tests --tty ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features "lightwalletd-grpc-tests" --workspace
-
-      # Run ignored by default acceptance tests, only showing command output if the test fails.
-      - name: Run ignored zebrad tests
-        run: |
-          docker run --name zebrad-tests-ignored --tty ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features "lightwalletd-grpc-tests" --workspace -- --ignored --nocapture
+          docker run --name zebrad-tests --tty ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features "lightwalletd-grpc-tests" --workspace -- --include-ignored
 
   # zebrad tests without cached state with `getblocktemplate-rpcs` feature
   #
@@ -232,15 +227,10 @@ jobs:
         with:
           short-length: 7
 
-      - name: Run basic zebrad tests
+      - name: Run zebrad tests
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run --name zebrad-tests --tty ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features "lightwalletd-grpc-tests getblocktemplate-rpcs" --workspace
-
-      - name: Run ignored zebrad tests
-        run: |
-          docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run --name zebrad-tests-ignored --tty ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features "lightwalletd-grpc-tests getblocktemplate-rpcs" --workspace -- --ignored --nocapture
+          docker run --name zebrad-tests --tty ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} cargo test --locked --release --features "lightwalletd-grpc-tests getblocktemplate-rpcs" --workspace -- --include-ignored
 
   # Run state tests with fake activation heights.
   #


### PR DESCRIPTION
## Motivation

Currently we spent half an hour re-compiling Zebra for one ignored test.

See ticket #5812 for details.

## Solution

Run the ignored tests with the other tests, saving half an hour in CI

Closes #5812 by achieving the same goal, but in a simpler way.

## Review

Anyone can review this PR, I've marked it as critical so it goes first in the queue, and speeds up other batches.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

