### PR TITLE
feat(log): Add a config for writing logs to a file

### DIFF
--- a/zebrad/src/components/tracing.rs
+++ b/zebrad/src/components/tracing.rs
@@ -101,6 +101,10 @@ pub struct Config {
     /// replaced with `.folded` and `.svg` for the respective files.
     pub flamegraph: Option<PathBuf>,
 
+    /// If set to a path, write the tracing logs to that path.
+    /// By default, logs are sent to the terminal standard output.
+    pub log_file: Option<PathBuf>,
+
     /// The use_journald flag sends tracing events to systemd-journald, on Linux
     /// distributions that use systemd.
     ///
@@ -117,6 +121,7 @@ impl Default for Config {
             buffer_limit: 128_000,
             endpoint_addr: None,
             flamegraph: None,
+            log_file: None,
             use_journald: false,
         }
     }


### PR DESCRIPTION
## Motivation

Zebra can't currently write logs to a file - it requires extra shell redirections or a service harness.

This might be confusing for some users.

## Solution

- Add a config with a file path for logging
- If configured, append logs to that file

## Review

This is a low-priority extra Zebra feature.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

