### PR TITLE
chore(actions): use newer method to set an output parameter

### DIFF
--- a/.github/workflows/build-crates-individually.patch.yml
+++ b/.github/workflows/build-crates-individually.patch.yml
@@ -53,7 +53,7 @@ jobs:
           ) | jq -c .)
           echo $MATRIX
           echo $MATRIX | jq .
-          echo "::set-output name=matrix::$MATRIX"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
   check-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-crates-individually.yml
+++ b/.github/workflows/build-crates-individually.yml
@@ -80,7 +80,7 @@ jobs:
           ) | jq -c .)
           echo $MATRIX
           echo $MATRIX | jq .
-          echo "::set-output name=matrix::$MATRIX"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
   check-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -57,7 +57,7 @@ jobs:
             return context.payload.release.tag_name.substring(0,2)
       - name: Setting API Version
         id: set
-        run: echo "::set-output name=major_version::${{ steps.get.outputs.result }}"
+        run: echo "major_version=${{ steps.get.outputs.result }}" >> "$GITHUB_OUTPUT"
 
   # Each time this workflow is executed, a build will be triggered to create a new image
   # with the corresponding tags using information from Git

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -145,28 +145,28 @@ jobs:
           LWD_TIP_DISK=$(gcloud compute images list --filter="status=READY AND name~lwd-cache-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-tip" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
           if [[ -z "$LWD_TIP_DISK" ]]; then
               echo "No TIP disk found for LWD"
-              echo "::set-output name=lwd_tip_disk::${{ toJSON(false) }}"
+              echo "lwd_tip_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
           else
               echo "Disk: $LWD_TIP_DISK"
-              echo "::set-output name=lwd_tip_disk::${{ toJSON(true) }}"
+              echo "lwd_tip_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
           fi
 
           ZEBRA_TIP_DISK=$(gcloud compute images list --filter="status=READY AND name~zebrad-cache-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-tip" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
           if [[ -z "$ZEBRA_TIP_DISK" ]]; then
               echo "No TIP disk found for ZEBRA"
-              echo "::set-output name=zebra_tip_disk::${{ toJSON(false) }}"
+              echo "zebra_tip_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
           else
               echo "Disk: $ZEBRA_TIP_DISK"
-              echo "::set-output name=zebra_tip_disk::${{ toJSON(true) }}"
+              echo "zebra_tip_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
           fi
 
           ZEBRA_CHECKPOINT_DISK=$(gcloud compute images list --filter="status=READY AND name~zebrad-cache-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-checkpoint" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
           if [[ -z "$ZEBRA_CHECKPOINT_DISK" ]]; then
               echo "No CHECKPOINT found for ZEBRA"
-              echo "::set-output name=zebra_checkpoint_disk::${{ toJSON(false) }}"
+              echo "zebra_checkpoint_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
           else
               echo "Disk: $ZEBRA_CHECKPOINT_DISK"
-              echo "::set-output name=zebra_checkpoint_disk::${{ toJSON(true) }}"
+              echo "zebra_checkpoint_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
           fi
 
   build:

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -148,7 +148,7 @@ jobs:
               echo "lwd_tip_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
           else
               echo "Disk: $LWD_TIP_DISK"
-              echo "lwd_tip_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
+              echo "lwd_tip_disk=${{ toJSON(true) }}" >> "$GITHUB_OUTPUT"
           fi
 
           ZEBRA_TIP_DISK=$(gcloud compute images list --filter="status=READY AND name~zebrad-cache-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-tip" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
@@ -157,7 +157,7 @@ jobs:
               echo "zebra_tip_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
           else
               echo "Disk: $ZEBRA_TIP_DISK"
-              echo "zebra_tip_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
+              echo "zebra_tip_disk=${{ toJSON(true) }}" >> "$GITHUB_OUTPUT"
           fi
 
           ZEBRA_CHECKPOINT_DISK=$(gcloud compute images list --filter="status=READY AND name~zebrad-cache-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-checkpoint" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
@@ -166,7 +166,7 @@ jobs:
               echo "zebra_checkpoint_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
           else
               echo "Disk: $ZEBRA_CHECKPOINT_DISK"
-              echo "zebra_checkpoint_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
+              echo "zebra_checkpoint_disk=${{ toJSON(true) }}" >> "$GITHUB_OUTPUT"
           fi
 
   build:

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -394,7 +394,7 @@ jobs:
           fi
 
           echo "Selected Disk: $CACHED_DISK_NAME"
-          echo "::set-output name=cached_disk_name::$CACHED_DISK_NAME"
+          echo "cached_disk_name=$CACHED_DISK_NAME" >> "$GITHUB_OUTPUT"
 
           echo "STATE_VERSION=$LOCAL_STATE_VERSION" >> "$GITHUB_ENV"
           echo "CACHED_DISK_NAME=$CACHED_DISK_NAME" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Motivation

The set-output command is deprecated and will be disabled soon.
For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Fixes #5736 

### Specifications

- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

## Solution

Apply the method used in the specifications.

## Review

Anyone can review this

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
