### PR TITLE
fix(ci): remove macOS tests from CI

### DIFF
--- a/.github/workflows/continous-integration-os.patch.yml
+++ b/.github/workflows/continous-integration-os.patch.yml
@@ -22,7 +22,8 @@ jobs:
     strategy:
       matrix:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
-        os: [ubuntu-latest, macos-latest]
+        # TODO: macOS tests were removed for now, see https://github.com/ZcashFoundation/zebra/issues/6824
+        os: [ubuntu-latest]
         rust: [stable, beta]
         features: ["", " --features getblocktemplate-rpcs"]
         exclude:

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -69,7 +69,8 @@ jobs:
       fail-fast: false
       matrix:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
-        os: [ubuntu-latest, macos-latest]
+        # TODO: macOS tests were removed for now, see https://github.com/ZcashFoundation/zebra/issues/6824
+        os: [ubuntu-latest]
         rust: [stable, beta]
         features: ["", " --features getblocktemplate-rpcs"]
         exclude:


### PR DESCRIPTION
## Motivation

We have crashes in every PR after rust upgraded to 1.70 in macOS tests. We don't know what tests are causing it so we are disabling all tests for this platform as they are not supported by Zebra in tier 1.

Fixes the CI error in https://github.com/ZcashFoundation/zebra/issues/6812, but not the underlying bug.

## Solution

Remove all macOS tests from CI.

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Investigate whats going on and re enable if possible. https://github.com/ZcashFoundation/zebra/issues/6824
