### PR TITLE
fix(ci): Run lightwalletd full sync in multi-job mode

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -490,6 +490,8 @@ jobs:
       test_id: lwd-full-sync
       test_description: Test lightwalletd full sync
       test_variables: '-e TEST_LWD_FULL_SYNC=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache -e LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache'
+      # This test runs for (just) longer than 6 hours, so it needs multiple jobs
+      is_long_test: true
       needs_zebra_state: true
       needs_lwd_state: false
       saves_to_disk: true


### PR DESCRIPTION
## Motivation

The lightwalletd full sync job is failing on the `main` branch due to a 6 hour job timeout.

Our last release was tagged and released while this test was still failing.

### Analysis

The last successful main branch merge was 3 weeks ago:
https://github.com/ZcashFoundation/zebra/actions/runs/3975488890

The first failure was:
https://github.com/ZcashFoundation/zebra/actions/runs/4020563302

The commit for the first failure 6f6b13300ef35120952717bbaab3b0e18b69ea1f doesn't seem to be performance-related, and the previous time was 5h54m anyway.

There are no PRs before the failure that seem performance-related:
https://github.com/ZcashFoundation/zebra/commits/main?after=41ee0da79cf5e6531ec7452433cd310b1bcf6c77+69&branch=main&qualified_name=refs%2Fheads%2Fmain

But it's tricky to tell, because CI was failing for other reasons at the same time.

## Solution

Activate multi-job mode for that job:
https://github.com/ZcashFoundation/zebra/blob/41ee0da79cf5e6531ec7452433cd310b1bcf6c77/.github/workflows/deploy-gcp-tests.yml#L30-L34

## Review

This PR is ready for review, but it needs a manual test (see the comments).

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

