### PR TITLE
fix(state): Fix minute-long delays in block verification after a chain fork

### DIFF
--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -169,8 +169,14 @@ impl ZcashDeserialize for Root {
 ///
 /// Note that it's handled as a byte buffer and not a point coordinate (jubjub::Fq)
 /// because that's how the spec handles the MerkleCRH^Sapling function inputs and outputs.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 struct Node([u8; 32]);
+
+impl fmt::Debug for Node {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Node").field(&hex::encode(self.0)).finish()
+    }
+}
 
 /// Required to convert [`NoteCommitmentTree`] into [`SerializedTree`].
 ///

--- a/zebra-chain/src/sprout/tree.rs
+++ b/zebra-chain/src/sprout/tree.rs
@@ -15,13 +15,13 @@ use std::{fmt, ops::Deref};
 use byteorder::{BigEndian, ByteOrder};
 use incrementalmerkletree::{bridgetree, Frontier};
 use lazy_static::lazy_static;
+use sha2::digest::generic_array::GenericArray;
 use thiserror::Error;
 
 use super::commitment::NoteCommitment;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
-use sha2::digest::generic_array::GenericArray;
 
 /// Sprout note commitment trees have a max depth of 29.
 ///
@@ -127,8 +127,14 @@ impl From<&Root> for [u8; 32] {
 }
 
 /// A node of the Sprout note commitment tree.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 struct Node([u8; 32]);
+
+impl fmt::Debug for Node {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Node").field(&hex::encode(self.0)).finish()
+    }
+}
 
 impl incrementalmerkletree::Hashable for Node {
     /// Returns an empty leaf.

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -281,7 +281,7 @@ impl NonFinalizedState {
         // Clone function arguments for different threads
         let block = contextual.block.clone();
         let network = new_chain.network();
-        let history_tree = new_chain.history_tree_at_tip();
+        let history_tree = new_chain.history_block_commitment_tree();
 
         let block2 = contextual.block.clone();
         let height = contextual.height;

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -481,8 +481,7 @@ impl NonFinalizedState {
                 let fork_chain = self
                     .chain_set
                     .iter()
-                    .find_map(|chain| chain.fork(parent_hash).transpose())
-                    .transpose()?
+                    .find_map(|chain| chain.fork(parent_hash))
                     .ok_or(ValidateContextError::NotReadyToBeCommitted)?;
 
                 Ok(Arc::new(fork_chain))

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -159,7 +159,6 @@ impl NonFinalizedState {
 
         let parent_chain = self.parent_chain(
             parent_hash,
-            finalized_state.sprout_note_commitment_tree(),
             finalized_state.sapling_note_commitment_tree(),
             finalized_state.orchard_note_commitment_tree(),
             finalized_state.history_tree(),
@@ -192,6 +191,9 @@ impl NonFinalizedState {
     ) -> Result<(), ValidateContextError> {
         let chain = Chain::new(
             self.network,
+            finalized_state
+                .finalized_tip_height()
+                .expect("finalized state contains blocks"),
             finalized_state.sprout_note_commitment_tree(),
             finalized_state.sapling_note_commitment_tree(),
             finalized_state.orchard_note_commitment_tree(),
@@ -456,16 +458,12 @@ impl NonFinalizedState {
 
     /// Return the chain whose tip block hash is `parent_hash`.
     ///
-    /// The chain can be an existing chain in the non-finalized state or a freshly
-    /// created fork, if needed.
-    ///
-    /// The trees must be the trees of the finalized tip.
-    /// They are used to recreate the trees if a fork is needed.
+    /// The chain can be an existing chain in the non-finalized state, or a freshly
+    /// created fork.
     #[allow(clippy::unwrap_in_result)]
     fn parent_chain(
         &mut self,
         parent_hash: block::Hash,
-        sprout_note_commitment_tree: Arc<sprout::tree::NoteCommitmentTree>,
         sapling_note_commitment_tree: Arc<sapling::tree::NoteCommitmentTree>,
         orchard_note_commitment_tree: Arc<orchard::tree::NoteCommitmentTree>,
         history_tree: Arc<HistoryTree>,
@@ -484,7 +482,6 @@ impl NonFinalizedState {
                         chain
                             .fork(
                                 parent_hash,
-                                sprout_note_commitment_tree.clone(),
                                 sapling_note_commitment_tree.clone(),
                                 orchard_note_commitment_tree.clone(),
                                 history_tree.clone(),

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -177,6 +177,7 @@ impl NonFinalizedState {
     /// Commit block to the non-finalized state as a new chain where its parent
     /// is the finalized tip.
     #[tracing::instrument(level = "debug", skip(self, finalized_state, prepared))]
+    #[allow(clippy::unwrap_in_result)]
     pub fn commit_new_chain(
         &mut self,
         prepared: PreparedBlock,

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
     history_tree::HistoryTree,
     orchard,
     parameters::Network,
-    sapling, sprout, transparent,
+    sprout, transparent,
 };
 
 use crate::{
@@ -159,7 +159,6 @@ impl NonFinalizedState {
 
         let parent_chain = self.parent_chain(
             parent_hash,
-            finalized_state.sapling_note_commitment_tree(),
             finalized_state.orchard_note_commitment_tree(),
             finalized_state.history_tree(),
         )?;
@@ -443,7 +442,10 @@ impl NonFinalizedState {
 
     /// Returns `true` if the best chain contains `sapling_nullifier`.
     #[cfg(test)]
-    pub fn best_contains_sapling_nullifier(&self, sapling_nullifier: &sapling::Nullifier) -> bool {
+    pub fn best_contains_sapling_nullifier(
+        &self,
+        sapling_nullifier: &zebra_chain::sapling::Nullifier,
+    ) -> bool {
         self.best_chain()
             .map(|best_chain| best_chain.sapling_nullifiers.contains(sapling_nullifier))
             .unwrap_or(false)
@@ -470,7 +472,6 @@ impl NonFinalizedState {
     fn parent_chain(
         &mut self,
         parent_hash: block::Hash,
-        sapling_note_commitment_tree: Arc<sapling::tree::NoteCommitmentTree>,
         orchard_note_commitment_tree: Arc<orchard::tree::NoteCommitmentTree>,
         history_tree: Arc<HistoryTree>,
     ) -> Result<Arc<Chain>, ValidateContextError> {
@@ -488,7 +489,6 @@ impl NonFinalizedState {
                         chain
                             .fork(
                                 parent_hash,
-                                sapling_note_commitment_tree.clone(),
                                 orchard_note_commitment_tree.clone(),
                                 history_tree.clone(),
                             )

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -189,11 +189,17 @@ impl NonFinalizedState {
         prepared: PreparedBlock,
         finalized_state: &ZebraDb,
     ) -> Result<(), ValidateContextError> {
+        let finalized_tip_height = finalized_state.finalized_tip_height();
+
+        // TODO: fix tests that don't initialize the finalized state
+        #[cfg(not(test))]
+        let finalized_tip_height = finalized_tip_height.expect("finalized state contains blocks");
+        #[cfg(test)]
+        let finalized_tip_height = finalized_tip_height.unwrap_or(zebra_chain::block::Height(0));
+
         let chain = Chain::new(
             self.network,
-            finalized_state
-                .finalized_tip_height()
-                .expect("finalized state contains blocks"),
+            finalized_tip_height,
             finalized_state.sprout_note_commitment_tree(),
             finalized_state.sapling_note_commitment_tree(),
             finalized_state.orchard_note_commitment_tree(),

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -327,13 +327,10 @@ impl Chain {
     }
 
     /// Fork and return a chain at the block with the given `fork_tip`, if it is part of this
-    /// chain. Otherwise, if this chain does not contain `fork_tip`, returns `Ok(None)`.
-    ///
-    /// If forking the chain fails, returns `Err(_)`.
-    #[allow(clippy::unwrap_in_result)]
-    pub fn fork(&self, fork_tip: block::Hash) -> Result<Option<Self>, ValidateContextError> {
+    /// chain. Otherwise, if this chain does not contain `fork_tip`, returns `None`.
+    pub fn fork(&self, fork_tip: block::Hash) -> Option<Self> {
         if !self.height_by_hash.contains_key(&fork_tip) {
-            return Ok(None);
+            return None;
         }
 
         let mut forked = self.clone();
@@ -343,7 +340,7 @@ impl Chain {
             forked.pop_tip();
         }
 
-        Ok(Some(forked))
+        Some(forked)
     }
 
     /// Returns the [`Network`] for this chain.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -477,22 +477,24 @@ impl Chain {
 
         // TODO: fix test code that incorrectly overwrites trees
         #[cfg(not(test))]
-        assert_eq!(
-            self.sprout_trees_by_height.insert(height, tree.clone()),
-            None,
-            "incorrect overwrite of sprout tree: trees must be reverted then inserted",
-        );
-        #[cfg(not(test))]
-        assert_eq!(
-            self.sprout_anchors_by_height.insert(height, anchor),
-            None,
-            "incorrect overwrite of sprout anchor: anchors must be reverted then inserted",
-        );
+        {
+            assert_eq!(
+                self.sprout_trees_by_height.insert(height, tree.clone()),
+                None,
+                "incorrect overwrite of sprout tree: trees must be reverted then inserted",
+            );
+            assert_eq!(
+                self.sprout_anchors_by_height.insert(height, anchor),
+                None,
+                "incorrect overwrite of sprout anchor: anchors must be reverted then inserted",
+            );
+        }
 
         #[cfg(test)]
-        self.sprout_trees_by_height.insert(height, tree.clone());
-        #[cfg(test)]
-        self.sprout_anchors_by_height.insert(height, anchor);
+        {
+            self.sprout_trees_by_height.insert(height, tree.clone());
+            self.sprout_anchors_by_height.insert(height, anchor);
+        }
 
         // Multiple inserts are expected here,
         // because the anchors only change if a block has shielded transactions.
@@ -587,22 +589,24 @@ impl Chain {
 
         // TODO: fix test code that incorrectly overwrites trees
         #[cfg(not(test))]
-        assert_eq!(
-            self.sapling_trees_by_height.insert(height, tree),
-            None,
-            "incorrect overwrite of sapling tree: trees must be reverted then inserted",
-        );
-        #[cfg(not(test))]
-        assert_eq!(
-            self.sapling_anchors_by_height.insert(height, anchor),
-            None,
-            "incorrect overwrite of sapling anchor: anchors must be reverted then inserted",
-        );
+        {
+            assert_eq!(
+                self.sapling_trees_by_height.insert(height, tree),
+                None,
+                "incorrect overwrite of sapling tree: trees must be reverted then inserted",
+            );
+            assert_eq!(
+                self.sapling_anchors_by_height.insert(height, anchor),
+                None,
+                "incorrect overwrite of sapling anchor: anchors must be reverted then inserted",
+            );
+        }
 
         #[cfg(test)]
-        self.sapling_trees_by_height.insert(height, tree);
-        #[cfg(test)]
-        self.sapling_anchors_by_height.insert(height, anchor);
+        {
+            self.sapling_trees_by_height.insert(height, tree);
+            self.sapling_anchors_by_height.insert(height, anchor);
+        }
 
         // Multiple inserts are expected here,
         // because the anchors only change if a block has shielded transactions.
@@ -699,22 +703,24 @@ impl Chain {
 
         // TODO: fix test code that incorrectly overwrites trees
         #[cfg(not(test))]
-        assert_eq!(
-            self.orchard_trees_by_height.insert(height, tree),
-            None,
-            "incorrect overwrite of orchard tree: trees must be reverted then inserted",
-        );
-        #[cfg(not(test))]
-        assert_eq!(
-            self.orchard_anchors_by_height.insert(height, anchor),
-            None,
-            "incorrect overwrite of orchard anchor: anchors must be reverted then inserted",
-        );
+        {
+            assert_eq!(
+                self.orchard_trees_by_height.insert(height, tree),
+                None,
+                "incorrect overwrite of orchard tree: trees must be reverted then inserted",
+            );
+            assert_eq!(
+                self.orchard_anchors_by_height.insert(height, anchor),
+                None,
+                "incorrect overwrite of orchard anchor: anchors must be reverted then inserted",
+            );
+        }
 
         #[cfg(test)]
-        self.orchard_trees_by_height.insert(height, tree);
-        #[cfg(test)]
-        self.orchard_anchors_by_height.insert(height, anchor);
+        {
+            self.orchard_trees_by_height.insert(height, tree);
+            self.orchard_anchors_by_height.insert(height, anchor);
+        }
 
         // Multiple inserts are expected here,
         // because the anchors only change if a block has shielded transactions.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -776,7 +776,7 @@ impl Chain {
     /// # Panics
     ///
     /// If this chain has no history trees. (This should be impossible.)
-    pub fn history_tree_at_tip(&self) -> Arc<HistoryTree> {
+    pub fn history_block_commitment_tree(&self) -> Arc<HistoryTree> {
         self.history_trees_by_height
             .last_key_value()
             .expect("only called while history_trees_by_height is populated")
@@ -1121,7 +1121,7 @@ impl Chain {
         let orchard_root = self.orchard_note_commitment_tree().root();
 
         // TODO: update the history trees in a rayon thread, if they show up in CPU profiles
-        let mut history_tree = self.history_tree_at_tip();
+        let mut history_tree = self.history_block_commitment_tree();
         let history_tree_mut = Arc::make_mut(&mut history_tree);
         history_tree_mut
             .push(

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -1639,11 +1639,9 @@ impl UpdateWith<Option<transaction::JoinSplitData<Groth16Proof>>> for Chain {
         _position: RevertPosition,
     ) {
         if let Some(joinsplit_data) = joinsplit_data {
-            // Note commitments are not removed from the Chain during a fork,
-            // because we don't support that operation yet. Instead, we
-            // recreate the tree from the finalized tip in Chain::fork().
-            //
-            // TODO: remove trees and anchors above the fork, to save CPU time (#4794)
+            // Note commitments are removed from the Chain during a fork,
+            // by removing trees above the fork height from the note commitment index.
+            // This happens when reverting the block itself.
 
             check::nullifier::remove_from_non_finalized_chain(
                 &mut self.sprout_nullifiers,
@@ -1685,11 +1683,9 @@ where
         _position: RevertPosition,
     ) {
         if let Some(sapling_shielded_data) = sapling_shielded_data {
-            // Note commitments are not removed from the Chain during a fork,
-            // because we don't support that operation yet. Instead, we
-            // recreate the tree from the finalized tip in Chain::fork().
-            //
-            // TODO: remove trees and anchors above the fork, to save CPU time (#4794)
+            // Note commitments are removed from the Chain during a fork,
+            // by removing trees above the fork height from the note commitment index.
+            // This happens when reverting the block itself.
 
             check::nullifier::remove_from_non_finalized_chain(
                 &mut self.sapling_nullifiers,
@@ -1728,11 +1724,9 @@ impl UpdateWith<Option<orchard::ShieldedData>> for Chain {
         _position: RevertPosition,
     ) {
         if let Some(orchard_shielded_data) = orchard_shielded_data {
-            // Note commitments are not removed from the Chain during a fork,
-            // because we don't support that operation yet. Instead, we
-            // recreate the tree from the finalized tip in Chain::fork().
-            //
-            // TODO: remove trees and anchors above the fork, to save CPU time (#4794)
+            // Note commitments are removed from the Chain during a fork,
+            // by removing trees above the fork height from the note commitment index.
+            // This happens when reverting the block itself.
 
             check::nullifier::remove_from_non_finalized_chain(
                 &mut self.orchard_nullifiers,

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -40,10 +40,15 @@ pub mod index;
 
 #[derive(Debug, Clone)]
 pub struct Chain {
-    // The function `eq_internal_state` must be updated every time a field is added to [`Chain`].
+    // Note: `eq_internal_state()` must be updated every time a field is added to [`Chain`].
+
+    // Config
+    //
     /// The configured network for this chain.
     network: Network,
 
+    // Blocks, heights, hashes, and transaction locations
+    //
     /// The contextually valid blocks which form this non-finalized partial chain, in height order.
     pub(crate) blocks: BTreeMap<block::Height, ContextuallyValidBlock>,
 
@@ -53,6 +58,8 @@ pub struct Chain {
     /// An index of [`TransactionLocation`]s for each transaction hash in `blocks`.
     pub tx_loc_by_hash: HashMap<transaction::Hash, TransactionLocation>,
 
+    // Transparent outputs and spends
+    //
     /// The [`transparent::Utxo`]s created by `blocks`.
     ///
     /// Note that these UTXOs may not be unspent.
@@ -64,6 +71,8 @@ pub struct Chain {
     /// including those created by earlier transactions or blocks in the chain.
     pub(crate) spent_utxos: HashSet<transparent::OutPoint>,
 
+    // Note commitment trees
+    //
     /// The Sprout note commitment tree of the tip of this [`Chain`],
     /// including all finalized notes, and the non-finalized notes in this chain.
     pub(super) sprout_note_commitment_tree: Arc<sprout::tree::NoteCommitmentTree>,
@@ -74,36 +83,47 @@ pub struct Chain {
     /// The Sprout note commitment tree for each height.
     pub(crate) sprout_trees_by_height:
         BTreeMap<block::Height, Arc<sprout::tree::NoteCommitmentTree>>,
+
     /// The Sapling note commitment tree of the tip of this [`Chain`],
     /// including all finalized notes, and the non-finalized notes in this chain.
     pub(super) sapling_note_commitment_tree: Arc<sapling::tree::NoteCommitmentTree>,
     /// The Sapling note commitment tree for each height.
     pub(crate) sapling_trees_by_height:
         BTreeMap<block::Height, Arc<sapling::tree::NoteCommitmentTree>>,
+
     /// The Orchard note commitment tree of the tip of this [`Chain`],
     /// including all finalized notes, and the non-finalized notes in this chain.
     pub(super) orchard_note_commitment_tree: Arc<orchard::tree::NoteCommitmentTree>,
     /// The Orchard note commitment tree for each height.
     pub(crate) orchard_trees_by_height:
         BTreeMap<block::Height, Arc<orchard::tree::NoteCommitmentTree>>,
+
+    // History trees
+    //
     /// The ZIP-221 history tree of the tip of this [`Chain`],
     /// including all finalized blocks, and the non-finalized `blocks` in this chain.
     pub(crate) history_tree: Arc<HistoryTree>,
     pub(crate) history_trees_by_height: BTreeMap<block::Height, Arc<HistoryTree>>,
 
+    // Anchors
+    //
     /// The Sprout anchors created by `blocks`.
     pub(crate) sprout_anchors: MultiSet<sprout::tree::Root>,
     /// The Sprout anchors created by each block in `blocks`.
     pub(crate) sprout_anchors_by_height: BTreeMap<block::Height, sprout::tree::Root>,
+
     /// The Sapling anchors created by `blocks`.
     pub(crate) sapling_anchors: MultiSet<sapling::tree::Root>,
     /// The Sapling anchors created by each block in `blocks`.
     pub(crate) sapling_anchors_by_height: BTreeMap<block::Height, sapling::tree::Root>,
+
     /// The Orchard anchors created by `blocks`.
     pub(crate) orchard_anchors: MultiSet<orchard::tree::Root>,
     /// The Orchard anchors created by each block in `blocks`.
     pub(crate) orchard_anchors_by_height: BTreeMap<block::Height, orchard::tree::Root>,
 
+    // Nullifiers
+    //
     /// The Sprout nullifiers revealed by `blocks`.
     pub(crate) sprout_nullifiers: HashSet<sprout::Nullifier>,
     /// The Sapling nullifiers revealed by `blocks`.
@@ -111,9 +131,14 @@ pub struct Chain {
     /// The Orchard nullifiers revealed by `blocks`.
     pub(crate) orchard_nullifiers: HashSet<orchard::Nullifier>,
 
+    // Transparent Transfers
+    // TODO: move to the transparent section
+    //
     /// Partial transparent address index data from `blocks`.
     pub(super) partial_transparent_transfers: HashMap<transparent::Address, TransparentTransfers>,
 
+    // Chain Work
+    //
     /// The cumulative work represented by `blocks`.
     ///
     /// Since the best chain is determined by the largest cumulative work,
@@ -121,6 +146,8 @@ pub struct Chain {
     /// because they are common to all non-finalized chains.
     pub(super) partial_cumulative_work: PartialCumulativeWork,
 
+    // Chain Pools
+    //
     /// The chain value pool balances of the tip of this [`Chain`],
     /// including the block value pool changes from all finalized blocks,
     /// and the non-finalized blocks in this chain.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -1159,6 +1159,7 @@ impl UpdateWith<ContextuallyValidBlock> for Chain {
             "hash must be present if block was added to chain"
         );
 
+        // TODO: move this to a Work or block header UpdateWith.revert...()?
         // remove work from partial_cumulative_work
         let block_work = block
             .header
@@ -1167,12 +1168,7 @@ impl UpdateWith<ContextuallyValidBlock> for Chain {
             .expect("work has already been validated");
         self.partial_cumulative_work -= block_work;
 
-        // Note: the history tree is not modified in this method.
-        // This method is called on two scenarios:
-        // - When popping the root: the history tree does not change.
-        // - When popping the tip: the history tree is rebuilt in fork().
-        //
-        // However, `history_trees_by_height` is reverted.
+        // TODO: move this to the history tree UpdateWith.revert...()?
         self.history_trees_by_height
             .remove(&height)
             .expect("History tree must be present if block was added to chain");
@@ -1220,6 +1216,7 @@ impl UpdateWith<ContextuallyValidBlock> for Chain {
             // reset the utxos this consumed
             self.revert_chain_with(&(inputs, transaction_hash, spent_outputs), position);
 
+            // TODO: move this to the history tree UpdateWith.revert...()?
             // remove `transaction.hash` from `tx_loc_by_hash`
             assert!(
                 self.tx_loc_by_hash.remove(transaction_hash).is_some(),
@@ -1233,6 +1230,7 @@ impl UpdateWith<ContextuallyValidBlock> for Chain {
             self.revert_chain_with(orchard_shielded_data, position);
         }
 
+        // TODO: move these to the shielded UpdateWith.revert...()
         let anchor = self
             .sprout_anchors_by_height
             .remove(&height)

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -618,10 +618,12 @@ impl Chain {
         // transaction are the anchor treestates of this block.
         //
         // Use the previously cached root which was calculated in parallel.
-        let sprout_root = tree.root();
-        self.sprout_anchors.insert(sprout_root);
-        self.sprout_anchors_by_height.insert(height, sprout_root);
-        self.sprout_trees_by_anchor.insert(sprout_root, tree);
+        let anchor = tree.root();
+        trace!(?height, ?anchor, "adding sprout tree");
+
+        self.sprout_anchors.insert(anchor);
+        self.sprout_anchors_by_height.insert(height, anchor);
+        self.sprout_trees_by_anchor.insert(anchor, tree);
     }
 
     /// Returns the Sapling
@@ -1304,6 +1306,9 @@ impl UpdateWith<ContextuallyValidBlock> for Chain {
                 .sprout_anchors_by_height
                 .remove(height)
                 .expect("Sprout anchor must be present if block was added to chain");
+
+            trace!(?height, ?position, ?anchor, "removing sprout tree");
+
             assert!(
                 self.sprout_anchors.remove(&anchor),
                 "Sprout anchor must be present if block was added to chain"

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -360,7 +360,12 @@ fn finalized_equals_pushed_genesis() -> Result<()> {
         }
 
         prop_assert_eq!(full_chain.blocks.len(), partial_chain.blocks.len());
-        prop_assert!(full_chain.eq_internal_state(&partial_chain));
+        prop_assert!(
+            full_chain.eq_internal_state(&partial_chain),
+            "\n\
+             full chain:\n{full_chain:#?}\n\n\
+             partial chain:\n{partial_chain:#?}\n",
+        );
     });
 
     Ok(())
@@ -432,7 +437,12 @@ fn finalized_equals_pushed_history_tree() -> Result<()> {
         }
 
         prop_assert_eq!(full_chain.blocks.len(), partial_chain.blocks.len());
-        prop_assert!(full_chain.eq_internal_state(&partial_chain));
+        prop_assert!(
+            full_chain.eq_internal_state(&partial_chain),
+            "\n\
+             full chain:\n{full_chain:#?}\n\n\
+             partial chain:\n{partial_chain:#?}\n",
+        );
     });
 
     Ok(())

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -204,7 +204,6 @@ fn forked_equals_pushed_genesis() -> Result<()> {
         let mut forked = full_chain
             .fork(
                 fork_tip_hash,
-                Default::default(),
                 empty_tree,
             )
             .expect("fork works")
@@ -274,7 +273,6 @@ fn forked_equals_pushed_history_tree() -> Result<()> {
         let mut forked = full_chain
             .fork(
                 fork_tip_hash,
-                Default::default(),
                 finalized_tree,
             )
             .expect("fork works")
@@ -338,7 +336,7 @@ fn finalized_equals_pushed_genesis() -> Result<()> {
             full_chain.non_finalized_tip_height(),
             full_chain.sprout_note_commitment_tree(),
             full_chain.sapling_note_commitment_tree(),
-            full_chain.orchard_note_commitment_tree.clone(),
+            full_chain.orchard_note_commitment_tree(),
             full_chain.history_tree.clone(),
             full_chain.chain_value_pools,
         );
@@ -418,7 +416,7 @@ fn finalized_equals_pushed_history_tree() -> Result<()> {
             Height(finalized_count.try_into().unwrap()),
             full_chain.sprout_note_commitment_tree(),
             full_chain.sapling_note_commitment_tree(),
-            full_chain.orchard_note_commitment_tree.clone(),
+            full_chain.orchard_note_commitment_tree(),
             full_chain.history_tree.clone(),
             full_chain.chain_value_pools,
         );
@@ -632,7 +630,6 @@ fn different_blocks_different_chains() -> Result<()> {
                 chain1.sprout_trees_by_anchor = chain2.sprout_trees_by_anchor.clone();
                 chain1.sprout_trees_by_height = chain2.sprout_trees_by_height.clone();
                 chain1.sapling_trees_by_height = chain2.sapling_trees_by_height.clone();
-                chain1.orchard_note_commitment_tree = chain2.orchard_note_commitment_tree.clone();
                 chain1.orchard_trees_by_height = chain2.orchard_trees_by_height.clone();
 
                 // history trees

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -329,7 +329,7 @@ fn finalized_equals_pushed_genesis() -> Result<()> {
             full_chain.sprout_note_commitment_tree(),
             full_chain.sapling_note_commitment_tree(),
             full_chain.orchard_note_commitment_tree(),
-            full_chain.history_tree_at_tip(),
+            full_chain.history_block_commitment_tree(),
             full_chain.chain_value_pools,
         );
         for block in chain
@@ -409,7 +409,7 @@ fn finalized_equals_pushed_history_tree() -> Result<()> {
             full_chain.sprout_note_commitment_tree(),
             full_chain.sapling_note_commitment_tree(),
             full_chain.orchard_note_commitment_tree(),
-            full_chain.history_tree_at_tip(),
+            full_chain.history_block_commitment_tree(),
             full_chain.chain_value_pools,
         );
 

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -167,7 +167,7 @@ fn forked_equals_pushed_genesis() -> Result<()> {
             Default::default(),
             Default::default(),
             Default::default(),
-            empty_tree.clone(),
+            empty_tree,
             ValueBalance::zero(),
         );
         for block in chain.iter().cloned() {
@@ -202,10 +202,7 @@ fn forked_equals_pushed_genesis() -> Result<()> {
 
         // Fork the chain.
         let mut forked = full_chain
-            .fork(
-                fork_tip_hash,
-                empty_tree,
-            )
+            .fork(fork_tip_hash)
             .expect("fork works")
             .expect("hash is present");
 
@@ -255,7 +252,7 @@ fn forked_equals_pushed_history_tree() -> Result<()> {
         let fork_tip_hash = chain[fork_at_count - 1].hash;
 
         let mut full_chain = Chain::new(network, Height(0), Default::default(), Default::default(), Default::default(), finalized_tree.clone(), ValueBalance::zero());
-        let mut partial_chain = Chain::new(network, Height(0), Default::default(), Default::default(), Default::default(), finalized_tree.clone(), ValueBalance::zero());
+        let mut partial_chain = Chain::new(network, Height(0), Default::default(), Default::default(), Default::default(), finalized_tree, ValueBalance::zero());
 
         for block in chain
             .iter()
@@ -271,10 +268,7 @@ fn forked_equals_pushed_history_tree() -> Result<()> {
             }
 
         let mut forked = full_chain
-            .fork(
-                fork_tip_hash,
-                finalized_tree,
-            )
+            .fork(fork_tip_hash)
             .expect("fork works")
             .expect("hash is present");
 
@@ -337,7 +331,7 @@ fn finalized_equals_pushed_genesis() -> Result<()> {
             full_chain.sprout_note_commitment_tree(),
             full_chain.sapling_note_commitment_tree(),
             full_chain.orchard_note_commitment_tree(),
-            full_chain.history_tree.clone(),
+            full_chain.history_tree_at_tip(),
             full_chain.chain_value_pools,
         );
         for block in chain
@@ -417,7 +411,7 @@ fn finalized_equals_pushed_history_tree() -> Result<()> {
             full_chain.sprout_note_commitment_tree(),
             full_chain.sapling_note_commitment_tree(),
             full_chain.orchard_note_commitment_tree(),
-            full_chain.history_tree.clone(),
+            full_chain.history_tree_at_tip(),
             full_chain.chain_value_pools,
         );
 
@@ -633,7 +627,6 @@ fn different_blocks_different_chains() -> Result<()> {
                 chain1.orchard_trees_by_height = chain2.orchard_trees_by_height.clone();
 
                 // history trees
-                chain1.history_tree = chain2.history_tree.clone();
                 chain1.history_trees_by_height = chain2.history_trees_by_height.clone();
 
                 // anchors

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -203,7 +203,6 @@ fn forked_equals_pushed_genesis() -> Result<()> {
         // Fork the chain.
         let mut forked = full_chain
             .fork(fork_tip_hash)
-            .expect("fork works")
             .expect("hash is present");
 
         // This check is redundant, but it's useful for debugging.
@@ -269,7 +268,6 @@ fn forked_equals_pushed_history_tree() -> Result<()> {
 
         let mut forked = full_chain
             .fork(fork_tip_hash)
-            .expect("fork works")
             .expect("hash is present");
 
         // the first check is redundant, but it's useful for debugging

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -205,7 +205,6 @@ fn forked_equals_pushed_genesis() -> Result<()> {
             .fork(
                 fork_tip_hash,
                 Default::default(),
-                Default::default(),
                 empty_tree,
             )
             .expect("fork works")
@@ -276,7 +275,6 @@ fn forked_equals_pushed_history_tree() -> Result<()> {
             .fork(
                 fork_tip_hash,
                 Default::default(),
-                Default::default(),
                 finalized_tree,
             )
             .expect("fork works")
@@ -339,7 +337,7 @@ fn finalized_equals_pushed_genesis() -> Result<()> {
             network,
             full_chain.non_finalized_tip_height(),
             full_chain.sprout_note_commitment_tree(),
-            full_chain.sapling_note_commitment_tree.clone(),
+            full_chain.sapling_note_commitment_tree(),
             full_chain.orchard_note_commitment_tree.clone(),
             full_chain.history_tree.clone(),
             full_chain.chain_value_pools,
@@ -419,7 +417,7 @@ fn finalized_equals_pushed_history_tree() -> Result<()> {
             network,
             Height(finalized_count.try_into().unwrap()),
             full_chain.sprout_note_commitment_tree(),
-            full_chain.sapling_note_commitment_tree.clone(),
+            full_chain.sapling_note_commitment_tree(),
             full_chain.orchard_note_commitment_tree.clone(),
             full_chain.history_tree.clone(),
             full_chain.chain_value_pools,
@@ -633,7 +631,6 @@ fn different_blocks_different_chains() -> Result<()> {
                 // note commitment trees
                 chain1.sprout_trees_by_anchor = chain2.sprout_trees_by_anchor.clone();
                 chain1.sprout_trees_by_height = chain2.sprout_trees_by_height.clone();
-                chain1.sapling_note_commitment_tree = chain2.sapling_note_commitment_tree.clone();
                 chain1.sapling_trees_by_height = chain2.sapling_trees_by_height.clone();
                 chain1.orchard_note_commitment_tree = chain2.orchard_note_commitment_tree.clone();
                 chain1.orchard_trees_by_height = chain2.orchard_trees_by_height.clone();

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use zebra_chain::{
     amount::NonNegative,
-    block::Block,
+    block::{Block, Height},
     history_tree::NonEmptyHistoryTree,
     parameters::{Network, NetworkUpgrade},
     serialization::ZcashDeserializeInto,
@@ -27,6 +27,7 @@ fn construct_empty() {
     let _init_guard = zebra_test::init();
     let _chain = Chain::new(
         Network::Mainnet,
+        Height(0),
         Default::default(),
         Default::default(),
         Default::default(),
@@ -43,6 +44,7 @@ fn construct_single() -> Result<()> {
 
     let mut chain = Chain::new(
         Network::Mainnet,
+        Height(0),
         Default::default(),
         Default::default(),
         Default::default(),
@@ -73,6 +75,7 @@ fn construct_many() -> Result<()> {
 
     let mut chain = Chain::new(
         Network::Mainnet,
+        Height(block.coinbase_height().unwrap().0 - 1),
         Default::default(),
         Default::default(),
         Default::default(),
@@ -99,6 +102,7 @@ fn ord_matches_work() -> Result<()> {
 
     let mut lesser_chain = Chain::new(
         Network::Mainnet,
+        Height(0),
         Default::default(),
         Default::default(),
         Default::default(),
@@ -109,6 +113,7 @@ fn ord_matches_work() -> Result<()> {
 
     let mut bigger_chain = Chain::new(
         Network::Mainnet,
+        Height(0),
         Default::default(),
         Default::default(),
         Default::default(),

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -471,7 +471,7 @@ fn history_tree_is_updated_for_network_upgrade(
     let tree = NonEmptyHistoryTree::from_block(
         Network::Mainnet,
         activation_block.clone(),
-        &chain.sapling_note_commitment_tree.root(),
+        &chain.sapling_note_commitment_tree().root(),
         &chain.orchard_note_commitment_tree.root(),
     )
     .unwrap();
@@ -546,7 +546,7 @@ fn commitment_is_validated_for_network_upgrade(network: Network, network_upgrade
     let tree = NonEmptyHistoryTree::from_block(
         Network::Mainnet,
         activation_block.clone(),
-        &chain.sapling_note_commitment_tree.root(),
+        &chain.sapling_note_commitment_tree().root(),
         &chain.orchard_note_commitment_tree.root(),
     )
     .unwrap();

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -439,12 +439,12 @@ fn history_tree_is_updated_for_network_upgrade(
     let chain = state.best_chain().unwrap();
     if network_upgrade == NetworkUpgrade::Heartwood {
         assert!(
-            chain.history_tree.as_ref().is_none(),
+            chain.history_tree_at_tip().as_ref().is_none(),
             "history tree must not exist yet"
         );
     } else {
         assert!(
-            chain.history_tree.as_ref().is_some(),
+            chain.history_tree_at_tip().as_ref().is_some(),
             "history tree must already exist"
         );
     }
@@ -458,11 +458,16 @@ fn history_tree_is_updated_for_network_upgrade(
 
     let chain = state.best_chain().unwrap();
     assert!(
-        chain.history_tree.as_ref().is_some(),
+        chain.history_tree_at_tip().as_ref().is_some(),
         "history tree must have been (re)created"
     );
     assert_eq!(
-        chain.history_tree.as_ref().as_ref().unwrap().size(),
+        chain
+            .history_tree_at_tip()
+            .as_ref()
+            .as_ref()
+            .unwrap()
+            .size(),
         1,
         "history tree must have a single node"
     );
@@ -485,7 +490,12 @@ fn history_tree_is_updated_for_network_upgrade(
         .unwrap();
 
     assert!(
-        state.best_chain().unwrap().history_tree.as_ref().is_some(),
+        state
+            .best_chain()
+            .unwrap()
+            .history_tree_at_tip()
+            .as_ref()
+            .is_some(),
         "history tree must still exist"
     );
 

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -439,12 +439,12 @@ fn history_tree_is_updated_for_network_upgrade(
     let chain = state.best_chain().unwrap();
     if network_upgrade == NetworkUpgrade::Heartwood {
         assert!(
-            chain.history_tree_at_tip().as_ref().is_none(),
+            chain.history_block_commitment_tree().as_ref().is_none(),
             "history tree must not exist yet"
         );
     } else {
         assert!(
-            chain.history_tree_at_tip().as_ref().is_some(),
+            chain.history_block_commitment_tree().as_ref().is_some(),
             "history tree must already exist"
         );
     }
@@ -458,12 +458,12 @@ fn history_tree_is_updated_for_network_upgrade(
 
     let chain = state.best_chain().unwrap();
     assert!(
-        chain.history_tree_at_tip().as_ref().is_some(),
+        chain.history_block_commitment_tree().as_ref().is_some(),
         "history tree must have been (re)created"
     );
     assert_eq!(
         chain
-            .history_tree_at_tip()
+            .history_block_commitment_tree()
             .as_ref()
             .as_ref()
             .unwrap()
@@ -493,7 +493,7 @@ fn history_tree_is_updated_for_network_upgrade(
         state
             .best_chain()
             .unwrap()
-            .history_tree_at_tip()
+            .history_block_commitment_tree()
             .as_ref()
             .is_some(),
         "history tree must still exist"

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -472,7 +472,7 @@ fn history_tree_is_updated_for_network_upgrade(
         Network::Mainnet,
         activation_block.clone(),
         &chain.sapling_note_commitment_tree().root(),
-        &chain.orchard_note_commitment_tree.root(),
+        &chain.orchard_note_commitment_tree().root(),
     )
     .unwrap();
 
@@ -547,7 +547,7 @@ fn commitment_is_validated_for_network_upgrade(network: Network, network_upgrade
         Network::Mainnet,
         activation_block.clone(),
         &chain.sapling_note_commitment_tree().root(),
-        &chain.orchard_note_commitment_tree.root(),
+        &chain.orchard_note_commitment_tree().root(),
     )
     .unwrap();
 


### PR DESCRIPTION
## Motivation

Zebra can take multiple minutes to rebuild note commitment trees after a chain fork in the non-finalized chain. This also delays mining template updates and verifying mined blocks.

It only impacts mainnet at the moment, it is caused by a large number of shielded transactions in blocks.

Closes #4794.

### Specifications

This is a data structure and processing refactor. The consensus rule checks don't change, but we need to correctly store data so that we implement the consensus rules correctly.

### Complex Code or Requirements

This PR deletes a lot of complex code.

It temporarily stores the finalized tip trees and anchors in the tree indexes at the finalized tip height. These temporary entries are deleted when the first root block in the chain is finalized.

## Solution

- Replace sprout, sapling, orchard, and history tree fields with lookup methods
- Remove unused tree rebuild code
- Replace a custom clone function with `derive(Clone)`
- Remove unused arguments

Related changes:
- Refactor tree and anchor addition and removal functions
- Print sprout and sapling tree Nodes as hex when debugging
- Show full debug info when tests fail because chains aren't equal

### Testing

We already have good test coverage for this code. I am also running a partial and full sync locally on both mainnet and testnet.

## Review

There is an initial refactor to get the height indexes working in 98dfa875d429a05c27bb83ea1f0b929153b48eb6.
Then this PR repeats similar changes for sprout, sapling, and orchard. The best example is probably commit 3b0abd49130b715d535811f105cceb45beb1b474.
The history tree change is slightly different, it's commit 09e514891820dcf1fb7df767dcf793f5a556f50f.

This is a blocker for mining pools on mainnet, so it is a routine bug fix.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We could do further refactors, but this seemed like enough for now.