### PR TITLE
fix(consensus): Verify the lock times of mempool transactions

### DIFF
--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -186,6 +186,11 @@ pub enum TransactionError {
     #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     // This error variant is at least 128 bytes
     ValidateNullifiersAndAnchorsError(Box<ValidateContextError>),
+
+    #[error("could not validate mempool transaction lock time on best chain")]
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
+    // TODO: turn this into a typed error
+    ValidateMempoolLockTimeError(String),
 }
 
 impl From<ValidateContextError> for TransactionError {

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use color_eyre::eyre::Report;
 use halo2::pasta::{group::ff::PrimeField, pallas};
 use tower::{service_fn, ServiceExt};
@@ -261,6 +261,305 @@ async fn mempool_request_with_present_input_is_accepted() {
     };
 
     tokio::spawn(async move {
+        state
+            .expect_request(zebra_state::Request::BestChainNextMedianTimePast)
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::BestChainNextMedianTimePast(
+                DateTime32::MAX,
+            ));
+
+        state
+            .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::UnspentBestChainUtxo(
+                known_utxos
+                    .get(&input_outpoint)
+                    .map(|utxo| utxo.utxo.clone()),
+            ));
+
+        state
+            .expect_request_that(|req| {
+                matches!(
+                    req,
+                    zebra_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
+                )
+            })
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::ValidBestChainTipNullifiersAndAnchors);
+    });
+
+    let verifier_response = verifier
+        .oneshot(Request::Mempool {
+            transaction: tx.into(),
+            height,
+        })
+        .await;
+
+    assert!(
+        verifier_response.is_ok(),
+        "expected successful verification, got: {verifier_response:?}"
+    );
+}
+
+#[tokio::test]
+async fn mempool_request_with_invalid_lock_time_is_rejected() {
+    let mut state: MockService<_, _, _, _> = MockService::build().for_prop_tests();
+    let verifier = Verifier::new(Network::Mainnet, state.clone());
+
+    let height = NetworkUpgrade::Canopy
+        .activation_height(Network::Mainnet)
+        .expect("Canopy activation height is specified");
+    let fund_height = (height - 1).expect("fake source fund block height is too small");
+    let (input, output, known_utxos) = mock_transparent_transfer(fund_height, true, 0);
+
+    // Create a non-coinbase V4 tx with the last valid expiry height.
+    let tx = Transaction::V4 {
+        inputs: vec![input],
+        outputs: vec![output],
+        lock_time: LockTime::max_lock_time_timestamp(),
+        expiry_height: height,
+        joinsplit_data: None,
+        sapling_shielded_data: None,
+    };
+
+    let input_outpoint = match tx.inputs()[0] {
+        transparent::Input::PrevOut { outpoint, .. } => outpoint,
+        transparent::Input::Coinbase { .. } => panic!("requires a non-coinbase transaction"),
+    };
+
+    tokio::spawn(async move {
+        state
+            .expect_request(zebra_state::Request::BestChainNextMedianTimePast)
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::BestChainNextMedianTimePast(
+                DateTime32::from(
+                    u32::try_from(LockTime::MIN_TIMESTAMP).expect("min time is valid"),
+                ),
+            ));
+
+        state
+            .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::UnspentBestChainUtxo(
+                known_utxos
+                    .get(&input_outpoint)
+                    .map(|utxo| utxo.utxo.clone()),
+            ));
+
+        state
+            .expect_request_that(|req| {
+                matches!(
+                    req,
+                    zebra_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
+                )
+            })
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::ValidBestChainTipNullifiersAndAnchors);
+    });
+
+    let verifier_response = verifier
+        .oneshot(Request::Mempool {
+            transaction: tx.into(),
+            height,
+        })
+        .await;
+
+    assert_eq!(
+        verifier_response,
+        Err(TransactionError::LockedUntilAfterBlockTime(
+            Utc.timestamp_opt(u32::MAX.into(), 0).unwrap()
+        ))
+    );
+}
+
+#[tokio::test]
+async fn mempool_request_with_unlocked_lock_time_is_accepted() {
+    let mut state: MockService<_, _, _, _> = MockService::build().for_prop_tests();
+    let verifier = Verifier::new(Network::Mainnet, state.clone());
+
+    let height = NetworkUpgrade::Canopy
+        .activation_height(Network::Mainnet)
+        .expect("Canopy activation height is specified");
+    let fund_height = (height - 1).expect("fake source fund block height is too small");
+    let (input, output, known_utxos) = mock_transparent_transfer(fund_height, true, 0);
+
+    // Create a non-coinbase V4 tx with the last valid expiry height.
+    let tx = Transaction::V4 {
+        inputs: vec![input],
+        outputs: vec![output],
+        lock_time: LockTime::unlocked(),
+        expiry_height: height,
+        joinsplit_data: None,
+        sapling_shielded_data: None,
+    };
+
+    let input_outpoint = match tx.inputs()[0] {
+        transparent::Input::PrevOut { outpoint, .. } => outpoint,
+        transparent::Input::Coinbase { .. } => panic!("requires a non-coinbase transaction"),
+    };
+
+    tokio::spawn(async move {
+        state
+            .expect_request(zebra_state::Request::BestChainNextMedianTimePast)
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::BestChainNextMedianTimePast(
+                DateTime32::from(
+                    u32::try_from(LockTime::MIN_TIMESTAMP).expect("min time is valid"),
+                ),
+            ));
+
+        state
+            .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::UnspentBestChainUtxo(
+                known_utxos
+                    .get(&input_outpoint)
+                    .map(|utxo| utxo.utxo.clone()),
+            ));
+
+        state
+            .expect_request_that(|req| {
+                matches!(
+                    req,
+                    zebra_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
+                )
+            })
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::ValidBestChainTipNullifiersAndAnchors);
+    });
+
+    let verifier_response = verifier
+        .oneshot(Request::Mempool {
+            transaction: tx.into(),
+            height,
+        })
+        .await;
+
+    assert!(
+        verifier_response.is_ok(),
+        "expected successful verification, got: {verifier_response:?}"
+    );
+}
+
+#[tokio::test]
+async fn mempool_request_with_lock_time_max_sequence_number_is_accepted() {
+    let mut state: MockService<_, _, _, _> = MockService::build().for_prop_tests();
+    let verifier = Verifier::new(Network::Mainnet, state.clone());
+
+    let height = NetworkUpgrade::Canopy
+        .activation_height(Network::Mainnet)
+        .expect("Canopy activation height is specified");
+    let fund_height = (height - 1).expect("fake source fund block height is too small");
+    let (mut input, output, known_utxos) = mock_transparent_transfer(fund_height, true, 0);
+
+    // Ignore the lock time.
+    input.set_sequence(u32::MAX);
+
+    // Create a non-coinbase V4 tx with the last valid expiry height.
+    let tx = Transaction::V4 {
+        inputs: vec![input],
+        outputs: vec![output],
+        lock_time: LockTime::max_lock_time_timestamp(),
+        expiry_height: height,
+        joinsplit_data: None,
+        sapling_shielded_data: None,
+    };
+
+    let input_outpoint = match tx.inputs()[0] {
+        transparent::Input::PrevOut { outpoint, .. } => outpoint,
+        transparent::Input::Coinbase { .. } => panic!("requires a non-coinbase transaction"),
+    };
+
+    tokio::spawn(async move {
+        state
+            .expect_request(zebra_state::Request::BestChainNextMedianTimePast)
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::BestChainNextMedianTimePast(
+                DateTime32::from(
+                    u32::try_from(LockTime::MIN_TIMESTAMP).expect("min time is valid"),
+                ),
+            ));
+
+        state
+            .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::UnspentBestChainUtxo(
+                known_utxos
+                    .get(&input_outpoint)
+                    .map(|utxo| utxo.utxo.clone()),
+            ));
+
+        state
+            .expect_request_that(|req| {
+                matches!(
+                    req,
+                    zebra_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
+                )
+            })
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::ValidBestChainTipNullifiersAndAnchors);
+    });
+
+    let verifier_response = verifier
+        .oneshot(Request::Mempool {
+            transaction: tx.into(),
+            height,
+        })
+        .await;
+
+    assert!(
+        verifier_response.is_ok(),
+        "expected successful verification, got: {verifier_response:?}"
+    );
+}
+
+#[tokio::test]
+async fn mempool_request_with_past_lock_time_is_accepted() {
+    let mut state: MockService<_, _, _, _> = MockService::build().for_prop_tests();
+    let verifier = Verifier::new(Network::Mainnet, state.clone());
+
+    let height = NetworkUpgrade::Canopy
+        .activation_height(Network::Mainnet)
+        .expect("Canopy activation height is specified");
+    let fund_height = (height - 1).expect("fake source fund block height is too small");
+    let (input, output, known_utxos) = mock_transparent_transfer(fund_height, true, 0);
+
+    // Create a non-coinbase V4 tx with the last valid expiry height.
+    let tx = Transaction::V4 {
+        inputs: vec![input],
+        outputs: vec![output],
+        lock_time: LockTime::min_lock_time_timestamp(),
+        expiry_height: height,
+        joinsplit_data: None,
+        sapling_shielded_data: None,
+    };
+
+    let input_outpoint = match tx.inputs()[0] {
+        transparent::Input::PrevOut { outpoint, .. } => outpoint,
+        transparent::Input::Coinbase { .. } => panic!("requires a non-coinbase transaction"),
+    };
+
+    tokio::spawn(async move {
+        state
+            .expect_request(zebra_state::Request::BestChainNextMedianTimePast)
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::BestChainNextMedianTimePast(
+                DateTime32::MAX,
+            ));
+
         state
             .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
             .await

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -14,7 +14,7 @@ use zebra_chain::{
     parameters::{Network, NetworkUpgrade},
     primitives::{ed25519, x25519, Groth16Proof},
     sapling,
-    serialization::{ZcashDeserialize, ZcashDeserializeInto},
+    serialization::{DateTime32, ZcashDeserialize, ZcashDeserializeInto},
     sprout,
     transaction::{
         arbitrary::{
@@ -196,9 +196,17 @@ async fn mempool_request_with_missing_input_is_rejected() {
 
     tokio::spawn(async move {
         state
+            .expect_request(zebra_state::Request::BestChainNextMedianTimePast)
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::BestChainNextMedianTimePast(
+                DateTime32::MAX,
+            ));
+
+        state
             .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
             .await
-            .expect("verifier should call mock state service")
+            .expect("verifier should call mock state service with correct request")
             .respond(zebra_state::Response::UnspentBestChainUtxo(None));
 
         state
@@ -209,7 +217,7 @@ async fn mempool_request_with_missing_input_is_rejected() {
                 )
             })
             .await
-            .expect("verifier should call mock state service")
+            .expect("verifier should call mock state service with correct request")
             .respond(zebra_state::Response::ValidBestChainTipNullifiersAndAnchors);
     });
 
@@ -256,7 +264,7 @@ async fn mempool_request_with_present_input_is_accepted() {
         state
             .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
             .await
-            .expect("verifier should call mock state service")
+            .expect("verifier should call mock state service with correct request")
             .respond(zebra_state::Response::UnspentBestChainUtxo(
                 known_utxos
                     .get(&input_outpoint)
@@ -271,7 +279,7 @@ async fn mempool_request_with_present_input_is_accepted() {
                 )
             })
             .await
-            .expect("verifier should call mock state service")
+            .expect("verifier should call mock state service with correct request")
             .respond(zebra_state::Response::ValidBestChainTipNullifiersAndAnchors);
     });
 

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -559,6 +559,11 @@ pub enum Request {
     /// Returns [`Response::ValidBestChainTipNullifiersAndAnchors`]
     CheckBestChainTipNullifiersAndAnchors(UnminedTx),
 
+    /// Calculates the median-time-past for the *next* block on the best chain.
+    ///
+    /// Returns [`Response::BestChainNextMedianTimePast`] when successful.
+    BestChainNextMedianTimePast,
+
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Performs contextual validation of the given block, but does not commit it to the state.
     ///
@@ -584,6 +589,7 @@ impl Request {
             Request::CheckBestChainTipNullifiersAndAnchors(_) => {
                 "best_chain_tip_nullifiers_anchors"
             }
+            Request::BestChainNextMedianTimePast => "best_chain_next_median_time_past",
             #[cfg(feature = "getblocktemplate-rpcs")]
             Request::CheckBlockProposalValidity(_) => "check_block_proposal_validity",
         }
@@ -772,6 +778,11 @@ pub enum ReadRequest {
     /// Returns [`ReadResponse::ValidBestChainTipNullifiersAndAnchors`].
     CheckBestChainTipNullifiersAndAnchors(UnminedTx),
 
+    /// Calculates the median-time-past for the *next* block on the best chain.
+    ///
+    /// Returns [`ReadResponse::BestChainNextMedianTimePast`] when successful.
+    BestChainNextMedianTimePast,
+
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Looks up a block hash by height in the current best chain.
     ///
@@ -832,6 +843,7 @@ impl ReadRequest {
             ReadRequest::CheckBestChainTipNullifiersAndAnchors(_) => {
                 "best_chain_tip_nullifiers_anchors"
             }
+            ReadRequest::BestChainNextMedianTimePast => "best_chain_next_median_time_past",
             #[cfg(feature = "getblocktemplate-rpcs")]
             ReadRequest::BestChainBlockHash(_) => "best_chain_block_hash",
             #[cfg(feature = "getblocktemplate-rpcs")]
@@ -864,6 +876,7 @@ impl TryFrom<Request> for ReadRequest {
         match request {
             Request::Tip => Ok(ReadRequest::Tip),
             Request::Depth(hash) => Ok(ReadRequest::Depth(hash)),
+            Request::BestChainNextMedianTimePast => Ok(ReadRequest::BestChainNextMedianTimePast),
 
             Request::Block(hash_or_height) => Ok(ReadRequest::Block(hash_or_height)),
             Request::Transaction(tx_hash) => Ok(ReadRequest::Transaction(tx_hash)),

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -6,12 +6,13 @@ use zebra_chain::{
     amount::{Amount, NonNegative},
     block::{self, Block},
     orchard, sapling,
+    serialization::DateTime32,
     transaction::{self, Transaction},
     transparent,
 };
 
 #[cfg(feature = "getblocktemplate-rpcs")]
-use zebra_chain::{serialization::DateTime32, work::difficulty::CompactDifficulty};
+use zebra_chain::work::difficulty::CompactDifficulty;
 
 // Allow *only* these unused imports, so that rustdoc link resolution
 // will work with inline links.
@@ -59,6 +60,10 @@ pub enum Response {
     ///
     /// Does not check transparent UTXO inputs
     ValidBestChainTipNullifiersAndAnchors,
+
+    /// Response to [`Request::BestChainNextMedianTimePast`].
+    /// Contains the median-time-past for the *next* block on the best chain.
+    BestChainNextMedianTimePast(DateTime32),
 
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Response to [`Request::CheckBlockProposalValidity`](crate::Request::CheckBlockProposalValidity)
@@ -128,6 +133,10 @@ pub enum ReadResponse {
     /// Does not check transparent UTXO inputs
     ValidBestChainTipNullifiersAndAnchors,
 
+    /// Response to [`ReadRequest::BestChainNextMedianTimePast`].
+    /// Contains the median-time-past for the *next* block on the best chain.
+    BestChainNextMedianTimePast(DateTime32),
+
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Response to [`ReadRequest::BestChainBlockHash`](crate::ReadRequest::BestChainBlockHash) with the
     /// specified block hash.
@@ -195,6 +204,7 @@ impl TryFrom<ReadResponse> for Response {
         match response {
             ReadResponse::Tip(height_and_hash) => Ok(Response::Tip(height_and_hash)),
             ReadResponse::Depth(depth) => Ok(Response::Depth(depth)),
+            ReadResponse::BestChainNextMedianTimePast(median_time_past) => Ok(Response::BestChainNextMedianTimePast(median_time_past)),
 
             ReadResponse::Block(block) => Ok(Response::Block(block)),
             ReadResponse::Transaction(tx_and_height) => {

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -16,12 +16,11 @@ use crate::service;
 
 pub mod address;
 pub mod block;
+pub mod find;
+pub mod tree;
 
 #[cfg(feature = "getblocktemplate-rpcs")]
 pub mod difficulty;
-
-pub mod find;
-pub mod tree;
 
 #[cfg(test)]
 mod tests;
@@ -34,15 +33,14 @@ pub use address::{
 pub use block::{
     any_utxo, block, block_header, transaction, transaction_hashes_for_block, unspent_utxo, utxo,
 };
+pub use find::{
+    best_tip, block_locator, chain_contains_hash, depth, find_chain_hashes, find_chain_headers,
+    hash_by_height, height_by_hash, next_median_time_past, tip, tip_height,
+};
+pub use tree::{orchard_tree, sapling_tree};
 
 #[cfg(feature = "getblocktemplate-rpcs")]
 pub use difficulty::get_block_template_chain_info;
-
-pub use find::{
-    best_tip, block_locator, chain_contains_hash, depth, find_chain_hashes, find_chain_headers,
-    hash_by_height, height_by_hash, tip, tip_height,
-};
-pub use tree::{orchard_tree, sapling_tree};
 
 /// If a finalized state query is interrupted by a new finalized block,
 /// retry this many times.

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -406,10 +406,16 @@ impl Service<Request> for Mempool {
                 let mined_ids = block.transaction_hashes.iter().cloned().collect();
                 tx_downloads.cancel(&mined_ids);
                 storage.reject_and_remove_same_effects(&mined_ids, block.transactions);
+
+                // Clear any transaction rejections if they might have become valid after
+                // the new block was added to the tip.
                 storage.clear_tip_rejections();
             }
 
             // Remove expired transactions from the mempool.
+            //
+            // Lock times never expire, because block times are strictly increasing.
+            // So we don't need to check them here.
             if let Some(tip_height) = self.latest_chain_tip.best_tip_height() {
                 let expired_transactions = storage.remove_expired_transactions(tip_height);
                 // Remove transactions that are expired from the peers list

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -43,7 +43,7 @@ mod verified_set;
 pub(crate) const MAX_EVICTION_MEMORY_ENTRIES: usize = 40_000;
 
 /// Transactions rejected based on transaction authorizing data (scripts, proofs, signatures),
-/// These rejections are only valid for the current tip.
+/// or lock times. These rejections are only valid for the current tip.
 ///
 /// Each committed block clears these rejections, because new blocks can supply missing inputs.
 #[derive(Error, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
## Motivation

We need to check that mempool transaction lock times are valid, so the block templates created by Zebra are also valid.

Closes #5984

### Specifications

#### Mempool Transaction Verification

> Define the median-time-past of a block to be the median (as defined in § 7.7.3 ‘Difficulty adjustment’ on p. 131) of the nTime fields of the preceding PoWMedianBlockSpan blocks (or all preceding blocks if there are fewer than PoWMedianBlockSpan). The median-time-past of a genesis block is not defined.

> • As in Bitcoin, the nTime field MUST represent a time strictly greater than the median of the timestamps of the past PoWMedianBlockSpan blocks.

https://zips.z.cash/protocol/protocol.pdf#blockheader

> If greater than or equal to 500 million, locktime is parsed using the [Unix epoch time](https://en.wikipedia.org/wiki/Unix_time) format (the number of seconds elapsed since 1970-01-01T00:00 UTC—currently over 1.395 billion). The transaction can be added to any block whose block time is greater than the locktime.

https://developer.bitcoin.org/devguide/transactions.html#locktime-and-sequence-number

If the transaction's lock time is less than the median-time-past, it will always be less than the next block's time, because the next block's time is strictly greater than the median-time-past.

This is the rule implemented by `zcashd`:
https://github.com/zcash/zcash/blob/9e1efad2d13dca5ee094a38e6aa25b0f2464da94/src/main.cpp#L776-L784
https://github.com/zcash/zcash/blob/9e1efad2d13dca5ee094a38e6aa25b0f2464da94/src/main.cpp#L735

#### Mempool Updates on State Tip Changes

When a new block is added to the state tip:
- existing transactions in the mempool will always have valid lock times, because the block time is strictly increasing
- previously rejected lock times might have become valid, but the mempool already clears all verifier errors on every new block

### Complex Code or Requirements

This PR modifies async code, and state code that runs concurrently with block writes.

## Solution

- Implement the BestChainNextMedianTimePast state request
- Verify the lock times of mempool transactions
- Document that the mempool already handles lock time rejections correctly

This is a mempool consensus rule bug, so we don't want these changes behind a feature flag.

### Testing

- Fix existing tests to have valid lock times
- Add new tests for each lock time consensus rule: unlocked, sequence numbers, past lock time, before lock time

## Review

I marked this as a high priority because it is blocking most of our testing work.
Because it is a high priority, I'd like to avoid doing refactors in this PR.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

