### PR TITLE
fix(install): Downgrade `owo-colors` from 3.6.0 to 3.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "3.6.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69dc4ec9e7e12502579e09e8a53c6a305b3aceb62ad5c307a62f7c3eada78324"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "pairing"

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -27,7 +27,7 @@ color-eyre = "0.6.2"
 tinyvec = { version = "1.6.0", features = ["rustc_1_55"] }
 
 humantime = "2.1.0"
-owo-colors = "3.6.0"
+owo-colors = "3.5.0"
 spandoc = "0.2.2"
 thiserror = "1.0.38"
 


### PR DESCRIPTION
## Motivation

`owo-colors` v 0.3.6 is yanked. This PR downgrade to version 0.3.5. Close https://github.com/ZcashFoundation/zebra/issues/6197


## Solution

Downgrade.

Test the warning is gone with:

```
cargo install --locked --features getblocktemplate-rpcs --git https://github.com/ZcashFoundation/zebra --branch issue6197 zebrad
```

Dependabot will try to update, we will deny, dependabot will leave us alone until a greater version is released.

The change in `command.rs` is needed to fix a clippy lint that was not happening when `owo-colors` was at 0.3.6.

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
