### PR TITLE
fix(deps): Remove unused dependencies, and check for them in CI

### DIFF
--- a/.github/workflows/continous-integration-os.patch.yml
+++ b/.github/workflows/continous-integration-os.patch.yml
@@ -60,3 +60,10 @@ jobs:
 
     steps:
       - run: 'echo "No build required"'
+
+  unused-deps:
+    name: Check for unused dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -309,9 +309,10 @@ jobs:
           echo "-- full cargo machete output, including ignored dependencies --"
           cargo machete --skip-target-dir || true
           echo "-- unused dependencies are below this line, full output is above --"
-          (cargo machete --skip-target-dir 2>/dev/null || true) | \
-          grep -v -e gumdrop -e humantime-serde -e tinyvec -e "found the following" -e Cargo.toml -e Done \
-          && ( \
-          echo "New unused dependencies were found, please remove them!"; \
-          exit 1; \
-          )
+          if (cargo machete --skip-target-dir 2>/dev/null || true) | \
+          grep -v -e gumdrop -e humantime-serde -e tinyvec -e "found the following" -e Cargo.toml -e Done; then
+              echo "No unused dependencies found."
+          else
+              echo "New unused dependencies were found, please remove them!"
+              exit 1
+          fi

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -279,3 +279,38 @@ jobs:
         with:
           command: check ${{ matrix.checks }}
           arguments: --workspace ${{ matrix.features }}
+
+  unused-deps:
+    name: Check for unused dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout git repository
+        uses: actions/checkout@v3.3.0
+        with:
+          persist-credentials: false
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Install cargo-machete
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-machete
+
+      - name: Check unused dependencies
+        # Exclude macro and transitive dependencies by filtering them out of the output,
+        # then if there are any more unused dependencies, show the full output of the command.
+        run: |
+          cargo machete --skip-target-dir 2>/dev/null | \
+          rg -v -e gumdrop -e humantime-serde -e tinyvec -e "found the following" -e Cargo.toml -e Done \
+          && ( \
+          echo "-- unused dependencies above this line, full output below --"; \
+          cargo machete --skip-target-dir; \
+          echo "New unused dependencies were found, please remove them!"; \
+          exit 1; \
+          )

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -306,9 +306,10 @@ jobs:
         # Exclude macro and transitive dependencies by filtering them out of the output,
         # then if there are any more unused dependencies, show the full output of the command.
         run: |
-          cargo machete --skip-target-dir
+          echo "-- full cargo machete output, including ignored dependencies --"
+          cargo machete --skip-target-dir || true
           echo "-- unused dependencies are below this line, full output is above --"
-          cargo machete --skip-target-dir 2>/dev/null | \
+          (cargo machete --skip-target-dir 2>/dev/null || true) | \
           grep -v -e gumdrop -e humantime-serde -e tinyvec -e "found the following" -e Cargo.toml -e Done \
           && ( \
           echo "New unused dependencies were found, please remove them!"; \

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -306,11 +306,11 @@ jobs:
         # Exclude macro and transitive dependencies by filtering them out of the output,
         # then if there are any more unused dependencies, show the full output of the command.
         run: |
+          cargo machete --skip-target-dir
+          echo "-- unused dependencies are below this line, full output is above --"
           cargo machete --skip-target-dir 2>/dev/null | \
           grep -v -e gumdrop -e humantime-serde -e tinyvec -e "found the following" -e Cargo.toml -e Done \
           && ( \
-          echo "-- unused dependencies above this line, full output below --"; \
-          cargo machete --skip-target-dir; \
           echo "New unused dependencies were found, please remove them!"; \
           exit 1; \
           )

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -307,7 +307,7 @@ jobs:
         # then if there are any more unused dependencies, show the full output of the command.
         run: |
           cargo machete --skip-target-dir 2>/dev/null | \
-          rg -v -e gumdrop -e humantime-serde -e tinyvec -e "found the following" -e Cargo.toml -e Done \
+          grep -v -e gumdrop -e humantime-serde -e tinyvec -e "found the following" -e Cargo.toml -e Done \
           && ( \
           echo "-- unused dependencies above this line, full output below --"; \
           cargo machete --skip-target-dir; \

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -304,15 +304,15 @@ jobs:
 
       - name: Check unused dependencies
         # Exclude macro and transitive dependencies by filtering them out of the output,
-        # then if there are any more unused dependencies, show the full output of the command.
+        # then if there are any more unused dependencies, fail the job.
         run: |
           echo "-- full cargo machete output, including ignored dependencies --"
           cargo machete --skip-target-dir || true
           echo "-- unused dependencies are below this line, full output is above --"
           if (cargo machete --skip-target-dir 2>/dev/null || true) | \
           grep -v -e gumdrop -e humantime-serde -e tinyvec -e "found the following" -e Cargo.toml -e Done; then
-              echo "No unused dependencies found."
-          else
               echo "New unused dependencies were found, please remove them!"
               exit 1
+          else
+              echo "No unused dependencies found."
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,12 +298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 
 [[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
-
-[[package]]
 name = "bellman"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5316,7 +5310,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804268e702b664fc09d3e2ce82786d0addf4ae57ba6976469be63e09066bf9f7"
 dependencies = [
- "bech32 0.8.1",
+ "bech32",
  "bs58",
  "f4jumble",
  "zcash_encoding",
@@ -5476,13 +5470,10 @@ dependencies = [
 name = "zebra-chain"
 version = "1.0.0-beta.20"
 dependencies = [
- "aes",
- "bech32 0.9.1",
  "bitflags",
  "bitvec",
  "blake2b_simd",
  "blake2s_simd",
- "bls12_381",
  "bs58",
  "byteorder",
  "chrono",
@@ -5518,7 +5509,6 @@ dependencies = [
  "sha2",
  "spandoc",
  "static_assertions",
- "subtle",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -5546,7 +5536,6 @@ dependencies = [
  "bls12_381",
  "chrono",
  "color-eyre",
- "dirs",
  "displaydoc",
  "futures",
  "futures-util",
@@ -5639,7 +5628,6 @@ dependencies = [
  "jsonrpc-http-server",
  "num_cpus",
  "proptest",
- "proptest-derive",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -5647,7 +5635,6 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
- "tracing-futures",
  "zcash_address",
  "zebra-chain",
  "zebra-consensus",
@@ -5679,7 +5666,6 @@ dependencies = [
  "chrono",
  "color-eyre",
  "dirs",
- "displaydoc",
  "futures",
  "halo2_proofs",
  "hex",
@@ -5766,7 +5752,6 @@ dependencies = [
  "futures",
  "gumdrop",
  "hex",
- "humantime",
  "humantime-serde",
  "hyper",
  "indexmap",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -33,13 +33,10 @@ bench = ["zebra-test"]
 [dependencies]
 
 # Cryptography
-aes = "0.7.5"
-bech32 = "0.9.1"
 bitvec = "1.0.1"
 bitflags = "1.3.2"
 blake2b_simd = "1.0.1"
 blake2s_simd = "1.0.1"
-bls12_381 = "0.7.0"
 bs58 = { version = "0.4.0", features = ["check"] }
 byteorder = "1.4.3"
 equihash = "0.2.0"
@@ -53,7 +50,6 @@ ripemd = "0.1.3"
 # Matches version used by hdwallet
 secp256k1 = { version = "0.21.3", features = ["serde"] }
 sha2 = { version = "0.9.9", features = ["compress"] }
-subtle = "2.4.1"
 uint = "0.9.5"
 x25519-dalek = { version = "2.0.0-pre.1", features = ["serde"] }
 

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -30,7 +30,6 @@ rand = { version = "0.8.5", package = "rand" }
 rayon = "1.6.1"
 
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
-dirs = "4.0.0"
 displaydoc = "0.2.3"
 lazy_static = "1.4.0"
 once_cell = "1.17.1"

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -25,7 +25,6 @@ getblocktemplate-rpcs = [
 # Test-only features
 proptest-impl = [
     "proptest",
-    "proptest-derive",
     "zebra-consensus/proptest-impl",
     "zebra-state/proptest-impl",
     "zebra-network/proptest-impl",
@@ -52,7 +51,6 @@ tokio = { version = "1.25.0", features = ["time", "rt-multi-thread", "macros", "
 tower = "0.4.13"
 
 tracing = "0.1.37"
-tracing-futures = "0.2.5"
 
 hex = { version = "0.4.3", features = ["serde"] }
 serde = { version = "1.0.152", features = ["serde_derive"] }
@@ -64,7 +62,6 @@ zcash_address = { version = "0.2.0", optional = true }
 
 # Test-only feature proptest-impl
 proptest = { version = "0.10.1", optional = true }
-proptest-derive = { version = "0.3.0", optional = true }
 
 zebra-chain = { path = "../zebra-chain" }
 zebra-consensus = { path = "../zebra-consensus" }
@@ -77,7 +74,6 @@ zebra-state = { path = "../zebra-state" }
 insta = { version = "1.28.0", features = ["redactions", "json", "ron"] }
 
 proptest = "0.10.1"
-proptest-derive = "0.3.0"
 
 thiserror = "1.0.38"
 tokio = { version = "1.25.0", features = ["full", "tracing", "test-util"] }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -26,7 +26,6 @@ proptest-impl = [
 bincode = "1.3.3"
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
 dirs = "4.0.0"
-displaydoc = "0.2.3"
 futures = "0.3.26"
 hex = "0.4.3"
 indexmap = "1.9.2"

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -101,7 +101,6 @@ zebra-state = { path = "../zebra-state" }
 abscissa_core = "0.5"
 gumdrop = { version = "0.7", features = ["default_expr"]}
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
-humantime = "2.1.0"
 humantime-serde = "1.1.1"
 indexmap = "1.9.2"
 lazy_static = "1.4.0"


### PR DESCRIPTION
## Motivation

Having unused dependencies makes Zebra less secure. It also increases build time and binary size.

We deleted a lot of code recently, but we didn't delete the dependencies that were only used by that code. We also copy-pasted some dependencies that weren't actually needed.

Closes #6215

### Complex Code or Requirements

This has a bit of shell script in it, but it doesn't do anything unusual.

## Solution

- remove unused dependencies detected by `cargo-machete`
- add a CI job to detect unused dependencies
    - add a patch workflow so we can make this job part of the branch protection rules

This PR should appear in the changelog because it removes dependencies, which is visible to users.

## Review

This is a low priority change. It can go in after the release.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

After this PR merges, an admin should make the new job part of the branch protection rules.