### PR TITLE
example: zcash_address parsing example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5469,6 +5469,7 @@ dependencies = [
  "tracing",
  "uint",
  "x25519-dalek",
+ "zcash_address",
  "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5591,6 +5591,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-futures",
+ "zcash_address",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -13,7 +13,9 @@ default = []
 # Production features that activate extra functionality
 
 # Experimental mining RPC support
-getblocktemplate-rpcs = []
+getblocktemplate-rpcs = [
+    "zcash_address",
+]
 
 # Test-only features
 
@@ -87,6 +89,9 @@ rayon = "1.6.1"
 # ZF deps
 ed25519-zebra = "3.1.0"
 redjubjub = "0.5.0"
+
+# Experimental feature getblocktemplate-rpcs
+zcash_address = { version = "0.2.0", optional = true }
 
 # Optional testing dependencies
 proptest = { version = "0.10.1", optional = true }

--- a/zebra-chain/src/primitives.rs
+++ b/zebra-chain/src/primitives.rs
@@ -8,6 +8,9 @@ mod proofs;
 // TODO: re-export redpallas if needed, or reddsa if that gets merged https://github.com/ZcashFoundation/zebra/issues/2044
 pub mod redpallas;
 
+#[cfg(feature = "getblocktemplate-rpcs")]
+mod address;
+
 pub use ed25519_zebra as ed25519;
 pub use redjubjub;
 pub use x25519_dalek as x25519;

--- a/zebra-chain/src/primitives/address.rs
+++ b/zebra-chain/src/primitives/address.rs
@@ -1,0 +1,51 @@
+//! `zcash_address` conversion to `zebra_chain` address types.
+//!
+//! Usage: <https://docs.rs/zcash_address/0.2.0/zcash_address/trait.TryFromAddress.html#examples>
+
+use crate::{parameters::Network, transparent, BoxError};
+
+impl TryFrom<zcash_address::Network> for Network {
+    // TODO: better error type
+    type Error = BoxError;
+
+    fn try_from(network: zcash_address::Network) -> Result<Self, Self::Error> {
+        match network {
+            zcash_address::Network::Main => Ok(Network::Mainnet),
+            zcash_address::Network::Test => Ok(Network::Testnet),
+            zcash_address::Network::Regtest => Err("unsupported Zcash network parameters".into()),
+        }
+    }
+}
+
+impl From<Network> for zcash_address::Network {
+    fn from(network: Network) -> Self {
+        match network {
+            Network::Mainnet => zcash_address::Network::Main,
+            Network::Testnet => zcash_address::Network::Test,
+        }
+    }
+}
+
+// TODO: implement sprout, sapling, and unified on those types
+impl zcash_address::TryFromAddress for transparent::Address {
+    // TODO: crate::serialization::SerializationError
+    type Error = BoxError;
+
+    fn try_from_transparent_p2pkh(
+        network: zcash_address::Network,
+        data: [u8; 20],
+    ) -> Result<Self, zcash_address::ConversionError<Self::Error>> {
+        let network = network.try_into()?;
+
+        Ok(transparent::Address::from_pub_key_hash(network, data))
+    }
+
+    fn try_from_transparent_p2sh(
+        network: zcash_address::Network,
+        data: [u8; 20],
+    ) -> Result<Self, zcash_address::ConversionError<Self::Error>> {
+        let network = network.try_into()?;
+
+        Ok(transparent::Address::from_script_hash(network, data))
+    }
+}

--- a/zebra-chain/src/primitives/address.rs
+++ b/zebra-chain/src/primitives/address.rs
@@ -26,7 +26,12 @@ impl From<Network> for zcash_address::Network {
     }
 }
 
-// TODO: implement sprout, sapling, and unified on those types
+// TODO:
+// addresses with embedded networks:
+//       implement TryFromRawAddress for sprout, sapling, unified/sapling, unified/orchard
+//       use convert_if_network(network.into()) to convert raw addresses
+// addresses which require a separate network:
+//       implement TryFromAddress for unified/transparent (p2pkh and p2sh)
 impl zcash_address::TryFromAddress for transparent::Address {
     // TODO: crate::serialization::SerializationError
     type Error = BoxError;

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -15,6 +15,7 @@ default = []
 # Experimental mining RPC support
 getblocktemplate-rpcs = [
     "rand",
+    "zcash_address",
     "zebra-consensus/getblocktemplate-rpcs",
     "zebra-state/getblocktemplate-rpcs",
     "zebra-node-services/getblocktemplate-rpcs",
@@ -58,6 +59,7 @@ serde = { version = "1.0.152", features = ["serde_derive"] }
 
 # Experimental feature getblocktemplate-rpcs
 rand = { version = "0.8.5", package = "rand", optional = true }
+zcash_address = { version = "0.2.0", optional = true }
 
 # Test-only feature proptest-impl
 proptest = { version = "0.10.1", optional = true }

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -758,8 +758,15 @@ where
         .boxed()
     }
 
-    fn parse_address(&self, _address: String) -> BoxFuture<Result<String>> {
-        async { Ok("".to_string()) }.boxed()
+    fn parse_address(&self, address: String) -> BoxFuture<Result<String>> {
+        async move {
+            // TODO: return error as isvalid = false or a RPC error depending on the RPC
+            let address = ZcashAddress::try_from_encoded(&address);
+
+            // TODO: actually do something with the address fields here
+            Ok(format!("{address:?}"))
+        }
+        .boxed()
     }
 }
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -156,6 +156,14 @@ pub trait GetBlockTemplateRpc {
     /// zcashd reference: [`getpeerinfo`](https://zcash.github.io/rpc/getpeerinfo.html)
     #[rpc(name = "getpeerinfo")]
     fn get_peer_info(&self) -> BoxFuture<Result<Vec<PeerInfo>>>;
+
+    /// TODO: implement the actual return types for each address RPC
+    ///
+    /// Returns the parsed result for `address`, using the `zcash_address` crate.
+    ///
+    /// zcashd reference: TODO
+    #[rpc(name = "parseaddress")]
+    fn parse_address(&self, address: String) -> BoxFuture<Result<String>>;
 }
 
 /// RPC method implementations.
@@ -747,6 +755,10 @@ where
                 .collect())
         }
         .boxed()
+    }
+
+    fn parse_address(&self, _address: String) -> BoxFuture<Result<String>> {
+        async { Ok("".to_string()) }.boxed()
     }
 }
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -7,6 +7,7 @@ use jsonrpc_core::{self, BoxFuture, Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use tower::{buffer::Buffer, Service, ServiceExt};
 
+use zcash_address::{TryFromAddress, ZcashAddress};
 use zebra_chain::{
     block::{self, Block, Height},
     chain_sync_status::ChainSyncStatus,


### PR DESCRIPTION
## Motivation

Arya asked for this example of how to use `zcash_address` to parse addresses and extract information for the RPCs.

It's not for review, and it shouldn't be merged.