### PR TITLE
change(db): Make the first stable release forward-compatible with planned state changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5960,6 +5960,7 @@ dependencies = [
  "regex",
  "rlimit",
  "rocksdb",
+ "semver 1.0.17",
  "serde",
  "serde_json",
  "spandoc",

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -46,6 +46,7 @@ mset = "0.1.1"
 regex = "1.8.3"
 rlimit = "0.9.1"
 rocksdb = { version = "0.21.0", default_features = false, features = ["lz4"] }
+semver = "1.0.17"
 serde = { version = "1.0.163", features = ["serde_derive"] }
 tempfile = "3.5.0"
 thiserror = "1.0.40"

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -330,7 +330,16 @@ pub fn database_format_version_on_disk(
 }
 
 /// Writes the currently running semantic database version to the on-disk database.
+///
+/// # Correctness
+///
 /// This should only be called after all running format upgrades are complete.
+///
+/// # Concurrency
+///
+/// This must only be called while RocksDB has an open database for `config`.
+/// Otherwise, multiple Zebra processes could write the version at the same time,
+/// corrupting the file.
 pub fn write_database_format_version_to_disk(
     config: &Config,
     network: Network,
@@ -343,6 +352,9 @@ pub fn write_database_format_version_to_disk(
         DATABASE_FORMAT_MINOR_VERSION, DATABASE_FORMAT_PATCH_VERSION
     );
 
+    // # Concurrency
+    //
+    // The caller handles locking for this file write.
     fs::write(version_path, version.as_bytes())?;
 
     Ok(())

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -27,18 +27,31 @@ pub use zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
 pub const MAX_BLOCK_REORG_HEIGHT: u32 = MIN_TRANSPARENT_COINBASE_MATURITY - 1;
 
 /// The database format major version, incremented each time the on-disk database format has a
-/// breaking change.
+/// breaking data format change.
+///
+/// Breaking changes include:
+/// - deleting a column family, or
+/// - changing a column family's data format in an incompatible way.
+///
+/// Breaking changes become minor version changes if:
+/// - we previously added compatibility code, and
+/// - it's available in all supported Zebra versions.
 ///
 /// Use [`database_format_version_in_code()`] or [`database_format_version_on_disk()`]
 /// to get the full semantic format version.
 pub const DATABASE_FORMAT_VERSION: u64 = 25;
 
 /// The database format minor version, incremented each time the on-disk database format has a
-/// significant functional change.
+/// significant data format change.
+///
+/// Significant changes include:
+/// - adding new column families,
+/// - changing the format of a column family in a compatible way, or
+/// - breaking changes with compatibility code in all supported Zebra versions.
 pub const DATABASE_FORMAT_MINOR_VERSION: u64 = 0;
 
 /// The database format patch version, incremented each time the on-disk database format has a
-/// significant bug fix.
+/// significant format compatibility fix.
 pub const DATABASE_FORMAT_PATCH_VERSION: u64 = 1;
 
 /// The name of the file containing the minor and patch database versions.

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -1,4 +1,11 @@
-//! Definitions of constants.
+//! Constants that impact state behaviour.
+
+use lazy_static::lazy_static;
+use regex::Regex;
+
+// For doc comment links
+#[allow(unused_imports)]
+use crate::config::{database_format_version_in_code, database_format_version_on_disk};
 
 pub use zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
 
@@ -19,13 +26,29 @@ pub use zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
 // TODO: change to HeightDiff
 pub const MAX_BLOCK_REORG_HEIGHT: u32 = MIN_TRANSPARENT_COINBASE_MATURITY - 1;
 
-/// The database format version, incremented each time the database format changes.
-pub const DATABASE_FORMAT_VERSION: u32 = 25;
+/// The database format major version, incremented each time the on-disk database format has a
+/// breaking change.
+///
+/// Use [`database_format_version_in_code()`] or [`database_format_version_on_disk()`]
+/// to get the full semantic format version.
+pub const DATABASE_FORMAT_VERSION: u64 = 25;
+
+/// The database format minor version, incremented each time the on-disk database format has a
+/// significant functional change.
+pub const DATABASE_FORMAT_MINOR_VERSION: u64 = 0;
+
+/// The database format patch version, incremented each time the on-disk database format has a
+/// significant bug fix.
+pub const DATABASE_FORMAT_PATCH_VERSION: u64 = 1;
+
+/// The name of the file containing the minor and patch database versions.
+pub const DATABASE_FORMAT_VERSION_FILE_NAME: &str = "version";
 
 /// The maximum number of blocks to check for NU5 transactions,
 /// before we assume we are on a pre-NU5 legacy chain.
 ///
-/// Zebra usually only has to check back a few blocks, but on testnet it can be a long time between v5 transactions.
+/// Zebra usually only has to check back a few blocks on mainnet, but on testnet it can be a long
+/// time between v5 transactions.
 pub const MAX_LEGACY_CHAIN_BLOCKS: usize = 100_000;
 
 /// The maximum number of non-finalized chain forks Zebra will track.
@@ -57,9 +80,6 @@ const MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_PROTOCOL: u32 = 160;
 /// <https://github.com/bitcoin/bitcoin/pull/4468/files#r17026905>
 pub const MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_ZEBRA: u32 =
     MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_PROTOCOL - 2;
-
-use lazy_static::lazy_static;
-use regex::Regex;
 
 lazy_static! {
     /// Regex that matches the RocksDB error when its lock file is already open.

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -450,12 +450,13 @@ impl DiskDb {
         let db_options = DiskDb::options();
 
         // When opening the database in read/write mode, all column families must be opened.
+        //
         // To make Zebra forward-compatible with databases updated by later versions,
-        // we read that list off the disk, then add any new column families from our list as well.
+        // we read any existing column families off the disk, then add any new column families
+        // from the current implementation.
         //
         // <https://github.com/facebook/rocksdb/wiki/Column-Families#reference>
-        let column_families_on_disk =
-            DB::list_cf(&db_options, &path).expect("unable to read column families on disk");
+        let column_families_on_disk = DB::list_cf(&db_options, &path).unwrap_or_default();
         let column_families_in_code = Self::COLUMN_FAMILIES_IN_CODE
             .iter()
             .map(ToString::to_string);

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -107,16 +107,11 @@ impl ZebraDb {
             None => return Default::default(),
         };
 
-        let sapling_nct_handle = self.db.cf_handle("sapling_note_commitment_tree").unwrap();
-
-        self.db
-            .zs_get(&sapling_nct_handle, &height)
-            .map(Arc::new)
+        self.sapling_note_commitment_tree_by_height(&height)
             .expect("Sapling note commitment tree must exist if there is a finalized tip")
     }
 
     /// Returns the Sapling note commitment tree matching the given block height.
-    #[allow(dead_code)]
     #[allow(clippy::unwrap_in_result)]
     pub fn sapling_note_commitment_tree_by_height(
         &self,
@@ -135,16 +130,11 @@ impl ZebraDb {
             None => return Default::default(),
         };
 
-        let orchard_nct_handle = self.db.cf_handle("orchard_note_commitment_tree").unwrap();
-
-        self.db
-            .zs_get(&orchard_nct_handle, &height)
-            .map(Arc::new)
+        self.orchard_note_commitment_tree_by_height(&height)
             .expect("Orchard note commitment tree must exist if there is a finalized tip")
     }
 
     /// Returns the Orchard note commitment tree matching the given block height.
-    #[allow(dead_code)]
     #[allow(clippy::unwrap_in_result)]
     pub fn orchard_note_commitment_tree_by_height(
         &self,


### PR DESCRIPTION
## Motivation

We're going to change how the state database is implemented in ticket #6642, after the first stable release.

It would be nice if all stable Zebra versions could read those states, even if they have some format changes.

Close #6746

### Specifications

https://docs.rs/rocksdb/latest/rocksdb/struct.DBCommon.html#method.list_cf
https://docs.rs/rocksdb/latest/rocksdb/struct.DBIteratorWithThreadMode.html

### Complex Code or Requirements

This is all fairly straightforward, the tricky part will be tickets #6642 and #4784, where we actually change the state format.

## Solution

- Add a minor and patch version to the state disk database format, and log compatibility at startup
- Open all column families in the database, including ones added by future Zebra versions (compatibility with #6642)
- If there isn't a new note commitment tree for a height, look for the previous tree (compatibility with #4784)

### Testing

These changes are covered by existing state and RPC tests.

I don't think we should have specific forward compatibility tests, we can just support it on a best-effort basis.

## Review

This is a routine change that we'd like to get in the first stable release.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Actually change the state format.