### PR TITLE
change(docs): Add private IP address known issue to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ section of the Zebra book for more details.
 
 There are a few bugs in Zebra that we're still working on fixing:
 
+- Zebra currently gossips and connects to [private IP addresses](https://en.wikipedia.org/wiki/IP_address#Private_addresses), we want to [disable private IPs but provide a config (#3117)](https://github.com/ZcashFoundation/zebra/issues/3117) in an upcoming release
+
 - If Zebra fails downloading the Zcash parameters, use [the Zcash parameters download script](https://github.com/zcash/zcash/blob/master/zcutil/fetch-params.sh) instead.
 
 - Block download and verification sometimes times out during Zebra's initial sync [#5709](https://github.com/ZcashFoundation/zebra/issues/5709). The full sync still finishes reasonably quickly.


### PR DESCRIPTION
## Motivation

We want to stop using private IP addresses by default in Zebra (#3117), but we might not have time to do it before the first stable release.

## Solution

Add it as a known issue to the readme

## Review

This is a low priority doc update

Do we also want to add a note about private IPs to the next release changelog, or the stable release changelog?

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

