### PR TITLE
fix(deployment): explicitly use a service account and region

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -159,9 +159,11 @@ jobs:
           --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }},auto-delete=yes,size=300GB,type=pd-ssd \
           --container-mount-disk=mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ vars.GCP_SMALL_MACHINE }} \
+          --service-account ${{ vars.GCP_DEPLOYMENTS_SA }} \
           --scopes cloud-platform \
           --labels=app=zebrad,environment=prod,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
-          --tags zebrad
+          --tags zebrad \
+          --zone ${{ vars.GCP_ZONE }}
 
       # Check if our destination instance group exists already
       - name: Check if instance group exists
@@ -245,6 +247,7 @@ jobs:
           --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }},auto-delete=yes,size=300GB,type=pd-ssd \
           --container-mount-disk=mount-path='/zebrad-cache',name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ vars.GCP_SMALL_MACHINE }} \
-          --zone ${{ vars.GCP_ZONE }} \
+          --service-account ${{ vars.GCP_DEPLOYMENTS_SA }} \
           --labels=app=zebrad,environment=qa,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
-          --tags zebrad
+          --tags zebrad \
+          --zone ${{ vars.GCP_ZONE }}

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -67,10 +67,11 @@ jobs:
           --container-image electriccoinco/zcashd \
           --container-env ZCASHD_NETWORK="${{ inputs.network }}" \
           --machine-type ${{ vars.GCP_SMALL_MACHINE }} \
-          --service-account ${{ env.DEPLOY_SA }} \
+          --service-account ${{ vars.GCP_DEPLOYMENTS_SA }} \
           --scopes cloud-platform \
           --labels=app=zcashd,environment=prod,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
-          --tags zcashd
+          --tags zcashd \
+          --zone ${{ vars.GCP_ZONE }}
 
       # Check if our destination instance group exists already
       - name: Check if instance group exists


### PR DESCRIPTION
## Motivation

Some deployments were using default networks, which we no longer allow on our deployments.

## Solution

- Adding the network zone specified at our `${{ vars.GCP_ZONE }}` variable
- Also adding `${{ vars.GCP_DEPLOYMENTS_SA }}` to avoid future issues

## Review

Anyone from the DevOps team

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
