### PR TITLE
ci(build): fallback to a stable buildkit version for `docker/build-push-action`

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -155,3 +155,8 @@ jobs:
             type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache
             type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:main-cache
           cache-to: type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache,mode=max
+          # TODO: change after new buildkit version gets fixed
+          # https://github.com/moby/buildkit/issues/3347
+          # https://github.com/docker/build-push-action/issues/761
+          driver-opts: |
+            image=moby/buildkit:v0.10.6


### PR DESCRIPTION
## Motivation

Docker image builds are regularly failing due to a server error. This impacts all the Docker builds.

Fixes #5958


## Solution

There's a recent error causing this failures, which are being tracked here:
- https://github.com/moby/buildkit/issues/3347
- https://github.com/docker/build-push-action/issues/761

Using a previous version of buildkit seems to fix the issue. We'll keep this version pinned until they have a fix.

## Review

Anyone can review this

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
