### PR TITLE
fix(mempool): Stop ignoring new transactions after the mempool is newly activated

### DIFF
--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -319,14 +319,11 @@ impl Service<Request> for Mempool {
 
         let tip_action = self.chain_tip_change.last_tip_change();
 
-        // If the mempool was just freshly enabled,
-        // skip resetting and removing mined transactions for this tip.
-        if is_state_changed {
-            return Poll::Ready(Ok(()));
-        }
-
         // Clear the mempool and cancel downloads if there has been a chain tip reset.
-        if matches!(tip_action, Some(TipAction::Reset { .. })) {
+        //
+        // But if the mempool was just freshly enabled,
+        // skip resetting and removing mined transactions for this tip.
+        if !is_state_changed && matches!(tip_action, Some(TipAction::Reset { .. })) {
             info!(
                 tip_height = ?tip_action.as_ref().unwrap().best_tip_height(),
                 "resetting mempool: switched best chain, skipped blocks, or activated network upgrade"


### PR DESCRIPTION
## Motivation

Currently, when Zebra's mempool is newly activated, it skips adding newly verified transactions until the next request.

Instead, the first request to a newly activated mempool should show all available transactions.

This could be related to #6195, but I'm not sure if it is.

### Specifications

Mempool transaction selection is a standard rule, so either implementation is valid here.

## Solution

Only skip the reset when the mempool is newly activated, rather than skipping all of `poll_ready()`.

## Review

This is a routine mempool bug.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

