### PR TITLE
fix(ci): Give more time to the inbound service when queueing requests

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -41,9 +41,6 @@ skip-tree = [
     # wait for primitive-types to upgrade
     { name = "proc-macro-crate", version = "=0.1.5" },
 
-    # wait for rocksdb to upgrade
-    { name = "bindgen", version = "=0.64.0" },
-
     # wait for prost-build to upgrade
     { name = "prettyplease", version = "=0.1.25" },
 

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -1253,6 +1253,10 @@ where
         );
         self.update_state_metrics(format!("In::Req::{}", req.command()));
 
+        // Give the inbound service time to clear its queue,
+        // before sending the next inbound request.
+        tokio::task::yield_now().await;
+
         if self.svc.ready().await.is_err() {
             // Treat all service readiness errors as Overloaded
             // TODO: treat `TryRecvError::Closed` in `Inbound::poll_ready` as a fatal error (#1655)
@@ -1403,6 +1407,10 @@ where
         }
 
         debug!(state = %self.state, %req, %rsp, "sent Zebra response to peer");
+
+        // Give the inbound service time to clear its queue,
+        // before checking the connection for the next inbound or outbound request.
+        tokio::task::yield_now().await;
     }
 }
 


### PR DESCRIPTION
## Motivation

This is a potential fix for #6506.

### Specifications

https://docs.rs/tokio/latest/tokio/task/fn.yield_now.html

### Complex Code or Requirements

This doesn't change concurrency behaviour much - it just yields time to other tasks.

## Solution

Wait for the inbound service to process other requests before and after queueing a request

#### Unrelated changes

Remove redundant deny.toml entry

## Review

This is a routine fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

