### PR TITLE
change(rpc): Sort transaction hashes like zcashd in getrawmempool RPC response

### DIFF
--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -60,7 +60,7 @@ use super::{txid::TxIdBuilder, AuthDigest, Transaction};
 ///
 /// [ZIP-244]: https://zips.z.cash/zip-0244
 /// [Spec: Transaction Identifiers]: https://zips.z.cash/protocol/protocol.pdf#txnidentifiers
-#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct Hash(pub [u8; 32]);
 

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -648,66 +648,20 @@ where
     #[cfg(feature = "getblocktemplate-rpcs")]
     // TODO: use a generic error constructor (#5548)
     fn get_raw_mempool(&self) -> BoxFuture<Result<Vec<String>>> {
-        use std::cmp::Ordering;
-        use zebra_chain::transaction::VerifiedUnminedTx;
-
-        /// Returns relative score for sorting [`VerifiedUnminedTx`]s (fee/size)
-        fn tx_sort_score(tx: &VerifiedUnminedTx, tx2: &VerifiedUnminedTx) -> Option<u64> {
-            u64::try_from(tx2.transaction.size)
-                .expect("transaction size should fit in u64")
-                .checked_mul(u64::from(tx.miner_fee))
-        }
+        /// Determines whether the output of this RPC is sorted like zcashd
+        const SHOULD_USE_ZCASHD_ORDER: bool = true;
 
         let mut mempool = self.mempool.clone();
 
         async move {
-            let request = mempool::Request::FullTransactions;
-
-            // `zcashd` doesn't check if it is synced to the tip here, so we don't either.
-            let response = mempool
-                .ready()
-                .and_then(|service| service.call(request))
-                .await
-                .map_err(|error| Error {
-                    code: ErrorCode::ServerError(0),
-                    message: error.to_string(),
-                    data: None,
-                })?;
-
-            if let mempool::Response::FullTransactions(mut transactions) = response {
-                transactions.sort_by(|tx, tx2| {
-                    match tx_sort_score(tx2, tx).cmp(&tx_sort_score(tx, tx2)) {
-                        Ordering::Equal => {
-                            tracing::info!("tx_sort_scores are equal");
-
-                            tx.transaction
-                                .id
-                                .mined_id()
-                                .cmp(&tx2.transaction.id.mined_id())
-                        }
-                        gt_or_lt => gt_or_lt,
-                    }
-                });
-
-                let tx_ids: Vec<String> = transactions
-                    .iter()
-                    .map(|unmined_tx| unmined_tx.transaction.id.mined_id().encode_hex())
-                    .collect();
-
-                Ok(tx_ids)
+            #[cfg(feature = "getblocktemplate-rpcs")]
+            let request = if SHOULD_USE_ZCASHD_ORDER {
+                mempool::Request::FullTransactions
             } else {
-                unreachable!("unmatched response to a mempool::FullTransactions request")
-            }
-        }
-        .boxed()
-    }
+                mempool::Request::TransactionIds
+            };
 
-    #[cfg(not(feature = "getblocktemplate-rpcs"))]
-    // TODO: use a generic error constructor (#5548)
-    fn get_raw_mempool(&self) -> BoxFuture<Result<Vec<String>>> {
-        let mut mempool = self.mempool.clone();
-
-        async move {
+            #[cfg(not(feature = "getblocktemplate-rpcs"))]
             let request = mempool::Request::TransactionIds;
 
             // `zcashd` doesn't check if it is synced to the tip here, so we don't either.
@@ -722,6 +676,23 @@ where
                 })?;
 
             match response {
+                #[cfg(feature = "getblocktemplate-rpcs")]
+                mempool::Response::FullTransactions(mut transactions) => {
+                    transactions.sort_by_cached_key(|tx| {
+                        std::cmp::Reverse((
+                            u64::from(tx.miner_fee) / tx.transaction.size as u64,
+                            tx.transaction.id.mined_id(),
+                        ))
+                    });
+
+                    let tx_ids: Vec<String> = transactions
+                        .iter()
+                        .map(|unmined_tx| unmined_tx.transaction.id.mined_id().encode_hex())
+                        .collect();
+
+                    Ok(tx_ids)
+                }
+
                 mempool::Response::TransactionIds(unmined_transaction_ids) => {
                     let mut tx_ids: Vec<String> = unmined_transaction_ids
                         .iter()
@@ -729,11 +700,11 @@ where
                         .collect();
 
                     // Sort returned transaction IDs in numeric/string order.
-                    // (zcashd's sort order appears arbitrary.)
                     tx_ids.sort();
 
                     Ok(tx_ids)
                 }
+
                 _ => unreachable!("unmatched response to a transactionids request"),
             }
         }

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -656,11 +656,15 @@ where
         let mut mempool = self.mempool.clone();
 
         async move {
-            let request = if SHOULD_USE_ZCASHD_ORDER && cfg!(feature = "getblocktemplate-rpcs") {
+            #[cfg(feature = "getblocktemplate-rpcs")]
+            let request = if SHOULD_USE_ZCASHD_ORDER {
                 mempool::Request::FullTransactions
             } else {
                 mempool::Request::TransactionIds
             };
+
+            #[cfg(not(feature = "getblocktemplate-rpcs"))]
+            let request = mempool::Request::TransactionIds;
 
             // `zcashd` doesn't check if it is synced to the tip here, so we don't either.
             let response = mempool

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -657,7 +657,7 @@ where
 
         async move {
             #[cfg(feature = "getblocktemplate-rpcs")]
-            let request = if SHOULD_USE_ZCASHD_ORDER {
+            let request = if SHOULD_USE_ZCASHD_ORDER && cfg!(not(test)) {
                 mempool::Request::FullTransactions
             } else {
                 mempool::Request::TransactionIds

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -681,6 +681,7 @@ where
                     transactions.sort_by_cached_key(|tx| {
                         std::cmp::Reverse((
                             u64::from(tx.miner_fee) / tx.transaction.size as u64,
+                            // transaction hashes are compared in their serialized byte-order.
                             tx.transaction.id.mined_id(),
                         ))
                     });

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -650,6 +650,7 @@ where
         #[cfg(feature = "getblocktemplate-rpcs")]
         use zebra_chain::block::MAX_BLOCK_BYTES;
 
+        #[cfg(feature = "getblocktemplate-rpcs")]
         /// Determines whether the output of this RPC is sorted like zcashd
         const SHOULD_USE_ZCASHD_ORDER: bool = true;
 

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -658,7 +658,7 @@ where
 
         async move {
             #[cfg(feature = "getblocktemplate-rpcs")]
-            let request = if SHOULD_USE_ZCASHD_ORDER && cfg!(not(test)) {
+            let request = if SHOULD_USE_ZCASHD_ORDER {
                 mempool::Request::FullTransactions
             } else {
                 mempool::Request::TransactionIds

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -18,7 +18,7 @@ use zebra_chain::{
         NetworkUpgrade,
     },
     serialization::{ZcashDeserialize, ZcashSerialize},
-    transaction::{self, Transaction, UnminedTx, UnminedTxId},
+    transaction::{self, Transaction, UnminedTx, VerifiedUnminedTx},
     transparent,
 };
 use zebra_node_services::mempool;
@@ -313,7 +313,7 @@ proptest! {
     /// Make the mock mempool service return a list of transaction IDs, and check that the RPC call
     /// returns those IDs as hexadecimal strings.
     #[test]
-    fn mempool_transactions_are_sent_to_caller(transaction_ids in any::<HashSet<UnminedTxId>>()) {
+    fn mempool_transactions_are_sent_to_caller(transactions in any::<Vec<VerifiedUnminedTx>>()) {
         let (runtime, _init_guard) = zebra_test::init_async();
         let _guard = runtime.enter();
 
@@ -334,16 +334,51 @@ proptest! {
             );
 
             let call_task = tokio::spawn(rpc.get_raw_mempool());
-            let mut expected_response: Vec<String> = transaction_ids
-                .iter()
-                .map(|id| id.mined_id().encode_hex())
-                .collect();
-            expected_response.sort();
 
-            mempool
-                .expect_request(mempool::Request::TransactionIds)
-                .await?
-                .respond(mempool::Response::TransactionIds(transaction_ids));
+
+            #[cfg(not(feature = "getblocktemplate-rpcs"))]
+            let mut expected_response = {
+                let mut expected_response: Vec<String> = transaction_ids
+                    .iter()
+                    .map(|tx| tx.transaction.id.mined_id().encode_hex())
+                    .collect();
+                expected_response.sort();
+
+                mempool
+                    .expect_request(mempool::Request::TransactionIds)
+                    .await?
+                    .respond(mempool::Response::TransactionIds(transaction_ids));
+
+                expected_response
+            };
+
+            #[cfg(feature = "getblocktemplate-rpcs")]
+            let expected_response = {
+                let mut expected_response = transactions.clone();
+                expected_response.sort_by_cached_key(|tx| {
+                    // zcashd uses modified fee here but Zebra doesn't currently
+                    // support prioritizing transactions
+                    std::cmp::Reverse((
+                        i64::from(tx.miner_fee) as u128 * zebra_chain::block::MAX_BLOCK_BYTES as u128
+                            / tx.transaction.size as u128,
+                        // transaction hashes are compared in their serialized byte-order.
+                        tx.transaction.id.mined_id(),
+                    ))
+                });
+
+                let expected_response = expected_response
+                    .iter()
+                    .map(|tx| tx.transaction.id.mined_id().encode_hex())
+                    .collect();
+
+                // Note: this depends on `SHOULD_USE_ZCASHD_ORDER` being true.
+                mempool
+                    .expect_request(mempool::Request::FullTransactions)
+                    .await?
+                    .respond(mempool::Response::FullTransactions(transactions));
+
+                expected_response
+            };
 
             mempool.expect_no_requests().await?;
             state.expect_no_requests().await?;

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -337,10 +337,15 @@ proptest! {
 
 
             #[cfg(not(feature = "getblocktemplate-rpcs"))]
-            let mut expected_response = {
+            let expected_response = {
+                let transaction_ids: HashSet<_> = transactions
+                    .iter()
+                    .map(|tx| tx.transaction.id)
+                    .collect();
+
                 let mut expected_response: Vec<String> = transaction_ids
                     .iter()
-                    .map(|tx| tx.transaction.id.mined_id().encode_hex())
+                    .map(|id| id.mined_id().encode_hex())
                     .collect();
                 expected_response.sort();
 

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -352,6 +352,7 @@ proptest! {
                 expected_response
             };
 
+            // Note: this depends on `SHOULD_USE_ZCASHD_ORDER` being true.
             #[cfg(feature = "getblocktemplate-rpcs")]
             let expected_response = {
                 let mut expected_response = transactions.clone();
@@ -371,7 +372,6 @@ proptest! {
                     .map(|tx| tx.transaction.id.mined_id().encode_hex())
                     .collect();
 
-                // Note: this depends on `SHOULD_USE_ZCASHD_ORDER` being true.
                 mempool
                     .expect_request(mempool::Request::FullTransactions)
                     .await?

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -129,6 +129,15 @@ async fn test_rpc_response_data_for_network(network: Network) {
     // - a request to get all mempool transactions will be made by `getrawmempool` behind the scenes.
     // - as we have the mempool mocked we need to expect a request and wait for a response,
     // which will be an empty mempool in this case.
+    // Note: this depends on `SHOULD_USE_ZCASHD_ORDER` being true.
+    #[cfg(feature = "getblocktemplate-rpcs")]
+    let mempool_req = mempool
+        .expect_request_that(|request| matches!(request, mempool::Request::FullTransactions))
+        .map(|responder| {
+            responder.respond(mempool::Response::FullTransactions(vec![]));
+        });
+
+    #[cfg(not(feature = "getblocktemplate-rpcs"))]
     let mempool_req = mempool
         .expect_request_that(|request| matches!(request, mempool::Request::TransactionIds))
         .map(|responder| {


### PR DESCRIPTION
## Motivation

It would be convenient for the `getrawmempool` output to match zcashd's exactly so we can run zcash-rpc-diff continuously until there's a difference to examine.

## Solution

- Gets full transactions from mempool
- Sorts transactions by `fee/size` then id before returning `getrawmempool` results

## Review

Anyone can review. This doesn't have to merge, we could just use this branch for https://github.com/ZcashFoundation/zebra/issues/5935.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [x] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
