### PR TITLE
fix(testnet): Increase legacy chain limit to 100,000

### DIFF
--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -24,7 +24,7 @@ pub const DATABASE_FORMAT_VERSION: u32 = 25;
 /// before we assume we are on a pre-NU5 legacy chain.
 ///
 /// Zebra usually only has to check back a few blocks, but on testnet it can be a long time between v5 transactions.
-pub const MAX_LEGACY_CHAIN_BLOCKS: usize = 10_000;
+pub const MAX_LEGACY_CHAIN_BLOCKS: usize = 100_000;
 
 /// The maximum number of block hashes allowed in `getblocks` responses in the Zcash network protocol.
 pub const MAX_FIND_BLOCK_HASHES_RESULTS: u32 = 500;


### PR DESCRIPTION
## Motivation

I just restarted my testnet instance, and it has been 10,000 blocks without a v5 transaction. So we need to increase the limit again.

Ticket #5912 will make this check partly redundant, because it will verify all the checkpoints to make sure we are on the correct chain.

## Solution

Just increase the constant for the number of blocks.

## Review

This is a low priority testnet fix.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

