### PR TITLE
fix(state): Avoid temporary failures verifying the first non-finalized block or attempting to fork the chain before the final checkpoint

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -719,11 +719,7 @@ impl StateService {
                 "already finished committing checkpoint verified blocks: dropped duplicate block, \
                  block is already committed to the state",
             );
-        }
-        // TODO: avoid a temporary verification failure that can happen
-        //       if the first non-finalized block arrives before the last finalized block is committed
-        //       (#5125)
-        else if !self.can_fork_chain_at(&parent_hash) {
+        } else if !self.can_fork_chain_at(&parent_hash) {
             tracing::trace!("unready to verify, returning early");
         } else if self.finalized_block_write_sender.is_none() {
             // Wait until block commit task is ready to write non-finalized blocks before dequeuing them

--- a/zebra-state/src/service/queued_blocks.rs
+++ b/zebra-state/src/service/queued_blocks.rs
@@ -237,6 +237,10 @@ pub(crate) struct SentHashes {
 
     /// Known UTXOs.
     known_utxos: HashMap<transparent::OutPoint, transparent::Utxo>,
+
+    /// Whether the hashes in this struct can be used check if the chain can be forked.
+    /// This is set to false until all checkpoint-verified block hashes have been pruned.
+    pub(crate) can_fork_chain_at_hashes: bool,
 }
 
 impl SentHashes {
@@ -335,6 +339,8 @@ impl SentHashes {
         });
 
         self.sent.shrink_to_fit();
+        self.known_utxos.shrink_to_fit();
+        self.bufs.shrink_to_fit();
 
         self.update_metrics_for_cache();
     }
@@ -342,6 +348,11 @@ impl SentHashes {
     /// Returns true if SentHashes contains the `hash`
     pub fn contains(&self, hash: &block::Hash) -> bool {
         self.sent.contains_key(hash)
+    }
+
+    /// Returns true if the chain can be forked at the provided hash
+    pub fn can_fork_chain_at(&self, hash: &block::Hash) -> bool {
+        self.can_fork_chain_at_hashes && self.contains(hash)
     }
 
     /// Update sent block metrics after a block is sent.


### PR DESCRIPTION
## Motivation

This PR updates the `can_fork_chain_at()` method in zebra-state to ignore blocks below the finalized tip and fixes a bug where the first block past the final checkpoint will fail verification if it arrives in zebra-state before the final checkpoint block is written to disk.

Close #6388
Close #5125

Part of #5709

## Solution

- Add a `can_fork_chain_at_hashes` flag to `SentHashes`
- Add and use a `can_fork_chain_at(hash)` method to `SentHashes` that checks the new flag
- When closing finalized block write channel:
  - Replace `block_write_sent_hashes` with an empty `SentHashes` and mark `can_fork_chain_at_hashes` as true 
  - Start committing queued non-finalized child blocks of finalized tip

Related:

- Adds `shrink_to_fit()` calls in `prune_by_height()`

## Review

This is low-priority.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
