### PR TITLE
fix(deps): Add test dependency from zebra-rpc to zebra-network with correct features

### DIFF
--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -27,6 +27,7 @@ proptest-impl = [
     "proptest-derive",
     "zebra-consensus/proptest-impl",
     "zebra-state/proptest-impl",
+    "zebra-network/proptest-impl",
     "zebra-chain/proptest-impl",
 ]
 
@@ -79,5 +80,8 @@ thiserror = "1.0.38"
 tokio = { version = "1.24.1", features = ["full", "tracing", "test-util"] }
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
+
 zebra-test = { path = "../zebra-test" }


### PR DESCRIPTION
## Motivation

If I build the tests for the individual `zebra-rpc` crate, the build fails due to a missing dependency.

This is a bug from PR #5951.

## Solution

Add the correct dependencies for the `proptest-impl` feature.

## Review

Anyone can review this code. It blocks some kinds of testing, so I think it might be a high priority.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

I don't think we need any extra CI checks for this build bug, because it just happens in test code.