### PR TITLE
Delete outdated `TODOs` refering to closed issues

### DIFF
--- a/zebra-chain/src/orchard/sinsemilla.rs
+++ b/zebra-chain/src/orchard/sinsemilla.rs
@@ -159,10 +159,6 @@ pub fn sinsemilla_hash(D: &[u8], M: &BitVec<u8, Lsb0>) -> Option<pallas::Base> {
     extract_p_bottom(sinsemilla_hash_to_point(D, M))
 }
 
-// TODO: test the above correctness and compatibility with the zcash-hackworks test vectors
-// https://github.com/ZcashFoundation/zebra/issues/2079
-// https://github.com/zcash-hackworks/zcash-test-vectors/pulls
-
 #[cfg(test)]
 mod tests {
 

--- a/zebra-chain/src/work/difficulty/tests/vectors.rs
+++ b/zebra-chain/src/work/difficulty/tests/vectors.rs
@@ -457,7 +457,9 @@ fn check_testnet_minimum_difficulty_block(height: block::Height) -> Result<(), R
             .signed_duration_since(previous_block.header.time);
 
         // zcashd requires a gap that's strictly greater than 6 times the target
-        // threshold.
+        // threshold, as documented in ZIP-205 and ZIP-208:
+        // https://zips.z.cash/zip-0205#change-to-difficulty-adjustment-on-testnet
+        // https://zips.z.cash/zip-0208#minimum-difficulty-blocks-on-testnet
         match NetworkUpgrade::minimum_difficulty_spacing_for_height(Network::Testnet, height) {
             None => Err(eyre!("the minimum difficulty rule is not active"))?,
             Some(spacing) if (time_gap <= spacing) => Err(eyre!(

--- a/zebra-chain/src/work/difficulty/tests/vectors.rs
+++ b/zebra-chain/src/work/difficulty/tests/vectors.rs
@@ -457,7 +457,7 @@ fn check_testnet_minimum_difficulty_block(height: block::Height) -> Result<(), R
             .signed_duration_since(previous_block.header.time);
 
         // zcashd requires a gap that's strictly greater than 6 times the target
-        // threshold, but ZIP-205 and ZIP-208 are ambiguous. See bug #1276.
+        // threshold.
         match NetworkUpgrade::minimum_difficulty_spacing_for_height(Network::Testnet, height) {
             None => Err(eyre!("the minimum difficulty rule is not active"))?,
             Some(spacing) if (time_gap <= spacing) => Err(eyre!(

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -740,10 +740,6 @@ where
             orchard_shielded_data,
             &shielded_sighash,
         )?))
-
-        // TODO:
-        // - verify orchard shielded pool (ZIP-224) (#2105)
-        // - shielded input and output limits? (#2379)
     }
 
     /// Verifies if a V5 `transaction` is supported by `network_upgrade`.

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -347,7 +347,6 @@ impl<'de> Deserialize<'de> for Config {
 
         let config = DConfig::deserialize(deserializer)?;
 
-        // TODO: perform listener DNS lookups asynchronously with a timeout (#1631)
         let listen_addr = match config.listen_addr.parse::<SocketAddr>() {
             Ok(socket) => Ok(socket),
             Err(_) => match config.listen_addr.parse::<IpAddr>() {

--- a/zebra-network/src/peer_set/limit.rs
+++ b/zebra-network/src/peer_set/limit.rs
@@ -178,6 +178,9 @@ impl Drop for ConnectionTracker {
 
         // We ignore disconnected errors, because the receiver can be dropped
         // before some connections are dropped.
+        // # Security
+        //
+        // This channel is actually bounded by the inbound and outbound connection limit.
         let _ = self.close_notification_tx.send(ConnectionClosed);
     }
 }

--- a/zebra-network/src/peer_set/limit.rs
+++ b/zebra-network/src/peer_set/limit.rs
@@ -178,8 +178,6 @@ impl Drop for ConnectionTracker {
 
         // We ignore disconnected errors, because the receiver can be dropped
         // before some connections are dropped.
-        //
-        // TODO: This channel will be bounded by the connection limit (#1850, #1851, #2902).
         let _ = self.close_notification_tx.send(ConnectionClosed);
     }
 }

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -418,8 +418,6 @@ where
         for guard in self.guards.iter() {
             guard.abort();
         }
-
-        // TODO: implement graceful shutdown for InventoryRegistry (#1678)
     }
 
     /// Check busy peer services for request completion or errors.

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -504,7 +504,6 @@ where
     /// Checks if the minimum peer version has changed, and disconnects from outdated peers.
     fn disconnect_from_outdated_peers(&mut self) {
         if let Some(minimum_version) = self.minimum_peer_version.changed() {
-            // TODO: Remove when the code base migrates to Rust 2021 edition (#2709).
             let preselected_p2c_peer = &mut self.preselected_p2c_peer;
 
             self.ready_services.retain(|address, peer| {

--- a/zebra-network/src/peer_set/unready_service/tests/vectors.rs
+++ b/zebra-network/src/peer_set/unready_service/tests/vectors.rs
@@ -1,6 +1,4 @@
 //! Fixed test vectors for unready services.
-//!
-//! TODO: test that inner service errors are handled correctly (#3204)
 
 use std::marker::PhantomData;
 

--- a/zebra-network/src/policies.rs
+++ b/zebra-network/src/policies.rs
@@ -34,6 +34,11 @@ impl<Req: Clone + std::fmt::Debug, Res, E: std::fmt::Debug> Policy<Req, Res, E> 
                 Some(
                     // Let other tasks run, so we're more likely to choose a different peer,
                     // and so that any notfound inv entries win the race to the PeerSet.
+                    // # Security
+                    //
+                    // We want to choose different peers for retries, so we have a better chance of getting each block.
+                    // This is implemented by the connection state machine sending synthetic `notfound`s to the 
+                    // `InventoryRegistry`, as well as forwarding actual `notfound`s from peers.
                     Box::pin(tokio::task::yield_now().map(move |()| retry_outcome)),
                 )
             } else {

--- a/zebra-network/src/policies.rs
+++ b/zebra-network/src/policies.rs
@@ -34,9 +34,6 @@ impl<Req: Clone + std::fmt::Debug, Res, E: std::fmt::Debug> Policy<Req, Res, E> 
                 Some(
                     // Let other tasks run, so we're more likely to choose a different peer,
                     // and so that any notfound inv entries win the race to the PeerSet.
-                    //
-                    // TODO: move syncer retries into the PeerSet,
-                    //       so we always choose different peers (#3235)
                     Box::pin(tokio::task::yield_now().map(move |()| retry_outcome)),
                 )
             } else {

--- a/zebra-network/src/policies.rs
+++ b/zebra-network/src/policies.rs
@@ -34,10 +34,11 @@ impl<Req: Clone + std::fmt::Debug, Res, E: std::fmt::Debug> Policy<Req, Res, E> 
                 Some(
                     // Let other tasks run, so we're more likely to choose a different peer,
                     // and so that any notfound inv entries win the race to the PeerSet.
+                    //
                     // # Security
                     //
                     // We want to choose different peers for retries, so we have a better chance of getting each block.
-                    // This is implemented by the connection state machine sending synthetic `notfound`s to the 
+                    // This is implemented by the connection state machine sending synthetic `notfound`s to the
                     // `InventoryRegistry`, as well as forwarding actual `notfound`s from peers.
                     Box::pin(tokio::task::yield_now().map(move |()| retry_outcome)),
                 )

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -184,10 +184,6 @@ impl Codec {
     /// Obtain the size of the body of a given message. This will match the
     /// number of bytes written to the writer provided to `write_body` for the
     /// same message.
-    ///
-    /// TODO: Replace with a size estimate, to avoid multiple serializations
-    /// for large data structures like lists, blocks, and transactions.
-    /// See #1774.
     fn body_length(&self, msg: &Message) -> usize {
         let mut writer = FakeWriter(0);
 

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -184,6 +184,10 @@ impl Codec {
     /// Obtain the size of the body of a given message. This will match the
     /// number of bytes written to the writer provided to `write_body` for the
     /// same message.
+    // # Performance TODO
+    //
+    // If this code shows up in profiles, replace with a size estimate or cached size,
+    // to avoid multiple serializations for large data structures like lists, blocks, and transactions.
     fn body_length(&self, msg: &Message) -> usize {
         let mut writer = FakeWriter(0);
 

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -401,6 +401,8 @@ impl TryFrom<Message> for VersionMessage {
     }
 }
 
+// TODO: add tests for Error conversion and Reject message serialization
+ // (Zebra does not currently send reject messages, and it ignores received reject messages.)
 impl<E> From<E> for Message
 where
     E: Error,

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -401,8 +401,6 @@ impl TryFrom<Message> for VersionMessage {
     }
 }
 
-// TODO: add tests for Error conversion and Reject message serialization (#4633)
-// (Zebra does not currently send reject messages, and it ignores received reject messages.)
 impl<E> From<E> for Message
 where
     E: Error,

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -402,7 +402,7 @@ impl TryFrom<Message> for VersionMessage {
 }
 
 // TODO: add tests for Error conversion and Reject message serialization
- // (Zebra does not currently send reject messages, and it ignores received reject messages.)
+// (Zebra does not currently send reject messages, and it ignores received reject messages.)
 impl<E> From<E> for Message
 where
     E: Error,

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -110,7 +110,7 @@ pub trait GetBlockTemplateRpc {
     /// - the parent block is a valid block that Zebra already has, or will receive soon.
     ///
     /// Zebra verifies blocks in parallel, and keeps recent chains in parallel,
-    /// so moving between chains is very cheap.
+    /// so moving between chains and forking chains is very cheap.
     ///
     /// This rpc method is available only if zebra is built with `--features getblocktemplate-rpcs`.
     #[rpc(name = "getblocktemplate")]

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -110,8 +110,7 @@ pub trait GetBlockTemplateRpc {
     /// - the parent block is a valid block that Zebra already has, or will receive soon.
     ///
     /// Zebra verifies blocks in parallel, and keeps recent chains in parallel,
-    /// so moving between chains is very cheap. (But forking a new chain may take some time,
-    /// until bug #4794 is fixed.)
+    /// so moving between chains is very cheap.
     ///
     /// This rpc method is available only if zebra is built with `--features getblocktemplate-rpcs`.
     #[rpc(name = "getblocktemplate")]

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -29,10 +29,7 @@ pub struct Config {
     /// When Zebra's state format changes, it creates a new state subdirectory for that version,
     /// and re-syncs from genesis.
     ///
-    /// Old state versions are [not automatically deleted](https://github.com/ZcashFoundation/zebra/issues/1213).
-    /// It is ok to manually delete old state versions.
-    ///
-    /// It is also ok to delete the entire cached state directory.
+    /// It is ok to delete the entire cached state directory.
     /// If you do, Zebra will re-sync from genesis next time it is launched.
     ///
     /// The default directory is platform dependent, based on

--- a/zebra-state/src/service/check/utxo.rs
+++ b/zebra-state/src/service/check/utxo.rs
@@ -229,7 +229,6 @@ pub fn remaining_transaction_value(
     utxos: &HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
 ) -> Result<(), ValidateContextError> {
     for (tx_index_in_block, transaction) in prepared.block.transactions.iter().enumerate() {
-        // TODO: check coinbase transaction remaining value (#338, #1162)
         if transaction.is_coinbase() {
             continue;
         }

--- a/zebra-state/src/service/finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/tests/prop.rs
@@ -35,7 +35,6 @@ fn blocks_with_v5_transactions() -> Result<()> {
                 );
                 prop_assert_eq!(Some(height), state.finalized_tip_height());
                 prop_assert_eq!(hash.unwrap(), block.hash);
-                // TODO: check that the nullifiers were correctly inserted (#2230)
                 height = Height(height.0 + 1);
             }
     });

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
@@ -253,7 +253,6 @@ fn snapshot_block_and_transaction_data(state: &FinalizedState) {
         //       test the rest of the chain data (value balance).
         let history_tree_at_tip = state.history_tree();
 
-        // TODO: split out block snapshots into their own function (#3151)
         for query_height in 0..=max_height.0 {
             let query_height = Height(query_height);
 


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

We want to clean up any code comments relating to `TODO` tasks that have already been addressed.

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
If this PR changes network behaviour, quote and link to the Bitcoin network reference:
https://developer.bitcoin.org/reference/p2p_networking.html
-->

### Complex Code or Requirements

<!--
Does this PR change concurrency, unsafe code, or complex consensus rules?
If it does, ask for multiple reviewers on this PR.
-->

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
If this is a large change, list commits of key functional changes here.
-->
Deletes comments related to issues that have been closed as fixed.

Depends-On: #6737 
## Review

<!--
Is this PR blocking any other work?
If you want specific reviewers for this PR, tag them here.
-->

For each deleted comment the reviewer should double check that the PR really addresses the issue which is mentioned in the code comment. 

Informational comments that refer to closed issues should not be removed unless they are no longer relevant. 

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
This is just a first pass. There are still a number of issues that have been closed as `wont-fix` referenced in the code and we should decide what we do about those.

Depends-