### PR TITLE
fix(security): Limit blocks and transactions sent in response to a single request 

### DIFF
--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -24,7 +24,11 @@ use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, Service, Service
 use zebra_network as zn;
 use zebra_state as zs;
 
-use zebra_chain::{block, transaction::UnminedTxId};
+use zebra_chain::{
+    block::{self, Block},
+    serialization::ZcashSerialize,
+    transaction::UnminedTxId,
+};
 use zebra_consensus::chain::VerifyChainError;
 use zebra_network::{
     constants::{ADDR_RESPONSE_LIMIT_DENOMINATOR, MAX_ADDRS_IN_MESSAGE},
@@ -54,6 +58,16 @@ use downloads::Downloads as BlockDownloads;
 /// as used in `ProcessGetData()`:
 /// <https://github.com/zcash/zcash/blob/829dd94f9d253bb705f9e194f13cb8ca8e545e1e/src/main.cpp#L6410-L6412>
 pub const GETDATA_SENT_BYTES_LIMIT: usize = 1_000_000;
+
+/// The maximum number of blocks the [`Inbound`] service will queue in response to a block request,
+/// before ignoring any additional block IDs in that request.
+///
+/// This is the same as `zcashd`'s request limit:
+/// <https://github.com/zcash/zcash/blob/829dd94f9d253bb705f9e194f13cb8ca8e545e1e/src/main.h#L108>
+///
+/// (Zebra's request limit is one block in transit per peer, because it fans out block requests to
+/// many peers instead of just a few peers.)
+pub const GETDATA_MAX_BLOCK_COUNT: usize = 16;
 
 type BlockDownloadPeerSet =
     Buffer<BoxService<zn::Request, zn::Response, zn::BoxError>, zn::Request>;
@@ -378,43 +392,53 @@ impl Service<zn::Request> for Inbound {
             }
             zn::Request::BlocksByHash(hashes) => {
                 // We return an available or missing response to each inventory request,
-                // unless the request is empty.
+                // unless the request is empty, or it reaches a response limit.
                 if hashes.is_empty() {
                     return async { Ok(zn::Response::Nil) }.boxed();
                 }
 
-                // Correctness:
-                //
-                // We can't use `call_all` here, because it can hold one buffer slot per concurrent
-                // future, until the `CallAll` struct is dropped. We can't hold those slots in this
-                // future because:
-                // * we're not sure when the returned future will complete, and
-                // * we don't limit how many returned futures can be concurrently running
-                // https://github.com/tower-rs/tower/blob/master/tower/src/util/call_all/common.rs#L112
-                use futures::stream::TryStreamExt;
-                hashes
-                    .iter()
-                    .cloned()
-                    .map(|hash| zs::Request::Block(hash.into()))
-                    .map(|request| state.clone().oneshot(request))
-                    .collect::<futures::stream::FuturesOrdered<_>>()
-                    .try_filter_map(|response| async move {
-                        Ok(match response {
-                            zs::Response::Block(Some(block)) => Some(block),
-                            zs::Response::Block(None) => None,
-                            _ => unreachable!("wrong response from state"),
-                        })
-                    })
-                    .try_collect::<Vec<_>>()
-                    .map_ok(|blocks| {
-                        // Work out which hashes were missing.
-                        let available_hashes: HashSet<block::Hash> = blocks.iter().map(|block| block.hash()).collect();
-                        let available = blocks.into_iter().map(Available);
-                        let missing = hashes.into_iter().filter(|hash| !available_hashes.contains(hash)).map(Missing);
+                let state = state.clone();
 
-                        zn::Response::Blocks(available.chain(missing).collect())
-                    })
-                    .boxed()
+                async move {
+                    let mut blocks: Vec<InventoryResponse<Arc<Block>, block::Hash>> = Vec::new();
+                    let mut total_size = 0;
+
+                    // Ignore any block hashes past the response limit.
+                    // This saves us expensive database lookups.
+                    for &hash in hashes.iter().take(GETDATA_MAX_BLOCK_COUNT) {
+                        // We check the limit after including at least one block, so that we can
+                        // send blocks greater than 1 MB (but only one at a time)
+                        if total_size >= GETDATA_SENT_BYTES_LIMIT {
+                            break;
+                        }
+
+                        let response = state.clone().ready().await?.call(zs::Request::Block(hash.into())).await?;
+
+                        // Add the block responses to the list, while updating the size limit.
+                        //
+                        // If there was a database error, return the error,
+                        // and stop processing further chunks.
+                        match response {
+                            zs::Response::Block(Some(block)) => {
+                                // If checking the serialized size of the block performs badly,
+                                // return the size from the state using a wrapper type.
+                                total_size += block.zcash_serialized_size();
+
+                                blocks.push(Available(block))
+                            },
+                            // We don't need to limit the size of the missing block IDs list,
+                            // because it is already limited to the size of the getdata request
+                            // sent by the peer. (Their content and encodings are the same.)
+                            zs::Response::Block(None) => blocks.push(Missing(hash)),
+                            _ => unreachable!("wrong response from state"),
+                        }
+
+                    }
+
+                    // The network layer handles splitting this response into multiple `block`
+                    // messages, and a `notfound` message if needed.
+                    Ok(zn::Response::Blocks(blocks))
+                }.boxed()
             }
             zn::Request::TransactionsById(req_tx_ids) => {
                 // We return an available or missing response to each inventory request,


### PR DESCRIPTION
## Motivation

Zebra doesn't limit how many blocks or transactions it will send in response to a `getdata` request.

Since `getdata` requests are small hashes, this can become a network amplification attack.

### Specifications

Network response limits are not specified, nodes are free to implement any behaviour.

### Complex Code or Requirements

This PR replaces complex concurrent iterator code with simpler code that is not concurrent.

These changes should be compatible with both Zebra's and `zcashd`'s block syncing and mempool behaviour.

## Solution

- Stop queuing additional block and transaction responses after 1 MB of data has been queued
- Only answer the first 16 requests in a block request (`zcashd` sends up to 16, Zebra always sends 1)

### Testing

There are existing tests for responses. We don't test the limits, but they seem pretty trivial in the code.

I'm happy to add tests if anyone wants.

## Review

This PR is a routine security fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

