### PR TITLE
docs(release-checklist): add cargo update steps to task list

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -94,7 +94,7 @@ Sometimes `dependabot` misses some dependency updates, or we accidentally turned
 Here's how we make sure we got everything:
 - [ ] Run `cargo update` on the latest `main` branch, and keep the output
 - [ ] If needed, update [deny.toml](https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
-- [ ] Open a separate PR with the changes, including the output of `cargo update`
+- [ ] Open a separate PR with the changes, and add the output of `cargo update` to that PR as a comment
 
 ## Change Log
 

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -92,9 +92,9 @@ You can copy the latest checkpoints from CI by following [the zebra-checkpoints 
 Sometimes `dependabot` misses some dependency updates, or we accidentally turned them off.
 
 Here's how we make sure we got everything:
-1. Run `cargo update` on the latest `main` branch, and keep the output
-2. If needed, update [deny.toml](https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
-3. Open a separate PR with the changes, including the output of `cargo update`
+- [ ] Run `cargo update` on the latest `main` branch, and keep the output
+- [ ] If needed, update [deny.toml](https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
+- [ ] Open a separate PR with the changes, including the output of `cargo update`
 
 ## Change Log
 

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -184,6 +184,7 @@ and the updated changelog:
 ## Telling Zebra Users
 
 - [ ] Post a summary of the important changes in the release in the `#arborist` and `#communications` Slack channels
+
 If the release contains new features (`major` or `minor`), or high-priority bug fixes:
 - [ ] Ask the team about doing a blog post
 


### PR DESCRIPTION
## Motivation

The cargo update steps were missing in original PR for the next release (https://github.com/ZcashFoundation/zebra/pull/6632#discussion_r1189188333).

I think that to to make sure this is done we can add the steps of it to the tasklist.

## Solution

Add cargo update steps as task list.

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

