### PR TITLE
change(state): Stop re-downloading blocks that are in state queues

### DIFF
--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -159,7 +159,7 @@ where
                 .map_err(|source| VerifyBlockError::Depth { source, hash })?
             {
                 zs::Response::KnownBlock(Some(location)) => {
-                    return Err(BlockError::AlreadyInChain(hash, location).into())
+                    return Err(BlockError::AlreadyInState(hash, location).into())
                 }
                 zs::Response::KnownBlock(None) => {}
                 _ => unreachable!("wrong response to Request::KnownBlock"),

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -246,7 +246,7 @@ pub enum BlockError {
     DuplicateTransaction,
 
     #[error("block {0:?} is already in present in the state {1:?}")]
-    AlreadyInChain(zebra_chain::block::Hash, zebra_state::KnownBlock),
+    AlreadyInState(zebra_chain::block::Hash, zebra_state::KnownBlock),
 
     #[error("invalid block {0:?}: missing block height")]
     MissingHeight(zebra_chain::block::Hash),
@@ -311,6 +311,6 @@ impl BlockError {
     /// Returns `true` if this is definitely a duplicate request.
     /// Some duplicate requests might not be detected, and therefore return `false`.
     pub fn is_duplicate_request(&self) -> bool {
-        matches!(self, BlockError::AlreadyInChain(..))
+        matches!(self, BlockError::AlreadyInState(..))
     }
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -52,6 +52,7 @@ use crate::{
         MAX_FIND_BLOCK_HASHES_RESULTS, MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_ZEBRA,
         MAX_LEGACY_CHAIN_BLOCKS,
     },
+    response::KnownBlock,
     service::{
         block_iter::any_ancestor_blocks,
         chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip},
@@ -162,7 +163,7 @@ pub(crate) struct StateService {
 
     /// A set of block hashes that have been sent to the block write task.
     /// Hashes of blocks below the finalized tip height are periodically pruned.
-    sent_non_finalized_block_hashes: SentHashes,
+    sent_blocks: SentHashes,
 
     /// If an invalid block is sent on `finalized_block_write_sender`
     /// or `non_finalized_block_write_sender`,
@@ -408,7 +409,7 @@ impl StateService {
             non_finalized_block_write_sender: Some(non_finalized_block_write_sender),
             finalized_block_write_sender: Some(finalized_block_write_sender),
             last_sent_finalized_block_hash,
-            sent_non_finalized_block_hashes: SentHashes::default(),
+            sent_blocks: SentHashes::default(),
             invalid_block_reset_receiver,
             pending_utxos,
             last_prune: Instant::now(),
@@ -471,8 +472,7 @@ impl StateService {
         // If we're close to the final checkpoint, make the block's UTXOs available for
         // full verification of non-finalized blocks, even when it is in the channel.
         if self.is_close_to_final_checkpoint(queued_height) {
-            self.sent_non_finalized_block_hashes
-                .add_finalized(&finalized)
+            self.sent_blocks.add_finalized(&finalized)
         }
 
         let (rsp_tx, rsp_rx) = oneshot::channel();
@@ -551,22 +551,39 @@ impl StateService {
 
         // If a block failed, we need to start again from a valid tip.
         match self.invalid_block_reset_receiver.try_recv() {
-            Ok(reset_tip_hash) => self.last_sent_finalized_block_hash = reset_tip_hash,
+            Ok(reset_tip_hash) => {
+                // any blocks that may have been sent were either committed or dropped
+                // if a reset signal has been received, so we can clear `sent_blocks` and
+                // let Zebra re-download/verify blocks that were dropped.
+                self.sent_blocks.clear();
+                self.last_sent_finalized_block_hash = reset_tip_hash
+            }
             Err(TryRecvError::Disconnected) => {
                 info!("Block commit task closed the block reset channel. Is Zebra shutting down?");
                 return;
             }
             // There are no errors, so we can just use the last block hash we sent
-            Err(TryRecvError::Empty) => {}
+            Err(TryRecvError::Empty) => {
+                if let Some(finalized_tip_height) = self.read_service.db.finalized_tip_height() {
+                    self.sent_blocks.prune_by_height(finalized_tip_height);
+                }
+            }
         }
 
         while let Some(queued_block) = self
             .queued_finalized_blocks
             .remove(&self.last_sent_finalized_block_hash)
         {
-            let last_sent_finalized_block_height = queued_block.0.height;
+            let (finalized, _) = &queued_block;
+            let &FinalizedBlock { hash, height, .. } = finalized;
 
-            self.last_sent_finalized_block_hash = queued_block.0.hash;
+            self.last_sent_finalized_block_hash = hash;
+
+            // If we're not close to the final checkpoint, add the hash for checking if
+            // a block is present in a queue when called with `Request::KnownBlock`.
+            if !self.is_close_to_final_checkpoint(height) {
+                self.sent_blocks.add_finalized_hash(hash, height);
+            }
 
             // If we've finished sending finalized blocks, ignore any repeated blocks.
             // (Blocks can be repeated after a syncer reset.)
@@ -585,10 +602,7 @@ impl StateService {
                         "block commit task exited. Is Zebra shutting down?",
                     );
                 } else {
-                    metrics::gauge!(
-                        "state.checkpoint.sent.block.height",
-                        last_sent_finalized_block_height.0 as f64,
-                    );
+                    metrics::gauge!("state.checkpoint.sent.block.height", height.0 as f64,);
                 };
             }
         }
@@ -643,10 +657,7 @@ impl StateService {
         tracing::debug!(block = %prepared.block, "queueing block for contextual verification");
         let parent_hash = prepared.block.header.previous_block_hash;
 
-        if self
-            .sent_non_finalized_block_hashes
-            .contains(&prepared.hash)
-        {
+        if self.sent_blocks.contains(&prepared.hash) {
             let (rsp_tx, rsp_rx) = oneshot::channel();
             let _ = rsp_tx.send(Err(
                 "block has already been sent to be committed to the state".into(),
@@ -713,28 +724,26 @@ impl StateService {
             return rsp_rx;
         }
 
-        if self.finalized_block_write_sender.is_none() {
-            // Wait until block commit task is ready to write non-finalized blocks before dequeuing them
-            self.send_ready_non_finalized_queued(parent_hash);
+        // Wait until block commit task is ready to write non-finalized blocks before dequeuing them
+        self.send_ready_non_finalized_queued(parent_hash);
 
-            let finalized_tip_height = self.read_service.db.finalized_tip_height().expect(
+        let finalized_tip_height = self.read_service.db.finalized_tip_height().expect(
             "Finalized state must have at least one block before committing non-finalized state",
         );
 
-            self.queued_non_finalized_blocks
-                .prune_by_height(finalized_tip_height);
+        self.queued_non_finalized_blocks
+            .prune_by_height(finalized_tip_height);
 
-            self.sent_non_finalized_block_hashes
-                .prune_by_height(finalized_tip_height);
-        }
+        self.sent_blocks.prune_by_height(finalized_tip_height);
 
         rsp_rx
     }
 
     /// Returns `true` if `hash` is a valid previous block hash for new non-finalized blocks.
     fn can_fork_chain_at(&self, hash: &block::Hash) -> bool {
-        self.sent_non_finalized_block_hashes.contains(hash)
-            || &self.read_service.db.finalized_tip_hash() == hash
+        self.finalized_block_write_sender.is_none()
+            && (self.sent_blocks.contains(hash)
+                || &self.read_service.db.finalized_tip_hash() == hash)
     }
 
     /// Returns `true` if `queued_height` is near the final checkpoint.
@@ -764,7 +773,7 @@ impl StateService {
                 for queued_child in queued_children {
                     let (PreparedBlock { hash, .. }, _) = queued_child;
 
-                    self.sent_non_finalized_block_hashes.add(&queued_child.0);
+                    self.sent_blocks.add(&queued_child.0);
                     let send_result = non_finalized_block_write_sender.send(queued_child);
 
                     if let Err(SendError(queued)) = send_result {
@@ -785,7 +794,7 @@ impl StateService {
                 }
             }
 
-            self.sent_non_finalized_block_hashes.finish_batch();
+            self.sent_blocks.finish_batch();
         };
     }
 
@@ -806,6 +815,14 @@ impl StateService {
             blocks, and the canopy activation block, must be committed to the state as finalized \
             blocks"
         );
+    }
+
+    /// Returns true if the block hash is queued or has been sent to be validated and committed.
+    /// Returns false otherwise.
+    fn is_block_queued(&self, hash: &block::Hash) -> bool {
+        self.queued_non_finalized_blocks.contains_block_hash(hash)
+            || self.queued_finalized_blocks.contains_key(hash)
+            || self.sent_blocks.contains(hash)
     }
 }
 
@@ -1011,7 +1028,7 @@ impl Service<Request> for StateService {
                 }
 
                 // Check the sent non-finalized blocks
-                if let Some(utxo) = self.sent_non_finalized_block_hashes.utxo(&outpoint) {
+                if let Some(utxo) = self.sent_blocks.utxo(&outpoint) {
                     self.pending_utxos.respond(&outpoint, utxo);
 
                     // We're finished, the returned future gets the UTXO from the respond() channel.
@@ -1068,6 +1085,8 @@ impl Service<Request> for StateService {
             Request::KnownBlock(hash) => {
                 let timer = CodeTimer::start();
 
+                let is_block_queued = self.is_block_queued(&hash);
+
                 let read_service = self.read_service.clone();
 
                 async move {
@@ -1075,6 +1094,7 @@ impl Service<Request> for StateService {
                         &read_service.latest_non_finalized_state(),
                         hash,
                     )
+                    .or(is_block_queued.then_some(KnownBlock::Queue))
                     .or_else(|| read::finalized_state_contains_block_hash(&read_service.db, hash));
 
                     // The work is done in the future.

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -52,7 +52,6 @@ use crate::{
         MAX_FIND_BLOCK_HASHES_RESULTS, MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_ZEBRA,
         MAX_LEGACY_CHAIN_BLOCKS,
     },
-    response::KnownBlock,
     service::{
         block_iter::any_ancestor_blocks,
         chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip},
@@ -1090,12 +1089,12 @@ impl Service<Request> for StateService {
                 let read_service = self.read_service.clone();
 
                 async move {
-                    let response = read::non_finalized_state_contains_block_hash(
+                    let response = read::contains_block(
                         &read_service.latest_non_finalized_state(),
+                        &read_service.db,
+                        is_block_queued,
                         hash,
-                    )
-                    .or(is_block_queued.then_some(KnownBlock::Queue))
-                    .or_else(|| read::finalized_state_contains_block_hash(&read_service.db, hash));
+                    );
 
                     // The work is done in the future.
                     timer.finish(module_path!(), line!(), "Request::KnownBlock");

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -708,25 +708,25 @@ impl StateService {
         }
 
         // Wait until block commit task is ready to write non-finalized blocks before dequeuing them
-        self.send_ready_non_finalized_queued(parent_hash);
+        if self.finalized_block_write_sender.is_none() {
+            self.send_ready_non_finalized_queued(parent_hash);
 
-        let finalized_tip_height = self.read_service.db.finalized_tip_height().expect(
-            "Finalized state must have at least one block before committing non-finalized state",
-        );
+            let finalized_tip_height = self.read_service.db.finalized_tip_height().expect(
+                "Finalized state must have at least one block before committing non-finalized state",
+            );
 
-        self.queued_non_finalized_blocks
-            .prune_by_height(finalized_tip_height);
+            self.queued_non_finalized_blocks
+                .prune_by_height(finalized_tip_height);
 
-        self.sent_blocks.prune_by_height(finalized_tip_height);
+            self.sent_blocks.prune_by_height(finalized_tip_height);
+        }
 
         rsp_rx
     }
 
     /// Returns `true` if `hash` is a valid previous block hash for new non-finalized blocks.
     fn can_fork_chain_at(&self, hash: &block::Hash) -> bool {
-        self.finalized_block_write_sender.is_none()
-            && (self.sent_blocks.contains(hash)
-                || &self.read_service.db.finalized_tip_hash() == hash)
+        self.sent_blocks.contains(hash) || &self.read_service.db.finalized_tip_hash() == hash
     }
 
     /// Returns `true` if `queued_height` is near the final checkpoint.

--- a/zebra-state/src/service/queued_blocks.rs
+++ b/zebra-state/src/service/queued_blocks.rs
@@ -217,6 +217,12 @@ impl QueuedBlocks {
 
         self.blocks.drain()
     }
+
+    /// Returns true if QueuedBlocks contains a block with the given hash.
+    /// Returns false otherwise.
+    pub fn contains_block_hash(&self, hash: &block::Hash) -> bool {
+        self.blocks.contains_key(hash)
+    }
 }
 
 #[derive(Debug, Default)]
@@ -289,6 +295,20 @@ impl SentHashes {
         self.update_metrics_for_block(block.height);
     }
 
+    /// Stores the finalized `block`'s hash, so it can be used to check if a
+    /// block is in the state queue.
+    ///
+    /// Assumes that blocks are added in the order of their height between `finish_batch` calls
+    /// for efficient pruning.
+    ///
+    /// For more details see `add()`.
+    pub fn add_finalized_hash(&mut self, hash: block::Hash, height: block::Height) {
+        self.curr_buf.push_back((hash, height));
+        self.sent.insert(hash, vec![]);
+
+        self.update_metrics_for_block(height);
+    }
+
     /// Try to look up this UTXO in any sent block.
     #[instrument(skip(self))]
     pub fn utxo(&self, outpoint: &transparent::OutPoint) -> Option<transparent::Utxo> {
@@ -332,6 +352,15 @@ impl SentHashes {
 
         self.sent.shrink_to_fit();
 
+        self.update_metrics_for_cache();
+    }
+
+    /// Clears all data from `SentBlocks`
+    pub fn clear(&mut self) {
+        self.sent.clear();
+        self.bufs.clear();
+        self.curr_buf.clear();
+        self.known_utxos.clear();
         self.update_metrics_for_cache();
     }
 

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -34,9 +34,8 @@ pub use block::{
     any_utxo, block, block_header, transaction, transaction_hashes_for_block, unspent_utxo, utxo,
 };
 pub use find::{
-    best_tip, block_locator, chain_contains_hash, depth, finalized_state_contains_block_hash,
-    find_chain_hashes, find_chain_headers, hash_by_height, height_by_hash, next_median_time_past,
-    non_finalized_state_contains_block_hash, tip, tip_height,
+    best_tip, block_locator, chain_contains_hash, contains_block, depth, find_chain_hashes,
+    find_chain_headers, hash_by_height, height_by_hash, next_median_time_past, tip, tip_height,
 };
 pub use tree::{orchard_tree, sapling_tree};
 

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -101,10 +101,12 @@ where
     Some(tip.0 - height.0)
 }
 
-/// Returns the location of the block if present in the non-finalized state.
-/// Returns None if the block hash is not found in the non-finalized state.
-pub fn non_finalized_state_contains_block_hash(
+/// Returns [`KnownBlock`] indicating where the block is present in the state, or
+/// Returns None if the block with the provided hash is not found in the state.
+pub fn contains_block(
     non_finalized_state: &NonFinalizedState,
+    db: &ZebraDb,
+    is_block_queued: bool,
     hash: block::Hash,
 ) -> Option<KnownBlock> {
     let mut chains_iter = non_finalized_state.chain_set.iter().rev();
@@ -116,14 +118,10 @@ pub fn non_finalized_state_contains_block_hash(
     match best_chain.map(is_hash_in_chain) {
         Some(true) => Some(KnownBlock::BestChain),
         Some(false) if chains_iter.any(is_hash_in_chain) => Some(KnownBlock::SideChain),
+        Some(false) | None if is_block_queued => Some(KnownBlock::Queue),
+        Some(false) | None if db.contains_hash(hash) => Some(KnownBlock::BestChain),
         Some(false) | None => None,
     }
-}
-
-/// Returns the location of the block if present in the finalized state.
-/// Returns None if the block hash is not found in the finalized state.
-pub fn finalized_state_contains_block_hash(db: &ZebraDb, hash: block::Hash) -> Option<KnownBlock> {
-    db.contains_hash(hash).then_some(KnownBlock::BestChain)
 }
 
 /// Return the height for the block at `hash`, if `hash` is in `chain` or `db`.

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1156,7 +1156,7 @@ where
                 // https://github.com/ZcashFoundation/zebra/issues/2909
                 let err_str = format!("{e:?}");
                 if err_str.contains("AlreadyVerified")
-                    || err_str.contains("AlreadyInChain")
+                    || err_str.contains("AlreadyInState")
                     || err_str.contains("block is already committed to the state")
                     || err_str.contains("block has already been sent to be committed to the state")
                     || err_str.contains("NotFound")


### PR DESCRIPTION
## Motivation

This PR is a follow-up to https://github.com/ZcashFoundation/zebra/pull/6335 to look for block hashes from `Contains` requests in state queues.

Depends-On: https://github.com/ZcashFoundation/zebra/pull/6335

## Solution

- Add and prune finalized block hashes to `sent_blocks` in `drain_queue_and_commit_finalized`
- Checks if the block hash is in:
  - any non-finalized chains
  - `queued_non_finalized_blocks`, `queued_finalized_blocks`, or `sent_blocks`
  - finalized best chain

Related changes:
- Renames `sent_non_finalized_block_hashes` to `sent_blocks`

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
