### PR TITLE
change(ci): Run block proposal tests in CI

### DIFF
--- a/zebra-utils/src/bin/block-template-to-proposal/main.rs
+++ b/zebra-utils/src/bin/block-template-to-proposal/main.rs
@@ -96,7 +96,7 @@ fn main() -> Result<()> {
     let template: GetBlockTemplate = serde_json::from_value(template)?;
 
     // generate proposal according to arguments
-    let proposal = proposal_block_from_template(template, time_source)?;
+    let proposal = proposal_block_from_template(&template, time_source)?;
     eprintln!("{proposal:#?}");
 
     let proposal = proposal

--- a/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
@@ -145,12 +145,7 @@ async fn try_validate_block_template(client: &RPCRequestClient) -> Result<()> {
     // Propose a new block with an empty solution and nonce field
     tracing::info!("calling getblocktemplate with a block proposal...",);
 
-    // TODO: update this to use all valid time sources in the next PR
-    #[allow(clippy::single_element_loop)]
-    for proposal_block in [proposal_block_from_template(
-        response_json_result,
-        TimeSource::CurTime,
-    )?] {
+    for proposal_block in proposal_block_from_template(response_json_result)? {
         let raw_proposal_block = hex::encode(proposal_block.zcash_serialize_to_vec()?);
 
         let json_result = client

--- a/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
@@ -93,8 +93,6 @@ pub(crate) async fn run() -> Result<()> {
 
     tokio::time::sleep(EXPECTED_MEMPOOL_TRANSACTION_TIME).await;
 
-    /* TODO: activate this test after #5925 and #5953 have merged,
-             and we've checked for any other bugs using #5944.
     tracing::info!(
         "calling getblocktemplate RPC method at {rpc_address}, \
              with a mempool that likely has transactions and attempting \
@@ -104,7 +102,6 @@ pub(crate) async fn run() -> Result<()> {
     try_validate_block_template(&client)
         .await
         .expect("block proposal validation failed");
-     */
 
     zebrad.kill(false)?;
 
@@ -130,7 +127,6 @@ pub(crate) async fn run() -> Result<()> {
 /// If an RPC call returns a failure
 /// If the response result cannot be deserialized to `GetBlockTemplate` in 'template' mode
 /// or `ProposalResponse` in 'proposal' mode.
-#[allow(dead_code)]
 async fn try_validate_block_template(client: &RPCRequestClient) -> Result<()> {
     let response_json_result = client
         .json_result_from_call("getblocktemplate", "[]".to_string())

--- a/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
@@ -142,11 +142,16 @@ async fn try_validate_block_template(client: &RPCRequestClient) -> Result<()> {
         "got getblocktemplate response, hopefully with transactions"
     );
 
-    // Propose a new block with an empty solution and nonce field
-    tracing::info!("calling getblocktemplate with a block proposal...",);
+    for time_source in TimeSource::valid_sources() {
+        // Propose a new block with an empty solution and nonce field
+        tracing::info!(
+            "calling getblocktemplate with a block proposal and time source {time_source:?}...",
+        );
 
-    for proposal_block in proposal_block_from_template(response_json_result)? {
-        let raw_proposal_block = hex::encode(proposal_block.zcash_serialize_to_vec()?);
+        let raw_proposal_block = hex::encode(
+            proposal_block_from_template(&response_json_result, time_source)?
+                .zcash_serialize_to_vec()?,
+        );
 
         let json_result = client
             .json_result_from_call(
@@ -158,7 +163,7 @@ async fn try_validate_block_template(client: &RPCRequestClient) -> Result<()> {
 
         tracing::info!(
             ?json_result,
-            ?proposal_block.header.time,
+            ?time_source,
             "got getblocktemplate proposal response"
         );
 

--- a/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
@@ -29,7 +29,7 @@ pub const EXPECTED_MEMPOOL_TRANSACTION_TIME: Duration = Duration::from_secs(45);
 
 /// Number of times we want to try submitting a block template as a block proposal at an interval
 /// that allows testing the varying mempool contents.
-const NUM_SUCCESSFUL_BLOCK_PROPOSALS_REQUIRED: usize = 3;
+const NUM_SUCCESSFUL_BLOCK_PROPOSALS_REQUIRED: usize = 10;
 
 /// Launch Zebra, wait for it to sync, and check the getblocktemplate RPC returns without errors.
 pub(crate) async fn run() -> Result<()> {


### PR DESCRIPTION
## Motivation

We want to use `getblocktemplate` in proposal mode in the acceptance test to check that it's producing valid templates.

Depends-On: #6027

Closes #5685

### Complex Code or Requirements

We want to manually test that block proposals work before merging this automated test.

We need to fix all known block proposal and mempool bugs before running this test in CI.

## Solution

- Test all possible valid times in block proposals (min, proposal current, max, and current clamped to [min, max])
- Run block proposal tests as part of the existing block template test in CI

## Review

Anyone can review this PR.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

