### PR TITLE
fix(tests): Add an integration test for error conversions from zebra-state to zebra-consensus

### DIFF
--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -267,7 +267,7 @@ pub enum ValidateContextError {
 }
 
 /// Trait for creating the corresponding duplicate nullifier error from a nullifier.
-pub(crate) trait DuplicateNullifierError {
+pub trait DuplicateNullifierError {
     /// Returns the corresponding duplicate nullifier error for `self`.
     fn duplicate_nullifier_error(&self, in_finalized_state: bool) -> ValidateContextError;
 }

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -31,7 +31,9 @@ mod tests;
 
 pub use config::{check_and_delete_old_databases, Config};
 pub use constants::MAX_BLOCK_REORG_HEIGHT;
-pub use error::{BoxError, CloneError, CommitBlockError, ValidateContextError};
+pub use error::{
+    BoxError, CloneError, CommitBlockError, DuplicateNullifierError, ValidateContextError,
+};
 pub use request::{FinalizedBlock, HashOrHeight, PreparedBlock, ReadRequest, Request};
 pub use response::{KnownBlock, MinedTx, ReadResponse, Response};
 pub use service::{


### PR DESCRIPTION
## Motivation

The transaction verifier in zebra-consensus converts and propagates boxed ValidateContextErrors from zebra-state, but is missing unit tests.

Closes #6399.

## Solution

- Add a unit test in zebra-consensus that shows errors from the state service propagate correctly through the transaction verifier

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
