### PR TITLE
change: Improve CommitBlockError message by including underlying error message

### DIFF
--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -43,7 +43,7 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// An error describing the reason a block could not be committed to the state.
 #[derive(Debug, Error, PartialEq, Eq)]
-#[error("block is not contextually valid")]
+#[error("block is not contextually valid: {}", .0)]
 pub struct CommitBlockError(#[from] ValidateContextError);
 
 /// An error describing why a block failed contextual validation.


### PR DESCRIPTION
## Motivation

Improve logging of CommitBlockError logged with the default Display method by extending with the underlying ValidateContextError message.

For example, before this fix a CommitBlockError with a ValidateContextError::Orphaned error would be printed as:
```
block is not contextually valid
```
with this fix:
```
block is not contextually valid: block height 12 is lower than the current finalized height 127
```
fixes #6218 