### PR TITLE
fix(rpc): Return detailed errors to the RPC client when a block proposal fails

### DIFF
--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
@@ -31,7 +31,7 @@ pub mod parameters;
 pub mod proposal;
 
 pub use parameters::{GetBlockTemplateCapability, GetBlockTemplateRequestMode, JsonParameters};
-pub use proposal::{proposal_block_from_template, ProposalRejectReason, ProposalResponse};
+pub use proposal::{proposal_block_from_template, ProposalResponse};
 
 /// A serialized `getblocktemplate` RPC response in template mode.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_invalid-proposal@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_invalid-proposal@mainnet_10.snap
@@ -2,9 +2,4 @@
 source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
 expression: block_template
 ---
-{
-  "reject_reason": "rejected",
-  "capabilities": [
-    "proposal"
-  ]
-}
+"invalid proposal format: Io(\n    Error {\n        kind: UnexpectedEof,\n        message: \"failed to fill whole buffer\",\n    },\n)"

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_invalid-proposal@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_invalid-proposal@testnet_10.snap
@@ -2,9 +2,4 @@
 source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
 expression: block_template
 ---
-{
-  "reject_reason": "rejected",
-  "capabilities": [
-    "proposal"
-  ]
-}
+"invalid proposal format: Io(\n    Error {\n        kind: UnexpectedEof,\n        message: \"failed to fill whole buffer\",\n    },\n)"

--- a/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
@@ -167,7 +167,7 @@ async fn try_validate_block_template(client: &RPCRequestClient) -> Result<()> {
             "got getblocktemplate proposal response"
         );
 
-        if let ProposalResponse::ErrorResponse { reject_reason, .. } = json_result {
+        if let ProposalResponse::Rejected(reject_reason) = json_result {
             Err(eyre!(
                 "unsuccessful block proposal validation, reason: {reject_reason:?}"
             ))?;


### PR DESCRIPTION
## Motivation

We are currently testing Zebra's block templates in ticket #5803. But I can't work out if Zebra's errors are expected or the same as `zcashd`, because it doesn't return any error information at all.

This PR changes the error handling from bug #5981, it probably gets us closer to a fix.
(But to match `zcashd` we'd need to stop pretty printing, and change the format of the error string.)

### Specifications

We can do whatever we like here, because bug #5981 will fix up any mining pool compatibility issues.

## Solution

- Send the RPC client the kind of error, and the detailed error debug information

## Review

This seems like a high priority because testing is difficult without it.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

