### PR TITLE
cleanup(consensus): Remove unused `impl ZcashDeserialize for Height`

### DIFF
--- a/zebra-chain/src/block/height.rs
+++ b/zebra-chain/src/block/height.rs
@@ -1,14 +1,8 @@
 //! Block height.
 
-use crate::serialization::{SerializationError, ZcashDeserialize};
+use std::ops::{Add, Sub};
 
-use byteorder::{LittleEndian, ReadBytesExt};
-
-use std::{
-    convert::TryFrom,
-    io,
-    ops::{Add, Sub},
-};
+use crate::serialization::SerializationError;
 
 /// The length of the chain back to the genesis block.
 ///
@@ -19,6 +13,11 @@ use std::{
 /// # Invariants
 ///
 /// Users should not construct block heights greater than `Height::MAX`.
+///
+/// # Consensus
+///
+/// There are multiple formats for serializing a height, so we don't implement
+/// `ZcashSerialize` or `ZcashDeserialize` for `Height`.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Height(pub u32);
 
@@ -129,18 +128,6 @@ impl Sub<i32> for Height {
             h if (Height(h) <= Height::MAX && Height(h) >= Height::MIN) => Some(Height(h)),
             _ => None,
         }
-    }
-}
-
-impl ZcashDeserialize for Height {
-    fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let height = reader.read_u32::<LittleEndian>()?;
-
-        if height > Self::MAX.0 {
-            return Err(SerializationError::Parse("Height exceeds maximum height"));
-        }
-
-        Ok(Self(height))
     }
 }
 


### PR DESCRIPTION
## Motivation

There are two different ways to serialize heights in Zcash, so we should use the existing named methods for that.

Having an unused `impl ZcashDeserialize for Height` risks us using it in the wrong context, or it could become outdated.

### Specifications

Heights can be serialized as a coinbase script, or as a signed or unsigned 32-bit integer.

## Review

This is a low priority consensus rule cleanup.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

