### PR TITLE
fix(ci): Increase config test timeouts

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -249,7 +249,7 @@ jobs:
   # Test that Zebra works using the default config with the latest Zebra version
   test-configuration-file:
     name: Test Zebra default Docker config file
-    timeout-minutes: 5
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
@@ -274,7 +274,7 @@ jobs:
   # Test that Zebra works using the $ZEBRA_CONF_PATH config
   test-zebra-conf-path:
     name: Test Zebra custom Docker config file
-    timeout-minutes: 5
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}


### PR DESCRIPTION
## Motivation

Sometimes it takes longer than 5 minutes to download the Zebra docker image, so the config test fails:
https://github.com/ZcashFoundation/zebra/actions/runs/5070854383/jobs/9107736295?pr=6758#step:4:142

## Solution

Increase the timeout to 15 minutes

## Review

This is a low priority CI bugfix

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

