### PR TITLE
fix(release): Allow inbound connections to Zebra running in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -180,18 +180,18 @@ RUN set -ex; \
   { \
     echo "[network]"; \
     echo "network = '${NETWORK}'"; \
-    echo "listen_addr = '127.0.0.1'"; \
+    echo "listen_addr = '0.0.0.0'"; \
     echo "[consensus]"; \
     echo "checkpoint_sync = ${CHECKPOINT_SYNC}"; \
     echo "[state]"; \
     echo "cache_dir = '/zebrad-cache'"; \
     echo "[rpc]"; \
-    [ -n "$RPC_PORT" ] && echo "listen_addr = '127.0.0.1:${RPC_PORT}'"; \
+    [ -n "$RPC_PORT" ] && echo "listen_addr = '0.0.0.0:${RPC_PORT}'"; \
     echo "parallel_cpu_threads = 0"; \
     echo "[metrics]"; \
-    echo "#endpoint_addr = '127.0.0.1:9999'"; \
+    echo "#endpoint_addr = '0.0.0.0:9999'"; \
     echo "[tracing]"; \
-    echo "#endpoint_addr = '127.0.0.1:3000'"; \
+    echo "#endpoint_addr = '0.0.0.0:3000'"; \
   } > "${ZEBRA_CONF_PATH}"
 
 


### PR DESCRIPTION
## Motivation & Solution

Binding `127.0.0.1` means that Zebra will accept inbound connections coming only from the loopback network interface. This is desirable as long as Zebra runs on a native machine.

When Zebra runs inside a Docker container, incoming connections coming from the host machine don't come from the container's loopback interface. In order to be able to connect to Zebra from the host machine, we can listen on `0.0.0.0` so Zebra accepts inbound connections coming from any interface. Users then can limit inbound connection to the loopback of their host by

```bash
docker run -p 127.0.0.1:8232:8232 zfnd/zebra:1.0.0-rc.8
```

We should maybe document this, although Docker operators should be familiar with it.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

