### PR TITLE
fix(ci): Avoid inbound service overloads and fix failing tests

### DIFF
--- a/zebra-consensus/src/chain.rs
+++ b/zebra-consensus/src/chain.rs
@@ -322,10 +322,20 @@ where
                         unreachable!("unexpected response type: {response:?} from state request")
                     }
                     Err(e) => {
+                        #[cfg(not(test))]
                         tracing::warn!(
                             "unexpected error: {e:?} in state request while verifying previous \
-                             state checkpoints"
-                        )
+                             state checkpoints. Is Zebra shutting down?"
+                        );
+                        // This error happens a lot in some tests.
+                        //
+                        // TODO: fix the tests so they don't cause this error,
+                        //       or change the tracing filter
+                        #[cfg(test)]
+                        tracing::debug!(
+                            "unexpected error: {e:?} in state request while verifying previous \
+                             state checkpoints. Is Zebra shutting down?"
+                        );
                     }
                 }
             }

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -158,7 +158,7 @@ pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(59);
 /// connections are only initiated after this minimum time has elapsed.
 ///
 /// It also enforces a minimum per-peer reconnection interval, and filters failed outbound peers.
-pub const MIN_OUTBOUND_PEER_CONNECTION_INTERVAL: Duration = Duration::from_millis(50);
+pub const MIN_OUTBOUND_PEER_CONNECTION_INTERVAL: Duration = Duration::from_millis(100);
 
 /// The minimum time between _successful_ inbound peer connections, implemented by
 /// `peer_set::initialize::accept_inbound_connections`.
@@ -398,8 +398,8 @@ mod tests {
                 / (u32::try_from(MAX_ADDRS_IN_ADDRESS_BOOK).expect("fits in u32")
                     * MIN_OUTBOUND_PEER_CONNECTION_INTERVAL)
                     .as_secs() as f32
-                >= 0.5,
-            "most peers should get a connection attempt in each connection interval",
+                >= 0.2,
+            "some peers should get a connection attempt in each connection interval",
         );
 
         assert!(

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -59,10 +59,16 @@ pub const STOP_ON_LOAD_TIMEOUT: Duration = Duration::from_secs(10);
 /// The maximum amount of time Zebra should take to sync a few hundred blocks.
 ///
 /// Usually the small checkpoint is much shorter than this.
-pub const TINY_CHECKPOINT_TIMEOUT: Duration = Duration::from_secs(120);
+//
+// Tempoaraily increased to 4 minutes to get more diagnostic info in failed tests.
+// TODO: reduce to 120 when #6506 is fixed
+pub const TINY_CHECKPOINT_TIMEOUT: Duration = Duration::from_secs(240);
 
 /// The maximum amount of time Zebra should take to sync a thousand blocks.
-pub const LARGE_CHECKPOINT_TIMEOUT: Duration = Duration::from_secs(180);
+//
+// Tempoaraily increased to 4 minutes to get more diagnostic info in failed tests.
+// TODO: reduce to 180 when #6506 is fixed
+pub const LARGE_CHECKPOINT_TIMEOUT: Duration = Duration::from_secs(240);
 
 /// The maximum time to wait for Zebrad to synchronize up to the chain tip starting from a
 /// partially synchronized state.


### PR DESCRIPTION
## Motivation

It looks like the syncer or state is hanging, then the inbound service is getting overloaded, which causes CI failures in some tests.

This might fix #6506.

### Complex Code or Requirements

It's probably a concurrency bug, but this PR just tweaks some timings and test logs.

## Solution

Fixes:
- [Silence an extremely verbose error in zebra-consensus tests](https://github.com/ZcashFoundation/zebra/commit/0187b926cf9d7a56b88c6a93bf35615cc5c122cd)
    - This speeds up the tests, and makes diagnosing failures easier
- [Increase the outbound connection interval to 100ms](https://github.com/ZcashFoundation/zebra/commit/b263379748d8b4127e755406917145d5a75d2e67)
    - This slows down new connections, which add extra load to the inbound service
- [Start the inbound service as soon as possible, and the syncer last](https://github.com/ZcashFoundation/zebra/commit/9d6656e8dfb77720028e71a00edca182c7bde91f)
    - This delays the syncer start: the syncer opens new connections, which add extra load to the inbound service

Diagnostics:
- [Increase acceptance test time limits to get more debug info](https://github.com/ZcashFoundation/zebra/commit/3f70de7d1c48e1927356dd082639a88f2eed25e6)
- [Add more debug info to inbound service overload tracing messages](https://github.com/ZcashFoundation/zebra/pull/6537/commits/0e8cff77811274a3cbac44aa8fa48b764e7d49ff)

## Review

This is an urgent fix for failures that are stopping other PRs merging.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We might need to fix a state or syncer hang, but we need more debug info to know which one to fix.