### PR TITLE
fix(security): Randomly drop connections when inbound service is overloaded

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -316,20 +316,16 @@ pub const EWMA_DECAY_TIME_NANOS: f64 = 200.0 * NANOS_PER_SECOND;
 /// The number of nanoseconds in one second.
 const NANOS_PER_SECOND: f64 = 1_000_000_000.0;
 
-/// The minimum interval that must elapse for the drop probability of an overloaded connection to decrease.
+/// The duration it takes for the drop probability of an overloaded connection to
+/// reach [`MIN_OVERLOAD_DROP_PROBABILITY`].
 ///
 /// Peer connections that receive multiple overloads have a higher probability of being dropped.
-/// Each time this interval elapses after the last overload, the probability of a connection being
-/// dropped gradually decreases, until it reaches the default drop probability.
+///
+/// The probability of a connection being dropped gradually decreases during this interval
+/// until it reaches the default drop probability ([`MIN_OVERLOAD_DROP_PROBABILITY`]).
 ///
 /// Increasing this number increases the rate at which connections are dropped.
-pub const OVERLOAD_DROP_PROBABILITY_INTERVAL: Duration = Duration::from_millis(50);
-
-/// The number of [`OVERLOAD_DROP_PROBABILITY_INTERVAL`]s that must elapse to reach the minimum
-/// drop probability for an overloaded connection.
-///
-/// Increasing this number increases the rate at which connections are dropped.
-pub const NUM_OVERLOAD_DROP_PROBABILITY_INTERVALS: f32 = 10.0;
+pub const OVERLOAD_PROTECTION_INTERVAL: Duration = MIN_INBOUND_PEER_CONNECTION_INTERVAL;
 
 /// The minimum probability of dropping a peer connection when it receives an
 /// [`Overloaded`](crate::PeerError::Overloaded) error.

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -319,7 +319,7 @@ const NANOS_PER_SECOND: f64 = 1_000_000_000.0;
 /// The amount of time after a connection receives an overload error from the inbound
 /// service during which another overload error will have a higher likelihood of dropping
 /// the peer connection.
-pub const SHORT_OVERLOAD_INTERVAL: Duration = Duration::from_millis(500);
+pub const SHORT_OVERLOAD_INTERVAL: u128 = 50;
 
 lazy_static! {
     /// The minimum network protocol version accepted by this crate for each network,

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -316,6 +316,11 @@ pub const EWMA_DECAY_TIME_NANOS: f64 = 200.0 * NANOS_PER_SECOND;
 /// The number of nanoseconds in one second.
 const NANOS_PER_SECOND: f64 = 1_000_000_000.0;
 
+/// The amount of time after a connection receives an overload error from the inbound
+/// service during which another overload error will have a higher likelihood of dropping
+/// the peer connection.
+pub const SHORT_OVERLOAD_INTERVAL: Duration = Duration::from_millis(500);
+
 lazy_static! {
     /// The minimum network protocol version accepted by this crate for each network,
     /// represented as a network upgrade.

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -316,10 +316,28 @@ pub const EWMA_DECAY_TIME_NANOS: f64 = 200.0 * NANOS_PER_SECOND;
 /// The number of nanoseconds in one second.
 const NANOS_PER_SECOND: f64 = 1_000_000_000.0;
 
-/// The amount of time after a connection receives an overload error from the inbound
-/// service during which another overload error will have a higher likelihood of dropping
-/// the peer connection.
-pub const SHORT_OVERLOAD_INTERVAL: u128 = 50;
+/// The minimum interval that must elapse for the drop probability of an overloaded connection to decrease.
+///
+/// Peer connections that receive multiple overloads have a higher probability of being dropped.
+/// Each time this interval elapses after the last overload, the probability of a connection being
+/// dropped gradually decreases, until it reaches the default drop probability.
+///
+/// Increasing this number increases the rate at which connections are dropped.
+pub const OVERLOAD_DROP_PROBABILITY_INTERVAL: Duration = Duration::from_millis(50);
+
+/// The number of [`OVERLOAD_DROP_PROBABILITY_INTERVAL`]s that must elapse to reach the minimum
+/// drop probability for an overloaded connection.
+///
+/// Increasing this number increases the rate at which connections are dropped.
+pub const NUM_OVERLOAD_DROP_PROBABILITY_INTERVALS: f32 = 10.0;
+
+/// The minimum probability of dropping a peer connection when it receives an
+/// [`Overloaded`](crate::PeerError::Overloaded) error.
+pub const MIN_OVERLOAD_DROP_PROBABILITY: f32 = 0.05;
+
+/// The maximum probability of dropping a peer connection when it receives an
+/// [`Overloaded`](crate::PeerError::Overloaded) error.
+pub const MAX_OVERLOAD_DROP_PROBABILITY: f32 = 0.95;
 
 lazy_static! {
     /// The minimum network protocol version accepted by this crate for each network,

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -1265,9 +1265,7 @@ where
         tokio::task::yield_now().await;
 
         if self.svc.ready().await.is_err() {
-            // Treat all service readiness errors as Overloaded
-            // TODO: treat `TryRecvError::Closed` in `Inbound::poll_ready` as a fatal error (#1655)
-            self.fail_with(PeerError::Overloaded);
+            self.fail_with(PeerError::Fatal);
             return;
         }
 
@@ -1301,8 +1299,8 @@ where
                             (now - previous_overload_time).as_millis()
                                 / constants::SHORT_OVERLOAD_INTERVAL;
 
-                        // u128 between 1 and 10 should convert to f32
-                        0.95 - ((num_intervals_since_last_overload.pow(2)).clamp(0, 100) as f32)
+                        // u128 between 1 and 100 should convert to f32
+                        ((95 - num_intervals_since_last_overload.pow(2)).clamp(0, 90) as f32)
                             / 100.0
                     } else {
                         0.05

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -1318,8 +1318,7 @@ where
                                 / OVERLOAD_PROTECTION_INTERVAL.as_secs_f32();
                             // Quadratically increase the disconnection probability for very recent overloads.
                             // Negative values are ignored by clamping to MIN_OVERLOAD_DROP_PROBABILITY.
-                            let overload_fraction =
-                                1.0 - protection_fraction_since_last_overload.powi(2);
+                            let overload_fraction = protection_fraction_since_last_overload.powi(2);
                             let probability_range =
                                 MAX_OVERLOAD_DROP_PROBABILITY - MIN_OVERLOAD_DROP_PROBABILITY;
                             MAX_OVERLOAD_DROP_PROBABILITY - (overload_fraction * probability_range)

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -1342,8 +1342,16 @@ where
                             "inbound service is overloaded, closing connection",
                         );
 
+                        self.update_state_metrics(format!(
+                            "In::Req::{}/Rsp::Overload::Error",
+                            req.command()
+                        ));
                         self.fail_with(PeerError::Overloaded);
                     } else {
+                        self.update_state_metrics(format!(
+                            "In::Req::{}/Rsp::Overload::Ignored",
+                            req.command()
+                        ));
                         metrics::counter!("pool.ignored.loadshed", 1);
                     }
                 } else {
@@ -1357,6 +1365,7 @@ where
                         client_receiver = ?self.client_rx,
                         "error processing peer request",
                     );
+                    self.update_state_metrics(format!("In::Req::{}/Rsp::Error", req.command()));
                 }
                 return;
             }

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -84,7 +84,7 @@ pub enum PeerError {
 
     /// This node's internal services are no longer able to service requests.
     #[error("Internal services have failed or shutdown")]
-    Fatal,
+    ServiceShutdown,
 
     /// We requested data, but the peer replied with a `notfound` message.
     /// (Or it didn't respond before the request finished.)
@@ -142,7 +142,7 @@ impl PeerError {
             PeerError::Serialization(inner) => format!("Serialization({inner})").into(),
             PeerError::DuplicateHandshake => "DuplicateHandshake".into(),
             PeerError::Overloaded => "Overloaded".into(),
-            PeerError::Fatal => "Fatal".into(),
+            PeerError::ServiceShutdown => "ServiceShutdown".into(),
             PeerError::NotFoundResponse(_) => "NotFoundResponse".into(),
             PeerError::NotFoundRegistry(_) => "NotFoundRegistry".into(),
         }

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -82,6 +82,10 @@ pub enum PeerError {
     #[error("Internal services over capacity")]
     Overloaded,
 
+    /// This node's internal services are no longer able to service requests.
+    #[error("Internal services have failed or shutdown")]
+    Fatal,
+
     /// We requested data, but the peer replied with a `notfound` message.
     /// (Or it didn't respond before the request finished.)
     ///
@@ -138,6 +142,7 @@ impl PeerError {
             PeerError::Serialization(inner) => format!("Serialization({inner})").into(),
             PeerError::DuplicateHandshake => "DuplicateHandshake".into(),
             PeerError::Overloaded => "Overloaded".into(),
+            PeerError::Fatal => "Fatal".into(),
             PeerError::NotFoundResponse(_) => "NotFoundResponse".into(),
             PeerError::NotFoundRegistry(_) => "NotFoundRegistry".into(),
         }

--- a/zebra-test/src/mock_service.rs
+++ b/zebra-test/src/mock_service.rs
@@ -742,13 +742,17 @@ impl<Request, Response, Error> ResponseSender<Request, Response, Error> {
     ///
     /// # Panics
     ///
-    /// If one of the `respond*` methods isn't called, the caller will panic.
+    /// If one of the `respond*` methods isn't called, the [`MockService`] might panic with a
+    /// timeout error.
     ///
     /// # Example
     ///
     /// ```
     /// # use zebra_test::mock_service::MockService;
     /// # use tower::{Service, ServiceExt};
+    /// #
+    /// # #[derive(Debug, PartialEq, Eq)]
+    /// # struct Request;
     /// #
     /// # let reactor = tokio::runtime::Builder::new_current_thread()
     /// #     .enable_all()
@@ -762,19 +766,19 @@ impl<Request, Response, Error> ResponseSender<Request, Response, Error> {
     ///
     /// # let mut service = mock_service.clone();
     /// # let task = tokio::spawn(async move {
-    /// #     let first_call_result = (&mut service).oneshot(1).await;
-    /// #     let second_call_result = service.oneshot(1).await;
+    /// #     let first_call_result = (&mut service).oneshot(Request).await;
+    /// #     let second_call_result = service.oneshot(Request).await;
     /// #
     /// #     (first_call_result, second_call_result)
     /// # });
     /// #
     /// mock_service
-    ///     .expect_request(1)
+    ///     .expect_request(Request)
     ///     .await
-    ///     .respond("Received one".to_owned());
+    ///     .respond("Received Request".to_owned());
     ///
     /// mock_service
-    ///     .expect_request(1)
+    ///     .expect_request(Request)
     ///     .await
     ///     .respond(Err("Duplicate request"));
     /// # });
@@ -793,13 +797,17 @@ impl<Request, Response, Error> ResponseSender<Request, Response, Error> {
     ///
     /// # Panics
     ///
-    /// If one of the `respond*` methods isn't called, the caller will panic.
+    /// If one of the `respond*` methods isn't called, the [`MockService`] might panic with a
+    /// timeout error.
     ///
     /// # Example
     ///
     /// ```
     /// # use zebra_test::mock_service::MockService;
     /// # use tower::{Service, ServiceExt};
+    /// #
+    /// # #[derive(Debug, PartialEq, Eq)]
+    /// # struct Request;
     /// #
     /// # let reactor = tokio::runtime::Builder::new_current_thread()
     /// #     .enable_all()
@@ -813,21 +821,21 @@ impl<Request, Response, Error> ResponseSender<Request, Response, Error> {
     ///
     /// # let mut service = mock_service.clone();
     /// # let task = tokio::spawn(async move {
-    /// #     let first_call_result = (&mut service).oneshot(1).await;
-    /// #     let second_call_result = service.oneshot(1).await;
+    /// #     let first_call_result = (&mut service).oneshot(Request).await;
+    /// #     let second_call_result = service.oneshot(Request).await;
     /// #
     /// #     (first_call_result, second_call_result)
     /// # });
     /// #
     /// mock_service
-    ///     .expect_request(1)
+    ///     .expect_request(Request)
     ///     .await
-    ///     .respond_with(|req| format!("Received: {}", req));
+    ///     .respond_with(|req| format!("Received: {req:?}"));
     ///
     /// mock_service
-    ///     .expect_request(1)
+    ///     .expect_request(Request)
     ///     .await
-    ///     .respond_with(|req| Err(format!("Duplicate request: {}", req)));
+    ///     .respond_with(|req| Err(format!("Duplicate request: {req:?}")));
     /// # });
     /// ```
     pub fn respond_with<F, R>(self, response_fn: F)
@@ -849,13 +857,18 @@ impl<Request, Response, Error> ResponseSender<Request, Response, Error> {
     ///
     /// # Panics
     ///
-    /// If one of the `respond*` methods isn't called, the caller will panic.
+    /// If one of the `respond*` methods isn't called, the [`MockService`] might panic with a
+    /// timeout error.
     ///
     /// # Example
     ///
     /// ```
     /// # use zebra_test::mock_service::MockService;
     /// # use tower::{Service, ServiceExt};
+    /// #
+    /// # #[derive(Debug, PartialEq, Eq)]
+    /// # struct Request;
+    /// # struct Response;
     /// #
     /// # let reactor = tokio::runtime::Builder::new_current_thread()
     /// #     .enable_all()
@@ -864,21 +877,21 @@ impl<Request, Response, Error> ResponseSender<Request, Response, Error> {
     /// #
     /// # reactor.block_on(async {
     /// // Mock a service with a `String` as the service `Error` type.
-    /// let mut mock_service: MockService<_, _, _, String> =
+    /// let mut mock_service: MockService<Request, Response, _, String> =
     ///     MockService::build().for_unit_tests();
     ///
     /// # let mut service = mock_service.clone();
     /// # let task = tokio::spawn(async move {
-    /// #     let first_call_result = (&mut service).oneshot(1).await;
-    /// #     let second_call_result = service.oneshot(1).await;
+    /// #     let first_call_result = (&mut service).oneshot(Request).await;
+    /// #     let second_call_result = service.oneshot(Request).await;
     /// #
     /// #     (first_call_result, second_call_result)
     /// # });
     /// #
     /// mock_service
-    ///     .expect_request(1)
+    ///     .expect_request(Request)
     ///     .await
-    ///     .respond_error("Duplicate request");
+    ///     .respond_error("Duplicate request".to_string());
     /// # });
     /// ```
     pub fn respond_error(self, error: Error) {
@@ -897,13 +910,18 @@ impl<Request, Response, Error> ResponseSender<Request, Response, Error> {
     ///
     /// # Panics
     ///
-    /// If one of the `respond*` methods isn't called, the caller will panic.
+    /// If one of the `respond*` methods isn't called, the [`MockService`] might panic with a
+    /// timeout error.
     ///
     /// # Example
     ///
     /// ```
     /// # use zebra_test::mock_service::MockService;
     /// # use tower::{Service, ServiceExt};
+    /// #
+    /// # #[derive(Debug, PartialEq, Eq)]
+    /// # struct Request;
+    /// # struct Response;
     /// #
     /// # let reactor = tokio::runtime::Builder::new_current_thread()
     /// #     .enable_all()
@@ -912,21 +930,21 @@ impl<Request, Response, Error> ResponseSender<Request, Response, Error> {
     /// #
     /// # reactor.block_on(async {
     /// // Mock a service with a `String` as the service `Error` type.
-    /// let mut mock_service: MockService<_, _, _, String> =
+    /// let mut mock_service: MockService<Request, Response, _, String> =
     ///     MockService::build().for_unit_tests();
     ///
     /// # let mut service = mock_service.clone();
     /// # let task = tokio::spawn(async move {
-    /// #     let first_call_result = (&mut service).oneshot(1).await;
-    /// #     let second_call_result = service.oneshot(1).await;
+    /// #     let first_call_result = (&mut service).oneshot(Request).await;
+    /// #     let second_call_result = service.oneshot(Request).await;
     /// #
     /// #     (first_call_result, second_call_result)
     /// # });
     /// #
     /// mock_service
-    ///     .expect_request(1)
+    ///     .expect_request(Request)
     ///     .await
-    ///     .respond_with_error(|req| format!("Duplicate request: {}", req));
+    ///     .respond_with_error(|req| format!("Duplicate request: {req:?}"));
     /// # });
     /// ```
     pub fn respond_with_error<F>(self, response_fn: F)

--- a/zebra-test/src/mock_service.rs
+++ b/zebra-test/src/mock_service.rs
@@ -740,7 +740,9 @@ impl<Request, Response, Error> ResponseSender<Request, Response, Error> {
     /// This method takes ownership of the [`ResponseSender`] so that only one response can be
     /// sent.
     ///
-    /// If `respond` or `respond_with` are not called, the caller will panic.
+    /// # Panics
+    ///
+    /// If one of the `respond*` methods isn't called, the caller will panic.
     ///
     /// # Example
     ///
@@ -789,7 +791,9 @@ impl<Request, Response, Error> ResponseSender<Request, Response, Error> {
     /// This method takes ownership of the [`ResponseSender`] so that only one response can be
     /// sent.
     ///
-    /// If `respond` or `respond_with` are not called, the caller will panic.
+    /// # Panics
+    ///
+    /// If one of the `respond*` methods isn't called, the caller will panic.
     ///
     /// # Example
     ///
@@ -832,6 +836,106 @@ impl<Request, Response, Error> ResponseSender<Request, Response, Error> {
         R: ResponseResult<Response, Error>,
     {
         let response_result = response_fn(self.request()).into_result();
+        let _ = self.response_sender.send(response_result);
+    }
+
+    /// Respond to the request using a fixed error value.
+    ///
+    /// The `error` must be the `Error` type. This helps avoid type resolution issues in the
+    /// compiler.
+    ///
+    /// This method takes ownership of the [`ResponseSender`] so that only one response can be
+    /// sent.
+    ///
+    /// # Panics
+    ///
+    /// If one of the `respond*` methods isn't called, the caller will panic.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use zebra_test::mock_service::MockService;
+    /// # use tower::{Service, ServiceExt};
+    /// #
+    /// # let reactor = tokio::runtime::Builder::new_current_thread()
+    /// #     .enable_all()
+    /// #     .build()
+    /// #     .expect("Failed to build Tokio runtime");
+    /// #
+    /// # reactor.block_on(async {
+    /// // Mock a service with a `String` as the service `Error` type.
+    /// let mut mock_service: MockService<_, _, _, String> =
+    ///     MockService::build().for_unit_tests();
+    ///
+    /// # let mut service = mock_service.clone();
+    /// # let task = tokio::spawn(async move {
+    /// #     let first_call_result = (&mut service).oneshot(1).await;
+    /// #     let second_call_result = service.oneshot(1).await;
+    /// #
+    /// #     (first_call_result, second_call_result)
+    /// # });
+    /// #
+    /// mock_service
+    ///     .expect_request(1)
+    ///     .await
+    ///     .respond_error("Duplicate request");
+    /// # });
+    /// ```
+    pub fn respond_error(self, error: Error) {
+        // TODO: impl ResponseResult for BoxError/Error trait when overlapping impls are
+        //       better supported by the compiler
+        let _ = self.response_sender.send(Err(error));
+    }
+
+    /// Respond to the request by calculating an error from the request.
+    ///
+    /// The `error` must be the `Error` type. This helps avoid type resolution issues in the
+    /// compiler.
+    ///
+    /// This method takes ownership of the [`ResponseSender`] so that only one response can be
+    /// sent.
+    ///
+    /// # Panics
+    ///
+    /// If one of the `respond*` methods isn't called, the caller will panic.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use zebra_test::mock_service::MockService;
+    /// # use tower::{Service, ServiceExt};
+    /// #
+    /// # let reactor = tokio::runtime::Builder::new_current_thread()
+    /// #     .enable_all()
+    /// #     .build()
+    /// #     .expect("Failed to build Tokio runtime");
+    /// #
+    /// # reactor.block_on(async {
+    /// // Mock a service with a `String` as the service `Error` type.
+    /// let mut mock_service: MockService<_, _, _, String> =
+    ///     MockService::build().for_unit_tests();
+    ///
+    /// # let mut service = mock_service.clone();
+    /// # let task = tokio::spawn(async move {
+    /// #     let first_call_result = (&mut service).oneshot(1).await;
+    /// #     let second_call_result = service.oneshot(1).await;
+    /// #
+    /// #     (first_call_result, second_call_result)
+    /// # });
+    /// #
+    /// mock_service
+    ///     .expect_request(1)
+    ///     .await
+    ///     .respond_with_error(|req| format!("Duplicate request: {}", req));
+    /// # });
+    /// ```
+    pub fn respond_with_error<F>(self, response_fn: F)
+    where
+        F: FnOnce(&Request) -> Error,
+    {
+        // TODO: impl ResponseResult for BoxError/Error trait when overlapping impls are
+        //       better supported by the compiler
+        let response_result = Err(response_fn(self.request()));
         let _ = self.response_sender.send(response_result);
     }
 }


### PR DESCRIPTION
## Motivation

Zebra should avoid dropping all peer connections when the inbound service is overloaded by a subset of peers.

This PR will randomly drop connections that get an overloaded error, with a high probability 

Closes #6596.

## Solution

- Randomly drop connections that receive overloaded errors, with greater likelihood when a second overloaded error is seen soon after the first.
- Add a `ServiceShutdown` variant to `PeerError` for when the inbound service has failed or shutdown.

Testing:
- more overloads mean a higher probability of being dropped
- less overloads mean a lower probability
- frequent overloads significantly increase the probability
- when we make multiple connections, some are dropped and some aren't

Related fixes:
- add some test utility methods and fix docs

## Review

This is a routine fix.

The production code has already been reviewed privately, the tests are new.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- Use a skiplist to keep an ordered buffer queue
