### PR TITLE
fix(rpc): Check that mempool transactions are valid for the state's chain info in getblocktemplate

### DIFF
--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -108,7 +108,7 @@ pub enum Response {
         transactions: Vec<VerifiedUnminedTx>,
 
         /// Last seen chain tip hash by mempool service
-        last_seen_chain_tip: Option<zebra_chain::block::Hash>,
+        last_seen_tip_hash: zebra_chain::block::Hash,
     },
 
     /// Returns matching cached rejected [`UnminedTxId`]s from the mempool,

--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -103,7 +103,13 @@ pub enum Response {
     // TODO: make the Transactions response return VerifiedUnminedTx,
     //       and remove the FullTransactions variant
     #[cfg(feature = "getblocktemplate-rpcs")]
-    FullTransactions(Vec<VerifiedUnminedTx>),
+    FullTransactions {
+        /// All [`VerifiedUnminedTx`] in the mempool
+        transactions: Vec<VerifiedUnminedTx>,
+
+        /// Last seen chain tip hash by mempool service
+        last_seen_chain_tip: Option<zebra_chain::block::Hash>,
+    },
 
     /// Returns matching cached rejected [`UnminedTxId`]s from the mempool,
     RejectedTransactionIds(HashSet<UnminedTxId>),

--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -104,7 +104,7 @@ pub enum Response {
     //       and remove the FullTransactions variant
     #[cfg(feature = "getblocktemplate-rpcs")]
     FullTransactions {
-        /// All [`VerifiedUnminedTx`] in the mempool
+        /// All [`VerifiedUnminedTx`]s in the mempool
         transactions: Vec<VerifiedUnminedTx>,
 
         /// Last seen chain tip hash by mempool service

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -798,7 +798,10 @@ where
 
             match response {
                 #[cfg(feature = "getblocktemplate-rpcs")]
-                mempool::Response::FullTransactions(mut transactions) => {
+                mempool::Response::FullTransactions {
+                    mut transactions,
+                    last_seen_tip_hash: _,
+                } => {
                     // Sort transactions in descending order by fee/size, using hash in serialized byte order as a tie-breaker
                     transactions.sort_by_cached_key(|tx| {
                         // zcashd uses modified fee here but Zebra doesn't currently

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -514,8 +514,9 @@ where
                 let Some(mempool_txs) =
                     fetch_mempool_transactions(mempool.clone(), chain_tip_and_local_time.tip_hash)
                         .await?
-                        // Omit mempool transactions from the template if called without a long poll id, or
-                        // continue to the next iteration of the loop to make fresh state and mempool requests.
+                        // If the mempool and state responses are out of sync:
+                        // - if we are not long polling, omit mempool transactions from the template,
+                        // - if we are long polling, continue to the next iteration of the loop to make fresh state and mempool requests.
                         .or_else(|| client_long_poll_id.is_none().then(Vec::new)) else {
                             continue;
                         };

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -448,8 +448,14 @@ where
             .as_ref()
             .and_then(get_block_template::JsonParameters::block_proposal_data)
         {
-            return validate_block_proposal(self.chain_verifier.clone(), block_proposal_bytes)
-                .boxed();
+            return validate_block_proposal(
+                self.chain_verifier.clone(),
+                block_proposal_bytes,
+                network,
+                latest_chain_tip,
+                sync_status,
+            )
+            .boxed();
         }
 
         // To implement long polling correctly, we split this RPC into multiple phases.
@@ -505,9 +511,14 @@ where
                 //
                 // Optional TODO:
                 // - add a `MempoolChange` type with an `async changed()` method (like `ChainTip`)
-                let mempool_txs =
+                let Some(mempool_txs) =
                     fetch_mempool_transactions(mempool.clone(), chain_tip_and_local_time.tip_hash)
-                        .await?;
+                        .await?
+                        // Omit mempool transactions from the template if called without a long poll id, or
+                        // continue to the next iteration of the loop to make fresh state and mempool requests.
+                        .or_else(|| client_long_poll_id.is_none().then(Vec::new)) else {
+                            continue;
+                        };
 
                 // - Long poll ID calculation
                 let server_long_poll_id = LongPollInput::new(

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -505,7 +505,9 @@ where
                 //
                 // Optional TODO:
                 // - add a `MempoolChange` type with an `async changed()` method (like `ChainTip`)
-                let mempool_txs = fetch_mempool_transactions(mempool.clone()).await?;
+                let mempool_txs =
+                    fetch_mempool_transactions(mempool.clone(), chain_tip_and_local_time.tip_hash)
+                        .await?;
 
                 // - Long poll ID calculation
                 let server_long_poll_id = LongPollInput::new(

--- a/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
@@ -256,19 +256,16 @@ where
             data: None,
         })?;
 
-    if let mempool::Response::FullTransactions {
+    let mempool::Response::FullTransactions {
         transactions,
-        last_seen_chain_tip,
-    } = response
-    {
-        if last_seen_chain_tip == Some(chain_tip_hash) {
-            Ok(transactions)
-        } else {
-            Ok(vec![])
-        }
-    } else {
+        last_seen_tip_hash,
+    } = response else {
         unreachable!("unmatched response to a mempool::FullTransactions request")
-    }
+    };
+
+    Ok((last_seen_tip_hash == chain_tip_hash)
+        .then_some(transactions)
+        .unwrap_or_default())
 }
 
 // - Response processing

--- a/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
@@ -97,9 +97,12 @@ pub fn check_miner_address(
 /// usual acceptance rules (except proof-of-work).
 ///
 /// Returns a `getblocktemplate` [`Response`].
-pub async fn validate_block_proposal<ChainVerifier>(
+pub async fn validate_block_proposal<ChainVerifier, Tip, SyncStatus>(
     mut chain_verifier: ChainVerifier,
     block_proposal_bytes: Vec<u8>,
+    network: Network,
+    latest_chain_tip: Tip,
+    sync_status: SyncStatus,
 ) -> Result<Response>
 where
     ChainVerifier: Service<zebra_consensus::Request, Response = block::Hash, Error = zebra_consensus::BoxError>
@@ -107,7 +110,11 @@ where
         + Send
         + Sync
         + 'static,
+    Tip: ChainTip + Clone + Send + Sync + 'static,
+    SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
 {
+    check_synced_to_tip(network, latest_chain_tip, sync_status)?;
+
     let block: Block = match block_proposal_bytes.zcash_deserialize_into() {
         Ok(block) => block,
         Err(parse_error) => {
@@ -231,14 +238,15 @@ where
     Ok(chain_info)
 }
 
-/// Returns the transactions that are currently in `mempool`.
+/// Returns the transactions that are currently in `mempool`, or None if the
+/// `last_seen_tip_hash` from the mempool response doesn't match the tip hash from the state.
 ///
 /// You should call `check_synced_to_tip()` before calling this function.
 /// If the mempool is inactive because Zebra is not synced to the tip, returns no transactions.
 pub async fn fetch_mempool_transactions<Mempool>(
     mempool: Mempool,
     chain_tip_hash: block::Hash,
-) -> Result<Vec<VerifiedUnminedTx>>
+) -> Result<Option<Vec<VerifiedUnminedTx>>>
 where
     Mempool: Service<
             mempool::Request,
@@ -263,9 +271,7 @@ where
         unreachable!("unmatched response to a mempool::FullTransactions request")
     };
 
-    Ok((last_seen_tip_hash == chain_tip_hash)
-        .then_some(transactions)
-        .unwrap_or_default())
+    Ok((last_seen_tip_hash == chain_tip_hash).then_some(transactions))
 }
 
 // - Response processing

--- a/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
@@ -271,6 +271,7 @@ where
         unreachable!("unmatched response to a mempool::FullTransactions request")
     };
 
+    // Check that the mempool and state were in sync when we made the requests
     Ok((last_seen_tip_hash == chain_tip_hash).then_some(transactions))
 }
 

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -386,7 +386,10 @@ proptest! {
                 mempool
                     .expect_request(mempool::Request::FullTransactions)
                     .await?
-                    .respond(mempool::Response::FullTransactions(transactions));
+                    .respond(mempool::Response::FullTransactions {
+                        transactions,
+                        last_seen_tip_hash: [0; 32].into(),
+                    });
 
                 expected_response
             };

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -176,7 +176,10 @@ async fn test_rpc_response_data_for_network(network: Network) {
     let mempool_req = mempool
         .expect_request_that(|request| matches!(request, mempool::Request::FullTransactions))
         .map(|responder| {
-            responder.respond(mempool::Response::FullTransactions(vec![]));
+            responder.respond(mempool::Response::FullTransactions {
+                transactions: vec![],
+                last_seen_tip_hash: blocks[blocks.len() - 1].hash(),
+            });
         });
 
     #[cfg(not(feature = "getblocktemplate-rpcs"))]

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -221,7 +221,8 @@ pub async fn test_responses<State, ReadState>(
                 .await
                 .respond(mempool::Response::FullTransactions {
                     transactions: vec![],
-                    last_seen_tip_hash: [0; 32].into(),
+                    // tip hash needs to match chain info for long poll requests
+                    last_seen_tip_hash: fake_tip_hash,
                 });
         }
     };

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -219,7 +219,10 @@ pub async fn test_responses<State, ReadState>(
             mempool
                 .expect_request(mempool::Request::FullTransactions)
                 .await
-                .respond(mempool::Response::FullTransactions(vec![]));
+                .respond(mempool::Response::FullTransactions {
+                    transactions: vec![],
+                    last_seen_tip_hash: [0; 32].into(),
+                });
         }
     };
 

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1259,7 +1259,10 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
             mempool
                 .expect_request(mempool::Request::FullTransactions)
                 .await
-                .respond(mempool::Response::FullTransactions(vec![]));
+                .respond(mempool::Response::FullTransactions {
+                    transactions: vec![],
+                    last_seen_tip_hash: fake_tip_hash,
+                });
         }
     };
 

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1167,6 +1167,7 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
         block::{Hash, MAX_BLOCK_BYTES, ZCASH_BLOCK_VERSION},
         chain_sync_status::MockSyncStatus,
         serialization::DateTime32,
+        transaction::VerifiedUnminedTx,
         work::difficulty::{CompactDifficulty, ExpandedDifficulty, U256},
     };
     use zebra_consensus::MAX_BLOCK_SIGOPS;
@@ -1190,7 +1191,7 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
 
     let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
-    let mut read_state = MockService::build().for_unit_tests();
+    let read_state = MockService::build().for_unit_tests();
     let chain_verifier = MockService::build().for_unit_tests();
 
     let mut mock_sync_status = MockSyncStatus::default();
@@ -1238,30 +1239,34 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
     );
 
     // Fake the ChainInfo response
-    let mock_read_state_request_handler = async move {
-        read_state
-            .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
-            .await
-            .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
-                expected_difficulty: fake_difficulty,
-                tip_height: fake_tip_height,
-                tip_hash: fake_tip_hash,
-                cur_time: fake_cur_time,
-                min_time: fake_min_time,
-                max_time: fake_max_time,
-                history_tree: fake_history_tree(Mainnet),
-            }));
+    let make_mock_read_state_request_handler = || {
+        let mut read_state = read_state.clone();
+
+        async move {
+            read_state
+                .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
+                .await
+                .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
+                    expected_difficulty: fake_difficulty,
+                    tip_height: fake_tip_height,
+                    tip_hash: fake_tip_hash,
+                    cur_time: fake_cur_time,
+                    min_time: fake_min_time,
+                    max_time: fake_max_time,
+                    history_tree: fake_history_tree(Mainnet),
+                }));
+        }
     };
 
-    let mock_mempool_request_handler = {
+    let make_mock_mempool_request_handler = |transactions, last_seen_tip_hash| {
         let mut mempool = mempool.clone();
         async move {
             mempool
                 .expect_request(mempool::Request::FullTransactions)
                 .await
                 .respond(mempool::Response::FullTransactions {
-                    transactions: vec![],
-                    last_seen_tip_hash: fake_tip_hash,
+                    transactions,
+                    last_seen_tip_hash,
                 });
         }
     };
@@ -1269,8 +1274,8 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
     let get_block_template_fut = get_block_template_rpc.get_block_template(None);
     let (get_block_template, ..) = tokio::join!(
         get_block_template_fut,
-        mock_mempool_request_handler,
-        mock_read_state_request_handler,
+        make_mock_mempool_request_handler(vec![], fake_tip_hash),
+        make_mock_read_state_request_handler(),
     );
 
     let get_block_template::Response::TemplateMode(get_block_template) = get_block_template
@@ -1326,8 +1331,6 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
         get_block_template.coinbase_txn.fee,
         Amount::<NonNegative>::zero()
     );
-
-    mempool.expect_no_requests().await;
 
     mock_chain_tip_sender.send_estimated_distance_to_network_chain_tip(Some(200));
     let get_block_template_sync_error = get_block_template_rpc
@@ -1403,6 +1406,53 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
         get_block_template_sync_error.code,
         ErrorCode::ServerError(-10)
     );
+
+    // Try getting mempool transactions with a different tip hash
+
+    let tx = Arc::new(Transaction::V1 {
+        inputs: vec![],
+        outputs: vec![],
+        lock_time: transaction::LockTime::unlocked(),
+    });
+
+    let unmined_tx = UnminedTx {
+        transaction: tx.clone(),
+        id: tx.unmined_id(),
+        size: tx.zcash_serialized_size(),
+        conventional_fee: 0.try_into().unwrap(),
+    };
+
+    let verified_unmined_tx = VerifiedUnminedTx {
+        transaction: unmined_tx,
+        miner_fee: 0.try_into().unwrap(),
+        legacy_sigop_count: 0,
+        unpaid_actions: 0,
+        fee_weight_ratio: 1.0,
+    };
+
+    let next_fake_tip_hash =
+        Hash::from_hex("0000000000b6a5024aa412120b684a509ba8fd57e01de07bc2a84e4d3719a9f1").unwrap();
+
+    mock_sync_status.set_is_close_to_tip(true);
+
+    mock_chain_tip_sender.send_estimated_distance_to_network_chain_tip(Some(0));
+
+    let (get_block_template, ..) = tokio::join!(
+        get_block_template_rpc.get_block_template(None),
+        make_mock_mempool_request_handler(vec![verified_unmined_tx], next_fake_tip_hash),
+        make_mock_read_state_request_handler(),
+    );
+
+    let get_block_template::Response::TemplateMode(get_block_template) = get_block_template
+        .expect("unexpected error in getblocktemplate RPC call") else {
+            panic!("this getblocktemplate call without parameters should return the `TemplateMode` variant of the response")
+        };
+
+    // mempool transactions should be omitted if the tip hash in the GetChainInfo response from the state
+    // does not match the `last_seen_tip_hash` in the FullTransactions response from the mempool.
+    assert!(get_block_template.transactions.is_empty());
+
+    mempool.expect_no_requests().await;
 }
 
 #[cfg(feature = "getblocktemplate-rpcs")]

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -666,6 +666,15 @@ impl TipAction {
         }
     }
 
+    /// Returns the block hash and height of this tip action,
+    /// regardless of the underlying variant.
+    pub fn best_tip_hash_and_height(&self) -> (block::Hash, block::Height) {
+        match self {
+            Grow { block } => (block.hash, block.height),
+            Reset { hash, height } => (*hash, *height),
+        }
+    }
+
     /// Returns a [`Grow`] based on `block`.
     pub(crate) fn grow_with(block: ChainTipBlock) -> Self {
         Grow { block }

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -246,11 +246,11 @@ impl Mempool {
         is_debug_enabled
     }
 
-    /// Accepts an optional [`TipAction`] for setting a reset action's block hash as
-    /// the last seen hash, or uses the latest chain tip instead.
-    ///
     /// Update the mempool state (enabled / disabled) depending on how close to
     /// the tip is the synchronization, including side effects to state changes.
+    ///
+    /// Accepts an optional [`TipAction`] for setting the `last_seen_tip_hash` field
+    /// when enabling the mempool state, it will not enable the mempool if this is None.
     ///
     /// Returns `true` if the state changed.
     fn update_state(&mut self, tip_action: Option<&TipAction>) -> bool {

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -257,7 +257,7 @@ impl Mempool {
         let is_close_to_tip = self.sync_status.is_close_to_tip() || self.is_enabled_by_debug();
 
         match (is_close_to_tip, self.is_enabled(), tip_action) {
-            // the active state is up to date
+            // the active state is up to date, or there is no tip action to activate the mempool
             (false, false, _) | (true, true, _) | (true, false, None) => return false,
 
             // Enable state - there should be a chain tip when Zebra is close to the network tip

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -486,6 +486,7 @@ impl Service<Request> for Mempool {
             ActiveState::Enabled {
                 storage,
                 tx_downloads,
+                #[allow(unused_variables)]
                 last_seen_tip_hash,
             } => match req {
                 // Queries

--- a/zebrad/src/components/mempool/tests.rs
+++ b/zebrad/src/components/mempool/tests.rs
@@ -31,6 +31,8 @@ impl Mempool {
     }
 
     /// Enable the mempool by pretending the synchronization is close to the tip.
+    ///
+    /// Requires a chain tip action to enable the mempool before the future resolves.
     pub async fn enable(&mut self, recent_syncs: &mut RecentSyncLengths) {
         // Pretend we're close to tip
         SyncStatus::sync_close_to_tip(recent_syncs);

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -1,6 +1,6 @@
 //! Randomised property tests for the mempool.
 
-use std::{env, fmt};
+use std::{env, fmt, sync::Arc};
 
 use proptest::{collection::vec, prelude::*};
 use proptest_derive::Arbitrary;
@@ -10,15 +10,17 @@ use tokio::time;
 use tower::{buffer::Buffer, util::BoxService};
 
 use zebra_chain::{
-    block,
+    block::{self, Block},
     fmt::DisplayToDebug,
     parameters::{Network, NetworkUpgrade},
+    serialization::ZcashDeserializeInto,
     transaction::VerifiedUnminedTx,
 };
 use zebra_consensus::{error::TransactionError, transaction as tx};
 use zebra_network as zn;
 use zebra_state::{self as zs, ChainTipBlock, ChainTipSender};
 use zebra_test::mock_service::{MockService, PropTestAssertion};
+use zs::FinalizedBlock;
 
 use crate::components::{
     mempool::{config::Config, Mempool},
@@ -193,7 +195,7 @@ proptest! {
                 mut state_service,
                 mut tx_verifier,
                 mut recent_syncs,
-                _chain_tip_sender,
+                mut chain_tip_sender,
             ) = setup(network);
 
             time::pause();
@@ -217,6 +219,9 @@ proptest! {
             // This time a call to `poll_ready` should clear the storage.
             mempool.dummy_call().await;
 
+            // sends a new fake chain tip so that the mempool can be enabled
+            chain_tip_sender.set_finalized_tip(block1_chain_tip());
+
             // Enable the mempool again so the storage can be accessed.
             mempool.enable(&mut recent_syncs).await;
 
@@ -229,6 +234,22 @@ proptest! {
             Ok(())
         })?;
     }
+}
+
+fn genesis_chain_tip() -> Option<ChainTipBlock> {
+    zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into::<Arc<Block>>()
+        .map(FinalizedBlock::from)
+        .map(ChainTipBlock::from)
+        .ok()
+}
+
+fn block1_chain_tip() -> Option<ChainTipBlock> {
+    zebra_test::vectors::BLOCK_MAINNET_1_BYTES
+        .zcash_deserialize_into::<Arc<Block>>()
+        .map(FinalizedBlock::from)
+        .map(ChainTipBlock::from)
+        .ok()
 }
 
 /// Create a new [`Mempool`] instance using mocked services.
@@ -247,7 +268,8 @@ fn setup(
     let tx_verifier = MockService::build().for_prop_tests();
 
     let (sync_status, recent_syncs) = SyncStatus::new();
-    let (chain_tip_sender, latest_chain_tip, chain_tip_change) = ChainTipSender::new(None, network);
+    let (mut chain_tip_sender, latest_chain_tip, chain_tip_change) =
+        ChainTipSender::new(None, network);
 
     let (mempool, _transaction_receiver) = Mempool::new(
         &Config {
@@ -261,6 +283,9 @@ fn setup(
         latest_chain_tip,
         chain_tip_change,
     );
+
+    // sends a fake chain tip so that the mempool can be enabled
+    chain_tip_sender.set_finalized_tip(genesis_chain_tip());
 
     (
         mempool,


### PR DESCRIPTION
## Motivation

The getblocktemplate method could currently generate an invalid template with transactions that have been mined or are otherwise invalidated by a chain tip change if the best tip changes after it's checked in the mempool's poll_ready() call.

Closes #6173, closes #5991.

## Solution

- Add a `last_seen_tip_hash` field in `ActiveState`
- Update that field when enabling the mempool or processing a tip action
- Return `last_seen_tip_hash` in the `FullTransactions` response
- Check that it's the same as the tip hash in chain info in the `fetch_mempool_transactions` function
  - Omit the transactions if they don't match when called without a long poll id
  - Continue to the next iteration of the loop to make fresh state and mempool requests otherwise
- Test that transactions are omitted if the tip hash from the state doesn't match that from the mempool

Related changes: 
- [Check that Zebra is close to the tip before validating block proposals](https://github.com/ZcashFoundation/zebra/pull/6416/commits/f54d9fea973d84b5bfc8b0bcd7886fe93bb49b46)

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
