### PR TITLE
Get details from transaction differences in `getrawmempool`

### DIFF
--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -207,30 +207,22 @@ if [ "$1" == "getrawmempool" ] && [ $CHECK_EXIT_STATUS != 0 ]; then
     set TRANSACTION_HEX_FILE
     set TRANSACTION_DECODED
 
-    while IFS= read -r line
-    do
-        if [ "$line" != "[" ] && [ "$line" != "]" ]; then
-            if [[ "${line:0-1}" == "," ]]; then
-                TRANSACTION_ID="${line:3:-2}"
-            else
-                TRANSACTION_ID="${line:3:-1}"
-            fi
+    ZEBRAD_TRANSACTION_IDS=$(cat "$ZEBRAD_RESPONSE" | $JQ -r 'join(" ")')
+    for TRANSACTION_ID in $ZEBRAD_TRANSACTION_IDS; do
+        TRANSACTION_HEX_FILE="$ZCASH_RPC_TMP_DIR/$ZEBRAD-$ZEBRAD_NET-$ZEBRAD_HEIGHT-TRANSACTION_HEX-$TRANSACTION_ID.json"
 
-            TRANSACTION_HEX_FILE="$ZCASH_RPC_TMP_DIR/$ZEBRAD-$ZEBRAD_NET-$ZEBRAD_HEIGHT-TRANSACTION_HEX-$TRANSACTION_ID.json"
+        $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" getrawtransaction $TRANSACTION_ID 0 > $TRANSACTION_HEX_FILE
 
-            $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" getrawtransaction $TRANSACTION_ID 0 > $TRANSACTION_HEX_FILE
+        echo "## Displaying transaction $TRANSACTION_ID"
+        echo
 
-            echo "## Displaying transaction $TRANSACTION_ID"
-            echo
+        # read the proposal data from a file, to avoid command-line length limits
+        TRANSACTION_DECODED=`cat "$TRANSACTION_HEX_FILE" | \
+            $ZCASH_CLI $ZCASHD_EXTRA_ARGS -stdin decoderawtransaction`
 
-            # read the proposal data from a file, to avoid command-line length limits
-            TRANSACTION_DECODED=`cat "$TRANSACTION_HEX_FILE" | \
-                $ZCASH_CLI $ZCASHD_EXTRA_ARGS -stdin decoderawtransaction`
-
-            echo $TRANSACTION_DECODED | $JQ
-            echo
-        fi
-    done < "$ZEBRAD_RESPONSE"
+        echo $TRANSACTION_DECODED | $JQ
+        echo
+    done
 fi
 
 if [ $EXIT_STATUS -ne 0 ]; then

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -204,7 +204,7 @@ if [ "$1" == "getrawmempool" ] && [ $CHECK_EXIT_STATUS != 0 ]; then
     echo
 
     set TRANSACTION_ID
-    set TRANSACTION_HEX
+    set TRANSACTION_HEX_FILE
     set TRANSACTION_DECODED
 
     while IFS= read -r line
@@ -216,12 +216,16 @@ if [ "$1" == "getrawmempool" ] && [ $CHECK_EXIT_STATUS != 0 ]; then
                 TRANSACTION_ID="${line:3:-1}"
             fi
 
-            TRANSACTION_HEX=`$ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" getrawtransaction $TRANSACTION_ID 0`
+            TRANSACTION_HEX_FILE="$ZCASH_RPC_TMP_DIR/$ZEBRAD-$ZEBRAD_NET-$ZEBRAD_HEIGHT-TRANSACTION_HEX-$TRANSACTION_ID.json"
+
+            $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" getrawtransaction $TRANSACTION_ID 0 > $TRANSACTION_HEX_FILE
 
             echo "## Displaying transaction $TRANSACTION_ID"
             echo
 
-            TRANSACTION_DECODED=`$ZCASH_CLI $ZCASHD_EXTRA_ARGS decoderawtransaction $TRANSACTION_HEX`
+            # read the proposal data from a file, to avoid command-line length limits
+            TRANSACTION_DECODED=`cat "$TRANSACTION_HEX_FILE" | \
+                $ZCASH_CLI $ZCASHD_EXTRA_ARGS -stdin decoderawtransaction`
 
             echo $TRANSACTION_DECODED | $JQ
             echo

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -16,6 +16,7 @@ function usage()
 
 # Override the commands used by this script using these environmental variables:
 ZCASH_CLI="${ZCASH_CLI:-zcash-cli}"
+ZCASH_RPC_COOKIE_FILE="${ZCASH_RPC_COOKIE_FILE:-.cookie}"
 DIFF="${DIFF:-diff --unified --color=always}"
 JQ="${JQ:-jq}"
 
@@ -41,7 +42,7 @@ ZEBRAD=$(cat "$ZEBRAD_RELEASE_INFO" | grep '"subversion"' | cut -d: -f2 | cut -d
              tr 'A-Z' 'a-z' | sed 's/magicbean/zcashd/ ; s/zebra$/zebrad/')
 
 echo "Checking second node release info..."
-$ZCASH_CLI getinfo > "$ZCASHD_RELEASE_INFO"
+$ZCASH_CLI -rpccookiefile="$ZCASH_RPC_COOKIE_FILE" getinfo > "$ZCASHD_RELEASE_INFO"
 
 ZCASHD=$(cat "$ZCASHD_RELEASE_INFO" | grep '"subversion"' | cut -d: -f2 | cut -d/ -f2 | \
              tr 'A-Z' 'a-z' | sed 's/magicbean/zcashd/ ; s/zebra$/zebrad/')
@@ -60,7 +61,7 @@ ZEBRAD_NET=$(cat "$ZEBRAD_BLOCKCHAIN_INFO" | grep '"chain"' | cut -d: -f2 | tr -
 ZEBRAD_HEIGHT=$(cat "$ZEBRAD_BLOCKCHAIN_INFO" | grep '"blocks"' | cut -d: -f2 | tr -d ' ,"')
 
 echo "Checking $ZCASHD network and tip height..."
-$ZCASH_CLI getblockchaininfo > "$ZCASHD_BLOCKCHAIN_INFO"
+$ZCASH_CLI -rpccookiefile="$ZCASH_RPC_COOKIE_FILE" getblockchaininfo > "$ZCASHD_BLOCKCHAIN_INFO"
 
 ZCASHD_NET=$(cat "$ZCASHD_BLOCKCHAIN_INFO" | grep '"chain"' | cut -d: -f2 | tr -d ' ,"')
 ZCASHD_HEIGHT=$(cat "$ZCASHD_BLOCKCHAIN_INFO" | grep '"blocks"' | cut -d: -f2 | tr -d ' ,"')
@@ -93,7 +94,7 @@ time $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" "$@" > "$ZEBRAD_RESPONSE"
 echo
 
 echo "Querying $ZCASHD $ZCASHD_NET chain at height >=$ZCASHD_HEIGHT..."
-time $ZCASH_CLI "$@" > "$ZCASHD_RESPONSE"
+time $ZCASH_CLI -rpccookiefile="$ZCASH_RPC_COOKIE_FILE" "$@" > "$ZCASHD_RESPONSE"
 echo
 
 echo
@@ -136,7 +137,7 @@ echo "Querying $ZEBRAD $ZEBRAD_NET chain at height >=$ZEBRAD_HEIGHT..."
 $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" "$@" > "$ZEBRAD_CHECK_RESPONSE"
 
 echo "Querying $ZCASHD $ZCASHD_NET chain at height >=$ZCASHD_HEIGHT..."
-$ZCASH_CLI "$@" > "$ZCASHD_CHECK_RESPONSE"
+$ZCASH_CLI -rpccookiefile="$ZCASH_RPC_COOKIE_FILE" "$@" > "$ZCASHD_CHECK_RESPONSE"
 
 echo
 

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -213,7 +213,7 @@ if [ "$1" == "getrawmempool" ] && [ $CHECK_EXIT_STATUS != 0 ]; then
                 TRANSACTION_ID="${line:3:-1}"
             fi
 
-            TRANSACTION_HEX=`$ZCASH_CLI -rpccookiefile="$ZCASH_RPC_COOKIE_FILE" -rpcport="$ZEBRAD_RPC_PORT" getrawtransaction $TRANSACTION_ID 0`
+            TRANSACTION_HEX=`$ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" getrawtransaction $TRANSACTION_ID 0`
 
             echo "## Displaying transaction $TRANSACTION_ID"
             echo

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -120,6 +120,8 @@ EXIT_STATUS=$?
 
 if [ "$1" == "getaddressutxos" ]; then
     set "getaddressbalance" "$2"
+elif [ "$1" == "getrawmempool" ]; then
+    set "getrawmempool"
 else
     exit $EXIT_STATUS
 fi
@@ -191,6 +193,37 @@ if [ "$1" == "getaddressbalance" ]; then
     if [ $COMPARE_EXIT_STATUS -ne 0 ]; then
         exit $COMPARE_EXIT_STATUS
     fi
+fi
+
+if [ "$1" == "getrawmempool" ] && [ $CHECK_EXIT_STATUS != 0 ]; then
+    echo
+    echo "Obtaining transaction details"
+    echo
+
+    set TRANSACTION_ID
+    set TRANSACTION_HEX
+    set TRANSACTION_DECODED
+
+    while IFS= read -r line
+    do
+        if [ "$line" != "[" ] && [ "$line" != "]" ]; then
+            if [[ "${line:0-1}" == "," ]]; then
+                TRANSACTION_ID="${line:3:-2}"
+            else
+                TRANSACTION_ID="${line:3:-1}"
+            fi
+
+            TRANSACTION_HEX=`$ZCASH_CLI -rpccookiefile="$ZCASH_RPC_COOKIE_FILE" -rpcport="$ZEBRAD_RPC_PORT" getrawtransaction $TRANSACTION_ID 0`
+
+            echo "## Displaying transaction $TRANSACTION_ID"
+            echo
+
+            TRANSACTION_DECODED=`$ZCASH_CLI -rpccookiefile="$ZCASH_RPC_COOKIE_FILE" decoderawtransaction $TRANSACTION_HEX`
+
+            echo $TRANSACTION_DECODED | $JQ
+            echo
+        fi
+    done < "$ZEBRAD_RESPONSE"
 fi
 
 if [ $EXIT_STATUS -ne 0 ]; then

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -18,7 +18,7 @@ function usage()
 ZCASH_CLI="${ZCASH_CLI:-zcash-cli}"
 DIFF="${DIFF:-diff --unified --color=always}"
 JQ="${JQ:-jq}"
-# Zcashd authentification modes:
+# Zcashd authentication modes:
 # - Use `-rpccookiefile=your/cookie/file` for a cookie file.
 # - Use `-rpcpassword=your-password` for a password.
 ZCASHD_EXTRA_ARGS="${ZCASHD_EXTRA_ARGS:-}"
@@ -124,6 +124,7 @@ EXIT_STATUS=$?
 if [ "$1" == "getaddressutxos" ]; then
     set "getaddressbalance" "$2"
 elif [ "$1" == "getrawmempool" ]; then
+    # Call `getrawmempool` again as a dummy request (this script isn't set up to do multiple cross-check calls)
     set "getrawmempool"
 else
     exit $EXIT_STATUS
@@ -211,7 +212,7 @@ if [ "$1" == "getrawmempool" ] && [ $CHECK_EXIT_STATUS != 0 ]; then
     echo
 
     for TRANSACTION_ID in $ZEBRAD_TRANSACTION_IDS; do
-        TRANSACTION_HEX_FILE="$ZCASH_RPC_TMP_DIR/$ZEBRAD-$ZEBRAD_NET-$ZEBRAD_HEIGHT-TRANSACTION_HEX-$TRANSACTION_ID.json"
+        TRANSACTION_HEX_FILE="$ZCASH_RPC_TMP_DIR/$ZEBRAD-$ZEBRAD_NET-$ZEBRAD_HEIGHT-$TRANSACTION_ID.json"
 
         $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" getrawtransaction $TRANSACTION_ID 0 > $TRANSACTION_HEX_FILE
 
@@ -247,6 +248,8 @@ if [ "$1" == "getrawmempool" ] && [ $CHECK_EXIT_STATUS != 0 ]; then
     done
 
 fi
+
+echo "Full RPC output is in $ZCASH_RPC_TMP_DIR"
 
 if [ $EXIT_STATUS -ne 0 ]; then
     exit $EXIT_STATUS

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -16,9 +16,12 @@ function usage()
 
 # Override the commands used by this script using these environmental variables:
 ZCASH_CLI="${ZCASH_CLI:-zcash-cli}"
-ZCASH_RPC_COOKIE_FILE="${ZCASH_RPC_COOKIE_FILE:-.cookie}"
 DIFF="${DIFF:-diff --unified --color=always}"
 JQ="${JQ:-jq}"
+# Zcashd authentification modes:
+# - Use `-rpccookiefile=your/cookie/file` for a cookie file.
+# - Use `-rpcpassword=your-password` for a password.
+ZCASHD_EXTRA_ARGS="${ZCASHD_EXTRA_ARGS:-}"
 
 if [ $# -lt 2 ]; then
     usage
@@ -42,7 +45,7 @@ ZEBRAD=$(cat "$ZEBRAD_RELEASE_INFO" | grep '"subversion"' | cut -d: -f2 | cut -d
              tr 'A-Z' 'a-z' | sed 's/magicbean/zcashd/ ; s/zebra$/zebrad/')
 
 echo "Checking second node release info..."
-$ZCASH_CLI -rpccookiefile="$ZCASH_RPC_COOKIE_FILE" getinfo > "$ZCASHD_RELEASE_INFO"
+$ZCASH_CLI $ZCASHD_EXTRA_ARGS getinfo > "$ZCASHD_RELEASE_INFO"
 
 ZCASHD=$(cat "$ZCASHD_RELEASE_INFO" | grep '"subversion"' | cut -d: -f2 | cut -d/ -f2 | \
              tr 'A-Z' 'a-z' | sed 's/magicbean/zcashd/ ; s/zebra$/zebrad/')
@@ -61,7 +64,7 @@ ZEBRAD_NET=$(cat "$ZEBRAD_BLOCKCHAIN_INFO" | grep '"chain"' | cut -d: -f2 | tr -
 ZEBRAD_HEIGHT=$(cat "$ZEBRAD_BLOCKCHAIN_INFO" | grep '"blocks"' | cut -d: -f2 | tr -d ' ,"')
 
 echo "Checking $ZCASHD network and tip height..."
-$ZCASH_CLI -rpccookiefile="$ZCASH_RPC_COOKIE_FILE" getblockchaininfo > "$ZCASHD_BLOCKCHAIN_INFO"
+$ZCASH_CLI $ZCASHD_EXTRA_ARGS getblockchaininfo > "$ZCASHD_BLOCKCHAIN_INFO"
 
 ZCASHD_NET=$(cat "$ZCASHD_BLOCKCHAIN_INFO" | grep '"chain"' | cut -d: -f2 | tr -d ' ,"')
 ZCASHD_HEIGHT=$(cat "$ZCASHD_BLOCKCHAIN_INFO" | grep '"blocks"' | cut -d: -f2 | tr -d ' ,"')
@@ -94,7 +97,7 @@ time $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" "$@" > "$ZEBRAD_RESPONSE"
 echo
 
 echo "Querying $ZCASHD $ZCASHD_NET chain at height >=$ZCASHD_HEIGHT..."
-time $ZCASH_CLI -rpccookiefile="$ZCASH_RPC_COOKIE_FILE" "$@" > "$ZCASHD_RESPONSE"
+time $ZCASH_CLI $ZCASHD_EXTRA_ARGS "$@" > "$ZCASHD_RESPONSE"
 echo
 
 echo
@@ -139,7 +142,7 @@ echo "Querying $ZEBRAD $ZEBRAD_NET chain at height >=$ZEBRAD_HEIGHT..."
 $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" "$@" > "$ZEBRAD_CHECK_RESPONSE"
 
 echo "Querying $ZCASHD $ZCASHD_NET chain at height >=$ZCASHD_HEIGHT..."
-$ZCASH_CLI -rpccookiefile="$ZCASH_RPC_COOKIE_FILE" "$@" > "$ZCASHD_CHECK_RESPONSE"
+$ZCASH_CLI $ZCASHD_EXTRA_ARGS "$@" > "$ZCASHD_CHECK_RESPONSE"
 
 echo
 
@@ -218,7 +221,7 @@ if [ "$1" == "getrawmempool" ] && [ $CHECK_EXIT_STATUS != 0 ]; then
             echo "## Displaying transaction $TRANSACTION_ID"
             echo
 
-            TRANSACTION_DECODED=`$ZCASH_CLI -rpccookiefile="$ZCASH_RPC_COOKIE_FILE" decoderawtransaction $TRANSACTION_HEX`
+            TRANSACTION_DECODED=`$ZCASH_CLI $ZCASHD_EXTRA_ARGS decoderawtransaction $TRANSACTION_HEX`
 
             echo $TRANSACTION_DECODED | $JQ
             echo

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -199,21 +199,23 @@ if [ "$1" == "getaddressbalance" ]; then
 fi
 
 if [ "$1" == "getrawmempool" ] && [ $CHECK_EXIT_STATUS != 0 ]; then
-    echo
-    echo "Obtaining transaction details"
-    echo
-
     set TRANSACTION_ID
     set TRANSACTION_HEX_FILE
     set TRANSACTION_DECODED
 
     ZEBRAD_TRANSACTION_IDS=$(cat "$ZEBRAD_RESPONSE" | $JQ -r 'join(" ")')
+    ZCASHD_TRANSACTION_IDS=$(cat "$ZCASHD_RESPONSE" | $JQ -r 'join(" ")')
+
+    echo
+    echo "# Dumping transactions from zebrad mempool"
+    echo
+
     for TRANSACTION_ID in $ZEBRAD_TRANSACTION_IDS; do
         TRANSACTION_HEX_FILE="$ZCASH_RPC_TMP_DIR/$ZEBRAD-$ZEBRAD_NET-$ZEBRAD_HEIGHT-TRANSACTION_HEX-$TRANSACTION_ID.json"
 
         $ZCASH_CLI -rpcport="$ZEBRAD_RPC_PORT" getrawtransaction $TRANSACTION_ID 0 > $TRANSACTION_HEX_FILE
 
-        echo "## Displaying transaction $TRANSACTION_ID"
+        echo "## Displaying transaction $TRANSACTION_ID from zebrad"
         echo
 
         # read the proposal data from a file, to avoid command-line length limits
@@ -223,6 +225,27 @@ if [ "$1" == "getrawmempool" ] && [ $CHECK_EXIT_STATUS != 0 ]; then
         echo $TRANSACTION_DECODED | $JQ
         echo
     done
+
+    echo
+    echo "# Dumping transactions from zcashd mempool"
+    echo
+
+    for TRANSACTION_ID in $ZCASHD_TRANSACTION_IDS; do
+        TRANSACTION_HEX_FILE="$ZCASH_RPC_TMP_DIR/$ZCASHD-$ZCASHD_NET-$ZCASHD_HEIGHT-TRANSACTION_HEX-$TRANSACTION_ID.json"
+
+        $ZCASH_CLI $ZCASHD_EXTRA_ARGS getrawtransaction $TRANSACTION_ID 0 > $TRANSACTION_HEX_FILE
+
+        echo "## Displaying transaction $TRANSACTION_ID from zcashd"
+        echo
+
+        # read the proposal data from a file, to avoid command-line length limits
+        TRANSACTION_DECODED=`cat "$TRANSACTION_HEX_FILE" | \
+            $ZCASH_CLI $ZCASHD_EXTRA_ARGS -stdin decoderawtransaction`
+
+        echo $TRANSACTION_DECODED | $JQ
+        echo
+    done
+
 fi
 
 if [ $EXIT_STATUS -ne 0 ]; then


### PR DESCRIPTION
## Motivation

We know there are differences sometimes in the zebrad mempool and the zcashd one. We want to know what are the differences by getting transaction content among other data (tx hash, height).

This is for https://github.com/ZcashFoundation/zebra/issues/5935

## Solution

- Commit https://github.com/ZcashFoundation/zebra/commit/d5a28bcc40599d8b6c2e9032d1a1e73d1da8e9f2 is a bit unrelated, it adds the zcashd cookie file path as an env var. This makes my testing easier but i will not mind removing it if other people think is not a good idea.
- Commit  https://github.com/ZcashFoundation/zebra/commit/de68004025f1fae47493eacf840f5427ab983f1e actually adds the extra code for retrieving transaction data for each transaction in both mempools.

## Review

This has a problem. When a transaction is too big, the call to `decoderawtransaction` will fail with `Argument list too long`. This is an OS limitation and it seems not trivial to change the argument limit in linux, i am not sure if `zcash-cli` accepts a file as argument and if this can solve the problem. Researching also `xargs` but unsure if will work either.

The PR is a draft until i can fix that, ideas are welcome.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
