### PR TITLE
fix(rpc): Accept HashOrHeight as first parameter of getblock and update README.md to note differences between lightwalletd forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ It is recommended to use [adityapk00/lightwalletd](https://github.com/adityapk00
 
 If using [zcash/lightwalletd](https://github.com/zcash/lightwalletd.git):
 - note that it will require a zcash.conf file:
-  - `rpcuser` and `rpcpassword` are required but ignored by Zebra
+  - `rpcuser` and `rpcpassword` are required by `lightwalletd`, but Zebra ignores them if it receives them from `lightwalletd`
   - when using a non-default port, use `rpcport=28232` and `rpcbind=127.0.0.1`
   - when using testnet, use `testnet=1`
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ listen_addr = '127.0.0.1:8232'
 parallel_cpu_threads = 0
 ```
 
+It is recommended to use [adityapk00/lightwalletd](https://github.com/adityapk00/lightwalletd) because that is used in testing.
+
+If using [zcash/lightwalletd](https://github.com/zcash/lightwalletd.git):
+- note that it will require a zcash.conf file 
+- `rpcuser` and `rpcpassword` are required but ignored by Zebra
+- when using a non-default port, use `rpcport=28232` and `rpcbind=127.0.0.1`
+- when using testnet, use testnet=1
+
 **WARNING:** This config allows multiple Zebra instances to share the same RPC port.
 See the [RPC config documentation](https://doc.zebra.zfnd.org/zebra_rpc/config/struct.Config.html) for details.
 

--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ parallel_cpu_threads = 0
 It is recommended to use [adityapk00/lightwalletd](https://github.com/adityapk00/lightwalletd) because that is used in testing.
 
 If using [zcash/lightwalletd](https://github.com/zcash/lightwalletd.git):
-- note that it will require a zcash.conf file 
-- `rpcuser` and `rpcpassword` are required but ignored by Zebra
-- when using a non-default port, use `rpcport=28232` and `rpcbind=127.0.0.1`
-- when using testnet, use testnet=1
+- note that it will require a zcash.conf file:
+  - `rpcuser` and `rpcpassword` are required but ignored by Zebra
+  - when using a non-default port, use `rpcport=28232` and `rpcbind=127.0.0.1`
+  - when using testnet, use `testnet=1`
 
 **WARNING:** This config allows multiple Zebra instances to share the same RPC port.
 See the [RPC config documentation](https://doc.zebra.zfnd.org/zebra_rpc/config/struct.Config.html) for details.

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -82,12 +82,21 @@ async fn rpc_getblock() {
 
     // Make calls with verbosity=0 and check response
     for (i, block) in blocks.iter().enumerate() {
+        let expected_result = GetBlock::Raw(block.clone().into());
+
         let get_block = rpc
             .get_block(i.to_string(), 0u8)
             .await
             .expect("We should have a GetBlock struct");
 
-        assert_eq!(get_block, GetBlock::Raw(block.clone().into()));
+        assert_eq!(get_block, expected_result);
+
+        let get_block = rpc
+            .get_block(block.hash().to_string(), 0u8)
+            .await
+            .expect("We should have a GetBlock struct");
+
+        assert_eq!(get_block, expected_result);
     }
 
     // Make calls with verbosity=1 and check response


### PR DESCRIPTION
## Motivation

We want Zebra to work with [zcash/lightwalletd](https://github.com/zcash/lightwalletd) and to recommend the fork of lightwalletd that's used in testing.

`getblock` is used with a block hash in [zcash/lightwalletd](https://github.com/zcash/lightwalletd) here: https://github.com/zcash/lightwalletd/blob/5d174f7feb702dc19aec5b09d8be8b3d5b17ce45/common/common.go#L286

Closes #5770.


## Solution

- Accept a block height or hash in the `getblock` RPC method
- Note the fork of lightwalletd that Zebra is tested with in the "Configuring JSON-RPC for lightwalletd" section of the README.md

## Review

Part of regular scheduled work.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [x] How do you know it works? Does it have tests?
