### PR TITLE
fix(net): Try harder to drop connections when they shut down, Credit: Ziggurat Team

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5852,6 +5852,7 @@ dependencies = [
  "howudoin",
  "humantime-serde",
  "indexmap",
+ "itertools",
  "lazy_static",
  "metrics 0.21.0",
  "ordered-map",

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -30,6 +30,7 @@ chrono = { version = "0.4.25", default-features = false, features = ["clock", "s
 hex = "0.4.3"
 humantime-serde = "1.1.1"
 indexmap = { version = "1.9.3", features = ["serde"] }
+itertools = "0.10.5"
 lazy_static = "1.4.0"
 ordered-map = "0.4.2"
 pin-project = "1.1.0"

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -335,6 +335,9 @@ pub const MIN_OVERLOAD_DROP_PROBABILITY: f32 = 0.05;
 /// [`Overloaded`](crate::PeerError::Overloaded) error.
 pub const MAX_OVERLOAD_DROP_PROBABILITY: f32 = 0.95;
 
+/// The minimum interval between logging peer set status updates.
+pub const MIN_PEER_SET_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
 lazy_static! {
     /// The minimum network protocol version accepted by this crate for each network,
     /// represented as a network upgrade.

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -543,10 +543,14 @@ impl Client {
         // Prevent any senders from sending more messages to this peer.
         self.server_tx.close_channel();
 
-        // Stop the heartbeat task
+        // Ask the heartbeat task to stop.
         if let Some(shutdown_tx) = self.shutdown_tx.take() {
             let _ = shutdown_tx.send(CancelHeartbeatTask);
         }
+
+        // Force the connection and heartbeat tasks to stop.
+        self.connection_task.abort();
+        self.heartbeat_task.abort();
     }
 }
 

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -451,7 +451,10 @@ impl From<Request> for InboundMessage {
 }
 
 /// The channels, services, and associated state for a peer connection.
-pub struct Connection<S, Tx> {
+pub struct Connection<S, Tx>
+where
+    Tx: Sink<Message, Error = SerializationError> + Unpin,
+{
     /// The metadata for the connected peer `service`.
     ///
     /// This field is used for debugging.
@@ -519,7 +522,10 @@ pub struct Connection<S, Tx> {
     last_overload_time: Option<Instant>,
 }
 
-impl<S, Tx> fmt::Debug for Connection<S, Tx> {
+impl<S, Tx> fmt::Debug for Connection<S, Tx>
+where
+    Tx: Sink<Message, Error = SerializationError> + Unpin,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // skip the channels, they don't tell us anything useful
         f.debug_struct(std::any::type_name::<Connection<S, Tx>>())
@@ -534,7 +540,10 @@ impl<S, Tx> fmt::Debug for Connection<S, Tx> {
     }
 }
 
-impl<S, Tx> Connection<S, Tx> {
+impl<S, Tx> Connection<S, Tx>
+where
+    Tx: Sink<Message, Error = SerializationError> + Unpin,
+{
     /// Return a new connection from its channels, services, and shared state.
     pub(crate) fn new(
         inbound_service: S,
@@ -1499,7 +1508,10 @@ fn overload_drop_connection_probability(now: Instant, prev: Option<Instant>) -> 
     raw_drop_probability.clamp(MIN_OVERLOAD_DROP_PROBABILITY, MAX_OVERLOAD_DROP_PROBABILITY)
 }
 
-impl<S, Tx> Connection<S, Tx> {
+impl<S, Tx> Connection<S, Tx>
+where
+    Tx: Sink<Message, Error = SerializationError> + Unpin,
+{
     /// Update the connection state metrics for this connection,
     /// using `extra_state_info` as additional state information.
     fn update_state_metrics(&mut self, extra_state_info: impl Into<Option<String>>) {
@@ -1617,7 +1629,10 @@ impl<S, Tx> Connection<S, Tx> {
     }
 }
 
-impl<S, Tx> Drop for Connection<S, Tx> {
+impl<S, Tx> Drop for Connection<S, Tx>
+where
+    Tx: Sink<Message, Error = SerializationError> + Unpin,
+{
     fn drop(&mut self) {
         self.shutdown(PeerError::ConnectionDropped);
 

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -852,6 +852,8 @@ where
             }
         }
 
+        // TODO: close peer_rx here, after changing it from a stream to a channel
+
         let error = self.error_slot.try_get_error();
         assert!(
             error.is_some(),


### PR DESCRIPTION
## Changelog

The Ziggurat team needs to be credited in this PR's changelog entry. This should happen automatically.

## Motivation

Some users report that Zebra v1.0.0-rc.8 opens multiple connections to the same node.

Close #6805

### Complex Code or Requirements

This is concurrent code, but this PR mainly modifies the shutdown sequence. The task shutdowns could have timing issues, but the other shutdown code is not concurrent.

## Solution

- Force Client tasks to shut down when it is dropped
- Try to close the Connection peer sender sink on drop
- Reliably shut down the peer sender when the Connection is shut down
- Add PeerSet logging for duplicate peer connections, checking both IP:port and just IP 

### Testing

I couldn't reproduce the errors on the latest `main` branch, and I didn't find any bugs that would be easy to test.

I added logging so these kinds of issues are easier to detect in future.

## Review

This is a routine security fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Ask the Ziggurat team to re-test.