### PR TITLE
fix(ci): Update cached disk patch job name

### DIFF
--- a/.github/workflows/continous-integration-docker.patch.yml
+++ b/.github/workflows/continous-integration-docker.patch.yml
@@ -24,8 +24,9 @@ on:
       - '.github/workflows/build-docker-image.yml'
 
 jobs:
+  # We don't patch the testnet job, because testnet isn't required to merge (it's too unstable)
   get-available-disks:
-    name: Find available cached state disks
+    name: Check if cached state disks exist for Mainnet / Check if cached state disks exist
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'


### PR DESCRIPTION
## Motivation

This patch job update was missed in PR #6576.

## Solution

Use the new name for the mainnet job.

Don't patch testnet, because it isn't required to merge.

## Review

@gustavovalverde offered to review this one.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- [ ] Admin: Add this job name to the `main` branch protection rules