### PR TITLE
fix(dev): Make zcash-rpc-diff always check Zebra then zcashd

### DIFF
--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -69,15 +69,15 @@ echo
 
 if [ "$ZEBRAD_NET" != "$ZCASHD_NET" ]; then
     echo "WARNING: comparing RPC responses from different networks:"
-    echo "$ZCASHD is on: $ZCASHD_NET"
     echo "$ZEBRAD is on: $ZEBRAD_NET"
+    echo "$ZCASHD is on: $ZCASHD_NET"
     echo
 fi
 
 if [ "$ZEBRAD_HEIGHT" -ne "$ZCASHD_HEIGHT" ]; then
     echo "WARNING: comparing RPC responses from different heights:"
-    echo "$ZCASHD is at: $ZCASHD_HEIGHT"
     echo "$ZEBRAD is at: $ZEBRAD_HEIGHT"
+    echo "$ZCASHD is at: $ZCASHD_HEIGHT"
     echo
 fi
 
@@ -98,7 +98,7 @@ echo
 
 echo
 
-echo "Response diff between $ZCASHD and $ZEBRAD:"
+echo "Response diff between $ZEBRAD and $ZCASHD:"
 
 $DIFF "$ZEBRAD_RESPONSE" "$ZCASHD_RESPONSE" \
     && ( \
@@ -140,7 +140,7 @@ $ZCASH_CLI "$@" > "$ZCASHD_CHECK_RESPONSE"
 
 echo
 
-echo "$1 diff between $ZCASHD and $ZEBRAD:"
+echo "$1 diff between $ZEBRAD and $ZCASHD:"
 
 $DIFF "$ZEBRAD_CHECK_RESPONSE" "$ZCASHD_CHECK_RESPONSE" \
     && ( \
@@ -173,7 +173,7 @@ if [ "$1" == "getaddressbalance" ]; then
 
     echo
 
-    echo "Balance diff between $ZCASHD and $ZEBRAD:"
+    echo "Balance diff between $ZEBRAD and $ZCASHD:"
     echo "(for both getaddressbalance and getaddressutxos)"
 
     $DIFF --from-file="$ZEBRAD_NUM_RESPONSE" "$ZCASHD_NUM_RESPONSE" \


### PR DESCRIPTION
## Motivation

Sometimes they were in the opposite order in the script, which is confusing when reviewing diffs.

## Review

This is a minor usability fix for a developer testing tool.

I used it for the 3 diffs in:
https://github.com/ZcashFoundation/zebra/pull/5808#issuecomment-1342137431

### Reviewer Checklist

  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [x] How do you know it works? Does it have tests?
