### PR TITLE
fix(ci): remove warnings caused by missing `actions/checkout` step

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -225,7 +225,7 @@ jobs:
           --container-stdin \
           --container-tty \
           --container-image ${{ env.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
-          --create-disk=name=auto-delete=yes,size=300GB,type=pd-ssd \
+          --create-disk=auto-delete=yes,size=300GB,type=pd-ssd \
           --container-mount-disk=mount-path='/zebrad-cache' \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --zone ${{ env.ZONE }} \

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -99,6 +99,10 @@ jobs:
     if: ${{ !cancelled() && !failure() && ((github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'release') }}
 
     steps:
+      - uses: actions/checkout@v3.2.0
+        with:
+          persist-credentials: false
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
         with:
@@ -189,6 +193,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
 
     steps:
+      - uses: actions/checkout@v3.2.0
+        with:
+          persist-credentials: false
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
         with:

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -226,6 +226,7 @@ jobs:
           --container-tty \
           --container-image ${{ env.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
           --create-disk=auto-delete=yes,size=300GB,type=pd-ssd \
+          --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }},auto-delete=yes,size=300GB,type=pd-ssd \
           --container-mount-disk=mount-path='/zebrad-cache' \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --zone ${{ env.ZONE }} \

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -227,7 +227,7 @@ jobs:
           --container-image ${{ env.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
           --create-disk=auto-delete=yes,size=300GB,type=pd-ssd \
           --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }},auto-delete=yes,size=300GB,type=pd-ssd \
-          --container-mount-disk=mount-path='/zebrad-cache' \
+          --container-mount-disk=mount-path='/zebrad-cache',name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ env.MACHINE_TYPE }} \
           --zone ${{ env.ZONE }} \
           --labels=app=zebrad,environment=qa,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \


### PR DESCRIPTION
## Motivation

We get this warning when running the `continous-delivery.yml` workflow:

> Deploy single instance
> The "create_credentials_file" option is true, but the current GitHub workspace is empty. Did you forget to use "actions/checkout" before this step? If you do not intend to share authentication with future steps in this job, set "create_credentials_file" to false.

Fixes #5729

## Solution

Add missing `actions/checkout` steps  to allow the credentials file to be written correctly

## Review

Anyone can review this

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
