### PR TITLE
fix(ci): Make job names in build-crates-individually.patch.yml consistent

### DIFF
--- a/.github/workflows/build-crates-individually.patch.yml
+++ b/.github/workflows/build-crates-individually.patch.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   matrix:
-    name: Crates matrix
+    name: Generate crates matrix
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -54,6 +54,7 @@ jobs:
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
   check-matrix:
+    name: Check crates matrix
     runs-on: ubuntu-latest
     needs: [ matrix ]
     steps:


### PR DESCRIPTION
## Motivation

The job names in `build-crates-individually.patch.yml` do not match `build-crates-individually.yml`. This is a bug in PR #6690. (And it was a bug in the branch protection rules.)

This causes CI to hang for some PRs, waiting for a missing job in the branch protection rules.

## Solution

Make the names match

Admin: remove the incorrect branch protection rule

## Review

This is an urgent fix for CI hangs.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

