### PR TITLE
change(log): Report compiler version and Zebra features when starting Zebra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,26 +1306,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-iterator"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7add3873b5dd076766ee79c8e406ad1a472c385476b9e38849f8eec24f1be689"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
-dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "syn 2.0.15",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,18 +1615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "gimli"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,9 +1622,9 @@ checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "git2"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
+checksum = "8b7905cdfe33d31a88bb2e8419ddd054451f5432d1da9eaf2ac7804ee1ea12d5"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -2325,9 +2293,9 @@ checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.2+1.5.1"
+version = "0.15.1+1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+checksum = "fb4577bde8cdfc7d6a2a4bcb7b049598597de33ffd337276e9c7db6cd4a2cee7"
 dependencies = [
  "cc",
  "libc",
@@ -5211,17 +5179,14 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "7.5.1"
+version = "8.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
+checksum = "6e03272e388fb78fc79481a493424f78d77be1d55f21bcd314b5a6716e195afe"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
- "enum-iterator",
- "getset",
  "git2",
+ "rustc_version 0.4.0",
  "rustversion",
- "thiserror",
  "time 0.3.21",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5220,7 +5220,6 @@ dependencies = [
  "enum-iterator",
  "getset",
  "git2",
- "rustc_version 0.4.0",
  "rustversion",
  "thiserror",
  "time 0.3.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5220,6 +5220,7 @@ dependencies = [
  "enum-iterator",
  "getset",
  "git2",
+ "rustc_version 0.4.0",
  "rustversion",
  "thiserror",
  "time 0.3.21",

--- a/deny.toml
+++ b/deny.toml
@@ -57,7 +57,6 @@ skip-tree = [
     # wait for ed25519-zebra, indexmap, metrics-util, and metrics to upgrade
     # ed25519-zebra/hashbrown: https://github.com/ZcashFoundation/ed25519-zebra/pull/65
     { name = "ahash", version = "=0.7.6" },
-    { name = "hashbrown", version = "=0.12.3" },
 
     # wait for ed25519-zebra to upgrade
     { name = "curve25519-dalek", version = "=3.2.0" },
@@ -96,7 +95,6 @@ skip-tree = [
     # upgrade abscissa (required dependency) and arti (optional dependency)
     { name = "darling", version = "=0.10.2" },
     { name = "semver", version = "=0.9.0" },
-    { name = "signal-hook", version = "=0.1.17" },
     { name = "tracing-subscriber", version = "=0.1.6" },
 
     # Elasticsearch dependencies

--- a/deny.toml
+++ b/deny.toml
@@ -57,6 +57,7 @@ skip-tree = [
     # wait for ed25519-zebra, indexmap, metrics-util, and metrics to upgrade
     # ed25519-zebra/hashbrown: https://github.com/ZcashFoundation/ed25519-zebra/pull/65
     { name = "ahash", version = "=0.7.6" },
+    { name = "hashbrown", version = "=0.12.3" },
 
     # wait for ed25519-zebra to upgrade
     { name = "curve25519-dalek", version = "=3.2.0" },
@@ -95,6 +96,7 @@ skip-tree = [
     # upgrade abscissa (required dependency) and arti (optional dependency)
     { name = "darling", version = "=0.10.2" },
     { name = "semver", version = "=0.9.0" },
+    { name = "signal-hook", version = "=0.1.17" },
     { name = "tracing-subscriber", version = "=0.1.6" },
 
     # Elasticsearch dependencies

--- a/deny.toml
+++ b/deny.toml
@@ -74,9 +74,6 @@ skip-tree = [
 
     # Test-only dependencies
 
-    # wait for console-api -> console-subscriber to upgrade
-    { name = "tonic", version = "=0.8.3" },
-
     # wait for tokio-test -> tokio-stream to upgrade
     { name = "tokio-util", version = "=0.6.10" },
 
@@ -101,11 +98,6 @@ skip-tree = [
 
     # wait for elasticsearch to update base64, darling, rustc_version, serde_with
     { name = "elasticsearch", version = "=8.5.0-alpha.1" },
-
-    # Progress bar dependencies
-
-    # wait for indicatif to update
-    { name = "portable-atomic", version = "=0.3.19" },
 
     # Unused dependencies
 

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -185,7 +185,7 @@ proptest-derive = { version = "0.3.0", optional = true }
 console-subscriber = { version = "0.1.8", optional = true }
 
 [build-dependencies]
-vergen = { version = "8.1.3", default-features = false, features = ["cargo", "git", "gitoxide", "rustc"] }
+vergen = { version = "8.1.3", default-features = false, features = ["cargo", "git", "git2", "rustc"] }
 
 # test feature lightwalletd-grpc-tests
 tonic-build = { version = "0.9.2", optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -185,7 +185,7 @@ proptest-derive = { version = "0.3.0", optional = true }
 console-subscriber = { version = "0.1.8", optional = true }
 
 [build-dependencies]
-vergen = { version = "7.5.1", default-features = false, features = ["cargo", "git"] }
+vergen = { version = "7.5.1", default-features = false, features = ["cargo", "git", "rustc"] }
 
 # test feature lightwalletd-grpc-tests
 tonic-build = { version = "0.9.2", optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -185,7 +185,7 @@ proptest-derive = { version = "0.3.0", optional = true }
 console-subscriber = { version = "0.1.8", optional = true }
 
 [build-dependencies]
-vergen = { version = "7.5.1", default-features = false, features = ["cargo", "git", "rustc"] }
+vergen = { version = "8.1.3", default-features = false, features = ["cargo", "git", "gitoxide", "rustc"] }
 
 # test feature lightwalletd-grpc-tests
 tonic-build = { version = "0.9.2", optional = true }

--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -13,7 +13,7 @@ use vergen::EmitBuilder;
 fn base_vergen_builder() -> EmitBuilder {
     let mut vergen = EmitBuilder::builder();
 
-    vergen.all_cargo().all_rustc().fail_on_error();
+    vergen.all_cargo().all_rustc();
 
     vergen
 }
@@ -29,7 +29,7 @@ fn main() {
     vergen.git_describe(true, true, Some("v*.*.*"));
 
     // Disable git if we're building with an invalid `zebra/.git`
-    match vergen.emit() {
+    match vergen.fail_on_error().emit() {
         Ok(_) => {}
         Err(e) => {
             eprintln!("git error in vergen build script: skipping git env vars: {e:?}",);

--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -3,51 +3,36 @@
 //! Turns Zebra version information into build-time environmental variables,
 //! so that it can be compiled into `zebrad`, and used in diagnostics.
 
-use vergen::{vergen, Config, SemverKind, ShaKind};
+use vergen::EmitBuilder;
 
-/// Disable vergen env vars that could cause spurious reproducible build
-/// failures
-fn disable_non_reproducible(_config: &mut Config) {
-    /*
-    Currently, these features are disabled in `Cargo.toml`
+/// Returns a new `vergen` builder, configured for everything except for `git` env vars.
+/// This builder fails the build on error.
+fn base_vergen_builder() -> EmitBuilder {
+    let mut vergen = EmitBuilder::builder();
 
-    // We don't use build or host-specific env vars, because they can break
-    // reproducible builds.
-    *config.build_mut().enabled_mut() = false;
-    *config.rustc mut().host_triple_mut() = false;
+    vergen.all_cargo().all_rustc().fail_on_error();
 
-    // It's ok for reproducible builds to depend on the build OS. But most other
-    // sysinfo should not change reproducible builds, so we disable it.
-    *config.sysinfo mut().user_mut() = false;
-    *config.sysinfo mut().memory_mut() = false;
-    *config.sysinfo mut().cpu_vendor_mut() = false;
-    *config.sysinfo mut().cpu_core_count_mut() = false;
-    *config.sysinfo mut().cpu_name_mut() = false;
-    *config.sysinfo mut().cpu_brand_mut() = false;
-    *config.sysinfo mut().cpu_frequency_mut() = false;
-     */
+    vergen
 }
 
 /// Process entry point for `zebrad`'s build script
 #[allow(clippy::print_stderr)]
 fn main() {
-    let mut config = Config::default();
-    disable_non_reproducible(&mut config);
+    let mut vergen = base_vergen_builder();
 
-    *config.git_mut().sha_kind_mut() = ShaKind::Short;
-    *config.git_mut().semver_kind_mut() = SemverKind::Lightweight;
-    // git typically uses "-dirty", but we change that so:
-    // - we're explicit and direct about source code state
-    // - it matches the SemVer 2.0 format, using dot separators
-    *config.git_mut().semver_dirty_mut() = Some(".modified");
+    vergen.all_git().git_sha(true);
+    // git adds a "-dirty" flag if there are uncommitted changes.
+    // This doesn't quite match the  SemVer 2.0 format, which uses dot separators.
+    vergen.git_describe(true, true, Some("v*.*.*"));
 
     // Disable git if we're building with an invalid `zebra/.git`
-    match vergen(config.clone()) {
+    match vergen.emit() {
         Ok(_) => {}
         Err(e) => {
             eprintln!("git error in vergen build script: skipping git env vars: {e:?}",);
-            *config.git_mut().enabled_mut() = false;
-            vergen(config).expect("non-git vergen should succeed");
+            base_vergen_builder()
+                .emit()
+                .expect("non-git vergen should succeed");
         }
     }
 

--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -41,9 +41,6 @@ fn main() {
     // - it matches the SemVer 2.0 format, using dot separators
     *config.git_mut().semver_dirty_mut() = Some(".modified");
 
-    // Disable env vars we aren't using right now
-    *config.cargo_mut().features_mut() = false;
-
     // Disable git if we're building with an invalid `zebra/.git`
     match vergen(config.clone()) {
         Ok(_) => {}

--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -2,6 +2,9 @@
 //!
 //! Turns Zebra version information into build-time environmental variables,
 //! so that it can be compiled into `zebrad`, and used in diagnostics.
+//!
+//! When compiling the `lightwalletd` gRPC tests, also builds a gRPC client
+//! Rust API for `lightwalletd`.
 
 use vergen::EmitBuilder;
 

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -59,32 +59,32 @@ pub fn app_config() -> config::Reader<ZebradApp> {
 /// For details, see <https://semver.org/>
 pub fn app_version() -> Version {
     const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
-    let vergen_git_semver: Option<&str> = option_env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT");
+    let vergen_git_describe: Option<&str> = option_env!("VERGEN_GIT_DESCRIBE");
 
-    match vergen_git_semver {
-        // change the git semver format to the semver 2.0 format
-        Some(mut vergen_git_semver) if !vergen_git_semver.is_empty() => {
+    match vergen_git_describe {
+        // change the git describe format to the semver 2.0 format
+        Some(mut vergen_git_describe) if !vergen_git_describe.is_empty() => {
             // strip the leading "v", if present
-            if &vergen_git_semver[0..1] == "v" {
-                vergen_git_semver = &vergen_git_semver[1..];
+            if &vergen_git_describe[0..1] == "v" {
+                vergen_git_describe = &vergen_git_describe[1..];
             }
 
             // split into tag, commit count, hash
-            let rparts: Vec<_> = vergen_git_semver.rsplitn(3, '-').collect();
+            let rparts: Vec<_> = vergen_git_describe.rsplitn(3, '-').collect();
 
             match rparts.as_slice() {
                 // assume it's a cargo package version or a git tag with no hash
-                [_] | [_, _] => vergen_git_semver.parse().unwrap_or_else(|_| {
+                [_] | [_, _] => vergen_git_describe.parse().unwrap_or_else(|_| {
                     panic!(
-                        "VERGEN_GIT_SEMVER without a hash {vergen_git_semver:?} must be valid semver 2.0"
+                        "VERGEN_GIT_DESCRIBE without a hash {vergen_git_describe:?} must be valid semver 2.0"
                     )
                 }),
 
-                // it's the "git semver" format, which doesn't quite match SemVer 2.0
+                // it's the "git describe" format, which doesn't quite match SemVer 2.0
                 [hash, commit_count, tag] => {
                     let semver_fix = format!("{tag}+{commit_count}.{hash}");
                     semver_fix.parse().unwrap_or_else(|_|
-                                                      panic!("Modified VERGEN_GIT_SEMVER {vergen_git_semver:?} -> {rparts:?} -> {semver_fix:?} must be valid. Note: CARGO_PKG_VERSION was {CARGO_PKG_VERSION:?}."))
+                                                      panic!("Modified VERGEN_GIT_DESCRIBE {vergen_git_describe:?} -> {rparts:?} -> {semver_fix:?} must be valid. Note: CARGO_PKG_VERSION was {CARGO_PKG_VERSION:?}."))
                 }
 
                 _ => unreachable!("split is limited to 3 parts"),

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -141,7 +141,7 @@ impl ZebradApp {
     /// not match the compiled source code.
     pub fn git_commit() -> Option<&'static str> {
         const GIT_COMMIT_GCLOUD: Option<&str> = option_env!("SHORT_SHA");
-        const GIT_COMMIT_VERGEN: Option<&str> = option_env!("VERGEN_GIT_SHA_SHORT");
+        const GIT_COMMIT_VERGEN: Option<&str> = option_env!("VERGEN_GIT_SHA");
 
         GIT_COMMIT_GCLOUD.or(GIT_COMMIT_VERGEN)
     }

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -283,7 +283,8 @@ impl Application for ZebradApp {
             ("target triple", env!("VERGEN_CARGO_TARGET_TRIPLE")),
             ("rust compiler", env!("VERGEN_RUSTC_SEMVER")),
             ("rust release date", env!("VERGEN_RUSTC_COMMIT_DATE")),
-            ("build profile", env!("VERGEN_CARGO_PROFILE")),
+            ("optimization level", env!("VERGEN_CARGO_OPT_LEVEL")),
+            ("debug checks", env!("VERGEN_CARGO_DEBUG")),
         ]
         .iter()
         .map(|(k, v)| (*k, v.to_string()))

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -259,6 +259,7 @@ impl Application for ZebradApp {
             ("Zcash network", config.network.network.to_string()),
             // constants
             ("state version", DATABASE_FORMAT_VERSION.to_string()),
+            ("features", env!("VERGEN_CARGO_FEATURES").to_string()),
         ];
 
         // git env vars can be skipped if there is no `.git` during the
@@ -280,6 +281,8 @@ impl Application for ZebradApp {
 
         let build_metadata: Vec<_> = [
             ("target triple", env!("VERGEN_CARGO_TARGET_TRIPLE")),
+            ("rust compiler", env!("VERGEN_RUSTC_SEMVER")),
+            ("rust release date", env!("VERGEN_RUSTC_COMMIT_DATE")),
             ("build profile", env!("VERGEN_CARGO_PROFILE")),
         ]
         .iter()


### PR DESCRIPTION
## Motivation

We want to report the compiler version when Zebra panics, and when it starts up. This helps us diagnose some bugs.

As part of this change, I updated the vergen version, because it changes how the compiler version works.

Close #5422 
Close #6421

### Specifications

API reference:
https://docs.rs/vergen/latest/vergen/index.html#usage

### Complex Code or Requirements

This might break some of Zebra's existing version-handling code, which expects a semver-compliant version number.

It might also cause issues in PR #6601, which manually parses the version number.

## Solution

- Add the compiler version and compiler date (for nightly compilers) to logs and panics

Related changes:
- Add a list of enabled Zebra features to logs and panics
- Upgrade to vergen version 8 (ticket #6421)
    - Rewrite the vergen build script
    - Remove outdated disabled reproducible build code, vergen now has an env var to activate it
    - Replace the cargo profile with debug checks and optimization level
    - Change some environmental variable names
    - Turn vergen build errors into compiler warnings if `.git` doesn't exist

### Testing

See my manual testing here:
https://github.com/ZcashFoundation/zebra/pull/6606#issuecomment-1534001427

## Review

This is a routine change.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
