### PR TITLE
change(deps): Remove unused zebra-utils dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5460,6 +5460,7 @@ dependencies = [
  "tracing-subscriber 0.3.16",
  "zcash_proofs",
  "zebra-chain",
+ "zebra-node-services",
  "zebra-script",
  "zebra-state",
  "zebra-test",
@@ -5631,8 +5632,7 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber 0.3.16",
  "zebra-chain",
- "zebra-consensus",
- "zebra-state",
+ "zebra-node-services",
 ]
 
 [[package]]

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -7,10 +7,17 @@ edition = "2021"
 
 [features]
 default = []
+
+# Production features that activate extra dependencies, or extra features in dependencies
+
+# Experimental mining RPC support
 getblocktemplate-rpcs = [
-     "zebra-state/getblocktemplate-rpcs", 
-     "zebra-chain/getblocktemplate-rpcs", 
+     "zebra-state/getblocktemplate-rpcs",
+     "zebra-node-services/getblocktemplate-rpcs",
+     "zebra-chain/getblocktemplate-rpcs",
 ]
+
+# Test-only features
 proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl", "zebra-state/proptest-impl"]
 
 [dependencies]
@@ -45,10 +52,12 @@ zcash_proofs = { version = "0.9.0", features = ["local-prover", "multicore", "do
 tower-fallback = { path = "../tower-fallback/" }
 tower-batch = { path = "../tower-batch/" }
 
-zebra-chain = { path = "../zebra-chain" }
-zebra-state = { path = "../zebra-state" }
 zebra-script = { path = "../zebra-script" }
+zebra-state = { path = "../zebra-state" }
+zebra-node-services = { path = "../zebra-node-services" }
+zebra-chain = { path = "../zebra-chain" }
 
+# Test-only dependencies
 proptest = { version = "0.10.1", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 
@@ -67,6 +76,6 @@ tokio = { version = "1.24.1", features = ["full", "tracing", "test-util"] }
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.16"
 
-zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/" }

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -34,7 +34,16 @@ use zebra_chain::{
 };
 use zebra_state::{self as zs, FinalizedBlock};
 
-use crate::{block::VerifyBlockError, error::BlockError, BoxError};
+use crate::{
+    block::VerifyBlockError,
+    checkpoint::types::{
+        Progress,
+        Progress::*,
+        TargetHeight::{self, *},
+    },
+    error::BlockError,
+    BoxError,
+};
 
 pub(crate) mod list;
 mod types;
@@ -42,9 +51,9 @@ mod types;
 #[cfg(test)]
 mod tests;
 
+pub use zebra_node_services::constants::{MAX_CHECKPOINT_BYTE_COUNT, MAX_CHECKPOINT_HEIGHT_GAP};
+
 pub use list::CheckpointList;
-use types::{Progress, Progress::*};
-use types::{TargetHeight, TargetHeight::*};
 
 /// An unverified block, which is in the queue for checkpoint verification.
 #[derive(Debug)]
@@ -83,25 +92,6 @@ type QueuedBlockList = Vec<QueuedBlock>;
 /// downloads. When the verifier services process blocks, they reduce memory
 /// usage by committing blocks to the disk state. (Or dropping invalid blocks.)
 pub const MAX_QUEUED_BLOCKS_PER_HEIGHT: usize = 4;
-
-/// We limit the maximum number of blocks in each checkpoint. Each block uses a
-/// constant amount of memory for the supporting data structures and futures.
-///
-/// We choose a checkpoint gap that allows us to verify one checkpoint for
-/// every `ObtainTips` or `ExtendTips` response.
-///
-/// `zcashd`'s maximum `FindBlocks` response size is 500 hashes. `zebrad` uses
-/// 1 hash to verify the tip, and discards 1-2 hashes to work around `zcashd`
-/// bugs. So the most efficient gap is slightly less than 500 blocks.
-pub const MAX_CHECKPOINT_HEIGHT_GAP: usize = 400;
-
-/// We limit the memory usage and download contention for each checkpoint,
-/// based on the cumulative size of the serialized blocks in the chain.
-///
-/// Deserialized blocks (in memory) are slightly larger than serialized blocks
-/// (on the network or disk). But they should be within a constant factor of the
-/// serialized size.
-pub const MAX_CHECKPOINT_BYTE_COUNT: u64 = 32 * 1024 * 1024;
 
 /// Convert a tip into its hash and matching progress.
 fn progress_from_tip(

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -11,13 +11,9 @@ use tokio::time::timeout;
 use tower::{Service, ServiceExt};
 use tracing_futures::Instrument;
 
-use zebra_chain::parameters::Network::*;
-use zebra_chain::serialization::ZcashDeserialize;
+use zebra_chain::{parameters::Network::*, serialization::ZcashDeserialize};
 
-use super::{
-    types::{Progress::*, TargetHeight::*},
-    *,
-};
+use super::*;
 
 /// The timeout we apply to each verify future during testing.
 ///

--- a/zebra-node-services/src/constants.rs
+++ b/zebra-node-services/src/constants.rs
@@ -1,0 +1,20 @@
+//! Constants shared by some Zebra node services.
+
+/// We limit the maximum number of blocks in each checkpoint. Each block uses a
+/// constant amount of memory for the supporting data structures and futures.
+///
+/// We choose a checkpoint gap that allows us to verify one checkpoint for
+/// every `ObtainTips` or `ExtendTips` response.
+///
+/// `zcashd`'s maximum `FindBlocks` response size is 500 hashes. `zebrad` uses
+/// 1 hash to verify the tip, and discards 1-2 hashes to work around `zcashd`
+/// bugs. So the most efficient gap is slightly less than 500 blocks.
+pub const MAX_CHECKPOINT_HEIGHT_GAP: usize = 400;
+
+/// We limit the memory usage and download contention for each checkpoint,
+/// based on the cumulative size of the serialized blocks in the chain.
+///
+/// Deserialized blocks (in memory) are slightly larger than serialized blocks
+/// (on the network or disk). But they should be within a constant factor of the
+/// serialized size.
+pub const MAX_CHECKPOINT_BYTE_COUNT: u64 = 32 * 1024 * 1024;

--- a/zebra-node-services/src/lib.rs
+++ b/zebra-node-services/src/lib.rs
@@ -1,5 +1,6 @@
 //! The interfaces of some Zebra node services.
 
+pub mod constants;
 pub mod mempool;
 
 /// Error type alias to make working with tower traits easier.

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -19,6 +19,5 @@ serde_json = "1.0.91"
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.16"
 
+zebra-node-services = { path = "../zebra-node-services" }
 zebra-chain = { path = "../zebra-chain" }
-zebra-consensus = { path = "../zebra-consensus" }
-zebra-state = { path = "../zebra-state" }

--- a/zebra-utils/src/bin/zebra-checkpoints/args.rs
+++ b/zebra-utils/src/bin/zebra-checkpoints/args.rs
@@ -2,13 +2,10 @@
 //!
 //! For usage please refer to the program help: `zebra-checkpoints --help`
 
-#![deny(missing_docs)]
-#![allow(clippy::try_err)]
-
 use structopt::StructOpt;
 
 /// zebra-checkpoints arguments
-#[derive(Debug, StructOpt)]
+#[derive(Clone, Debug, Eq, PartialEq, StructOpt)]
 pub struct Args {
     /// Path to zcash-cli command
     #[structopt(default_value = "zcash-cli", short, long)]

--- a/zebra-utils/src/bin/zebra-checkpoints/main.rs
+++ b/zebra-utils/src/bin/zebra-checkpoints/main.rs
@@ -8,16 +8,18 @@
 //! zebra-consensus accepts an ordered list of checkpoints, starting with the
 //! genesis block. Checkpoint heights can be chosen arbitrarily.
 
-use color_eyre::eyre::{ensure, Result};
-use serde_json::Value;
 use std::process::Stdio;
-use structopt::StructOpt;
-
-use zebra_chain::block;
-use zebra_utils::init_tracing;
 
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
+
+use color_eyre::eyre::{ensure, Result};
+use serde_json::Value;
+use structopt::StructOpt;
+
+use zebra_chain::{block, transparent::MIN_TRANSPARENT_COINBASE_MATURITY};
+use zebra_node_services::constants::{MAX_CHECKPOINT_BYTE_COUNT, MAX_CHECKPOINT_HEIGHT_GAP};
+use zebra_utils::init_tracing;
 
 mod args;
 
@@ -74,7 +76,7 @@ fn main() -> Result<()> {
     // Zcash reorg limit.
     let height_limit = height_limit
         .0
-        .checked_sub(zebra_state::MAX_BLOCK_REORG_HEIGHT)
+        .checked_sub(MIN_TRANSPARENT_COINBASE_MATURITY)
         .map(block::Height)
         .expect("zcashd has some mature blocks: wait for zcashd to sync more blocks");
 
@@ -120,8 +122,8 @@ fn main() -> Result<()> {
 
         // check if checkpoint
         if height == block::Height(0)
-            || cumulative_bytes >= zebra_consensus::MAX_CHECKPOINT_BYTE_COUNT
-            || height_gap.0 >= zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP as u32
+            || cumulative_bytes >= MAX_CHECKPOINT_BYTE_COUNT
+            || height_gap.0 >= MAX_CHECKPOINT_HEIGHT_GAP as u32
         {
             // print to output
             println!("{} {hash}", height.0);

--- a/zebra-utils/src/bin/zebra-checkpoints/main.rs
+++ b/zebra-utils/src/bin/zebra-checkpoints/main.rs
@@ -62,8 +62,8 @@ fn cmd_output(cmd: &mut std::process::Command) -> Result<String> {
 
 #[allow(clippy::print_stdout)]
 fn main() -> Result<()> {
+    // initialise
     init_tracing();
-
     color_eyre::install()?;
 
     // get the current block count


### PR DESCRIPTION
## Motivation

`zebra-utils` only uses some constants from `zebra-state`, but it depends on the whole of `zebra-state`. (Including `rocksdb` and other large dependencies.)

It is much faster to compile the utilities if we minimise their dependencies. It also makes them easier to maintain and secure.

This is blocking RPC testing.

## Solution

Move some state constants into `zebra-node-services`, and update the corresponding dependency files and imports.

## Review

This is blocking RPC testing, it is a bit urgent.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

