### PR TITLE
feat(elasticsearch): Export block data to elasticsearch database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "async-compression"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +285,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
@@ -1043,6 +1062,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
@@ -1067,6 +1096,20 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.47",
+ "quote 1.0.20",
+ "strsim 0.10.0",
+ "syn 1.0.104",
+]
+
+[[package]]
+name = "darling_core"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
@@ -1086,6 +1129,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
+ "quote 1.0.20",
+ "syn 1.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
  "quote 1.0.20",
  "syn 1.0.104",
 ]
@@ -1180,6 +1234,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
+
+[[package]]
 name = "ed25519-zebra"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1259,26 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "elasticsearch"
+version = "8.5.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d9bd57d914cc66ce878f098f63ed7b5d5b64c30644a5adb950b008f874a6c6"
+dependencies = [
+ "base64 0.11.0",
+ "bytes",
+ "dyn-clone",
+ "lazy_static",
+ "percent-encoding",
+ "reqwest",
+ "rustc_version 0.2.3",
+ "serde",
+ "serde_json",
+ "serde_with 1.14.0",
+ "url",
+ "void",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -3454,6 +3534,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
+ "async-compression",
  "base64 0.21.0",
  "bytes",
  "encoding_rs",
@@ -3481,6 +3562,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util 0.7.7",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3570,6 +3652,15 @@ name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
 
 [[package]]
 name = "rustc_version"
@@ -3787,7 +3878,7 @@ dependencies = [
  "hostname",
  "libc",
  "os_info",
- "rustc_version",
+ "rustc_version 0.4.0",
  "sentry-core",
  "uname",
 ]
@@ -3897,6 +3988,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d904179146de381af4c93d3af6ca4984b3152db687dacb9c3c35e86f39809c"
@@ -3907,8 +4008,20 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "serde_with_macros",
+ "serde_with_macros 2.2.0",
  "time 0.3.17",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling 0.13.4",
+ "proc-macro2 1.0.47",
+ "quote 1.0.20",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -4922,6 +5035,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5487,7 +5606,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde-big-array",
- "serde_with",
+ "serde_with 2.2.0",
  "sha2",
  "spandoc",
  "static_assertions",
@@ -5648,6 +5767,7 @@ dependencies = [
  "chrono",
  "color-eyre",
  "dirs",
+ "elasticsearch",
  "futures",
  "halo2_proofs",
  "hex",
@@ -5666,6 +5786,7 @@ dependencies = [
  "rlimit",
  "rocksdb",
  "serde",
+ "serde_json",
  "spandoc",
  "tempfile",
  "thiserror",

--- a/deny.toml
+++ b/deny.toml
@@ -94,6 +94,23 @@ skip-tree = [
     { name = "darling", version = "=0.10.2" },
     { name = "semver", version = "=0.9.0" },
     { name = "tracing-subscriber", version = "=0.1.6" },
+
+    # Elasticsearch dependencies
+
+    # wait for elasticsearch to update.
+    { name = "base64", version = "=0.11.0" },
+    # wait for elasticsearch to update.
+    { name = "darling", version = "=0.13.4" },
+    # wait for elasticsearch to update.
+    { name = "darling_core", version = "=0.13.4" },
+    # wait for elasticsearch to update.
+    { name = "darling_macro", version = "=0.13.4" },
+    # wait for elasticsearch to update.
+    { name = "rustc_version", version = "=0.2.3" },
+    # wait for elasticsearch to update.
+    { name = "serde_with", version = "=1.14.0" },
+    # wait for elasticsearch to update.
+    { name = "serde_with_macros", version = "=1.5.2" },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -23,7 +23,10 @@ proptest-impl = [
 ]
 
 # Experimental elasticsearch support
-elasticsearch = []
+elasticsearch = [
+    "dep:elasticsearch",
+    "dep:serde_json",
+]
 
 [dependencies]
 bincode = "1.3.3"
@@ -48,9 +51,9 @@ tokio = { version = "1.25.0", features = ["sync", "tracing"] }
 tower = { version = "0.4.13", features = ["buffer", "util"] }
 tracing = "0.1.37"
 
-# this should be behind a feature
-elasticsearch = "8.5.0-alpha.1"
-serde_json = "1.0.93"
+# elasticsearch specific dependencies.
+elasticsearch = { version = "8.5.0-alpha.1", package = "elasticsearch", optional = true }
+serde_json = { version = "1.0.93", package = "serde_json", optional = true }
 
 zebra-chain = { path = "../zebra-chain" }
 zebra-test = { path = "../zebra-test/", optional = true }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -45,6 +45,10 @@ tokio = { version = "1.25.0", features = ["sync", "tracing"] }
 tower = { version = "0.4.13", features = ["buffer", "util"] }
 tracing = "0.1.37"
 
+# this should be behind a feature
+elasticsearch = "8.5.0-alpha.1"
+serde_json = "1.0.93"
+
 zebra-chain = { path = "../zebra-chain" }
 zebra-test = { path = "../zebra-test/", optional = true }
 

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -22,6 +22,9 @@ proptest-impl = [
     "zebra-chain/proptest-impl"
 ]
 
+# Experimental elasticsearch support
+elasticsearch = []
+
 [dependencies]
 bincode = "1.3.3"
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -71,6 +71,18 @@ pub struct Config {
     /// no check for old database versions will be made and nothing will be
     /// deleted.
     pub delete_old_database: bool,
+
+    #[cfg(feature = "elasticsearch")]
+    /// The elasticsearch database url.
+    pub elasticsearch_url: String,
+
+    #[cfg(feature = "elasticsearch")]
+    /// The elasticsearch database username.
+    pub elasticsearch_username: String,
+
+    #[cfg(feature = "elasticsearch")]
+    /// The elasticsearch database password.
+    pub elasticsearch_password: String,
 }
 
 fn gen_temp_path(prefix: &str) -> PathBuf {
@@ -123,6 +135,12 @@ impl Default for Config {
             ephemeral: false,
             debug_stop_at_height: None,
             delete_old_database: true,
+            #[cfg(feature = "elasticsearch")]
+            elasticsearch_url: "https://localhost:9200".to_string(),
+            #[cfg(feature = "elasticsearch")]
+            elasticsearch_username: "elastic".to_string(),
+            #[cfg(feature = "elasticsearch")]
+            elasticsearch_password: "".to_string(),
         }
     }
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -319,7 +319,7 @@ impl StateService {
             };
 
             let conn_pool = SingleNodeConnectionPool::new(
-                Url::parse(&config.elasticsearch_url.as_str()).unwrap(),
+                Url::parse(config.elasticsearch_url.as_str()).unwrap(),
             );
             let transport = TransportBuilder::new(conn_pool)
                 .cert_validation(CertificateValidation::None)
@@ -329,17 +329,18 @@ impl StateService {
                 ))
                 .build()
                 .unwrap();
-            Elasticsearch::new(transport)
+            Some(Elasticsearch::new(transport))
         };
 
         let finalized_state = FinalizedState::new(
             &config,
             network,
-            #[cfg(feature = "elasticsearch")]
-            elasticsearch_client,
+            match elasticsearch_client {
+                Some(_) => elasticsearch_client,
+                None => None,
+            },
         );
 
-        // let finalized_state = FinalizedState::new(&config, network, elasticsearch_client);
         timer.finish(module_path!(), line!(), "opening finalized state database");
 
         let timer = CodeTimer::start();

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -32,14 +32,6 @@ use tracing::{instrument, Instrument, Span};
 #[cfg(any(test, feature = "proptest-impl"))]
 use tower::buffer::Buffer;
 
-use elasticsearch::{
-    auth::Credentials::Basic,
-    cert::CertificateValidation,
-    http::transport::{SingleNodeConnectionPool, TransportBuilder},
-    http::Url,
-    Elasticsearch,
-};
-
 use zebra_chain::{
     block::{self, CountedHeader},
     diagnostic::CodeTimer,
@@ -316,20 +308,38 @@ impl StateService {
     ) -> (Self, ReadStateService, LatestChainTip, ChainTipChange) {
         let timer = CodeTimer::start();
 
-        // if elasticsearch feature is enabled
-        let conn_pool =
-            SingleNodeConnectionPool::new(Url::parse("https://localhost:9200").unwrap());
-        let transport = TransportBuilder::new(conn_pool)
-            .cert_validation(CertificateValidation::None)
-            .auth(Basic(
-                "elastic".to_string(),
-                "my_password".to_string(),
-            ))
-            .build()
-            .unwrap();
-        let client = Elasticsearch::new(transport);
+        #[cfg(feature = "elasticsearch")]
+        let elasticsearch_client = {
+            use elasticsearch::{
+                auth::Credentials::Basic,
+                cert::CertificateValidation,
+                http::transport::{SingleNodeConnectionPool, TransportBuilder},
+                http::Url,
+                Elasticsearch,
+            };
 
-        let finalized_state = FinalizedState::new(&config, network, Some(client));
+            let conn_pool = SingleNodeConnectionPool::new(
+                Url::parse(&config.elasticsearch_url.as_str()).unwrap(),
+            );
+            let transport = TransportBuilder::new(conn_pool)
+                .cert_validation(CertificateValidation::None)
+                .auth(Basic(
+                    config.clone().elasticsearch_username,
+                    config.clone().elasticsearch_password,
+                ))
+                .build()
+                .unwrap();
+            Elasticsearch::new(transport)
+        };
+
+        let finalized_state = FinalizedState::new(
+            &config,
+            network,
+            #[cfg(feature = "elasticsearch")]
+            elasticsearch_client,
+        );
+
+        // let finalized_state = FinalizedState::new(&config, network, elasticsearch_client);
         timer.finish(module_path!(), line!(), "opening finalized state database");
 
         let timer = CodeTimer::start();

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -230,7 +230,7 @@ impl FinalizedState {
 
         // Save blocks to elasticsearch if the feature is enabled.
         #[cfg(feature = "elasticsearch")]
-        self.elasticsearch(&finalized, &committed_tip_height);
+        self.elasticsearch(&finalized.block, &committed_tip_height);
 
         // Assert that callers (including unit tests) get the chain order correct
         if self.db.is_empty() {
@@ -354,11 +354,10 @@ impl FinalizedState {
     /// synchronizing the chain, when we get close to tip we index blocks one by one.
     pub fn elasticsearch(
         &mut self,
-        finalized: &FinalizedBlock,
+        block: &Arc<block::Block>,
         committed_tip_height: &Option<block::Height>,
     ) {
         if let Some(client) = self.elastic_db.clone() {
-            let block = &finalized.block;
             let block_time = block.header.time.timestamp();
             let local_time = chrono::Utc::now().timestamp();
 

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -390,7 +390,7 @@ impl FinalizedState {
             // We are in bulk time, insert to ES all we have.
             if self.elastic_blocks.len() >= blocks_size_to_dump {
                 let rt = tokio::runtime::Runtime::new()
-                    .expect("wuntime creation for elasticsearch should not fail.");
+                    .expect("runtime creation for elasticsearch should not fail.");
                 let blocks = self.elastic_blocks.clone();
                 let network = self.network;
 

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -355,7 +355,7 @@ impl FinalizedState {
         use elasticsearch::BulkParts;
         use serde_json::Value;
 
-        let block = finalized.block.clone();
+        let block = &finalized.block;
         let block_time = block.header.time.timestamp();
         let local_time = Utc::now().timestamp();
 

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -361,7 +361,7 @@ impl FinalizedState {
 
         const AWAY_FROM_TIP_BULK_SIZE: usize = 800;
         const CLOSE_TO_TIP_BULK_SIZE: usize = 2;
-        const CLOSE_TO_TIP_SECONDS: i64 = 900;
+        const CLOSE_TO_TIP_SECONDS: i64 = 14400; // 4 hours
 
         // If we are close to the tip index one block per bulk call.
         let mut blocks_size_to_dump = AWAY_FROM_TIP_BULK_SIZE;

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -389,10 +389,11 @@ impl FinalizedState {
             let client = self.elastic_db.clone();
             let rt = tokio::runtime::Runtime::new().unwrap();
             let blocks = self.elastic_blocks.clone();
+            let network = self.network.clone();
 
             rt.block_on(async move {
                 let response = client
-                    .bulk(BulkParts::Index("testing"))
+                    .bulk(BulkParts::Index(format!("Zcash_{network}").as_str()))
                     .body(blocks)
                     .send()
                     .await

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -94,7 +94,7 @@ impl FinalizedState {
     pub fn new(
         config: &Config,
         network: Network,
-        #[cfg(feature = "elasticsearch")] elastic_db: elasticsearch::Elasticsearch,
+        elastic_db: Option<elasticsearch::Elasticsearch>,
     ) -> Self {
         let db = ZebraDb::new(config, network);
 
@@ -103,7 +103,7 @@ impl FinalizedState {
             debug_stop_at_height: config.debug_stop_at_height.map(block::Height),
             db,
             #[cfg(feature = "elasticsearch")]
-            elastic_db,
+            elastic_db: elastic_db.expect("database handle should be here"),
             #[cfg(feature = "elasticsearch")]
             elastic_blocks: vec![],
         };
@@ -278,7 +278,7 @@ impl FinalizedState {
                         .expect("ES response parsing to a json_body should never fail");
                     assert!(!response_body["errors"]
                         .as_bool()
-                        .expect(format!("ES error: {}", response_body).as_str()));
+                        .unwrap_or_else(|| panic!("ES error: {response_body}")));
                 });
 
                 // clean the storage.

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
@@ -62,7 +62,7 @@ fn test_raw_rocksdb_column_families_with_network(network: Network) {
     let mut net_suffix = network.to_string();
     net_suffix.make_ascii_lowercase();
 
-    let mut state = FinalizedState::new(&Config::ephemeral(), network);
+    let mut state = FinalizedState::new(&Config::ephemeral(), network, None);
 
     // Snapshot the column family names
     let mut cf_names = state.db.list_cf().expect("empty database is valid");

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
@@ -62,7 +62,12 @@ fn test_raw_rocksdb_column_families_with_network(network: Network) {
     let mut net_suffix = network.to_string();
     net_suffix.make_ascii_lowercase();
 
-    let mut state = FinalizedState::new(&Config::ephemeral(), network, None);
+    let mut state = FinalizedState::new(
+        &Config::ephemeral(),
+        network,
+        #[cfg(feature = "elasticsearch")]
+        None,
+    );
 
     // Snapshot the column family names
     let mut cf_names = state.db.list_cf().expect("empty database is valid");

--- a/zebra-state/src/service/finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/tests/prop.rs
@@ -24,7 +24,7 @@ fn blocks_with_v5_transactions() -> Result<()> {
         .and_then(|v| v.parse().ok())
         .unwrap_or(DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES)),
         |((chain, count, network, _history_tree) in PreparedChain::default())| {
-            let mut state = FinalizedState::new(&Config::ephemeral(), network, None);
+            let mut state = FinalizedState::new(&Config::ephemeral(), network, #[cfg(feature = "elasticsearch")] None);
             let mut height = Height(0);
             // use `count` to minimize test failures, so they are easier to diagnose
             for block in chain.iter().take(count) {
@@ -65,7 +65,7 @@ fn all_upgrades_and_wrong_commitments_with_fake_activation_heights() -> Result<(
         .unwrap_or(DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES)),
         |((chain, _count, network, _history_tree) in PreparedChain::default().with_valid_commitments().no_shrink())| {
 
-            let mut state = FinalizedState::new(&Config::ephemeral(), network, None);
+            let mut state = FinalizedState::new(&Config::ephemeral(), network, #[cfg(feature = "elasticsearch")] None);
             let mut height = Height(0);
             let heartwood_height = NetworkUpgrade::Heartwood.activation_height(network).unwrap();
             let heartwood_height_plus1 = (heartwood_height + 1).unwrap();

--- a/zebra-state/src/service/finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/tests/prop.rs
@@ -24,7 +24,7 @@ fn blocks_with_v5_transactions() -> Result<()> {
         .and_then(|v| v.parse().ok())
         .unwrap_or(DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES)),
         |((chain, count, network, _history_tree) in PreparedChain::default())| {
-            let mut state = FinalizedState::new(&Config::ephemeral(), network);
+            let mut state = FinalizedState::new(&Config::ephemeral(), network, None);
             let mut height = Height(0);
             // use `count` to minimize test failures, so they are easier to diagnose
             for block in chain.iter().take(count) {
@@ -65,7 +65,7 @@ fn all_upgrades_and_wrong_commitments_with_fake_activation_heights() -> Result<(
         .unwrap_or(DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES)),
         |((chain, _count, network, _history_tree) in PreparedChain::default().with_valid_commitments().no_shrink())| {
 
-            let mut state = FinalizedState::new(&Config::ephemeral(), network);
+            let mut state = FinalizedState::new(&Config::ephemeral(), network, None);
             let mut height = Height(0);
             let heartwood_height = NetworkUpgrade::Heartwood.activation_height(network).unwrap();
             let heartwood_height_plus1 = (heartwood_height + 1).unwrap();

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
@@ -165,7 +165,12 @@ fn test_block_and_transaction_data_with_network(network: Network) {
     let mut net_suffix = network.to_string();
     net_suffix.make_ascii_lowercase();
 
-    let mut state = FinalizedState::new(&Config::ephemeral(), network, None);
+    let mut state = FinalizedState::new(
+        &Config::ephemeral(),
+        network,
+        #[cfg(feature = "elasticsearch")]
+        None,
+    );
 
     // Assert that empty databases are the same, regardless of the network.
     let mut settings = insta::Settings::clone_current();

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
@@ -165,7 +165,7 @@ fn test_block_and_transaction_data_with_network(network: Network) {
     let mut net_suffix = network.to_string();
     net_suffix.make_ascii_lowercase();
 
-    let mut state = FinalizedState::new(&Config::ephemeral(), network);
+    let mut state = FinalizedState::new(&Config::ephemeral(), network, None);
 
     // Assert that empty databases are the same, regardless of the network.
     let mut settings = insta::Settings::clone_current();

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -77,7 +77,12 @@ fn test_block_db_round_trip_with(
 ) {
     let _init_guard = zebra_test::init();
 
-    let state = FinalizedState::new(&Config::ephemeral(), network, None);
+    let state = FinalizedState::new(
+        &Config::ephemeral(),
+        network,
+        #[cfg(feature = "elasticsearch")]
+        None,
+    );
 
     // Check that each block round-trips to the database
     for original_block in block_test_cases.into_iter() {

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -77,7 +77,7 @@ fn test_block_db_round_trip_with(
 ) {
     let _init_guard = zebra_test::init();
 
-    let state = FinalizedState::new(&Config::ephemeral(), network);
+    let state = FinalizedState::new(&Config::ephemeral(), network, None);
 
     // Check that each block round-trips to the database
     for original_block in block_test_cases.into_iter() {

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -478,7 +478,7 @@ fn rejection_restores_internal_state_genesis() -> Result<()> {
       }
       ))| {
         let mut state = NonFinalizedState::new(network);
-        let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
+        let finalized_state = FinalizedState::new(&Config::ephemeral(), network, #[cfg(feature = "elasticsearch")] None);
 
         let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
         finalized_state.set_finalized_value_pool(fake_value_pool);

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -478,7 +478,7 @@ fn rejection_restores_internal_state_genesis() -> Result<()> {
       }
       ))| {
         let mut state = NonFinalizedState::new(network);
-        let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+        let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
 
         let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
         finalized_state.set_finalized_value_pool(fake_value_pool);

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -156,7 +156,7 @@ fn best_chain_wins_for_network(network: Network) -> Result<()> {
     let expected_hash = block2.hash();
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
 
     state.commit_new_chain(block2.prepare(), &finalized_state)?;
     state.commit_new_chain(child.prepare(), &finalized_state)?;
@@ -194,7 +194,7 @@ fn finalize_pops_from_best_chain_for_network(network: Network) -> Result<()> {
     let child = block1.make_fake_child().set_work(1);
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -247,7 +247,7 @@ fn commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(
     let child2 = block2.make_fake_child().set_work(1);
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -294,7 +294,7 @@ fn shorter_chain_can_be_best_chain_for_network(network: Network) -> Result<()> {
     let short_chain_block = block1.make_fake_child().set_work(3);
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -341,7 +341,7 @@ fn longer_chain_with_more_work_wins_for_network(network: Network) -> Result<()> 
     let short_chain_block = block1.make_fake_child().set_work(3);
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -386,7 +386,7 @@ fn equal_length_goes_to_more_work_for_network(network: Network) -> Result<()> {
     let expected_hash = more_work_child.hash();
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -430,7 +430,7 @@ fn history_tree_is_updated_for_network_upgrade(
     );
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
 
     state
         .commit_new_chain(prev_block.clone().prepare(), &finalized_state)
@@ -526,7 +526,7 @@ fn commitment_is_validated_for_network_upgrade(network: Network, network_upgrade
     );
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
 
     state
         .commit_new_chain(prev_block.clone().prepare(), &finalized_state)

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -156,7 +156,12 @@ fn best_chain_wins_for_network(network: Network) -> Result<()> {
     let expected_hash = block2.hash();
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        network,
+        #[cfg(feature = "elasticsearch")]
+        None,
+    );
 
     state.commit_new_chain(block2.prepare(), &finalized_state)?;
     state.commit_new_chain(child.prepare(), &finalized_state)?;
@@ -194,7 +199,12 @@ fn finalize_pops_from_best_chain_for_network(network: Network) -> Result<()> {
     let child = block1.make_fake_child().set_work(1);
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        network,
+        #[cfg(feature = "elasticsearch")]
+        None,
+    );
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -247,7 +257,12 @@ fn commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(
     let child2 = block2.make_fake_child().set_work(1);
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        network,
+        #[cfg(feature = "elasticsearch")]
+        None,
+    );
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -294,7 +309,12 @@ fn shorter_chain_can_be_best_chain_for_network(network: Network) -> Result<()> {
     let short_chain_block = block1.make_fake_child().set_work(3);
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        network,
+        #[cfg(feature = "elasticsearch")]
+        None,
+    );
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -341,7 +361,12 @@ fn longer_chain_with_more_work_wins_for_network(network: Network) -> Result<()> 
     let short_chain_block = block1.make_fake_child().set_work(3);
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        network,
+        #[cfg(feature = "elasticsearch")]
+        None,
+    );
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -386,7 +411,12 @@ fn equal_length_goes_to_more_work_for_network(network: Network) -> Result<()> {
     let expected_hash = more_work_child.hash();
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        network,
+        #[cfg(feature = "elasticsearch")]
+        None,
+    );
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -430,7 +460,12 @@ fn history_tree_is_updated_for_network_upgrade(
     );
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        network,
+        #[cfg(feature = "elasticsearch")]
+        None,
+    );
 
     state
         .commit_new_chain(prev_block.clone().prepare(), &finalized_state)
@@ -526,7 +561,12 @@ fn commitment_is_validated_for_network_upgrade(network: Network, network_upgrade
     );
 
     let mut state = NonFinalizedState::new(network);
-    let finalized_state = FinalizedState::new(&Config::ephemeral(), network, None);
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        network,
+        #[cfg(feature = "elasticsearch")]
+        None,
+    );
 
     state
         .commit_new_chain(prev_block.clone().prepare(), &finalized_state)

--- a/zebra-state/src/tests/setup.rs
+++ b/zebra-state/src/tests/setup.rs
@@ -92,7 +92,12 @@ pub(crate) fn new_state_with_mainnet_genesis() -> (FinalizedState, NonFinalizedS
     let config = Config::ephemeral();
     let network = Mainnet;
 
-    let mut finalized_state = FinalizedState::new(&config, network, None);
+    let mut finalized_state = FinalizedState::new(
+        &config,
+        network,
+        #[cfg(feature = "elasticsearch")]
+        None,
+    );
     let non_finalized_state = NonFinalizedState::new(network);
 
     assert_eq!(

--- a/zebra-state/src/tests/setup.rs
+++ b/zebra-state/src/tests/setup.rs
@@ -92,7 +92,7 @@ pub(crate) fn new_state_with_mainnet_genesis() -> (FinalizedState, NonFinalizedS
     let config = Config::ephemeral();
     let network = Mainnet;
 
-    let mut finalized_state = FinalizedState::new(&config, network);
+    let mut finalized_state = FinalizedState::new(&config, network, None);
     let non_finalized_state = NonFinalizedState::new(network);
 
     assert_eq!(

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -34,6 +34,10 @@ getblocktemplate-rpcs = [
     "zebra-chain/getblocktemplate-rpcs",
 ]
 
+elasticsearch = [
+    "zebra-state/elasticsearch",
+]
+
 sentry = ["dep:sentry"]
 flamegraph = ["tracing-flame", "inferno"]
 journald = ["tracing-journald"]


### PR DESCRIPTION
## Motivation

We want to export block data from the Zcash blockchain using Zebra into an elasticsearch database

https://github.com/ZcashFoundation/zebra/issues/6270

### Specifications

All finalized blocks pass through the `commit_finalized_direct` method of the `FinalizedState` structure.

Here, if the `elasticsearch` rust feature is enabled we call a new method `elasticsearch()` that will take the additional work of sending the blocks to the elasticsearch database.

Url, username and elasticsearch database password are configurable. 

### Complex Code or Requirements

Indexing blocks one by one is a performance pain for the entire blockchain. The idea is to use the bulk elasticsearch api to send a batch of blocks from time to time when we are far away from the tip and then starting indexing by one when we get closer so we will end up with a real time thing.

## Solution

TBA

## Review


### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Possible TODOs:

- Test with the mainnet.
- Add to CI?
- Improve performance.

