### PR TITLE
ci: reduce the amount of API calls made by `arduino/setup-protoc@v1`

### DIFF
--- a/.github/workflows/build-crates-individually.yml
+++ b/.github/workflows/build-crates-individually.yml
@@ -113,7 +113,8 @@ jobs:
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.21.12'
+          # TODO: increase to latest version after https://github.com/arduino/setup-protoc/issues/33 is fixed
+          version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/build-crates-individually.yml
+++ b/.github/workflows/build-crates-individually.yml
@@ -111,9 +111,9 @@ jobs:
           persist-credentials: false
 
       - name: Install last version of Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.x'
+          version: '3.21.12'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -82,9 +82,9 @@ jobs:
           persist-credentials: false
 
       - name: Install last version of Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.x'
+          version: '3.21.12'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1
@@ -224,9 +224,9 @@ jobs:
           persist-credentials: false
 
       - name: Install last version of Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.x'
+          version: '3.21.12'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -84,7 +84,8 @@ jobs:
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.21.12'
+          # TODO: increase to latest version after https://github.com/arduino/setup-protoc/issues/33 is fixed
+          version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1
@@ -226,7 +227,8 @@ jobs:
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.21.12'
+          # TODO: increase to latest version after https://github.com/arduino/setup-protoc/issues/33 is fixed
+          version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,9 +42,9 @@ jobs:
           persist-credentials: false
 
       - name: Install last version of Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.x'
+          version: '3.21.12'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install latest beta

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,8 @@ jobs:
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.21.12'
+          # TODO: increase to latest version after https://github.com/arduino/setup-protoc/issues/33 is fixed
+          version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install latest beta

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,9 +67,9 @@ jobs:
           persist-credentials: false
 
       - name: Install last version of Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.x'
+          version: '3.21.12'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check workflow permissions
@@ -117,9 +117,9 @@ jobs:
           persist-credentials: false
 
       - name: Install last version of Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.x'
+          version: '3.21.12'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1.0.6
@@ -157,9 +157,9 @@ jobs:
           persist-credentials: false
 
       - name: Install last version of Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.x'
+          version: '3.21.12'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1.0.6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,8 @@ jobs:
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.21.12'
+          # TODO: increase to latest version after https://github.com/arduino/setup-protoc/issues/33 is fixed
+          version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check workflow permissions
@@ -119,7 +120,8 @@ jobs:
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.21.12'
+          # TODO: increase to latest version after https://github.com/arduino/setup-protoc/issues/33 is fixed
+          version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1.0.6
@@ -159,7 +161,8 @@ jobs:
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.21.12'
+          # TODO: increase to latest version after https://github.com/arduino/setup-protoc/issues/33 is fixed
+          version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1.0.6


### PR DESCRIPTION
## Motivation

Every few days, multiple PRs will fail with GitHub "API rate-limit exceeded" errors. These errors seem to happen when there are multiple pushes to a PR within a short period of time.

Fixes #5819

## Solution

If the `protoc` compiler version is not available locally, the action will look for the most recent version. We use a fixed version to reduce the amount of API calls being done in all workflows, but mainly on `build-crates-individually.yml`

*Note:* A recent update on `bump tj-actions/changed-files` also reduced the amount of API calls, based on our actual fetch configuration. 

## Review

Anyone can review this

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
