### PR TITLE
ci(deploy): templates do not allow the `zone` argument

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -163,8 +163,7 @@ jobs:
           --service-account ${{ vars.GCP_DEPLOYMENTS_SA }} \
           --scopes cloud-platform \
           --labels=app=zebrad,environment=prod,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
-          --tags zebrad \
-          --zone ${{ vars.GCP_ZONE }}
+          --tags zebrad
 
       # Check if our destination instance group exists already
       - name: Check if instance group exists

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -71,8 +71,7 @@ jobs:
           --service-account ${{ vars.GCP_DEPLOYMENTS_SA }} \
           --scopes cloud-platform \
           --labels=app=zcashd,environment=prod,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }} \
-          --tags zcashd \
-          --zone ${{ vars.GCP_ZONE }}
+          --tags zcashd
 
       # Check if our destination instance group exists already
       - name: Check if instance group exists


### PR DESCRIPTION
## Motivation

We introduced a bug in https://github.com/ZcashFoundation/zebra/pull/6643

## Solution

Removed unsupported argument from the `gcloud compute instance-templates` command

## Review

Anyone from DevOps

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
