### PR TITLE
fix(test): Fix a test child process panic bug

### DIFF
--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -846,8 +846,10 @@ impl<T> TestChild<T> {
             self.kill(true)?;
         }
 
-        let timeout =
-            humantime::format_duration(self.timeout.expect("already checked past_deadline()"));
+        let timeout = self
+            .timeout
+            .map(|timeout| humantime::format_duration(timeout).to_string())
+            .unwrap_or_else(|| "unlimited".to_string());
 
         let report = eyre!(
             "{stream_name} of command did not log any matches for the given regex,\n\


### PR DESCRIPTION
## Motivation

If a Zebra test child process exits and finishes its output, but it doesn't have a timeout, the test can panic.

Instead, it should return an error that says that it didn't find the output it wanted, and that there is no timeout.

## Review

This is a low priority test fix.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

