### PR TITLE
fix(ci): Use valid names for concurrency groups

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -314,7 +314,7 @@ jobs:
     #
     # See the concurrency comment on the zebrad test-full-sync job for details.
     concurrency:
-      group: ${{ github.workflow }}−manual-${{ fromJSON(github.event.inputs.regenerate-disks) }}-regenerate-stateful-disks
+      group: ${{ github.workflow }}−manual-${{ format('{0}', github.event.inputs.regenerate-disks == 'true') }}-regenerate-stateful-disks
       cancel-in-progress: false
 
   # Test that Zebra syncs and fully validates a few thousand blocks from a cached mandatory checkpoint disk
@@ -383,7 +383,7 @@ jobs:
     # TODO:
     # - allow multiple manual syncs on a branch by adding '-${{ github.run_id }}' when github.event.inputs.run-full-sync is true
     concurrency:
-      group: ${{ github.workflow }}−manual-${{ fromJSON(github.event.inputs.run-full-sync) }}-test-full-sync
+      group: ${{ github.workflow }}−manual-${{ format('{0}', github.event.inputs.run-full-sync == 'true') }}-test-full-sync
       cancel-in-progress: false
 
   # Test that Zebra can sync to the chain tip, using a cached Zebra tip state,
@@ -497,7 +497,7 @@ jobs:
     # TODO:
     # - allow multiple manual syncs on a branch by adding '-${{ github.run_id }}' when github.event.inputs.run-full-sync is true
     concurrency:
-      group: ${{ github.workflow }}−manual-${{ fromJSON(github.event.inputs.run-full-sync) }}-test-full-sync-testnet
+      group: ${{ github.workflow }}−manual-${{ format('{0}', github.event.inputs.run-full-sync == 'true') }}-test-full-sync-testnet
       cancel-in-progress: false
 
   # Test that Zebra can generate testnet checkpoints after syncing to the chain tip,
@@ -572,7 +572,7 @@ jobs:
     #
     # See the concurrency comment on the zebrad test-full-sync job for details.
     concurrency:
-      group: ${{ github.workflow }}−manual-${{ fromJSON(github.event.inputs.run-lwd-sync) }}-lightwalletd-full-sync
+      group: ${{ github.workflow }}−manual-${{ format('{0}', github.event.inputs.run-lwd-sync == 'true') }}-lightwalletd-full-sync
       cancel-in-progress: false
 
   # Test update sync of lightwalletd with a lightwalletd and Zebra tip state


### PR DESCRIPTION
## Motivation

The concurrency group names aren't parsing correctly in CI, instead, they are silently failing.

### Specifications

https://docs.github.com/en/actions/learn-github-actions/expressions#format

## Solution

Compare the string to `true` rather than trying to convert a potentially empty string from JSON

## Review

This is an urgent fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

