### PR TITLE
change(deps): Upgrade shared dependencies to match `zcashd` 5.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher 0.4.4",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,26 +324,26 @@ checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
 name = "bech32"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bellman"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4dd656ef4fdf7debb6d87d4dd92642fcbcdb78cbf6600c13e25c87e4d1a3807"
+checksum = "9afceed28bac7f9f5a508bca8aeeff51cdfa4770c0b967ac55c621e2ddfd6171"
 dependencies = [
  "bitvec",
  "blake2s_simd",
  "byteorder",
  "crossbeam-channel",
- "ff 0.12.1",
- "group 0.12.1",
+ "ff 0.13.0",
+ "group 0.13.0",
  "lazy_static",
  "log",
  "num_cpus",
- "pairing",
+ "pairing 0.23.0",
  "rand_core 0.6.4",
  "rayon",
  "subtle",
@@ -375,10 +386,24 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0830ae4cc96b0617cc912970c2b17e89456fecbf55e8eed53a956f37ab50c41"
 dependencies = [
- "hmac",
- "pbkdf2",
+ "hmac 0.11.0",
+ "pbkdf2 0.9.0",
  "rand 0.8.5",
  "sha2 0.9.9",
+ "unicode-normalization",
+ "zeroize",
+]
+
+[[package]]
+name = "bip0039"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef0f0152ec5cf17f49a5866afaa3439816207fd4f0a224c0211ffaf5e278426"
+dependencies = [
+ "hmac 0.12.1",
+ "pbkdf2 0.10.1",
+ "rand 0.8.5",
+ "sha2 0.10.6",
  "unicode-normalization",
  "zeroize",
 ]
@@ -496,7 +521,7 @@ checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
 dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
- "pairing",
+ "pairing 0.22.0",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -508,6 +533,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
 dependencies = [
  "ff 0.13.0",
+ "group 0.13.0",
+ "pairing 0.23.0",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -583,6 +610,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.4",
+]
 
 [[package]]
 name = "cc"
@@ -1193,15 +1229,16 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
 name = "directories"
-version = "4.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+checksum = "74be3be809c18e089de43bdc504652bb2bc473fca8756131f8689db8cf079ba9"
 dependencies = [
- "dirs-sys 0.3.7",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1210,18 +1247,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
 dependencies = [
- "dirs-sys 0.4.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1425,6 +1451,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -1508,6 +1535,20 @@ checksum = "cd910db5f9ca4dc3116f8c46367825807aa2b942f72565f16b4be0b208a00a9e"
 dependencies = [
  "block-modes",
  "cipher 0.3.0",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "fpe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c4b37de5ae15812a764c958297cfc50f5c010438f60c6ce75d11b802abd404"
+dependencies = [
+ "cbc",
+ "cipher 0.4.4",
  "libm",
  "num-bigint",
  "num-integer",
@@ -1721,6 +1762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff 0.13.0",
+ "memuse",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -1780,13 +1822,37 @@ dependencies = [
  "bitvec",
  "ff 0.12.1",
  "group 0.12.1",
- "halo2_proofs",
+ "halo2_proofs 0.2.0",
  "lazy_static",
  "pasta_curves 0.4.1",
  "rand 0.8.5",
  "subtle",
  "uint",
 ]
+
+[[package]]
+name = "halo2_gadgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126a150072b0c38c7b573fe3eaf0af944a7fed09e154071bf2436d3f016f7230"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "halo2_proofs 0.3.0",
+ "lazy_static",
+ "pasta_curves 0.5.1",
+ "rand 0.8.5",
+ "subtle",
+ "uint",
+]
+
+[[package]]
+name = "halo2_legacy_pdqsort"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47716fe1ae67969c5e0b2ef826f32db8c3be72be325e1aa3c1951d06b5575ec5"
 
 [[package]]
 name = "halo2_proofs"
@@ -1800,6 +1866,22 @@ dependencies = [
  "pasta_curves 0.4.1",
  "rand_core 0.6.4",
  "rayon",
+ "tracing",
+]
+
+[[package]]
+name = "halo2_proofs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b867a8d9bbb85fca76fff60652b5cd19b853a1c4d0665cb89bee68b18d2caf0"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "halo2_legacy_pdqsort",
+ "maybe-rayon",
+ "pasta_curves 0.5.1",
+ "rand_core 0.6.4",
  "tracing",
 ]
 
@@ -1893,6 +1975,15 @@ checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2335,6 +2426,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "lazycell"
@@ -2497,6 +2591,16 @@ name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if 1.0.0",
+ "rayon",
+]
 
 [[package]]
 name = "maybe-uninit"
@@ -2842,14 +2946,14 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f06b263206a75a7d96ca75d46a3e9ca8eaf7ab7feea209749bb8b818d22f427"
 dependencies = [
- "aes",
+ "aes 0.7.5",
  "bitvec",
  "blake2b_simd",
  "ff 0.12.1",
- "fpe",
+ "fpe 0.5.1",
  "group 0.12.1",
- "halo2_gadgets",
- "halo2_proofs",
+ "halo2_gadgets 0.2.0",
+ "halo2_proofs 0.2.0",
  "hex",
  "incrementalmerkletree",
  "lazy_static",
@@ -2861,7 +2965,35 @@ dependencies = [
  "serde",
  "subtle",
  "tracing",
- "zcash_note_encryption",
+ "zcash_note_encryption 0.2.0",
+]
+
+[[package]]
+name = "orchard"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6f418f2c25573923f81a091f38b4b19bc20f6c92b5070fb8f0711e64a2b998"
+dependencies = [
+ "aes 0.8.2",
+ "bitvec",
+ "blake2b_simd",
+ "ff 0.13.0",
+ "fpe 0.6.1",
+ "group 0.13.0",
+ "halo2_gadgets 0.3.0",
+ "halo2_proofs 0.3.0",
+ "hex",
+ "incrementalmerkletree",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "pasta_curves 0.5.1",
+ "rand 0.8.5",
+ "reddsa 0.5.0",
+ "serde",
+ "subtle",
+ "tracing",
+ "zcash_note_encryption 0.3.0",
 ]
 
 [[package]]
@@ -2919,6 +3051,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
 dependencies = [
  "group 0.12.1",
+]
+
+[[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group 0.13.0",
 ]
 
 [[package]]
@@ -3027,8 +3168,10 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
 dependencies = [
+ "blake2b_simd",
  "ff 0.13.0",
  "group 0.13.0",
+ "lazy_static",
  "rand 0.8.5",
  "static_assertions",
  "subtle",
@@ -3041,6 +3184,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05894bce6a1ba4be299d0c5f29563e08af2bc18bb7d48313113bed71e904739"
 dependencies = [
  "crypto-mac",
+ "password-hash",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
+dependencies = [
+ "digest 0.10.6",
  "password-hash",
 ]
 
@@ -3599,15 +3752,12 @@ dependencies = [
 
 [[package]]
 name = "redjubjub"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6039ff156887caf92df308cbaccdc058c9d3155a913da046add6e48c4cdbd91d"
+checksum = "7a60db2c3bc9c6fd1e8631fee75abc008841d27144be744951d6b9b75f9b569c"
 dependencies = [
- "blake2b_simd",
- "byteorder",
- "digest 0.9.0",
- "jubjub 0.9.0",
  "rand_core 0.6.4",
+ "reddsa 0.5.0",
  "serde",
  "thiserror",
  "zeroize",
@@ -5557,9 +5707,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804268e702b664fc09d3e2ce82786d0addf4ae57ba6976469be63e09066bf9f7"
+checksum = "52be35a205369d480378646bff9c9fedafd8efe8af1e0e54bb858f405883f2b2"
 dependencies = [
  "bech32",
  "bs58",
@@ -5602,13 +5752,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_note_encryption"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb2149e6cd5fbee36c5b87c601715a8c35554602f7fe84af38b636afa2db318"
+dependencies = [
+ "chacha20",
+ "chacha20poly1305",
+ "cipher 0.4.4",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "zcash_primitives"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f9a45953c4ddd81d68f45920955707f45c8926800671f354dd13b97507edf28"
 dependencies = [
- "aes",
- "bip0039",
+ "aes 0.7.5",
+ "bip0039 0.9.0",
  "bitvec",
  "blake2b_simd",
  "blake2s_simd",
@@ -5616,7 +5779,7 @@ dependencies = [
  "byteorder",
  "equihash",
  "ff 0.12.1",
- "fpe",
+ "fpe 0.5.1",
  "group 0.12.1",
  "hdwallet",
  "hex",
@@ -5625,7 +5788,7 @@ dependencies = [
  "lazy_static",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.3.0",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "ripemd",
@@ -5634,63 +5797,63 @@ dependencies = [
  "subtle",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption",
+ "zcash_note_encryption 0.2.0",
 ]
 
 [[package]]
 name = "zcash_primitives"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8aed1d098e9f1b2bcd957ceab4188bf343cea30e7d0327fa49cea6ec44b167"
+checksum = "914d2195a478d5b63191584dff126f552751115181857b290211ec88e68acc3e"
 dependencies = [
- "aes",
- "bip0039",
+ "aes 0.8.2",
+ "bip0039 0.10.1",
  "bitvec",
  "blake2b_simd",
  "blake2s_simd",
- "bls12_381 0.7.1",
+ "bls12_381 0.8.0",
  "byteorder",
  "equihash",
- "ff 0.12.1",
- "fpe",
- "group 0.12.1",
+ "ff 0.13.0",
+ "fpe 0.6.1",
+ "group 0.13.0",
  "hdwallet",
  "hex",
  "incrementalmerkletree",
- "jubjub 0.9.0",
+ "jubjub 0.10.0",
  "lazy_static",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.4.0",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "ripemd",
  "secp256k1",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "subtle",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption",
+ "zcash_note_encryption 0.3.0",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ca180a8138ae6e2de2b88573ed19dd57798f42a79a00d992b4d727132c7081"
+checksum = "e5c8147884952748b00aa443d36511ae2d7b49acfec74cfd39c0959fbb61ef14"
 dependencies = [
  "bellman",
  "blake2b_simd",
- "bls12_381 0.7.1",
+ "bls12_381 0.8.0",
  "directories",
- "group 0.12.1",
- "jubjub 0.9.0",
+ "group 0.13.0",
+ "jubjub 0.10.0",
  "lazy_static",
  "minreq",
  "rand_core 0.6.4",
  "redjubjub",
  "tracing",
- "zcash_primitives 0.10.2",
+ "zcash_primitives 0.11.0",
 ]
 
 [[package]]
@@ -5706,12 +5869,12 @@ dependencies = [
  "cxx-gen",
  "libc",
  "memuse",
- "orchard",
+ "orchard 0.3.0",
  "rand_core 0.6.4",
  "syn 1.0.109",
  "tracing",
  "zcash_encoding",
- "zcash_note_encryption",
+ "zcash_note_encryption 0.2.0",
  "zcash_primitives 0.9.1",
 ]
 
@@ -5733,15 +5896,15 @@ dependencies = [
  "ed25519-zebra",
  "equihash",
  "futures",
- "group 0.12.1",
- "halo2_proofs",
+ "group 0.13.0",
+ "halo2_proofs 0.3.0",
  "hex",
  "humantime",
  "incrementalmerkletree",
  "itertools",
- "jubjub 0.9.0",
+ "jubjub 0.10.0",
  "lazy_static",
- "orchard",
+ "orchard 0.4.0",
  "primitive-types",
  "proptest",
  "proptest-derive",
@@ -5768,8 +5931,8 @@ dependencies = [
  "zcash_address",
  "zcash_encoding",
  "zcash_history",
- "zcash_note_encryption",
- "zcash_primitives 0.10.2",
+ "zcash_note_encryption 0.3.0",
+ "zcash_primitives 0.11.0",
  "zebra-test",
 ]
 
@@ -5787,20 +5950,20 @@ version = "1.0.0-beta.22"
 dependencies = [
  "bellman",
  "blake2b_simd",
- "bls12_381 0.7.1",
+ "bls12_381 0.8.0",
  "chrono",
  "color-eyre",
  "displaydoc",
  "futures",
  "futures-util",
- "halo2_proofs",
+ "halo2_proofs 0.3.0",
  "hex",
  "howudoin",
- "jubjub 0.9.0",
+ "jubjub 0.10.0",
  "lazy_static",
  "metrics",
  "once_cell",
- "orchard",
+ "orchard 0.4.0",
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
@@ -5924,13 +6087,13 @@ dependencies = [
  "dirs",
  "elasticsearch",
  "futures",
- "halo2_proofs",
+ "halo2_proofs 0.3.0",
  "hex",
  "howudoin",
  "indexmap",
  "insta",
  "itertools",
- "jubjub 0.9.0",
+ "jubjub 0.10.0",
  "lazy_static",
  "metrics",
  "mset",

--- a/deny.toml
+++ b/deny.toml
@@ -64,12 +64,6 @@ skip-tree = [
     # wait for zcash_primitives to remove duplicated dependencies
     { name = "block-buffer", version = "=0.9.0" },
 
-    # wait for zcash_address to upgrade
-    { name = "bech32", version = "=0.8.1"},
-
-    # wait for zcash_proofs to upgrade `directories`
-    { name = "dirs-sys", version = "=0.3.7"},
-
     # zebra-utils dependencies
 
     # wait for structopt upgrade (or upgrade to clap 3)

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -41,9 +41,9 @@ blake2s_simd = "1.0.1"
 bs58 = { version = "0.4.0", features = ["check"] }
 byteorder = "1.4.3"
 equihash = "0.2.0"
-group = "0.12.0"
+group = "0.13.0"
 incrementalmerkletree = "0.3.1"
-jubjub = "0.9.0"
+jubjub = "0.10.0"
 lazy_static = "1.4.0"
 primitive-types = "0.11.1"
 rand_core = "0.6.4"
@@ -55,12 +55,12 @@ uint = "0.9.5"
 x25519-dalek = { version = "2.0.0-pre.1", features = ["serde"] }
 
 # ECC deps
-halo2 = { package = "halo2_proofs", version = "0.2.0" }
-orchard = "0.3.0"
+halo2 = { package = "halo2_proofs", version = "0.3.0" }
+orchard = "0.4.0"
 zcash_encoding = "0.2.0"
 zcash_history = "0.3.0"
-zcash_note_encryption = "0.2.0"
-zcash_primitives = { version = "0.10.2", features = ["transparent-inputs"] }
+zcash_note_encryption = "0.3.0"
+zcash_primitives = { version = "0.11.0", features = ["transparent-inputs"] }
 
 # Time
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "std", "serde"] }
@@ -85,11 +85,11 @@ rayon = "1.7.0"
 
 # ZF deps
 ed25519-zebra = "3.1.0"
-redjubjub = "0.5.0"
+redjubjub = "0.7.0"
 reddsa = "0.5.0"
 
 # Experimental feature getblocktemplate-rpcs
-zcash_address = { version = "0.2.0", optional = true }
+zcash_address = { version = "0.2.1", optional = true }
 
 # Optional testing dependencies
 proptest = { version = "1.1.0", optional = true }

--- a/zebra-chain/src/orchard/arbitrary.rs
+++ b/zebra-chain/src/orchard/arbitrary.rs
@@ -1,10 +1,13 @@
 //! Randomised data generation for Orchard types.
 
-use group::{ff::PrimeField, prime::PrimeCurveAffine};
-use halo2::{arithmetic::FieldExt, pasta::pallas};
-use proptest::{arbitrary::any, array, collection::vec, prelude::*};
-
+use group::{
+    ff::{FromUniformBytes, PrimeField},
+    prime::PrimeCurveAffine,
+};
+use halo2::pasta::pallas;
 use reddsa::{orchard::SpendAuth, Signature, SigningKey, VerificationKey, VerificationKeyBytes};
+
+use proptest::{arbitrary::any, array, collection::vec, prelude::*};
 
 use super::{
     keys::*, note, tree, Action, AuthorizedAction, Flags, NoteCommitment, ValueCommitment,
@@ -42,7 +45,7 @@ impl Arbitrary for note::Nullifier {
         (vec(any::<u8>(), 64))
             .prop_map(|bytes| {
                 let bytes = bytes.try_into().expect("vec is the correct length");
-                Self::try_from(pallas::Scalar::from_bytes_wide(&bytes).to_repr())
+                Self::try_from(pallas::Scalar::from_uniform_bytes(&bytes).to_repr())
                     .expect("a valid generated nullifier")
             })
             .boxed()
@@ -98,7 +101,7 @@ impl Arbitrary for SpendAuthVerificationKeyBytes {
             .prop_map(|bytes| {
                 let bytes = bytes.try_into().expect("vec is the correct length");
                 // Convert to a scalar
-                let sk_scalar = pallas::Scalar::from_bytes_wide(&bytes);
+                let sk_scalar = pallas::Scalar::from_uniform_bytes(&bytes);
                 // Convert that back to a (canonical) encoding
                 let sk_bytes = sk_scalar.to_repr();
                 // Decode it into a signing key
@@ -129,7 +132,7 @@ impl Arbitrary for tree::Root {
         (vec(any::<u8>(), 64))
             .prop_map(|bytes| {
                 let bytes = bytes.try_into().expect("vec is the correct length");
-                Self::try_from(pallas::Base::from_bytes_wide(&bytes).to_repr())
+                Self::try_from(pallas::Base::from_uniform_bytes(&bytes).to_repr())
                     .expect("a valid generated Orchard note commitment tree root")
             })
             .boxed()

--- a/zebra-chain/src/orchard/commitment.rs
+++ b/zebra-chain/src/orchard/commitment.rs
@@ -2,9 +2,13 @@
 
 use std::{fmt, io};
 
-use group::{ff::PrimeField, prime::PrimeCurveAffine, GroupEncoding};
+use group::{
+    ff::{FromUniformBytes, PrimeField},
+    prime::PrimeCurveAffine,
+    GroupEncoding,
+};
 use halo2::{
-    arithmetic::{Coordinates, CurveAffine, FieldExt},
+    arithmetic::{Coordinates, CurveAffine},
     pasta::pallas,
 };
 use lazy_static::lazy_static;
@@ -29,7 +33,7 @@ where
     let mut bytes = [0u8; 64];
     csprng.fill_bytes(&mut bytes);
     // pallas::Scalar::from_bytes_wide() reduces the input modulo q_P under the hood.
-    pallas::Scalar::from_bytes_wide(&bytes)
+    pallas::Scalar::from_uniform_bytes(&bytes)
 }
 
 /// The randomness used in the Simsemilla hash for note commitment.

--- a/zebra-chain/src/sapling/arbitrary.rs
+++ b/zebra-chain/src/sapling/arbitrary.rs
@@ -1,10 +1,11 @@
-use std::convert::TryInto;
+//! Randomised data generation for sapling types.
 
 use group::Group;
 use jubjub::{AffinePoint, ExtendedPoint};
-use proptest::{arbitrary::any, collection::vec, prelude::*};
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
+
+use proptest::{arbitrary::any, collection::vec, prelude::*};
 
 use crate::primitives::Groth16Proof;
 

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -27,10 +27,10 @@ proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl", "ze
 
 [dependencies]
 blake2b_simd = "1.0.1"
-bellman = "0.13.0"
-bls12_381 = "0.7.0"
-halo2 = { package = "halo2_proofs", version = "0.2.0" }
-jubjub = "0.9.0"
+bellman = "0.14.0"
+bls12_381 = "0.8.0"
+halo2 = { package = "halo2_proofs", version = "0.3.0" }
+jubjub = "0.10.0"
 rand = { version = "0.8.5", package = "rand" }
 rayon = "1.7.0"
 
@@ -49,9 +49,9 @@ tower = { version = "0.4.13", features = ["timeout", "util", "buffer"] }
 tracing = "0.1.37"
 tracing-futures = "0.2.5"
 
-orchard = "0.3.0"
+orchard = "0.4.0"
 
-zcash_proofs = { version = "0.10.0", features = ["local-prover", "multicore", "download-params"] }
+zcash_proofs = { version = "0.11.0", features = ["local-prover", "multicore", "download-params"] }
 
 tower-fallback = { path = "../tower-fallback/" }
 tower-batch = { path = "../tower-batch/" }

--- a/zebra-consensus/src/primitives/halo2/tests.rs
+++ b/zebra-consensus/src/primitives/halo2/tests.rs
@@ -131,8 +131,6 @@ where
 }
 
 #[tokio::test(flavor = "multi_thread")]
-// TODO: This test fails on nightly so it is temporally disabled. Enable when #6232 is resolved.
-#[ignore]
 async fn verify_generated_halo2_proofs() {
     let _init_guard = zebra_test::init();
 

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -58,7 +58,7 @@ serde = { version = "1.0.160", features = ["serde_derive"] }
 # Experimental feature getblocktemplate-rpcs
 rand = { version = "0.8.5", package = "rand", optional = true }
 # ECC deps used by getblocktemplate-rpcs feature
-zcash_address = { version = "0.2.0", optional = true }
+zcash_address = { version = "0.2.1", optional = true }
 
 # Test-only feature proptest-impl
 proptest = { version = "1.1.0", optional = true }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -84,8 +84,8 @@ insta = { version = "1.29.0", features = ["ron"] }
 proptest = "1.1.0"
 proptest-derive = "0.3.0"
 
-halo2 = { package = "halo2_proofs", version = "0.2.0" }
-jubjub = "0.9.0"
+halo2 = { package = "halo2_proofs", version = "0.3.0" }
+jubjub = "0.10.0"
 
 tokio = { version = "1.27.0", features = ["full", "tracing", "test-util"] }
 


### PR DESCRIPTION
## Motivation

We want to use the same shared dependencies as the latest `zcashd` version 5.5.0.

Closes #6232 

### Specifications

These libraries already implement the consensus rules as specified.

## Solution

#### Dependencies

Upgrade the following shared dependencies:
- bellman
- bls12_381
- group
- halo2
- halo2_proofs
- jubjub
- orchard
- redjubjub
- zcash_address
- zcash_note_encryption
- zcash_primitives
- zcash_proofs

Remove redundant `deny.toml` entries


#### Code Changes

[Replace orchard::from_bytes_wide() with ff::from_uniform_bytes()](https://github.com/ZcashFoundation/zebra/commit/f9d71774b8bd129fba80a826f05960b78d3359ce)

## Review

This is an urgent change we want in the next release, so we continue building with Rust 1.69.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Upgrade zcash_script:
- #6535