### PR TITLE
fix(mempool): Stop ignoring some transaction broadcasts

### DIFF
--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -203,9 +203,9 @@ impl fmt::Display for Request {
             Request::Ping(_) => "Ping".to_string(),
 
             Request::BlocksByHash(hashes) => {
-                format!("BlocksByHash {{ hashes: {} }}", hashes.len())
+                format!("BlocksByHash({})", hashes.len())
             }
-            Request::TransactionsById(ids) => format!("TransactionsById {{ ids: {} }}", ids.len()),
+            Request::TransactionsById(ids) => format!("TransactionsById({})", ids.len()),
 
             Request::FindBlocks { known_blocks, stop } => format!(
                 "FindBlocks {{ known_blocks: {}, stop: {} }}",
@@ -220,7 +220,7 @@ impl fmt::Display for Request {
 
             Request::PushTransaction(_) => "PushTransaction".to_string(),
             Request::AdvertiseTransactionIds(ids) => {
-                format!("AdvertiseTransactionIds {{ ids: {} }}", ids.len())
+                format!("AdvertiseTransactionIds({})", ids.len())
             }
 
             Request::AdvertiseBlock(_) => "AdvertiseBlock".to_string(),

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -450,6 +450,9 @@ impl Service<Request> for Mempool {
             if !send_to_peers_ids.is_empty() {
                 tracing::trace!(?send_to_peers_ids, "sending new transactions to peers");
 
+                // TODO:
+                // - if the transaction gossip task is slow, we can overwrite unsent IDs here
+                // - does this happen often enough to be worth a fix?
                 self.transaction_sender.send(send_to_peers_ids)?;
             }
         }

--- a/zebrad/src/components/mempool/gossip.rs
+++ b/zebrad/src/components/mempool/gossip.rs
@@ -60,10 +60,10 @@ where
         let request = zn::Request::AdvertiseTransactionIds(txs);
 
         // TODO: rate-limit this info level log?
-        info!(%request, %combined_changes, "sending mempool transaction broadcast");
+        info!(%request, changes = %combined_changes, "sending mempool transaction broadcast");
         debug!(
             ?request,
-            ?combined_changes,
+            changes = ?combined_changes,
             "full list of mempool transactions in broadcast"
         );
 

--- a/zebrad/src/components/mempool/gossip.rs
+++ b/zebrad/src/components/mempool/gossip.rs
@@ -47,7 +47,9 @@ where
 
         // also combine transactions that arrived shortly after this one
         while receiver.has_changed()? && combined_changes < MAX_CHANGES_BEFORE_SEND {
-            // Correctness: reset has_changed(), don't hold the lock
+            // Correctness
+            // - set the has_changed() flag to false using borrow_and_update()
+            // - clone() so we don't hold the watch channel lock while modifying txs 
             let extra_txs = receiver.borrow_and_update().clone();
             txs.extend(extra_txs.iter());
 

--- a/zebrad/src/components/mempool/gossip.rs
+++ b/zebrad/src/components/mempool/gossip.rs
@@ -51,7 +51,9 @@ where
         let txs_len = txs.len();
         let request = zn::Request::AdvertiseTransactionIds(txs);
 
-        info!(?request, "sending mempool transaction broadcast");
+        // TODO: rate-limit this info level log?
+        info!(%request, "sending mempool transaction broadcast");
+        debug!(?request, "full list of mempool transactions in broadcast");
 
         // broadcast requests don't return errors, and we'd just want to ignore them anyway
         let _ = broadcast_network.ready().await?.call(request).await;

--- a/zebrad/src/components/mempool/gossip.rs
+++ b/zebrad/src/components/mempool/gossip.rs
@@ -49,7 +49,7 @@ where
         while receiver.has_changed()? && combined_changes < MAX_CHANGES_BEFORE_SEND {
             // Correctness
             // - set the has_changed() flag to false using borrow_and_update()
-            // - clone() so we don't hold the watch channel lock while modifying txs 
+            // - clone() so we don't hold the watch channel lock while modifying txs
             let extra_txs = receiver.borrow_and_update().clone();
             txs.extend(extra_txs.iter());
 


### PR DESCRIPTION
## Motivation

Sometimes Zebra will overwrite transactions in the mempool gossip watch channel, and never broadcast them to the network.

Fixing this is important for reliably sending newly created `lightwalletd` transactions. (For all other transactions, nodes can get them from elsewhere on the network.)

### Specifications

Nodes are not required to broadcast new mempool transactions, but they should:
https://developer.bitcoin.org/devguide/p2p_network.html#transaction-broadcasting

Zebra does not rely on peers broadcasting transactions, it also actively crawls memory pools.

### Complex Code or Requirements

This PR fixes a concurrency bug by repeatedly checking for new transactions from the mempool before broadcasting any.

It has a limit on the number of times it will wait for new changes, which ensures we eventually broadcast and don't infinitely loop.

## Solution

- Combine some transaction IDs that arrive close together rather than overwriting and ignoring them
- Limit the number of times we will wait for new transaction IDs

Related changes:
- Reduce verbosity of transaction broadcast logging

## Review

This is a low-priority bug fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

If we're still dropping some transaction IDs, we might want to change from a watch channel to a broadcast channel. But based on my logs that's unlikely, I'm only seeing a new transaction every few seconds.