### PR TITLE
fix(test): Avoid spurious rpc_getblocktemplate test failure

### DIFF
--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -971,23 +971,19 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
     );
 
     // Fake the ChainInfo response
-    let mock_read_state_request_handler = {
-        async move {
-            read_state
-                .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
-                .await
-                .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
-                    expected_difficulty: CompactDifficulty::from(ExpandedDifficulty::from(
-                        U256::one(),
-                    )),
-                    tip_height: fake_tip_height,
-                    tip_hash: fake_tip_hash,
-                    cur_time: fake_cur_time,
-                    min_time: fake_min_time,
-                    max_time: fake_max_time,
-                    history_tree: fake_history_tree(Mainnet),
-                }));
-        }
+    let mock_read_state_request_handler = async move {
+        read_state
+            .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
+            .await
+            .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
+                expected_difficulty: CompactDifficulty::from(ExpandedDifficulty::from(U256::one())),
+                tip_height: fake_tip_height,
+                tip_hash: fake_tip_hash,
+                cur_time: fake_cur_time,
+                min_time: fake_min_time,
+                max_time: fake_max_time,
+                history_tree: fake_history_tree(Mainnet),
+            }));
     };
 
     let mock_mempool_request_handler = {

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -901,8 +901,6 @@ async fn rpc_getblocktemplate() {
 
 #[cfg(feature = "getblocktemplate-rpcs")]
 async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
-    use std::panic;
-
     use zebra_chain::{
         amount::NonNegative,
         block::{Hash, MAX_BLOCK_BYTES, ZCASH_BLOCK_VERSION},
@@ -931,7 +929,7 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
 
     let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
-    let read_state = MockService::build().for_unit_tests();
+    let mut read_state = MockService::build().for_unit_tests();
     let chain_verifier = MockService::build().for_unit_tests();
 
     let mut mock_sync_status = MockSyncStatus::default();
@@ -973,38 +971,45 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
     );
 
     // Fake the ChainInfo response
-    tokio::spawn(async move {
-        read_state
-            .clone()
-            .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
-            .await
-            .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
-                expected_difficulty: CompactDifficulty::from(ExpandedDifficulty::from(U256::one())),
-                tip_height: fake_tip_height,
-                tip_hash: fake_tip_hash,
-                cur_time: fake_cur_time,
-                min_time: fake_min_time,
-                max_time: fake_max_time,
-                history_tree: fake_history_tree(Mainnet),
-            }));
-    });
+    let mock_read_state_request_handler = {
+        async move {
+            read_state
+                .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
+                .await
+                .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
+                    expected_difficulty: CompactDifficulty::from(ExpandedDifficulty::from(
+                        U256::one(),
+                    )),
+                    tip_height: fake_tip_height,
+                    tip_hash: fake_tip_hash,
+                    cur_time: fake_cur_time,
+                    min_time: fake_min_time,
+                    max_time: fake_max_time,
+                    history_tree: fake_history_tree(Mainnet),
+                }));
+        }
+    };
 
-    let get_block_template = tokio::spawn(get_block_template_rpc.get_block_template(None));
+    let mock_mempool_request_handler = {
+        let mut mempool = mempool.clone();
+        async move {
+            mempool
+                .expect_request(mempool::Request::FullTransactions)
+                .await
+                .respond(mempool::Response::FullTransactions(vec![]));
+        }
+    };
 
-    mempool
-        .expect_request(mempool::Request::FullTransactions)
-        .await
-        .respond(mempool::Response::FullTransactions(vec![]));
+    let get_block_template_fut = get_block_template_rpc.get_block_template(None);
 
-    let get_block_template = get_block_template
-        .await
-        .unwrap_or_else(|error| match error.try_into_panic() {
-            Ok(panic_object) => panic::resume_unwind(panic_object),
-            Err(cancelled_error) => {
-                panic!("getblocktemplate task was unexpectedly cancelled: {cancelled_error:?}")
-            }
-        })
-        .expect("unexpected error in getblocktemplate RPC call");
+    let (get_block_template, ..) = tokio::join!(
+        get_block_template_fut,
+        mock_mempool_request_handler,
+        mock_read_state_request_handler,
+    );
+
+    let get_block_template =
+        get_block_template.expect("unexpected error in getblocktemplate RPC call");
 
     assert_eq!(
         get_block_template.capabilities,


### PR DESCRIPTION
## Motivation

There are occasional test failures in CI from an `expect_request` call on the mock state or mempool panic on timeout. This failure can be observed locally as well.

<details>

> The application panicked (crashed).
> Message:  timeout while waiting for a request
>  in zebra_test::mock_service::MockService<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, zebra_test::mock_service::PanicAssertion, alloc::boxed::Box<dyn core::error::Error+core::marker::Sync+core::marker::Send>>
> Location: /opt/zebrad/zebra-test/src/mock_service.rs:449

https://github.com/ZcashFoundation/zebra/actions/runs/3825986911/jobs/6509836292#step:3:2254
</details>

## Solution

- Drive mock service request handling futures on main thread

## Review

Anyone can review.

I ran it 100x in a loop so it would usually fail before the change, this seems to have fixed it so it passes consistently.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
