### PR TITLE
change(docs): Replaces XXX with TODO

### DIFF
--- a/zebra-chain/src/block/tests.rs
+++ b/zebra-chain/src/block/tests.rs
@@ -1,6 +1,6 @@
 //! Tests for Zebra blocks
 
-// XXX generate should be rewritten as strategies
+// TODO: generate should be rewritten as strategies
 #[cfg(any(test, feature = "bench", feature = "proptest-impl"))]
 pub mod generate;
 #[cfg(test)]

--- a/zebra-chain/src/block/tests/vectors.rs
+++ b/zebra-chain/src/block/tests/vectors.rs
@@ -17,7 +17,7 @@ use crate::{
     transaction::LockTime,
 };
 
-use super::generate; // XXX this should be rewritten as strategies
+use super::generate; // TODO: this should be rewritten as strategies
 
 #[test]
 fn blockheaderhash_debug() {

--- a/zebra-chain/src/serialization/error.rs
+++ b/zebra-chain/src/serialization/error.rs
@@ -5,7 +5,7 @@ use std::{array::TryFromSliceError, io, num::TryFromIntError, str::Utf8Error};
 use thiserror::Error;
 
 /// A serialization error.
-// XXX refine error types -- better to use boxed errors?
+// TODO: refine error types -- better to use boxed errors?
 #[derive(Error, Debug)]
 pub enum SerializationError {
     /// An io error that prevented deserialization
@@ -13,7 +13,7 @@ pub enum SerializationError {
     Io(#[from] io::Error),
 
     /// The data to be deserialized was malformed.
-    // XXX refine errors
+    // TODO: refine errors
     #[error("parse error: {0}")]
     Parse(&'static str),
 

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -130,12 +130,12 @@ pub enum TransactionError {
     #[error("spend description cv and rk MUST NOT be of small order")]
     SmallOrder,
 
-    // XXX: the underlying error is bellman::VerificationError, but it does not implement
+    // TODO: the underlying error is bellman::VerificationError, but it does not implement
     // Arbitrary as required here.
     #[error("spend proof MUST be valid given a primary input formed from the other fields except spendAuthSig")]
     Groth16(String),
 
-    // XXX: the underlying error is io::Error, but it does not implement Clone as required here.
+    // TODO: the underlying error is io::Error, but it does not implement Clone as required here.
     #[error("Groth16 proof is malformed")]
     MalformedGroth16(String),
 

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -10,7 +10,7 @@ use std::{collections::HashMap, time::Duration};
 use lazy_static::lazy_static;
 use regex::Regex;
 
-// XXX should these constants be split into protocol also?
+// TODO: should these constants be split into protocol also?
 use crate::protocol::external::types::*;
 
 use zebra_chain::{

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -135,7 +135,7 @@ impl Handler {
     /// Unexpected messages are left unprocessed, and may be rejected later.
     fn process_message(&mut self, msg: Message) -> Option<Message> {
         let mut ignored_msg = None;
-        // XXX can this be avoided?
+        // TODO: can this be avoided?
         let tmp_state = std::mem::replace(self, Handler::Finished(Ok(Response::Nil)));
 
         debug!(handler = %tmp_state, %msg, "received peer response to Zebra request");

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -912,7 +912,7 @@ where
 
             // Reconfigure the codec to use the negotiated version.
             //
-            // XXX The tokio documentation says not to do this while any frames are still being processed.
+            // TODO: The tokio documentation says not to do this while any frames are still being processed.
             // Since we don't know that here, another way might be to release the tcp
             // stream from the unversioned Framed wrapper and construct a new one with a versioned codec.
             let bare_codec = peer_conn.codec_mut();

--- a/zebra-network/src/policies.rs
+++ b/zebra-network/src/policies.rs
@@ -5,7 +5,7 @@ use tower::retry::Policy;
 
 /// A very basic retry policy with a limited number of retry attempts.
 ///
-/// XXX Remove this when <https://github.com/tower-rs/tower/pull/414> lands.
+/// TODO: Remove this when <https://github.com/tower-rs/tower/pull/414> lands.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct RetryLimit {
     remaining_tries: usize,


### PR DESCRIPTION
## Motivation

Annotations in the codebase that contain the string XXX and appear to represent a TODO or future task may not be identified or documented via code searches for open issues.

Closes #6342.

## Solution

- Replace "XXX" with "TODO:" where applicable

## Review

Optional priority, anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
