### PR TITLE
docs(utilities): remove old comment

### DIFF
--- a/zebra-utils/src/lib.rs
+++ b/zebra-utils/src/lib.rs
@@ -1,6 +1,4 @@
 //! Utilities for Zebra development, not for library or application users.
-//!
-//! Currently this consists only of the zebra-checkpoints binary.
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
 #![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_utils")]


### PR DESCRIPTION
## Motivation

We have an old line of doc in the utilities code that needs to be either updated or removed.

## Solution

Remove doc comment.

## Review

This is very minor, anyone can review.

## Follow Up Work

https://github.com/ZcashFoundation/zebra/issues/6438