### PR TITLE
fix(net): Rate-limit MetaAddrChange::Responded from peers

### DIFF
--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -316,6 +316,12 @@ where
 
     /// Add new `addrs` to the address book.
     async fn send_addrs(&self, addrs: impl IntoIterator<Item = MetaAddr>) {
+        // # Security
+        //
+        // New gossiped peers are rate-limited because:
+        // - Zebra initiates requests for new gossiped peers
+        // - the fanout is limited
+        // - the number of addresses per peer is limited
         let addrs: Vec<MetaAddrChange> = addrs
             .into_iter()
             .map(MetaAddr::new_gossiped_change)

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -433,6 +433,12 @@ async fn limit_initial_peers(
 
     // Send every initial peer to the address book, in preferred order.
     // (This treats initial peers the same way we treat gossiped peers.)
+    //
+    // # Security
+    //
+    // Initial peers are limited because:
+    // - the number of initial peers is limited
+    // - this code only runs once at startup
     for peer in preferred_peers.values().flatten() {
         let peer_addr = MetaAddr::new_initial_peer(*peer);
         // `send` only waits when the channel is full.


### PR DESCRIPTION
## Motivation

There is no limit to the amount of `MetaAddrChange::Responded` updates a peer can send to the shared address book updater channel.

This is a remotely-triggerable security issue, likely resulting in a hang or very slow network performance.

### Complex Code or Requirements

This code runs concurrently for every peer, then writes to a channel shared between all peers. Writing on the channel blocks if it is full.

## Solution

- Stop allowing peers to send a `Ping` or `Pong` message to generate a `MetaAddrChange::Responded`
- Instead, generate a `MetaAddrChange::Responded` after every successful heartbeat, which is already rate-limited by Zebra

## Review

This is a security fix that we might want to block the stable release for.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

