### PR TITLE
fix(state): Corrects panic/timer messages in state request

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1605,12 +1605,19 @@ impl Service<ReadRequest> for ReadStateService {
                         )?;
 
                         // The work is done in the future.
-                        timer.finish(module_path!(), line!(), "ReadRequest::UnspentBestChainUtxo");
+                        timer.finish(
+                            module_path!(),
+                            line!(),
+                            "ReadRequest::CheckBestChainTipNullifiersAndAnchors",
+                        );
 
                         Ok(ReadResponse::ValidBestChainTipNullifiersAndAnchors)
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::UnspentBestChainUtxo"))
+                .map(|join_result| {
+                    join_result
+                        .expect("panic in ReadRequest::CheckBestChainTipNullifiersAndAnchors")
+                })
                 .boxed()
             }
 


### PR DESCRIPTION
## Motivation

The messages were for the wrong state request, it could be confusing when debugging.

## Solution

- Updates incorrect panic/timer messages in `CheckBestChainTipNullifiersAndAnchors` request

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
