### PR TITLE
change(release): Add arborist and comms summaries to the release checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -166,8 +166,9 @@ and the updated changelog:
 - [ ] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
 
 
-## Blog Post
+## Telling Zebra Users
 
+- [ ] Post a summary of the important changes in the release in the `#arborist` and `#communications` Slack channels
 If the release contains new features (`major` or `minor`), or high-priority bug fixes:
 - [ ] Ask the team about doing a blog post
 


### PR DESCRIPTION
## Motivation

We want to make it easy to share Zebra releases with users. Currently we do that in Arborist calls, and on Twitter.

## Solution

Add a checklist item for posting a release summary on Slack.

## Review

This is a low priority change.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?

