### PR TITLE
fix(release): Use Mergify queue freezes for releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -135,11 +135,8 @@ and the updated changelog:
       (for example: `bump-v1.0.0-rc.0` - this needs to be different to the tag name)
 - [ ] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/v1.0.0-rc.0-release?expand=1&template=release-checklist.md)).
   - [ ] Add the list of deleted changelog entries as a comment to make reviewing easier.
-- [ ] Turn on [Merge Freeze](https://www.mergefreeze.com/installations/3676/branches).
-- [ ] Once the PR is ready to be merged, unfreeze it [here](https://www.mergefreeze.com/installations/3676/branches).
-      Do not unfreeze the whole repository.
-- [ ] Update the PR to the latest `main` branch using `@mergifyio update`. Then Mergify should merge it in-place.
-      If it makes a merge PR instead, that PR will get cancelled by the merge freeze. So just merge the changelog PR manually.
+- [ ] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
+- [ ] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
 
 ### Create the Release
 
@@ -166,7 +163,7 @@ and the updated changelog:
 - [ ] Test the Docker image using `docker run --tty --interactive zfnd/zebra:1.0.0-rc.<version>`,
       and put the output in a comment on the PR
       <!-- TODO: replace with `zfnd/zebra` when we release 1.0.0 -->
-- [ ] Turn off [Merge Freeze](https://www.mergefreeze.com/installations/3676/branches) for the whole repository
+- [ ] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
 
 
 ## Blog Post


### PR DESCRIPTION
## Motivation

When we use the Merge Freeze app for releases, it doesn't really work well with Mergify. All PRs look failed, and merge PRs get cancelled by Mergify due to Merge Freeze.

If we freeze the standard-priority "batched" queue in Mergify instead, it will work much better.

### Specifications

https://docs.mergify.com/actions/queue/#queue-freeze

## Solution

- Replace Merge Freeze with Mergify queue freeze in the release checklist
- Remove a redundant `@mergifyio update` step

### Testing

I'll make sure this works when I tag the next release.

## Review

This is a low-priority change, it just needs to get merged before the next release.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- Remove the merge freeze check from the `main` branch protection rules
- Remove the merge freeze app from Zebra's GitHub settings