### PR TITLE
fix(devops): Use A-devops label for dependabot GitHub Actions PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - 'C-trivial'
-      - 'A-infrastructure'
+      - 'A-devops'
       - 'A-dependencies'
       - 'P-Low :snowflake:'


### PR DESCRIPTION
## Motivation

We're using the infrastructure label for dependabot GitHub Actions PRs, but we should be using the devops label.

## Review

This is a low priority PR auto-labelling fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

