### PR TITLE
fix(state): Remove an outdated anchor assertion in a comment

### DIFF
--- a/zebra-state/src/service/check/anchors.rs
+++ b/zebra-state/src/service/check/anchors.rs
@@ -155,23 +155,14 @@ fn fetch_sprout_final_treestates(
             .or_else(|| finalized_state.sprout_note_commitment_tree_by_anchor(&joinsplit.anchor));
 
         if let Some(input_tree) = input_tree {
-            /* TODO:
-                 - fix tests that generate incorrect root data
-                 - assert that roots match the fetched tree during tests
-                 - move this CPU-intensive check to sprout_anchors_refer_to_treestates()
-
-            assert_eq!(
-                input_tree.root(),
-                joinsplit.anchor,
-                "anchor and fetched input tree root did not match:\n\
-                 anchor: {anchor:?},\n\
-                 input tree root: {input_tree_root:?},\n\
-                 input_tree: {input_tree:?}",
-                anchor = joinsplit.anchor
-            );
-             */
-
             sprout_final_treestates.insert(joinsplit.anchor, input_tree);
+
+            /* TODO:
+               - fix tests that generate incorrect root data
+               - assert that joinsplit.anchor matches input_tree.root() during tests,
+                 but don't assert in production, because the check is CPU-intensive,
+                 and sprout_anchors_refer_to_treestates() constructs the map correctly
+            */
 
             tracing::debug!(
                 sprout_final_treestate_count = ?sprout_final_treestates.len(),


### PR DESCRIPTION
## Motivation

There is an outdated assertion in the state Sprout anchor checking code, which has already been commented out.

This assertion could be expensive, so we can only do it during tests.

Close #6389

### Specifications

This assertion is not consensus-critical, the existing production code already constructs the anchor map correctly.

## Solution

- Remove the commented-out assertion
- Update the TODO to only apply to tests

## Review

This is an audit fix, it should be reviewed first.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We could fix the tests, but it's not important at all.