### PR TITLE
fix(state): Avoid panicking on state errors during shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ There are a few bugs in Zebra that we're still working on fixing:
 
 - Block download and verification sometimes times out during Zebra's initial sync [#5709](https://github.com/ZcashFoundation/zebra/issues/5709). The full sync still finishes reasonably quickly.
 
+- Rust 1.70 [causes crashes during shutdown on macOS x86_64 (#6812)](https://github.com/ZcashFoundation/zebra/issues/6812). The state cache should stay valid despite the crash.
+
 - No Windows support [#3801](https://github.com/ZcashFoundation/zebra/issues/3801). We used to test with Windows Server 2019, but not any more; see the issue for details.
 
 - Experimental Tor support is disabled until [Zebra upgrades to the latest `arti-client`](https://github.com/ZcashFoundation/zebra/issues/5492). This happened due to a Rust dependency conflict, which could only be resolved by `arti` upgrading to a version of `x25519-dalek` with the dependency fix.

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -722,12 +722,41 @@ impl DiskDb {
         let path = self.path();
         debug!(?path, "flushing database to disk");
 
-        self.db
-            .flush()
-            .expect("unexpected failure flushing SST data to disk");
-        self.db
-            .flush_wal(true)
-            .expect("unexpected failure flushing WAL data to disk");
+        // These flushes can fail during forced shutdown or during Drop after a shutdown,
+        // particularly in tests. If they fail, there's nothing we can do about it anyway.
+        if let Err(error) = self.db.flush() {
+            let error = format!("{error:?}");
+            if error.to_ascii_lowercase().contains("shutdown in progress") {
+                debug!(
+                    ?error,
+                    ?path,
+                    "expected shutdown error flushing database SST files to disk"
+                );
+            } else {
+                info!(
+                    ?error,
+                    ?path,
+                    "unexpected error flushing database SST files to disk during shutdown"
+                );
+            }
+        }
+
+        if let Err(error) = self.db.flush_wal(true) {
+            let error = format!("{error:?}");
+            if error.to_ascii_lowercase().contains("shutdown in progress") {
+                debug!(
+                    ?error,
+                    ?path,
+                    "expected shutdown error flushing database WAL buffer to disk"
+                );
+            } else {
+                info!(
+                    ?error,
+                    ?path,
+                    "unexpected error flushing database WAL buffer to disk during shutdown"
+                );
+            }
+        }
 
         // # Memory Safety
         //

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -776,13 +776,15 @@ impl DiskDb {
         // We disabled cancel_all_background_work() due to failures on:
         // - Rust 1.64 on Linux
         //
-        // We conditionally enabled cancel_all_background_work() due to failures on:
-        // - macOS 12.6.5 on x86_64
-        // But there weren't any failures without cancel_all_background_work() on:
+        // We tried enabling cancel_all_background_work() due to failures on:
+        // - Rust 1.70 on macOS 12.6.5 on x86_64
+        // but it didn't stop the aborts happening (PR #6820).
+        //
+        // There weren't any failures with cancel_all_background_work() disabled on:
         // - Rust 1.69 or earlier
-        // - macOS 13.2 on aarch64 (M1), native and emulated x86_64, with Rust 1.70
         // - Linux with Rust 1.70
-        // We didn't check if Linux failed with cancel_all_background_work() enabled.
+        // And with cancel_all_background_work() enabled or disabled on:
+        // - macOS 13.2 on aarch64 (M1), native and emulated x86_64, with Rust 1.70
         //
         // # Detailed Description
         //
@@ -812,11 +814,13 @@ impl DiskDb {
         // > Users need to make sure rocksdb::DB instances are destroyed before those static variables.
         //
         // <https://github.com/facebook/rocksdb/wiki/Known-Issues>
-        #[cfg(target_os = "macos")]
-        {
-            info!(?path, "stopping background database tasks");
-            self.db.cancel_all_background_work(true);
-        }
+        //
+        // # TODO
+        //
+        // Try re-enabling this code and fixing the underlying concurrency bug.
+        //
+        //info!(?path, "stopping background database tasks");
+        //self.db.cancel_all_background_work(true);
 
         // We'd like to drop the database before deleting its files,
         // because that closes the column families and the database correctly.


### PR DESCRIPTION
## Motivation

Zebra can panic if there's a disk error during shutdown, but there's nothing we can do about that error anyway.

### Specifications

https://docs.rs/rocksdb/latest/rocksdb/struct.DBCommon.html#method.flush
https://docs.rs/rocksdb/latest/rocksdb/struct.DBCommon.html#method.flush_wal

### Complex Code or Requirements

This is concurrent code, but this PR just updates error handling and comments.

## Solution

- Ignore errors during state shutdown and just log them
- Document the different ways we've tried to handle database shutdown
- Add the macOS shutdown crash to the README known issues

### Testing

This is covered by existing state tests.

## Review

This is a low priority cleanup.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Fix the actual shutdown bug.