### PR TITLE
change(rpc): return u64 from `get_network_sol_ps` and remove `arbitrary_precision` feature from serde

### DIFF
--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -43,7 +43,7 @@ jsonrpc-http-server = "18.0.0"
 num_cpus = "1.14.0"
 
 # zebra-rpc needs the preserve_order feature in serde_json, which is a dependency of jsonrpc-core
-serde_json = { version = "1.0.89", features = ["preserve_order", "arbitrary_precision"] }
+serde_json = { version = "1.0.89", features = ["preserve_order"] }
 indexmap = { version = "1.9.2", features = ["serde"] }
 
 tokio = { version = "1.23.0", features = ["time", "rt-multi-thread", "macros", "tracing"] }

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -154,7 +154,7 @@ pub trait GetBlockTemplateRpc {
         &self,
         num_blocks: Option<usize>,
         height: Option<i32>,
-    ) -> BoxFuture<Result<u128>>;
+    ) -> BoxFuture<Result<u64>>;
 
     /// Returns the estimated network solutions per second based on the last `num_blocks` before `height`.
     /// If `num_blocks` is not supplied, uses 120 blocks.
@@ -166,7 +166,7 @@ pub trait GetBlockTemplateRpc {
         &self,
         num_blocks: Option<usize>,
         height: Option<i32>,
-    ) -> BoxFuture<Result<u128>> {
+    ) -> BoxFuture<Result<u64>> {
         self.get_network_sol_ps(num_blocks, height)
     }
 }
@@ -585,7 +585,7 @@ where
         &self,
         num_blocks: Option<usize>,
         height: Option<i32>,
-    ) -> BoxFuture<Result<u128>> {
+    ) -> BoxFuture<Result<u64>> {
         let num_blocks = num_blocks
             .map(|num_blocks| num_blocks.max(1))
             .unwrap_or(DEFAULT_SOLUTION_RATE_WINDOW_SIZE);
@@ -614,7 +614,7 @@ where
                 _ => unreachable!("unmatched response to a solution rate request"),
             };
 
-            Ok(solution_rate)
+            Ok(solution_rate as u64)
         }
         .boxed()
     }

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -614,7 +614,7 @@ where
                 _ => unreachable!("unmatched response to a solution rate request"),
             };
 
-            Ok(solution_rate as u64)
+            Ok(solution_rate.try_into().expect("per-second solution rate always fits in u64"))
         }
         .boxed()
     }

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -614,7 +614,9 @@ where
                 _ => unreachable!("unmatched response to a solution rate request"),
             };
 
-            Ok(solution_rate.try_into().expect("per-second solution rate always fits in u64"))
+            Ok(solution_rate
+                .try_into()
+                .expect("per-second solution rate always fits in u64"))
         }
         .boxed()
     }

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
@@ -6,10 +6,10 @@ use zebra_chain::parameters::Network;
 #[derive(Debug, PartialEq, Eq, serde::Serialize)]
 pub struct Response {
     /// The estimated network solution rate in Sol/s.
-    networksolps: u128,
+    networksolps: u64,
 
     /// The estimated network solution rate in Sol/s.
-    networkhashps: u128,
+    networkhashps: u64,
 
     /// Current network name as defined in BIP70 (main, test, regtest)
     chain: String,
@@ -20,7 +20,7 @@ pub struct Response {
 
 impl Response {
     /// Creates a new `getmininginfo` response
-    pub fn new(network: Network, networksolps: u128) -> Self {
+    pub fn new(network: Network, networksolps: u64) -> Self {
         Self {
             networksolps,
             networkhashps: networksolps,

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -250,6 +250,6 @@ fn snapshot_rpc_getmininginfo(
 }
 
 /// Snapshot `getnetworksolps` response, using `cargo insta` and JSON serialization.
-fn snapshot_rpc_getnetworksolps(get_network_sol_ps: u128, settings: &insta::Settings) {
+fn snapshot_rpc_getnetworksolps(get_network_sol_ps: u64, settings: &insta::Settings) {
     settings.bind(|| insta::assert_json_snapshot!("get_network_sol_ps", get_network_sol_ps));
 }


### PR DESCRIPTION
## Motivation

Mining RPCs responding with the network solution rate added in https://github.com/ZcashFoundation/zebra/pull/5808 are returning a `u128`, requiring the `arbitrary_precision` feature from `serde`.

There are issues open in `serde` about the `arbitrary_precision` feature (see https://github.com/serde-rs/json/issues/505 and https://github.com/serde-rs/serde/issues/1183). We haven't run into these issues but we only need `u64` for any feasible solution rate that might be returned anyways, so we should use a `u64` instead of a `u128`.

## Solution

- Cast `solution_rate` to a `u64`
- Return a u64 from `getnetworksolps`, `getnetworkhashps`, and `getmininginfo`

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
