### PR TITLE
fix(state): Stop aborting on shutdown in state tests on macOS

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -722,12 +722,41 @@ impl DiskDb {
         let path = self.path();
         debug!(?path, "flushing database to disk");
 
-        self.db
-            .flush()
-            .expect("unexpected failure flushing SST data to disk");
-        self.db
-            .flush_wal(true)
-            .expect("unexpected failure flushing WAL data to disk");
+        // These flushes can fail during forced shutdown or during Drop after a shutdown,
+        // particularly in tests. If they fail, there's nothing we can do about it anyway.
+        if let Err(error) = self.db.flush() {
+            let error = format!("{error:?}");
+            if error.to_ascii_lowercase().contains("shutdown in progress") {
+                debug!(
+                    ?error,
+                    ?path,
+                    "expected shutdown error flushing database SST files to disk"
+                );
+            } else {
+                info!(
+                    ?error,
+                    ?path,
+                    "unexpected error flushing database SST files to disk during shutdown"
+                );
+            }
+        }
+
+        if let Err(error) = self.db.flush_wal(true) {
+            let error = format!("{error:?}");
+            if error.to_ascii_lowercase().contains("shutdown in progress") {
+                debug!(
+                    ?error,
+                    ?path,
+                    "expected shutdown error flushing database WAL buffer to disk"
+                );
+            } else {
+                info!(
+                    ?error,
+                    ?path,
+                    "unexpected error flushing database WAL buffer to disk during shutdown"
+                );
+            }
+        }
 
         // # Memory Safety
         //


### PR DESCRIPTION
## Motivation

We're seeing process aborts in the state on some macOS versions starting in Rust 1.70. This is the code that last caused that problem.

Close #6812

### Specifications

https://docs.rs/rocksdb/latest/rocksdb/struct.DBCommon.html#method.cancel_all_background_work

### Complex Code or Requirements

This is an ongoing concurrency bug: the database must shut down before its destructors run, but running the shutdown code also sometimes causes crashes.

## Solution

- Only run the shutdown code on macOS
- Ignore "shutdown in progress" errors in the state shutdown code, and just log other errors

### Testing

I haven't tested this yet because I don't have an x86_64 macOS machine. CI will test it.

## Review

This fixes a CI failure that's stopping all Rust PRs merging. We've disabled that job requirement, so it is urgent but not critical.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- [ ] Admin: re-enable the macOS requirement after this PR has merged, and all failing PRs have been merged/updated