### PR TITLE
Revert "refactor(ci): migrate from abandoned `actions-rs/*`"

### DIFF
--- a/.github/workflows/build-crates-individually.patch.yml
+++ b/.github/workflows/build-crates-individually.patch.yml
@@ -25,11 +25,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.2
 
-      # Setup Rust with stable toolchain and minimal profile
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
 
+      - uses: actions-rs/cargo@v1.0.3
       # This step is meant to dynamically create a JSON containing the values of each crate
       # available in this repo in the root directory. We use `cargo tree` to accomplish this task.
       #

--- a/.github/workflows/build-crates-individually.yml
+++ b/.github/workflows/build-crates-individually.yml
@@ -52,11 +52,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.2
 
-      # Setup Rust with stable toolchain and minimal profile
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
 
+      - uses: actions-rs/cargo@v1.0.3
       # This step is meant to dynamically create a JSON containing the values of each crate
       # available in this repo in the root directory. We use `cargo tree` to accomplish this task.
       #
@@ -115,23 +117,30 @@ jobs:
           version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Setup Rust with stable toolchain and minimal profile
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
 
         # We could use `features: ['', '--all-features', '--no-default-features']` as a matrix argument,
         # but it's faster to run these commands sequentially, so they can re-use the local cargo cache.
         #
         # Some Zebra crates do not have any features, and most don't have any default features.
       - name: Build ${{ matrix.crate }} crate with no default features
-        run: |
-          cargo build --package ${{ matrix.crate }} --no-default-features
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+          args: --package ${{ matrix.crate }} --no-default-features
 
       - name: Build ${{ matrix.crate }} crate normally
-        run: |
-          cargo build --package ${{ matrix.crate }}
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+          args: --package ${{ matrix.crate }}
 
       - name: Build ${{ matrix.crate }} crate with all features
-        run: |
-          cargo build --package ${{ matrix.crate }} --all-features
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+          args: --package ${{ matrix.crate }} --all-features

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -94,13 +94,13 @@ jobs:
           version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Setup Rust with ${{ matrix.rust }} toolchain and minimal profile
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=${{ matrix.rust }} --profile=minimal
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
 
-
-      - uses: Swatinem/rust-cache@v2.2.1
+      - uses: Swatinem/rust-cache@v1
         # TODO: change Rust cache target directory on Windows,
         #       or remove this workaround once the build is more efficient (#3005).
         #with:
@@ -120,8 +120,9 @@ jobs:
           echo "CARGO_TARGET_DIR=C:\\zebra-target" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
 
       - name: cargo fetch
-        run: |
-          cargo fetch
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: fetch
 
       - name: Install LLVM on Windows
         if: matrix.os == 'windows-latest'
@@ -176,8 +177,10 @@ jobs:
       #
       # If some tests hang, add "-- --nocapture" for just that test, or for all the tests.
       - name: Run tests${{ matrix.features }}
-        run: |
-          cargo test ${{ matrix.features }} --release --verbose --workspace
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+          args: ${{ matrix.features }} --release --verbose --workspace
 
       # Explicitly run any tests that are usually #[ignored]
 
@@ -186,8 +189,11 @@ jobs:
         # Currently, this also skips large sync with `getblocktemplate-rpcs`,
         # but that is already covered by the Docker tests.
         if: matrix.os == 'macos-latest'
-        run: |
-          cargo test ${{ matrix.features }} --release --verbose --package zebrad --test acceptance -- --nocapture --include-ignored sync_large_checkpoints_
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+          # Note: this only runs the zebrad acceptance tests, because re-running all the test binaries is slow on Windows
+          args: ${{ matrix.features }} --release --verbose --package zebrad --test acceptance -- --nocapture --include-ignored sync_large_checkpoints_
 
   # Install Zebra with lockfile dependencies, with no caching and default features
   install-from-lockfile-no-cache:
@@ -200,14 +206,17 @@ jobs:
         with:
           persist-credentials: false
 
-      # Setup Rust with stable toolchain and minimal profile
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
 
-      - name: Install zebrad
-        run: |
-          cargo install --locked --path ./zebrad/ zebrad
+      - name: Install
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: install
+          args: --locked --path ./zebrad/ zebrad
 
   # Check that Cargo.lock includes any Cargo.toml changes.
   # This check makes sure the `cargo-deny` crate dependency checks are accurate.
@@ -228,18 +237,22 @@ jobs:
           version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Setup Rust with stable toolchain and minimal profile
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
-
-      - uses: Swatinem/rust-cache@v2.2.1
+      - uses: actions-rs/toolchain@v1
         with:
-          shared-key: "clippy-cargo-lock"
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          # TODO: change to shared-key when we switch to Swatinem/rust-cache@v2
+          sharedKey: "clippy-cargo-lock"
 
       - name: Check Cargo.lock is up to date
-        run: |
-          cargo check --locked --all-features --all-targets
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          args: --locked --all-features --all-targets
 
   cargo-deny:
     name: Check deny.toml ${{ matrix.checks }} ${{ matrix.features }}
@@ -277,10 +290,12 @@ jobs:
         with:
           persist-credentials: false
 
-      # Setup Rust with stable toolchain and minimal profile
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
 
       - name: Install cargo-machete
         uses: baptiste0928/cargo-install@v2.0.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,10 +61,12 @@ jobs:
         with:
           persist-credentials: false
 
-      # Setup Rust with stable toolchain and minimal profile
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal --component=llvm-tools-preview
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov cargo command
         run: cargo install cargo-llvm-cov

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,12 +51,14 @@ jobs:
           version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Setup Rust with beta toolchain and default profile (to include rust-docs)
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=beta --profile=default
+      - name: Install latest beta
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: beta
+          components: rust-docs
+          override: true
 
-      - uses: Swatinem/rust-cache@v2.2.1
+      - uses: Swatinem/rust-cache@v1
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1.2.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,16 +81,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Setup Rust with stable toolchain and default profile
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
-
-      - uses: Swatinem/rust-cache@v2.2.1
+      - uses: Swatinem/rust-cache@v1
         with:
-          shared-key: "clippy-cargo-lock"
+          # TODO: change to shared-key when we switch to Swatinem/rust-cache@v2
+          sharedKey: "clippy-cargo-lock"
 
-      # TODO: keep this action until we find a better solution
       - name: Run clippy action to produce annotations
         uses: actions-rs/clippy-check@v1.0.7
         if: ${{ steps.check_permissions.outputs.has-permission }}
@@ -99,6 +94,12 @@ jobs:
           name: Clippy (stable) Results
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
+
+      - uses: actions-rs/toolchain@v1.0.1
+        if: ${{ !steps.check_permissions.outputs.has-permission }}
+        with:
+          toolchain: stable
+          override: true
 
       - name: Run clippy manually without annotations
         if: ${{ !steps.check_permissions.outputs.has-permission }}
@@ -123,17 +124,20 @@ jobs:
           version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Setup Rust with stable toolchain and default profile
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
+      - uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: stable
+          components: rustfmt
+          override: true
 
       # We don't cache `fmt` outputs because the job is quick,
       # and we want to use the limited GitHub actions cache space for slower jobs.
-      #- uses: Swatinem/rust-cache@v2.2.1
+      #- uses: Swatinem/rust-cache@v1
 
-      - run: |
-          cargo fmt --all -- --check
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: fmt
+          args: --all -- --check
 
   docs:
     name: Rust doc
@@ -161,13 +165,16 @@ jobs:
           version: '3.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Setup Rust with stable toolchain and default profile
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
+      - uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
 
-      - run: |
-          cargo doc --no-deps --document-private-items --all-features
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: doc
+          args: --no-deps --document-private-items --all-features
 
   actionlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts ZcashFoundation/zebra#6628

## Motivation

We started getting internal GitHub Actions errors after merging this PR to `main`:
https://github.com/ZcashFoundation/zebra/actions/runs/4938132684

It's hard to tell if that change is the cause, because GitHub is also having infrastructure issues:
https://www.githubstatus.com/