### PR TITLE
fix(clippy): Inline a format variable in some new code

### DIFF
--- a/zebra-utils/src/bin/block-template-to-proposal/main.rs
+++ b/zebra-utils/src/bin/block-template-to-proposal/main.rs
@@ -86,10 +86,7 @@ fn main() -> Result<()> {
 
     template_obj.entry("maxtime").or_insert_with(|| {
         if time_source.uses_max_time() {
-            eprintln!(
-                "maxtime field is missing, using curtime for maxtime: {:?}",
-                current_time,
-            );
+            eprintln!("maxtime field is missing, using curtime for maxtime: {current_time:?}");
         }
 
         current_time.timestamp().into()


### PR DESCRIPTION
## Motivation

I'm not sure how we missed this during review or in CI, but one of the new Rust tools has a clippy lint warning.

## Review

This is a low priority lint fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

It's possible the tool isn't being built in CI, or it isn't being built with "deny warnings". Maybe we should fix that eventually. But I think it's a low priority.
