### PR TITLE
fix(rpc): Wait for 3 minutes to check Zebra is synced to the tip, rather than 2

### DIFF
--- a/zebra-test/src/mock_service.rs
+++ b/zebra-test/src/mock_service.rs
@@ -77,8 +77,9 @@ const DEFAULT_PROXY_CHANNEL_SIZE: usize = 100;
 /// Note that if a test checks that no requests are received, each check has to wait for this
 /// amount of time, so this may affect the test execution time.
 ///
-/// We've seen delays up to 67ms on busy Linux and macOS machines.
-pub const DEFAULT_MAX_REQUEST_DELAY: Duration = Duration::from_millis(150);
+/// We've seen delays up to 67ms on busy Linux and macOS machines,
+/// and some other timeout failures even with a 150ms timeout.
+pub const DEFAULT_MAX_REQUEST_DELAY: Duration = Duration::from_millis(300);
 
 /// An internal type representing the item that's sent in the [`broadcast`] channel.
 ///

--- a/zebrad/src/components/sync/recent_sync_lengths.rs
+++ b/zebrad/src/components/sync/recent_sync_lengths.rs
@@ -31,7 +31,7 @@ impl RecentSyncLengths {
     /// * clearing temporary errors and temporary syncs quickly
     /// * distinguishing between temporary and sustained syncs/errors
     /// * activating the syncer shortly after reaching the chain tip
-    pub const MAX_RECENT_LENGTHS: usize = 2;
+    pub const MAX_RECENT_LENGTHS: usize = 3;
 
     /// Create a new instance of [`RecentSyncLengths`]
     /// and a [`watch::Receiver`] endpoint for receiving recent sync lengths.


### PR DESCRIPTION
## Motivation

When I have been testing the `getblocktemplate` RPC, Zebra sometimes reports it is synced before it is actually at the tip. This will be bad for miners, but could also impact other RPCs and general Zebra usage.

This is a partial fix for #4649.

## Solution

Wait for 3 syncs to check that Zebra is synced, rather than 2.

## Review

Anyone can review this PR, it is a routine fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We might want to fix the rest of #4649, or this could be enough for now.