### PR TITLE
fix(ci): Increase macOS CI timeout

### DIFF
--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -61,9 +61,9 @@ jobs:
   test:
     name: Test ${{ matrix.rust }} on ${{ matrix.os }}${{ matrix.features }}
     # The large timeout is to accommodate:
-    # - Windows builds (75 minutes, typically 30-50 minutes), and
-    # - parameter downloads (an extra 90 minutes, but only when the cache expires)
-    timeout-minutes: 165
+    # - macOS and Windows builds (90 minutes, typically 30-70 minutes), and
+    # - parameter downloads (an extra 100 minutes, but only when the cache expires)
+    timeout-minutes: 190
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Motivation

When macOS refreshes the Zcash parameter cache, its CI sometimes takes longer than 165 minutes:
https://github.com/ZcashFoundation/zebra/actions/runs/4188656916/jobs/7260060480

(This one timed out in the last step, so it appears successful, but fails the PR.)

## Review

This might be urgent if the cache was not actually written, because the next PR will do the same thing.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

