### PR TITLE
fix(clippy): Silence future-incompat warnings until we upgrade Abscissa

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,11 @@
 # Zebra cargo configuration
 
+# Disabled until we upgrade to abscissa 0.7 or later:
+# https://github.com/ZcashFoundation/zebra/issues/5502
+# https://doc.rust-lang.org/cargo/reference/future-incompat-report.html
+[future-incompat-report]
+frequency = "never"
+
 # Flags that apply to all Zebra crates and configurations
 [target.'cfg(all())']
 rustflags = [
@@ -38,7 +44,7 @@ rustflags = [
     # Incomplete code
     "-Wclippy::dbg_macro",
     "-Wclippy::todo",
-    
+
     # Manual debugging output.
     # Use tracing::trace!() or tracing::debug!() instead.
     "-Wclippy::print_stdout",
@@ -51,13 +57,13 @@ rustflags = [
     # Panics
     "-Wclippy::fallible_impl_from",
     "-Wclippy::unwrap_in_result",
-    
+
     # Documentation
     "-Wmissing_docs",
 
     # These rustdoc -A and -W settings must be the same as the RUSTDOCFLAGS in:
     # https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/lint.yml#L152
-    
+
     # Links in public docs can point to private items.
     "-Arustdoc::private_intra_doc_links",
 

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -19,11 +19,14 @@ on:
       # production code and test code
       - '**/*.rs'
       # hard-coded checkpoints
-      # TODO: skip proptest regressions
+      # TODO: skip proptest regressions?
       - '**/*.txt'
+      # test data snapshots
+      - '**/*.snap'
       # dependencies
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+      - '**/deny.toml'
       # configuration files
       - '.cargo/config.toml'
       - '**/clippy.toml'
@@ -41,6 +44,9 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - '**/deny.toml'
+      # configuration files
+      - '.cargo/config.toml'
+      - '**/clippy.toml'
       # workflow definitions
       - '.github/workflows/continous-integration-os.yml'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,6 +35,8 @@ on:
       - '**/*.snap'
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+      - '.cargo/config.toml'
+      - '**/clippy.toml'
       - 'codecov.yml'
       - '.github/workflows/coverage.yml'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,9 @@ on:
       - '**/*.rs'
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+      # configuration files
+      - '.cargo/config.toml'
+      - '**/clippy.toml'
       # workflow definitions
       - '.github/workflows/docs.yml'
 


### PR DESCRIPTION
## Motivation

Nightly Rust has started warning that abscissa 0.5.2 might not be supported by the 2024 Rust edition.

Let's turn that warning off until we are ready to upgrade Abscissa:
https://github.com/ZcashFoundation/zebra/issues/5502

## Solution

Disable all future incompatibility warnings for now.

There is a small risk we will miss another incompatibility warning, but it will also likely be in the 2024 Rust edition, which is optional to upgrade to.

## Review

This is a low priority.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [x] How do you know it works? Does it have tests?

## Follow Up Work

We might want to upgrade abscissa some time in the next year or so:
https://github.com/ZcashFoundation/zebra/issues/5502