### PR TITLE
fix(ci): Allow testnet syncs to take longer than 6 hours

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -479,8 +479,9 @@ jobs:
       # The value of FULL_SYNC_TESTNET_TIMEOUT_MINUTES is currently ignored.
       test_variables: '-e FULL_SYNC_TESTNET_TIMEOUT_MINUTES=0 -e ZEBRA_FORCE_USE_COLOR=1'
       network: 'Testnet'
-      # A full testnet sync took about 2 hours in April 2023
-      is_long_test: false
+      # A full testnet sync could take 2-10 hours in April 2023.
+      # The time varies a lot due to the small number of nodes.
+      is_long_test: true
       needs_zebra_state: false
       saves_to_disk: true
       disk_suffix: tip


### PR DESCRIPTION
## Motivation

Testnet syncs can be as short as 2 hours, but also take over 6 hours, depending on which testnet nodes are running at the time.

## Solution

Allow this job to take longer than 6 hours.

## Review

This is a fix for a CI failure on `main`, so it's urgent. It doesn't need to be documented in the CHANGELOG.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?

