### PR TITLE
change(deps): Upgrade to the zcash_primitives 0.10 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5341,39 +5341,6 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9a45953c4ddd81d68f45920955707f45c8926800671f354dd13b97507edf28"
-dependencies = [
- "aes",
- "bip0039",
- "bitvec",
- "blake2b_simd",
- "blake2s_simd",
- "bls12_381",
- "byteorder",
- "equihash",
- "ff",
- "fpe",
- "group",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "lazy_static",
- "memuse",
- "nonempty",
- "orchard",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "sha2",
- "subtle",
- "zcash_address",
- "zcash_encoding",
- "zcash_note_encryption",
-]
-
-[[package]]
-name = "zcash_primitives"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6879bd4026d9269a41ca91858f453b523f30824288248148211e1cab23b3e0d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5356,6 +5356,39 @@ dependencies = [
  "ff",
  "fpe",
  "group",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "orchard",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "sha2",
+ "subtle",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_note_encryption",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6879bd4026d9269a41ca91858f453b523f30824288248148211e1cab23b3e0d"
+dependencies = [
+ "aes",
+ "bip0039",
+ "bitvec",
+ "blake2b_simd",
+ "blake2s_simd",
+ "bls12_381",
+ "byteorder",
+ "equihash",
+ "ff",
+ "fpe",
+ "group",
  "hdwallet",
  "hex",
  "incrementalmerkletree",
@@ -5377,9 +5410,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77381adc72286874e563ee36ba99953946abcbd195ada45440a2754ca823d407"
+checksum = "28ca180a8138ae6e2de2b88573ed19dd57798f42a79a00d992b4d727132c7081"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5392,7 +5425,7 @@ dependencies = [
  "rand_core 0.6.4",
  "redjubjub",
  "tracing",
- "zcash_primitives 0.9.1",
+ "zcash_primitives 0.10.0",
 ]
 
 [[package]]
@@ -5472,7 +5505,7 @@ dependencies = [
  "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.9.1",
+ "zcash_primitives 0.10.0",
  "zebra-test",
 ]
 

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -61,7 +61,7 @@ orchard = "0.3.0"
 zcash_encoding = "0.2.0"
 zcash_history = "0.3.0"
 zcash_note_encryption = "0.2.0"
-zcash_primitives = { version = "0.9.1", features = ["transparent-inputs"] }
+zcash_primitives = { version = "0.10.0", features = ["transparent-inputs"] }
 
 # Time
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "std", "serde"] }

--- a/zebra-chain/src/primitives/zcash_note_encryption.rs
+++ b/zebra-chain/src/primitives/zcash_note_encryption.rs
@@ -1,6 +1,6 @@
 //! Contains code that interfaces with the zcash_note_encryption crate from
 //! librustzcash.
-//!
+
 use crate::{
     block::Height,
     parameters::{Network, NetworkUpgrade},
@@ -24,7 +24,7 @@ pub fn decrypts_successfully(transaction: &Transaction, network: Network, height
     let null_sapling_ovk = zcash_primitives::keys::OutgoingViewingKey([0u8; 32]);
 
     if let Some(bundle) = alt_tx.sapling_bundle() {
-        for output in bundle.shielded_outputs.iter() {
+        for output in bundle.shielded_outputs().iter() {
             let recovery = match network {
                 Network::Mainnet => {
                     zcash_primitives::sapling::note_encryption::try_sapling_output_recovery(

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -13,6 +13,8 @@ use crate::{
     transparent::{self, Script},
 };
 
+// TODO: move copied and modified code to a separate module.
+//
 // Used by boilerplate code below.
 
 #[derive(Clone, Debug)]
@@ -87,10 +89,18 @@ impl
         zp_tx::components::sapling::Authorized,
     > for IdentityMap
 {
-    fn map_proof(
+    fn map_spend_proof(
         &self,
-        p: <zp_tx::components::sapling::Authorized as zp_tx::components::sapling::Authorization>::Proof,
-    ) -> <zp_tx::components::sapling::Authorized as zp_tx::components::sapling::Authorization>::Proof
+        p: <zp_tx::components::sapling::Authorized as zp_tx::components::sapling::Authorization>::SpendProof,
+    ) -> <zp_tx::components::sapling::Authorized as zp_tx::components::sapling::Authorization>::SpendProof
+    {
+        p
+    }
+
+    fn map_output_proof(
+        &self,
+        p: <zp_tx::components::sapling::Authorized as zp_tx::components::sapling::Authorization>::OutputProof,
+    ) -> <zp_tx::components::sapling::Authorized as zp_tx::components::sapling::Authorization>::OutputProof
     {
         p
     }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -47,7 +47,7 @@ tracing-futures = "0.2.5"
 
 orchard = "0.3.0"
 
-zcash_proofs = { version = "0.9.0", features = ["local-prover", "multicore", "download-params"] }
+zcash_proofs = { version = "0.10.0", features = ["local-prover", "multicore", "download-params"] }
 
 tower-fallback = { path = "../tower-fallback/" }
 tower-batch = { path = "../tower-batch/" }


### PR DESCRIPTION
## Motivation

This upgrades to the latest versions of zcash_primitives and zcash_proofs.

Close #5978

## Solution

- upgrade zcash_primitives and zcash_proofs to 0.10.0
- apply the API changes that were previously in PR #5966

## Review

This is a routine dependency upgrade with some code changes.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

