### PR TITLE
fix(clippy): Resolve nightly clippy lints

### DIFF
--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -77,7 +77,7 @@ where
         Self {
             network,
             state: Timeout::new(state, UTXO_LOOKUP_TIMEOUT),
-            script_verifier: script::Verifier::default(),
+            script_verifier: script::Verifier,
         }
     }
 }

--- a/zebra-network/src/peer_set/unready_service/tests/vectors.rs
+++ b/zebra-network/src/peer_set/unready_service/tests/vectors.rs
@@ -31,7 +31,7 @@ async fn unready_service_result_ok() {
         key: Some(MockKey),
         cancel,
         service: Some(mock_client),
-        _req: PhantomData::default(),
+        _req: PhantomData,
     };
 
     let result = unready_service.await;
@@ -50,7 +50,7 @@ async fn unready_service_result_canceled() {
         key: Some(MockKey),
         cancel,
         service: Some(mock_client),
-        _req: PhantomData::default(),
+        _req: PhantomData,
     };
 
     cancel_sender
@@ -73,7 +73,7 @@ async fn unready_service_result_cancel_handle_dropped() {
         key: Some(MockKey),
         cancel,
         service: Some(mock_client),
-        _req: PhantomData::default(),
+        _req: PhantomData,
     };
 
     std::mem::drop(cancel_sender);

--- a/zebra-state/src/service/check/tests/nullifier.rs
+++ b/zebra-state/src/service/check/tests/nullifier.rs
@@ -1033,7 +1033,7 @@ fn transaction_v4_with_joinsplit_data(
         joinsplit_data.first.vpub_old = zero_amount;
         joinsplit_data.first.vpub_new = zero_amount;
 
-        for mut joinsplit in &mut joinsplit_data.rest {
+        for joinsplit in &mut joinsplit_data.rest {
             joinsplit.vpub_old = zero_amount;
             joinsplit.vpub_new = zero_amount;
         }


### PR DESCRIPTION
## Motivation

Nightly clippy has new lints.

## Solution

- remove unused `mut` in tests
- remove unused `default()`s in production and test code

## Review

This is a routine cleanup. It doesn't need to be in the next release.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

