### PR TITLE
build(deps): Bump zcash_script version and update deny.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,7 +993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.5",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1023,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f83d0ebf42c6eafb8d7c52f7e5f2d3003b89c7aa4fd2b79229209459a849af8"
+checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1047,15 +1046,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d2199b00553eda8012dfec8d3b1c75fce747cf27c169a270b3b99e3448ab78"
+checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
+checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.20",
@@ -5358,9 +5357,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2e24cb5e3352f751c699f47d363279178871b126d23f49d9018f6bae49219a"
+checksum = "0f9a45953c4ddd81d68f45920955707f45c8926800671f354dd13b97507edf28"
 dependencies = [
  "aes",
  "bip0039",
@@ -5368,9 +5367,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "bls12_381",
- "bs58",
  "byteorder",
- "chacha20poly1305",
  "equihash",
  "ff",
  "fpe",
@@ -5452,9 +5449,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4696f0dcc0d9dd4d9d4a8fa5009caa85cfad93faca63164cd02e5a2c6757ac27"
+checksum = "70ae95d6cd4849b814313ddbd633e5c0c7843df3daf52832be547c66fed989e0"
 dependencies = [
  "bindgen 0.60.1",
  "blake2b_simd",
@@ -5469,7 +5466,7 @@ dependencies = [
  "tracing",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_primitives 0.8.1",
+ "zcash_primitives 0.9.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,29 +335,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "clap 3.2.20",
- "env_logger 0.9.1",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2 1.0.47",
- "quote 1.0.20",
- "regex",
- "rustc-hash",
- "shlex",
- "which",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
@@ -367,6 +344,7 @@ dependencies = [
  "clang-sys",
  "lazy_static",
  "lazycell",
+ "log",
  "peeking_take_while",
  "proc-macro2 1.0.47",
  "quote 1.0.20",
@@ -374,6 +352,7 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 1.0.104",
+ "which",
 ]
 
 [[package]]
@@ -745,12 +724,9 @@ version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
- "atty",
  "bitflags",
  "clap_lex",
  "indexmap",
- "strsim 0.10.0",
- "termcolor",
  "textwrap 0.15.0",
 ]
 
@@ -1273,19 +1249,6 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "log",
  "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -2212,7 +2175,7 @@ version = "0.10.0+7.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fe4d5874f5ff2bc616e55e8c6086d478fcda13faf9495768a4aa1c22042d30b"
 dependencies = [
- "bindgen 0.64.0",
+ "bindgen",
  "bzip2-sys",
  "cc",
  "glob",
@@ -3226,7 +3189,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger",
  "log",
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -5449,11 +5412,11 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ae95d6cd4849b814313ddbd633e5c0c7843df3daf52832be547c66fed989e0"
+checksum = "a27a0e71f69f4c8661b4dc947518d8588c1f29bd3f035749068a40bd5cdee4e8"
 dependencies = [
- "bindgen 0.60.1",
+ "bindgen",
  "blake2b_simd",
  "cc",
  "cxx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5412,9 +5412,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27a0e71f69f4c8661b4dc947518d8588c1f29bd3f035749068a40bd5cdee4e8"
+checksum = "bd2f9cb33d1244816179614fcd76d62df2d9b3e76e5513e70186c96650eba3c6"
 dependencies = [
  "bindgen",
  "blake2b_simd",

--- a/deny.toml
+++ b/deny.toml
@@ -51,7 +51,7 @@ skip-tree = [
 
     # wait for zcash_script to upgrade
     # https://github.com/ZcashFoundation/zcash_script/pulls
-    { name = "zcash_primitives", version = "=0.8.1" },
+    { name = "zcash_primitives", version = "=0.9.1" },
     { name = "bindgen", version = "=0.60.1" },
 
     # wait for ed25519-zebra, indexmap, metrics-util, and metrics to upgrade

--- a/deny.toml
+++ b/deny.toml
@@ -52,7 +52,6 @@ skip-tree = [
     # wait for zcash_script to upgrade
     # https://github.com/ZcashFoundation/zcash_script/pulls
     { name = "zcash_primitives", version = "=0.9.1" },
-    { name = "bindgen", version = "=0.60.1" },
 
     # wait for ed25519-zebra, indexmap, metrics-util, and metrics to upgrade
     # ed25519-zebra/hashbrown: https://github.com/ZcashFoundation/ed25519-zebra/pull/63

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zcash_script = "0.1.8"
+zcash_script = "0.1.9"
 
 zebra-chain = { path = "../zebra-chain" }
 

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zcash_script = "0.1.9"
+zcash_script = "0.1.10"
 
 zebra-chain = { path = "../zebra-chain" }
 

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zcash_script = "0.1.10"
+zcash_script = "0.1.11"
 
 zebra-chain = { path = "../zebra-chain" }
 


### PR DESCRIPTION
## Motivation

Bumps zcash_script from 0.1.8 to 0.1.11

Closes #6107.

## Solution

- Bump `zcash_script` version from 0.1.8 to 0.1.11 in `zebra_script`
- Update deny.toml to skip zcash_primitives 0.9.1 instead of 0.8.1
- Remove entry for bindgen from deny.toml

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

