### PR TITLE
fix(net): Drop Firo cryptocurrency nodes from Zebra's address book, because they are not compatible with Zcash

### DIFF
--- a/zebra-network/src/peer/priority.rs
+++ b/zebra-network/src/peer/priority.rs
@@ -123,9 +123,14 @@ fn address_is_valid_for_outbound_connections(
             return Err(
                 "invalid peer port: port is for Regtest, but Zebra does not support that network",
             );
-        } else if [16125, 26125].contains(&peer_addr.port()) {
-            // 16125/26125 is used by Flux/ZelCash, which uses the same network magic numbers as Zcash,
-            // so we have to reject it by port
+        } else if [16125, 26125, 8168, 18168, 38168].contains(&peer_addr.port()) {
+            // 16125/26125 are used by Flux/ZelCash, which uses the same network magic numbers as Zcash,
+            // so we have to reject it by port:
+            // - https://github.com/RunOnFlux/fluxd/blob/master/src/zelnode/zelnodeconfig.cpp#L76
+            // - https://github.com/RunOnFlux/fluxd/blob/master/src/init.cpp#L409
+            // 8168/18168/38168 are used by Firo/Zcoin, which uses the same network magic numbers as Zcash,
+            // so we have to reject it by port:
+            // - https://github.com/firoorg/firo/blob/master/src/chainparamsseeds.h
             return Err("invalid peer port: port is for a non-Zcash network");
         }
     }


### PR DESCRIPTION
## Motivation

Firo is a network that uses the same network magic values as Zcash, but it's not actually compatible with Zcash. This means that our address book can get full of invalid nodes, and we can waste a lot of resources connecting to them.

Just like we did for Flux, we can drop nodes with the default Firo ports from our address book.

### Complex Code or Requirements

This is existing code that just needs some extra ports added to it.

## Solution

- Add the default Firo main, test, and dev network ports to our invalid ports list

## Review

This is a medium priority network efficiency/security fix.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

