### PR TITLE
fix(net): Allow each initial peer to send one inbound request before disconnecting any peers

### DIFF
--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -78,7 +78,8 @@ pub(crate) const TRANSACTION_VERIFY_TIMEOUT: Duration = BLOCK_VERIFY_TIMEOUT;
 /// The maximum number of concurrent inbound download and verify tasks.
 ///
 /// We expect the mempool crawler to download and verify most mempool transactions, so this bound
-/// can be small.
+/// can be small. But it should be at least the default `network.peerset_initial_target_size` config,
+/// to avoid disconnecting peers on startup.
 ///
 /// ## Security
 ///
@@ -95,7 +96,9 @@ pub(crate) const TRANSACTION_VERIFY_TIMEOUT: Duration = BLOCK_VERIFY_TIMEOUT;
 /// Since Zebra keeps an `inv` index, inbound downloads for malicious transactions
 /// will be directed to the malicious node that originally gossiped the hash.
 /// Therefore, this attack can be carried out by a single malicious node.
-pub const MAX_INBOUND_CONCURRENCY: usize = 10;
+//
+// TODO: replace with the configured value of network.peerset_initial_target_size
+pub const MAX_INBOUND_CONCURRENCY: usize = 25;
 
 /// A marker struct for the oneshot channels which cancel a pending download and verify.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Motivation

We're not allowing enough pending inbound requests for our target peer set size. This is causing CI failures multiple times per day.

Closes #6506.

### Complex Code or Requirements

This PR just increases a buffer limit, the concurrent code itself is unchanged.

## Solution

- allow one inbound request for each peer in the default initial peer set size

## Review

This is urgent because it fixes CI failures.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

If this bug happens again, we might want to slow down the rate of outbound connections as well.