### PR TITLE
fix(ci): Reduce number of sent transactions in tests

### DIFF
--- a/zebrad/tests/common/lightwalletd/send_transaction_test.rs
+++ b/zebrad/tests/common/lightwalletd/send_transaction_test.rs
@@ -45,7 +45,7 @@ use crate::common::{
 /// TODO: replace with a const when `min()` stabilises as a const function:
 ///       https://github.com/rust-lang/rust/issues/92391
 fn max_sent_transactions() -> usize {
-    min(CHANNEL_AND_QUEUE_CAPACITY, MAX_INBOUND_CONCURRENCY) - 1
+    min(CHANNEL_AND_QUEUE_CAPACITY, MAX_INBOUND_CONCURRENCY)/2
 }
 
 /// Number of blocks past the finalized to load transactions from.

--- a/zebrad/tests/common/lightwalletd/send_transaction_test.rs
+++ b/zebrad/tests/common/lightwalletd/send_transaction_test.rs
@@ -45,7 +45,7 @@ use crate::common::{
 /// TODO: replace with a const when `min()` stabilises as a const function:
 ///       https://github.com/rust-lang/rust/issues/92391
 fn max_sent_transactions() -> usize {
-    min(CHANNEL_AND_QUEUE_CAPACITY, MAX_INBOUND_CONCURRENCY)/2
+    min(CHANNEL_AND_QUEUE_CAPACITY, MAX_INBOUND_CONCURRENCY) / 2
 }
 
 /// Number of blocks past the finalized to load transactions from.


### PR DESCRIPTION
## Motivation

The `sending_transactions_using_lightwalletd` test failed with:
> {"app":"lightwalletd","error":"Post \"[http://127.0.0.1:44501\](http://127.0.0.1:44501/)": read tcp 127.0.0.1:50572-\u003e127.0.0.1:44501: read: connection reset by peer","level":"fatal","msg":"error zcashd getbestblockhash rpc","time":"2023-05-21T20:25:36Z"}

https://github.com/ZcashFoundation/zebra/actions/runs/5039261000/jobs/9037575030?pr=6704#step:8:420

I'm not sure why this is happening, but we don't need to send 19 transactions in that test.

### Complex Code or Requirements

This test concurrently runs `zebrad` and `lightwalletd`. But this PR just changes a transaction limit.

## Solution

Reduce the number of transactions sent in the test from 19 to 10

## Review

This is a high priority because it might fix a CI failure.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Work out why the test is actually failing.