### PR TITLE
Add instructions for mining with s-nomp to Zebra book

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -11,7 +11,7 @@
   - [Lightwalletd](user/lightwalletd.md)
   - [zk-SNARK Parameters](user/parameters.md)
   - [Mining](user/mining.md)
-    - [Testing with s-nomp](user/mining-testnet-s-nomp.md)
+    - [Testnet Mining with s-nomp](user/mining-testnet-s-nomp.md)
 - [Developer Documentation](dev.md)
   - [Contribution Guide](CONTRIBUTING.md)
   - [Design Overview](dev/overview.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -11,6 +11,7 @@
   - [Lightwalletd](user/lightwalletd.md)
   - [zk-SNARK Parameters](user/parameters.md)
   - [Mining](user/mining.md)
+  - [Mining on Testnet](user/mining-testnet-s-nomp.md)
 - [Developer Documentation](dev.md)
   - [Contribution Guide](CONTRIBUTING.md)
   - [Design Overview](dev/overview.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -11,7 +11,7 @@
   - [Lightwalletd](user/lightwalletd.md)
   - [zk-SNARK Parameters](user/parameters.md)
   - [Mining](user/mining.md)
-  - [Mining on Testnet](user/mining-testnet-s-nomp.md)
+    - [Testing with s-nomp](user/mining-testnet-s-nomp.md)
 - [Developer Documentation](dev.md)
   - [Contribution Guide](CONTRIBUTING.md)
   - [Design Overview](dev/overview.md)

--- a/book/src/user/mining.md
+++ b/book/src/user/mining.md
@@ -175,6 +175,6 @@ If you can see something similar to the following then you are good to go.
 
 Just point your mining pool software to the Zebra RPC endpoint (127.0.0.1:8232). Zebra supports the RPC methods needed to run most mining pool software.
 
-If you want to run an experimental `s-nomp` mining pool with Zebra on testnet, please refer to [this document](https://github.com/ZcashFoundation/zebra/blob/main/book/src/user/mining-testnet-s-nomp.md) for a very detailed guide. `s-nomp` is not compatible with NU5, so some mining functions are disabled.
+If you want to run an experimental `s-nomp` mining pool with Zebra on testnet, please refer to [this document](mining-testnet-s-nomp.md) for a very detailed guide. `s-nomp` is not compatible with NU5, so some mining functions are disabled.
 
 If your mining pool software needs additional support, or if you as a miner need additional RPC methods, then please open a ticket in the [Zebra repository](https://github.com/ZcashFoundation/zebra/issues/new).


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

Detailed mining instructions point back to this zebra github repo instead of the Zebra book even though they are within the book directory.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
If this is a large change, list commits of key functional changes here.
-->
Add the file to the contents on `SUMMARY.md` and link to its location in the book. 
## Review

<!--
Is this PR blocking any other work?
If you want specific reviewers for this PR, tag them here.
-->
Do we actually want to show this in the book or was it fine the way it was?

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
