### PR TITLE
change(mempool): Re-verify mempool transactions after a chain fork, rather than re-downloading them all

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,19 +235,13 @@ So Zebra's state should always be valid, unless your OS or disk hardware is corr
 
 There are a few bugs in Zebra that we're still working on fixing:
 
-- Zebra falsely estimates that it's close to the tip when the network connection goes down [#4649](https://github.com/ZcashFoundation/zebra/issues/4649)
-
-  - One of the consequences of this issue is that Zebra might add unwanted load
-    to other peers when the connection goes back up. This load will last only
-    for a short period of time because Zebra will quickly find out that it's
-    still not close to the tip.
+- Zebra falsely estimates that it's close to the tip when the network connection goes down [#4649](https://github.com/ZcashFoundation/zebra/issues/4649).
 
 - If Zebra fails downloading the Zcash parameters, use [the Zcash parameters download script](https://github.com/zcash/zcash/blob/master/zcutil/fetch-params.sh) instead. This script might be needed on macOS, even with Rust stable.
-- No Windows support [#3801](https://github.com/ZcashFoundation/zebra/issues/3801)
-  - We used to test with Windows Server 2019, but not anymore; see issue for details
 
-- Experimental Tor support is disabled until [`arti-client` upgrades to `x25519-dalek` 2.0.0 or later](https://github.com/ZcashFoundation/zebra/issues/5492)
-  - This happens due to a Rust dependency conflict, which can only be resolved by changing the dependencies of `x25519-dalek`
+- No Windows support [#3801](https://github.com/ZcashFoundation/zebra/issues/3801). We used to test with Windows Server 2019, but not anymore; see the issue for details.
+
+- Experimental Tor support is disabled until [`arti-client` upgrades to `x25519-dalek` 2.0.0 or later](https://github.com/ZcashFoundation/zebra/issues/5492). This happens due to a Rust dependency conflict, which can only be resolved by upgrading to a version of `x25519-dalek` with the dependency fix.
 
 - Output of `help`, `--help` flag, and usage of invalid commands or options are inconsistent. Reports of these issues can be found [here](https://github.com/ZcashFoundation/zebra/issues/5502) and are planned to be fixed in the context of [upgrading Abscissa](https://github.com/ZcashFoundation/zebra/issues/5502).
 

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -139,8 +139,17 @@ impl fmt::Display for Transaction {
         let mut fmter = f.debug_struct("Transaction");
 
         fmter.field("version", &self.version());
+
         if let Some(network_upgrade) = self.network_upgrade() {
             fmter.field("network_upgrade", &network_upgrade);
+        }
+
+        if let Some(lock_time) = self.lock_time() {
+            fmter.field("lock_time", &lock_time);
+        }
+
+        if let Some(expiry_height) = self.expiry_height() {
+            fmter.field("expiry_height", &expiry_height);
         }
 
         fmter.field("transparent_inputs", &self.inputs().len());

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -223,7 +223,7 @@ pub struct UnminedTx {
 impl fmt::Display for UnminedTx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("UnminedTx")
-            .field("transaction", &self.transaction)
+            .field("transaction", &self.transaction.to_string())
             .field("serialized_size", &self.size)
             .field("conventional_fee", &self.conventional_fee)
             .finish()
@@ -327,7 +327,7 @@ pub struct VerifiedUnminedTx {
 impl fmt::Display for VerifiedUnminedTx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("VerifiedUnminedTx")
-            .field("transaction", &self.transaction)
+            .field("transaction", &self.transaction.to_string())
             .field("miner_fee", &self.miner_fee)
             .field("legacy_sigop_count", &self.legacy_sigop_count)
             .field("unpaid_actions", &self.unpaid_actions)

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -5,7 +5,7 @@
 //! * [LatestChainTip] for efficient access to the current best tip, and
 //! * [ChainTipChange] to `await` specific changes to the chain tip.
 
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use tokio::sync::watch;
@@ -71,6 +71,16 @@ pub struct ChainTipBlock {
     /// If the best chain fork has changed, or some blocks have been skipped,
     /// this hash will be different to the last returned `ChainTipBlock.hash`.
     pub previous_block_hash: block::Hash,
+}
+
+impl fmt::Display for ChainTipBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChainTipBlock")
+            .field("height", &self.height)
+            .field("hash", &self.hash)
+            .field("transactions", &self.transactions.len())
+            .finish()
+    }
 }
 
 impl From<ContextuallyValidBlock> for ChainTipBlock {

--- a/zebra-test/src/mock_service.rs
+++ b/zebra-test/src/mock_service.rs
@@ -434,7 +434,8 @@ impl<Request, Response, Error> MockService<Request, Response, PanicAssertion, Er
         }
     }
 
-    /// A helper method to get the next request from the queue.
+    /// Returns the next request from the queue,
+    /// or panics if there are no requests after a short timeout.
     ///
     /// Returns the next request in the internal queue or waits at most the max delay time
     /// configured by [`MockServiceBuilder::with_max_request_delay`] for a new request to be
@@ -687,7 +688,7 @@ impl<Request, Response, Assertion, Error> MockService<Request, Response, Asserti
     /// If too many requests are received and the queue fills up, the oldest requests are dropped
     /// and ignored. This means that calling this may not receive the next request if the queue is
     /// not dimensioned properly with the [`MockServiceBuilder::with_proxy_channel_size`] method.
-    async fn try_next_request(&mut self) -> Option<ResponseSender<Request, Response, Error>> {
+    pub async fn try_next_request(&mut self) -> Option<ResponseSender<Request, Response, Error>> {
         loop {
             match timeout(self.max_request_delay, self.receiver.recv()).await {
                 Ok(Ok(item)) => {

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -107,14 +107,6 @@ impl Default for ActiveState {
     }
 }
 
-impl Drop for ActiveState {
-    fn drop(&mut self) {
-        if let ActiveState::Enabled { tx_downloads, .. } = self {
-            tx_downloads.cancel_all();
-        }
-    }
-}
-
 impl ActiveState {
     /// Returns the current state, leaving [`Self::Disabled`] in its place.
     fn take(&mut self) -> Self {

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -58,9 +58,9 @@ proptest! {
         runtime.block_on(async move {
             let (
                 mut mempool,
-                mut peer_set,
-                mut state_service,
-                mut tx_verifier,
+                _peer_set,
+                _state_service,
+                _tx_verifier,
                 mut recent_syncs,
                 mut chain_tip_sender,
             ) = setup(network);
@@ -88,9 +88,8 @@ proptest! {
 
             prop_assert_eq!(mempool.storage().transaction_count(), 0);
 
-            peer_set.expect_no_requests().await?;
-            state_service.expect_no_requests().await?;
-            tx_verifier.expect_no_requests().await?;
+            // The services might or might not get requests,
+            // depending on how many transactions get re-queued, and if they need downloading.
 
             Ok(())
         })?;
@@ -109,9 +108,9 @@ proptest! {
         runtime.block_on(async move {
             let (
                 mut mempool,
-                mut peer_set,
-                mut state_service,
-                mut tx_verifier,
+                _peer_set,
+                _state_service,
+                _tx_verifier,
                 mut recent_syncs,
                 mut chain_tip_sender,
             ) = setup(network);
@@ -172,9 +171,8 @@ proptest! {
                 previous_chain_tip = chain_tip.into();
             }
 
-            peer_set.expect_no_requests().await?;
-            state_service.expect_no_requests().await?;
-            tx_verifier.expect_no_requests().await?;
+            // The services might or might not get requests,
+            // depending on how many transactions get re-queued, and if they need downloading.
 
             Ok(())
         })?;


### PR DESCRIPTION
## Motivation

Zebra drops all its mempool transactions when there is a chain fork. But it would be faster and put less load on the network if we re-verified them instead.

I discovered this bug while testing the `getblocktemplate` RPC.

### Complex Code or Requirements

We need to make sure we clear the mempool, then re-verify all the stored or pending transactions.

Otherwise, we could break a consensus rule.

## Solution

- Re-verify mempool transactions after a fork, rather than re-downloading them all
- Update tests for mempool transaction re-verification after forks
- [Update README based on recent mitigations for some issues](https://github.com/ZcashFoundation/zebra/commit/e086e90c4c52b2d3f12dd389e85c8ac47fcd003a)
    - also includes some mitigations from PR #5840

Related bug fixes:
- [Move Drop from mempool::ActiveState to mempool::Downloads, to avoid bugs](https://github.com/ZcashFoundation/zebra/commit/a7f820d80a55247ac1842374254e446a60f4cde4)
    - In the previous design, we could drop the mempool Downloads without cancelling all the tasks

Related cleanups:
- Use a marker struct for cancelling mempool tasks
- Make mempool proptests easier to debug

This doesn't need to be behind a feature, because it's a bug fix for the production mempool as well.

## Review

This is a routine bug fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?


