### PR TITLE
fix(ux): Disable issue URLs for a known shutdown panic in abscissa

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -90,7 +90,7 @@ skip-tree = [
     # wait for console-subscriber and tower to update hdrhistogram.
     # also wait for ron to update insta, and wait for tonic update.
     { name = "base64", version = "=0.13.1" },
-    
+
     # wait for proptest's rusty-fork dependency to upgrade quick-error
     { name = "quick-error", version = "=1.2.3" },
 

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -1,8 +1,5 @@
 //! Zebrad Abscissa Application
 
-mod entry_point;
-use self::entry_point::EntryPoint;
-
 use std::{fmt::Write as _, io::Write as _, process};
 
 use abscissa_core::{
@@ -17,6 +14,9 @@ use zebra_network::constants::PORT_IN_USE_ERROR;
 use zebra_state::constants::{DATABASE_FORMAT_VERSION, LOCK_FILE_ERROR};
 
 use crate::{commands::ZebradCmd, components::tracing::Tracing, config::ZebradConfig};
+
+mod entry_point;
+use entry_point::EntryPoint;
 
 /// See <https://docs.rs/abscissa_core/latest/src/abscissa_core/application/exit.rs.html#7-10>
 /// Print a fatal error message and exit
@@ -309,10 +309,14 @@ impl Application for ZebradApp {
                         return false;
                     }
 
+                    // Don't ask users to create bug reports for timeouts, duplicate blocks,
+                    // full disks, or updated binaries.
                     let error_str = error.to_string();
                     !error_str.contains("timed out")
                         && !error_str.contains("duplicate hash")
                         && !error_str.contains("No space left on device")
+                        // abscissa panics like this when the running zebrad binary has been updated
+                        && !error_str.contains("error canonicalizing application path")
                 }
             });
 

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -309,7 +309,7 @@ impl Application for ZebradApp {
                         return false;
                     }
 
-                    // Don't ask users to create bug reports for timeouts, duplicate blocks,
+                    // Don't ask users to create bug reports for known timeouts, duplicate blocks,
                     // full disks, or updated binaries.
                     let error_str = error.to_string();
                     !error_str.contains("timed out")


### PR DESCRIPTION
## Motivation

When the running `zebrad` binary is updated, Abscissa panics on shutdown due to an application path check.

It should ignore the path error instead, hopefully this is fixed by the latest Abscissa version in #5502.

In the meantime, we don't want users to report this known issue as a new bug.

## Solution

- Disable issue URLs for this specific panic message

## Review

This is a low priority usability fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

