### PR TITLE
fix(test): Disable `verify_generated_halo2_proofs` test

### DIFF
--- a/zebra-consensus/src/primitives/halo2/tests.rs
+++ b/zebra-consensus/src/primitives/halo2/tests.rs
@@ -131,6 +131,8 @@ where
 }
 
 #[tokio::test(flavor = "multi_thread")]
+// TODO: This test fails on nightly so it is temporally disabled. Enable when #6232 is resolved.
+#[ignore]
 async fn verify_generated_halo2_proofs() {
     let _init_guard = zebra_test::init();
 


### PR DESCRIPTION
## Motivation

Test `verify_generated_halo2_proofs` is failing in CI with nightly rust: https://github.com/ZcashFoundation/zebra/issues/6232

All merging is blocked until this is fixed.

## Solution

Temporally disable test with `ignore`. I think this might be enough.

## Review

Anyone can review. I think we should merge soon if the CI pass as it is blocking all open pull requests in the main queue.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [x] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
