### PR TITLE
refactor(ci): migrate from abandoned `actions-rs/*`

### DIFF
--- a/.github/workflows/build-crates-individually.patch.yml
+++ b/.github/workflows/build-crates-individually.patch.yml
@@ -25,13 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.2
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      # Setup Rust with stable toolchain and minimal profile
+      - name: Setup Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
 
-      - uses: actions-rs/cargo@v1.0.3
       # This step is meant to dynamically create a JSON containing the values of each crate
       # available in this repo in the root directory. We use `cargo tree` to accomplish this task.
       #

--- a/.github/workflows/build-crates-individually.yml
+++ b/.github/workflows/build-crates-individually.yml
@@ -52,13 +52,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.2
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      # Setup Rust with stable toolchain and minimal profile
+      - name: Setup Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
 
-      - uses: actions-rs/cargo@v1.0.3
       # This step is meant to dynamically create a JSON containing the values of each crate
       # available in this repo in the root directory. We use `cargo tree` to accomplish this task.
       #
@@ -117,30 +115,23 @@ jobs:
           version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      # Setup Rust with stable toolchain and minimal profile
+      - name: Setup Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
 
         # We could use `features: ['', '--all-features', '--no-default-features']` as a matrix argument,
         # but it's faster to run these commands sequentially, so they can re-use the local cargo cache.
         #
         # Some Zebra crates do not have any features, and most don't have any default features.
       - name: Build ${{ matrix.crate }} crate with no default features
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: build
-          args: --package ${{ matrix.crate }} --no-default-features
+        run: |
+          cargo build --package ${{ matrix.crate }} --no-default-features
 
       - name: Build ${{ matrix.crate }} crate normally
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: build
-          args: --package ${{ matrix.crate }}
+        run: |
+          cargo build --package ${{ matrix.crate }}
 
       - name: Build ${{ matrix.crate }} crate with all features
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: build
-          args: --package ${{ matrix.crate }} --all-features
+        run: |
+          cargo build --package ${{ matrix.crate }} --all-features

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -94,13 +94,13 @@ jobs:
           version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
+      # Setup Rust with ${{ matrix.rust }} toolchain and minimal profile
+      - name: Setup Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=${{ matrix.rust }} --profile=minimal
 
-      - uses: Swatinem/rust-cache@v1
+
+      - uses: Swatinem/rust-cache@v2.2.1
         # TODO: change Rust cache target directory on Windows,
         #       or remove this workaround once the build is more efficient (#3005).
         #with:
@@ -120,9 +120,8 @@ jobs:
           echo "CARGO_TARGET_DIR=C:\\zebra-target" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
 
       - name: cargo fetch
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: fetch
+        run: |
+          cargo fetch
 
       - name: Install LLVM on Windows
         if: matrix.os == 'windows-latest'
@@ -177,10 +176,8 @@ jobs:
       #
       # If some tests hang, add "-- --nocapture" for just that test, or for all the tests.
       - name: Run tests${{ matrix.features }}
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: test
-          args: ${{ matrix.features }} --release --verbose --workspace
+        run: |
+          cargo test ${{ matrix.features }} --release --verbose --workspace
 
       # Explicitly run any tests that are usually #[ignored]
 
@@ -189,11 +186,8 @@ jobs:
         # Currently, this also skips large sync with `getblocktemplate-rpcs`,
         # but that is already covered by the Docker tests.
         if: matrix.os == 'macos-latest'
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: test
-          # Note: this only runs the zebrad acceptance tests, because re-running all the test binaries is slow on Windows
-          args: ${{ matrix.features }} --release --verbose --package zebrad --test acceptance -- --nocapture --include-ignored sync_large_checkpoints_
+        run: |
+          cargo test ${{ matrix.features }} --release --verbose --package zebrad --test acceptance -- --nocapture --include-ignored sync_large_checkpoints_
 
   # Install Zebra with lockfile dependencies, with no caching and default features
   install-from-lockfile-no-cache:
@@ -206,17 +200,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      # Setup Rust with stable toolchain and minimal profile
+      - name: Setup Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
 
-      - name: Install
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: install
-          args: --locked --path ./zebrad/ zebrad
+      - name: Install zebrad
+        run: |
+          cargo install --locked --path ./zebrad/ zebrad
 
   # Check that Cargo.lock includes any Cargo.toml changes.
   # This check makes sure the `cargo-deny` crate dependency checks are accurate.
@@ -237,22 +228,18 @@ jobs:
           version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      # Setup Rust with stable toolchain and minimal profile
+      - name: Setup Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2.2.1
         with:
-          # TODO: change to shared-key when we switch to Swatinem/rust-cache@v2
-          sharedKey: "clippy-cargo-lock"
+          shared-key: "clippy-cargo-lock"
 
       - name: Check Cargo.lock is up to date
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: check
-          args: --locked --all-features --all-targets
+        run: |
+          cargo check --locked --all-features --all-targets
 
   cargo-deny:
     name: Check deny.toml ${{ matrix.checks }} ${{ matrix.features }}
@@ -290,12 +277,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      # Setup Rust with stable toolchain and minimal profile
+      - name: Setup Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
 
       - name: Install cargo-machete
         uses: baptiste0928/cargo-install@v2.0.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,12 +61,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          toolchain: stable
-          override: true
-          profile: minimal
-          components: llvm-tools-preview
+      # Setup Rust with stable toolchain and minimal profile
+      - name: Setup Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal --component=llvm-tools-preview
 
       - name: Install cargo-llvm-cov cargo command
         run: cargo install cargo-llvm-cov

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,14 +51,12 @@ jobs:
           version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install latest beta
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
-          components: rust-docs
-          override: true
+      # Setup Rust with beta toolchain and default profile (to include rust-docs)
+      - name: Setup Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=beta --profile=default
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2.2.1
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1.2.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -83,7 +83,6 @@ jobs:
 
       # Setup Rust with stable toolchain and default profile
       - name: Setup Rust
-        if: ${{ !steps.check_permissions.outputs.has-permission }}
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
 
@@ -91,7 +90,17 @@ jobs:
         with:
           shared-key: "clippy-cargo-lock"
 
-      - name: Run clippy
+      # TODO: keep this action until we find a better solution
+      - name: Run clippy action to produce annotations
+        uses: actions-rs/clippy-check@v1.0.7
+        if: ${{ steps.check_permissions.outputs.has-permission }}
+        with:
+          # GitHub displays the clippy job and its results as separate entries
+          name: Clippy (stable) Results
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features --all-targets -- -D warnings
+
+      - name: Run clippy manually without annotations
         if: ${{ !steps.check_permissions.outputs.has-permission }}
         run: cargo clippy --all-features --all-targets -- -D warnings
 
@@ -116,7 +125,6 @@ jobs:
 
       # Setup Rust with stable toolchain and default profile
       - name: Setup Rust
-        if: ${{ !steps.check_permissions.outputs.has-permission }}
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
 
@@ -155,7 +163,6 @@ jobs:
 
       # Setup Rust with stable toolchain and default profile
       - name: Setup Rust
-        if: ${{ !steps.check_permissions.outputs.has-permission }}
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,27 +81,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: Swatinem/rust-cache@v1
-        with:
-          # TODO: change to shared-key when we switch to Swatinem/rust-cache@v2
-          sharedKey: "clippy-cargo-lock"
-
-      - name: Run clippy action to produce annotations
-        uses: actions-rs/clippy-check@v1.0.7
-        if: ${{ steps.check_permissions.outputs.has-permission }}
-        with:
-          # GitHub displays the clippy job and its results as separate entries
-          name: Clippy (stable) Results
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets -- -D warnings
-
-      - uses: actions-rs/toolchain@v1.0.1
+      # Setup Rust with stable toolchain and default profile
+      - name: Setup Rust
         if: ${{ !steps.check_permissions.outputs.has-permission }}
-        with:
-          toolchain: stable
-          override: true
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
 
-      - name: Run clippy manually without annotations
+      - uses: Swatinem/rust-cache@v2.2.1
+        with:
+          shared-key: "clippy-cargo-lock"
+
+      - name: Run clippy
         if: ${{ !steps.check_permissions.outputs.has-permission }}
         run: cargo clippy --all-features --all-targets -- -D warnings
 
@@ -124,20 +114,18 @@ jobs:
           version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: stable
-          components: rustfmt
-          override: true
+      # Setup Rust with stable toolchain and default profile
+      - name: Setup Rust
+        if: ${{ !steps.check_permissions.outputs.has-permission }}
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
 
       # We don't cache `fmt` outputs because the job is quick,
       # and we want to use the limited GitHub actions cache space for slower jobs.
-      #- uses: Swatinem/rust-cache@v1
+      #- uses: Swatinem/rust-cache@v2.2.1
 
-      - uses: actions-rs/cargo@v1.0.3
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: |
+          cargo fmt --all -- --check
 
   docs:
     name: Rust doc
@@ -165,16 +153,14 @@ jobs:
           version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      # Setup Rust with stable toolchain and default profile
+      - name: Setup Rust
+        if: ${{ !steps.check_permissions.outputs.has-permission }}
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
 
-      - uses: actions-rs/cargo@v1.0.3
-        with:
-          command: doc
-          args: --no-deps --document-private-items --all-features
+      - run: |
+          cargo doc --no-deps --document-private-items --all-features
 
   actionlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

All Rust related repositories at `actions-rs/*` are no longer being maintained

Fixes: #6048 

## Solution

- Do not depend on external actions if we have a way to do it manually with little verbosity
- Setup Rust and Cargo using their official documentation https://doc.rust-lang.org/cargo/getting-started/installation.html
- Install Toolchains, Components and Profiles with manual instructions: https://rust-lang.github.io/rustup/concepts/toolchains.html

## Review

Anyone from @ZcashFoundation/devops-reviewers 

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
