### PR TITLE
feat(rpc): Implement the `getblocksubsidy` RPC

### DIFF
--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -16,10 +16,6 @@ use std::{
 use crate::serialization::{ZcashDeserialize, ZcashSerialize};
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt, WriteBytesExt};
 
-pub mod zec;
-
-pub use zec::Zec;
-
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod arbitrary;
 

--- a/zebra-chain/src/amount/zec.rs
+++ b/zebra-chain/src/amount/zec.rs
@@ -1,4 +1,7 @@
-//! ZEC-specific formatting, similar to the `zcashd` implementation.
+//! ZEC amount formatting.
+//!
+//! The `f64` values returned by this type should not be used in consensus-critical code.
+//! The values themselves are accurate, but any calculations using them could be lossy.
 
 use std::{
     cmp::Ordering,
@@ -7,8 +10,6 @@ use std::{
     ops,
     str::FromStr,
 };
-
-use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 use crate::{
     amount::{self, Amount, Constraint, COIN},
@@ -20,93 +21,103 @@ use crate::{
 ///
 /// This is the same as the `getblocksubsidy` RPC in `zcashd`:
 /// <https://github.com/zcash/zcash/blob/f6a4f68115ea4c58d55c8538579d0877ba9c8f79/src/rpc/server.cpp#L134>
-pub const MAX_ZAT_PRECISION: usize = 8;
+pub const MAX_ZEC_FORMAT_PRECISION: usize = 8;
 
-/// A wrapper type that formats [`Amount`]s as ZEC,
-/// using fixed-point integer calculations.
-#[derive(Clone, Copy, SerializeDisplay, DeserializeFromStr)]
+/// A wrapper type that formats [`Amount`]s as ZEC, using double-precision floating point.
+///
+/// This formatting is accurate to the nearest zatoshi, as long as the number of floating-point
+/// calculations is very small. This is because [`MAX_MONEY`] uses 51 bits, but [`f64`] has
+/// [53 bits of precision](f64::MANTISSA_DIGITS).
+///
+/// Rust uses [`roundTiesToEven`](f32), which can lose one bit of precision per calculation
+/// in the worst case. (Assuming the platform implements it correctly.)
+///
+/// Unlike `zcashd`, Zebra doesn't have control over its JSON number precision,
+/// because it uses `serde_json`'s formatter. But `zcashd` uses a fixed-point calculation:
+/// <https://github.com/zcash/zcash/blob/f6a4f68115ea4c58d55c8538579d0877ba9c8f79/src/rpc/server.cpp#L134>
+#[derive(Clone, Copy, Serialize, Deserialize)]
+#[serde(try_from = "f64")]
+#[serde(into = "f64")]
+#[serde(bound = "C: Constraint + Clone")]
 pub struct Zec<C: Constraint>(Amount<C>);
 
-impl<C: Constraint> fmt::Display for Zec<C> {
-    // We don't use floating-point here, because it is inaccurate
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl<C: Constraint> Zec<C> {
+    /// Returns the `f64` ZEC value for the inner amount.
+    ///
+    /// The returned value should not be used for consensus-critical calculations,
+    /// because it is lossy.
+    pub fn lossy_zec(&self) -> f64 {
         let zats = self.zatoshis();
+        // These conversions are exact, because f64 has 53 bits of precision,
+        // MAX_MONEY has <51, and COIN has <27, so we have 2 extra bits of precision.
+        let zats = zats as f64;
+        let coin = COIN as f64;
 
-        // Get the fixed-point ZEC and remaining zats values
-        let abs_coins = zats
-            .checked_abs()
-            .expect("-MAX_MONEY is much smaller than i64::MIN")
-            / COIN;
-        let positive_remainder = zats.rem_euclid(COIN);
+        // After this calculation, we might have lost one bit of precision,
+        // leaving us with only 1 extra bit.
+        zats / coin
+    }
 
-        // Format just like `zcashd` by default
-        let decimals = f.precision().unwrap_or(MAX_ZAT_PRECISION);
-        let string = format!("{abs_coins}.{positive_remainder:.decimals$}");
-        f.pad_integral(zats >= 0, "", &string)
+    /// Converts a `f64` ZEC value to a [`Zec`] amount.
+    ///
+    /// This method should not be used for consensus-critical calculations, because it is lossy.
+    pub fn from_lossy_zec(lossy_zec: f64) -> Result<Self, BoxError> {
+        // This conversion is exact, because f64 has 53 bits of precision, but COIN has <27
+        let coin = COIN as f64;
+
+        // After this calculation, we might have lost one bit of precision
+        let zats = lossy_zec * coin;
+
+        if zats != zats.trunc() {
+            return Err(
+                "loss of precision parsing ZEC value: floating point had fractional zatoshis"
+                    .into(),
+            );
+        }
+
+        // We know this conversion is exact, because we just checked.
+        let zats = zats as i64;
+        let zats = Amount::try_from(zats)?;
+
+        Ok(Self(zats))
     }
 }
 
-// This is mainly used in tests
+// These conversions are lossy, so they should not be used in consensus-critical code
+impl<C: Constraint> From<Zec<C>> for f64 {
+    fn from(zec: Zec<C>) -> f64 {
+        zec.lossy_zec()
+    }
+}
+
+impl<C: Constraint> TryFrom<f64> for Zec<C> {
+    type Error = BoxError;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Self::from_lossy_zec(value)
+    }
+}
+
+// This formatter should not be used for consensus-critical outputs.
+impl<C: Constraint> fmt::Display for Zec<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let zec = self.lossy_zec();
+
+        // Try to format like `zcashd` by default
+        let decimals = f.precision().unwrap_or(MAX_ZEC_FORMAT_PRECISION);
+        let string = format!("{zec:.decimals$}");
+        f.pad_integral(zec >= 0.0, "", &string)
+    }
+}
+
+// This parser should not be used for consensus-critical inputs.
 impl<C: Constraint> FromStr for Zec<C> {
     type Err = BoxError;
 
-    // We don't use floating-point here, because it is inaccurate
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Get the fixed-point ZEC and remaining zats values
-        let (signed_coins, abs_remainder) = match s.trim().split_once('.') {
-            Some(("", positive_zats)) => ("0", positive_zats),
-            Some((signed_coins, "")) => (signed_coins, "0"),
-            Some((signed_coins, abs_remainder)) => (signed_coins, abs_remainder),
-            None => (s, "0"),
-        };
+        let lossy_zec: f64 = s.parse()?;
 
-        // Convert ZEC to integer
-        let signed_coins: i64 = signed_coins.parse()?;
-
-        // Check for spurious + or - after the decimal point
-        if !abs_remainder
-            .chars()
-            .next()
-            .expect("just checked for empty strings")
-            .is_numeric()
-        {
-            return Err("invalid ZEC amount: fractional part must start with 0-9".into());
-        }
-
-        // Check for loss of precision, after removing trailing zeroes
-        let abs_remainder = abs_remainder.trim_end_matches('0');
-        if abs_remainder.len() > MAX_ZAT_PRECISION {
-            return Err("loss of precision: ZEC value contains fractional zatoshis".into());
-        }
-
-        // Zero-pad to an amount in zats, then parse
-        let abs_remainder =
-            abs_remainder.to_owned() + &"0".repeat(MAX_ZAT_PRECISION - abs_remainder.len());
-        let abs_remainder: u32 = abs_remainder.parse()?;
-        let abs_remainder: i64 = abs_remainder.into();
-        assert!(
-            abs_remainder < COIN,
-            "unexpected parsing error: just checked zat value was less than one ZEC in length"
-        );
-
-        // Now convert everything to zatoshi amounts, with the correct sign
-        let zats = signed_coins
-            .checked_mul(COIN)
-            .ok_or("ZEC value too large")?;
-        let remainder = if zats > 0 {
-            abs_remainder
-        } else {
-            -abs_remainder
-        };
-
-        let mut zats: Amount<C> = zats.try_into()?;
-        let remainder: Amount<C> = remainder
-            .try_into()
-            .expect("already checked range and sign");
-
-        zats = (zats + remainder)?;
-
-        Ok(Self(zats))
+        Self::from_lossy_zec(lossy_zec)
     }
 }
 

--- a/zebra-chain/src/amount/zec.rs
+++ b/zebra-chain/src/amount/zec.rs
@@ -1,0 +1,211 @@
+//! ZEC-specific formatting, similar to the `zcashd` implementation.
+
+use std::{
+    cmp::Ordering,
+    fmt,
+    hash::{Hash, Hasher},
+    ops,
+    str::FromStr,
+};
+
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+use crate::{
+    amount::{self, Amount, Constraint, COIN},
+    BoxError,
+};
+
+/// The maximum precision of a zatoshi in ZEC.
+/// Also used as the default decimal precision for ZEC formatting.
+///
+/// This is the same as the `getblocksubsidy` RPC in `zcashd`:
+/// <https://github.com/zcash/zcash/blob/f6a4f68115ea4c58d55c8538579d0877ba9c8f79/src/rpc/server.cpp#L134>
+pub const MAX_ZAT_PRECISION: usize = 8;
+
+/// A wrapper type that formats [`Amount`]s as ZEC,
+/// using fixed-point integer calculations.
+#[derive(Clone, Copy, SerializeDisplay, DeserializeFromStr)]
+pub struct Zec<C: Constraint>(Amount<C>);
+
+impl<C: Constraint> fmt::Display for Zec<C> {
+    // We don't use floating-point here, because it is inaccurate
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let zats = self.zatoshis();
+
+        // Get the fixed-point ZEC and remaining zats values
+        let abs_coins = zats
+            .checked_abs()
+            .expect("-MAX_MONEY is much smaller than i64::MIN")
+            / COIN;
+        let positive_remainder = zats.rem_euclid(COIN);
+
+        // Format just like `zcashd` by default
+        let decimals = f.precision().unwrap_or(MAX_ZAT_PRECISION);
+        let string = format!("{abs_coins}.{positive_remainder:.decimals$}");
+        f.pad_integral(zats >= 0, "", &string)
+    }
+}
+
+// This is mainly used in tests
+impl<C: Constraint> FromStr for Zec<C> {
+    type Err = BoxError;
+
+    // We don't use floating-point here, because it is inaccurate
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Get the fixed-point ZEC and remaining zats values
+        let (signed_coins, abs_remainder) = match s.trim().split_once('.') {
+            Some(("", positive_zats)) => ("0", positive_zats),
+            Some((signed_coins, "")) => (signed_coins, "0"),
+            Some((signed_coins, abs_remainder)) => (signed_coins, abs_remainder),
+            None => (s, "0"),
+        };
+
+        // Convert ZEC to integer
+        let signed_coins: i64 = signed_coins.parse()?;
+
+        // Check for spurious + or - after the decimal point
+        if !abs_remainder
+            .chars()
+            .next()
+            .expect("just checked for empty strings")
+            .is_numeric()
+        {
+            return Err("invalid ZEC amount: fractional part must start with 0-9".into());
+        }
+
+        // Check for loss of precision, after removing trailing zeroes
+        let abs_remainder = abs_remainder.trim_end_matches('0');
+        if abs_remainder.len() > MAX_ZAT_PRECISION {
+            return Err("loss of precision: ZEC value contains fractional zatoshis".into());
+        }
+
+        // Zero-pad to an amount in zats, then parse
+        let abs_remainder =
+            abs_remainder.to_owned() + &"0".repeat(MAX_ZAT_PRECISION - abs_remainder.len());
+        let abs_remainder: u32 = abs_remainder.parse()?;
+        let abs_remainder: i64 = abs_remainder.into();
+        assert!(
+            abs_remainder < COIN,
+            "unexpected parsing error: just checked zat value was less than one ZEC in length"
+        );
+
+        // Now convert everything to zatoshi amounts, with the correct sign
+        let zats = signed_coins
+            .checked_mul(COIN)
+            .ok_or("ZEC value too large")?;
+        let remainder = if zats > 0 {
+            abs_remainder
+        } else {
+            -abs_remainder
+        };
+
+        let mut zats: Amount<C> = zats.try_into()?;
+        let remainder: Amount<C> = remainder
+            .try_into()
+            .expect("already checked range and sign");
+
+        zats = (zats + remainder)?;
+
+        Ok(Self(zats))
+    }
+}
+
+impl<C: Constraint> std::fmt::Debug for Zec<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(&format!("Zec<{}>", std::any::type_name::<C>()))
+            .field("ZEC", &self.to_string())
+            .field("zat", &self.0)
+            .finish()
+    }
+}
+
+impl<C: Constraint> ops::Deref for Zec<C> {
+    type Target = Amount<C>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<C: Constraint> ops::DerefMut for Zec<C> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<C: Constraint> From<Amount<C>> for Zec<C> {
+    fn from(amount: Amount<C>) -> Self {
+        Self(amount)
+    }
+}
+
+impl<C: Constraint> From<Zec<C>> for Amount<C> {
+    fn from(zec: Zec<C>) -> Amount<C> {
+        zec.0
+    }
+}
+
+impl<C: Constraint> From<Zec<C>> for i64 {
+    fn from(zec: Zec<C>) -> i64 {
+        zec.0.into()
+    }
+}
+
+impl<C: Constraint> TryFrom<i64> for Zec<C> {
+    type Error = amount::Error;
+
+    fn try_from(value: i64) -> Result<Self, Self::Error> {
+        Ok(Self(Amount::try_from(value)?))
+    }
+}
+
+impl<C: Constraint> Hash for Zec<C> {
+    /// Zecs with the same value are equal, even if they have different constraints
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<C1: Constraint, C2: Constraint> PartialEq<Zec<C2>> for Zec<C1> {
+    fn eq(&self, other: &Zec<C2>) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<C: Constraint> PartialEq<i64> for Zec<C> {
+    fn eq(&self, other: &i64) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl<C: Constraint> PartialEq<Zec<C>> for i64 {
+    fn eq(&self, other: &Zec<C>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl<C1: Constraint, C2: Constraint> PartialEq<Amount<C2>> for Zec<C1> {
+    fn eq(&self, other: &Amount<C2>) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl<C1: Constraint, C2: Constraint> PartialEq<Zec<C2>> for Amount<C1> {
+    fn eq(&self, other: &Zec<C2>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl<C: Constraint> Eq for Zec<C> {}
+
+impl<C1: Constraint, C2: Constraint> PartialOrd<Zec<C2>> for Zec<C1> {
+    fn partial_cmp(&self, other: &Zec<C2>) -> Option<Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl<C: Constraint> Ord for Zec<C> {
+    fn cmp(&self, other: &Zec<C>) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}

--- a/zebra-chain/src/amount/zec.rs
+++ b/zebra-chain/src/amount/zec.rs
@@ -16,6 +16,10 @@ use crate::{
     BoxError,
 };
 
+// Doc links only
+#[allow(clippy::unused_imports)]
+use crate::amount::MAX_MONEY;
+
 /// The maximum precision of a zatoshi in ZEC.
 /// Also used as the default decimal precision for ZEC formatting.
 ///

--- a/zebra-consensus/src/block/subsidy/funding_streams.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams.rs
@@ -121,6 +121,17 @@ pub fn funding_stream_address(
     transparent::Address::from_str(address).expect("address should deserialize")
 }
 
+/// Return a human-readable name and a specification URL for the funding stream `receiver`.
+pub fn funding_stream_recipient_info(
+    receiver: FundingStreamReceiver,
+) -> (&'static str, &'static str) {
+    let name = FUNDING_STREAM_NAMES
+        .get(&receiver)
+        .expect("all funding streams have a name");
+
+    (name, FUNDING_STREAM_SPECIFICATION)
+}
+
 /// Given a funding stream P2SH address, create a script and check if it is the same
 /// as the given lock_script as described in [protocol specification §7.10][7.10]
 ///

--- a/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
@@ -65,7 +65,8 @@ fn test_funding_stream_addresses() -> Result<(), Report> {
     for (network, receivers) in FUNDING_STREAM_ADDRESSES.iter() {
         for (receiver, addresses) in receivers {
             for address in addresses {
-                let address = Address::from_str(address).expect("address should deserialize");
+                let address =
+                    transparent::Address::from_str(address).expect("address should deserialize");
                 assert_eq!(
                     &address.network(),
                     network,

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -48,7 +48,10 @@ pub mod error;
 
 pub use block::{
     subsidy::{
-        funding_streams::{funding_stream_address, funding_stream_values, new_coinbase_script},
+        funding_streams::{
+            funding_stream_address, funding_stream_recipient_info, funding_stream_values,
+            height_for_first_halving, new_coinbase_script,
+        },
         general::miner_subsidy,
     },
     Request, VerifyBlockError, MAX_BLOCK_SIGOPS,

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -71,8 +71,7 @@ pub const FUNDING_STREAM_SPECIFICATION: &str = "https://zips.z.cash/zip-0214";
 // TODO: use a struct for the info for each funding stream, like zcashd does:
 // https://github.com/zcash/zcash/blob/3f09cfa00a3c90336580a127e0096d99e25a38d6/src/consensus/funding.cpp#L13-L32
 lazy_static! {
-    /// The name for each funding stream receiver,
-    /// as described in [ZIP-1014] and [`zcashd`].
+    /// The name for each funding stream receiver, as described in [ZIP-1014] and [`zcashd`].
     ///
     /// [ZIP-1014]: https://zips.z.cash/zip-1014#abstract
     /// [`zcashd`]: https://github.com/zcash/zcash/blob/3f09cfa00a3c90336580a127e0096d99e25a38d6/src/consensus/funding.cpp#L13-L32

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -63,7 +63,28 @@ pub enum FundingStreamReceiver {
 /// [7.10.1]: https://zips.z.cash/protocol/protocol.pdf#zip214fundingstreams
 pub const FUNDING_STREAM_RECEIVER_DENOMINATOR: u64 = 100;
 
+/// The specification for all current funding stream receivers, a URL that links to [ZIP-214].
+///
+/// [ZIP-214]: https://zips.z.cash/zip-0214
+pub const FUNDING_STREAM_SPECIFICATION: &str = "https://zips.z.cash/zip-0214";
+
+// TODO: use a struct for the info for each funding stream, like zcashd does:
+// https://github.com/zcash/zcash/blob/3f09cfa00a3c90336580a127e0096d99e25a38d6/src/consensus/funding.cpp#L13-L32
 lazy_static! {
+    /// The name for each funding stream receiver,
+    /// as described in [ZIP-1014] and [`zcashd`].
+    ///
+    /// [ZIP-1014]: https://zips.z.cash/zip-1014#abstract
+    /// [`zcashd`]: https://github.com/zcash/zcash/blob/3f09cfa00a3c90336580a127e0096d99e25a38d6/src/consensus/funding.cpp#L13-L32
+    pub static ref FUNDING_STREAM_NAMES: HashMap<FundingStreamReceiver, &'static str> = {
+        let mut hash_map = HashMap::new();
+        hash_map.insert(FundingStreamReceiver::Ecc, "Electric Coin Company");
+        hash_map.insert(FundingStreamReceiver::ZcashFoundation, "Zcash Foundation");
+        hash_map.insert(FundingStreamReceiver::MajorGrants, "Major Grants");
+        hash_map
+    };
+
+
     /// The numerator for each funding stream receiver category
     /// as described in [protocol specification §7.10.1][7.10.1].
     ///

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -167,8 +167,8 @@ pub trait GetBlockTemplateRpc {
     #[rpc(name = "getpeerinfo")]
     fn get_peer_info(&self) -> BoxFuture<Result<Vec<PeerInfo>>>;
 
-    /// Returns the block subsidy reward of the block at `height`,
-    /// taking into account the mining slow start and the founders reward.
+    /// Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
+    /// Returns an error if `height` is less than the height of the first halving for the current network.
     ///
     /// `height` can be any valid current or future height.
     /// If `height` is not supplied, uses the tip height.
@@ -783,7 +783,7 @@ where
             if height < height_for_first_halving(network) {
                 return Err(Error {
                     code: ErrorCode::ServerError(0),
-                    message: "Zebra does not support funding stream subsidies, \
+                    message: "Zebra does not support founders' reward subsidies, \
                               use a block height that is after the first halving"
                         .into(),
                     data: None,

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -812,8 +812,8 @@ where
                 .collect();
 
             Ok(BlockSubsidy {
-                miner,
-                founders,
+                miner: miner.into(),
+                founders: founders.into(),
                 funding_streams,
             })
         }

--- a/zebra-rpc/src/methods/get_block_template_rpcs/constants.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/constants.rs
@@ -2,6 +2,8 @@
 
 use jsonrpc_core::ErrorCode;
 
+use zebra_consensus::FundingStreamReceiver::{self, *};
+
 /// When long polling, the amount of time we wait between mempool queries.
 /// (And sync status queries, which we do right before mempool queries.)
 ///
@@ -52,3 +54,9 @@ pub const NOT_SYNCED_ERROR_CODE: ErrorCode = ErrorCode::ServerError(-10);
 ///
 /// Based on default value in zcashd.
 pub const DEFAULT_SOLUTION_RATE_WINDOW_SIZE: usize = 120;
+
+/// The funding stream order in `zcashd` RPC responses.
+///
+/// [`zcashd`]: https://github.com/zcash/zcash/blob/3f09cfa00a3c90336580a127e0096d99e25a38d6/src/consensus/funding.cpp#L13-L32
+pub const ZCASHD_FUNDING_STREAM_ORDER: &[FundingStreamReceiver] =
+    &[Ecc, ZcashFoundation, MajorGrants];

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types.rs
@@ -7,4 +7,5 @@ pub mod hex_data;
 pub mod long_poll;
 pub mod peer_info;
 pub mod submit_block;
+pub mod subsidy;
 pub mod transaction;

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types.rs
@@ -9,3 +9,4 @@ pub mod peer_info;
 pub mod submit_block;
 pub mod subsidy;
 pub mod transaction;
+pub mod zec;

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/subsidy.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/subsidy.rs
@@ -1,10 +1,12 @@
 //! Types for the `getblocksubsidy` RPC.
 
 use zebra_chain::{
-    amount::{Amount, NonNegative, Zec},
+    amount::{Amount, NonNegative},
     transparent,
 };
 use zebra_consensus::{funding_stream_recipient_info, FundingStreamReceiver};
+
+use crate::methods::get_block_template_rpcs::types::zec::Zec;
 
 /// A response to a `getblocksubsidy` RPC request
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/subsidy.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/subsidy.rs
@@ -1,7 +1,7 @@
 //! Types for the `getblocksubsidy` RPC.
 
 use zebra_chain::{
-    amount::{Amount, NonNegative},
+    amount::{Amount, NonNegative, Zec},
     transparent,
 };
 use zebra_consensus::{funding_stream_recipient_info, FundingStreamReceiver};
@@ -12,16 +12,13 @@ pub struct BlockSubsidy {
     /// The mining reward amount in ZEC.
     ///
     /// This does not include the miner fee.
-    //
-    // TODO: format ZEC amounts as fixed-point decimal, like `zcashd`:
-    // https://github.com/zcash/zcash/blob/f6a4f68115ea4c58d55c8538579d0877ba9c8f79/src/rpc/server.cpp#L127-L135
-    pub miner: Amount<NonNegative>,
+    pub miner: Zec<NonNegative>,
 
     /// The founders' reward amount in ZEC.
     ///
     /// Zebra returns an error when asked for founders reward heights,
     /// because it checkpoints those blocks instead.
-    pub founders: Amount<NonNegative>,
+    pub founders: Zec<NonNegative>,
 
     /// An array of funding stream descriptions.
     /// Always present, because Zebra returns an error for heights before the first halving.
@@ -39,7 +36,7 @@ pub struct FundingStream {
     pub specification: String,
 
     /// The funding stream amount in ZEC.
-    pub value: Amount<NonNegative>,
+    pub value: Zec<NonNegative>,
 
     /// The funding stream amount in zatoshis.
     #[serde(rename = "valueZat")]
@@ -64,7 +61,7 @@ impl FundingStream {
         FundingStream {
             recipient: recipient.to_string(),
             specification: specification.to_string(),
-            value,
+            value: value.into(),
             value_zat: value,
             address,
         }

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/subsidy.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/subsidy.rs
@@ -1,0 +1,72 @@
+//! Types for the `getblocksubsidy` RPC.
+
+use zebra_chain::{
+    amount::{Amount, NonNegative},
+    transparent,
+};
+use zebra_consensus::{funding_stream_recipient_info, FundingStreamReceiver};
+
+/// A response to a `getblocksubsidy` RPC request
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct BlockSubsidy {
+    /// The mining reward amount in ZEC.
+    ///
+    /// This does not include the miner fee.
+    //
+    // TODO: format ZEC amounts as fixed-point decimal, like `zcashd`:
+    // https://github.com/zcash/zcash/blob/f6a4f68115ea4c58d55c8538579d0877ba9c8f79/src/rpc/server.cpp#L127-L135
+    pub miner: Amount<NonNegative>,
+
+    /// The founders' reward amount in ZEC.
+    ///
+    /// Zebra returns an error when asked for founders reward heights,
+    /// because it checkpoints those blocks instead.
+    pub founders: Amount<NonNegative>,
+
+    /// An array of funding stream descriptions.
+    /// Always present, because Zebra returns an error for heights before the first halving.
+    #[serde(rename = "fundingstreams")]
+    pub funding_streams: Vec<FundingStream>,
+}
+
+/// A single funding stream's information in a  `getblocksubsidy` RPC request
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct FundingStream {
+    /// A description of the funding stream recipient.
+    pub recipient: String,
+
+    /// A URL for the specification of this funding stream.
+    pub specification: String,
+
+    /// The funding stream amount in ZEC.
+    pub value: Amount<NonNegative>,
+
+    /// The funding stream amount in zatoshis.
+    #[serde(rename = "valueZat")]
+    pub value_zat: Amount<NonNegative>,
+
+    /// The transparent or Sapling address of the funding stream recipient.
+    ///
+    /// The current Zcash funding streams only use transparent addresses,
+    /// so Zebra doesn't support Sapling addresses in this RPC.
+    pub address: transparent::Address,
+}
+
+impl FundingStream {
+    /// Convert a `receiver`, `value`, and `address` into a `FundingStream` response.
+    pub fn new(
+        receiver: FundingStreamReceiver,
+        value: Amount<NonNegative>,
+        address: transparent::Address,
+    ) -> FundingStream {
+        let (recipient, specification) = funding_stream_recipient_info(receiver);
+
+        FundingStream {
+            recipient: recipient.to_string(),
+            specification: specification.to_string(),
+            value,
+            value_zat: value,
+            address,
+        }
+    }
+}

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/subsidy.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/subsidy.rs
@@ -9,6 +9,11 @@ use zebra_consensus::{funding_stream_recipient_info, FundingStreamReceiver};
 /// A response to a `getblocksubsidy` RPC request
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct BlockSubsidy {
+    /// An array of funding stream descriptions.
+    /// Always present, because Zebra returns an error for heights before the first halving.
+    #[serde(rename = "fundingstreams")]
+    pub funding_streams: Vec<FundingStream>,
+
     /// The mining reward amount in ZEC.
     ///
     /// This does not include the miner fee.
@@ -19,11 +24,6 @@ pub struct BlockSubsidy {
     /// Zebra returns an error when asked for founders reward heights,
     /// because it checkpoints those blocks instead.
     pub founders: Zec<NonNegative>,
-
-    /// An array of funding stream descriptions.
-    /// Always present, because Zebra returns an error for heights before the first halving.
-    #[serde(rename = "fundingstreams")]
-    pub funding_streams: Vec<FundingStream>,
 }
 
 /// A single funding stream's information in a  `getblocksubsidy` RPC request

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/zec.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/zec.rs
@@ -11,14 +11,13 @@ use std::{
     str::FromStr,
 };
 
-use crate::{
-    amount::{self, Amount, Constraint, COIN},
-    BoxError,
-};
+use zebra_chain::amount::{self, Amount, Constraint, COIN};
+
+use zebra_node_services::BoxError;
 
 // Doc links only
 #[allow(clippy::unused_imports)]
-use crate::amount::MAX_MONEY;
+use zebra_chain::amount::MAX_MONEY;
 
 /// The maximum precision of a zatoshi in ZEC.
 /// Also used as the default decimal precision for ZEC formatting.

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/zec.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/zec.rs
@@ -15,7 +15,7 @@ use zebra_chain::amount::{self, Amount, Constraint, COIN};
 use zebra_node_services::BoxError;
 
 // Doc links only
-#[allow(clippy::unused_imports)]
+#[allow(unused_imports)]
 use zebra_chain::amount::MAX_MONEY;
 
 /// The maximum precision of a zatoshi in ZEC.

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/zec.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/zec.rs
@@ -37,7 +37,7 @@ pub const MAX_ZEC_FORMAT_PRECISION: usize = 8;
 /// Unlike `zcashd`, Zebra doesn't have control over its JSON number precision,
 /// because it uses `serde_json`'s formatter. But `zcashd` uses a fixed-point calculation:
 /// <https://github.com/zcash/zcash/blob/f6a4f68115ea4c58d55c8538579d0877ba9c8f79/src/rpc/server.cpp#L134>
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, serde::Serialize, serde::Deserialize)]
 #[serde(try_from = "f64")]
 #[serde(into = "f64")]
 #[serde(bound = "C: Constraint + Clone")]

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/zec.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/zec.rs
@@ -4,7 +4,6 @@
 //! The values themselves are accurate, but any calculations using them could be lossy.
 
 use std::{
-    cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
     ops,
@@ -211,15 +210,3 @@ impl<C1: Constraint, C2: Constraint> PartialEq<Zec<C2>> for Amount<C1> {
 }
 
 impl<C: Constraint> Eq for Zec<C> {}
-
-impl<C1: Constraint, C2: Constraint> PartialOrd<Zec<C2>> for Zec<C1> {
-    fn partial_cmp(&self, other: &Zec<C2>) -> Option<Ordering> {
-        self.0.partial_cmp(&other.0)
-    }
-}
-
-impl<C: Constraint> Ord for Zec<C> {
-    fn cmp(&self, other: &Zec<C>) -> Ordering {
-        self.0.cmp(&other.0)
-    }
-}

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -41,6 +41,7 @@ use crate::methods::{
             long_poll::{LongPollId, LONG_POLL_ID_LENGTH},
             peer_info::PeerInfo,
             submit_block,
+            subsidy::BlockSubsidy,
         },
     },
     tests::utils::fake_history_tree,
@@ -157,6 +158,14 @@ pub async fn test_responses<State, ReadState>(
         .await
         .expect("We should have a success response");
     snapshot_rpc_getmininginfo(get_mining_info, &settings);
+
+    // `getblocksubsidy`
+    let fake_future_block_height = fake_tip_height.0 + 100_000;
+    let get_block_subsidy = get_block_template_rpc
+        .get_block_subsidy(Some(fake_future_block_height))
+        .await
+        .expect("We should have a success response");
+    snapshot_rpc_getblocksubsidy(get_block_subsidy, &settings);
 
     // `getpeerinfo`
     let get_peer_info = get_block_template_rpc
@@ -411,6 +420,11 @@ fn snapshot_rpc_getmininginfo(
     settings: &insta::Settings,
 ) {
     settings.bind(|| insta::assert_json_snapshot!("get_mining_info", get_mining_info));
+}
+
+/// Snapshot `getblocksubsidy` response, using `cargo insta` and JSON serialization.
+fn snapshot_rpc_getblocksubsidy(get_block_subsidy: BlockSubsidy, settings: &insta::Settings) {
+    settings.bind(|| insta::assert_json_snapshot!("get_block_subsidy", get_block_subsidy));
 }
 
 /// Snapshot `getpeerinfo` response, using `cargo insta` and JSON serialization.

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_subsidy@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_subsidy@mainnet_10.snap
@@ -1,0 +1,31 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+expression: get_block_subsidy
+---
+{
+  "fundingstreams": [
+    {
+      "recipient": "Electric Coin Company",
+      "specification": "https://zips.z.cash/zip-0214",
+      "value": 0.21875,
+      "valueZat": 21875000,
+      "address": "t3PdBRr2S1XTDzrV8bnZkXF3SJcrzHWe1wj"
+    },
+    {
+      "recipient": "Zcash Foundation",
+      "specification": "https://zips.z.cash/zip-0214",
+      "value": 0.15625,
+      "valueZat": 15625000,
+      "address": "t3dvVE3SQEi7kqNzwrfNePxZ1d4hUyztBA1"
+    },
+    {
+      "recipient": "Major Grants",
+      "specification": "https://zips.z.cash/zip-0214",
+      "value": 0.25,
+      "valueZat": 25000000,
+      "address": "t3XyYW8yBFRuMnfvm5KLGFbEVz25kckZXym"
+    }
+  ],
+  "miner": 2.5,
+  "founders": 0.0
+}

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_subsidy@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_subsidy@testnet_10.snap
@@ -1,0 +1,31 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+expression: get_block_subsidy
+---
+{
+  "fundingstreams": [
+    {
+      "recipient": "Electric Coin Company",
+      "specification": "https://zips.z.cash/zip-0214",
+      "value": 0.21875,
+      "valueZat": 21875000,
+      "address": "t2HxbP5keQSx7p592zWQ5bJ5GrMmGDsV2Xa"
+    },
+    {
+      "recipient": "Zcash Foundation",
+      "specification": "https://zips.z.cash/zip-0214",
+      "value": 0.15625,
+      "valueZat": 15625000,
+      "address": "t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v"
+    },
+    {
+      "recipient": "Major Grants",
+      "specification": "https://zips.z.cash/zip-0214",
+      "value": 0.25,
+      "valueZat": 25000000,
+      "address": "t2Gvxv2uNM7hbbACjNox4H6DjByoKZ2Fa3P"
+    }
+  ],
+  "miner": 2.5,
+  "founders": 0.0
+}


### PR DESCRIPTION
## Motivation

Some mining pools use `getblocksubsidy` to generate their own coinbase transactions.

Closes #5302

### Specifications

The specification is here:
https://zcash.github.io/rpc/getblocksubsidy.html

And the `zcashd` implementation of the RPC is:
https://github.com/zcash/zcash/blob/20996b4eb771efde6bcb57d5aa8749a5705cd493/src/rpc/mining.cpp#L999-L1054

### Complex Code or Requirements

This RPC uses the state tip as the default height, but otherwise it is very simple - it just calls the existing subsidy and funding stream calculation functions directly.

## Solution

Implement the `getblocksubsidy` RPC:
- Implement the RPC return type and method
    - Use the state tip height if there is no height argument
    - Return an error for heights below the first halving (miners only use this RPC for new blocks at the chain tip)
    - Add a ZEC formatting wrapper for Amount in zebra-rpc
- Put RPC fields and funding streams in the same order as `zcashd`

We will never be able to match `zcashd`'s format exactly, because they manually format their ZEC values, but we use `serde_json`, which requires `f64` values and formats them itself.

Related changes:
- Make it clearer that Zebra only supports transparent funding streams

### Testing

- Snapshot the output of the RPC
- Manually compare the `zcashd` and `zebrad` RPC output using https://github.com/ZcashFoundation/zebra/blob/main/zebra-utils/zcash-rpc-diff (see the first comment)

## Review

This is ready for review, feel free to be very critical, there are parts of it that I don't like either!

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow-Up Work

Testing:
- Test calling the RPC from the mining pool software (in ticket #5934)