### PR TITLE
change(doc): Add "incompatible with nightly Rust (1.69)" to the README known issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Zebra 1.0.0-rc.6](https://github.com/ZcashFoundation/zebra/releases/tag/v1.0.0-rc.6) - 2023-03-TODO INSERT DATE HERE
+
+This release:
+- TODO: insert summary here
+
+### Known Issues
+
+- `orchard` 0.3.0 can't verify `halo2` proofs when compiled with Rust 1.69 or later (currently nightly Rust TODO: update this based on https://releases.rs/ ). Compile Zebra with stable Rust to avoid this bug. ([halo2/#737](https://github.com/zcash/halo2/issues/737))
+    - TODO: turn this into a breaking change if the bug is fixed in `orchard` 0.3.1 or 0.4.0, and [Zebra has updated #6232](https://github.com/ZcashFoundation/zebra/issues/6232)
+
+TODO: insert the rest of the changelog here
+
 ## [Zebra 1.0.0-rc.5](https://github.com/ZcashFoundation/zebra/releases/tag/v1.0.0-rc.5) - 2023-02-23
 
 This release:

--- a/README.md
+++ b/README.md
@@ -246,7 +246,9 @@ There are a few bugs in Zebra that we're still working on fixing:
 
 - No Windows support [#3801](https://github.com/ZcashFoundation/zebra/issues/3801). We used to test with Windows Server 2019, but not any more; see the issue for details.
 
-- Experimental Tor support is disabled until [`arti-client` upgrades to `x25519-dalek` 2.0.0 or later](https://github.com/ZcashFoundation/zebra/issues/5492). This happens due to a Rust dependency conflict, which can only be resolved by upgrading to a version of `x25519-dalek` with the dependency fix.
+- Experimental Tor support is disabled until [Zebra upgrades to the latest `arti-client`](https://github.com/ZcashFoundation/zebra/issues/5492). This happened due to a Rust dependency conflict, which could only be resolved by `arti` upgrading to a version of `x25519-dalek` with the dependency fix.
+
+- Orchard proofs [fail to verify when Zebra is compiled with Rust 1.69 (nightly Rust)](https://github.com/zcash/halo2/issues/737). This will be resolved in the next Orchard release after 0.3.0.
 
 - Output of `help`, `--help` flag, and usage of invalid commands or options are inconsistent [#5502](https://github.com/ZcashFoundation/zebra/issues/5502). See the issue for details.
 


### PR DESCRIPTION
## Motivation

ECC has diagnosed some Orchard verification failures and planned fixes:
https://github.com/zcash/halo2/issues/737

We need to document the issue in our README until it is resolved.

## Review

This is a low priority doc update.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [x] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the documentation make sense?

## Follow Up Work

- [x] #6232