### PR TITLE
test(rpc): Add raw getblocktemplate RPC difficulty fields for testing only

### DIFF
--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
@@ -159,6 +159,30 @@ pub struct GetBlockTemplate {
     #[serde(default)]
     #[serde(rename = "submitold")]
     pub submit_old: Option<bool>,
+
+    /// The expected difficulty for the new block displayed in expanded form,
+    /// with no testnet minimum difficulty adjutment.
+    #[serde(with = "hex")]
+    pub raw_target: ExpandedDifficulty,
+
+    /// The expected difficulty for the new block displayed in compact form,
+    /// with no testnet minimum difficulty adjutment.
+    #[serde(with = "hex")]
+    pub raw_bits: CompactDifficulty,
+
+    /// The current system time, with no clamping or testnet minimum difficulty adjutment.
+    #[serde(rename = "raw_curtime")]
+    pub raw_cur_time: DateTime32,
+
+    /// The minimum time the miner can use in the block,
+    /// with no testnet minimum difficulty adjutment.
+    #[serde(rename = "raw_mintime")]
+    pub raw_min_time: DateTime32,
+
+    /// The maximum time the miner can use in the block,
+    /// with no testnet minimum difficulty adjutment.
+    #[serde(rename = "raw_maxtime")]
+    pub raw_max_time: DateTime32,
 }
 
 impl GetBlockTemplate {
@@ -250,6 +274,17 @@ impl GetBlockTemplate {
             max_time: chain_tip_and_local_time.max_time,
 
             submit_old,
+
+            // TODO: remove these fields after we have finished testing
+            raw_target: chain_tip_and_local_time
+                .raw_expected_difficulty
+                .to_expanded()
+                .expect("state always returns a valid difficulty value"),
+
+            raw_bits: chain_tip_and_local_time.raw_expected_difficulty,
+            raw_cur_time: chain_tip_and_local_time.raw_cur_time,
+            raw_min_time: chain_tip_and_local_time.raw_min_time,
+            raw_max_time: chain_tip_and_local_time.raw_max_time,
         }
     }
 }

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -186,6 +186,10 @@ pub async fn test_responses<State, ReadState>(
                 min_time: fake_min_time,
                 max_time: fake_max_time,
                 history_tree: fake_history_tree(network),
+                raw_expected_difficulty: fake_difficulty,
+                raw_cur_time: fake_cur_time,
+                raw_min_time: fake_min_time,
+                raw_max_time: fake_max_time,
             }));
     });
 
@@ -233,6 +237,10 @@ pub async fn test_responses<State, ReadState>(
                 min_time: fake_min_time,
                 max_time: fake_max_time,
                 history_tree: fake_history_tree(network),
+                raw_expected_difficulty: fake_difficulty,
+                raw_cur_time: fake_cur_time,
+                raw_min_time: fake_min_time,
+                raw_max_time: fake_max_time,
             }));
     });
 

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -103,6 +103,7 @@ pub async fn test_responses<State, ReadState>(
     let fake_cur_time = DateTime32::from(1654008617);
     // nu5 block time + 123
     let fake_max_time = DateTime32::from(1654008728);
+    let fake_difficulty = CompactDifficulty::from(ExpandedDifficulty::from(U256::one()));
 
     let (mock_chain_tip, mock_chain_tip_sender) = MockChainTip::new();
     mock_chain_tip_sender.send_best_tip_height(fake_tip_height);
@@ -178,7 +179,7 @@ pub async fn test_responses<State, ReadState>(
             .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
             .await
             .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
-                expected_difficulty: CompactDifficulty::from(ExpandedDifficulty::from(U256::one())),
+                expected_difficulty: fake_difficulty,
                 tip_height: fake_tip_height,
                 tip_hash: fake_tip_hash,
                 cur_time: fake_cur_time,
@@ -225,7 +226,7 @@ pub async fn test_responses<State, ReadState>(
             .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
             .await
             .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
-                expected_difficulty: CompactDifficulty::from(ExpandedDifficulty::from(U256::one())),
+                expected_difficulty: fake_difficulty,
                 tip_height: fake_tip_height,
                 tip_hash: fake_tip_hash,
                 cur_time: fake_cur_time,

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_basic@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_basic@mainnet_10.snap
@@ -39,5 +39,10 @@ expression: block_template
   "curtime": 1654008617,
   "bits": "01010000",
   "height": 1687105,
-  "maxtime": 1654008728
+  "maxtime": 1654008728,
+  "raw_target": "0000000000000000000000000000000000000000000000000000000000000001",
+  "raw_bits": "01010000",
+  "raw_curtime": 1654008617,
+  "raw_mintime": 1654008606,
+  "raw_maxtime": 1654008728
 }

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_basic@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_basic@testnet_10.snap
@@ -39,5 +39,10 @@ expression: block_template
   "curtime": 1654008617,
   "bits": "01010000",
   "height": 1842421,
-  "maxtime": 1654008728
+  "maxtime": 1654008728,
+  "raw_target": "0000000000000000000000000000000000000000000000000000000000000001",
+  "raw_bits": "01010000",
+  "raw_curtime": 1654008617,
+  "raw_mintime": 1654008606,
+  "raw_maxtime": 1654008728
 }

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_long_poll@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_long_poll@mainnet_10.snap
@@ -40,5 +40,10 @@ expression: block_template
   "bits": "01010000",
   "height": 1687105,
   "maxtime": 1654008728,
-  "submitold": false
+  "submitold": false,
+  "raw_target": "0000000000000000000000000000000000000000000000000000000000000001",
+  "raw_bits": "01010000",
+  "raw_curtime": 1654008617,
+  "raw_mintime": 1654008606,
+  "raw_maxtime": 1654008728
 }

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_long_poll@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_long_poll@testnet_10.snap
@@ -40,5 +40,10 @@ expression: block_template
   "bits": "01010000",
   "height": 1842421,
   "maxtime": 1654008728,
-  "submitold": false
+  "submitold": false,
+  "raw_target": "0000000000000000000000000000000000000000000000000000000000000001",
+  "raw_bits": "01010000",
+  "raw_curtime": 1654008617,
+  "raw_mintime": 1654008606,
+  "raw_maxtime": 1654008728
 }

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -984,6 +984,10 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
                 min_time: fake_min_time,
                 max_time: fake_max_time,
                 history_tree: fake_history_tree(Mainnet),
+                raw_expected_difficulty: fake_difficulty,
+                raw_cur_time: fake_cur_time,
+                raw_min_time: fake_min_time,
+                raw_max_time: fake_max_time,
             }));
     };
 

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -953,6 +953,7 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
     let fake_cur_time = DateTime32::from(1654008617);
     // nu5 block time + 123
     let fake_max_time = DateTime32::from(1654008728);
+    let fake_difficulty = CompactDifficulty::from(ExpandedDifficulty::from(U256::one()));
 
     let (mock_chain_tip, mock_chain_tip_sender) = MockChainTip::new();
     mock_chain_tip_sender.send_best_tip_height(fake_tip_height);
@@ -976,7 +977,7 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
             .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
             .await
             .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
-                expected_difficulty: CompactDifficulty::from(ExpandedDifficulty::from(U256::one())),
+                expected_difficulty: fake_difficulty,
                 tip_height: fake_tip_height,
                 tip_hash: fake_tip_hash,
                 cur_time: fake_cur_time,

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -175,6 +175,29 @@ pub struct GetBlockTemplateChainInfo {
     /// The maximum time the miner can use in this block.
     /// Depends on the `tip_hash`, and the local clock on testnet.
     pub max_time: DateTime32,
+
+    // Raw data derived from the state tip, recent blocks, and local clock.
+    //
+    // TODO: remove these fields after we have finished testing
+    //
+    /// The expected difficulty of the candidate block,
+    /// with no testnet minimum difficulty adjutment.
+    /// Depends on the `tip_hash` only.
+    pub raw_expected_difficulty: CompactDifficulty,
+
+    /// The current system time, with no clamping or testnet minimum difficulty adjutment.
+    /// Depends on the local clock only.
+    pub raw_cur_time: DateTime32,
+
+    /// The mininimum time the miner can use in this block,
+    /// with no testnet minimum difficulty adjutment.
+    /// Depends on the `tip_hash` only.
+    pub raw_min_time: DateTime32,
+
+    /// The maximum time the miner can use in this block,
+    /// with no testnet minimum difficulty adjutment.
+    /// Depends on the `tip_hash` only.
+    pub raw_max_time: DateTime32,
 }
 
 /// Conversion from read-only [`ReadResponse`]s to read-write [`Response`]s.

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -158,16 +158,14 @@ pub struct GetBlockTemplateChainInfo {
     /// Depends on the `tip_hash`.
     pub history_tree: Arc<zebra_chain::history_tree::HistoryTree>,
 
-    // Data derived from the state tip and recent blocks.
-    //
-    /// The expected difficulty of the candidate block.
-    /// Depends on the `tip_hash`.
-    pub expected_difficulty: CompactDifficulty,
-
     // Data derived from the state tip and recent blocks, and the current local clock.
     //
+    /// The expected difficulty of the candidate block.
+    /// Depends on the `tip_hash`, and the local clock on testnet.
+    pub expected_difficulty: CompactDifficulty,
+
     /// The current system time, adjusted to fit within `min_time` and `max_time`.
-    /// Depends on the local clock and the `tip_hash`.
+    /// Always depends on the local clock and the `tip_hash`.
     pub cur_time: DateTime32,
 
     /// The mininimum time the miner can use in this block.

--- a/zebra-state/src/service/read/difficulty.rs
+++ b/zebra-state/src/service/read/difficulty.rs
@@ -187,6 +187,7 @@ fn difficulty_time_and_history_tree(
         .collect();
 
     let cur_time = DateTime32::now();
+    let raw_cur_time = cur_time;
 
     // Get the median-time-past, which doesn't depend on the time or the previous block height.
     // `context` will always have the correct length, because this function takes an array.
@@ -237,6 +238,10 @@ fn difficulty_time_and_history_tree(
         cur_time,
         min_time,
         max_time,
+        raw_expected_difficulty: expected_difficulty,
+        raw_cur_time,
+        raw_min_time: min_time,
+        raw_max_time: max_time,
     };
 
     adjust_difficulty_and_time_for_testnet(&mut result, network, tip_height, relevant_data);

--- a/zebra-state/src/service/read/difficulty.rs
+++ b/zebra-state/src/service/read/difficulty.rs
@@ -227,12 +227,13 @@ fn difficulty_time_and_history_tree(
         network,
         relevant_data.iter().cloned(),
     );
+    let expected_difficulty = difficulty_adjustment.expected_difficulty_threshold();
 
     let mut result = GetBlockTemplateChainInfo {
         tip_hash,
         tip_height,
         history_tree,
-        expected_difficulty: difficulty_adjustment.expected_difficulty_threshold(),
+        expected_difficulty,
         cur_time,
         min_time,
         max_time,


### PR DESCRIPTION
## Motivation

As part of fixing bug #5871, I added some raw fields to the `getblocktemplate` RPC response. These fields have the difficulty values before the testnet difficulty adjustment.

### Specifications

> On Testnet from block height 299188 onward, the difficulty adjustment algorithm [6](https://zips.z.cash/zip-0208#protocol-diffadjustment) allows minimum-difficulty blocks, as described in [10](https://zips.z.cash/zip-0208#zip-0205), when the block time is greater than a given threshold. This specification changes this threshold to be proportional to the block target spacing.
>
> That is, if the block time of a block at height height ≥ 299188 is greater than 6 · PoWTargetSpacing(height) seconds after that of the preceding block, then the block is a minimum-difficulty block. In that case its nBits field MUST be set to ToCompact(PoWLimit), where PoWLimit is the value defined for Testnet in section [5](https://zips.z.cash/zip-0208#protocol-constants).3 of the Zcash Protocol Specification 5, and ToCompact is as defined in section [7](https://zips.z.cash/zip-0208#protocol-nbits).7.4 of that specification 7.
>
> ...
>
> This change does not affect Mainnet.

https://zips.z.cash/zip-0208#minimum-difficulty-blocks-on-testnet

### Analysis

It looks like the `min_time` is being adjusted wrong, see https://github.com/ZcashFoundation/zebra/issues/5871#issuecomment-1371853411

## Solution

TODO

## Review

Not ready for review yet.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Actually fix the bug, either in this PR, or in another one.