### PR TITLE
fix(ci): Switch CI to a GCP zone with available instances

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -91,7 +91,7 @@ env:
   IMAGE_NAME: zebrad-test
   GAR_BASE: us-docker.pkg.dev/zealous-zebra/zebra
   # what kind of Google Cloud instance we want to launch
-  ZONE: us-central1-a
+  ZONE: us-central1-f
   MACHINE_TYPE: c2d-standard-16
   # How many previous log lines we show at the start of each new log job.
   # Increase this number if some log lines are skipped between jobs


### PR DESCRIPTION
## Motivation

GCP CI fails with:
> A c2d-standard-16 VM instance is currently unavailable in the us-central1-a
> zone. Consider trying your request in the us-central1-f, us-central1-b, us-central1-c
> zone(s), which currently has capacity to accommodate your request. Alternatively,
> you can try your request again with a different VM hardware configuration or
> at a later time. For more information, see the troubleshooting documentation.

https://github.com/ZcashFoundation/zebra/actions/runs/4429186789/jobs/7772459849#step:10:94

## Solution

- Switch the only workflow that uses c2d-standard-16 machines to us-central1-f

## Review

This is an urgent CI failure fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We'll also need to change the corresponding variable in PR #6357.