### PR TITLE
fix(test): Refactor a network test function to be more robust

### DIFF
--- a/zebra-network/src/address_book/tests/prop.rs
+++ b/zebra-network/src/address_book/tests/prop.rs
@@ -77,7 +77,7 @@ proptest! {
             MetaAddrChange::addr_changes_strategy(MAX_ADDR_CHANGE),
             2..MAX_ADDR_CHANGE
         ),
-        addr_limit in 0..=MAX_ADDR_CHANGE,
+        addr_limit in 1..=MAX_ADDR_CHANGE,
         pre_fill in any::<bool>(),
     ) {
         let _init_guard = zebra_test::init();


### PR DESCRIPTION
## Motivation

Fix https://github.com/ZcashFoundation/zebra/issues/6674. This is a note from the audit where a test function creates a list taking some elements and then deduplicating as they get inserted with the same key to another collection.
 
## Solution

Do not truncate in creating the iterator and insert to the final collection until a limit is reached.

`addr_limit` of `0` will not work anymore so i added an assert, i think requiring a max value to be at least 1 makes sense.

## Review

I think anyone can review, the changes are small and in test code only.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
