### PR TITLE
fix(ci): Move docker push fix to the setup action

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -91,6 +91,12 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          # TODO: change after new buildkit version gets fixed
+          # https://github.com/moby/buildkit/issues/3347
+          # https://github.com/docker/build-push-action/issues/761#issuecomment-1383822381
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -155,8 +161,3 @@ jobs:
             type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache
             type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:main-cache
           cache-to: type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache,mode=max
-          # TODO: change after new buildkit version gets fixed
-          # https://github.com/moby/buildkit/issues/3347
-          # https://github.com/docker/build-push-action/issues/761
-          driver-opts: |
-            image=moby/buildkit:v0.10.6

--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -102,6 +102,12 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          # TODO: change after new buildkit version gets fixed
+          # https://github.com/moby/buildkit/issues/3347
+          # https://github.com/docker/build-push-action/issues/761#issuecomment-1383822381
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud


### PR DESCRIPTION
## Motivation

1. Move the workaround in https://github.com/docker/build-push-action/issues/761#issuecomment-1383822381 to the setup workflow
2. Apply the same workaround to the lightwalletd Docker push

Close #5958

## Review

This is an urgent fix to stop CI failures.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

