### PR TITLE
fix typos in some consensus rules

### DIFF
--- a/zebra-chain/src/sapling/output.rs
+++ b/zebra-chain/src/sapling/output.rs
@@ -136,7 +136,7 @@ impl ZcashDeserialize for OutputInTransactionV4 {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
         // # Consensus
         //
-        // > Elements of a Output description MUST be valid encodings of the types given above.
+        // > Elements of an Output description MUST be valid encodings of the types given above.
         //
         // https://zips.z.cash/protocol/protocol.pdf#outputdesc
         //
@@ -199,7 +199,7 @@ impl ZcashDeserialize for OutputPrefixInTransactionV5 {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
         // # Consensus
         //
-        // > Elements of a Output description MUST be valid encodings of the types given above.
+        // > Elements of an Output description MUST be valid encodings of the types given above.
         //
         // https://zips.z.cash/protocol/protocol.pdf#outputdesc
         //

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -253,7 +253,7 @@ impl ZcashDeserialize for Option<sapling::ShieldedData<SharedAnchor>> {
         //
         // # Consensus
         //
-        // > Elements of a Output description MUST be valid encodings of the types given above.
+        // > Elements of an Output description MUST be valid encodings of the types given above.
         //
         // https://zips.z.cash/protocol/protocol.pdf#outputdesc
         //


### PR DESCRIPTION
## Motivation

This is small typo fix which can be important for people searching for the consensus rule by a part of its text (a.k.a. me some hours ago)

### Specifications

Original text of the rule for reference:

![image](https://user-images.githubusercontent.com/35766/213782714-bc4cd83f-8f8d-421e-a4f5-a605405b3034.png)


### Complex Code or Requirements

<!--
Does this PR change concurrency, unsafe code, or complex consensus rules?
If it does, ask for multiple reviewers on this PR.
-->

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
If this is a large change, list commits of key functional changes here.
-->

## Review

This is super low priority, and comment-only, so we may want to just admin-merge it

<!--
Is this PR blocking any other work?
If you want specific reviewers for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
