### PR TITLE
fix(ci): Delete mainnet and testnet disks separately

### DIFF
--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -115,23 +115,25 @@ jobs:
             IFS=$'\n'
           done
 
-      # Deletes cache images older than $DELETE_AGE_DAYS days.
+      # Deletes mainnet and testnet cache images older than $DELETE_AGE_DAYS days.
       #
       # Keeps all images younger than $DELETE_AGE_DAYS.
-      # Also keeps $KEEP_LATEST_IMAGE_COUNT older images of each type:
+      # Also keeps $KEEP_LATEST_IMAGE_COUNT older images of each type, for each network:
       # - zebrad checkpoint cache
       # - zebrad tip cache
       # - lightwalletd + zebrad tip cache
       #
       # TODO:
-      # - keep the latest $KEEP_LATEST_IMAGE_COUNT, if there are at least that many recent images, delete all the outdated images
-      # - when we add testnet to the workflows, keep the latest $KEEP_LATEST_IMAGE_COUNT testnet images, 
-      #   and the latest $KEEP_LATEST_IMAGE_COUNT mainnet images.
+      # - refactor out repeated shell script code
       - name: Delete old cache disks
         run: |
           DELETE_BEFORE_DATE=$(date --date="$DELETE_AGE_DAYS days ago" '+%Y%m%d')
 
-          ZEBRAD_CHECKPOINT_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*net-checkpoint AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          # As of April 2023, these disk names look like:
+          # zebrad-cache-6039-merge-62c8ecc-v25-mainnet-checkpoint-053559
+          #
+          # Mainnet zebrad checkpoint
+          ZEBRAD_CHECKPOINT_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*-mainnet-checkpoint AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
           KEPT_IMAGES=0
           for IMAGE in $ZEBRAD_CHECKPOINT_IMAGES
           do
@@ -145,7 +147,26 @@ jobs:
             gcloud compute images delete "${IMAGE}" || continue
           done
 
-          ZEBRAD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*net-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          # Testnet zebrad checkpoint
+          ZEBRAD_CHECKPOINT_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*-testnet-checkpoint AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          KEPT_IMAGES=0
+          for IMAGE in $ZEBRAD_CHECKPOINT_IMAGES
+          do
+            if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
+            then
+              KEPT_IMAGES=$((KEPT_IMAGES+1))
+              echo "Keeping image $KEPT_IMAGES named $IMAGE"
+              continue
+            fi
+
+            gcloud compute images delete "${IMAGE}" || continue
+          done
+
+          # As of April 2023, these disk names look like:
+          # zebrad-cache-6556-merge-a2ca4de-v25-mainnet-tip(-u)?-140654
+          #
+          # Mainnet zebrad tip
+          ZEBRAD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*-mainnet-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
           KEPT_IMAGES=0
           for IMAGE in $ZEBRAD_TIP_IMAGES
           do
@@ -158,8 +179,42 @@ jobs:
 
             gcloud compute images delete "${IMAGE}" || continue
           done
-          
-          LWD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^lwd-cache-.*net-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+
+          # Testnet zebrad tip
+          ZEBRAD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*-testnet-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          KEPT_IMAGES=0
+          for IMAGE in $ZEBRAD_TIP_IMAGES
+          do
+            if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
+            then
+              KEPT_IMAGES=$((KEPT_IMAGES+1))
+              echo "Keeping image $KEPT_IMAGES named $IMAGE"
+              continue
+            fi
+
+            gcloud compute images delete "${IMAGE}" || continue
+          done
+
+          # As of April 2023, these disk names look like:
+          # lwd-cache-main-fb3fec0-v25-mainnet-tip(-u)?-061314
+          #
+          # Mainnet lightwalletd tip
+          LWD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^lwd-cache-.*-mainnet-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          KEPT_IMAGES=0
+          for IMAGE in $LWD_TIP_IMAGES
+          do
+            if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
+            then
+              KEPT_IMAGES=$((KEPT_IMAGES+1))
+              echo "Keeping image $KEPT_IMAGES named $IMAGE"
+              continue
+            fi
+
+            gcloud compute images delete "${IMAGE}" || continue
+          done
+
+          # Testnet lightwalletd tip
+          LWD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^lwd-cache-.*-testnet-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
           KEPT_IMAGES=0
           for IMAGE in $LWD_TIP_IMAGES
           do

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -102,7 +102,7 @@ jobs:
             gcloud compute disks delete --verbosity=info ${DISK_AND_LOCATION} || continue
             IFS=$'\n'
           done
-          
+
           IFS=$'\n'
           # Disks created by managed instance groups, and other jobs that start with "zebrad-"
           ZEBRAD_DISKS=$(gcloud compute disks list --sort-by=creationTimestamp --filter="name~^zebrad- AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME,LOCATION,LOCATION_SCOPE)' | \
@@ -136,12 +136,12 @@ jobs:
           for IMAGE in $ZEBRAD_CHECKPOINT_IMAGES
           do
             if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
-            then              
+            then
               KEPT_IMAGES=$((KEPT_IMAGES+1))
               echo "Keeping image $KEPT_IMAGES named $IMAGE"
               continue
             fi
-            
+
             gcloud compute images delete "${IMAGE}" || continue
           done
 
@@ -150,12 +150,12 @@ jobs:
           for IMAGE in $ZEBRAD_TIP_IMAGES
           do
             if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
-            then              
+            then
               KEPT_IMAGES=$((KEPT_IMAGES+1))
               echo "Keeping image $KEPT_IMAGES named $IMAGE"
               continue
             fi
-            
+
             gcloud compute images delete "${IMAGE}" || continue
           done
           
@@ -164,12 +164,12 @@ jobs:
           for IMAGE in $LWD_TIP_IMAGES
           do
             if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
-            then              
+            then
               KEPT_IMAGES=$((KEPT_IMAGES+1))
               echo "Keeping image $KEPT_IMAGES named $IMAGE"
               continue
             fi
-            
+
             gcloud compute images delete "${IMAGE}" || continue
           done
 

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1.1.0
 
-      # Deletes all instances older than $DELETE_INSTANCE_DAYS days.
+      # Deletes all mainnet and testnet instances older than $DELETE_INSTANCE_DAYS days.
       #
       # We only delete instances that end in 7 or more hex characters,
       # to avoid deleting managed instance groups and manually created instances.
@@ -80,7 +80,7 @@ jobs:
             gcloud compute instance-templates delete "${TEMPLATE}" || continue
           done
 
-      # Deletes all the disks older than $DELETE_AGE_DAYS days.
+      # Deletes all mainnet and testnet disks older than $DELETE_AGE_DAYS days.
       #
       # Disks that are attached to an instance template can't be deleted, so it is safe to try to delete all disks here.
       #
@@ -175,6 +175,8 @@ jobs:
 
   # We're using a generic approach here, which allows multiple registries to be included,
   # even those not related to GCP. Enough reason to create a separate job.
+  #
+  # The same artifacts are used for both mainnet and testnet.
   clean-registries:
     name: Delete unused artifacts in registry
     runs-on: ubuntu-latest

--- a/.github/workflows/delete-gcp-resources.yml
+++ b/.github/workflows/delete-gcp-resources.yml
@@ -133,9 +133,9 @@ jobs:
           # zebrad-cache-6039-merge-62c8ecc-v25-mainnet-checkpoint-053559
           #
           # Mainnet zebrad checkpoint
-          ZEBRAD_CHECKPOINT_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*-mainnet-checkpoint AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          ZEBRAD_MAINNET_CHECKPOINT_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*-mainnet-checkpoint AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
           KEPT_IMAGES=0
-          for IMAGE in $ZEBRAD_CHECKPOINT_IMAGES
+          for IMAGE in $ZEBRAD_MAINNET_CHECKPOINT_IMAGES
           do
             if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
             then
@@ -148,9 +148,9 @@ jobs:
           done
 
           # Testnet zebrad checkpoint
-          ZEBRAD_CHECKPOINT_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*-testnet-checkpoint AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          ZEBRAD_TESTNET_CHECKPOINT_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*-testnet-checkpoint AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
           KEPT_IMAGES=0
-          for IMAGE in $ZEBRAD_CHECKPOINT_IMAGES
+          for IMAGE in $ZEBRAD_TESTNET_CHECKPOINT_IMAGES
           do
             if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
             then
@@ -166,9 +166,9 @@ jobs:
           # zebrad-cache-6556-merge-a2ca4de-v25-mainnet-tip(-u)?-140654
           #
           # Mainnet zebrad tip
-          ZEBRAD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*-mainnet-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          ZEBRAD_MAINNET_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*-mainnet-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
           KEPT_IMAGES=0
-          for IMAGE in $ZEBRAD_TIP_IMAGES
+          for IMAGE in $ZEBRAD_MAINNET_TIP_IMAGES
           do
             if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
             then
@@ -181,9 +181,9 @@ jobs:
           done
 
           # Testnet zebrad tip
-          ZEBRAD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*-testnet-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          ZEBRAD_TESTNET_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^zebrad-cache-.*-testnet-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
           KEPT_IMAGES=0
-          for IMAGE in $ZEBRAD_TIP_IMAGES
+          for IMAGE in $ZEBRAD_TESTNET_TIP_IMAGES
           do
             if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
             then
@@ -199,9 +199,9 @@ jobs:
           # lwd-cache-main-fb3fec0-v25-mainnet-tip(-u)?-061314
           #
           # Mainnet lightwalletd tip
-          LWD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^lwd-cache-.*-mainnet-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          LWD_MAINNET_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^lwd-cache-.*-mainnet-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
           KEPT_IMAGES=0
-          for IMAGE in $LWD_TIP_IMAGES
+          for IMAGE in $LWD_MAINNET_TIP_IMAGES
           do
             if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
             then
@@ -214,9 +214,9 @@ jobs:
           done
 
           # Testnet lightwalletd tip
-          LWD_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^lwd-cache-.*-testnet-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
+          LWD_TESTNET_TIP_IMAGES=$(gcloud compute images list --sort-by=~creationTimestamp --filter="name~^lwd-cache-.*-testnet-tip AND creationTimestamp < $DELETE_BEFORE_DATE" --format='value(NAME)')
           KEPT_IMAGES=0
-          for IMAGE in $LWD_TIP_IMAGES
+          for IMAGE in $LWD_TESTNET_TIP_IMAGES
           do
             if [[ "$KEPT_IMAGES" -lt "$KEEP_LATEST_IMAGE_COUNT" ]];
             then


### PR DESCRIPTION
## Motivation

In PR #6581, I started creating testnet cached state disks.

But the current disk cleanup job will treat them like mainnet disks, causing CI bugs like:
- CI will take 3 days to run if all the recent disks are testnet, and all the mainnet disks are deleted 
- CI will fail if all the mainnet disks are deleted in the middle of a job

This is part of #6367.

To avoid these bugs, I temporarily disabled the disk deletion workflow in GitHub Actions.

## Solution

Delete the mainnet and testnet disks separately, so each network always keeps a few disks.

## Review

This is an urgent fix because it could stop all PRs merging for 3 days.

Here's a manual run of this workflow from this branch, after PR #6581 generated some testnet disks:
https://github.com/ZcashFoundation/zebra/actions/runs/4824829115

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Re-enable disk deletion by turning this action back on:
https://github.com/ZcashFoundation/zebra/actions/workflows/delete-gcp-resources.yml