### PR TITLE
fix(testnet): `listen_addr` default deserialization

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -335,7 +335,7 @@ impl<'de> Deserialize<'de> for Config {
             fn default() -> Self {
                 let config = Config::default();
                 Self {
-                    listen_addr: config.listen_addr.to_string(),
+                    listen_addr: "0.0.0.0".to_string(),
                     network: config.network,
                     initial_mainnet_peers: config.initial_mainnet_peers,
                     initial_testnet_peers: config.initial_testnet_peers,


### PR DESCRIPTION
## Motivation

Resolve a small bug report. Fixes https://github.com/ZcashFoundation/zebra/issues/6386

## Solution

- Changed deserialization to `0.0.0.0` as suggested. 
- Tested manually, bug is gone.
- All tests pass locally.
- Need to see if the CI pass.

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
