### PR TITLE
fix(docker): do not mix cache images with test images

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -84,7 +84,6 @@ jobs:
             type=ref,event=pr
             type=sha
             # edge is the latest commit on the default branch.
-            # TODO: We only want edge builds for `us-docker.pkg.dev`, because DockerHub doesn't keep up with every `main` branch commit.
             type=edge,enable={{is_default_branch}}
 
       # Setup Docker Buildx to allow use of docker cache layers from GH
@@ -158,6 +157,7 @@ jobs:
           # The caches are tried in top-down order, the first available cache is used:
           # https://github.com/moby/moby/pull/26839#issuecomment-277383550
           cache-from: |
-            type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache
-            type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:main-cache
-          cache-to: type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache,mode=max
+            type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra-caching/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache
+            type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra-caching/${{ inputs.image_name }}:main-cache
+          cache-to: |
+            type=registry,ref=us-docker.pkg.dev/zealous-zebra/zebra-caching/${{ inputs.image_name }}:${{ env.GITHUB_REF_SLUG_URL }}-cache,mode=max


### PR DESCRIPTION
## Motivation

Docker does not allow to use multiple tags for cache images in their `cache-from` and `cache-to` options. Which makes some images to lose previous tags, if the same.

This cause automated mechanims for deletion to fail, as those cache images were dependant on the main image, and deleting the cache alone was raising an error if the main image was not deleted first.

Fixes #5933 

### Complex Code or Requirements

- This required to create a new repository in GCP to hold all cache images: https://console.cloud.google.com/artifacts/docker/zealous-zebra/us/zebra-caching

## Solution

A workaround for this was making a separate repository which can hold this cache images. Which also reduces clutter from the main registries.

## Review

Anyone can review this, mainly testing a re-run is using the caching images

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
