### PR TITLE
feat(script): Add binary for finding references to closed issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5949,6 +5949,7 @@ dependencies = [
  "structopt",
  "thiserror",
  "tinyvec",
+ "tokio",
  "tracing-error",
  "tracing-subscriber 0.3.16",
  "zebra-chain",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5943,6 +5943,8 @@ version = "1.0.0-beta.21"
 dependencies = [
  "color-eyre",
  "hex",
+ "regex",
+ "reqwest",
  "serde_json",
  "structopt",
  "thiserror",

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -16,8 +16,15 @@ name = "block-template-to-proposal"
 path = "src/bin/block-template-to-proposal/main.rs"
 required-features = ["getblocktemplate-rpcs"]
 
+[[bin]]
+name = "search-todos"
+path = "src/bin/search-todos/main.rs"
+required-features = ["search-todos"]
+
 [features]
 default = []
+
+search-todos = ["regex", "reqwest/blocking"]
 
 # Production features that activate extra dependencies, or extra features in dependencies
 
@@ -40,6 +47,10 @@ serde_json = "1.0.94"
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.16"
 thiserror = "1.0.40"
+
+# These crates are needed for the search-todos binary
+regex = { version = "1.7.1", optional = true }
+reqwest =  { version = "0.11.14", features = ["blocking"], optional = true }
 
 zebra-node-services = { path = "../zebra-node-services" }
 zebra-chain = { path = "../zebra-chain" }

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -17,14 +17,14 @@ path = "src/bin/block-template-to-proposal/main.rs"
 required-features = ["getblocktemplate-rpcs"]
 
 [[bin]]
-name = "search-todos"
-path = "src/bin/search-todos/main.rs"
-required-features = ["search-todos"]
+name = "search-issue-refs"
+path = "src/bin/search-issue-refs/main.rs"
+required-features = ["search-issue-refs"]
 
 [features]
 default = []
 
-search-todos = ["regex", "reqwest/blocking"]
+search-issue-refs = ["regex", "reqwest/blocking"]
 
 # Production features that activate extra dependencies, or extra features in dependencies
 

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -48,7 +48,7 @@ tracing-error = "0.2.0"
 tracing-subscriber = "0.3.16"
 thiserror = "1.0.40"
 
-# These crates are needed for the search-todos binary
+# These crates are needed for the search-issue-refs binary
 regex = { version = "1.7.1", optional = true }
 reqwest =  { version = "0.11.14", features = ["blocking"], optional = true }
 

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -24,7 +24,7 @@ required-features = ["search-issue-refs"]
 [features]
 default = []
 
-search-issue-refs = ["regex", "reqwest/blocking"]
+search-issue-refs = ["regex", "reqwest", "tokio"]
 
 # Production features that activate extra dependencies, or extra features in dependencies
 
@@ -50,7 +50,8 @@ thiserror = "1.0.40"
 
 # These crates are needed for the search-issue-refs binary
 regex = { version = "1.7.1", optional = true }
-reqwest =  { version = "0.11.14", features = ["blocking"], optional = true }
+reqwest =  { version = "0.11.14", optional = true }
+tokio = { version = "1.26.0", features = ["full"], optional = true }
 
 zebra-node-services = { path = "../zebra-node-services" }
 zebra-chain = { path = "../zebra-chain" }

--- a/zebra-utils/src/bin/search-issue-refs/main.rs
+++ b/zebra-utils/src/bin/search-issue-refs/main.rs
@@ -16,16 +16,19 @@
 //! > Found 3 possible issue refs, checking Github issue statuses..
 //! >
 //! > --------------------------------------
-//! > Found reference to closed issue #1140: ./zebra-test/tests/command.rs:130:57
-//! > <https://github.com/ZcashFoundation/zebra/issues/1140>
+//! > Found reference to closed issue #4794: ./zebra-rpc/src/methods/get_block_template_rpcs.rs:114:19
+//! > <https://github.com/ZcashFoundation/zebra/blob/main/zebra-rpc/src/methods/get_block_template_rpcs.rs#L114>
+//! > <https://github.com/ZcashFoundation/zebra/issues/4794>
 //! >
 //! > --------------------------------------
-//! > Found reference to closed issue #1140: ./zebra-test/tests/command.rs:157:51
-//! > <https://github.com/ZcashFoundation/zebra/issues/1140>
+//! > Found reference to closed issue #2379: ./zebra-consensus/src/transaction.rs:717:49
+//! > <https://github.com/ZcashFoundation/zebra/blob/main/zebra-consensus/src/transaction.rs#L717>
+//! > <https://github.com/ZcashFoundation/zebra/issues/2379>
 //! >
 //! > --------------------------------------
-//! > Found reference to closed issue #1140: ./zebra-test/tests/command.rs:445:61
-//! > <https://github.com/ZcashFoundation/zebra/issues/1140>
+//! > Found reference to closed issue #3027: ./zebra-consensus/src/transaction/check.rs:319:6
+//! > <https://github.com/ZcashFoundation/zebra/blob/main/zebra-consensus/src/transaction/check.rs#L319>
+//! > <https://github.com/ZcashFoundation/zebra/issues/3027>
 //! >
 //! > Found 3 references to closed issues.
 

--- a/zebra-utils/src/bin/search-issue-refs/main.rs
+++ b/zebra-utils/src/bin/search-issue-refs/main.rs
@@ -106,8 +106,9 @@ async fn main() -> Result<()> {
 
     let file_paths = search_directory(&".".into())?;
 
+    // Zebra's github issue numbers could be up to 4 digits
     let issue_regex =
-        Regex::new(r"(https://github.com/ZcashFoundation/zebra/issues/|#)(\d{1,6})").unwrap();
+        Regex::new(r"(https://github.com/ZcashFoundation/zebra/issues/|#)(\d{1,4})").unwrap();
 
     let mut possible_issue_refs: Vec<PossibleIssueRef> = vec![];
 
@@ -122,7 +123,6 @@ async fn main() -> Result<()> {
                 let potential_issue_ref = captures.get(2).expect("matches should have 2 captures");
                 let matching_text = potential_issue_ref.as_str();
 
-                println!("{matching_text}");
                 let id =
                     matching_text[matching_text.len().checked_sub(4).unwrap_or(1)..].to_string();
 

--- a/zebra-utils/src/bin/search-issue-refs/main.rs
+++ b/zebra-utils/src/bin/search-issue-refs/main.rs
@@ -199,7 +199,7 @@ async fn main() -> Result<()> {
         };
 
         let Ok(json): Result<serde_json::Value, _> = serde_json::from_str(&text) else {
-            println!("warning: failed to get 'closed_at' field from response");
+            println!("warning: failed to get serde_json::Value from response");
             continue;
         };
 

--- a/zebra-utils/src/bin/search-issue-refs/main.rs
+++ b/zebra-utils/src/bin/search-issue-refs/main.rs
@@ -165,7 +165,7 @@ async fn main() -> Result<()> {
         Some((_, github_token)) => github_token,
         _ => {
             println!(
-                "Can't find {GITHUB_TOKEN_ENV_KEY} in env vars, printing all found possible issue refs,\
+                "Can't find {GITHUB_TOKEN_ENV_KEY} in env vars, printing all found possible issue refs, \
 see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token \
 to create a github token."
             );

--- a/zebra-utils/src/bin/search-issue-refs/main.rs
+++ b/zebra-utils/src/bin/search-issue-refs/main.rs
@@ -178,17 +178,15 @@ async fn main() -> Result<()> {
     }
 
     while let Some(res) = github_api_requests.join_next().await {
-        let (
-            res,
+        let Ok((
+            Ok(res),
             PossibleIssueRef {
                 file_path,
                 line_number,
                 column,
                 id,
             },
-        ) = if let Ok((Ok(res), issue_ref)) = res {
-            (res, issue_ref)
-        } else {
+        )) = res else {
             println!("warning: no response from github api");
             continue;
         };

--- a/zebra-utils/src/bin/search-issue-refs/main.rs
+++ b/zebra-utils/src/bin/search-issue-refs/main.rs
@@ -129,7 +129,11 @@ async fn main() -> Result<()> {
                 PossibleIssueRef {
                     file_path: file_path.clone(),
                     line_number: line_idx + 1,
-                    column: potential_issue_ref.start() + 1,
+                    column: captures
+                        .get(1)
+                        .expect("matches should have 2 captures")
+                        .start()
+                        + 1,
                     id,
                 }
             }))

--- a/zebra-utils/src/bin/search-issue-refs/main.rs
+++ b/zebra-utils/src/bin/search-issue-refs/main.rs
@@ -1,4 +1,4 @@
-//! Searches local directory for issue references near TODO comments.
+//! Searches local directory for references to issues that are closed.
 //!
 //! Requires a Github access token.
 //!
@@ -8,7 +8,7 @@
 //!
 //! (from the root directory of the Zebra repo)
 //! ```console
-//! GITHUB_TOKEN={valid_github_access_token} search-todos
+//! GITHUB_TOKEN={valid_github_access_token} search-issue-refs
 //! ```
 //!
 //! Example output:
@@ -17,15 +17,15 @@
 //! >
 //! > --------------------------------------
 //! > Found reference to closed issue #1140: ./zebra-test/tests/command.rs:130:57
-//! > https://github.com/ZcashFoundation/zebra/issues/1140
+//! > <https://github.com/ZcashFoundation/zebra/issues/1140>
 //! >
 //! > --------------------------------------
 //! > Found reference to closed issue #1140: ./zebra-test/tests/command.rs:157:51
-//! > https://github.com/ZcashFoundation/zebra/issues/1140
+//! > <https://github.com/ZcashFoundation/zebra/issues/1140>
 //! >
 //! > --------------------------------------
 //! > Found reference to closed issue #1140: ./zebra-test/tests/command.rs:445:61
-//! > https://github.com/ZcashFoundation/zebra/issues/1140
+//! > <https://github.com/ZcashFoundation/zebra/issues/1140>
 //! >
 //! > Found 3 references to closed issues.
 
@@ -83,7 +83,7 @@ struct PossibleIssueRef {
     id: String,
 }
 
-/// Process entry point for `search-todos`
+/// Process entry point for `search-issue-refs`
 #[allow(clippy::print_stdout, clippy::print_stderr)]
 fn main() -> Result<()> {
     init_tracing();

--- a/zebra-utils/src/bin/search-issue-refs/main.rs
+++ b/zebra-utils/src/bin/search-issue-refs/main.rs
@@ -85,6 +85,11 @@ fn github_issue_url(issue_id: &str) -> String {
     format!("https://github.com/ZcashFoundation/zebra/issues/{issue_id}")
 }
 
+fn github_remote_file_ref(file_path: &str, line: usize) -> String {
+    let file_path = &file_path[2..];
+    format!("https://github.com/ZcashFoundation/zebra/blob/main/{file_path}#L{line}")
+}
+
 fn github_issue_api_url(issue_id: &str) -> String {
     format!("https://api.github.com/repos/ZcashFoundation/zebra/issues/{issue_id}")
 }
@@ -157,7 +162,9 @@ async fn main() -> Result<()> {
         Some((_, github_token)) => github_token,
         _ => {
             println!(
-                "Can't find {GITHUB_TOKEN_ENV_KEY} in env vars, printing all found possible issue refs"
+                "Can't find {GITHUB_TOKEN_ENV_KEY} in env vars, printing all found possible issue refs,\
+see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token \
+to create a github token."
             );
 
             for PossibleIssueRef {
@@ -168,9 +175,11 @@ async fn main() -> Result<()> {
             } in possible_issue_refs
             {
                 let github_url = github_issue_url(&id);
+                let github_file_ref = github_remote_file_ref(&file_path, line_number);
 
                 println!("\n--------------------------------------");
                 println!("Found possible reference to closed issue #{id}: {file_path}:{line_number}:{column}");
+                println!("{github_file_ref}");
                 println!("{github_url}");
             }
 
@@ -239,9 +248,11 @@ async fn main() -> Result<()> {
         num_possible_issue_refs += 1;
 
         let github_url = github_issue_url(&id);
+        let github_file_ref = github_remote_file_ref(&file_path, line_number);
 
         println!("\n--------------------------------------");
         println!("Found reference to closed issue #{id}: {file_path}:{line_number}:{column}");
+        println!("{github_file_ref}");
         println!("{github_url}");
     }
 

--- a/zebra-utils/src/bin/search-issue-refs/main.rs
+++ b/zebra-utils/src/bin/search-issue-refs/main.rs
@@ -202,18 +202,24 @@ async fn main() -> Result<()> {
             continue;
         };
 
+        let file_path = file_path
+            .to_str()
+            .expect("paths from read_dir should be valid unicode");
+
+        let ref_location = format!("{file_path}:{line_number}:{column}");
+
         let Ok(res) = res else {
-            println!("warning: no response from github api about issue #{id}");
+            println!("warning: no response from github api about issue #{id}, {ref_location}");
             continue;
         };
 
         let Ok(text) = res.text().await else {
-            println!("warning: failed to get text from response about issue #{id}");
+            println!("warning: failed to get text from response about issue #{id}, {ref_location}");
             continue;
         };
 
         let Ok(json): Result<serde_json::Value, _> = serde_json::from_str(&text) else {
-            println!("warning: failed to get serde_json::Value from response for issue #{id}");
+            println!("warning: failed to get serde_json::Value from response for issue #{id}, {ref_location}");
             continue;
         };
 
@@ -224,12 +230,9 @@ async fn main() -> Result<()> {
         num_possible_issue_refs += 1;
 
         let github_url = github_issue_url(&id);
-        let file_path = file_path
-            .to_str()
-            .expect("paths from read_dir should be valid unicode");
 
         println!("\n--------------------------------------");
-        println!("Found reference to closed issue #{id}: {file_path}:{line_number}:{column}");
+        println!("Found reference to closed issue #{id}: {ref_location}");
         println!("{github_url}");
     }
 

--- a/zebra-utils/src/bin/search-issue-refs/main.rs
+++ b/zebra-utils/src/bin/search-issue-refs/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Requires a Github access token.
 //!
-//! See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+//! See <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>
 //!
 //! Example usage:
 //!

--- a/zebra-utils/src/bin/search-todos/main.rs
+++ b/zebra-utils/src/bin/search-todos/main.rs
@@ -7,7 +7,9 @@
 //! Example usage:
 //!
 //! (from the root directory of the Zebra repo)
+//! ```console
 //! GITHUB_TOKEN={valid_github_access_token} search-todos
+//! ```
 //!
 //! Example output:
 //!

--- a/zebra-utils/src/bin/search-todos/main.rs
+++ b/zebra-utils/src/bin/search-todos/main.rs
@@ -1,0 +1,186 @@
+//! Searches local directory for issue references near TODO comments.
+//!
+//! Requires a Github access token.
+//!
+//! See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+//!
+//! Example usage:
+//!
+//! (from the root directory of the Zebra repo)
+//! GITHUB_TOKEN={valid_github_access_token} search-todos
+//!
+//! Example output:
+//!
+//! > Found 2 posssible issue refs, checking Github issue statuses..
+//! >
+//! > --------------------------------------
+//! > Found reference to closed issue #1140: ./zebra-test/tests/command.rs:130:57
+//! > https://github.com/ZcashFoundation/zebra/issues/1140
+//! >
+//! > --------------------------------------
+//! > Found reference to closed issue #1140: ./zebra-test/tests/command.rs:157:51
+//! > https://github.com/ZcashFoundation/zebra/issues/1140
+//! >
+//! > --------------------------------------
+//! > Found reference to closed issue #1140: ./zebra-test/tests/command.rs:445:61
+//! > https://github.com/ZcashFoundation/zebra/issues/1140
+//! >
+//! > Found 2 references to closed issues.
+
+use std::{
+    env,
+    fs::{self, File},
+    io::{self, BufRead},
+    path::PathBuf,
+};
+
+use color_eyre::eyre::Result;
+use regex::Regex;
+use reqwest::{
+    blocking::ClientBuilder,
+    header::{self, HeaderMap, HeaderValue},
+};
+
+use zebra_utils::init_tracing;
+
+const GITHUB_TOKEN_ENV_KEY: &str = "GITHUB_TOKEN";
+
+fn search_directory(path: &PathBuf) -> Result<Vec<PathBuf>> {
+    Ok(fs::read_dir(path)?
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+
+            if path.is_dir() {
+                search_directory(&path).ok()
+            } else if path.is_file() {
+                match path.extension() {
+                    Some(ext) if ext == "rs" && !path.starts_with("/target/") => Some(vec![path]),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        })
+        .flatten()
+        .collect())
+}
+
+fn github_issue_url(issue_id: &str) -> String {
+    format!("https://github.com/ZcashFoundation/zebra/issues/{issue_id}")
+}
+
+fn github_issue_api_url(issue_id: &str) -> String {
+    format!("https://api.github.com/repos/ZcashFoundation/zebra/issues/{issue_id}")
+}
+
+#[derive(Debug)]
+struct PossibleIssueRef {
+    file_path: PathBuf,
+    line_number: usize,
+    column: usize,
+    id: String,
+}
+
+/// Process entry point for `search-todos`
+#[allow(clippy::print_stdout, clippy::print_stderr)]
+fn main() -> Result<()> {
+    init_tracing();
+    color_eyre::install()?;
+
+    let file_paths = search_directory(&".".into())?;
+
+    let issue_regex = Regex::new(r"#\d{4}").unwrap();
+
+    let mut possible_issue_refs: Vec<PossibleIssueRef> = vec![];
+
+    for file_path in file_paths {
+        let file = File::open(&file_path)?;
+        let lines = io::BufReader::new(file).lines();
+
+        for (line_idx, line) in lines.into_iter().enumerate() {
+            let line = line?;
+
+            possible_issue_refs.extend(issue_regex.find_iter(&line).map(|potential_issue_ref| {
+                PossibleIssueRef {
+                    file_path: file_path.clone(),
+                    line_number: line_idx + 1,
+                    column: potential_issue_ref.start(),
+                    id: potential_issue_ref.as_str()[1..].to_string(),
+                }
+            }))
+        }
+    }
+
+    let num_possible_issue_refs = possible_issue_refs.len();
+
+    println!("\nFound {num_possible_issue_refs} posssible issue refs, checking Github issue statuses..\n");
+
+    // check if issues are closed
+
+    let github_token = match env::vars().find(|(key, _)| key == GITHUB_TOKEN_ENV_KEY) {
+        Some((_, github_token)) => github_token,
+        _ => {
+            println!(
+                "Can't find {GITHUB_TOKEN_ENV_KEY} in env vars, printing all found possible issue refs"
+            );
+
+            for issue in possible_issue_refs {
+                println!("{issue:?}");
+            }
+
+            return Ok(());
+        }
+    };
+
+    let mut headers = HeaderMap::new();
+    let mut auth_value = HeaderValue::from_str(&format!("Bearer {github_token}"))?;
+    let accept_value = HeaderValue::from_static("application/vnd.github+json");
+    let github_api_version_value = HeaderValue::from_static("2022-11-28");
+    let user_agent_value = HeaderValue::from_static("search-todos");
+
+    auth_value.set_sensitive(true);
+
+    headers.insert(header::AUTHORIZATION, auth_value);
+    headers.insert(header::ACCEPT, accept_value);
+    headers.insert("X-GitHub-Api-Version", github_api_version_value);
+    headers.insert(header::USER_AGENT, user_agent_value);
+
+    let client = ClientBuilder::new().default_headers(headers).build()?;
+
+    possible_issue_refs.retain(|possible_issue_ref| {
+        client
+            .get(github_issue_api_url(&possible_issue_ref.id))
+            .send()
+            .ok()
+            .and_then(|response| response.text().ok())
+            .and_then(|response_text| serde_json::from_str(&response_text).ok())
+            .map(|response_json: serde_json::Value| {
+                serde_json::Value::Null != response_json["closed_at"]
+            })
+            .unwrap_or(false)
+    });
+
+    let num_possible_issue_refs = possible_issue_refs.len();
+
+    for PossibleIssueRef {
+        file_path,
+        line_number,
+        column,
+        id,
+        ..
+    } in &possible_issue_refs
+    {
+        let github_url = github_issue_url(id);
+        let file_path = file_path
+            .to_str()
+            .expect("paths from read_dir should be valid unicode");
+
+        println!("\n--------------------------------------");
+        println!("Found reference to closed issue #{id}: {file_path}:{line_number}:{column}");
+        println!("{github_url}");
+    }
+
+    println!("\nFound {num_possible_issue_refs} references to closed issues.\n");
+
+    Ok(())
+}

--- a/zebra-utils/src/bin/search-todos/main.rs
+++ b/zebra-utils/src/bin/search-todos/main.rs
@@ -11,7 +11,7 @@
 //!
 //! Example output:
 //!
-//! > Found 2 posssible issue refs, checking Github issue statuses..
+//! > Found 3 posssible issue refs, checking Github issue statuses..
 //! >
 //! > --------------------------------------
 //! > Found reference to closed issue #1140: ./zebra-test/tests/command.rs:130:57
@@ -25,7 +25,7 @@
 //! > Found reference to closed issue #1140: ./zebra-test/tests/command.rs:445:61
 //! > https://github.com/ZcashFoundation/zebra/issues/1140
 //! >
-//! > Found 2 references to closed issues.
+//! > Found 3 references to closed issues.
 
 use std::{
     env,

--- a/zebra-utils/src/bin/search-todos/main.rs
+++ b/zebra-utils/src/bin/search-todos/main.rs
@@ -91,7 +91,8 @@ fn main() -> Result<()> {
 
     let file_paths = search_directory(&".".into())?;
 
-    let issue_regex = Regex::new(r"#\d{4}").unwrap();
+    let issue_regex =
+        Regex::new(r"(https://github.com/ZcashFoundation/zebra/issues/|#)\d{4}").unwrap();
 
     let mut possible_issue_refs: Vec<PossibleIssueRef> = vec![];
 
@@ -103,11 +104,14 @@ fn main() -> Result<()> {
             let line = line?;
 
             possible_issue_refs.extend(issue_regex.find_iter(&line).map(|potential_issue_ref| {
+                let matching_text = potential_issue_ref.as_str();
+                let id = matching_text[matching_text.len() - 4..].to_string();
+
                 PossibleIssueRef {
                     file_path: file_path.clone(),
                     line_number: line_idx + 1,
-                    column: potential_issue_ref.start(),
-                    id: potential_issue_ref.as_str()[1..].to_string(),
+                    column: potential_issue_ref.start() + 1,
+                    id,
                 }
             }))
         }


### PR DESCRIPTION
## Motivation

We want a full list of comments in the repo referencing issues that are closed.

Closes #6278.

## Solution

- Add a `search-issue-refs` binary to `zebra-utils`
  - Search all .rs, .yml, .yaml, and .toml files in the local directory for possible issue refs
  - Filter out any possible issue refs that don't have closed issues in Zebra
  - Print out a list of closed issues and their locations

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
