### PR TITLE
change(ci): Turn CI errors into PR annotations for most CI jobs

### DIFF
--- a/.github/workflows/build-crates-individually.yml
+++ b/.github/workflows/build-crates-individually.yml
@@ -51,6 +51,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v3.5.2
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       # Setup Rust with stable toolchain and minimal profile
       - name: Setup Rust
@@ -107,6 +108,7 @@ jobs:
       - uses: actions/checkout@v3.5.2
         with:
           persist-credentials: false
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1.1.2

--- a/.github/workflows/build-crates-individually.yml
+++ b/.github/workflows/build-crates-individually.yml
@@ -45,7 +45,7 @@ env:
 
 jobs:
   matrix:
-    name: Crates matrix
+    name: Generate crates matrix
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -82,6 +82,7 @@ jobs:
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
   check-matrix:
+    name: Check crates matrix
     runs-on: ubuntu-latest
     needs: [ matrix ]
     steps:

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -43,14 +43,14 @@ on:
         required: false
         default: "sentry"
         type: string
-      test_features: 
+      test_features:
         required: false
         default: "lightwalletd-grpc-tests zebra-checkpoints"
         type: string
-      rpc_port: 
+      rpc_port:
         required: false
         type: string
-      tag_suffix: 
+      tag_suffix:
         required: false
         type: string
 
@@ -74,6 +74,7 @@ jobs:
       - uses: actions/checkout@v3.5.2
         with:
           persist-credentials: false
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -78,6 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
         with:

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -137,6 +137,8 @@ jobs:
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
         with:
@@ -159,6 +161,8 @@ jobs:
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
         with:
@@ -184,6 +188,8 @@ jobs:
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
         with:
@@ -205,6 +211,8 @@ jobs:
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
         with:
@@ -224,6 +232,8 @@ jobs:
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
         with:
@@ -244,6 +254,8 @@ jobs:
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
         with:
@@ -267,6 +279,8 @@ jobs:
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
         with:
@@ -684,7 +698,7 @@ jobs:
       zebra_state_dir: 'zebrad-cache'
       lwd_state_dir: 'lwd-cache'
     secrets: inherit
-    
+
   ## getblocktemplate-rpcs using cached Zebra state on mainnet
   #
   # TODO: move these below the rest of the mainnet jobs that just use Zebra cached state

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -86,6 +86,7 @@ jobs:
       - uses: actions/checkout@v3.5.2
         with:
           persist-credentials: false
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1.1.2
@@ -199,6 +200,7 @@ jobs:
       - uses: actions/checkout@v3.5.2
         with:
           persist-credentials: false
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       # Setup Rust with stable toolchain and minimal profile
       - name: Setup Rust
@@ -220,6 +222,7 @@ jobs:
       - uses: actions/checkout@v3.5.2
         with:
           persist-credentials: false
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1.1.2
@@ -260,6 +263,7 @@ jobs:
       - uses: actions/checkout@v3.5.2
         with:
           persist-credentials: false
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       # The --all-features job is the only job that gives accurate "skip tree root was not found" warnings.
       # In other jobs, we expect some of these warnings, due to disabled features.
@@ -278,6 +282,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           persist-credentials: false
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       # Setup Rust with stable toolchain and minimal profile
       - name: Setup Rust

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -113,6 +113,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: '2'
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -207,6 +208,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: '2'
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -272,6 +274,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: '2'
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -449,6 +452,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: '2'
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -585,6 +589,11 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: '2'
+      # We can't use the standard Rust problem matchers on these jobs,
+      # because they produce a lot of output.
+      #
+      # TODO: create a custom matcher config for these specific jobs
+      #- uses: r7kamura/rust-problem-matchers@v1.3.0
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -1546,6 +1555,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: '2'
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
@@ -1749,6 +1759,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: '2'
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -115,6 +115,7 @@ jobs:
       - uses: actions/checkout@v3.5.2
         with:
           persist-credentials: false
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1.1.2
@@ -153,6 +154,7 @@ jobs:
       - uses: actions/checkout@v3.5.2
         with:
           persist-credentials: false
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
 
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v1.1.2


### PR DESCRIPTION
## Motivation

At today's engineering sync, we talked about making PR failures easier to diagnose. One way to do that is to put the error next to the failing code in the PR.

### Specifications

> Problem Matchers are a way to scan the output of actions for a specified regex pattern and surface that information prominently in the UI. Both [GitHub Annotations](https://developer.github.com/v3/checks/runs/#annotations-object-1) and log file decorations are created when a match is detected.

https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md

This new action:
https://github.com/r7kamura/rust-problem-matchers#usage

## Solution

- Add the rust-problem-matchers action to most workflows

## Review

This is tricky to review unless we deliberately cause failures in this PR.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Fork the action and add our own regexes to catch Zebra-specific failures.