### PR TITLE
Halborn 2023 02 20

### DIFF
--- a/zebra-chain/src/serialization.rs
+++ b/zebra-chain/src/serialization.rs
@@ -32,8 +32,9 @@ pub use error::SerializationError;
 pub use read_zcash::ReadZcashExt;
 pub use write_zcash::WriteZcashExt;
 pub use zcash_deserialize::{
-    zcash_deserialize_bytes_external_count, zcash_deserialize_external_count, TrustedPreallocate,
-    ZcashDeserialize, ZcashDeserializeInto,
+    zcash_deserialize_bytes_external_count, zcash_deserialize_external_count,
+    zcash_deserialize_string_external_count, TrustedPreallocate, ZcashDeserialize,
+    ZcashDeserializeInto,
 };
 pub use zcash_serialize::{
     zcash_serialize_bytes, zcash_serialize_bytes_external_count, zcash_serialize_empty_list,

--- a/zebra-network/src/peer_set/inventory_registry.rs
+++ b/zebra-network/src/peer_set/inventory_registry.rs
@@ -265,6 +265,17 @@ impl InventoryRegistry {
             .is_some()
     }
 
+    /// Returns an iterator over peer inventory status hashes.
+    ///
+    /// Yields current statuses first, then previously rotated statuses.
+    /// This can include multiple statuses for the same hash.
+    #[allow(dead_code)]
+    pub fn status_hashes(
+        &self,
+    ) -> impl Iterator<Item = (&InventoryHash, &IndexMap<SocketAddr, InventoryMarker>)> {
+        self.current.iter().chain(self.prev.iter())
+    }
+
     /// Returns a future that polls once for new registry updates.
     #[allow(dead_code)]
     pub fn update(&mut self) -> Update {

--- a/zebra-network/src/peer_set/inventory_registry/tests/vectors.rs
+++ b/zebra-network/src/peer_set/inventory_registry/tests/vectors.rs
@@ -1,9 +1,14 @@
 //! Fixed test vectors for the inventory registry.
 
-use zebra_chain::block;
+use std::{cmp::min, net::SocketAddr};
+
+use zebra_chain::{block, serialization::AtLeastOne, transaction};
 
 use crate::{
-    peer_set::inventory_registry::{tests::new_inv_registry, InventoryStatus},
+    peer_set::inventory_registry::{
+        tests::new_inv_registry, InventoryMarker, InventoryStatus, MAX_INV_PER_MAP,
+        MAX_PEERS_PER_INV,
+    },
     protocol::external::InventoryHash,
 };
 
@@ -180,5 +185,98 @@ async fn inv_registry_prefer_current_order(missing_current: bool) {
         );
         assert_eq!(inv_registry.advertising_peers(test_hash).count(), 1);
         assert_eq!(inv_registry.missing_peers(test_hash).count(), 0);
+    }
+}
+
+/// Check inventory registration limits.
+#[tokio::test]
+async fn inv_registry_limit() {
+    inv_registry_limit_for(InventoryMarker::Available(())).await;
+    inv_registry_limit_for(InventoryMarker::Missing(())).await;
+}
+
+/// Check the inventory registration limit for `status`.
+async fn inv_registry_limit_for(status: InventoryMarker) {
+    let single_test_hash = InventoryHash::Block(block::Hash([0xbb; 32]));
+    let single_test_peer = "1.1.1.1:1"
+        .parse()
+        .expect("unexpected invalid peer address");
+
+    let (mut inv_registry, inv_stream_tx) = new_inv_registry();
+
+    // Check hash limit
+    for hash_count in 0..(MAX_INV_PER_MAP + 10) {
+        let mut test_hash = hash_count.to_ne_bytes().to_vec();
+        test_hash.resize(32, 0);
+        let test_hash = InventoryHash::Tx(transaction::Hash(test_hash.try_into().unwrap()));
+
+        let test_change = status.map(|()| (AtLeastOne::from_one(test_hash), single_test_peer));
+
+        let receiver_count = inv_stream_tx
+            .send(test_change)
+            .expect("unexpected failed inventory status send");
+
+        assert_eq!(receiver_count, 1);
+
+        inv_registry
+            .update()
+            .await
+            .expect("unexpected dropped registry sender channel");
+
+        if status.is_available() {
+            assert_eq!(inv_registry.advertising_peers(test_hash).count(), 1);
+            assert_eq!(inv_registry.missing_peers(test_hash).count(), 0);
+        } else {
+            assert_eq!(inv_registry.advertising_peers(test_hash).count(), 0);
+            assert_eq!(inv_registry.missing_peers(test_hash).count(), 1);
+        }
+
+        // SECURITY: limit inventory memory usage
+        assert_eq!(
+            inv_registry.status_hashes().count(),
+            min(hash_count + 1, MAX_INV_PER_MAP),
+        );
+    }
+
+    // Check peer address per hash limit
+    let (mut inv_registry, inv_stream_tx) = new_inv_registry();
+
+    for peer_count in 0..(MAX_PEERS_PER_INV + 10) {
+        let test_peer = SocketAddr::new(
+            "2.2.2.2".parse().unwrap(),
+            peer_count.try_into().expect("fits in u16"),
+        );
+
+        let test_change = status.map(|()| (AtLeastOne::from_one(single_test_hash), test_peer));
+
+        let receiver_count = inv_stream_tx
+            .send(test_change)
+            .expect("unexpected failed inventory status send");
+
+        assert_eq!(receiver_count, 1);
+
+        inv_registry
+            .update()
+            .await
+            .expect("unexpected dropped registry sender channel");
+
+        assert_eq!(inv_registry.status_hashes().count(), 1);
+
+        let limited_count = min(peer_count + 1, MAX_PEERS_PER_INV);
+
+        // SECURITY: limit inventory memory usage
+        if status.is_available() {
+            assert_eq!(
+                inv_registry.advertising_peers(single_test_hash).count(),
+                limited_count,
+            );
+            assert_eq!(inv_registry.missing_peers(single_test_hash).count(), 0);
+        } else {
+            assert_eq!(inv_registry.advertising_peers(single_test_hash).count(), 0);
+            assert_eq!(
+                inv_registry.missing_peers(single_test_hash).count(),
+                limited_count,
+            );
+        }
     }
 }

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -364,13 +364,17 @@ pub struct VersionMessage {
 
 /// The maximum size of the rejection message.
 ///
-/// This is equivalent to `COMMAND_SIZE` in zcashd.
-const MAX_REJECT_MESSAGE_LENGTH: usize = 12;
+/// This is equivalent to `COMMAND_SIZE` in zcashd:
+/// <https://github.com/zcash/zcash/blob/adfc7218435faa1c8985a727f997a795dcffa0c7/src/protocol.h#L33>
+/// <https://github.com/zcash/zcash/blob/c0fbeb809bf2303e30acef0d2b74db11e9177427/src/main.cpp#L7544>
+pub const MAX_REJECT_MESSAGE_LENGTH: usize = 12;
 
 /// The maximum size of the rejection reason.
 ///
-/// This is equivalent to `MAX_REJECT_MESSAGE_LENGTH` in zcashd.
-const MAX_REJECT_REASON_LENGTH: usize = 111;
+/// This is equivalent to `MAX_REJECT_MESSAGE_LENGTH` in zcashd:
+/// <https://github.com/zcash/zcash/blob/adfc7218435faa1c8985a727f997a795dcffa0c7/src/main.h#L126>
+/// <https://github.com/zcash/zcash/blob/c0fbeb809bf2303e30acef0d2b74db11e9177427/src/main.cpp#L7544>
+pub const MAX_REJECT_REASON_LENGTH: usize = 111;
 
 impl From<VersionMessage> for Message {
     fn from(version_message: VersionMessage) -> Self {

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -293,6 +293,12 @@ pub enum Message {
     FilterClear,
 }
 
+/// The maximum size of the user agent string.
+///
+/// This is equivalent to `MAX_SUBVERSION_LENGTH` in `zcashd`:
+/// <https://github.com/zcash/zcash/blob/adfc7218435faa1c8985a727f997a795dcffa0c7/src/net.h#L56>
+pub const MAX_USER_AGENT_LENGTH: usize = 256;
+
 /// A `version` message.
 ///
 /// Note that although this is called `version` in Bitcoin, its role is really


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

This PR fixes some issues we found when investigating the [Halborn disclosures](https://www.halborn.com/blog/post/halborn-discovers-zero-day-impacting-dogecoin-and-280-networks) from February 2023, and other related network protocol memory usage issues. 

The security researchers looked at the `zebrad` codebase and said their exploit will not work against it as-is. 

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

Most of these network protocol limits are undocumented, see the code comments for specific links to `zcashd` source code.

### Complex Code or Requirements

<!--
Does this PR change concurrency, unsafe code, or complex consensus rules?
If it does, ask for multiple reviewers on this PR.
-->

These are network protocol changes, they are compatible with other implementations under normal usage.

There are no consensus-critical or concurrent code changes.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
If this is a large change, list commits of key functional changes here.
-->

This PR contains the simplest possible fixes to these issues.

Halborn:
1. limit inventory registry size to ~16 MB, currently unlimited (but dropped after 2 minutes)
    1. limit registry hashes to 1000, much larger than the typical number of pending gossiped blocks and mempool transactions
        - also limit inventory hashes in each pending inventory update to 1000
    2. limit peers per hash to 70, slightly lower than our default peer set size
        - this avoids large behavior differences around the peer limit
        - for example, if an inventory is globally missing, we could always query 1 peer if we have 74 peers, but we can't query any if we have 75
    3. remove the oldest hash or peer when the limit is reached, for simplicity
        - we might want to change to weighted random later, to avoid inventory flooding/removal attacks
    4. don't delay inventory rotation under load
        - instead, do the current rotation now, and the next rotation earlier to catch up

Testing:
- registry going over the limit
    - inv limit
    - addr per inv limit

Related - similar attack:
1. Limit version user agents to 256 bytes, currently the 2 MB message limit
    - since we store one version message per connected peer, an attack can use up to 400 MB of memory

Testing:
- version user agent over the limit

### Less urgent

These fixes are not urgent, but we'll do them at the same time anyway:
1. Limit reject messages to 128 bytes, currently the default 2 MB message limit
    - we already drop these messages soon after receiving them, but they could be stored in logs and fill up the disk
2. Don't print every gossiped transaction ID to the logs by default
    - an attacker sending a lot of tiny transactions to the mempool could fill up the disk with logs

Testing:
- reject command and reject reason
    - over the limit
    - at or under the limit (rejects are rare on the network, so our integration tests don't cover them)

Doesn't need to be in the initial fix or release:
1. Limit inv messages to 50,000 hashes, currently ~58,000 (the default 2 MB message limit)
     - minimal impact, 1.8 MB vs 2 MB, we already drop these messages soon after receiving them

## Review

<!--
Is this PR blocking any other work?
If you want specific reviewers for this PR, tag them here.
-->

Reviewed by several people privately already.

### Reviewer Checklist

  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
    - [ ] Are there any security risks remaining, or any new security risks introduced?
  - [x] Do the security docs explain and justify the code changes?
  - [ ] How do you know it works? Does it have tests?
      - [x] Existing tests pass (except for CI setup issues)
      - [ ] New tests pass
      - [x] Manual sync tests pass

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
