### PR TITLE
fix(release): do not hardcode the name of our images

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -88,7 +88,7 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             us-docker.pkg.dev/${{ vars.GCP_PROJECT }}/zebra/${{ inputs.image_name }}
-            zfnd/zebra,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            zfnd/${{ inputs.image_name }},enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
           # appends inputs.tag_suffix to image tags/names
           flavor: |
             suffix=${{ inputs.tag_suffix }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -41,7 +41,7 @@ jobs:
     with:
       dockerfile_path: ./docker/Dockerfile
       dockerfile_target: runtime
-      image_name: zebrad-mining-rpcs-testnet
+      image_name: zebra
       # TODO: change this to `-experimental` when we release Zebra `1.0.0`
       tag_suffix: .experimental
       network: Testnet

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -18,14 +18,14 @@ jobs:
   # Each time this workflow is executed, a build will be triggered to create a new image
   # with the corresponding tags using information from git
 
-  # The image will be named `zebrad:<semver>`
+  # The image will be named `zebra:<semver>`
   build:
     name: Build Release Docker
     uses: ./.github/workflows/build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile
       dockerfile_target: runtime
-      image_name: zebrad
+      image_name: zebra
       network: Mainnet
       checkpoint_sync: true
       rust_backtrace: '1'

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -34,7 +34,7 @@ jobs:
     # This step needs access to Docker Hub secrets to run successfully
     secrets: inherit
 
-  # The image will be named `zebrad-mining-rpcs-testnet:<semver>.experimental`
+  # The image will be named `zebra:<semver>.experimental`
   build-mining-testnet:
     name: Build Release Testnet Mining Docker
     uses: ./.github/workflows/build-docker-image.yml


### PR DESCRIPTION
## Motivation

Our main image in DockerHub is called `zebra` not `zebrad`.

This hardcoded value is also causing the mining image to also be called `zebra` instead of `zebrad-mining-rpcs-testnet`


We should also decide between having a different image `name`, `tag` or both. Basically deciding between:
- `zebra:v1.0.0-rc.8.experimental`
- `zebra:v1.0.0-rc.8.mining`
- `zebrad-mining-rpcs-testnet:v1.0.0-rc.8.experimental`

## Solution

- Use `zfnd/${{ inputs.image_name }}` instead of `zfnd/zebra`
- Do not name experimental tags with a different image name for Docker Hub

## Review

Anyone from the DevOps team can review this.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
