### PR TITLE
change(rpc): Simplify `getdifficulty` RPC implementation

### DIFF
--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -972,7 +972,8 @@ where
             let pow_limit = pow_limit >> 128;
             let difficulty = difficulty >> 128;
 
-            // Convert to u128 then f64
+            // Convert to u128 then f64.
+            // We could also convert U256 to String, then parse as f64, but that's slower.
             let pow_limit = pow_limit.as_u128() as f64;
             let difficulty = difficulty.as_u128() as f64;
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -922,7 +922,8 @@ where
             // # TODO
             // - add a separate request like BestChainNextMedianTimePast, but skipping the
             //   consistency check, because any block's difficulty is ok for display
-            // - return 1.0 for a "not enough blocks in the state" error
+            // - return 1.0 for a "not enough blocks in the state" error, like `zcashd`:
+            // <https://github.com/zcash/zcash/blob/7b28054e8b46eb46a9589d0bdc8e29f9fa1dc82d/src/rpc/blockchain.cpp#L40-L41>
             let response = state
                 .ready()
                 .and_then(|service| service.call(request))

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -950,7 +950,7 @@ where
             let difficulty = chain_info
                 .expected_difficulty
                 .to_work()
-                .expect("valid blocks have valid difficulties, work is within u218");
+                .expect("valid blocks have valid difficulties, work is within u128");
 
             // Convert to u128 then f64
             let pow_limit = pow_limit.as_u128() as f64;

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -19,7 +19,7 @@ use zebra_chain::{
     serialization::{DateTime32, ZcashDeserializeInto},
     transaction::Transaction,
     transparent,
-    work::difficulty::{CompactDifficulty, ExpandedDifficulty, U256},
+    work::difficulty::{CompactDifficulty, ExpandedDifficulty},
 };
 use zebra_network::{address_book_peers::MockAddressBookPeers, types::MetaAddr};
 use zebra_node_services::mempool;
@@ -112,7 +112,11 @@ pub async fn test_responses<State, ReadState>(
     let fake_cur_time = DateTime32::from(1654008617);
     // nu5 block time + 123
     let fake_max_time = DateTime32::from(1654008728);
-    let fake_difficulty = CompactDifficulty::from(ExpandedDifficulty::from(U256::one()));
+
+    // Use a valid fractional difficulty for snapshots
+    let pow_limit = ExpandedDifficulty::target_difficulty_limit(network);
+    let fake_difficulty = pow_limit * 2 / 3;
+    let fake_difficulty = CompactDifficulty::from(fake_difficulty);
 
     let (mock_chain_tip, mock_chain_tip_sender) = MockChainTip::new();
     mock_chain_tip_sender.send_best_tip_height(fake_tip_height);

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_basic@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_basic@mainnet_10.snap
@@ -28,7 +28,7 @@ expression: block_template
     "required": true
   },
   "longpollid": "00016871043eab7f731654008728000000000000000000",
-  "target": "0000000000000000000000000000000000000000000000000000000000000001",
+  "target": "0005555400000000000000000000000000000000000000000000000000000000",
   "mintime": 1654008606,
   "mutable": [
     "time",
@@ -39,7 +39,7 @@ expression: block_template
   "sigoplimit": 20000,
   "sizelimit": 2000000,
   "curtime": 1654008617,
-  "bits": "01010000",
+  "bits": "1f055554",
   "height": 1687105,
   "maxtime": 1654008728
 }

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_basic@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_basic@testnet_10.snap
@@ -28,7 +28,7 @@ expression: block_template
     "required": true
   },
   "longpollid": "00018424203eab7f731654008728000000000000000000",
-  "target": "0000000000000000000000000000000000000000000000000000000000000001",
+  "target": "0555540000000000000000000000000000000000000000000000000000000000",
   "mintime": 1654008606,
   "mutable": [
     "time",
@@ -39,7 +39,7 @@ expression: block_template
   "sigoplimit": 20000,
   "sizelimit": 2000000,
   "curtime": 1654008617,
-  "bits": "01010000",
+  "bits": "20055554",
   "height": 1842421,
   "maxtime": 1654008728
 }

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_long_poll@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_long_poll@mainnet_10.snap
@@ -28,7 +28,7 @@ expression: block_template
     "required": true
   },
   "longpollid": "00016871043eab7f731654008728000000000000000000",
-  "target": "0000000000000000000000000000000000000000000000000000000000000001",
+  "target": "0005555400000000000000000000000000000000000000000000000000000000",
   "mintime": 1654008606,
   "mutable": [
     "time",
@@ -39,7 +39,7 @@ expression: block_template
   "sigoplimit": 20000,
   "sizelimit": 2000000,
   "curtime": 1654008617,
-  "bits": "01010000",
+  "bits": "1f055554",
   "height": 1687105,
   "maxtime": 1654008728,
   "submitold": false

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_long_poll@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_block_template_long_poll@testnet_10.snap
@@ -28,7 +28,7 @@ expression: block_template
     "required": true
   },
   "longpollid": "00018424203eab7f731654008728000000000000000000",
-  "target": "0000000000000000000000000000000000000000000000000000000000000001",
+  "target": "0555540000000000000000000000000000000000000000000000000000000000",
   "mintime": 1654008606,
   "mutable": [
     "time",
@@ -39,7 +39,7 @@ expression: block_template
   "sigoplimit": 20000,
   "sizelimit": 2000000,
   "curtime": 1654008617,
-  "bits": "01010000",
+  "bits": "20055554",
   "height": 1842421,
   "maxtime": 1654008728,
   "submitold": false

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_difficulty@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_difficulty@mainnet_10.snap
@@ -2,4 +2,4 @@
 source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
 expression: difficulty
 ---
-14134749558280407000000000000000000000000000000000000000000000000000000000.0
+1.5

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_difficulty@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_difficulty@mainnet_10.snap
@@ -2,4 +2,4 @@
 source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
 expression: difficulty
 ---
-1.5
+1.5000028610338632

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_difficulty@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_difficulty@testnet_10.snap
@@ -2,4 +2,4 @@
 source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
 expression: difficulty
 ---
-3618495886919784300000000000000000000000000000000000000000000000000000000000.0
+1.5

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_difficulty@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_difficulty@testnet_10.snap
@@ -2,4 +2,4 @@
 source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
 expression: difficulty
 ---
-1.5
+1.5000028610338632

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1448,7 +1448,9 @@ async fn rpc_getdifficulty() {
     let get_difficulty_fut = get_block_template_rpc.get_difficulty();
     let (get_difficulty, ..) = tokio::join!(get_difficulty_fut, mock_read_state_request_handler,);
 
-    assert_eq!(format!("{:.8}", get_difficulty.unwrap()), "0.00012207");
+    // Our implementation is slightly different to `zcashd`, so we require 6 significant figures
+    // of accuracy in our unit tests. (Most clients will hide more than 2-3.)
+    assert_eq!(format!("{:.9}", get_difficulty.unwrap()), "0.000122072");
 
     // Fake the ChainInfo response: difficulty limit - smallest valid difficulty
     let pow_limit = ExpandedDifficulty::target_difficulty_limit(Mainnet);
@@ -1472,7 +1474,7 @@ async fn rpc_getdifficulty() {
     let get_difficulty_fut = get_block_template_rpc.get_difficulty();
     let (get_difficulty, ..) = tokio::join!(get_difficulty_fut, mock_read_state_request_handler,);
 
-    assert_eq!(format!("{}", get_difficulty.unwrap()), "1");
+    assert_eq!(format!("{:.5}", get_difficulty.unwrap()), "1.00000");
 
     // Fake the ChainInfo response: fractional difficulty
     let fake_difficulty = pow_limit * 2 / 3;
@@ -1495,7 +1497,7 @@ async fn rpc_getdifficulty() {
     let get_difficulty_fut = get_block_template_rpc.get_difficulty();
     let (get_difficulty, ..) = tokio::join!(get_difficulty_fut, mock_read_state_request_handler,);
 
-    assert_eq!(format!("{:.4}", get_difficulty.unwrap()), "1.5000");
+    assert_eq!(format!("{:.5}", get_difficulty.unwrap()), "1.50000");
 
     // Fake the ChainInfo response: large integer difficulty
     let fake_difficulty = pow_limit / 4096;
@@ -1518,5 +1520,5 @@ async fn rpc_getdifficulty() {
     let get_difficulty_fut = get_block_template_rpc.get_difficulty();
     let (get_difficulty, ..) = tokio::join!(get_difficulty_fut, mock_read_state_request_handler,);
 
-    assert_eq!(format!("{:.1}", get_difficulty.unwrap()), "4096.0");
+    assert_eq!(format!("{:.2}", get_difficulty.unwrap()), "4096.00");
 }

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1387,7 +1387,7 @@ async fn rpc_getdifficulty() {
 
     let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
-    let mut read_state = MockService::build().for_unit_tests();
+    let read_state = MockService::build().for_unit_tests();
     let chain_verifier = MockService::build().for_unit_tests();
 
     let mut mock_sync_status = MockSyncStatus::default();
@@ -1408,7 +1408,6 @@ async fn rpc_getdifficulty() {
     let fake_cur_time = DateTime32::from(1654008617);
     // nu5 block time + 123
     let fake_max_time = DateTime32::from(1654008728);
-    let fake_difficulty = CompactDifficulty::from(ExpandedDifficulty::from(U256::MAX));
 
     let (mock_chain_tip, mock_chain_tip_sender) = MockChainTip::new();
     mock_chain_tip_sender.send_best_tip_height(fake_tip_height);
@@ -1427,9 +1426,12 @@ async fn rpc_getdifficulty() {
         MockAddressBookPeers::default(),
     );
 
-    // Fake the ChainInfo response
+    // Fake the ChainInfo response: smallest numeric difficulty
+    // (this is invalid on mainnet and testnet under the consensus rules)
+    let fake_difficulty = CompactDifficulty::from(ExpandedDifficulty::from(U256::MAX));
+    let mut read_state1 = read_state.clone();
     let mock_read_state_request_handler = async move {
-        read_state
+        read_state1
             .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
             .await
             .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
@@ -1446,5 +1448,75 @@ async fn rpc_getdifficulty() {
     let get_difficulty_fut = get_block_template_rpc.get_difficulty();
     let (get_difficulty, ..) = tokio::join!(get_difficulty_fut, mock_read_state_request_handler,);
 
-    assert_eq!(get_difficulty.unwrap(), 0.00012207194233937495);
+    assert_eq!(format!("{:.8}", get_difficulty.unwrap()), "0.00012207");
+
+    // Fake the ChainInfo response: difficulty limit - smallest valid difficulty
+    let pow_limit = ExpandedDifficulty::target_difficulty_limit(Mainnet);
+    let fake_difficulty = pow_limit.into();
+    let mut read_state2 = read_state.clone();
+    let mock_read_state_request_handler = async move {
+        read_state2
+            .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
+            .await
+            .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
+                expected_difficulty: fake_difficulty,
+                tip_height: fake_tip_height,
+                tip_hash: fake_tip_hash,
+                cur_time: fake_cur_time,
+                min_time: fake_min_time,
+                max_time: fake_max_time,
+                history_tree: fake_history_tree(Mainnet),
+            }));
+    };
+
+    let get_difficulty_fut = get_block_template_rpc.get_difficulty();
+    let (get_difficulty, ..) = tokio::join!(get_difficulty_fut, mock_read_state_request_handler,);
+
+    assert_eq!(format!("{}", get_difficulty.unwrap()), "1");
+
+    // Fake the ChainInfo response: fractional difficulty
+    let fake_difficulty = pow_limit * 2 / 3;
+    let mut read_state3 = read_state.clone();
+    let mock_read_state_request_handler = async move {
+        read_state3
+            .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
+            .await
+            .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
+                expected_difficulty: fake_difficulty.into(),
+                tip_height: fake_tip_height,
+                tip_hash: fake_tip_hash,
+                cur_time: fake_cur_time,
+                min_time: fake_min_time,
+                max_time: fake_max_time,
+                history_tree: fake_history_tree(Mainnet),
+            }));
+    };
+
+    let get_difficulty_fut = get_block_template_rpc.get_difficulty();
+    let (get_difficulty, ..) = tokio::join!(get_difficulty_fut, mock_read_state_request_handler,);
+
+    assert_eq!(format!("{:.4}", get_difficulty.unwrap()), "1.5000");
+
+    // Fake the ChainInfo response: large integer difficulty
+    let fake_difficulty = pow_limit / 4096;
+    let mut read_state4 = read_state.clone();
+    let mock_read_state_request_handler = async move {
+        read_state4
+            .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
+            .await
+            .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
+                expected_difficulty: fake_difficulty.into(),
+                tip_height: fake_tip_height,
+                tip_hash: fake_tip_hash,
+                cur_time: fake_cur_time,
+                min_time: fake_min_time,
+                max_time: fake_max_time,
+                history_tree: fake_history_tree(Mainnet),
+            }));
+    };
+
+    let get_difficulty_fut = get_block_template_rpc.get_difficulty();
+    let (get_difficulty, ..) = tokio::join!(get_difficulty_fut, mock_read_state_request_handler,);
+
+    assert_eq!(format!("{:.1}", get_difficulty.unwrap()), "4096.0");
 }


### PR DESCRIPTION
## Motivation

We already have `ExpandedDifficulty` and `Work` types that implement the calculations required for the `getdifficulty` RPC.

### Specifications

https://zcash.github.io/rpc/getdifficulty.html

`ToTarget()` from:
https://zips.z.cash/protocol/protocol.pdf#nbits

### Complex Code or Requirements

We're using floating-point here, so the results from `zcashd` and Zebra will be slightly different.

`zcashd` does `(double)limit.mantissa / (double)bits.mantissa * 256.0^(limit.exponent - bits.exponent)`:
https://github.com/zcash/zcash/blob/7b28054e8b46eb46a9589d0bdc8e29f9fa1dc82d/src/rpc/blockchain.cpp#L46-L73

This PR makes Zebra just divide the first 128 bits, because floats only have 53 bits of accuracy anyway:
```
(expanded_pow_limit >> 128) as u128 as f64 / (expanded_difficulty >> 128) as u128 as f64
```

A previous version of this PR did:
 `(2^256 / (bits.mantissa * 256^bits.exponent)) as f64 /  (2^256 / (limit.mantissa * 256^limit.exponent)) as f64`, which was less accurate due to the integer division:
https://github.com/ZcashFoundation/zebra/blob/d67b3b641d2a9bb5680c91cd3281bddf40670c42/zebra-chain/src/work/difficulty.rs#L314-L329

## Solution

- Divide the first 128 bits to simplify the `getdifficulty` RPC implementation
- Update the tests to ignore small differences, but require 6 significant figures
- Add extra test cases with valid difficulties
- Change all snapshots to use a valid fractional difficulty

## Review

This is a suggestion for PR #6099.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

I added some TODOs to this PR, but we don't need to fix them any time soon. The current code works.