### PR TITLE
fix: Inconsistent Docs for Downloading ZKP Params

### DIFF
--- a/zebra-consensus/src/primitives/groth16/params.rs
+++ b/zebra-consensus/src/primitives/groth16/params.rs
@@ -23,11 +23,11 @@ pub const PARAMETER_DOWNLOAD_MAX_ATTEMPTS: usize = 3;
 lazy_static::lazy_static! {
     /// Groth16 Zero-Knowledge Proof parameters for the Sapling and Sprout circuits.
     ///
-    /// This static is accessed when:
+    /// This static is accessed when Zebra:
     ///
-    /// - Zebra needs to download and cache the parameters to a shared directory, or
-    /// - Zebra checks the file hashes for both newly downloaded and previously cached files, or
-    /// - Zebra loads the parameters.
+    /// - needs to download and cache the parameters to a shared directory, or
+    /// - checks the file hashes for both newly downloaded and previously cached files, or
+    /// - loads the parameters.
     ///
     /// # Panics
     ///

--- a/zebra-consensus/src/primitives/groth16/params.rs
+++ b/zebra-consensus/src/primitives/groth16/params.rs
@@ -23,10 +23,11 @@ pub const PARAMETER_DOWNLOAD_MAX_ATTEMPTS: usize = 3;
 lazy_static::lazy_static! {
     /// Groth16 Zero-Knowledge Proof parameters for the Sapling and Sprout circuits.
     ///
-    /// When this static is accessed:
-    /// - the parameters are downloaded if needed, then cached to a shared directory,
-    /// - the file hashes are checked, for both newly downloaded and previously cached files,
-    /// - the parameters are loaded into Zebra.
+    /// This static is accessed when:
+    ///
+    /// - Zebra needs to download and cache the parameters to a shared directory, or
+    /// - Zebra checks the file hashes for both newly downloaded and previously cached files, or
+    /// - Zebra loads the parameters.
     ///
     /// # Panics
     ///
@@ -60,7 +61,9 @@ pub struct SproutParameters {
 }
 
 impl Groth16Parameters {
-    /// Download if needed, cache, check, and load the Sprout and Sapling Groth16 parameters.
+    /// Loads the Sprout and Sapling Groth16 parameters, checking the sizes and hashes of the files.
+    ///
+    /// If the parameters are not present, they are automatically downloaded and cached.
     ///
     /// # Panics
     ///
@@ -150,12 +153,12 @@ impl Groth16Parameters {
         }
     }
 
-    /// Try to download the Sapling parameters once, and return the result.
+    /// Tries to download the Sapling parameters once and returns the result.
     ///
     /// # Panics
     ///
-    /// If the parameters were downloaded to different paths to `sapling_spend_path`
-    /// or `sapling_output_path`.
+    /// If the parameters were downloaded to paths different to `sapling_spend_path` or
+    /// `sapling_output_path`.
     fn download_sapling_parameters_once(
         sapling_spend_path: &Path,
         sapling_output_path: &Path,
@@ -199,11 +202,11 @@ impl Groth16Parameters {
         }
     }
 
-    /// Try to download the Sprout parameters once, and return the result.
+    /// Tries to download the Sprout parameters once and returns the result.
     ///
     /// # Panics
     ///
-    /// If the parameters were downloaded to a different path to `sprout_path`.
+    /// If the parameters were downloaded to a path different to `sprout_path`.
     fn download_sprout_parameters_once(sprout_path: &Path) -> Result<PathBuf, BoxError> {
         let new_sprout_path =
             zcash_proofs::download_sprout_parameters(Some(PARAMETER_DOWNLOAD_TIMEOUT))?;

--- a/zebra-consensus/src/primitives/groth16/params.rs
+++ b/zebra-consensus/src/primitives/groth16/params.rs
@@ -15,11 +15,10 @@ use crate::BoxError;
 /// But `zebrad start` downloads blocks at the same time, so we allow some extra time.
 pub const PARAMETER_DOWNLOAD_TIMEOUT: u64 = 60 * 60;
 
-/// The maximum number of times to retry download parameters.
+/// The maximum number of times Zebra tries to download the parameters.
 ///
-/// Zebra will retry to download Sprout of Sapling parameters only if they
-/// failed for whatever reason.
-pub const PARAMETER_DOWNLOAD_MAX_RETRIES: usize = 3;
+/// Zebra will retry the download only if the previous attempt fails.
+pub const PARAMETER_DOWNLOAD_MAX_ATTEMPTS: usize = 3;
 
 lazy_static::lazy_static! {
     /// Groth16 Zero-Knowledge Proof parameters for the Sapling and Sprout circuits.
@@ -65,20 +64,17 @@ impl Groth16Parameters {
     ///
     /// # Panics
     ///
-    /// If the parameters were downloaded to the wrong path.
-    /// After `PARAMETER_DOWNLOAD_MAX_RETRIES` failed download attempts.
-    /// If the downloaded or pre-existing parameter files are invalid.
+    /// - If the parameters were downloaded to a wrong path.
+    /// - After [`PARAMETER_DOWNLOAD_MAX_ATTEMPTS`] failed download attempts.
+    /// - If the downloaded or pre-existing parameter files are invalid.
     fn new() -> Groth16Parameters {
         let params_directory = Groth16Parameters::directory();
         let sapling_spend_path = params_directory.join(zcash_proofs::SAPLING_SPEND_NAME);
         let sapling_output_path = params_directory.join(zcash_proofs::SAPLING_OUTPUT_NAME);
         let sprout_path = params_directory.join(zcash_proofs::SPROUT_NAME);
 
-        Groth16Parameters::retry_download_sapling_parameters(
-            &sapling_spend_path,
-            &sapling_output_path,
-        );
-        Groth16Parameters::retry_download_sprout_parameters(&sprout_path);
+        Groth16Parameters::download_sapling_parameters(&sapling_spend_path, &sapling_output_path);
+        Groth16Parameters::download_sprout_parameters(&sprout_path);
 
         // TODO: if loading fails, log a message including `failure_hint`
         tracing::info!("checking and loading Zcash Sapling and Sprout parameters");
@@ -119,13 +115,13 @@ impl Groth16Parameters {
         )
     }
 
-    /// Download Sapling parameters and retry [`PARAMETER_DOWNLOAD_MAX_RETRIES`] if it fails.
+    /// Downloads the Sapling parameters.
     ///
     /// # Panics
     ///
-    /// If the parameters were downloaded to the wrong path.
-    /// After `PARAMETER_DOWNLOAD_MAX_RETRIES` failed download attempts.
-    fn retry_download_sapling_parameters(sapling_spend_path: &Path, sapling_output_path: &Path) {
+    /// - If the parameters were downloaded to a wrong path.
+    /// - After [`PARAMETER_DOWNLOAD_MAX_ATTEMPTS`] failed download attempts.
+    fn download_sapling_parameters(sapling_spend_path: &Path, sapling_output_path: &Path) {
         // TODO: instead of the path check, add a zcash_proofs argument to skip hashing existing files
         //       (we check them on load anyway)
         if !sapling_spend_path.exists() || !sapling_output_path.exists() {
@@ -137,10 +133,10 @@ impl Groth16Parameters {
                 sapling_output_path,
             ) {
                 retries += 1;
-                if retries >= PARAMETER_DOWNLOAD_MAX_RETRIES {
+                if retries >= PARAMETER_DOWNLOAD_MAX_ATTEMPTS {
                     panic!(
                         "error downloading Sapling parameter files after {} retries. {:?} {}",
-                        PARAMETER_DOWNLOAD_MAX_RETRIES,
+                        PARAMETER_DOWNLOAD_MAX_ATTEMPTS,
                         error,
                         Groth16Parameters::failure_hint(),
                     );
@@ -173,23 +169,23 @@ impl Groth16Parameters {
         Ok(new_sapling_paths)
     }
 
-    /// Download Sprout parameters and retry [`PARAMETER_DOWNLOAD_MAX_RETRIES`] if it fails.
+    /// Downloads the Sprout parameters.
     ///
     /// # Panics
     ///
-    /// If the parameters were downloaded to the wrong path.
-    /// After `PARAMETER_DOWNLOAD_MAX_RETRIES` failed download attempts.
-    fn retry_download_sprout_parameters(sprout_path: &Path) {
+    /// - If the parameters were downloaded to a wrong path.
+    /// - After [`PARAMETER_DOWNLOAD_MAX_ATTEMPTS`] failed download attempts.
+    fn download_sprout_parameters(sprout_path: &Path) {
         if !sprout_path.exists() {
             tracing::info!("downloading Zcash Sprout parameters");
 
             let mut retries = 0;
             while let Err(error) = Groth16Parameters::download_sprout_parameters_once(sprout_path) {
                 retries += 1;
-                if retries >= PARAMETER_DOWNLOAD_MAX_RETRIES {
+                if retries >= PARAMETER_DOWNLOAD_MAX_ATTEMPTS {
                     panic!(
                         "error downloading Sprout parameter files after {} retries. {:?} {}",
-                        PARAMETER_DOWNLOAD_MAX_RETRIES,
+                        PARAMETER_DOWNLOAD_MAX_ATTEMPTS,
                         error,
                         Groth16Parameters::failure_hint(),
                     );


### PR DESCRIPTION
## Motivation

Close #6340.

## Solution

This PR:

- adjusts the implementation so that `PARAMETER_DOWNLOAD_MAX_RETRIES` is regarded as the max number of _retries_ instead of _attempts_;
- removes the prefix `retry_` from functions that download the parameters;
- cleans up the docs a bit.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?