### PR TITLE
refactor(state): Make implementation of block consensus rules clearer

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1573,7 +1573,11 @@ impl Service<ReadRequest> for ReadStateService {
                     span.in_scope(move || {
                         let hash = state.non_finalized_state_receiver.with_watch_data(
                             |non_finalized_state| {
-                                read::hash(non_finalized_state.best_chain(), &state.db, height)
+                                read::hash_by_height(
+                                    non_finalized_state.best_chain(),
+                                    &state.db,
+                                    height,
+                                )
                             },
                         );
 

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -100,7 +100,7 @@ where
     });
     let difficulty_adjustment =
         AdjustedDifficulty::new_from_block(&prepared.block, network, relevant_data);
-    check::difficulty_threshold_is_valid(
+    check::difficulty_threshold_and_time_are_valid(
         prepared.block.header.difficulty_threshold,
         difficulty_adjustment,
     )?;
@@ -233,7 +233,7 @@ fn height_one_more_than_parent_height(
 ///
 /// These checks are performed together, because the time field is used to
 /// calculate the expected difficulty adjustment.
-fn difficulty_threshold_is_valid(
+fn difficulty_threshold_and_time_are_valid(
     difficulty_threshold: CompactDifficulty,
     difficulty_adjustment: AdjustedDifficulty,
 ) -> Result<(), ValidateContextError> {

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -16,8 +16,10 @@ use crate::service;
 
 pub mod address;
 pub mod block;
+
 #[cfg(feature = "getblocktemplate-rpcs")]
 pub mod difficulty;
+
 pub mod find;
 pub mod tree;
 
@@ -29,13 +31,12 @@ pub use address::{
     tx_id::transparent_tx_ids,
     utxo::{address_utxos, AddressUtxos, ADDRESS_HEIGHTS_FULL_RANGE},
 };
-
 pub use block::{
     any_utxo, block, block_header, transaction, transaction_hashes_for_block, unspent_utxo, utxo,
 };
 
 #[cfg(feature = "getblocktemplate-rpcs")]
-pub use {block::hash, difficulty::get_block_template_chain_info};
+pub use difficulty::get_block_template_chain_info;
 
 pub use find::{
     best_tip, block_locator, chain_contains_hash, depth, find_chain_hashes, find_chain_headers,

--- a/zebra-state/src/service/read/block.rs
+++ b/zebra-state/src/service/read/block.rs
@@ -183,25 +183,3 @@ pub fn any_utxo(
         .any_utxo(&outpoint)
         .or_else(|| db.utxo(&outpoint).map(|utxo| utxo.utxo))
 }
-
-#[cfg(feature = "getblocktemplate-rpcs")]
-/// Returns the [`Hash`] given [`block::Height`](zebra_chain::block::Height), if it exists in
-/// the non-finalized `chain` or finalized `db`.
-pub fn hash<C>(chain: Option<C>, db: &ZebraDb, height: Height) -> Option<zebra_chain::block::Hash>
-where
-    C: AsRef<Chain>,
-{
-    // # Correctness
-    //
-    // The StateService commits blocks to the finalized state before updating
-    // the latest chain, and it can commit additional blocks after we've cloned
-    // this `chain` variable.
-    //
-    // Since blocks are the same in the finalized and non-finalized state, we
-    // check the most efficient alternative first. (`chain` is always in memory,
-    // but `db` stores blocks on disk, with a memory cache.)
-    chain
-        .as_ref()
-        .and_then(|chain| chain.as_ref().hash_by_height(height))
-        .or_else(|| db.hash(height))
-}


### PR DESCRIPTION
## Motivation

This PR changes two consensus-critical functions where the consensus rule implementation was unclear or duplicated.

This is not a security issue, but it might cause issues with future changes if we don't fix it.

## Solution

1. Rename a function to make it clear what consensus rules it implements
2. Delete a duplicate consensus-critical function

Closes #5914
Closes #5910

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [x] Does it change concurrent code, unsafe code, or consensus rules?
  - [x] How do you know it works? Does it have tests?

