### PR TITLE
fix(ci): Run all the duplicate dependency checks, even if one fails

### DIFF
--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -250,6 +250,8 @@ jobs:
           - bans
           - sources
         features: ['', '--all-features', '--no-default-features']
+      # We always want to run the --all-features job, because it gives accurate "skip tree root was not found" warnings
+      fail-fast: false
 
     # Prevent sudden announcement of a new advisory from failing ci:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
@@ -259,8 +261,8 @@ jobs:
         with:
           persist-credentials: false
 
-      # this check also runs with optional features off
-      # so we expect some warnings about "skip tree root was not found"
+      # The --all-features job is the only job that gives accurate "skip tree root was not found" warnings.
+      # In other jobs, we expect some of these warnings, due to disabled features.
       - name: Check ${{ matrix.checks }} with features ${{ matrix.features }}
         uses: EmbarkStudios/cargo-deny-action@v1
         with:


### PR DESCRIPTION
## Motivation

Sometimes we need to see the output of a specific duplicate dependency job to fix a dependency update PR.

### Specifications

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast

## Solution

Run all the duplicate dependency jobs to completion, even if one fails.

These jobs are quick, so this won't change CI run time.

## Review

This is a fix that is needed to fix other open PRs. It doesn't need to go in the changelog.

### Reviewer Checklist

  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?

