### PR TITLE
fix(consensus): Check that Zebra's state contains the social consensus chain on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Zebra are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Zebra 1.0.0-rc.5](https://github.com/ZcashFoundation/zebra/releases/tag/v1.0.0-rc.5) - 2023-02-TODO INSERT DATE HERE
+
+In this release we ... (TODO)
+We also check that Zebra is following the consensus chain each time it starts up.
+
+### Security
+- Check that Zebra's state contains the consensus chain each time it starts up. This implements
+  the "settled network upgrade" consensus rule using all of Zebra's checkpoints ([#6163](https://github.com/ZcashFoundation/zebra/pull/6163)).
+  *User action required:*
+  - If your config is based on an old version of Zebra, or you have manually edited it,
+    make sure `consensus.checkpoint_sync = true`.
+    This option has been true by default since March 2022.
+
+### Deprecated
+- The `consensus.checkpoint_sync` config in `zebrad.toml` is deprecated. It might be ignored or
+  removed in a future release. ([#6163](https://github.com/ZcashFoundation/zebra/pull/6163))
+
+TODO: add other changes here
+
+
 ## [Zebra 1.0.0-rc.4](https://github.com/ZcashFoundation/zebra/releases/tag/v1.0.0-rc.4) - 2023-01-30
 
 In this release we fixed bugs and inconsistencies between zcashd and zebrad in the output of the `getblocktemplate` RPC method. In addition, we added block proposal mode to the `getblocktemplate` RPC, while we continue the effort of adding and testing mining pool RPC methods.

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -394,6 +394,11 @@ pub fn init_checkpoint_list(config: Config, network: Network) -> (CheckpointList
 /// The background task handles for `zebra-consensus` verifier initialization.
 #[derive(Debug)]
 pub struct BackgroundTaskHandles {
+    /// A handle to the Groth16 parameter download task.
+    /// Finishes when the parameters are downloaded and their checksums verified.
     pub groth16_download_handle: JoinHandle<()>,
+
+    /// A handle to the state checkpoint verify task.
+    /// Finishes when all the checkpoints are verified, or when the state tip is reached.
     pub state_checkpoint_verify_handle: JoinHandle<()>,
 }

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -269,7 +269,7 @@ where
     let state_checkpoint_verify_handle = tokio::task::spawn(
         // TODO: move this into an async function?
         async move {
-            tracing::info!("starting state checkpoint validation...");
+            tracing::info!("starting state checkpoint validation");
 
             // # Consensus
             //

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -266,7 +266,7 @@ where
 
     let checkpoint_state_service = state_service.clone();
     let checkpoint_sync = config.checkpoint_sync;
-    let _state_checkpoint_verify_handle = tokio::task::spawn(
+    let state_checkpoint_verify_handle = tokio::task::spawn(
         // TODO: move this into an async function?
         async move {
             tracing::info!("starting state checkpoint validation...");
@@ -368,7 +368,8 @@ where
     (
         chain,
         transaction,
-        groth16_download_handle,
+        // TODO: turn this into a struct?
+        vec![groth16_download_handle, state_checkpoint_verify_handle],
         max_checkpoint_height,
     )
 }

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -310,7 +310,8 @@ where
                             tracing::warn!(
                                 "state is not fully synced yet, remaining checkpoints will be \
                                  verified next time Zebra starts up. Zebra will be less secure \
-                                 until it is restarted"
+                                 until it is restarted. Use consensus.checkpoint_sync = true \
+                                 in zebrad.toml to make sure you are following a valid chain"
                             );
                         }
 

--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -297,20 +297,20 @@ where
                     Ok(zebra_state::Response::BlockHash(Some(state_hash))) => assert_eq!(
                         *checkpoint_hash, state_hash,
                         "invalid block in state: a previous Zebra instance followed an \
-                     incorrect chain. Delete and re-sync your state to use the best chain"
+                         incorrect chain. Delete and re-sync your state to use the best chain"
                     ),
 
                     Ok(zebra_state::Response::BlockHash(None)) => {
                         if checkpoint_sync {
                             tracing::info!(
                                 "state is not fully synced yet, remaining checkpoints will be \
-                             verified during syncing"
+                                 verified during syncing"
                             );
                         } else {
                             tracing::warn!(
                                 "state is not fully synced yet, remaining checkpoints will be \
-                             verified next time Zebra starts up. Zebra will be less secure \
-                             until it is restarted"
+                                 verified next time Zebra starts up. Zebra will be less secure \
+                                 until it is restarted"
                             );
                         }
 
@@ -323,7 +323,7 @@ where
                     Err(e) => {
                         tracing::warn!(
                             "unexpected error: {e:?} in state request while verifying previous \
-                         state checkpoints"
+                             state checkpoints"
                         )
                     }
                 }

--- a/zebra-consensus/src/checkpoint/list.rs
+++ b/zebra-consensus/src/checkpoint/list.rs
@@ -196,4 +196,9 @@ impl CheckpointList {
     {
         self.0.range(range).map(|(height, _)| *height).next_back()
     }
+
+    /// Returns an iterator over all the checkpoints, in increasing height order.
+    pub fn iter(&self) -> impl Iterator<Item = (&block::Height, &block::Hash)> {
+        self.0.iter()
+    }
 }

--- a/zebra-consensus/src/config.rs
+++ b/zebra-consensus/src/config.rs
@@ -4,17 +4,28 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
-    /// Should Zebra use its optional checkpoints to sync?
+    /// Should Zebra make sure that it follows the consensus chain while syncing?
+    /// This is a developer-only option.
     ///
-    /// This option is `true` by default, and allows for faster chain synchronization.
+    /// # Security
     ///
-    /// Zebra requires some checkpoints to validate legacy network upgrades.
-    /// But it also ships with optional checkpoints, which can be used instead of full block validation.
+    /// Disabling this option leaves your node vulnerable to some kinds of chain-based attacks.
+    /// Zebra regularly updates its checkpoints to ensure nodes are following the best chain.
     ///
-    /// Disabling this option makes Zebra start full validation as soon as possible.
-    /// This helps developers debug Zebra, by running full validation on more blocks.
+    /// # Details
     ///
-    /// Future versions of Zebra may change the required and optional checkpoints.
+    /// This option is `true` by default, because it prevents some kinds of chain attacks.
+    ///
+    /// Disabling this option makes Zebra start full validation earlier.
+    /// It is slower and less secure.
+    ///
+    /// Zebra requires some checkpoints to simplify validation of legacy network upgrades.
+    /// So those checkpoints are always active, even when this option is `false`.
+    ///
+    /// # Deprecation
+    ///
+    /// For security reasons, this option might be deprecated or ignored in a future Zebra
+    /// release.
     pub checkpoint_sync: bool,
 
     /// Skip the pre-download of Groth16 parameters if this option is true.

--- a/zebra-consensus/src/config.rs
+++ b/zebra-consensus/src/config.rs
@@ -1,6 +1,9 @@
+//! Configuration for semantic verification which is run in parallel.
+
 use serde::{Deserialize, Serialize};
 
-/// Consensus configuration.
+/// Configuration for parallel semantic verification:
+/// <https://zebra.zfnd.org/dev/rfcs/0002-parallel-verification.html#definitions>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
@@ -20,7 +23,7 @@ pub struct Config {
     /// It is slower and less secure.
     ///
     /// Zebra requires some checkpoints to simplify validation of legacy network upgrades.
-    /// So those checkpoints are always active, even when this option is `false`.
+    /// Required checkpoints are always active, even when this option is `false`.
     ///
     /// # Deprecation
     ///

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -20,6 +20,7 @@ use proptest_derive::Arbitrary;
 const MAX_EXPIRY_HEIGHT: block::Height = block::Height::MAX_EXPIRY_HEIGHT;
 
 #[derive(Error, Copy, Clone, Debug, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum SubsidyError {
     #[error("no coinbase transaction in block")]
     NoCoinbase,
@@ -36,6 +37,7 @@ pub enum SubsidyError {
 
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
+#[allow(missing_docs)]
 pub enum TransactionError {
     #[error("first transaction must be coinbase")]
     CoinbasePosition,
@@ -226,6 +228,7 @@ impl From<BoxError> for TransactionError {
 }
 
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum BlockError {
     #[error("block contains invalid transactions")]
     Transaction(#[from] TransactionError),

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -40,11 +40,10 @@ mod config;
 mod parameters;
 mod primitives;
 mod script;
-pub mod transaction;
 
 pub mod chain;
-#[allow(missing_docs)]
 pub mod error;
+pub mod transaction;
 
 pub use block::{
     subsidy::{

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -15,11 +15,12 @@
 #[macro_use]
 extern crate tracing;
 
+pub mod constants;
+
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod arbitrary;
 
 mod config;
-pub mod constants;
 mod error;
 mod request;
 mod response;
@@ -32,8 +33,6 @@ pub use config::{check_and_delete_old_databases, Config};
 pub use constants::MAX_BLOCK_REORG_HEIGHT;
 pub use error::{BoxError, CloneError, CommitBlockError, ValidateContextError};
 pub use request::{FinalizedBlock, HashOrHeight, PreparedBlock, ReadRequest, Request};
-#[cfg(feature = "getblocktemplate-rpcs")]
-pub use response::GetBlockTemplateChainInfo;
 pub use response::{ReadResponse, Response};
 pub use service::{
     chain_tip::{ChainTipChange, LatestChainTip, TipAction},
@@ -42,11 +41,15 @@ pub use service::{
     OutputIndex, OutputLocation, TransactionLocation,
 };
 
+#[cfg(feature = "getblocktemplate-rpcs")]
+pub use response::GetBlockTemplateChainInfo;
+
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use service::{
     arbitrary::{populated_state, CHAIN_TIP_UPDATE_WAIT_LIMIT},
     chain_tip::{ChainTipBlock, ChainTipSender},
-    init_test, init_test_services,
+    finalized_state::{DiskWriteBatch, WriteDisk},
+    init_test, init_test_services, ReadStateService,
 };
 
 pub(crate) use request::ContextuallyValidBlock;

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -65,15 +65,19 @@ pub enum Response {
     /// Contains the median-time-past for the *next* block on the best chain.
     BestChainNextMedianTimePast(DateTime32),
 
+    /// Response to [`Request::BestChainBlockHash`](Request::BestChainBlockHash) with the
+    /// specified block hash.
+    BlockHash(Option<block::Hash>),
+
     #[cfg(feature = "getblocktemplate-rpcs")]
-    /// Response to [`Request::CheckBlockProposalValidity`](crate::Request::CheckBlockProposalValidity)
+    /// Response to [`Request::CheckBlockProposalValidity`](Request::CheckBlockProposalValidity)
     ValidBlockProposal,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// A response to a read-only
 /// [`ReadStateService`](crate::service::ReadStateService)'s
-/// [`ReadRequest`](crate::ReadRequest).
+/// [`ReadRequest`](ReadRequest).
 pub enum ReadResponse {
     /// Response to [`ReadRequest::Tip`] with the current best chain tip.
     Tip(Option<(block::Height, block::Hash)>),
@@ -137,21 +141,21 @@ pub enum ReadResponse {
     /// Contains the median-time-past for the *next* block on the best chain.
     BestChainNextMedianTimePast(DateTime32),
 
-    /// Response to [`ReadRequest::BestChainBlockHash`](crate::ReadRequest::BestChainBlockHash) with the
+    /// Response to [`ReadRequest::BestChainBlockHash`](ReadRequest::BestChainBlockHash) with the
     /// specified block hash.
     BlockHash(Option<block::Hash>),
 
     #[cfg(feature = "getblocktemplate-rpcs")]
-    /// Response to [`ReadRequest::ChainInfo`](crate::ReadRequest::ChainInfo) with the state
+    /// Response to [`ReadRequest::ChainInfo`](ReadRequest::ChainInfo) with the state
     /// information needed by the `getblocktemplate` RPC method.
     ChainInfo(GetBlockTemplateChainInfo),
 
     #[cfg(feature = "getblocktemplate-rpcs")]
-    /// Response to [`ReadRequest::SolutionRate`](crate::ReadRequest::SolutionRate)
+    /// Response to [`ReadRequest::SolutionRate`](ReadRequest::SolutionRate)
     SolutionRate(Option<u128>),
 
     #[cfg(feature = "getblocktemplate-rpcs")]
-    /// Response to [`ReadRequest::CheckBlockProposalValidity`](crate::ReadRequest::CheckBlockProposalValidity)
+    /// Response to [`ReadRequest::CheckBlockProposalValidity`](ReadRequest::CheckBlockProposalValidity)
     ValidBlockProposal,
 }
 
@@ -204,6 +208,7 @@ impl TryFrom<ReadResponse> for Response {
             ReadResponse::Tip(height_and_hash) => Ok(Response::Tip(height_and_hash)),
             ReadResponse::Depth(depth) => Ok(Response::Depth(depth)),
             ReadResponse::BestChainNextMedianTimePast(median_time_past) => Ok(Response::BestChainNextMedianTimePast(median_time_past)),
+            ReadResponse::BlockHash(hash) => Ok(Response::BlockHash(hash)),
 
             ReadResponse::Block(block) => Ok(Response::Block(block)),
             ReadResponse::Transaction(tx_and_height) => {
@@ -227,10 +232,6 @@ impl TryFrom<ReadResponse> for Response {
             | ReadResponse::AddressBalance(_)
             | ReadResponse::AddressesTransactionIds(_)
             | ReadResponse::AddressUtxos(_) => {
-                Err("there is no corresponding Response for this ReadResponse")
-            }
-
-            ReadResponse::BlockHash(_) => {
                 Err("there is no corresponding Response for this ReadResponse")
             }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -809,6 +809,13 @@ impl ReadStateService {
     fn latest_best_chain(&self) -> Option<Arc<Chain>> {
         self.latest_non_finalized_state().best_chain().cloned()
     }
+
+    /// Test-only access to the inner database.
+    /// Can be used to modify the database without doing any consensus checks.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn db(&self) -> &ZebraDb {
+        &self.db
+    }
 }
 
 impl Service<Request> for StateService {
@@ -1875,9 +1882,7 @@ pub fn spawn_init(
 
 /// Returns a [`StateService`] with an ephemeral [`Config`] and a buffer with a single slot.
 ///
-/// This can be used to create a state service for testing.
-///
-/// See also [`init`].
+/// This can be used to create a state service for testing. See also [`init`].
 #[cfg(any(test, feature = "proptest-impl"))]
 pub fn init_test(network: Network) -> Buffer<BoxService<Request, Response, BoxError>, Request> {
     // TODO: pass max_checkpoint_height and checkpoint_verify_concurrency limit

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1032,6 +1032,7 @@ impl Service<Request> for StateService {
             Request::Tip
             | Request::Depth(_)
             | Request::BestChainNextMedianTimePast
+            | Request::BestChainBlockHash(_)
             | Request::BlockLocator
             | Request::Transaction(_)
             | Request::UnspentBestChainUtxo(_)

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -42,6 +42,9 @@ pub use disk_format::{OutputIndex, OutputLocation, TransactionLocation};
 
 pub(super) use zebra_db::ZebraDb;
 
+#[cfg(any(test, feature = "proptest-impl"))]
+pub use disk_db::{DiskWriteBatch, WriteDisk};
+
 /// The finalized part of the chain state, stored in the db.
 ///
 /// `rocksdb` allows concurrent writes through a shared reference,

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -67,7 +67,7 @@ impl ZebraDb {
     /// It should only be used in debugging or test code, immediately before a manual shutdown.
     ///
     /// See [`DiskDb::shutdown`] for details.
-    pub(crate) fn shutdown(&mut self, force: bool) {
+    pub fn shutdown(&mut self, force: bool) {
         self.check_max_on_disk_tip_height();
 
         self.db.shutdown(force);

--- a/zebra-state/src/service/finalized_state/zebra_db/arbitrary.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/arbitrary.rs
@@ -1,7 +1,5 @@
 //! Arbitrary value generation and test harnesses for high-level typed database access.
 
-#![allow(dead_code)]
-
 use std::ops::Deref;
 
 use zebra_chain::{

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -314,6 +314,10 @@ pub fn check_sync_logs_until(
     if check_legacy_chain {
         zebrad.expect_stdout_line_matches("starting legacy chain check")?;
         zebrad.expect_stdout_line_matches("no legacy chain found")?;
+
+        zebrad.expect_stdout_line_matches("starting state checkpoint validation")?;
+        // TODO: what if the mempool is enabled for debugging before this finishes?
+        zebrad.expect_stdout_line_matches("finished state checkpoint validation")?;
     }
 
     // before the stop regex, expect mempool activation


### PR DESCRIPTION
## Motivation

Zebra does not check that the state has followed the correct chain, but this is a new consensus requirement on mainnet.

Closes #5912

### Specifications

> A network upgrade is settled on a given network when there is a social consensus that it has activated with a given activation block hash. A full validator that potentially risks Mainnet funds or displays Mainnet transaction information to a user MUST do so only for a block chain that includes the activation block of the most recent settled network upgrade

https://zips.z.cash/protocol/protocol.pdf#blockchain

### Complex Code or Requirements

This PR adds another short startup task using the existing concurrent task framework and event loop.

## Solution

- [Validate existing state block hashes at startup](https://github.com/ZcashFoundation/zebra/commit/c5a685a0ef2038129c21f3914828b0c24f3538f2)
    - [Make Request::BestChainBlockHash redirect to the ReadStateService](https://github.com/ZcashFoundation/zebra/commit/f2955cb552f382e19fb630537d7b07927285dbd5)
- [Monitor state block hash checkpoint task in the start command](https://github.com/ZcashFoundation/zebra/commit/f5dca6cb4491ef940829b8bfce73354580454d25)
- [Re-write the checkpoint_sync config docs based on the latest consensus rules](https://github.com/ZcashFoundation/zebra/commit/320b61c8ad004bd427003240c64ddc94f68a0981)

Unrelated cleanups:
- [Allow missing docs directly on derived error types](https://github.com/ZcashFoundation/zebra/commit/b1565ace0b4499a170712b6eab93ae39b34c3cfa)

### Testing

New tests:
- check that this code is active in the existing cached state tests
- check that it fails when the checkpoints don't match the previous cached state (and succeeds when they do)

I also did full and partial syncs locally, and they passed. (I had some unrelated issues with syncing due to proof errors, likely caused by disk corruption.)

### Changelog

Added security and deprecation notes in this PR.

## Review

This PR's code is ready for review. It is not on the critical path.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [x] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up

- #6178