### PR TITLE
fix(network): Ignore out of order Address Book changes, unless they are concurrent

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -90,6 +90,13 @@ pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 /// nodes, and on testnet.
 pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(3);
 
+/// The maximum time difference for two address book changes to be considered concurrent.
+///
+/// This timeout should be less than the reconnection and keepalive/heartbeat timeouts,
+/// but more than the amount of time between connection events and address book updates,
+/// even under heavy load. (In tests, we have observed delays up to 500ms.)
+pub const CONCURRENT_ADDRESS_CHANGE_PERIOD: Duration = HANDSHAKE_TIMEOUT;
+
 /// We expect to receive a message from a live peer at least once in this time duration.
 ///
 /// This is the sum of:

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -92,10 +92,21 @@ pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// The maximum time difference for two address book changes to be considered concurrent.
 ///
-/// This timeout should be less than the reconnection and keepalive/heartbeat timeouts,
-/// but more than the amount of time between connection events and address book updates,
-/// even under heavy load. (In tests, we have observed delays up to 500ms.)
-pub const CONCURRENT_ADDRESS_CHANGE_PERIOD: Duration = HANDSHAKE_TIMEOUT;
+/// This prevents simultaneous or nearby important changes or connection progress
+/// being overridden by less important changes.
+///
+/// This timeout should be less than:
+/// - the [peer reconnection delay](MIN_PEER_RECONNECTION_DELAY), and
+/// - the [peer keepalive/heartbeat interval](HEARTBEAT_INTERVAL).
+///
+/// But more than:
+/// - the amount of time between connection events and address book updates,
+///   even under heavy load (in tests, we have observed delays up to 500ms),
+/// - the delay between an outbound connection failing,
+///   and the [CandidateSet](crate::peer_set::CandidateSet) registering the failure, and
+/// - the delay between the application closing a connection,
+///   and any remaining positive changes from the peer.
+pub const CONCURRENT_ADDRESS_CHANGE_PERIOD: Duration = Duration::from_secs(5);
 
 /// We expect to receive a message from a live peer at least once in this time duration.
 ///

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -87,11 +87,7 @@ impl PeerAddrState {
     fn connection_state_order(&self, other: &Self) -> Ordering {
         use Ordering::*;
         match (self, other) {
-            (NeverAttemptedAlternate, NeverAttemptedAlternate)
-            | (NeverAttemptedGossiped, NeverAttemptedGossiped)
-            | (AttemptPending, AttemptPending)
-            | (Responded, Responded)
-            | (Failed, Failed) => Equal,
+            _ if self == other => Equal,
             // Peers start in one of the "never attempted" states,
             // then typically progress towards a "responded" or "failed" state.
             //
@@ -109,7 +105,10 @@ impl PeerAddrState {
             (_, AttemptPending) => Greater,
             (Responded, _) => Less,
             (_, Responded) => Greater,
-            // Failed is covered by the other cases
+            // These patterns are redundant, but Rust doesn't assume that `==` is reflexive,
+            // so the first is still required (but unreachable).
+            (Failed, _) => Less,
+            //(_, Failed) => Greater,
         }
     }
 }
@@ -133,11 +132,7 @@ impl Ord for PeerAddrState {
     fn cmp(&self, other: &Self) -> Ordering {
         use Ordering::*;
         match (self, other) {
-            (Responded, Responded)
-            | (NeverAttemptedGossiped, NeverAttemptedGossiped)
-            | (NeverAttemptedAlternate, NeverAttemptedAlternate)
-            | (Failed, Failed)
-            | (AttemptPending, AttemptPending) => Equal,
+            _ if self == other => Equal,
             // We reconnect to `Responded` peers that have stopped sending messages,
             // then `NeverAttempted` peers, then `Failed` peers
             (Responded, _) => Less,
@@ -148,7 +143,10 @@ impl Ord for PeerAddrState {
             (_, NeverAttemptedAlternate) => Greater,
             (Failed, _) => Less,
             (_, Failed) => Greater,
-            // AttemptPending is covered by the other cases
+            // These patterns are redundant, but Rust doesn't assume that `==` is reflexive,
+            // so the first is still required (but unreachable).
+            (AttemptPending, _) => Less,
+            //(_, AttemptPending) => Greater,
         }
     }
 }

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -753,7 +753,7 @@ impl MetaAddrChange {
     //
     // Since the connection tasks run concurrently in an unspecified order, and the address book
     // updater runs in a separate thread, these times are almost always very similar. If Zebra's
-    // address book is under load, we should increase the rate-limits for new inbound or outbound
+    // address book is under load, we should use lower rate-limits for new inbound or outbound
     // connections, disconnections, peer gossip crawls, or peer `UpdateResponded` updates.
     //
     // TODO:

--- a/zebra-network/src/meta_addr/arbitrary.rs
+++ b/zebra-network/src/meta_addr/arbitrary.rs
@@ -57,12 +57,14 @@ impl MetaAddr {
             any::<Instant>(),
             any::<DateTime32>(),
         )
-            .prop_map(|(socket_addr, untrusted_services, instant_now, local_now)| {
-                // instant_now is not actually used for this variant,
-                // so we could just provide a default value
-                MetaAddr::new_alternate(socket_addr, &untrusted_services)
-                    .into_new_meta_addr(instant_now, local_now)
-            })
+            .prop_map(
+                |(socket_addr, untrusted_services, instant_now, local_now)| {
+                    // instant_now is not actually used for this variant,
+                    // so we could just provide a default value
+                    MetaAddr::new_alternate(socket_addr, &untrusted_services)
+                        .into_new_meta_addr(instant_now, local_now)
+                },
+            )
             .boxed()
     }
 }

--- a/zebra-network/src/meta_addr/arbitrary.rs
+++ b/zebra-network/src/meta_addr/arbitrary.rs
@@ -57,11 +57,11 @@ impl MetaAddr {
             any::<Instant>(),
             any::<DateTime32>(),
         )
-            .prop_map(|(socket_addr, untrusted_services, instant_now, wall_now)| {
+            .prop_map(|(socket_addr, untrusted_services, instant_now, local_now)| {
                 // instant_now is not actually used for this variant,
                 // so we could just provide a default value
                 MetaAddr::new_alternate(socket_addr, &untrusted_services)
-                    .into_new_meta_addr(instant_now, wall_now)
+                    .into_new_meta_addr(instant_now, local_now)
             })
             .boxed()
     }
@@ -113,14 +113,14 @@ impl MetaAddrChange {
         )
             .prop_filter_map(
                 "failed MetaAddr::is_valid_for_outbound",
-                |(addr, instant_now, wall_now)| {
+                |(addr, instant_now, local_now)| {
                     // Alternate nodes use the current time, so they're always ready
                     //
                     // TODO: create a "Zebra supported services" constant
 
                     let change = MetaAddr::new_alternate(addr, &PeerServices::NODE_NETWORK);
                     if change
-                        .into_new_meta_addr(instant_now, wall_now)
+                        .into_new_meta_addr(instant_now, local_now)
                         .last_known_info_is_valid_for_outbound(Mainnet)
                     {
                         Some(change)

--- a/zebra-network/src/meta_addr/tests/prop.rs
+++ b/zebra-network/src/meta_addr/tests/prop.rs
@@ -65,7 +65,7 @@ proptest! {
 
         let instant_now = std::time::Instant::now();
         let chrono_now = Utc::now();
-        let wall_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
+        let local_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
 
         for change in changes {
             if let Some(changed_addr) = change.apply_to_meta_addr(addr, instant_now, chrono_now) {
@@ -76,7 +76,7 @@ proptest! {
                 } else {
                     prop_assert_eq!(
                         changed_addr.untrusted_last_seen,
-                        change.untrusted_last_seen(wall_now)
+                        change.untrusted_last_seen(local_now)
                     );
                 }
 

--- a/zebra-network/src/meta_addr/tests/prop.rs
+++ b/zebra-network/src/meta_addr/tests/prop.rs
@@ -4,7 +4,6 @@ use std::{collections::HashMap, env, net::SocketAddr, str::FromStr, sync::Arc, t
 
 use chrono::Utc;
 use proptest::{collection::vec, prelude::*};
-use tokio::time::Instant;
 use tower::service_fn;
 use tracing::Span;
 
@@ -64,8 +63,12 @@ proptest! {
     ) {
         let _init_guard = zebra_test::init();
 
+        let instant_now = std::time::Instant::now();
+        let chrono_now = Utc::now();
+        let wall_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
+
         for change in changes {
-            if let Some(changed_addr) = change.apply_to_meta_addr(addr) {
+            if let Some(changed_addr) = change.apply_to_meta_addr(addr, instant_now, chrono_now) {
                 // untrusted last seen times:
                 // check that we replace None with Some, but leave Some unchanged
                 if addr.untrusted_last_seen.is_some() {
@@ -73,7 +76,7 @@ proptest! {
                 } else {
                     prop_assert_eq!(
                         changed_addr.untrusted_last_seen,
-                        change.untrusted_last_seen()
+                        change.untrusted_last_seen(wall_now)
                     );
                 }
 
@@ -118,12 +121,12 @@ proptest! {
 
                 // Simulate an attempt
                 addr = MetaAddr::new_reconnect(addr.addr)
-                    .apply_to_meta_addr(addr)
+                    .apply_to_meta_addr(addr, instant_now, chrono_now)
                     .expect("unexpected invalid attempt");
             }
 
             // If `change` is invalid for the current MetaAddr state, skip it.
-            if let Some(changed_addr) = change.apply_to_meta_addr(addr) {
+            if let Some(changed_addr) = change.apply_to_meta_addr(addr, instant_now, chrono_now) {
                 prop_assert_eq!(changed_addr.addr, addr.addr);
                 addr = changed_addr;
             }
@@ -155,7 +158,7 @@ proptest! {
         );
         let sanitized_addrs = address_book.sanitized(chrono_now);
 
-        let expected_local_listener = address_book.local_listener_meta_addr();
+        let expected_local_listener = address_book.local_listener_meta_addr(chrono_now);
         let canonical_local_listener = canonical_peer_addr(local_listener);
         let book_sanitized_local_listener = sanitized_addrs
             .iter()
@@ -186,9 +189,12 @@ proptest! {
 
         let local_listener = "0.0.0.0:0".parse().expect("unexpected invalid SocketAddr");
 
+        let instant_now = std::time::Instant::now();
+        let chrono_now = Utc::now();
+
         for change in changes {
             // Check direct application
-            let new_addr = change.apply_to_meta_addr(None);
+            let new_addr = change.apply_to_meta_addr(None, instant_now, chrono_now);
 
             prop_assert!(
                 new_addr.is_some(),
@@ -328,7 +334,7 @@ proptest! {
             tokio::time::pause();
 
             // The earliest time we can have a valid next attempt for this peer
-            let earliest_next_attempt = Instant::now() + MIN_PEER_RECONNECTION_DELAY;
+            let earliest_next_attempt = tokio::time::Instant::now() + MIN_PEER_RECONNECTION_DELAY;
 
             // The number of attempts for this peer in the last MIN_PEER_RECONNECTION_DELAY
             let mut attempt_count: usize = 0;
@@ -349,7 +355,7 @@ proptest! {
                          original addr was in address book: {}\n",
                         candidate_addr,
                         i,
-                        Instant::now(),
+                        tokio::time::Instant::now(),
                         earliest_next_attempt,
                         attempt_count,
                         LIVE_PEER_INTERVALS,
@@ -365,7 +371,7 @@ proptest! {
                 address_book.clone().lock().unwrap().update(change);
 
                 tokio::time::advance(peer_change_interval).await;
-                if Instant::now() >= earliest_next_attempt {
+                if tokio::time::Instant::now() >= earliest_next_attempt {
                     attempt_count = 0;
                 }
             }
@@ -430,13 +436,13 @@ proptest! {
 
                         // Simulate an attempt
                         *addr = MetaAddr::new_reconnect(addr.addr)
-                            .apply_to_meta_addr(*addr)
+                            .apply_to_meta_addr(*addr, instant_now, chrono_now)
                             .expect("unexpected invalid attempt");
                     }
 
                     // If `change` is invalid for the current MetaAddr state, skip it.
                     // If we've run out of changes for this addr, do nothing.
-                    if let Some(changed_addr) = change.and_then(|change| change.apply_to_meta_addr(*addr))
+                    if let Some(changed_addr) = change.and_then(|change| change.apply_to_meta_addr(*addr, instant_now, chrono_now))
                     {
                         prop_assert_eq!(changed_addr.addr, addr.addr);
                         *addr = changed_addr;

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -9,7 +9,11 @@ use zebra_chain::{
     serialization::{DateTime32, Duration32},
 };
 
-use crate::{constants::MAX_PEER_ACTIVE_FOR_GOSSIP, protocol::types::PeerServices, PeerSocketAddr};
+use crate::{
+    constants::{CONCURRENT_ADDRESS_CHANGE_PERIOD, MAX_PEER_ACTIVE_FOR_GOSSIP},
+    protocol::types::PeerServices,
+    PeerSocketAddr,
+};
 
 use super::{super::MetaAddr, check};
 
@@ -61,11 +65,11 @@ fn new_local_listener_is_gossipable() {
 
     let instant_now = Instant::now();
     let chrono_now = Utc::now();
-    let wall_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
+    let local_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
 
     let address = PeerSocketAddr::from(([192, 168, 180, 9], 10_000));
     let peer =
-        MetaAddr::new_local_listener_change(address).into_new_meta_addr(instant_now, wall_now);
+        MetaAddr::new_local_listener_change(address).into_new_meta_addr(instant_now, local_now);
 
     assert!(peer.is_active_for_gossip(chrono_now));
 }
@@ -80,11 +84,11 @@ fn new_alternate_peer_address_is_not_gossipable() {
 
     let instant_now = Instant::now();
     let chrono_now = Utc::now();
-    let wall_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
+    let local_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
 
     let address = PeerSocketAddr::from(([192, 168, 180, 9], 10_000));
     let peer = MetaAddr::new_alternate(address, &PeerServices::NODE_NETWORK)
-        .into_new_meta_addr(instant_now, wall_now);
+        .into_new_meta_addr(instant_now, local_now);
 
     assert!(!peer.is_active_for_gossip(chrono_now));
 }
@@ -159,11 +163,11 @@ fn recently_responded_peer_is_gossipable() {
 
     let instant_now = Instant::now();
     let chrono_now = Utc::now();
-    let wall_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
+    let local_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
 
     let address = PeerSocketAddr::from(([192, 168, 180, 9], 10_000));
     let peer_seed = MetaAddr::new_alternate(address, &PeerServices::NODE_NETWORK)
-        .into_new_meta_addr(instant_now, wall_now);
+        .into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
     let peer = MetaAddr::new_responded(address, &PeerServices::NODE_NETWORK)
@@ -180,11 +184,11 @@ fn not_so_recently_responded_peer_is_still_gossipable() {
 
     let instant_now = Instant::now();
     let chrono_now = Utc::now();
-    let wall_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
+    let local_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
 
     let address = PeerSocketAddr::from(([192, 168, 180, 9], 10_000));
     let peer_seed = MetaAddr::new_alternate(address, &PeerServices::NODE_NETWORK)
-        .into_new_meta_addr(instant_now, wall_now);
+        .into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
     let mut peer = MetaAddr::new_responded(address, &PeerServices::NODE_NETWORK)
@@ -211,11 +215,11 @@ fn responded_long_ago_peer_is_not_gossipable() {
 
     let instant_now = Instant::now();
     let chrono_now = Utc::now();
-    let wall_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
+    let local_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
 
     let address = PeerSocketAddr::from(([192, 168, 180, 9], 10_000));
     let peer_seed = MetaAddr::new_alternate(address, &PeerServices::NODE_NETWORK)
-        .into_new_meta_addr(instant_now, wall_now);
+        .into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
     let mut peer = MetaAddr::new_responded(address, &PeerServices::NODE_NETWORK)

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -282,7 +282,7 @@ fn long_delayed_change_is_not_applied() {
     );
 }
 
-/// Test that a change that happens long time after the previous change
+/// Test that a change that happens a long time after the previous change
 /// is applied to the address state, even if it is a revert.
 #[test]
 fn later_revert_change_is_applied() {

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -1145,7 +1145,7 @@ async fn self_connections_should_fail() {
             .lock()
             .expect("unexpected panic in address book");
 
-        let real_self_listener = unlocked_address_book.local_listener_meta_addr();
+        let real_self_listener = unlocked_address_book.local_listener_meta_addr(Utc::now());
 
         // Set a fake listener to get past the check for adding our own address
         unlocked_address_book.set_local_listener("192.168.0.0:1".parse().unwrap());
@@ -1384,7 +1384,10 @@ async fn local_listener_port_with(listen_addr: SocketAddr, network: Network) {
         "Test user agent".to_string(),
     )
     .await;
-    let local_listener = address_book.lock().unwrap().local_listener_meta_addr();
+    let local_listener = address_book
+        .lock()
+        .unwrap()
+        .local_listener_meta_addr(Utc::now());
 
     if listen_addr.port() == 0 {
         assert_ne!(

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -5,7 +5,10 @@
 //! cargo insta test --review --features getblocktemplate-rpcs --delete-unreferenced-snapshots
 //! ```
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    time::Instant,
+};
 
 use hex::FromHex;
 use insta::Settings;
@@ -133,8 +136,7 @@ pub async fn test_responses<State, ReadState>(
         )
         .into(),
     )
-    .into_new_meta_addr()
-    .unwrap()]);
+    .into_new_meta_addr(Instant::now(), DateTime32::now())]);
 
     // get an rpc instance with continuous blockchain state
     let get_block_template_rpc = GetBlockTemplateRpcImpl::new(

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -951,8 +951,10 @@ async fn rpc_getpeerinfo() {
         )
         .into(),
     )
-    .into_new_meta_addr()
-    .unwrap();
+    .into_new_meta_addr(
+        std::time::Instant::now(),
+        zebra_chain::serialization::DateTime32::now(),
+    );
 
     let mock_address_book = MockAddressBookPeers::new(vec![mock_peer_address]);
 


### PR DESCRIPTION
## Motivation

We want to ignore earlier address book changes which are delayed, so we don't accidentally reset the peer state to an earlier value. But some changes can be concurrent, so the change application order doesn't always match the network order.

Close #6672 

### Specifications

There is no formal specification for peer network behaviour, but in general, the peer's internal address book state should reflect the actual behaviour of its peers.

### Complex Code or Requirements

This code runs concurrently, it is accessed from both the address book updater task and the candidate set peer dialler task. 

Changes can arrive earlier or later than their network order because of:
- waiting on the address book mutex
- async runtime or OS thread scheduling
- monotonic clock resolution, or OS or hardware time bugs
- wall clock time updates

The application can also independently initiate a change to the connection state, which can be simultaneous (or before) a change from the peer. In this case, the application-provided change needs to take priority. (Because it is typically failing the connection.)

## Solution

Fix the code that applies changes to the address book, so that:
- Concurrent changes are applied if they progress the connection state, but ignored if they revert it
- Much earlier changes are ignored, even if they progress the connection state

Refactor the code that applies changes so it is easier to read.

Add TODOs for further changes that are not required to fix this security issue.

### Testing

- Add tests for the failure and success cases for the new checks, the extra success cases are:
    - Much later changes are applied, even if they revert the connection state
- Allow tests to provide synthetic times for address book updates
    - This resolves some technical debt caused by a partial refactor
    - Calling time APIs less will also improve performance on some systems

There are existing tests for the other kinds of changes.

## Review

This is one of the more complex audit changes that we have left to do. I'm happy to do a video review if that helps!

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [x] How do you know it works? Does it have tests?

## Follow Up Work

Make it much harder for remote peers to delay changes by flooding the change channel:
- #6738