### PR TITLE
fix(ci): Disable unnecessary GitHub Actions runner checks

### DIFF
--- a/.github/workflows/continous-integration-os.patch.yml
+++ b/.github/workflows/continous-integration-os.patch.yml
@@ -30,6 +30,9 @@ jobs:
             rust: beta
           - os: macos-latest
             features: " --features getblocktemplate-rpcs"
+          - os: ubuntu-latest
+            rust: beta
+            features: " --features getblocktemplate-rpcs"
 
     steps:
       - run: 'echo "No build required"'
@@ -56,7 +59,7 @@ jobs:
         checks:
           - bans
           - sources
-        features: ['', '--all-features', '--no-default-features']
+        features: ['', '--all-features']
 
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -81,6 +81,11 @@ jobs:
             rust: beta
           - os: macos-latest
             features: " --features getblocktemplate-rpcs"
+        # getblocktemplate-rpcs is an experimental feature, so we just need to test it on stable Rust
+        # beta is unlikely to fail just for this feature, and if it does, we can fix it when it reaches stable.
+          - os: ubuntu-latest
+            rust: beta
+            features: " --features getblocktemplate-rpcs"
 
     steps:
       - uses: actions/checkout@v3.5.2
@@ -252,7 +257,10 @@ jobs:
         checks:
           - bans
           - sources
-        features: ['', '--all-features', '--no-default-features']
+        # We don't need to check `--no-default-features` here, because (except in very rare cases):
+        # - disabling features isn't going to add duplicate dependencies
+        # - disabling features isn't going to add more crate sources
+        features: ['', '--all-features']
       # We always want to run the --all-features job, because it gives accurate "skip tree root was not found" warnings
       fail-fast: false
 


### PR DESCRIPTION
## Motivation

Some of our GitHub Actions matrixes do checks that aren't giving us any extra useful information.

## Solution

- disable `getblocktemplate-rpcs` on beta Rust, because we already do it on stable Rust
- disable `cargo deny --no-default-features`, because it isn't going to add new duplicate dependencies or crate sources
- remove the patch jobs for these checks

This saves us 6 GitHub Actions jobs (3 jobs + 3 patch jobs).

Admin:
- [x] remove the main branch protection requirements for these checks

## Review

This is a low priority CI cleanup.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?


