### PR TITLE
ci: unpin specific `buildkit` version and fix deployment subnets

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -110,12 +110,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          # TODO: change after new buildkit version gets fixed
-          # https://github.com/moby/buildkit/issues/3347
-          # https://github.com/docker/build-push-action/issues/761#issuecomment-1383822381
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
 
       - name: Authenticate to Google Cloud
         id: auth

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -159,6 +159,7 @@ jobs:
           --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }},auto-delete=yes,size=300GB,type=pd-ssd \
           --container-mount-disk=mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ vars.GCP_SMALL_MACHINE }} \
+          --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \
           --service-account ${{ vars.GCP_DEPLOYMENTS_SA }} \
           --scopes cloud-platform \
           --labels=app=zebrad,environment=prod,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
@@ -247,6 +248,7 @@ jobs:
           --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }},auto-delete=yes,size=300GB,type=pd-ssd \
           --container-mount-disk=mount-path='/zebrad-cache',name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }} \
           --machine-type ${{ vars.GCP_SMALL_MACHINE }} \
+          --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \
           --service-account ${{ vars.GCP_DEPLOYMENTS_SA }} \
           --labels=app=zebrad,environment=qa,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
           --tags zebrad \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -165,6 +165,7 @@ jobs:
           --create-disk=name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=300GB,type=pd-ssd \
           --container-image=gcr.io/google-containers/busybox \
           --machine-type ${{ vars.GCP_LARGE_MACHINE }} \
+          --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \
           --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
@@ -406,6 +407,7 @@ jobs:
           --create-disk=image=${{ env.CACHED_DISK_NAME }},name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=300GB,type=pd-ssd \
           --container-image=gcr.io/google-containers/busybox \
           --machine-type ${{ vars.GCP_LARGE_MACHINE }} \
+          --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \
           --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \

--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -106,12 +106,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          # TODO: change after new buildkit version gets fixed
-          # https://github.com/moby/buildkit/issues/3347
-          # https://github.com/docker/build-push-action/issues/761#issuecomment-1383822381
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -67,6 +67,7 @@ jobs:
           --container-image electriccoinco/zcashd \
           --container-env ZCASHD_NETWORK="${{ inputs.network }}" \
           --machine-type ${{ vars.GCP_SMALL_MACHINE }} \
+          --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \
           --service-account ${{ vars.GCP_DEPLOYMENTS_SA }} \
           --scopes cloud-platform \
           --labels=app=zcashd,environment=prod,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \


### PR DESCRIPTION
## Motivation

We previously had an issue with the following error: `cannot reuse body, request must be retried` and it's happening once again, but it might be for a different reason.

This commonly was a wrong error, caused by a containerd issue which has being tracked and solved here: https://github.com/docker/build-push-action/issues/761#issuecomment-1406261692

We had this previously reported in: https://github.com/ZcashFoundation/zebra/issues/3665

This PR also fixes the following error:

```
Invalid value for field 'resource.networkInterfaces[0].network': 'https://compute.googleapis.com/compute/v1/projects/zfnd-dev-zebra/global/networks/default'. The referenced network resource cannot be found.
```

### Specifications

We're having errors when building, and this might be caused by an underlying error which containerd is not showing us correctly.

## Solution

- Unpin our old `buildkit` version and use the latest with included fixes
- GCP VMs not only need a specific region set, but also a subnetwork, as we don't have default subnetworks available (those have to be explicitly created)

## Review

Anyone from DevOps team

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
