### PR TITLE
Manual test: Run unit tests on nightly

### DIFF
--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -70,7 +70,7 @@ jobs:
       matrix:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
         os: [ubuntu-latest, macos-latest]
-        rust: [stable, beta]
+        rust: [stable, beta, nightly]
         features: ["", " --features getblocktemplate-rpcs"]
         exclude:
         # We're excluding macOS for the following reasons:
@@ -79,6 +79,8 @@ jobs:
         # - macOS is a second-tier Zebra support platform
           - os: macos-latest
             rust: beta
+          - os: macos-latest
+            rust: nightly
           - os: macos-latest
             features: " --features getblocktemplate-rpcs"
 


### PR DESCRIPTION
I'm seeing some issues with halo2 proof verification on my machine, but they aren't appearing in CI.

One of the possibilities is that I'm using nightly. (Others are a corrupt disk, or a different Rust configuration.)

If nightly also fails in CI, then we should ask ECC to open a Rust miscompilation ticket.
If CI passes, then my machine has the issue.