### PR TITLE
refactor(actions): use `development` GitHub environment

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -108,12 +108,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          # TODO: change after new buildkit version gets fixed
-          # https://github.com/moby/buildkit/issues/3347
-          # https://github.com/docker/build-push-action/issues/761#issuecomment-1383822381
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
 
       - name: Authenticate to Google Cloud
         id: auth

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -61,6 +61,7 @@ jobs:
     name: Build images
     timeout-minutes: 210
     runs-on: ubuntu-latest
+    environment: development
     outputs:
       image_digest: ${{ steps.docker_build.outputs.digest }}
       image_name: ${{ fromJSON(steps.docker_build.outputs.metadata)['image.name'] }}

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -79,6 +79,7 @@ on:
 jobs:
   get-available-disks:
     runs-on: ubuntu-latest
+    environment: development
     name: Find available cached state disks
     outputs:
       lwd_tip_disk: ${{ steps.get-available-disks.outputs.lwd_tip_disk }}
@@ -184,6 +185,7 @@ jobs:
   test-all:
     name: Test all
     runs-on: ubuntu-latest
+    environment: development
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
@@ -206,6 +208,7 @@ jobs:
   test-all-getblocktemplate-rpcs:
     name: Test all with getblocktemplate-rpcs feature
     runs-on: ubuntu-latest
+    environment: development
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
@@ -231,6 +234,7 @@ jobs:
   test-fake-activation-heights:
     name: Test with fake activation heights
     runs-on: ubuntu-latest
+    environment: development
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
@@ -252,6 +256,7 @@ jobs:
   test-empty-sync:
     name: Test checkpoint sync from empty state
     runs-on: ubuntu-latest
+    environment: development
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
@@ -271,6 +276,7 @@ jobs:
   test-lightwalletd-integration:
     name: Test integration with lightwalletd
     runs-on: ubuntu-latest
+    environment: development
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
@@ -291,6 +297,7 @@ jobs:
     name: Test Zebra default Docker config file
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    environment: development
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
@@ -314,6 +321,7 @@ jobs:
     name: Test Zebra custom Docker config file
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    environment: development
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -166,6 +166,7 @@ jobs:
           --create-disk=name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=300GB,type=pd-ssd \
           --container-image=gcr.io/google-containers/busybox \
           --machine-type ${{ vars.GCP_LARGE_MACHINE }} \
+          --network-interface=subnet=projects/zfnd-dev-net-spoke-0/regions/us-east1/subnetworks/dev-default-ue1 \
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \
           --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
@@ -409,6 +410,7 @@ jobs:
           --create-disk=image=${{ env.CACHED_DISK_NAME }},name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=300GB,type=pd-ssd \
           --container-image=gcr.io/google-containers/busybox \
           --machine-type ${{ vars.GCP_LARGE_MACHINE }} \
+          --network-interface=subnet=projects/zfnd-dev-net-spoke-0/regions/us-east1/subnetworks/dev-default-ue1 \
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \
           --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1551,6 +1551,7 @@ jobs:
   create-state-image:
     name: Create ${{ inputs.test_id }} cached state image
     runs-on: ubuntu-latest
+    environment: development
     needs: [ test-result, setup-with-cached-state ]
     # We run exactly one of without-cached-state or with-cached-state, and we always skip the other one.
     # Normally, if a job is skipped, all the jobs that depend on it are also skipped.
@@ -1754,6 +1755,7 @@ jobs:
   delete-instance:
     name: Delete ${{ inputs.test_id }} instance
     runs-on: ubuntu-latest
+    environment: development
     needs: [ create-state-image ]
     # If a disk generation step timeouts (+6 hours) the previous job (creating the image) will be skipped.
     # Even if the instance continues running, no image will be created, so it's better to delete it.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -105,6 +105,7 @@ jobs:
     name: Setup ${{ inputs.test_id }} test
     if: ${{ !inputs.needs_zebra_state }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -198,6 +199,7 @@ jobs:
     # If creating the Google Cloud instance fails, we don't want to launch another docker instance.
     if: ${{ !cancelled() && !failure() && !inputs.needs_zebra_state }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -261,6 +263,7 @@ jobs:
     name: Setup ${{ inputs.test_id }} test
     if: ${{ inputs.needs_zebra_state }}
     runs-on: ubuntu-latest
+    environment: development
     outputs:
       cached_disk_name: ${{ steps.get-disk-name.outputs.cached_disk_name }}
     permissions:
@@ -439,6 +442,7 @@ jobs:
     # If creating the Google Cloud instance fails, we don't want to launch another docker instance.
     if: ${{ !cancelled() && !failure() && inputs.needs_zebra_state }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -575,6 +579,7 @@ jobs:
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -622,6 +627,7 @@ jobs:
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -694,6 +700,7 @@ jobs:
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -761,6 +768,7 @@ jobs:
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -830,6 +838,7 @@ jobs:
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -899,6 +908,7 @@ jobs:
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -969,6 +979,7 @@ jobs:
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -1038,6 +1049,7 @@ jobs:
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -1107,6 +1119,7 @@ jobs:
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -1176,6 +1189,7 @@ jobs:
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -1245,6 +1259,7 @@ jobs:
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -1313,6 +1328,7 @@ jobs:
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -1379,6 +1395,7 @@ jobs:
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -1454,6 +1471,7 @@ jobs:
     # so that the branch protection rule fails in Mergify and GitHub.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
+    environment: development
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
## Motivation

[WIP]

This PR is meant to validate the use of GitHub Environments, which should give us extra visibility when we're deploying to Mainnet, Testnet, to our development environment and later on when we're production ready and have to handle all these different environment differently.

### Specifications

https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-protection-rules

### Complex Code or Requirements

Not yet

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
If this is a large change, list commits of key functional changes here.
-->

## Review

Not ready to review

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
