### PR TITLE
fix(test): Skip editor files and other hidden files in test configs directory

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -572,8 +572,8 @@ fn config_tests() -> Result<()> {
     // Check that we have a current version of the config stored
     last_config_is_stored()?;
 
-    // Check that Zebra stored configuration works
-    stored_configs_works()?;
+    // Check that Zebra's previous configurations still work
+    stored_configs_work()?;
 
     // Runs `zebrad` serially to avoid potential port conflicts
     app_no_args()?;
@@ -702,13 +702,29 @@ fn last_config_is_stored() -> Result<()> {
         .to_string();
 
     // Loop all the stored configs
+    //
+    // TODO: use the same filename list code in last_config_is_stored() and stored_configs_work()
     for config_file in configs_dir()
         .read_dir()
         .expect("read_dir call failed")
         .flatten()
     {
+        let config_file_path = config_file.path();
+
+        if config_file_path
+            .file_name()
+            .expect("config files must have a file name")
+            .to_string_lossy()
+            .as_ref()
+            .starts_with('.')
+        {
+            // Skip editor files and other invalid config paths
+            tracing::info!(?config_file_path, "skipping hidden config file path");
+            continue;
+        }
+
         // Read stored config
-        let stored_content = fs::read_to_string(config_file_full_path(config_file.path()))
+        let stored_content = fs::read_to_string(config_file_full_path(config_file_path))
             .expect("Should have been able to read the file")
             .trim()
             .to_string();
@@ -832,7 +848,7 @@ fn invalid_generated_config() -> Result<()> {
 
 /// Test all versions of `zebrad.toml` we have stored can be parsed by the latest `zebrad`.
 #[tracing::instrument]
-fn stored_configs_works() -> Result<()> {
+fn stored_configs_work() -> Result<()> {
     let old_configs_dir = configs_dir();
 
     for config_file in old_configs_dir
@@ -840,15 +856,29 @@ fn stored_configs_works() -> Result<()> {
         .expect("read_dir call failed")
         .flatten()
     {
+        let config_file_path = config_file.path();
+        let config_file_name = config_file_path
+            .file_name()
+            .expect("config files must have a file name")
+            .to_string_lossy();
+
+        if config_file_name.as_ref().starts_with('.') {
+            // Skip editor files and other invalid config paths
+            tracing::info!(?config_file_path, "skipping hidden config file path");
+            continue;
+        }
+
         // ignore files starting with getblocktemplate prefix
         // if we were not built with the getblocktemplate-rpcs feature.
         #[cfg(not(feature = "getblocktemplate-rpcs"))]
-        if config_file
-            .file_name()
-            .into_string()
-            .expect("all files names should be string convertible")
+        if config_file_name
+            .as_ref()
             .starts_with(GET_BLOCK_TEMPLATE_CONFIG_PREFIX)
         {
+            tracing::info!(
+                ?config_file_path,
+                "skipping getblocktemplate-rpcs config file path"
+            );
             continue;
         }
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -710,16 +710,18 @@ fn last_config_is_stored() -> Result<()> {
         .flatten()
     {
         let config_file_path = config_file.path();
-
-        if config_file_path
+        let config_file_name = config_file_path
             .file_name()
             .expect("config files must have a file name")
-            .to_string_lossy()
-            .as_ref()
-            .starts_with('.')
+            .to_string_lossy();
+
+        if config_file_name.as_ref().starts_with('.') || config_file_name.as_ref().starts_with('#')
         {
             // Skip editor files and other invalid config paths
-            tracing::info!(?config_file_path, "skipping hidden config file path");
+            tracing::info!(
+                ?config_file_path,
+                "skipping hidden/temporary config file path"
+            );
             continue;
         }
 
@@ -862,9 +864,13 @@ fn stored_configs_work() -> Result<()> {
             .expect("config files must have a file name")
             .to_string_lossy();
 
-        if config_file_name.as_ref().starts_with('.') {
+        if config_file_name.as_ref().starts_with('.') || config_file_name.as_ref().starts_with('#')
+        {
             // Skip editor files and other invalid config paths
-            tracing::info!(?config_file_path, "skipping hidden config file path");
+            tracing::info!(
+                ?config_file_path,
+                "skipping hidden/temporary config file path"
+            );
             continue;
         }
 


### PR DESCRIPTION
## Motivation

Sometimes editors and other tools leave hidden files in a directory. Zebra's tests need to skip those files.

This usually impacts local tests, CI is a fresh checkout each time, so it doesn't have this problem.

## Solution

In the `zebrad.toml` tests, skip any files starting with `.` (hidden files on unix OSes) or `#` (editor temporary files)

## Review

This is a low priority test fix.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

