### PR TITLE
refactor(state): Simplify difficulty and median-time-past state and mempool requests

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -363,6 +363,17 @@ impl Transaction {
         }
     }
 
+    /// Returns `true` if this transaction's lock time is a time.
+    /// Returns `false` if it is a height, is unlocked,
+    /// or if the transparent input sequence numbers have disabled lock times.
+    pub fn lock_time_is_time(&self) -> bool {
+        if let Some(lock_time) = self.lock_time() {
+            return lock_time.is_time();
+        }
+
+        false
+    }
+
     /// Get this transaction's expiry height, if any.
     pub fn expiry_height(&self) -> Option<block::Height> {
         match self {

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -363,8 +363,8 @@ impl Transaction {
         }
     }
 
-    /// Returns `true` if this transaction's lock time is a time.
-    /// Returns `false` if it is a height, is unlocked,
+    /// Returns `true` if this transaction's `lock_time` is a [`LockTime::Time`].
+    /// Returns `false` if it is a [`LockTime::Height`] (locked or unlocked), is unlocked,
     /// or if the transparent input sequence numbers have disabled lock times.
     pub fn lock_time_is_time(&self) -> bool {
         if let Some(lock_time) = self.lock_time() {

--- a/zebra-chain/src/transaction/lock_time.rs
+++ b/zebra-chain/src/transaction/lock_time.rs
@@ -93,6 +93,11 @@ impl LockTime {
                 .expect("in-range number of seconds and valid nanosecond"),
         )
     }
+
+    /// Returns `true` if this lock time is a time, or `false` if it is a height.
+    pub fn is_time(&self) -> bool {
+        matches!(self, LockTime::Time(_))
+    }
 }
 
 impl ZcashSerialize for LockTime {

--- a/zebra-chain/src/transaction/lock_time.rs
+++ b/zebra-chain/src/transaction/lock_time.rs
@@ -94,7 +94,7 @@ impl LockTime {
         )
     }
 
-    /// Returns `true` if this lock time is a time, or `false` if it is a height.
+    /// Returns `true` if this lock time is a [`LockTime::Time`], or `false` if it is a [`LockTime::Height`].
     pub fn is_time(&self) -> bool {
         matches!(self, LockTime::Time(_))
     }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -347,15 +347,15 @@ where
             if let Some(block_time) = req.block_time() {
                 check::lock_time_has_passed(&tx, req.height(), block_time)?;
             } else {
-                let mut next_median_time_past = None;
-
                 // Skip the state query if we don't need the time for this check.
-                if tx.lock_time_is_time() {
+                let next_median_time_past = if tx.lock_time_is_time() {
                     // This state query is much faster than loading UTXOs from the database,
                     // so it doesn't need to be executed in parallel
                     let state = state.clone();
-                    next_median_time_past = Some(Self::mempool_best_chain_next_median_time_past(state).await?.to_chrono());
-                }
+                    Some(Self::mempool_best_chain_next_median_time_past(state).await?.to_chrono())
+                } else {
+                    None
+                };
 
                 // This consensus check makes sure Zebra produces valid block templates.
                 check::lock_time_has_passed(&tx, req.height(), next_median_time_past)?;

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -19,19 +19,47 @@ use crate::error::TransactionError;
 
 /// Checks if the transaction's lock time allows this transaction to be included in a block.
 ///
-/// Consensus rule:
+/// Arguments:
+/// - `block_height`: the height of the mined block, or the height of the next block for mempool
+///                   transactions
+/// - `block_time`: the time in the mined block header, or the median-time-past of the next block
+///                 for the mempool. Optional if the lock time is a height.
+///
+/// # Panics
+///
+/// If the lock time is a time, and `block_time` is `None`.
+///
+/// # Consensus
 ///
 /// > The transaction must be finalized: either its locktime must be in the past (or less
 /// > than or equal to the current block height), or all of its sequence numbers must be
 /// > 0xffffffff.
 ///
 /// [`Transaction::lock_time`] validates the transparent input sequence numbers, returning [`None`]
-/// if they indicate that the transaction is finalized by them. Otherwise, this function validates
-/// if the lock time is in the past.
+/// if they indicate that the transaction is finalized by them.
+/// Otherwise, this function checks that the lock time is in the past.
+///
+/// ## Mempool Consensus for Block Templates
+///
+/// > the nTime field MUST represent a time strictly greater than the median of the
+/// > timestamps of the past PoWMedianBlockSpan blocks.
+/// <https://zips.z.cash/protocol/protocol.pdf#blockheader>
+///
+/// > The transaction can be added to any block whose block time is greater than the locktime.
+/// <https://developer.bitcoin.org/devguide/transactions.html#locktime-and-sequence-number>
+///
+/// If the transaction's lock time is less than the median-time-past,
+/// it will always be less than the next block's time,
+/// because the next block's time is strictly greater than the median-time-past.
+/// (That is, `lock-time < median-time-past < block-header-time`.)
+///
+/// Using `median-time-past + 1` would also satisfy this consensus rule,
+/// but we prefer the rule implemented by `zcashd`'s mempool:
+/// <https://github.com/zcash/zcash/blob/9e1efad2d13dca5ee094a38e6aa25b0f2464da94/src/main.cpp#L776-L784>
 pub fn lock_time_has_passed(
     tx: &Transaction,
     block_height: Height,
-    block_time: DateTime<Utc>,
+    block_time: impl Into<Option<DateTime<Utc>>>,
 ) -> Result<(), TransactionError> {
     match tx.lock_time() {
         Some(LockTime::Height(unlock_height)) => {
@@ -48,6 +76,10 @@ pub fn lock_time_has_passed(
         Some(LockTime::Time(unlock_time)) => {
             // > The transaction can be added to any block whose block time is greater than the locktime.
             // https://developer.bitcoin.org/devguide/transactions.html#locktime-and-sequence-number
+            let block_time = block_time
+                .into()
+                .expect("time must be provided if LockTime is a time");
+
             if block_time > unlock_time {
                 Ok(())
             } else {

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -53,7 +53,7 @@ use crate::error::TransactionError;
 /// because the next block's time is strictly greater than the median-time-past.
 /// (That is, `lock-time < median-time-past < block-header-time`.)
 ///
-/// Using `median-time-past + 1` would also satisfy this consensus rule,
+/// Using `median-time-past + 1s` (the next block's mintime) would also satisfy this consensus rule,
 /// but we prefer the rule implemented by `zcashd`'s mempool:
 /// <https://github.com/zcash/zcash/blob/9e1efad2d13dca5ee094a38e6aa25b0f2464da94/src/main.cpp#L776-L784>
 pub fn lock_time_has_passed(

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -1,4 +1,6 @@
 //! Tests for Zcash transaction consensus checks.
+//
+// TODO: split fixed test vectors into a `vectors` module?
 
 use std::{collections::HashMap, sync::Arc};
 
@@ -195,13 +197,8 @@ async fn mempool_request_with_missing_input_is_rejected() {
     };
 
     tokio::spawn(async move {
-        state
-            .expect_request(zebra_state::Request::BestChainNextMedianTimePast)
-            .await
-            .expect("verifier should call mock state service with correct request")
-            .respond(zebra_state::Response::BestChainNextMedianTimePast(
-                DateTime32::MAX,
-            ));
+        // The first non-coinbase transaction with transparent inputs in our test vectors
+        // does not use a lock time, so we don't see Request::BestChainNextMedianTimePast here
 
         state
             .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
@@ -261,14 +258,6 @@ async fn mempool_request_with_present_input_is_accepted() {
     };
 
     tokio::spawn(async move {
-        state
-            .expect_request(zebra_state::Request::BestChainNextMedianTimePast)
-            .await
-            .expect("verifier should call mock state service with correct request")
-            .respond(zebra_state::Response::BestChainNextMedianTimePast(
-                DateTime32::MAX,
-            ));
-
         state
             .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
             .await
@@ -406,16 +395,6 @@ async fn mempool_request_with_unlocked_lock_time_is_accepted() {
 
     tokio::spawn(async move {
         state
-            .expect_request(zebra_state::Request::BestChainNextMedianTimePast)
-            .await
-            .expect("verifier should call mock state service with correct request")
-            .respond(zebra_state::Response::BestChainNextMedianTimePast(
-                DateTime32::from(
-                    u32::try_from(LockTime::MIN_TIMESTAMP).expect("min time is valid"),
-                ),
-            ));
-
-        state
             .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
             .await
             .expect("verifier should call mock state service with correct request")
@@ -480,16 +459,6 @@ async fn mempool_request_with_lock_time_max_sequence_number_is_accepted() {
     };
 
     tokio::spawn(async move {
-        state
-            .expect_request(zebra_state::Request::BestChainNextMedianTimePast)
-            .await
-            .expect("verifier should call mock state service with correct request")
-            .respond(zebra_state::Response::BestChainNextMedianTimePast(
-                DateTime32::from(
-                    u32::try_from(LockTime::MIN_TIMESTAMP).expect("min time is valid"),
-                ),
-            ));
-
         state
             .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
             .await

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -807,10 +807,7 @@ impl ReadStateService {
     /// Gets a clone of the latest, best non-finalized chain from the `non_finalized_state_receiver`
     #[allow(dead_code)]
     fn latest_best_chain(&self) -> Option<Arc<Chain>> {
-        self.non_finalized_state_receiver
-            .cloned_watch_data()
-            .best_chain()
-            .cloned()
+        self.latest_non_finalized_state().best_chain().cloned()
     }
 }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -47,7 +47,7 @@ use crate::{
         block_iter::any_ancestor_blocks,
         chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip},
         finalized_state::{FinalizedState, ZebraDb},
-        non_finalized_state::NonFinalizedState,
+        non_finalized_state::{Chain, NonFinalizedState},
         pending_utxos::PendingUtxos,
         queued_blocks::QueuedBlocks,
         watch_receiver::WatchReceiver,
@@ -802,6 +802,15 @@ impl ReadStateService {
     /// Gets a clone of the latest non-finalized state from the `non_finalized_state_receiver`
     fn latest_non_finalized_state(&self) -> NonFinalizedState {
         self.non_finalized_state_receiver.cloned_watch_data()
+    }
+
+    /// Gets a clone of the latest, best non-finalized chain from the `non_finalized_state_receiver`
+    #[allow(dead_code)]
+    fn latest_best_chain(&self) -> Option<Arc<Chain>> {
+        self.non_finalized_state_receiver
+            .cloned_watch_data()
+            .best_chain()
+            .cloned()
     }
 }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1152,7 +1152,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::Depth(depth))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::Tip"))
+                .map(|join_result| join_result.expect("panic in ReadRequest::Depth"))
                 .boxed()
             }
 
@@ -1268,7 +1268,9 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::TransactionIdsForBlock(transaction_ids))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::Block"))
+                .map(|join_result| {
+                    join_result.expect("panic in ReadRequest::TransactionIdsForBlock")
+                })
                 .boxed()
             }
 
@@ -1348,7 +1350,7 @@ impl Service<ReadRequest> for ReadStateService {
                         ))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::Tip"))
+                .map(|join_result| join_result.expect("panic in ReadRequest::BlockLocator"))
                 .boxed()
             }
 
@@ -1379,7 +1381,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::BlockHashes(block_hashes))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::Tip"))
+                .map(|join_result| join_result.expect("panic in ReadRequest::FindBlockHashes"))
                 .boxed()
             }
 
@@ -1415,7 +1417,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::BlockHeaders(block_headers))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::Tip"))
+                .map(|join_result| join_result.expect("panic in ReadRequest::FindBlockHeaders"))
                 .boxed()
             }
 
@@ -1728,12 +1730,12 @@ impl Service<ReadRequest> for ReadStateService {
                         });
 
                         // The work is done in the future.
-                        timer.finish(module_path!(), line!(), "ReadRequest::ChainInfo");
+                        timer.finish(module_path!(), line!(), "ReadRequest::SolutionRate");
 
                         Ok(ReadResponse::SolutionRate(solution_rate))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::ChainInfo"))
+                .map(|join_result| join_result.expect("panic in ReadRequest::SolutionRate"))
                 .boxed()
             }
 

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -330,7 +330,7 @@ impl AdjustedDifficulty {
     /// slice of `PoWMedianBlockSpan` (11) blocks in the relevant chain.
     ///
     /// Implements `MedianTime` from the Zcash specification.
-    fn median_time(
+    pub(crate) fn median_time(
         mut median_block_span_times: [DateTime<Utc>; POW_MEDIAN_BLOCK_SPAN],
     ) -> DateTime<Utc> {
         median_block_span_times.sort_unstable();

--- a/zebra-state/src/service/read/difficulty.rs
+++ b/zebra-state/src/service/read/difficulty.rs
@@ -16,7 +16,9 @@ use crate::{
     service::{
         any_ancestor_blocks,
         check::{
-            difficulty::{BLOCK_MAX_TIME_SINCE_MEDIAN, POW_ADJUSTMENT_BLOCK_SPAN},
+            difficulty::{
+                BLOCK_MAX_TIME_SINCE_MEDIAN, POW_ADJUSTMENT_BLOCK_SPAN, POW_MEDIAN_BLOCK_SPAN,
+            },
             AdjustedDifficulty,
         },
         finalized_state::ZebraDb,
@@ -206,7 +208,12 @@ fn difficulty_time_and_history_tree(
     // > For each block other than the genesis block , nTime MUST be strictly greater than
     // > the median-time-past of that block.
     // https://zips.z.cash/protocol/protocol.pdf#blockheader
-    let median_time_past = calculate_median_time_past(relevant_chain);
+    let median_time_past = calculate_median_time_past(
+        relevant_chain[0..POW_MEDIAN_BLOCK_SPAN]
+            .to_vec()
+            .try_into()
+            .expect("slice is correct size"),
+    );
 
     let min_time = median_time_past
         .checked_add(Duration32::from_seconds(1))

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -20,16 +20,14 @@ use std::{
 use chrono::{DateTime, Utc};
 use zebra_chain::{
     block::{self, Block, Height},
-    parameters::Network,
     serialization::DateTime32,
-    work::difficulty::CompactDifficulty,
 };
 
 use crate::{
     constants,
     service::{
         block_iter::any_ancestor_blocks,
-        check::{difficulty::POW_ADJUSTMENT_BLOCK_SPAN, AdjustedDifficulty},
+        check::{difficulty::POW_MEDIAN_BLOCK_SPAN, AdjustedDifficulty},
         finalized_state::ZebraDb,
         non_finalized_state::{Chain, NonFinalizedState},
         read::{self, block::block_header, FINALIZED_STATE_QUERY_RETRIES},
@@ -573,7 +571,7 @@ pub fn next_median_time_past(
 fn best_relevant_chain(
     non_finalized_state: &NonFinalizedState,
     db: &ZebraDb,
-) -> Result<[Arc<Block>; POW_ADJUSTMENT_BLOCK_SPAN], BoxError> {
+) -> Result<[Arc<Block>; POW_MEDIAN_BLOCK_SPAN], BoxError> {
     let state_tip_before_queries = read::best_tip(non_finalized_state, db).ok_or_else(|| {
         BoxError::from("Zebra's state is empty, wait until it syncs to the chain tip")
     })?;
@@ -582,7 +580,7 @@ fn best_relevant_chain(
         any_ancestor_blocks(non_finalized_state, db, state_tip_before_queries.1);
     let best_relevant_chain: Vec<_> = best_relevant_chain
         .into_iter()
-        .take(POW_ADJUSTMENT_BLOCK_SPAN)
+        .take(POW_MEDIAN_BLOCK_SPAN)
         .collect();
     let best_relevant_chain = best_relevant_chain.try_into().map_err(|_error| {
         "Zebra's state only has a few blocks, wait until it syncs to the chain tip"
@@ -606,32 +604,22 @@ fn best_relevant_chain(
 ///
 /// See [`next_median_time_past()`] for details.
 pub(crate) fn calculate_median_time_past(
-    relevant_chain: [Arc<Block>; POW_ADJUSTMENT_BLOCK_SPAN],
+    relevant_chain: [Arc<Block>; POW_MEDIAN_BLOCK_SPAN],
 ) -> DateTime32 {
-    let relevant_data: Vec<(CompactDifficulty, DateTime<Utc>)> = relevant_chain
+    let relevant_data: Vec<DateTime<Utc>> = relevant_chain
         .iter()
-        .map(|block| (block.header.difficulty_threshold, block.header.time))
+        .map(|block| block.header.time)
         .collect();
-
-    // TODO: split out median-time-past into its own struct,
-    //       so we don't have to supply these arguments
-    let ignored_time = DateTime::default();
-    let ignored_height = Height(0);
-    let ignored_network = Network::Mainnet;
-
-    // Get the median-time-past, which doesn't depend on the time or the previous block height.
-    // `context` will always have the correct length, because this function takes an array.
-    let median_time_past = AdjustedDifficulty::new_from_header_time(
-        ignored_time,
-        ignored_height,
-        ignored_network,
-        relevant_data,
-    )
-    .median_time_past();
 
     // > Define the median-time-past of a block to be the median of the nTime fields of the
     // > preceding PoWMedianBlockSpan blocks (or all preceding blocks if there are fewer than
     // > PoWMedianBlockSpan). The median-time-past of a genesis block is not defined.
     // https://zips.z.cash/protocol/protocol.pdf#blockheader
+    let median_time_past = AdjustedDifficulty::median_time(
+        relevant_data
+            .try_into()
+            .expect("always has the correct length due to function argument type"),
+    );
+
     DateTime32::try_from(median_time_past).expect("valid blocks have in-range times")
 }

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -605,7 +605,7 @@ fn best_relevant_chain(
 /// The `relevant_chain` has blocks in reverse height order.
 ///
 /// See [`next_median_time_past()`] for details.
-fn calculate_median_time_past(
+pub(crate) fn calculate_median_time_past(
     relevant_chain: [Arc<Block>; POW_ADJUSTMENT_BLOCK_SPAN],
 ) -> DateTime32 {
     let relevant_data: Vec<(CompactDifficulty, DateTime<Utc>)> = relevant_chain
@@ -613,7 +613,8 @@ fn calculate_median_time_past(
         .map(|block| (block.header.difficulty_threshold, block.header.time))
         .collect();
 
-    // TODO: split out median-time-past into its own struct?
+    // TODO: split out median-time-past into its own struct,
+    //       so we don't have to supply these arguments
     let ignored_time = DateTime::default();
     let ignored_height = Height(0);
     let ignored_network = Network::Mainnet;


### PR DESCRIPTION
## Motivation

This PR contains refactors and cleanups after PR #6027.

It shouldn't change any behaviour, or block any other work.

Depends-On: #6027

### Complex Code or Requirements

This PR changes a consensus rule implementation by replacing duplicate code.
It also changes another consensus rule implementation by making an argument optional if it is unused.

## Solution

Refactors:
- Only get the state tip median-time-past when needed in the transaction verifier
- Use the new `calculate_median_time_past()` function in the existing difficulty code, to remove duplicate code
- Simplify `calculate_median_time_past()` by removing dummy arguments and extra blocks
- Add a ReadState best chain clone method (currently unused)

Documentation and logging:
- Clarify difficulty state request docs, rename variables
- Fix state request log typos

## Review

This is a low priority.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

