### PR TITLE
feature(rpc): Add basic long polling support to the `getblocktemplate` RPC

### DIFF
--- a/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
@@ -32,7 +32,7 @@ pub use crate::methods::get_block_template_rpcs::types::get_block_template::*;
 
 /// Returns an error if the get block template RPC `parameters` are invalid.
 pub fn check_block_template_parameters(
-    parameters: get_block_template::JsonParameters,
+    parameters: &get_block_template::JsonParameters,
 ) -> Result<()> {
     if parameters.data.is_some() || parameters.mode == GetBlockTemplateRequestMode::Proposal {
         return Err(Error {

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template/parameters.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template/parameters.rs
@@ -85,5 +85,6 @@ pub struct JsonParameters {
     /// An ID that delays the RPC response until the template changes.
     ///
     /// In Zebra, the ID represents the chain tip, max time, and mempool contents.
-    pub longpollid: Option<LongPollId>,
+    #[serde(rename = "longpollid")]
+    pub long_poll_id: Option<LongPollId>,
 }

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1108,7 +1108,7 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
         .get_block_template(Some(get_block_template::JsonParameters {
             // This must parse as a LongPollId.
             // It must be the correct length and have hex/decimal digits.
-            longpollid: Some(
+            long_poll_id: Some(
                 "0".repeat(LONG_POLL_ID_LENGTH)
                     .parse()
                     .expect("unexpected invalid LongPollId"),

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -150,7 +150,7 @@ pub struct GetBlockTemplateChainInfo {
     pub tip_hash: block::Hash,
 
     /// The current state tip height.
-    /// The block template OAfor the candidate block is the next block after this block.
+    /// The block template for the candidate block is the next block after this block.
     /// Depends on the `tip_hash`.
     pub tip_height: block::Height,
 


### PR DESCRIPTION
## Motivation

This PR implements basic long polling support, checking for changes by re-fetching from the sync status, state and mempool.

Part of ticket #5720.

### Complex Code or Requirements

We need to hold the RPC request open until the response will change. This means running a loop and a `select!{}` in a future.

## Solution

Implement inefficient long polling by checking the state/mempool/syncer, waiting 5 seconds, then checking it again. Also wait for the max time.

Related changes:
- Change `impl From<LongPollInput> for LongPollId` into a named method
- Rename the `long_poll_id` field
- Cleanup some comments

## Review

This is ready for review, I'm doing some manual testing now. Automated testing will happen in the next PR.

Efficiency and refactors are out of scope for this PR, I'd like to focus on getting some kind of working implementation merged.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- medium priority: check for state changes efficiently
- low priority: check for sync status and mempool changes efficiently