### PR TITLE
fix(docker): Actually cache the test build in the Dockerfile test stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -106,10 +106,8 @@ COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd /opt/lightwalletd
 # Re-hydrate the minimum project skeleton identified by `cargo chef prepare` in the planner stage,
 # and build it to cache all possible sentry and test dependencies.
 #
-# This is the caching Docker layer for Rust!
-#
-# TODO: is it faster to use --tests here?
-RUN cargo chef cook --release --features "${TEST_FEATURES} ${FEATURES}" --workspace --recipe-path recipe.json
+# This is the caching Docker layer for Rust tests!
+RUN cargo chef cook --tests --release --features "${TEST_FEATURES} ${FEATURES}" --workspace --recipe-path recipe.json
 
 COPY . .
 RUN cargo test --locked --release --features "${TEST_FEATURES} ${FEATURES}" --workspace --no-run
@@ -127,6 +125,8 @@ ENTRYPOINT [ "/entrypoint.sh" ]
 # This step also adds `cargo chef` as this stage is completely independent from the
 # `test` stage. This step is a dependency for the `runtime` stage, which uses the resulting
 # zebrad binary from this step.
+#
+# This is the caching Docker layer for Rust production!
 FROM deps AS release
 RUN cargo chef cook --release --features "${FEATURES}" --recipe-path recipe.json
 


### PR DESCRIPTION
## Motivation

I think our Docker test stage is actually caching a production build, not a test build.

This could be causing really long test build times in every PR. 

### Specifications

This could also be a different issue around timestamps in git checkouts:
https://github.com/LukeMathWalker/cargo-chef#limitations-and-caveats

There are tools that cache and restore timestamps if file hashes match:

For Docker builds:
`git-restore-mtime` in https://github.com/MestreLion/git-tools

For builds in GitHub runners:
https://github.com/marketplace/actions/git-restore-mtime

## Solution

Build the test cache using `--tests`

### Testing

Build this PR twice, with a minor code change in between, and test that the second build is faster than the first

## Review

This is a low priority CI speed bug.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Open a ticket for using the `git-restore-mtime` action/script to stop `cargo` rebuilding everything