### PR TITLE
cleanup(rust): Simplify code using closure capture in Rust 2021 edition

### DIFF
--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -865,7 +865,8 @@ async fn v5_transaction_is_rejected_before_nu5_activation() {
         let state_service = service_fn(|_| async { unreachable!("Service should not be called") });
         let verifier = Verifier::new(network, state_service);
 
-        let transaction = fake_v5_transactions_for_network(network, blocks).next_back()
+        let transaction = fake_v5_transactions_for_network(network, blocks)
+            .next_back()
             .expect("At least one fake V5 transaction in the test vectors");
 
         let result = verifier
@@ -915,7 +916,8 @@ fn v5_transaction_is_accepted_after_nu5_activation_for_network(network: Network)
         let state_service = service_fn(|_| async { unreachable!("Service should not be called") });
         let verifier = Verifier::new(network, state_service);
 
-        let mut transaction = fake_v5_transactions_for_network(network, blocks).next_back()
+        let mut transaction = fake_v5_transactions_for_network(network, blocks)
+            .next_back()
             .expect("At least one fake V5 transaction in the test vectors");
         if transaction
             .expiry_height()

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -865,9 +865,7 @@ async fn v5_transaction_is_rejected_before_nu5_activation() {
         let state_service = service_fn(|_| async { unreachable!("Service should not be called") });
         let verifier = Verifier::new(network, state_service);
 
-        let transaction = fake_v5_transactions_for_network(network, blocks)
-            .rev()
-            .next()
+        let transaction = fake_v5_transactions_for_network(network, blocks).next_back()
             .expect("At least one fake V5 transaction in the test vectors");
 
         let result = verifier
@@ -917,9 +915,7 @@ fn v5_transaction_is_accepted_after_nu5_activation_for_network(network: Network)
         let state_service = service_fn(|_| async { unreachable!("Service should not be called") });
         let verifier = Verifier::new(network, state_service);
 
-        let mut transaction = fake_v5_transactions_for_network(network, blocks)
-            .rev()
-            .next()
+        let mut transaction = fake_v5_transactions_for_network(network, blocks).next_back()
             .expect("At least one fake V5 transaction in the test vectors");
         if transaction
             .expiry_height()

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -504,15 +504,12 @@ where
     /// Checks if the minimum peer version has changed, and disconnects from outdated peers.
     fn disconnect_from_outdated_peers(&mut self) {
         if let Some(minimum_version) = self.minimum_peer_version.changed() {
-            // TODO: Remove when the code base migrates to Rust 2021 edition (#2709).
-            let preselected_p2c_peer = &mut self.preselected_p2c_peer;
-
             self.ready_services.retain(|address, peer| {
                 if peer.remote_version() >= minimum_version {
                     true
                 } else {
-                    if *preselected_p2c_peer == Some(*address) {
-                        *preselected_p2c_peer = None;
+                    if self.preselected_p2c_peer == Some(*address) {
+                        self.preselected_p2c_peer = None;
                     }
 
                     false

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -1,5 +1,8 @@
 //! Fixed test vectors for the RPC server.
 
+// These tests call functions which can take unit arguments if some features aren't enabled.
+#![allow(clippy::unit_arg)]
+
 use std::{
     net::{Ipv4Addr, SocketAddrV4},
     time::Duration,

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -549,7 +549,7 @@ impl NonFinalizedState {
 
     /// Return the non-finalized portion of the current best chain.
     pub fn best_chain(&self) -> Option<&Arc<Chain>> {
-        self.chain_set.iter().rev().next()
+        self.chain_iter().next()
     }
 
     /// Return the number of chains.


### PR DESCRIPTION
## Motivation

Rust's new closure capture rules in the 2021 edition allow us to simplify some code.

There are some new clippy errors in Rust nightly.

### Reference

In Rust 2021 edition, closures only capture the fields they need to, not the entire `self` or argument:
https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html

## Solution

Remove a temporary variable

Fix clippy lints

## Review

This is a low priority cleanup.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

