### PR TITLE
change(state): Stop re-downloading blocks that are in non-finalized side chains

### DIFF
--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -159,7 +159,7 @@ where
                 .map_err(|source| VerifyBlockError::Depth { source, hash })?
             {
                 zs::Response::KnownBlock(Some(location)) => {
-                    return Err(BlockError::AlreadyInState(hash, location).into())
+                    return Err(BlockError::AlreadyInChain(hash, location).into())
                 }
                 zs::Response::KnownBlock(None) => {}
                 _ => unreachable!("wrong response to Request::KnownBlock"),

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -154,7 +154,7 @@ where
                 .ready()
                 .await
                 .map_err(|source| VerifyBlockError::Depth { source, hash })?
-                .call(zs::Request::Contains(hash))
+                .call(zs::Request::KnownBlock(hash))
                 .await
                 .map_err(|source| VerifyBlockError::Depth { source, hash })?
             {

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -159,7 +159,7 @@ where
                 .map_err(|source| VerifyBlockError::Depth { source, hash })?
             {
                 zs::Response::KnownBlock(Some(location)) => {
-                    return Err(BlockError::AlreadyInChain(hash, location).into())
+                    return Err(BlockError::AlreadyInState(hash, location).into())
                 }
                 zs::Response::KnownBlock(None) => {}
                 _ => unreachable!("wrong response to Request::Depth"),

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -154,14 +154,14 @@ where
                 .ready()
                 .await
                 .map_err(|source| VerifyBlockError::Depth { source, hash })?
-                .call(zs::Request::Depth(hash))
+                .call(zs::Request::Contains(hash))
                 .await
                 .map_err(|source| VerifyBlockError::Depth { source, hash })?
             {
-                zs::Response::Depth(Some(depth)) => {
-                    return Err(BlockError::AlreadyInChain(hash, depth).into())
+                zs::Response::BlockLocation(Some(location)) => {
+                    return Err(BlockError::AlreadyInChain(hash, location).into())
                 }
-                zs::Response::Depth(None) => {}
+                zs::Response::BlockLocation(None) => {}
                 _ => unreachable!("wrong response to Request::Depth"),
             }
 

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -158,10 +158,10 @@ where
                 .await
                 .map_err(|source| VerifyBlockError::Depth { source, hash })?
             {
-                zs::Response::BlockLocation(Some(location)) => {
+                zs::Response::KnownBlock(Some(location)) => {
                     return Err(BlockError::AlreadyInChain(hash, location).into())
                 }
-                zs::Response::BlockLocation(None) => {}
+                zs::Response::KnownBlock(None) => {}
                 _ => unreachable!("wrong response to Request::Depth"),
             }
 

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -162,7 +162,7 @@ where
                     return Err(BlockError::AlreadyInState(hash, location).into())
                 }
                 zs::Response::KnownBlock(None) => {}
-                _ => unreachable!("wrong response to Request::Depth"),
+                _ => unreachable!("wrong response to Request::KnownBlock"),
             }
 
             tracing::trace!("performing block checks");

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -246,7 +246,7 @@ pub enum BlockError {
     DuplicateTransaction,
 
     #[error("block {0:?} is already in present in the state {1:?}")]
-    AlreadyInState(zebra_chain::block::Hash, zebra_state::KnownBlock),
+    AlreadyInChain(zebra_chain::block::Hash, zebra_state::KnownBlock),
 
     #[error("invalid block {0:?}: missing block height")]
     MissingHeight(zebra_chain::block::Hash),
@@ -311,6 +311,6 @@ impl BlockError {
     /// Returns `true` if this is definitely a duplicate request.
     /// Some duplicate requests might not be detected, and therefore return `false`.
     pub fn is_duplicate_request(&self) -> bool {
-        matches!(self, BlockError::AlreadyInState(..))
+        matches!(self, BlockError::AlreadyInChain(..))
     }
 }

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -246,7 +246,7 @@ pub enum BlockError {
     DuplicateTransaction,
 
     #[error("block {0:?} is already in the chain at depth {1:?}")]
-    AlreadyInChain(zebra_chain::block::Hash, u32),
+    AlreadyInChain(zebra_chain::block::Hash, zebra_state::BlockLocation),
 
     #[error("invalid block {0:?}: missing block height")]
     MissingHeight(zebra_chain::block::Hash),

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -246,7 +246,7 @@ pub enum BlockError {
     DuplicateTransaction,
 
     #[error("block {0:?} is already in the chain at depth {1:?}")]
-    AlreadyInChain(zebra_chain::block::Hash, zebra_state::BlockLocation),
+    AlreadyInChain(zebra_chain::block::Hash, zebra_state::KnownBlock),
 
     #[error("invalid block {0:?}: missing block height")]
     MissingHeight(zebra_chain::block::Hash),

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -245,8 +245,8 @@ pub enum BlockError {
     #[error("block contains duplicate transactions")]
     DuplicateTransaction,
 
-    #[error("block {0:?} is already in the chain at depth {1:?}")]
-    AlreadyInChain(zebra_chain::block::Hash, zebra_state::KnownBlock),
+    #[error("block {0:?} is already in present in the state {1:?}")]
+    AlreadyInState(zebra_chain::block::Hash, zebra_state::KnownBlock),
 
     #[error("invalid block {0:?}: missing block height")]
     MissingHeight(zebra_chain::block::Hash),
@@ -311,6 +311,6 @@ impl BlockError {
     /// Returns `true` if this is definitely a duplicate request.
     /// Some duplicate requests might not be detected, and therefore return `false`.
     pub fn is_duplicate_request(&self) -> bool {
-        matches!(self, BlockError::AlreadyInChain(..))
+        matches!(self, BlockError::AlreadyInState(..))
     }
 }

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -33,7 +33,7 @@ pub use config::{check_and_delete_old_databases, Config};
 pub use constants::MAX_BLOCK_REORG_HEIGHT;
 pub use error::{BoxError, CloneError, CommitBlockError, ValidateContextError};
 pub use request::{FinalizedBlock, HashOrHeight, PreparedBlock, ReadRequest, Request};
-pub use response::{ReadResponse, Response};
+pub use response::{BlockLocation, ReadResponse, Response};
 pub use service::{
     chain_tip::{ChainTipChange, LatestChainTip, TipAction},
     init, spawn_init,

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -33,7 +33,7 @@ pub use config::{check_and_delete_old_databases, Config};
 pub use constants::MAX_BLOCK_REORG_HEIGHT;
 pub use error::{BoxError, CloneError, CommitBlockError, ValidateContextError};
 pub use request::{FinalizedBlock, HashOrHeight, PreparedBlock, ReadRequest, Request};
-pub use response::{BlockLocation, ReadResponse, Response};
+pub use response::{KnownBlock, ReadResponse, Response};
 pub use service::{
     chain_tip::{ChainTipChange, LatestChainTip, TipAction},
     init, spawn_init,

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -641,7 +641,7 @@ impl Request {
             }
             Request::BestChainNextMedianTimePast => "best_chain_next_median_time_past",
             Request::BestChainBlockHash(_) => "best_chain_block_hash",
-            Request::Contains(_) => "contains",
+            Request::KnownBlock(_) => "known_block",
             #[cfg(feature = "getblocktemplate-rpcs")]
             Request::CheckBlockProposalValidity(_) => "check_block_proposal_validity",
         }
@@ -955,7 +955,7 @@ impl TryFrom<Request> for ReadRequest {
                      Manually convert the request to ReadRequest::AnyChainUtxo, \
                      and handle pending UTXOs"),
 
-            Request::Contains(_) => Err("ReadService does not track queued blocks"),
+            Request::KnownBlock(_) => Err("ReadService does not track queued blocks"),
 
             #[cfg(feature = "getblocktemplate-rpcs")]
             Request::CheckBlockProposalValidity(prepared) => {

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -607,11 +607,12 @@ pub enum Request {
     /// * [`Response::BlockHash(None)`](Response::BlockHash) otherwise.
     BestChainBlockHash(block::Height),
 
-    /// Checks if a block is present anywhere in the state service; Looks up hash in block stores.
+    /// Checks if a block is present anywhere in the state service.
+    /// Looks up `hash` in block queues as well as the finalized chain and all non-finalized chains.
     ///
     /// Returns [`Response::BlockLocation(Some(Location))`](Response::BlockLocation) if the block is in the best state service.
     /// Returns [`Response::BlockLocation(None)`](Response::BlockLocation) otherwise.
-    Contains(block::Hash),
+    KnownBlock(block::Hash),
 
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Performs contextual validation of the given block, but does not commit it to the state.

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -607,6 +607,12 @@ pub enum Request {
     /// * [`Response::BlockHash(None)`](Response::BlockHash) otherwise.
     BestChainBlockHash(block::Height),
 
+    /// Checks if a block is present anywhere in the state service; Looks up hash in block stores.
+    ///
+    /// Returns [`Response::BlockLocation(Some(Location))`](Response::BlockLocation) if the block is in the best state service.
+    /// Returns [`Response::BlockLocation(None)`](Response::BlockLocation) otherwise.
+    Contains(block::Hash),
+
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Performs contextual validation of the given block, but does not commit it to the state.
     ///
@@ -634,6 +640,7 @@ impl Request {
             }
             Request::BestChainNextMedianTimePast => "best_chain_next_median_time_past",
             Request::BestChainBlockHash(_) => "best_chain_block_hash",
+            Request::Contains(_) => "contains",
             #[cfg(feature = "getblocktemplate-rpcs")]
             Request::CheckBlockProposalValidity(_) => "check_block_proposal_validity",
         }
@@ -946,6 +953,8 @@ impl TryFrom<Request> for ReadRequest {
             Request::AwaitUtxo(_) => Err("ReadService does not track pending UTXOs. \
                      Manually convert the request to ReadRequest::AnyChainUtxo, \
                      and handle pending UTXOs"),
+
+            Request::Contains(_) => Err("ReadService does not track queued blocks"),
 
             #[cfg(feature = "getblocktemplate-rpcs")]
             Request::CheckBlockProposalValidity(prepared) => {

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -610,8 +610,8 @@ pub enum Request {
     /// Checks if a block is present anywhere in the state service.
     /// Looks up `hash` in block queues as well as the finalized chain and all non-finalized chains.
     ///
-    /// Returns [`Response::BlockLocation(Some(Location))`](Response::BlockLocation) if the block is in the best state service.
-    /// Returns [`Response::BlockLocation(None)`](Response::BlockLocation) otherwise.
+    /// Returns [`Response::KnownBlock(Some(Location))`](Response::KnownBlock) if the block is in the best state service.
+    /// Returns [`Response::KnownBlock(None)`](Response::KnownBlock) otherwise.
     KnownBlock(block::Hash),
 
     #[cfg(feature = "getblocktemplate-rpcs")]

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -69,7 +69,7 @@ pub enum Response {
     /// specified block hash.
     BlockHash(Option<block::Hash>),
 
-    /// Response to [`Request::Contains`].
+    /// Response to [`Request::KnownBlock`].
     BlockLocation(Option<BlockLocation>),
 
     #[cfg(feature = "getblocktemplate-rpcs")]

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -90,12 +90,6 @@ pub enum BlockLocation {
     Queue,
 }
 
-impl From<Option<BlockLocation>> for Response {
-    fn from(block_location: Option<BlockLocation>) -> Self {
-        Self::BlockLocation(block_location)
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// A response to a read-only
 /// [`ReadStateService`](crate::service::ReadStateService)'s

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -69,9 +69,31 @@ pub enum Response {
     /// specified block hash.
     BlockHash(Option<block::Hash>),
 
+    /// Response to [`Request::Contains`].
+    BlockLocation(Option<BlockLocation>),
+
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Response to [`Request::CheckBlockProposalValidity`](Request::CheckBlockProposalValidity)
     ValidBlockProposal,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// An enum of block stores in the state where a block hash could be found.
+pub enum BlockLocation {
+    /// Block is in the best chain.
+    BestChain,
+
+    /// Block is in a side chain.
+    SideChain,
+
+    /// Block is queued to be validated and committed.
+    Queue,
+}
+
+impl From<Option<BlockLocation>> for Response {
+    fn from(block_location: Option<BlockLocation>) -> Self {
+        Self::BlockLocation(block_location)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -70,7 +70,7 @@ pub enum Response {
     BlockHash(Option<block::Hash>),
 
     /// Response to [`Request::KnownBlock`].
-    BlockLocation(Option<BlockLocation>),
+    KnownBlock(Option<KnownBlock>),
 
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Response to [`Request::CheckBlockProposalValidity`](Request::CheckBlockProposalValidity)
@@ -79,7 +79,7 @@ pub enum Response {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// An enum of block stores in the state where a block hash could be found.
-pub enum BlockLocation {
+pub enum KnownBlock {
     /// Block is in the best chain.
     BestChain,
 

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -86,7 +86,7 @@ pub enum BlockLocation {
     /// Block is in a side chain.
     SideChain,
 
-    /// Block is queued to be validated and committed.
+    /// Block is queued to be validated and committed, or rejected and dropped.
     Queue,
 }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -52,6 +52,7 @@ use crate::{
         MAX_FIND_BLOCK_HASHES_RESULTS, MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_ZEBRA,
         MAX_LEGACY_CHAIN_BLOCKS,
     },
+    response::BlockLocation,
     service::{
         block_iter::any_ancestor_blocks,
         chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip},
@@ -162,7 +163,7 @@ pub(crate) struct StateService {
 
     /// A set of non-finalized block hashes that have been sent to the block write task.
     /// Hashes of blocks below the finalized tip height are periodically pruned.
-    sent_non_finalized_block_hashes: SentHashes,
+    sent_blocks: SentHashes,
 
     /// If an invalid block is sent on `finalized_block_write_sender`
     /// or `non_finalized_block_write_sender`,
@@ -408,7 +409,7 @@ impl StateService {
             non_finalized_block_write_sender: Some(non_finalized_block_write_sender),
             finalized_block_write_sender: Some(finalized_block_write_sender),
             last_sent_finalized_block_hash,
-            sent_non_finalized_block_hashes: SentHashes::default(),
+            sent_blocks: SentHashes::default(),
             invalid_block_reset_receiver,
             pending_utxos,
             last_prune: Instant::now(),
@@ -468,13 +469,6 @@ impl StateService {
         let queued_prev_hash = finalized.block.header.previous_block_hash;
         let queued_height = finalized.height;
 
-        // If we're close to the final checkpoint, make the block's UTXOs available for
-        // full verification of non-finalized blocks, even when it is in the channel.
-        if self.is_close_to_final_checkpoint(queued_height) {
-            self.sent_non_finalized_block_hashes
-                .add_finalized(&finalized)
-        }
-
         let (rsp_tx, rsp_rx) = oneshot::channel();
         let queued = (finalized, rsp_tx);
 
@@ -491,6 +485,10 @@ impl StateService {
             }
 
             self.drain_queue_and_commit_finalized();
+
+            if let Some(finalized_tip_height) = self.read_service.db.finalized_tip_height() {
+                self.sent_blocks.prune_by_height(finalized_tip_height);
+            }
         } else {
             // We've finished committing finalized blocks, so drop any repeated queued blocks,
             // and return an error.
@@ -564,9 +562,20 @@ impl StateService {
             .queued_finalized_blocks
             .remove(&self.last_sent_finalized_block_hash)
         {
-            let last_sent_finalized_block_height = queued_block.0.height;
+            let (finalized, _) = &queued_block;
+            let &FinalizedBlock { hash, height, .. } = finalized;
 
-            self.last_sent_finalized_block_hash = queued_block.0.hash;
+            self.last_sent_finalized_block_hash = hash;
+
+            // If we're close to the final checkpoint, make the block's UTXOs available for
+            // full verification of non-finalized blocks, even when it is in the channel.
+            // If we're not close to the final checkpoint, add the hash for checking if
+            // a block is present in a queue when called with `Request::Contains`.
+            if self.is_close_to_final_checkpoint(height) {
+                self.sent_blocks.add_finalized(finalized)
+            } else {
+                self.sent_blocks.add_finalized_hash(hash, height);
+            }
 
             // If we've finished sending finalized blocks, ignore any repeated blocks.
             // (Blocks can be repeated after a syncer reset.)
@@ -585,10 +594,7 @@ impl StateService {
                         "block commit task exited. Is Zebra shutting down?",
                     );
                 } else {
-                    metrics::gauge!(
-                        "state.checkpoint.sent.block.height",
-                        last_sent_finalized_block_height.0 as f64,
-                    );
+                    metrics::gauge!("state.checkpoint.sent.block.height", height.0 as f64,);
                 };
             }
         }
@@ -643,10 +649,7 @@ impl StateService {
         tracing::debug!(block = %prepared.block, "queueing block for contextual verification");
         let parent_hash = prepared.block.header.previous_block_hash;
 
-        if self
-            .sent_non_finalized_block_hashes
-            .contains(&prepared.hash)
-        {
+        if self.sent_blocks.contains(&prepared.hash) {
             let (rsp_tx, rsp_rx) = oneshot::channel();
             let _ = rsp_tx.send(Err(
                 "block has already been sent to be committed to the state".into(),
@@ -724,8 +727,7 @@ impl StateService {
             self.queued_non_finalized_blocks
                 .prune_by_height(finalized_tip_height);
 
-            self.sent_non_finalized_block_hashes
-                .prune_by_height(finalized_tip_height);
+            self.sent_blocks.prune_by_height(finalized_tip_height);
         }
 
         rsp_rx
@@ -733,8 +735,7 @@ impl StateService {
 
     /// Returns `true` if `hash` is a valid previous block hash for new non-finalized blocks.
     fn can_fork_chain_at(&self, hash: &block::Hash) -> bool {
-        self.sent_non_finalized_block_hashes.contains(hash)
-            || &self.read_service.db.finalized_tip_hash() == hash
+        self.sent_blocks.contains(hash) || &self.read_service.db.finalized_tip_hash() == hash
     }
 
     /// Returns `true` if `queued_height` is near the final checkpoint.
@@ -764,7 +765,7 @@ impl StateService {
                 for queued_child in queued_children {
                     let (PreparedBlock { hash, .. }, _) = queued_child;
 
-                    self.sent_non_finalized_block_hashes.add(&queued_child.0);
+                    self.sent_blocks.add(&queued_child.0);
                     let send_result = non_finalized_block_write_sender.send(queued_child);
 
                     if let Err(SendError(queued)) = send_result {
@@ -785,7 +786,7 @@ impl StateService {
                 }
             }
 
-            self.sent_non_finalized_block_hashes.finish_batch();
+            self.sent_blocks.finish_batch();
         };
     }
 
@@ -806,6 +807,14 @@ impl StateService {
             blocks, and the canopy activation block, must be committed to the state as finalized \
             blocks"
         );
+    }
+
+    /// Returns true if the block hash is queued or has been sent to be validated and committed.
+    /// Returns false otherwise.
+    fn is_block_queued(&self, hash: &block::Hash) -> bool {
+        self.queued_non_finalized_blocks.contains(hash)
+            || self.queued_finalized_blocks.contains_key(hash)
+            || self.sent_blocks.contains(hash)
     }
 }
 
@@ -1011,7 +1020,7 @@ impl Service<Request> for StateService {
                 }
 
                 // Check the sent non-finalized blocks
-                if let Some(utxo) = self.sent_non_finalized_block_hashes.utxo(&outpoint) {
+                if let Some(utxo) = self.sent_blocks.utxo(&outpoint) {
                     self.pending_utxos.respond(&outpoint, utxo);
 
                     // We're finished, the returned future gets the UTXO from the respond() channel.
@@ -1059,6 +1068,35 @@ impl Service<Request> for StateService {
                     timer.finish(module_path!(), line!(), "AwaitUtxo/waiting");
 
                     response_fut.await
+                }
+                .boxed()
+            }
+
+            // Used by sync, inbound, and block verifier to check if a block is already in the state
+            // before downloading or validating it.
+            Request::Contains(hash) => {
+                let timer = CodeTimer::start();
+
+                let is_block_queued = self.is_block_queued(&hash);
+
+                let read_service = self.read_service.clone();
+
+                async move {
+                    let response = if is_block_queued {
+                        Some(BlockLocation::Queue)
+                    } else {
+                        read::contains(
+                            &read_service.latest_non_finalized_state(),
+                            &read_service.db,
+                            hash,
+                        )
+                    }
+                    .into();
+
+                    // The work is done in the future.
+                    timer.finish(module_path!(), line!(), "Request::Contains");
+
+                    Ok(response)
                 }
                 .boxed()
             }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -812,7 +812,7 @@ impl StateService {
     /// Returns true if the block hash is queued or has been sent to be validated and committed.
     /// Returns false otherwise.
     fn is_block_queued(&self, hash: &block::Hash) -> bool {
-        self.queued_non_finalized_blocks.contains(hash)
+        self.queued_non_finalized_blocks.contains_block_hash(hash)
             || self.queued_finalized_blocks.contains_key(hash)
             || self.sent_blocks.contains(hash)
     }
@@ -1082,12 +1082,12 @@ impl Service<Request> for StateService {
                 let read_service = self.read_service.clone();
 
                 async move {
-                    let response = read::non_finalized_state_contains_hash(
+                    let response = read::non_finalized_state_contains_block_hash(
                         &read_service.latest_non_finalized_state(),
                         hash,
                     )
                     .or(is_block_queued.then_some(KnownBlock::Queue))
-                    .or_else(|| read::finalized_state_contains_hash(&read_service.db, hash));
+                    .or_else(|| read::finalized_state_contains_block_hash(&read_service.db, hash));
 
                     // The work is done in the future.
                     timer.finish(module_path!(), line!(), "Request::KnownBlock");

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -161,7 +161,7 @@ pub(crate) struct StateService {
     // - remove block hashes once their heights are strictly less than the finalized tip
     last_sent_finalized_block_hash: block::Hash,
 
-    /// A set of non-finalized block hashes that have been sent to the block write task.
+    /// A set of block hashes that have been sent to the block write task.
     /// Hashes of blocks below the finalized tip height are periodically pruned.
     sent_blocks: SentHashes,
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -570,7 +570,7 @@ impl StateService {
             // If we're close to the final checkpoint, make the block's UTXOs available for
             // full verification of non-finalized blocks, even when it is in the channel.
             // If we're not close to the final checkpoint, add the hash for checking if
-            // a block is present in a queue when called with `Request::Contains`.
+            // a block is present in a queue when called with `Request::KnownBlock`.
             if self.is_close_to_final_checkpoint(height) {
                 self.sent_blocks.add_finalized(finalized)
             } else {
@@ -1074,7 +1074,7 @@ impl Service<Request> for StateService {
 
             // Used by sync, inbound, and block verifier to check if a block is already in the state
             // before downloading or validating it.
-            Request::Contains(hash) => {
+            Request::KnownBlock(hash) => {
                 let timer = CodeTimer::start();
 
                 let is_block_queued = self.is_block_queued(&hash);
@@ -1091,7 +1091,7 @@ impl Service<Request> for StateService {
                     });
 
                     // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "Request::Contains");
+                    timer.finish(module_path!(), line!(), "Request::KnownBlock");
 
                     Ok(Response::BlockLocation(response))
                 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -52,7 +52,7 @@ use crate::{
         MAX_FIND_BLOCK_HASHES_RESULTS, MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_ZEBRA,
         MAX_LEGACY_CHAIN_BLOCKS,
     },
-    response::BlockLocation,
+    response::KnownBlock,
     service::{
         block_iter::any_ancestor_blocks,
         chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip},
@@ -1082,7 +1082,7 @@ impl Service<Request> for StateService {
                 let read_service = self.read_service.clone();
 
                 async move {
-                    let response = is_block_queued.then_some(BlockLocation::Queue).or_else(|| {
+                    let response = is_block_queued.then_some(KnownBlock::Queue).or_else(|| {
                         read::contains(
                             &read_service.latest_non_finalized_state(),
                             &read_service.db,
@@ -1093,7 +1093,7 @@ impl Service<Request> for StateService {
                     // The work is done in the future.
                     timer.finish(module_path!(), line!(), "Request::KnownBlock");
 
-                    Ok(Response::BlockLocation(response))
+                    Ok(Response::KnownBlock(response))
                 }
                 .boxed()
             }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1082,13 +1082,12 @@ impl Service<Request> for StateService {
                 let read_service = self.read_service.clone();
 
                 async move {
-                    let response = is_block_queued.then_some(KnownBlock::Queue).or_else(|| {
-                        read::contains(
-                            &read_service.latest_non_finalized_state(),
-                            &read_service.db,
-                            hash,
-                        )
-                    });
+                    let response = read::non_finalized_state_contains_hash(
+                        &read_service.latest_non_finalized_state(),
+                        hash,
+                    )
+                    .or(is_block_queued.then_some(KnownBlock::Queue))
+                    .or_else(|| read::finalized_state_contains_hash(&read_service.db, hash));
 
                     // The work is done in the future.
                     timer.finish(module_path!(), line!(), "Request::KnownBlock");

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -422,7 +422,7 @@ impl Chain {
 
     /// Returns true is the chain contains the given block hash.
     /// Returns false otherwise.
-    pub fn contains(&self, hash: &block::Hash) -> bool {
+    pub fn contains_block_hash(&self, hash: &block::Hash) -> bool {
         self.height_by_hash.contains_key(hash)
     }
 

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -420,6 +420,12 @@ impl Chain {
         self.height_by_hash.get(&hash).cloned()
     }
 
+    /// Returns true is the chain contains the given block hash.
+    /// Returns false otherwise.
+    pub fn contains(&self, hash: &block::Hash) -> bool {
+        self.height_by_hash.contains_key(hash)
+    }
+
     /// Returns the non-finalized tip block height and hash.
     pub fn non_finalized_tip(&self) -> (Height, block::Hash) {
         (

--- a/zebra-state/src/service/queued_blocks.rs
+++ b/zebra-state/src/service/queued_blocks.rs
@@ -273,6 +273,9 @@ impl SentHashes {
     /// Used for finalized blocks close to the final checkpoint, so non-finalized blocks can look up
     /// their UTXOs.
     ///
+    /// Assumes that blocks are added in the order of their height between `finish_batch` calls
+    /// for efficient pruning.
+    ///
     /// For more details see `add()`.
     pub fn add_finalized(&mut self, block: &FinalizedBlock) {
         // Track known UTXOs in sent blocks.
@@ -294,6 +297,9 @@ impl SentHashes {
 
     /// Stores the finalized `block`'s hash, so it can be used to check if a
     /// block is in the state queue.
+    ///
+    /// Assumes that blocks are added in the order of their height between `finish_batch` calls
+    /// for efficient pruning.
     ///
     /// For more details see `add()`.
     pub fn add_finalized_hash(&mut self, hash: block::Hash, height: block::Height) {

--- a/zebra-state/src/service/queued_blocks.rs
+++ b/zebra-state/src/service/queued_blocks.rs
@@ -217,6 +217,12 @@ impl QueuedBlocks {
 
         self.blocks.drain()
     }
+
+    /// Returns true if QueuedBlocks contains a block with the given hash.
+    /// Returns false otherwise.
+    pub fn contains(&self, hash: &block::Hash) -> bool {
+        self.blocks.contains_key(hash)
+    }
 }
 
 #[derive(Debug, Default)]
@@ -284,6 +290,17 @@ impl SentHashes {
         self.sent.insert(block.hash, outpoints);
 
         self.update_metrics_for_block(block.height);
+    }
+
+    /// Stores the finalized `block`'s hash, so it can be used to check if a
+    /// block is in the state queue.
+    ///
+    /// For more details see `add()`.
+    pub fn add_finalized_hash(&mut self, hash: block::Hash, height: block::Height) {
+        self.curr_buf.push_back((hash, height));
+        self.sent.insert(hash, vec![]);
+
+        self.update_metrics_for_block(height);
     }
 
     /// Try to look up this UTXO in any sent block.

--- a/zebra-state/src/service/queued_blocks.rs
+++ b/zebra-state/src/service/queued_blocks.rs
@@ -220,7 +220,7 @@ impl QueuedBlocks {
 
     /// Returns true if QueuedBlocks contains a block with the given hash.
     /// Returns false otherwise.
-    pub fn contains(&self, hash: &block::Hash) -> bool {
+    pub fn contains_block_hash(&self, hash: &block::Hash) -> bool {
         self.blocks.contains_key(hash)
     }
 }

--- a/zebra-state/src/service/queued_blocks.rs
+++ b/zebra-state/src/service/queued_blocks.rs
@@ -217,12 +217,6 @@ impl QueuedBlocks {
 
         self.blocks.drain()
     }
-
-    /// Returns true if QueuedBlocks contains a block with the given hash.
-    /// Returns false otherwise.
-    pub fn contains_block_hash(&self, hash: &block::Hash) -> bool {
-        self.blocks.contains_key(hash)
-    }
 }
 
 #[derive(Debug, Default)]
@@ -295,20 +289,6 @@ impl SentHashes {
         self.update_metrics_for_block(block.height);
     }
 
-    /// Stores the finalized `block`'s hash, so it can be used to check if a
-    /// block is in the state queue.
-    ///
-    /// Assumes that blocks are added in the order of their height between `finish_batch` calls
-    /// for efficient pruning.
-    ///
-    /// For more details see `add()`.
-    pub fn add_finalized_hash(&mut self, hash: block::Hash, height: block::Height) {
-        self.curr_buf.push_back((hash, height));
-        self.sent.insert(hash, vec![]);
-
-        self.update_metrics_for_block(height);
-    }
-
     /// Try to look up this UTXO in any sent block.
     #[instrument(skip(self))]
     pub fn utxo(&self, outpoint: &transparent::OutPoint) -> Option<transparent::Utxo> {
@@ -352,15 +332,6 @@ impl SentHashes {
 
         self.sent.shrink_to_fit();
 
-        self.update_metrics_for_cache();
-    }
-
-    /// Clears all data from `SentBlocks`
-    pub fn clear(&mut self) {
-        self.sent.clear();
-        self.bufs.clear();
-        self.curr_buf.clear();
-        self.known_utxos.clear();
         self.update_metrics_for_cache();
     }
 

--- a/zebra-state/src/service/queued_blocks.rs
+++ b/zebra-state/src/service/queued_blocks.rs
@@ -355,6 +355,15 @@ impl SentHashes {
         self.update_metrics_for_cache();
     }
 
+    /// Clears all data from `SentBlocks`
+    pub fn clear(&mut self) {
+        self.sent.clear();
+        self.bufs.clear();
+        self.curr_buf.clear();
+        self.known_utxos.clear();
+        self.update_metrics_for_cache();
+    }
+
     /// Returns true if SentHashes contains the `hash`
     pub fn contains(&self, hash: &block::Hash) -> bool {
         self.sent.contains_key(hash)

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -34,8 +34,8 @@ pub use block::{
     any_utxo, block, block_header, transaction, transaction_hashes_for_block, unspent_utxo, utxo,
 };
 pub use find::{
-    best_tip, block_locator, chain_contains_hash, depth, find_chain_hashes, find_chain_headers,
-    hash_by_height, height_by_hash, next_median_time_past, tip, tip_height,
+    best_tip, block_locator, chain_contains_hash, contains, depth, find_chain_hashes,
+    find_chain_headers, hash_by_height, height_by_hash, next_median_time_past, tip, tip_height,
 };
 pub use tree::{orchard_tree, sapling_tree};
 

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -34,9 +34,9 @@ pub use block::{
     any_utxo, block, block_header, transaction, transaction_hashes_for_block, unspent_utxo, utxo,
 };
 pub use find::{
-    best_tip, block_locator, chain_contains_hash, depth, finalized_state_contains_hash,
+    best_tip, block_locator, chain_contains_hash, depth, finalized_state_contains_block_hash,
     find_chain_hashes, find_chain_headers, hash_by_height, height_by_hash, next_median_time_past,
-    non_finalized_state_contains_hash, tip, tip_height,
+    non_finalized_state_contains_block_hash, tip, tip_height,
 };
 pub use tree::{orchard_tree, sapling_tree};
 

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -34,8 +34,9 @@ pub use block::{
     any_utxo, block, block_header, transaction, transaction_hashes_for_block, unspent_utxo, utxo,
 };
 pub use find::{
-    best_tip, block_locator, chain_contains_hash, contains, depth, find_chain_hashes,
-    find_chain_headers, hash_by_height, height_by_hash, next_median_time_past, tip, tip_height,
+    best_tip, block_locator, chain_contains_hash, depth, finalized_state_contains_hash,
+    find_chain_hashes, find_chain_headers, hash_by_height, height_by_hash, next_median_time_past,
+    non_finalized_state_contains_hash, tip, tip_height,
 };
 pub use tree::{orchard_tree, sapling_tree};
 

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -101,11 +101,10 @@ where
     Some(tip.0 - height.0)
 }
 
-/// Returns the location of the block in the state service if present.
-/// Returns None if the block hash is not found in the state.
-pub fn contains(
+/// Returns the location of the block if present in the non-finalized state.
+/// Returns None if the block hash is not found in the non-finalized state.
+pub fn non_finalized_state_contains_hash(
     non_finalized_state: &NonFinalizedState,
-    db: &ZebraDb,
     hash: block::Hash,
 ) -> Option<KnownBlock> {
     let mut chains_iter = non_finalized_state.chain_set.iter().rev();
@@ -117,9 +116,14 @@ pub fn contains(
     match best_chain.map(is_hash_in_chain) {
         Some(true) => Some(KnownBlock::BestChain),
         Some(false) if chains_iter.any(is_hash_in_chain) => Some(KnownBlock::SideChain),
-        Some(false) | None if db.contains_hash(hash) => Some(KnownBlock::BestChain),
         Some(false) | None => None,
     }
+}
+
+/// Returns the location of the block if present in the finalized state.
+/// Returns None if the block hash is not found in the finalized state.
+pub fn finalized_state_contains_hash(db: &ZebraDb, hash: block::Hash) -> Option<KnownBlock> {
+    db.contains_hash(hash).then_some(KnownBlock::BestChain)
 }
 
 /// Return the height for the block at `hash`, if `hash` is in `chain` or `db`.

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -32,7 +32,7 @@ use crate::{
         non_finalized_state::{Chain, NonFinalizedState},
         read::{self, block::block_header, FINALIZED_STATE_QUERY_RETRIES},
     },
-    BlockLocation, BoxError,
+    BoxError, KnownBlock,
 };
 
 #[cfg(test)]
@@ -107,7 +107,7 @@ pub fn contains(
     non_finalized_state: &NonFinalizedState,
     db: &ZebraDb,
     hash: block::Hash,
-) -> Option<BlockLocation> {
+) -> Option<KnownBlock> {
     let mut chains_iter = non_finalized_state.chain_set.iter().rev();
     let is_hash_in_chain = |chain: &Arc<Chain>| chain.contains(&hash);
 
@@ -115,9 +115,9 @@ pub fn contains(
     let best_chain = chains_iter.next();
 
     match best_chain.map(is_hash_in_chain) {
-        Some(true) => Some(BlockLocation::BestChain),
-        Some(false) if chains_iter.any(is_hash_in_chain) => Some(BlockLocation::SideChain),
-        Some(false) | None if db.contains_hash(hash) => Some(BlockLocation::BestChain),
+        Some(true) => Some(KnownBlock::BestChain),
+        Some(false) if chains_iter.any(is_hash_in_chain) => Some(KnownBlock::SideChain),
+        Some(false) | None if db.contains_hash(hash) => Some(KnownBlock::BestChain),
         Some(false) | None => None,
     }
 }

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -103,12 +103,12 @@ where
 
 /// Returns the location of the block if present in the non-finalized state.
 /// Returns None if the block hash is not found in the non-finalized state.
-pub fn non_finalized_state_contains_hash(
+pub fn non_finalized_state_contains_block_hash(
     non_finalized_state: &NonFinalizedState,
     hash: block::Hash,
 ) -> Option<KnownBlock> {
     let mut chains_iter = non_finalized_state.chain_set.iter().rev();
-    let is_hash_in_chain = |chain: &Arc<Chain>| chain.contains(&hash);
+    let is_hash_in_chain = |chain: &Arc<Chain>| chain.contains_block_hash(&hash);
 
     // Equivalent to `chain_set.iter().next_back()` in `NonFinalizedState.best_chain()` method.
     let best_chain = chains_iter.next();
@@ -122,7 +122,7 @@ pub fn non_finalized_state_contains_hash(
 
 /// Returns the location of the block if present in the finalized state.
 /// Returns None if the block hash is not found in the finalized state.
-pub fn finalized_state_contains_hash(db: &ZebraDb, hash: block::Hash) -> Option<KnownBlock> {
+pub fn finalized_state_contains_block_hash(db: &ZebraDb, hash: block::Hash) -> Option<KnownBlock> {
     db.contains_hash(hash).then_some(KnownBlock::BestChain)
 }
 

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -242,11 +242,9 @@ where
 
         let fut = async move {
             // Check if the block is already in the state.
-            // BUG: check if the hash is in any chain (#862).
-            // Depth only checks the main chain.
-            match state.oneshot(zs::Request::Depth(hash)).await {
-                Ok(zs::Response::Depth(None)) => Ok(()),
-                Ok(zs::Response::Depth(Some(_))) => Err("already present".into()),
+            match state.oneshot(zs::Request::Contains(hash)).await {
+                Ok(zs::Response::BlockLocation(None)) => Ok(()),
+                Ok(zs::Response::BlockLocation(Some(_))) => Err("already present".into()),
                 Ok(_) => unreachable!("wrong response"),
                 Err(e) => Err(e),
             }?;

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -243,8 +243,8 @@ where
         let fut = async move {
             // Check if the block is already in the state.
             match state.oneshot(zs::Request::KnownBlock(hash)).await {
-                Ok(zs::Response::BlockLocation(None)) => Ok(()),
-                Ok(zs::Response::BlockLocation(Some(_))) => Err("already present".into()),
+                Ok(zs::Response::KnownBlock(None)) => Ok(()),
+                Ok(zs::Response::KnownBlock(Some(_))) => Err("already present".into()),
                 Ok(_) => unreachable!("wrong response"),
                 Err(e) => Err(e),
             }?;

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -242,7 +242,7 @@ where
 
         let fut = async move {
             // Check if the block is already in the state.
-            match state.oneshot(zs::Request::Contains(hash)).await {
+            match state.oneshot(zs::Request::KnownBlock(hash)).await {
                 Ok(zs::Response::BlockLocation(None)) => Ok(()),
                 Ok(zs::Response::BlockLocation(Some(_))) => Err("already present".into()),
                 Ok(_) => unreachable!("wrong response"),

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1067,7 +1067,7 @@ where
             .await
             .map_err(|e| eyre!(e))?
         {
-            zs::Response::BlockLocation(loc) => Ok(loc.is_some()),
+            zs::Response::KnownBlock(loc) => Ok(loc.is_some()),
             _ => unreachable!("wrong response to depth request"),
         }
     }

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1063,7 +1063,7 @@ where
             .ready()
             .await
             .map_err(|e| eyre!(e))?
-            .call(zebra_state::Request::Contains(hash))
+            .call(zebra_state::Request::KnownBlock(hash))
             .await
             .map_err(|e| eyre!(e))?
         {

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1068,7 +1068,7 @@ where
             .map_err(|e| eyre!(e))?
         {
             zs::Response::KnownBlock(loc) => Ok(loc.is_some()),
-            _ => unreachable!("wrong response to depth request"),
+            _ => unreachable!("wrong response to known block request"),
         }
     }
 

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1156,7 +1156,7 @@ where
                 // https://github.com/ZcashFoundation/zebra/issues/2909
                 let err_str = format!("{e:?}");
                 if err_str.contains("AlreadyVerified")
-                    || err_str.contains("AlreadyInState")
+                    || err_str.contains("AlreadyInChain")
                     || err_str.contains("block is already committed to the state")
                     || err_str.contains("block has already been sent to be committed to the state")
                     || err_str.contains("NotFound")

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1057,21 +1057,17 @@ where
 
     /// Returns `true` if the hash is present in the state, and `false`
     /// if the hash is not present in the state.
-    ///
-    /// TODO BUG: check if the hash is in any chain (#862)
-    /// Depth only checks the main chain.
     async fn state_contains(&mut self, hash: block::Hash) -> Result<bool, Report> {
         match self
             .state
             .ready()
             .await
             .map_err(|e| eyre!(e))?
-            .call(zebra_state::Request::Depth(hash))
+            .call(zebra_state::Request::Contains(hash))
             .await
             .map_err(|e| eyre!(e))?
         {
-            zs::Response::Depth(Some(_)) => Ok(true),
-            zs::Response::Depth(None) => Ok(false),
+            zs::Response::BlockLocation(loc) => Ok(loc.is_some()),
             _ => unreachable!("wrong response to depth request"),
         }
     }

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1156,7 +1156,7 @@ where
                 // https://github.com/ZcashFoundation/zebra/issues/2909
                 let err_str = format!("{e:?}");
                 if err_str.contains("AlreadyVerified")
-                    || err_str.contains("AlreadyInChain")
+                    || err_str.contains("AlreadyInState")
                     || err_str.contains("block is already committed to the state")
                     || err_str.contains("block has already been sent to be committed to the state")
                     || err_str.contains("NotFound")

--- a/zebrad/src/components/sync/tests/timing.rs
+++ b/zebrad/src/components/sync/tests/timing.rs
@@ -144,7 +144,7 @@ fn request_genesis_is_rate_limited() {
     // panic in any other type of request.
     let state_service = tower::service_fn(move |request| {
         match request {
-            zebra_state::Request::Contains(_) => {
+            zebra_state::Request::KnownBlock(_) => {
                 // Track the call
                 state_requests_counter_in_service.fetch_add(1, Ordering::SeqCst);
                 // Respond with `None`

--- a/zebrad/src/components/sync/tests/timing.rs
+++ b/zebrad/src/components/sync/tests/timing.rs
@@ -148,7 +148,7 @@ fn request_genesis_is_rate_limited() {
                 // Track the call
                 state_requests_counter_in_service.fetch_add(1, Ordering::SeqCst);
                 // Respond with `None`
-                future::ok(zebra_state::Response::BlockLocation(None))
+                future::ok(zebra_state::Response::KnownBlock(None))
             }
             _ => unreachable!("no other request is allowed"),
         }

--- a/zebrad/src/components/sync/tests/timing.rs
+++ b/zebrad/src/components/sync/tests/timing.rs
@@ -144,11 +144,11 @@ fn request_genesis_is_rate_limited() {
     // panic in any other type of request.
     let state_service = tower::service_fn(move |request| {
         match request {
-            zebra_state::Request::Depth(_) => {
+            zebra_state::Request::Contains(_) => {
                 // Track the call
                 state_requests_counter_in_service.fetch_add(1, Ordering::SeqCst);
                 // Respond with `None`
-                future::ok(zebra_state::Response::Depth(None))
+                future::ok(zebra_state::Response::BlockLocation(None))
             }
             _ => unreachable!("no other request is allowed"),
         }

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -80,7 +80,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
 
     // Block 0 is fetched and committed to the state
     peer_set
@@ -102,9 +102,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
-        .respond(zs::Response::BlockLocation(Some(
-            zs::BlockLocation::BestChain,
-        )));
+        .respond(zs::Response::KnownBlock(Some(zs::KnownBlock::BestChain)));
 
     // ChainSync::obtain_tips
 
@@ -131,7 +129,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block1_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
 
     // Clear remaining block locator requests
     for _ in 0..(sync::FANOUT - 1) {
@@ -152,11 +150,11 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block1_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
     state_service
         .expect_request(zs::Request::KnownBlock(block2_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
 
     // Blocks 1 & 2 are fetched in order, then verified concurrently
     peer_set
@@ -309,7 +307,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
 
     // Block 0 is fetched and committed to the state
     peer_set
@@ -331,9 +329,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
-        .respond(zs::Response::BlockLocation(Some(
-            zs::BlockLocation::BestChain,
-        )));
+        .respond(zs::Response::KnownBlock(Some(zs::KnownBlock::BestChain)));
 
     // ChainSync::obtain_tips
 
@@ -362,7 +358,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block1_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
 
     // Clear remaining block locator requests
     for _ in 0..(sync::FANOUT - 1) {
@@ -383,11 +379,11 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block1_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
     state_service
         .expect_request(zs::Request::KnownBlock(block2_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
 
     // Blocks 1 & 2 are fetched in order, then verified concurrently
     peer_set
@@ -526,7 +522,7 @@ async fn sync_block_lookahead_drop() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
 
     // Block 0 is fetched, but the peer returns a much higher block.
     // (Mismatching hashes are usually ignored by the network service,
@@ -593,7 +589,7 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
 
     // Block 0 is fetched and committed to the state
     peer_set
@@ -615,9 +611,7 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
-        .respond(zs::Response::BlockLocation(Some(
-            zs::BlockLocation::BestChain,
-        )));
+        .respond(zs::Response::KnownBlock(Some(zs::KnownBlock::BestChain)));
 
     // ChainSync::obtain_tips
 
@@ -645,7 +639,7 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block982k_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
 
     // Clear remaining block locator requests
     for _ in 0..(sync::FANOUT - 1) {
@@ -666,15 +660,15 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block982k_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
     state_service
         .expect_request(zs::Request::KnownBlock(block1_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
     state_service
         .expect_request(zs::Request::KnownBlock(block2_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
 
     // Blocks 982k, 1, 2 are fetched in order, then verified concurrently,
     // but block 982k verification is skipped because it is too high.
@@ -756,7 +750,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
 
     // Block 0 is fetched and committed to the state
     peer_set
@@ -778,9 +772,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
-        .respond(zs::Response::BlockLocation(Some(
-            zs::BlockLocation::BestChain,
-        )));
+        .respond(zs::Response::KnownBlock(Some(zs::KnownBlock::BestChain)));
 
     // ChainSync::obtain_tips
 
@@ -807,7 +799,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block1_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
 
     // Clear remaining block locator requests
     for _ in 0..(sync::FANOUT - 1) {
@@ -828,11 +820,11 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
     state_service
         .expect_request(zs::Request::KnownBlock(block1_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
     state_service
         .expect_request(zs::Request::KnownBlock(block2_hash))
         .await
-        .respond(zs::Response::BlockLocation(None));
+        .respond(zs::Response::KnownBlock(None));
 
     // Blocks 1 & 2 are fetched in order, then verified concurrently
     peer_set

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -78,7 +78,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis
     state_service
-        .expect_request(zs::Request::Contains(block0_hash))
+        .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
 
@@ -100,7 +100,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis again
     state_service
-        .expect_request(zs::Request::Contains(block0_hash))
+        .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
         .respond(zs::Response::BlockLocation(Some(
             zs::BlockLocation::BestChain,
@@ -129,7 +129,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for the first unknown block (block 1)
     state_service
-        .expect_request(zs::Request::Contains(block1_hash))
+        .expect_request(zs::Request::KnownBlock(block1_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
 
@@ -150,11 +150,11 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for all non-tip blocks (blocks 1 & 2) in response order
     state_service
-        .expect_request(zs::Request::Contains(block1_hash))
+        .expect_request(zs::Request::KnownBlock(block1_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
     state_service
-        .expect_request(zs::Request::Contains(block2_hash))
+        .expect_request(zs::Request::KnownBlock(block2_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
 
@@ -307,7 +307,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis
     state_service
-        .expect_request(zs::Request::Contains(block0_hash))
+        .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
 
@@ -329,7 +329,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis again
     state_service
-        .expect_request(zs::Request::Contains(block0_hash))
+        .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
         .respond(zs::Response::BlockLocation(Some(
             zs::BlockLocation::BestChain,
@@ -360,7 +360,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for the first unknown block (block 1)
     state_service
-        .expect_request(zs::Request::Contains(block1_hash))
+        .expect_request(zs::Request::KnownBlock(block1_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
 
@@ -381,11 +381,11 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for all non-tip blocks (blocks 1 & 2) in response order
     state_service
-        .expect_request(zs::Request::Contains(block1_hash))
+        .expect_request(zs::Request::KnownBlock(block1_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
     state_service
-        .expect_request(zs::Request::Contains(block2_hash))
+        .expect_request(zs::Request::KnownBlock(block2_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
 
@@ -524,7 +524,7 @@ async fn sync_block_lookahead_drop() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis
     state_service
-        .expect_request(zs::Request::Contains(block0_hash))
+        .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
 
@@ -591,7 +591,7 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis
     state_service
-        .expect_request(zs::Request::Contains(block0_hash))
+        .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
 
@@ -613,7 +613,7 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis again
     state_service
-        .expect_request(zs::Request::Contains(block0_hash))
+        .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
         .respond(zs::Response::BlockLocation(Some(
             zs::BlockLocation::BestChain,
@@ -643,7 +643,7 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for the first unknown block (block 982k)
     state_service
-        .expect_request(zs::Request::Contains(block982k_hash))
+        .expect_request(zs::Request::KnownBlock(block982k_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
 
@@ -664,15 +664,15 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for all non-tip blocks (blocks 982k, 1, 2) in response order
     state_service
-        .expect_request(zs::Request::Contains(block982k_hash))
+        .expect_request(zs::Request::KnownBlock(block982k_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
     state_service
-        .expect_request(zs::Request::Contains(block1_hash))
+        .expect_request(zs::Request::KnownBlock(block1_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
     state_service
-        .expect_request(zs::Request::Contains(block2_hash))
+        .expect_request(zs::Request::KnownBlock(block2_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
 
@@ -754,7 +754,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis
     state_service
-        .expect_request(zs::Request::Contains(block0_hash))
+        .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
 
@@ -776,7 +776,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis again
     state_service
-        .expect_request(zs::Request::Contains(block0_hash))
+        .expect_request(zs::Request::KnownBlock(block0_hash))
         .await
         .respond(zs::Response::BlockLocation(Some(
             zs::BlockLocation::BestChain,
@@ -805,7 +805,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for the first unknown block (block 1)
     state_service
-        .expect_request(zs::Request::Contains(block1_hash))
+        .expect_request(zs::Request::KnownBlock(block1_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
 
@@ -826,11 +826,11 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for all non-tip blocks (blocks 1 & 2) in response order
     state_service
-        .expect_request(zs::Request::Contains(block1_hash))
+        .expect_request(zs::Request::KnownBlock(block1_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
     state_service
-        .expect_request(zs::Request::Contains(block2_hash))
+        .expect_request(zs::Request::KnownBlock(block2_hash))
         .await
         .respond(zs::Response::BlockLocation(None));
 

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -78,9 +78,9 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis
     state_service
-        .expect_request(zs::Request::Depth(block0_hash))
+        .expect_request(zs::Request::Contains(block0_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
 
     // Block 0 is fetched and committed to the state
     peer_set
@@ -100,9 +100,11 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis again
     state_service
-        .expect_request(zs::Request::Depth(block0_hash))
+        .expect_request(zs::Request::Contains(block0_hash))
         .await
-        .respond(zs::Response::Depth(Some(0)));
+        .respond(zs::Response::BlockLocation(Some(
+            zs::BlockLocation::BestChain,
+        )));
 
     // ChainSync::obtain_tips
 
@@ -127,9 +129,9 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for the first unknown block (block 1)
     state_service
-        .expect_request(zs::Request::Depth(block1_hash))
+        .expect_request(zs::Request::Contains(block1_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
 
     // Clear remaining block locator requests
     for _ in 0..(sync::FANOUT - 1) {
@@ -148,13 +150,13 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for all non-tip blocks (blocks 1 & 2) in response order
     state_service
-        .expect_request(zs::Request::Depth(block1_hash))
+        .expect_request(zs::Request::Contains(block1_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
     state_service
-        .expect_request(zs::Request::Depth(block2_hash))
+        .expect_request(zs::Request::Contains(block2_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
 
     // Blocks 1 & 2 are fetched in order, then verified concurrently
     peer_set
@@ -305,9 +307,9 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis
     state_service
-        .expect_request(zs::Request::Depth(block0_hash))
+        .expect_request(zs::Request::Contains(block0_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
 
     // Block 0 is fetched and committed to the state
     peer_set
@@ -327,9 +329,11 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis again
     state_service
-        .expect_request(zs::Request::Depth(block0_hash))
+        .expect_request(zs::Request::Contains(block0_hash))
         .await
-        .respond(zs::Response::Depth(Some(0)));
+        .respond(zs::Response::BlockLocation(Some(
+            zs::BlockLocation::BestChain,
+        )));
 
     // ChainSync::obtain_tips
 
@@ -356,9 +360,9 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for the first unknown block (block 1)
     state_service
-        .expect_request(zs::Request::Depth(block1_hash))
+        .expect_request(zs::Request::Contains(block1_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
 
     // Clear remaining block locator requests
     for _ in 0..(sync::FANOUT - 1) {
@@ -377,13 +381,13 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
 
     // State is checked for all non-tip blocks (blocks 1 & 2) in response order
     state_service
-        .expect_request(zs::Request::Depth(block1_hash))
+        .expect_request(zs::Request::Contains(block1_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
     state_service
-        .expect_request(zs::Request::Depth(block2_hash))
+        .expect_request(zs::Request::Contains(block2_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
 
     // Blocks 1 & 2 are fetched in order, then verified concurrently
     peer_set
@@ -520,9 +524,9 @@ async fn sync_block_lookahead_drop() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis
     state_service
-        .expect_request(zs::Request::Depth(block0_hash))
+        .expect_request(zs::Request::Contains(block0_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
 
     // Block 0 is fetched, but the peer returns a much higher block.
     // (Mismatching hashes are usually ignored by the network service,
@@ -587,9 +591,9 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis
     state_service
-        .expect_request(zs::Request::Depth(block0_hash))
+        .expect_request(zs::Request::Contains(block0_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
 
     // Block 0 is fetched and committed to the state
     peer_set
@@ -609,9 +613,11 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis again
     state_service
-        .expect_request(zs::Request::Depth(block0_hash))
+        .expect_request(zs::Request::Contains(block0_hash))
         .await
-        .respond(zs::Response::Depth(Some(0)));
+        .respond(zs::Response::BlockLocation(Some(
+            zs::BlockLocation::BestChain,
+        )));
 
     // ChainSync::obtain_tips
 
@@ -637,9 +643,9 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for the first unknown block (block 982k)
     state_service
-        .expect_request(zs::Request::Depth(block982k_hash))
+        .expect_request(zs::Request::Contains(block982k_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
 
     // Clear remaining block locator requests
     for _ in 0..(sync::FANOUT - 1) {
@@ -658,17 +664,17 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for all non-tip blocks (blocks 982k, 1, 2) in response order
     state_service
-        .expect_request(zs::Request::Depth(block982k_hash))
+        .expect_request(zs::Request::Contains(block982k_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
     state_service
-        .expect_request(zs::Request::Depth(block1_hash))
+        .expect_request(zs::Request::Contains(block1_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
     state_service
-        .expect_request(zs::Request::Depth(block2_hash))
+        .expect_request(zs::Request::Contains(block2_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
 
     // Blocks 982k, 1, 2 are fetched in order, then verified concurrently,
     // but block 982k verification is skipped because it is too high.
@@ -748,9 +754,9 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis
     state_service
-        .expect_request(zs::Request::Depth(block0_hash))
+        .expect_request(zs::Request::Contains(block0_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
 
     // Block 0 is fetched and committed to the state
     peer_set
@@ -770,9 +776,11 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for genesis again
     state_service
-        .expect_request(zs::Request::Depth(block0_hash))
+        .expect_request(zs::Request::Contains(block0_hash))
         .await
-        .respond(zs::Response::Depth(Some(0)));
+        .respond(zs::Response::BlockLocation(Some(
+            zs::BlockLocation::BestChain,
+        )));
 
     // ChainSync::obtain_tips
 
@@ -797,9 +805,9 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for the first unknown block (block 1)
     state_service
-        .expect_request(zs::Request::Depth(block1_hash))
+        .expect_request(zs::Request::Contains(block1_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
 
     // Clear remaining block locator requests
     for _ in 0..(sync::FANOUT - 1) {
@@ -818,13 +826,13 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
 
     // State is checked for all non-tip blocks (blocks 1 & 2) in response order
     state_service
-        .expect_request(zs::Request::Depth(block1_hash))
+        .expect_request(zs::Request::Contains(block1_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
     state_service
-        .expect_request(zs::Request::Depth(block2_hash))
+        .expect_request(zs::Request::Contains(block2_hash))
         .await
-        .respond(zs::Response::Depth(None));
+        .respond(zs::Response::BlockLocation(None));
 
     // Blocks 1 & 2 are fetched in order, then verified concurrently
     peer_set


### PR DESCRIPTION
## Motivation

The sync task, inbound downloader, and the block verifier need to check if a block hash is present in the state to avoid redundant work and unnecessary errors. They currently call the state service with `Depth` requests, but this only checks if a block hash has been committed to the best chain, and returns `None` when the block is in a side chain or queued for validation.

This PR adds a `Contains` request to the state for checking if a block hash is present in any chain and uses it from sync, inbound and the block verifier instead of `Depth`.

Closes #862.

## Solution

- Add a `Contains` request to the state service that responds with an `Option<BlockLocation>`
  - Checks if the block hash is in:
    - non-finalized best chain
    - non-finalized side chains
    - finalized best chain
- Call state with `Contains` request from sync, inbound, and block verifier to check if the block hash is in any chain

## Review

Anyone can review.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [x] Does it change concurrent code, unsafe code, or consensus rules?
  - [x] How do you know it works? Does it have tests?
