### PR TITLE
fix(net): Limit the number of leftover nonces in the self-connection nonce set

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -149,14 +149,32 @@ pub const MAX_RECENT_PEER_AGE: Duration32 = Duration32::from_days(3);
 /// Using a prime number makes sure that heartbeats don't synchronise with crawls.
 pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(59);
 
-/// The minimum time between successive calls to
+/// The minimum time between outbound peer connections, implemented by
 /// [`CandidateSet::next`][crate::peer_set::CandidateSet::next].
 ///
 /// ## Security
 ///
-/// Zebra resists distributed denial of service attacks by making sure that new peer connections
-/// are initiated at least [`MIN_PEER_CONNECTION_INTERVAL`] apart.
-pub const MIN_PEER_CONNECTION_INTERVAL: Duration = Duration::from_millis(25);
+/// Zebra resists distributed denial of service attacks by making sure that new outbound peer
+/// connections are only initiated after this minimum time has elapsed.
+///
+/// It also enforces a minimum per-peer reconnection interval, and filters failed outbound peers.
+pub const MIN_OUTBOUND_PEER_CONNECTION_INTERVAL: Duration = Duration::from_millis(50);
+
+/// The minimum time between inbound peer connections, implemented by
+/// `peer_set::initialize::accept_inbound_connections`.
+///
+/// To support multiple peers connecting simultaneously, this is less than the
+/// [`HANDSHAKE_TIMEOUT`].
+///
+/// ## Security
+///
+/// Zebra resists distributed denial of service attacks by making sure that new inbound
+/// peer connections are only accepted, and our side of the handshake initiated, after this
+/// minimum time has elapsed.
+///
+/// The inbound interval is much longer than the outbound interval, because Zebra does not
+/// control the selection or reconnections of inbound peers.
+pub const MIN_INBOUND_PEER_CONNECTION_INTERVAL: Duration = Duration::from_secs(1);
 
 /// The minimum time between successive calls to
 /// [`CandidateSet::update`][crate::peer_set::CandidateSet::update].
@@ -324,9 +342,6 @@ pub mod magics {
 
 #[cfg(test)]
 mod tests {
-
-    use std::convert::TryFrom;
-
     use zebra_chain::parameters::POST_BLOSSOM_POW_TARGET_SPACING;
 
     use super::*;
@@ -363,18 +378,20 @@ mod tests {
                 "The EWMA decay time should be higher than the request timeout, so timed out peers are penalised by the EWMA.");
 
         assert!(
-            u32::try_from(MAX_ADDRS_IN_ADDRESS_BOOK).expect("fits in u32")
-                * MIN_PEER_CONNECTION_INTERVAL
-                < MIN_PEER_RECONNECTION_DELAY,
-            "each peer should get at least one connection attempt in each connection interval",
+            MIN_PEER_RECONNECTION_DELAY.as_secs() as f32
+                / (u32::try_from(MAX_ADDRS_IN_ADDRESS_BOOK).expect("fits in u32")
+                    * MIN_OUTBOUND_PEER_CONNECTION_INTERVAL)
+                    .as_secs() as f32
+                >= 0.5,
+            "most peers should get a connection attempt in each connection interval",
         );
 
         assert!(
-            MIN_PEER_RECONNECTION_DELAY.as_secs()
+            MIN_PEER_RECONNECTION_DELAY.as_secs() as f32
                 / (u32::try_from(MAX_ADDRS_IN_ADDRESS_BOOK).expect("fits in u32")
-                    * MIN_PEER_CONNECTION_INTERVAL)
-                    .as_secs()
-                <= 2,
+                    * MIN_OUTBOUND_PEER_CONNECTION_INTERVAL)
+                    .as_secs() as f32
+                <= 2.0,
             "each peer should only have a few connection attempts in each connection interval",
         );
     }

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -261,24 +261,6 @@ pub const ADDR_RESPONSE_LIMIT_DENOMINATOR: usize = 3;
 pub const MAX_ADDRS_IN_ADDRESS_BOOK: usize =
     MAX_ADDRS_IN_MESSAGE * (ADDR_RESPONSE_LIMIT_DENOMINATOR + 1);
 
-/// The maximum number of self-connection nonces Zebra will track.
-/// Most nonces are cleaned up when their handshake finishes,
-/// but some errors leave them in the nonce set.
-///
-/// Our handshake timeout is a few seconds, and we can make just over a hundred connections
-/// per second.
-///
-/// This is a tradeoff between:
-/// - avoiding memory denial of service attacks which make large numbers of connections:
-///     - 500 successful inbound connections takes about 9 minutes;
-///     - 500 failed inbound connections takes 5 seconds;
-///     - 500 outbound connections takes about 25 seconds,
-///       but outbound connection peer selection and reconnections are controlled by Zebra
-/// - memory usage: 16 bytes per `Nonce`, 8 kB for 500 nonces
-/// - collision probability: 2^32 has ~50% collision probability, so we use a much lower limit
-///   <https://en.wikipedia.org/wiki/Birthday_problem#Probability_of_a_shared_birthday_(collision)>
-pub const MAX_SELF_CONNECTION_NONCES: usize = 500;
-
 /// Truncate timestamps in outbound address messages to this time interval.
 ///
 /// ## SECURITY

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -160,7 +160,7 @@ pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(59);
 /// It also enforces a minimum per-peer reconnection interval, and filters failed outbound peers.
 pub const MIN_OUTBOUND_PEER_CONNECTION_INTERVAL: Duration = Duration::from_millis(50);
 
-/// The minimum time between inbound peer connections, implemented by
+/// The minimum time between _successful_ inbound peer connections, implemented by
 /// `peer_set::initialize::accept_inbound_connections`.
 ///
 /// To support multiple peers connecting simultaneously, this is less than the
@@ -168,13 +168,29 @@ pub const MIN_OUTBOUND_PEER_CONNECTION_INTERVAL: Duration = Duration::from_milli
 ///
 /// ## Security
 ///
-/// Zebra resists distributed denial of service attacks by making sure that new inbound
-/// peer connections are only accepted, and our side of the handshake initiated, after this
-/// minimum time has elapsed.
+/// Zebra resists distributed denial of service attacks by limiting the inbound connection rate.
+/// After a _successful_ inbound connection, new inbound peer connections are only accepted,
+/// and our side of the handshake initiated, after this minimum time has elapsed.
 ///
 /// The inbound interval is much longer than the outbound interval, because Zebra does not
 /// control the selection or reconnections of inbound peers.
 pub const MIN_INBOUND_PEER_CONNECTION_INTERVAL: Duration = Duration::from_secs(1);
+
+/// The minimum time between _failed_ inbound peer connections, implemented by
+/// `peer_set::initialize::accept_inbound_connections`.
+///
+/// This is a tradeoff between:
+/// - the memory, CPU, and network usage of each new connection attempt, and
+/// - denying service to honest peers due to an attack which makes many inbound connections.
+///
+/// Attacks that reach this limit should be managed using a firewall or intrusion prevention system.
+///
+/// ## Security
+///
+/// Zebra resists distributed denial of service attacks by limiting the inbound connection rate.
+/// After a _failed_ inbound connection, new inbound peer connections are only accepted,
+/// and our side of the handshake initiated, after this minimum time has elapsed.
+pub const MIN_INBOUND_PEER_FAILED_CONNECTION_INTERVAL: Duration = Duration::from_millis(10);
 
 /// The minimum time between successive calls to
 /// [`CandidateSet::update`][crate::peer_set::CandidateSet::update].

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -245,6 +245,24 @@ pub const ADDR_RESPONSE_LIMIT_DENOMINATOR: usize = 3;
 pub const MAX_ADDRS_IN_ADDRESS_BOOK: usize =
     MAX_ADDRS_IN_MESSAGE * (ADDR_RESPONSE_LIMIT_DENOMINATOR + 1);
 
+/// The maximum number of self-connection nonces Zebra will track.
+/// Most nonces are cleaned up when their handshake finishes,
+/// but some errors leave them in the nonce set.
+///
+/// Our handshake timeout is a few seconds, and we can make just over a hundred connections
+/// per second.
+///
+/// This is a tradeoff between:
+/// - avoiding memory denial of service attacks which make large numbers of connections:
+///     - 500 successful inbound connections takes about 9 minutes;
+///     - 500 failed inbound connections takes 5 seconds;
+///     - 500 outbound connections takes about 25 seconds,
+///       but outbound connection peer selection and reconnections are controlled by Zebra
+/// - memory usage: 16 bytes per `Nonce`, 8 kB for 500 nonces
+/// - collision probability: 2^32 has ~50% collision probability, so we use a much lower limit
+///   <https://en.wikipedia.org/wiki/Birthday_problem#Probability_of_a_shared_birthday_(collision)>
+pub const MAX_SELF_CONNECTION_NONCES: usize = 500;
+
 /// Truncate timestamps in outbound address messages to this time interval.
 ///
 /// ## SECURITY

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -48,6 +48,9 @@ use crate::{
     BoxError, Config, VersionMessage,
 };
 
+#[cfg(test)]
+mod tests;
+
 /// A [`Service`] that handshakes with a remote peer and constructs a
 /// client/server pair.
 ///

--- a/zebra-network/src/peer/handshake/tests.rs
+++ b/zebra-network/src/peer/handshake/tests.rs
@@ -1,0 +1,15 @@
+//! Implements methods for testing [`Handshake`]
+
+use super::*;
+
+impl<S, C> Handshake<S, C>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send,
+    C: ChainTip + Clone + Send + 'static,
+{
+    /// Returns a count of how many connection nonces are stored in this [`Handshake`]
+    pub async fn nonce_count(&self) -> usize {
+        self.nonces.lock().await.len()
+    }
+}

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -1,3 +1,5 @@
+//! Candidate peer selection for outbound connections using the [`CandidateSet`].
+
 use std::{cmp::min, sync::Arc};
 
 use chrono::Utc;
@@ -361,7 +363,8 @@ where
     ///
     /// Zebra resists distributed denial of service attacks by making sure that
     /// new peer connections are initiated at least
-    /// [`MIN_PEER_CONNECTION_INTERVAL`][constants::MIN_PEER_CONNECTION_INTERVAL] apart.
+    /// [`MIN_OUTBOUND_PEER_CONNECTION_INTERVAL`][constants::MIN_OUTBOUND_PEER_CONNECTION_INTERVAL]
+    /// apart.
     ///
     /// [`Responded`]: crate::PeerAddrState::Responded
     pub async fn next(&mut self) -> Option<MetaAddr> {
@@ -397,7 +400,7 @@ where
 
         // Security: rate-limit new outbound peer connections
         sleep_until(self.min_next_handshake).await;
-        self.min_next_handshake = Instant::now() + constants::MIN_PEER_CONNECTION_INTERVAL;
+        self.min_next_handshake = Instant::now() + constants::MIN_OUTBOUND_PEER_CONNECTION_INTERVAL;
 
         Some(next_peer)
     }

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -7,6 +7,7 @@ use std::{
     collections::{BTreeMap, HashSet},
     net::SocketAddr,
     sync::Arc,
+    time::Duration,
 };
 
 use futures::{
@@ -175,6 +176,7 @@ where
     let listen_fut = accept_inbound_connections(
         config.clone(),
         tcp_listener,
+        constants::MIN_INBOUND_PEER_CONNECTION_INTERVAL,
         listen_handshaker,
         peerset_tx.clone(),
     );
@@ -273,9 +275,7 @@ where
     // # Security
     //
     // Resists distributed denial of service attacks by making sure that
-    // new peer connections are initiated at least
-    // [`MIN_PEER_CONNECTION_INTERVAL`][constants::MIN_PEER_CONNECTION_INTERVAL]
-    // apart.
+    // new peer connections are initiated at least `MIN_OUTBOUND_PEER_CONNECTION_INTERVAL` apart.
     //
     // # Correctness
     //
@@ -297,9 +297,13 @@ where
             // Spawn a new task to make the outbound connection.
             tokio::spawn(
                 async move {
-                    // Only spawn one outbound connector per `MIN_PEER_CONNECTION_INTERVAL`,
-                    // sleeping for an interval according to its index in the list.
-                    sleep(constants::MIN_PEER_CONNECTION_INTERVAL.saturating_mul(i as u32)).await;
+                    // Only spawn one outbound connector per
+                    // `MIN_OUTBOUND_PEER_CONNECTION_INTERVAL`,
+                    // by sleeping for the interval multiplied by the peer's index in the list.
+                    sleep(
+                        constants::MIN_OUTBOUND_PEER_CONNECTION_INTERVAL.saturating_mul(i as u32),
+                    )
+                    .await;
 
                     // As soon as we create the connector future,
                     // the handshake starts running as a spawned task.
@@ -507,11 +511,13 @@ pub(crate) async fn open_listener(config: &Config) -> (TcpListener, SocketAddr) 
 /// Uses `handshaker` to perform a Zcash network protocol handshake, and sends
 /// the [`peer::Client`] result over `peerset_tx`.
 ///
-/// Limit the number of active inbound connections based on `config`.
+/// Limits the number of active inbound connections based on `config`,
+/// and waits `min_inbound_peer_connection_interval` between connections.
 #[instrument(skip(config, listener, handshaker, peerset_tx), fields(listener_addr = ?listener.local_addr()))]
 async fn accept_inbound_connections<S>(
     config: Config,
     listener: TcpListener,
+    min_inbound_peer_connection_interval: Duration,
     mut handshaker: S,
     peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
 ) -> Result<(), BoxError>
@@ -596,15 +602,16 @@ where
                 handshakes.push(Box::pin(handshake_task));
             }
 
-            // Only spawn one inbound connection handshake per `MIN_PEER_CONNECTION_INTERVAL`.
-            // But clear out failed connections as fast as possible.
+            // Rate-limit inbound connection handshakes.
+            // But only sleep after a successful connection,
+            // so we clear out failed connections as fast as possible.
             //
             // If there is a flood of connections,
             // this stops Zebra overloading the network with handshake data.
             //
             // Zebra can't control how many queued connections are waiting,
             // but most OSes also limit the number of queued inbound connections on a listener port.
-            tokio::time::sleep(constants::MIN_PEER_CONNECTION_INTERVAL).await;
+            tokio::time::sleep(min_inbound_peer_connection_interval).await;
         } else {
             debug!(?inbound_result, "error accepting inbound connection");
         }
@@ -617,7 +624,6 @@ where
 }
 
 /// An action that the peer crawler can take.
-#[allow(dead_code)]
 enum CrawlerAction {
     /// Drop the demand signal because there are too many pending handshakes.
     DemandDrop,

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -621,7 +621,11 @@ where
 
         // Security: Let other tasks run after each connection is processed.
         //
-        // Avoids remote peers starving other Zebra tasks using inbound connection successes or errors.
+        // Avoids remote peers starving other Zebra tasks using inbound connection successes or
+        // errors.
+        //
+        // Preventing a denial of service is important in this code, so we want to sleep *and* make
+        // the next connection after other tasks have run. (Sleeps are not guaranteed to do that.)
         tokio::task::yield_now().await;
     }
 }

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -58,6 +58,9 @@ const CRAWLER_TEST_DURATION: Duration = Duration::from_secs(10);
 /// Using a very short time can make the listener not run at all.
 const LISTENER_TEST_DURATION: Duration = Duration::from_secs(10);
 
+/// The amount of time to make the inbound connection acceptor wait between peer connections.
+const MIN_INBOUND_PEER_CONNECTION_INTERVAL_FOR_TESTS: Duration = Duration::from_millis(25);
+
 /// Test that zebra-network discovers dynamic bind-to-all-interfaces listener ports,
 /// and sends them to the `AddressBook`.
 ///
@@ -1067,7 +1070,9 @@ async fn add_initial_peers_is_rate_limited() {
     assert_eq!(connections.len(), PEER_COUNT);
     // Make sure the rate limiting worked by checking if it took long enough
     assert!(
-        elapsed > constants::MIN_PEER_CONNECTION_INTERVAL.saturating_mul((PEER_COUNT - 1) as u32),
+        elapsed
+            > constants::MIN_OUTBOUND_PEER_CONNECTION_INTERVAL
+                .saturating_mul((PEER_COUNT - 1) as u32),
         "elapsed only {elapsed:?}"
     );
 
@@ -1360,6 +1365,7 @@ where
     let listen_fut = accept_inbound_connections(
         config.clone(),
         tcp_listener,
+        MIN_INBOUND_PEER_CONNECTION_INTERVAL_FOR_TESTS,
         listen_handshaker,
         peerset_tx.clone(),
     );


### PR DESCRIPTION
## Motivation

This PR prevents a memory exhaustion attack on Zebra.

It also limits the inbound connection rate to make similar attacks harder in future.

### Complex Code or Requirements

This PR modifies concurrent network handshake code, where futures run concurrently.
It also adds more code to a futures mutex critical section.

It has already been reviewed privately by two Zebra developers.

## Solution

- Limit the number of nonces in the nonce set to ~500 or 8 kB~ the configured connection limit
- Limit the inbound connection rate to 1 per second
- Slightly decrease the outbound connection rate to one every 50 milliseconds

## Review

This is ready for review. It needs to get merged before the next Zebra release.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

