### PR TITLE
fix(ci): Split lightwalletd full sync into two jobs

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -822,7 +822,7 @@ jobs:
           grep --max-count=1 --extended-regexp --color=always \
           -e 'estimated progress.*current_height.*=.*17[4-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
-          -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*[2-9][0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'test result:.*finished in' \
           "
 
@@ -891,7 +891,7 @@ jobs:
           grep --max-count=1 --extended-regexp --color=always \
           -e 'estimated progress.*current_height.*=.*17[6-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
-          -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*[2-9][0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'test result:.*finished in' \
           "
 
@@ -960,7 +960,7 @@ jobs:
           grep --max-count=1 --extended-regexp --color=always \
           -e 'estimated progress.*current_height.*=.*17[8-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
-          -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*[2-9][0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'test result:.*finished in' \
           "
 
@@ -1029,7 +1029,7 @@ jobs:
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           -e 'estimated progress.*current_height.*=.*1[8-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
-          -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*[2-9][0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'test result:.*finished in' \
           "
 
@@ -1099,7 +1099,7 @@ jobs:
           grep --max-count=1 --extended-regexp --color=always \
           -e 'estimated progress.*current_height.*=.*18[2-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'estimated progress.*current_height.*=.*19[0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
-          -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*[2-9][0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'test result:.*finished in' \
           "
 
@@ -1168,7 +1168,7 @@ jobs:
           grep --max-count=1 --extended-regexp --color=always \
           -e 'estimated progress.*current_height.*=.*18[5-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'estimated progress.*current_height.*=.*19[0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
-          -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*[2-9][0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'test result:.*finished in' \
           "
 
@@ -1237,7 +1237,7 @@ jobs:
           grep --max-count=1 --extended-regexp --color=always \
           -e 'estimated progress.*current_height.*=.*18[8-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'estimated progress.*current_height.*=.*19[0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
-          -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*[2-9][0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'test result:.*finished in' \
           "
 
@@ -1305,7 +1305,7 @@ jobs:
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           -e 'estimated progress.*current_height.*=.*19[2-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
-          -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*[2-9][0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'test result:.*finished in' \
           "
 
@@ -1373,11 +1373,12 @@ jobs:
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           -e 'estimated progress.*current_height.*=.*19[6-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
-          -e 'estimated progress.*current_height.*=.*2[0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
+          -e 'estimated progress.*current_height.*=.*[2-9][0-9][0-9][0-9][0-9][0-9][0-9].*remaining_sync_blocks' \
           -e 'test result:.*finished in' \
           "
 
-  # follow the logs of the test we just launched, up to the last checkpoint (or the test finishing)
+  # follow the logs of the test we just launched, up to the last checkpoint, or the test finishing,
+  # or for lightwalletd tests, about 5 hours into the full lightwalletd sync (block 1880k)
   logs-checkpoint:
     name: Log ${{ inputs.test_id }} test (checkpoint)
     needs: [ logs-1960k ]
@@ -1421,7 +1422,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1.1.0
 
-      # Show recent logs, following until the last checkpoint (or the test finishes)
+      # Show recent logs, following until the last checkpoint, or the test finishes, or 5 hours of lightwalletd sync (1880k)
       #
       # TODO: when doing obtain/extend tips, log the verifier in use, and check for full verification here
       - name: Show logs for ${{ inputs.test_id }} test (checkpoint)
@@ -1440,6 +1441,9 @@ jobs:
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           -e 'verified final checkpoint' \
+          -e 'lightwalletd.*Adding block to cache 18[8-9][0-9][0-9][0-9][0-9]' \
+          -e 'lightwalletd.*Adding block to cache 19[0-9][0-9][0-9][0-9][0-9]' \
+          -e 'lightwalletd.*Adding block to cache [2-9][0-9][0-9][0-9][0-9][0-9][0-9]' \
           -e 'test result:.*finished in' \
           "
 


### PR DESCRIPTION
## Motivation

The lightwalletd full sync test is timing out in the `main` branch CI:
> lightwalletd tip / Log lwd-full-sync test (checkpoint)
> The job running on runner GitHub Actions 3 has exceeded the maximum execution time of 360 minutes.

https://github.com/ZcashFoundation/zebra/actions/runs/4443966205

### Complex Code or Requirements

We've got these regexes wrong before, so please check them carefully.

This is the log the regex is trying to split the job on:
> {"app":"lightwalletd","level":"info","msg":"Adding block to cache 1880007 000000000161f0b6fd7de3ca8b316f60292d887dc1e1559e4a58ad192e6c0fb2","time":"2023-03-20T14:06:44Z"}

https://github.com/ZcashFoundation/zebra/actions/runs/4443966205/jobs/7852219769#step:8:7311

## Solution

- Split the lightwalletd sync "checkpoint" job into the "run" job at around 5 hours, by adding a lightwalletd-specific regex

This doesn't change the Zebra full sync test, because it only checks for lightwalletd logs.

Related fixes:
- Make all the regexes support blocks 3 million and above

## Review

This is an urgent fix to a CI failure on the `main` branch.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

This is a bit of a weird job to split, but it's the job that's timing out, so we have to split it. We might want to rename it later, or add more lightwalletd jobs after the checkpoint job. But hopefully we do self-hosted runners before that.