### PR TITLE
fix(README): Fix `lightwalletd` instructions to be compatible with Zebra

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,16 +118,13 @@ listen_addr = '127.0.0.1:8232'
 parallel_cpu_threads = 0
 ```
 
-It is recommended to use [adityapk00/lightwalletd](https://github.com/adityapk00/lightwalletd) because that is used in testing.
-
-If using [zcash/lightwalletd](https://github.com/zcash/lightwalletd.git):
-- note that it will require a zcash.conf file:
-  - `rpcuser` and `rpcpassword` are required by `lightwalletd`, but Zebra ignores them if it receives them from `lightwalletd`
-  - when using a non-default port, use `rpcport=28232` and `rpcbind=127.0.0.1`
-  - when using testnet, use `testnet=1`
-
 **WARNING:** This config allows multiple Zebra instances to share the same RPC port.
 See the [RPC config documentation](https://doc.zebra.zfnd.org/zebra_rpc/config/struct.Config.html) for details.
+
+`lightwalletd` also requires a `zcash.conf` file.
+
+It is recommended to use [adityapk00/lightwalletd](https://github.com/adityapk00/lightwalletd) because that is used in testing.
+Other `lightwalletd` forks have limited support, see the [detailed `lightwalletd` instructions](https://github.com/ZcashFoundation/zebra/blob/main/book/src/user/lightwalletd.md#sync-lightwalletd).
 
 ### Optional Features
 

--- a/book/src/user/lightwalletd.md
+++ b/book/src/user/lightwalletd.md
@@ -81,14 +81,14 @@ For implementing zebra as a service please see [here](https://github.com/ZcashFo
 ## Download and build lightwalletd
 [#download-and-build-lightwalletd]: #download-and-build-lightwalletd
 
-While you synchronize Zebra you can install [lightwalletd](https://github.com/zcash/lightwalletd).
+While you synchronize Zebra you can install [lightwalletd](https://github.com/adityapk00/lightwalletd).
 
 Before installing, you need to have `go` in place. Please visit the [go install page](https://go.dev/doc/install) with download and installation instructions.
 
 With go installed and in your path, download and install lightwalletd:
 
 ```console
-git clone https://github.com/zcash/lightwalletd
+git clone https://github.com/adityapk00/lightwalletd
 cd lightwalletd
 make
 make install
@@ -101,7 +101,10 @@ If everything went good you should have a `lightwalletd` binary in `~/go/bin/`.
 
 Please make sure you have zebrad running (with RPC endpoint and up to date blockchain) to synchronize lightwalletd.
 
-- `lightwalletd` requires a `zcash.conf` file located somewhere, however this file can be empty if you are using the default zebra rpc endpoint (`127.0.0.1:8232`).
+- `lightwalletd` requires a `zcash.conf` file, however this file can be empty if you are using the default Zebra rpc endpoint (`127.0.0.1:8232`) and the `adityapk00/lightwalletd` fork 
+    - Some `lightwalletd` forks also require a `rpcuser` and `rpcpassword`, but Zebra ignores them if it receives them from `lightwalletd`
+    - When using a non-default port, use `rpcport=28232` and `rpcbind=127.0.0.1`
+    - When using testnet, use `testnet=1`
 
 - For production setups `lightwalletd` requires a `cert.pem`. For more information on how to do this please [see here](https://github.com/zcash/lightwalletd#production-usage).
 


### PR DESCRIPTION
## Motivation

1. Our `lightwalletd` docs recommend an incompatible fork
2. We have some detailed information about different `lightwalletd` forks in the README, but we're trying to make the README an easily read summary

## Solution

- Change to a working `lightwalletd` fork
- Move details from the README to the detailed doc

## Review

This is a low priority documentation bug.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Fix the RPC compatibility bug:
- #6085