### PR TITLE
feat(ci): delete unused artifacts in registries

### DIFF
--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -17,9 +17,9 @@ env:
   # But keep the latest $KEEP_LATEST_IMAGE_COUNT images of each type.
   # We keep this small to reduce storage costs.
   KEEP_LATEST_IMAGE_COUNT: 2
-  # Delete all artifacts in registry created before $DELETE_IMAGE_DAYS days ago.
+  # Delete all artifacts in registry created before $DELETE_IMAGE_HOURS hours ago.
   # We keep this long enough for PRs that are still on the same commit can re-run with the same image.
-  DELETE_IMAGE_DAYS: 21d
+  DELETE_IMAGE_HOURS: 504h # 21 days
 
 jobs:
   delete-resources:
@@ -202,7 +202,7 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
-      # Deletes all images older than $DELETE_IMAGE_DAYS days.
+      # Deletes all images older than $DELETE_IMAGE_HOURS days.
       - uses: 'docker://us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli'
         # Refer to the official documentation to understand available arguments:
         # https://github.com/GoogleCloudPlatform/gcr-cleaner
@@ -210,5 +210,5 @@ jobs:
           args: >-
             -repo=us-docker.pkg.dev/zealous-zebra/zebra/zebrad-test
             -repo=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd
-            -grace=${{ env.DELETE_IMAGE_DAYS }}
+            -grace=${{ env.DELETE_IMAGE_HOURS }}
             -keep=2

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -205,6 +205,7 @@ jobs:
 
       # Deletes all images older than $DELETE_IMAGE_HOURS days.
       - uses: 'docker://us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli'
+        continue-on-error: true # TODO: remove after fixig https://github.com/ZcashFoundation/zebra/issues/5933
         # Refer to the official documentation to understand available arguments:
         # https://github.com/GoogleCloudPlatform/gcr-cleaner
         with:

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -17,6 +17,9 @@ env:
   # But keep the latest $KEEP_LATEST_IMAGE_COUNT images of each type.
   # We keep this small to reduce storage costs.
   KEEP_LATEST_IMAGE_COUNT: 2
+  # Delete all artifacts in registry created before $DELETE_IMAGE_DAYS days ago.
+  # We keep this long enough for PRs that are still on the same commit can re-run with the same image.
+  DELETE_IMAGE_DAYS: 21d
 
 jobs:
   delete-resources:
@@ -168,3 +171,44 @@ jobs:
             
             gcloud compute images delete "${IMAGE}" || continue
           done
+
+  # We're using a generic approach here, which allows multiple registries to be included,
+  # even those not related to GCP. Enough reason to create a separate job.
+  clean-registries:
+    name: Delete unused artifacts in registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v3.2.0
+        with:
+          persist-credentials: false
+
+      # Setup gcloud CLI
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v1.0.0
+        with:
+          retries: '3'
+          workload_identity_provider: 'projects/143793276228/locations/global/workloadIdentityPools/github-actions/providers/github-oidc'
+          service_account: 'github-service-account@zealous-zebra.iam.gserviceaccount.com'
+          token_format: 'access_token'
+
+      - name: Login to Google Artifact Registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      # Deletes all images older than $DELETE_IMAGE_DAYS days.
+      - uses: 'docker://us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli'
+        # Refer to the official documentation to understand available arguments:
+        # https://github.com/GoogleCloudPlatform/gcr-cleaner
+        with:
+          args: >-
+            -repo=us-docker.pkg.dev/zealous-zebra/zebra/zebrad-test
+            -repo=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd
+            -grace=${{ env.DELETE_IMAGE_DAYS }}
+            -keep=2

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -212,4 +212,4 @@ jobs:
             -repo=us-docker.pkg.dev/zealous-zebra/zebra/zebrad-test
             -repo=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd
             -grace=${{ env.DELETE_IMAGE_HOURS }}
-            -keep=2
+            -keep=${{ env.KEEP_LATEST_IMAGE_COUNT }}

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -1,3 +1,4 @@
+# TODO: rename this action name and filename to Delete infra resources
 name: Delete GCP resources
 
 on:


### PR DESCRIPTION
## Previous behavior:
Docker artifacts are costing us a good part of our infrastructure budget, and we needed a way to remove unused artifacts.

## Expected behavior:
Delete unused (not just old) docker artifacts in GAR (Google Artifact Registry), preferably using a generic solution is this needs to be expanded into other Docker registries.

## Solution:
Implement GCR Cleaner https://github.com/GoogleCloudPlatform/gcr-cleaner, as this tools provided integration with `docker/login-action` to interact with multiple Docker v2 registries.

Fixes #5750 

## Review

Anyone can review, just have to wait for manual execution to validate it's working 

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [x] How do you know it works? Does it have tests?

