### PR TITLE
fix(net): Fix off-by-one error in DNS seed peer retries, and clarify logs

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -31,7 +31,7 @@ mod tests;
 /// check if it has enough peer addresses from other seed peers. If it has
 /// enough addresses, it won't retry this peer again.
 ///
-/// If the number of tries is `0`, other peers are checked after every successful
+/// If the number of retries is `0`, other peers are checked after every successful
 /// or failed DNS attempt.
 const MAX_SINGLE_SEED_PEER_DNS_RETRIES: usize = 0;
 
@@ -197,22 +197,22 @@ impl Config {
     ///
     /// If DNS continues to fail, returns an empty list of addresses.
     async fn resolve_host(host: &str, max_retries: usize) -> HashSet<SocketAddr> {
-        for attempts in 0..=max_retries {
+        for retries in 0..=max_retries {
             if let Ok(addresses) = Config::resolve_host_once(host).await {
                 return addresses;
             }
 
-            if attempts < max_retries {
+            if retries < max_retries {
                 tracing::info!(
                     ?host,
-                    previous_attempts = ?(attempts + 1),
+                    previous_attempts = ?(retries + 1),
                     "Waiting {DNS_LOOKUP_TIMEOUT:?} to retry seed peer DNS resolution",
                 );
                 tokio::time::sleep(DNS_LOOKUP_TIMEOUT).await;
             } else {
                 tracing::info!(
                     ?host,
-                    attempts = ?(attempts + 1),
+                    attempts = ?(retries + 1),
                     "Seed peer DNS resolution failed, checking for addresses from other seed peers",
                 );
             }


### PR DESCRIPTION
## Motivation

Zebra's DNS seed peer retries aren't documented or named correctly: the number of DNS attempts implied by the name doesn't match the implementation.

Closes #6393

### Complex Code or Requirements

This is concurrent async code, but this PR doesn't change the number of retries.

## Solution

- Change the value of the constant and the implementation of the loop to actually implement retries, not attempts
- Don't wait for the next retry if we're not actually going to retry
- Rename the constant to clarify what it does
- Split the log messages to clarify what is happening

## Review

This is a routine audit fix.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

