### PR TITLE
ci: add a test to check that the Docker image config works

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -77,6 +77,28 @@ jobs:
       zebra_skip_ipv6_tests: '1'
       rust_log: info
 
+  # Test that Zebra works using the default config with the latest Zebra version
+  test-configuration-file:
+    name: Test Zebra default Docker config file
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
+      - name: Run tests using the default config
+        run: |
+          set -ex
+          docker pull ${{ env.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
+          docker run --detach --name default-conf-tests -t ${{ env.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
+          EXIT_STATUS=$(docker logs --tail all --follow default-conf-tests 2>&1 | grep -q --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter'; echo $?; )
+          docker stop default-conf-tests
+          docker logs default-conf-tests
+          exit "$EXIT_STATUS"
+
   # This jobs handles the deployment of a Managed Instance Group (MiG) with 2 nodes in
   # the us-central1 region. Two different groups of MiGs are deployed one for pushes to
   # the main branch and another for version releases of Zebra

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -112,7 +112,7 @@ jobs:
   # - on every release, when it's published
   deploy-nodes:
     name: Deploy ${{ inputs.network || 'Mainnet' }} nodes
-    needs: [ build, versioning ]
+    needs: [ build, test-configuration-file, versioning ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -206,7 +206,7 @@ jobs:
   # Note: this instances are not automatically replaced or deleted
   deploy-instance:
     name: Deploy single instance
-    needs: build
+    needs: [ build, test-configuration-file ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/continous-integration-docker.patch.yml
+++ b/.github/workflows/continous-integration-docker.patch.yml
@@ -66,6 +66,18 @@ jobs:
     steps:
       - run: 'echo "No build required"'
 
+  test-configuration-file:
+    name: Test Zebra default Docker config file
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  test-zebra-conf-path:
+    name: Test Zebra custom Docker config file
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
   test-stateful-sync:
     name: Zebra checkpoint update / Run sync-past-checkpoint test
     runs-on: ubuntu-latest

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -316,14 +316,14 @@ jobs:
       - name: Run tests using the default config
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run --detach --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
+          docker run --detach --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} zebrad start
           docker logs --tail all --follow default-conf-tests | tee --output-error=exit /dev/stderr | grep --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter'
           docker stop default-conf-tests
 
       - name: Run tests using the $ZEBRA_CONF_PATH
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run --detach -e ZEBRA_CONF_PATH --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
+          docker run --detach -e ZEBRA_CONF_PATH --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} zebrad -c $ZEBRA_CONF_PATH start
           docker logs --tail all --follow variable-conf-tests | tee --output-error=exit /dev/stderr | grep --extended-regexp --max-count=1 -e 'v1.0.0-rc.2.toml'
           docker stop variable-conf-tests
         env:

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -320,6 +320,19 @@ jobs:
           docker logs --tail all --follow default-conf-tests | tee --output-error=exit /dev/stderr | grep --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter'
           docker stop default-conf-tests
 
+
+  # Test that Zebra works using the $ZEBRA_CONF_PATH config
+  test-zebra-conf-path:
+    name: Test Zebra configuration file
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' && github.event.inputs.run-lwd-send-tx != 'true' }}
+    steps:
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
       - name: Run tests using the $ZEBRA_CONF_PATH
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -316,12 +316,12 @@ jobs:
       - name: Run tests using the default config
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run --rm --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} | grep --max-count=1 'estimated progress to chain tip.*BeforeOverwinter'
+          docker run --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} | grep --max-count=1 'estimated progress to chain tip.*BeforeOverwinter'
 
       - name: Run tests using the $ZEBRA_CONF_PATH
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run -e ZEBRA_CONF_PATH --rm --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} | grep --max-count=1 'v1.0.0-rc.2.toml'
+          docker run -e ZEBRA_CONF_PATH --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} | grep --max-count=1 'v1.0.0-rc.2.toml'
         env:
           ZEBRA_CONF_PATH: 'zebra/zebrad/tests/common/configs/v1.0.0-rc.2.toml'
 

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -316,14 +316,14 @@ jobs:
       - name: Run tests using the default config
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run --detach --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} zebrad start
+          docker run --detach --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} start
           docker logs --tail all --follow default-conf-tests | tee --output-error=exit /dev/stderr | grep --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter'
           docker stop default-conf-tests
 
       - name: Run tests using the $ZEBRA_CONF_PATH
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run --detach -e ZEBRA_CONF_PATH --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} zebrad -c $ZEBRA_CONF_PATH start
+          docker run --detach -e ZEBRA_CONF_PATH --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} -c $ZEBRA_CONF_PATH start
           docker logs --tail all --follow variable-conf-tests | tee --output-error=exit /dev/stderr | grep --extended-regexp --max-count=1 -e 'v1.0.0-rc.2.toml'
           docker stop variable-conf-tests
         env:

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -316,12 +316,12 @@ jobs:
       - name: Run tests using the default config
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} | grep --max-count=1 'estimated progress to chain tip.*BeforeOverwinter'
+          docker run --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} | grep --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter'
 
       - name: Run tests using the $ZEBRA_CONF_PATH
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run -e ZEBRA_CONF_PATH --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} | grep --max-count=1 'v1.0.0-rc.2.toml'
+          docker run -e ZEBRA_CONF_PATH --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} | grep --extended-regexp --max-count=1 -e 'v1.0.0-rc.2.toml'
         env:
           ZEBRA_CONF_PATH: 'zebra/zebrad/tests/common/configs/v1.0.0-rc.2.toml'
 

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -316,12 +316,16 @@ jobs:
       - name: Run tests using the default config
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} | grep --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter'
+          docker run --detach --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
+          docker logs --tail all --follow default-conf-tests | tee --output-error=exit /dev/stderr | grep --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter'
+          docker stop default-conf-tests
 
       - name: Run tests using the $ZEBRA_CONF_PATH
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run -e ZEBRA_CONF_PATH --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} | grep --extended-regexp --max-count=1 -e 'v1.0.0-rc.2.toml'
+          docker run --detach -e ZEBRA_CONF_PATH --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
+          docker logs --tail all --follow variable-conf-tests | tee --output-error=exit /dev/stderr | grep --extended-regexp --max-count=1 -e 'v1.0.0-rc.2.toml'
+          docker stop variable-conf-tests
         env:
           ZEBRA_CONF_PATH: 'zebra/zebrad/tests/common/configs/v1.0.0-rc.2.toml'
 

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -299,6 +299,32 @@ jobs:
         env:
           ZEBRA_TEST_LIGHTWALLETD: '1'
 
+  # Test that Zebra works using the default config with the latest Zebra version
+  #
+  # Also check that $ZEBRA_CONF_PATH works
+  test-configuration-file:
+    name: Test Zebra configuration file
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' && github.event.inputs.run-lwd-send-tx != 'true' }}
+    steps:
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
+      - name: Run tests using the default config
+        run: |
+          docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
+          docker run --rm --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} | grep --max-count=1 'estimated progress to chain tip.*BeforeOverwinter'
+
+      - name: Run tests using the $ZEBRA_CONF_PATH
+        run: |
+          docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
+          docker run -e ZEBRA_CONF_PATH --rm --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} | grep --max-count=1 'v1.0.0-rc.2.toml'
+        env:
+          ZEBRA_CONF_PATH: 'zebra/zebrad/tests/common/configs/v1.0.0-rc.2.toml'
+
   # zebrad cached checkpoint state tests
 
   # Regenerate mandatory checkpoint Zebra cached state disks.

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -316,10 +316,9 @@ jobs:
       - name: Run tests using the default config
         run: |
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
-          docker run --detach --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} start
+          docker run --detach --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} zebrad start
           docker logs --tail all --follow default-conf-tests | tee --output-error=exit /dev/stderr | grep --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter'
           docker stop default-conf-tests
-
 
   # Test that Zebra works using the $ZEBRA_CONF_PATH config
   test-zebra-conf-path:

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -315,6 +315,7 @@ jobs:
 
       - name: Run tests using the default config
         run: |
+          set -x
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
           docker run --detach --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} zebrad start
           docker logs --tail all --follow default-conf-tests | tee --output-error=exit /dev/stderr | grep --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter'
@@ -334,6 +335,7 @@ jobs:
 
       - name: Run tests using the $ZEBRA_CONF_PATH
         run: |
+          set -x
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
           docker run --detach -e ZEBRA_CONF_PATH --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} -c $ZEBRA_CONF_PATH start
           docker logs --tail all --follow variable-conf-tests | tee --output-error=exit /dev/stderr | grep --extended-regexp --max-count=1 -e 'v1.0.0-rc.2.toml'

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -303,7 +303,7 @@ jobs:
   #
   # Also check that $ZEBRA_CONF_PATH works
   test-configuration-file:
-    name: Test Zebra configuration file
+    name: Test Zebra default Docker config file
     runs-on: ubuntu-latest
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' && github.event.inputs.run-lwd-send-tx != 'true' }}
@@ -324,7 +324,7 @@ jobs:
 
   # Test that Zebra works using the $ZEBRA_CONF_PATH config
   test-zebra-conf-path:
-    name: Test Zebra configuration file
+    name: Test Zebra custom Docker config file
     runs-on: ubuntu-latest
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' && github.event.inputs.run-lwd-send-tx != 'true' }}

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -343,7 +343,7 @@ jobs:
           docker stop variable-conf-tests
           docker logs variable-conf-tests
         env:
-          ZEBRA_CONF_PATH: 'zebra/zebrad/tests/common/configs/v1.0.0-rc.2.toml'
+          ZEBRA_CONF_PATH: 'zebrad/tests/common/configs/v1.0.0-rc.2.toml'
 
   # zebrad cached checkpoint state tests
 

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -315,7 +315,7 @@ jobs:
 
       - name: Run tests using the default config
         run: |
-          set -x
+          set -ex
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
           docker run --detach --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} zebrad start
           EXIT_STATUS=$(docker logs --tail all --follow default-conf-tests 2>&1 | grep -q --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter'; echo $?; )
@@ -337,7 +337,7 @@ jobs:
 
       - name: Run tests using the $ZEBRA_CONF_PATH
         run: |
-          set -x
+          set -ex
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
           docker run --detach -e ZEBRA_CONF_PATH --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} -c $ZEBRA_CONF_PATH start
           EXIT_STATUS=$(docker logs --tail all --follow variable-conf-tests 2>&1 | grep -q --extended-regexp --max-count=1 -e 'v1.0.0-rc.2.toml'; echo $?; )

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -300,8 +300,6 @@ jobs:
           ZEBRA_TEST_LIGHTWALLETD: '1'
 
   # Test that Zebra works using the default config with the latest Zebra version
-  #
-  # Also check that $ZEBRA_CONF_PATH works
   test-configuration-file:
     name: Test Zebra default Docker config file
     timeout-minutes: 5

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -318,8 +318,10 @@ jobs:
           set -x
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
           docker run --detach --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} zebrad start
-          docker logs --tail all --follow default-conf-tests 2>&1 | grep --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter' || exit 1
+          EXIT_STATUS=$(docker logs --tail all --follow default-conf-tests 2>&1 | grep -q --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter'; echo $?; )
           docker stop default-conf-tests
+          docker logs default-conf-tests
+          exit "$EXIT_STATUS"
 
   # Test that Zebra works using the $ZEBRA_CONF_PATH config
   test-zebra-conf-path:
@@ -338,8 +340,10 @@ jobs:
           set -x
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
           docker run --detach -e ZEBRA_CONF_PATH --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} -c $ZEBRA_CONF_PATH start
-          docker logs --tail all --follow variable-conf-tests 2>&1 | grep --extended-regexp --max-count=1 -e 'v1.0.0-rc.2.toml' || exit 1
+          EXIT_STATUS=$(docker logs --tail all --follow variable-conf-tests 2>&1 | grep -q --extended-regexp --max-count=1 -e 'v1.0.0-rc.2.toml'; echo $?; )
           docker stop variable-conf-tests
+          docker logs variable-conf-tests
+          exit "$EXIT_STATUS"
         env:
           ZEBRA_CONF_PATH: 'zebrad/tests/common/configs/v1.0.0-rc.2.toml'
 

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -320,6 +320,7 @@ jobs:
           docker run --detach --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} zebrad start
           docker logs --tail all --follow default-conf-tests | tee --output-error=exit /dev/stderr | grep --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter'
           docker stop default-conf-tests
+          docker logs default-conf-tests
 
   # Test that Zebra works using the $ZEBRA_CONF_PATH config
   test-zebra-conf-path:
@@ -340,6 +341,7 @@ jobs:
           docker run --detach -e ZEBRA_CONF_PATH --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} -c $ZEBRA_CONF_PATH start
           docker logs --tail all --follow variable-conf-tests | tee --output-error=exit /dev/stderr | grep --extended-regexp --max-count=1 -e 'v1.0.0-rc.2.toml'
           docker stop variable-conf-tests
+          docker logs variable-conf-tests
         env:
           ZEBRA_CONF_PATH: 'zebra/zebrad/tests/common/configs/v1.0.0-rc.2.toml'
 

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -318,9 +318,8 @@ jobs:
           set -x
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
           docker run --detach --name default-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} zebrad start
-          docker logs --tail all --follow default-conf-tests | tee --output-error=exit /dev/stderr | grep --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter'
+          docker logs --tail all --follow default-conf-tests 2>&1 | grep --extended-regexp --max-count=1 -e 'estimated progress to chain tip.*BeforeOverwinter' || exit 1
           docker stop default-conf-tests
-          docker logs default-conf-tests
 
   # Test that Zebra works using the $ZEBRA_CONF_PATH config
   test-zebra-conf-path:
@@ -339,9 +338,8 @@ jobs:
           set -x
           docker pull ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}
           docker run --detach -e ZEBRA_CONF_PATH --name variable-conf-tests -t ${{ env.GAR_BASE }}/${{ env.IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} -c $ZEBRA_CONF_PATH start
-          docker logs --tail all --follow variable-conf-tests | tee --output-error=exit /dev/stderr | grep --extended-regexp --max-count=1 -e 'v1.0.0-rc.2.toml'
+          docker logs --tail all --follow variable-conf-tests 2>&1 | grep --extended-regexp --max-count=1 -e 'v1.0.0-rc.2.toml' || exit 1
           docker stop variable-conf-tests
-          docker logs variable-conf-tests
         env:
           ZEBRA_CONF_PATH: 'zebrad/tests/common/configs/v1.0.0-rc.2.toml'
 

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -304,6 +304,7 @@ jobs:
   # Also check that $ZEBRA_CONF_PATH works
   test-configuration-file:
     name: Test Zebra default Docker config file
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' && github.event.inputs.run-lwd-send-tx != 'true' }}
@@ -326,6 +327,7 @@ jobs:
   # Test that Zebra works using the $ZEBRA_CONF_PATH config
   test-zebra-conf-path:
     name: Test Zebra custom Docker config file
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' && github.event.inputs.run-lwd-send-tx != 'true' }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -103,7 +103,7 @@ COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd /opt/lightwalletd
 RUN cargo chef cook --release --features sentry,lightwalletd-grpc-tests --workspace --recipe-path recipe.json
 
 COPY . .
-RUN cargo test --locked --release --features lightwalletd-grpc-tests --workspace --no-run
+RUN cargo test --locked --release --features lightwalletd-grpc-tests --workspace --no-run --bins
 
 COPY ./docker/entrypoint.sh /
 RUN chmod u+x /entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -103,7 +103,8 @@ COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd /opt/lightwalletd
 RUN cargo chef cook --release --features sentry,lightwalletd-grpc-tests --workspace --recipe-path recipe.json
 
 COPY . .
-RUN cargo test --locked --release --features lightwalletd-grpc-tests --workspace --no-run --bins
+RUN cargo test --locked --release --features lightwalletd-grpc-tests --workspace --no-run
+RUN cp /opt/zebrad/target/release/zebrad /usr/local/bin
 
 COPY ./docker/entrypoint.sh /
 RUN chmod u+x /entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -140,11 +140,14 @@ ARG CHECKPOINT_SYNC=true
 ARG NETWORK=Mainnet
 
 # Use a configurable dir and file for the zebrad configuration file
-ARG ZEBRA_CONF_PATH=/etc/zebra
-ENV ZEBRA_CONF_PATH ${ZEBRA_CONF_PATH}
+ARG ZEBRA_CONF_DIR=/etc/zebra
+ENV ZEBRA_CONF_DIR ${ZEBRA_CONF_DIR}
 
 ARG ZEBRA_CONF_FILE=zebrad.toml
 ENV ZEBRA_CONF_FILE ${ZEBRA_CONF_FILE}
+
+ARG ZEBRA_CONF_PATH=${ZEBRA_CONF_DIR}/${ZEBRA_CONF_FILE}
+ENV ZEBRA_CONF_PATH ${ZEBRA_CONF_PATH}
 
 # Build the `zebrad.toml` before starting the container, using the arguments from build
 # time, or using the default values set just above. And create the conf path and file if
@@ -160,8 +163,8 @@ ENV ZEBRA_CONF_FILE ${ZEBRA_CONF_FILE}
 #  - move this file creation to an entrypoint as we can use default values at runtime,
 #    and modify those as needed when starting the container (at runtime and not at build time)
 #  - make `cache_dir`, `rpc.listen_addr`, `metrics.endpoint_addr`, and `tracing.endpoint_addr` into Docker arguments
-RUN mkdir -p ${ZEBRA_CONF_PATH} \
-    && touch ${ZEBRA_CONF_PATH}/${ZEBRA_CONF_FILE}
+RUN mkdir -p ${ZEBRA_CONF_DIR} \
+    && touch ${ZEBRA_CONF_PATH}
 RUN set -ex; \
   { \
     echo "[network]"; \
@@ -177,7 +180,7 @@ RUN set -ex; \
     echo "#endpoint_addr = '127.0.0.1:9999'"; \
     echo "[tracing]"; \
     echo "#endpoint_addr = '127.0.0.1:3000'"; \
-  } > "${ZEBRA_CONF_PATH}/${ZEBRA_CONF_FILE}"
+  } > "${ZEBRA_CONF_PATH}"
 
 EXPOSE 8233 18233
 
@@ -188,4 +191,4 @@ ARG SENTRY_DSN
 ENV SENTRY_DSN ${SENTRY_DSN}
 
 # TODO: remove the specified config file location and use the default expected by zebrad
-CMD zebrad -c "${ZEBRA_CONF_PATH}/${ZEBRA_CONF_FILE}" start
+CMD zebrad -c "${ZEBRA_CONF_PATH}" start

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,7 +110,6 @@ RUN chmod u+x /entrypoint.sh
 
 # By default, runs the entrypoint tests specified by the environmental variables (if any are set)
 ENTRYPOINT [ "/entrypoint.sh" ]
-CMD [ "cargo" ]
 
 # In this stage we build a release (generate the zebrad binary)
 #

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -91,7 +91,7 @@ case "$1" in
         #
         # TODO: test that the following 3 cases actually work, or remove them
         else
-            exec cargo "$@"
+            exec "$@"
         fi
         ;;
     -*)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -95,5 +95,4 @@ case "$1" in
         else
             exec "$@"
         fi
-        ;;
 esac

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,7 +15,13 @@ echo "ZEBRA_CACHED_STATE_DIR=$ZEBRA_CACHED_STATE_DIR"
 echo "LIGHTWALLETD_DATA_DIR=$LIGHTWALLETD_DATA_DIR"
 
 case "$1" in
-    -- | cargo)
+    -- | zebrad)
+        exec zebrad "$@"
+        ;;
+    -*)
+        exec zebrad "$@"
+        ;;
+    *)
         # For these tests, we activate the gRPC feature to avoid recompiling `zebrad`,
         # but we might not actually run any gRPC tests.
         if [[ "$RUN_ALL_TESTS" -eq "1" ]]; then
@@ -86,17 +92,8 @@ case "$1" in
             # Starting with a cached Zebra tip, test sending a block to Zebra's RPC port.
             ls -lh "$ZEBRA_CACHED_STATE_DIR"/*/* || (echo "No $ZEBRA_CACHED_STATE_DIR/*/*"; ls -lhR  "$ZEBRA_CACHED_STATE_DIR" | head -50 || echo "No $ZEBRA_CACHED_STATE_DIR directory")
             cargo test --locked --release --features getblocktemplate-rpcs --package zebrad --test acceptance -- --nocapture --include-ignored submit_block
-
-        # These command-lines are provided by the caller.
-        #
-        # TODO: test that the following 3 cases actually work, or remove them
         else
             exec "$@"
         fi
         ;;
-    -*)
-        exec zebrad "$@"
-        ;;
-    *)
-        exec "$@"
 esac

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -91,10 +91,10 @@ case "$1" in
         #
         # TODO: test that the following 3 cases actually work, or remove them
         else
-            exec "$@"
+            exec cargo "$@"
         fi
         ;;
-    zebrad)
+    -*)
         exec zebrad "$@"
         ;;
     *)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,10 +15,7 @@ echo "ZEBRA_CACHED_STATE_DIR=$ZEBRA_CACHED_STATE_DIR"
 echo "LIGHTWALLETD_DATA_DIR=$LIGHTWALLETD_DATA_DIR"
 
 case "$1" in
-    -- | zebrad)
-        exec zebrad "$@"
-        ;;
-    -*)
+    --* | -*)
         exec zebrad "$@"
         ;;
     *)


### PR DESCRIPTION
## Motivation

We want to test that our Docker build scripts configure Zebra correctly:

- check that $ZEBRA_CONF_PATH works
- make sure the default Docker config works with the latest Zebra version

Fixes #5168

## Solution

- Add a Docker test for the default config
- Add a Docker test for $ZEBRA_CONF_PATH

## Review

Anyone can review this, validating the test is using the right configuration

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [x] How do you know it works? Does it have tests?

## Follow Up Work

Use a custom file instead of the existing one living inside `common/configs`
