### PR TITLE
fix(mempool): Re-verify transactions that were verified at a different tip height

### DIFF
--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -382,7 +382,7 @@ impl Service<Request> for Mempool {
                         //
                         // It's okay to use tip height here instead of the tip hash since
                         // chain_tip_change.last_tip_change() returns a `TipAction::Reset` when
-                        // the previous block hash doesn't match the `last_change_hash` and the
+                        // the best chain changes (which is the only way to stay at the same height), and the
                         // mempool re-verifies all pending tx_downloads when there's a `TipAction::Reset`.
                         if best_tip_height == Some(expected_tip_height) {
                             let insert_result = storage.insert(tx.clone());

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -446,6 +446,11 @@ impl Service<Request> for Mempool {
             }
         }
 
+        // TODO: Move the above into a loop, check that the tip action hasn't changed before returning
+        //       and leave a note about correctness for using tip_height instead of tip_hash
+        //       to check that pending verifications
+        //       are still valid .
+
         Poll::Ready(Ok(()))
     }
 

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -384,7 +384,7 @@ impl Service<Request> for Mempool {
                         // chain_tip_change.last_tip_change() returns a `TipAction::Reset` when
                         // the best chain changes (which is the only way to stay at the same height), and the
                         // mempool re-verifies all pending tx_downloads when there's a `TipAction::Reset`.
-                        if best_tip_height == Some(expected_tip_height) {
+                        if best_tip_height == expected_tip_height {
                             let insert_result = storage.insert(tx.clone());
 
                             tracing::trace!(
@@ -453,8 +453,6 @@ impl Service<Request> for Mempool {
                 self.transaction_sender.send(send_to_peers_ids)?;
             }
         }
-
-        // TODO: Move the above into a loop, check that the tip action hasn't changed before returning
 
         Poll::Ready(Ok(()))
     }

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -838,20 +838,13 @@ async fn mempool_reverifies_after_tip_change() -> Result<(), Report> {
         .await
         .unwrap();
 
-    // Wait for the chain tip update
-    if let Err(timeout_error) = timeout(
-        CHAIN_TIP_UPDATE_WAIT_LIMIT,
-        chain_tip_change.wait_for_tip_change(),
-    )
-    .await
-    .map(|change_result| change_result.expect("unexpected chain tip update failure"))
-    {
-        info!(
-            timeout = ?humantime_seconds(CHAIN_TIP_UPDATE_WAIT_LIMIT),
-            ?timeout_error,
-            "timeout waiting for chain tip change after committing block"
-        );
-    }
+    // Wait for the chain tip update without a timeout
+    // (skipping the chain tip change here may cause the test to 
+    // pass without reverifying transactions for  `TipAction::Grow`)
+    chain_tip_change
+        .wait_for_tip_change()
+        .await
+        .expect("unexpected chain tip update failure");
 
     // Queue transaction from block 3 for download
     let tx = block3.transactions[0].clone();

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -839,7 +839,7 @@ async fn mempool_reverifies_after_tip_change() -> Result<(), Report> {
         .unwrap();
 
     // Wait for the chain tip update without a timeout
-    // (skipping the chain tip change here may cause the test to 
+    // (skipping the chain tip change here may cause the test to
     // pass without reverifying transactions for  `TipAction::Grow`)
     chain_tip_change
         .wait_for_tip_change()


### PR DESCRIPTION
## Motivation

We want to ensure that transactions in the mempool will be valid in the next block at the end of `poll_ready()`.

Closes #6132 (it's hard to be entirely certain that this bug caused that failure but I don't see what else could've caused it.)

## Solution

- Returns the tip height at which a mempool transaction is verified
- Checks that the tip height hasn't changed before inserting the verified transaction into the mempool

## Review

Anyone can review, we may want 2 reviewers for the concurrency.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- See #6173