### PR TITLE
change(state): Stop dropping blocks in state

### DIFF
--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -200,7 +200,13 @@ impl FinalizedState {
         // and the block write task.
         let result = result.map_err(CloneError::from);
 
-        let _ = rsp_tx.send(result.clone().map_err(BoxError::from));
+        if let Some(rsp_tx) = rsp_tx
+            .lock()
+            .map_err(|e| BoxError::from(e.to_string()))?
+            .take()
+        {
+            let _ = rsp_tx.send(result.clone().map_err(BoxError::from));
+        }
 
         result.map(|_hash| finalized).map_err(BoxError::from)
     }


### PR DESCRIPTION
## Motivation

In PR https://github.com/ZcashFoundation/zebra/pull/6335, the state adds the hashes of queued finalized blocks to `sent_blocks` to check when responding to a `KnownBlock` request, and clears `sent_blocks` when there's a reset signal from the write task so blocks that could not be validated can be re-downloaded/verified.

This PR keeps queued finalized blocks in the state until they fall below the finalized tip height so Zebra won't need to re-download or re-verify them.

## Solution

- Puts `oneshot::Sender` into a `Arc<Mutex<Option<T>>>` 
- Sends a clone of `QueuedFinalized` to the block write task without removing it from `queued_finalized_blocks`
- Omits finalized hashes from `sent_blocks` (I'll revert the rename if we go with this approach)

## Review

This is meant to merge into https://github.com/ZcashFoundation/zebra/pull/6335 and needs some polish before it replaces adding finalized block hashes to `sent_blocks`.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
