### PR TITLE
doc(net): Explain how we prioritise peer messages, and why it is secure

### DIFF
--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -603,7 +603,7 @@ where
                     // - incoming messages from the remote peer, then
                     // - outgoing messages to the remote peer.
                     //
-                    // This improves the performance of peer responses to Zebra requests,and new
+                    // This improves the performance of peer responses to Zebra requests, and new
                     // peer requests to Zebra's inbound service.
                     //
                     // `futures::StreamExt::next()` is cancel-safe:

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -608,8 +608,8 @@ where
                     //
                     // `futures::StreamExt::next()` is cancel-safe:
                     // <https://docs.rs/tokio/latest/tokio/macro.select.html#cancellation-safety>
-                    // This means that messages from the future that isn't selected will be selected
-                    // the next time that future is ready.
+                    // This means that messages from the future that isn't selected stay in the stream,
+                    // and they will be returned next time the future is checked.
                     //
                     // If an inbound peer message arrives at a ready peer that also has a pending
                     // request from Zebra, we want to process the peer's message first.


### PR DESCRIPTION
## Motivation

The auditors asked about a TODO about peer starvation.

Closes #6344

### Complex Code or Requirements

This PR documents concurrent code. If it's unclear, please ask questions or suggest changes in the PR.

## Solution

- Explain why we want to prefer inbound messages when waiting for a request
- Explain why we prefer cancellations and timeouts when waiting for a response

## Review

This is a routine audit fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

