### PR TITLE
change: Add a template for private security issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/private_security_issue.yml
+++ b/.github/ISSUE_TEMPLATE/private_security_issue.yml
@@ -1,0 +1,15 @@
+---
+name: Private Security Issue
+about: Zebra team use only
+title: 'Security Issue #NNN'
+labels: C-security, S-needs-triage
+assignees: ''
+
+---
+
+## Motivation
+
+This ticket is a public placeholder for a security issue that the Zebra team is fixing privately.
+The issue number is chosen by our internal tracker, it is not meaningful.
+
+Zebra developers must discuss the details of this issue using secure channels.


### PR DESCRIPTION
## Motivation

We want to have a standard template for private security issues, so we don't leak any information about the actual problem when we create them.

## Review

This is for Pili to review.

## Follow Up Work

Review how this template is working after we've fixed a few security issues.