### PR TITLE
✨ Release 1.0.0 ✨

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 This is our 1.0.0 stable release.
 
-This release also fixes a panic at startup when parsing the app version, begins publishing to crates.io, and publishes to Docker Hub under the `latest` tag.
+This release also fixes a panic at startup when parsing the app version, [publishes `zebrad` to crates.io](https://crates.io/crates/zebrad), and [publishes to Docker Hub under the `latest` tag](https://hub.docker.com/r/zfnd/zebra/tags).
 
 Please report bugs to [the Zebra GitHub repository](https://github.com/ZcashFoundation/zebra/issues/new?assignees=&labels=C-bug%2C+S-needs-triage&projects=&template=bug_report.yml&title=)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Please report bugs to [the Zebra GitHub repository](https://github.com/ZcashFoun
 
 ### Fixed
 
-- Stop panicking at startup when parsing the app version - release blocker ([#6888](https://github.com/ZcashFoundation/zebra/pull/6888))
+- Stop panicking at startup when parsing the app version ([#6888](https://github.com/ZcashFoundation/zebra/pull/6888))
 - Allow the container to raise in MIGs ([#6893](https://github.com/ZcashFoundation/zebra/pull/6893))
 - Avoid a race condition in testing modified JoinSplits ([#6921](https://github.com/ZcashFoundation/zebra/pull/6921))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 This is our 1.0.0 stable release.
 
+This release also fixes a panic at startup when parsing the app version, begins publishing to crates.io, and publishes to Docker Hub under the `latest` tag.
+
 Please report bugs to [the Zebra GitHub repository](https://github.com/ZcashFoundation/zebra/issues/new?assignees=&labels=C-bug%2C+S-needs-triage&projects=&template=bug_report.yml&title=)
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ Please report bugs to [the Zebra GitHub repository](https://github.com/ZcashFoun
 ### Fixed
 
 - Stop panicking at startup when parsing the app version ([#6888](https://github.com/ZcashFoundation/zebra/pull/6888))
-- Allow the container to raise in MIGs ([#6893](https://github.com/ZcashFoundation/zebra/pull/6893))
 - Avoid a race condition in testing modified JoinSplits ([#6921](https://github.com/ZcashFoundation/zebra/pull/6921))
 
 ### Contributors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
 
+## [Zebra 1.0.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.0.0) - 2023-06-14
+
+This is our 1.0.0 stable release.
+
+Please report bugs to [the Zebra GitHub repository](https://github.com/ZcashFoundation/zebra/issues/new?assignees=&labels=C-bug%2C+S-needs-triage&projects=&template=bug_report.yml&title=)
+
+### Security
+
+- Avoid potential concurrency bugs in outbound handshakes ([#6869](https://github.com/ZcashFoundation/zebra/pull/6869))
+
+### Changed
+
+- Rename tower-batch to tower-batch-control ([#6907](https://github.com/ZcashFoundation/zebra/pull/6907))
+- Upgrade to ed25519-zebra 4.0.0 ([#6881](https://github.com/ZcashFoundation/zebra/pull/6881))
+
+### Fixed
+
+- Stop panicking at startup when parsing the app version - release blocker ([#6888](https://github.com/ZcashFoundation/zebra/pull/6888))
+- Allow the container to raise in MIGs ([#6893](https://github.com/ZcashFoundation/zebra/pull/6893))
+- Avoid a race condition in testing modified JoinSplits ([#6921](https://github.com/ZcashFoundation/zebra/pull/6921))
+
+### Contributors
+
+Thank you to everyone who contributed to this release, we couldn't make Zebra without you:
+@dconnolly, @gustavovalverde, @oxarbitrage, @teor2345 and @upbqdn
+
+
 ## [Zebra 1.0.0-rc.9](https://github.com/ZcashFoundation/zebra/releases/tag/v1.0.0-rc.9) - 2023-06-07
 
 This release continues to address audit findings. It fixes multiple network protocol and RPC bugs,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please report bugs to [the Zebra GitHub repository](https://github.com/ZcashFoun
 
 ### Changed
 
+- Publish to [crates.io](https://crates.io/crates/zebrad) ([#6908(https://github.com/ZcashFoundation/zebra/pull/6908))
 - Rename tower-batch to tower-batch-control ([#6907](https://github.com/ZcashFoundation/zebra/pull/6907))
 - Upgrade to ed25519-zebra 4.0.0 ([#6881](https://github.com/ZcashFoundation/zebra/pull/6881))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4719,7 +4719,7 @@ dependencies = [
 
 [[package]]
 name = "tower-batch-control"
-version = "0.2.41-beta.1"
+version = "0.2.41-beta.2"
 dependencies = [
  "color-eyre",
  "ed25519-zebra",
@@ -4743,7 +4743,7 @@ dependencies = [
 
 [[package]]
 name = "tower-fallback"
-version = "0.2.41-beta.1"
+version = "0.2.41-beta.2"
 dependencies = [
  "futures-core",
  "pin-project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 dependencies = [
  "bitflags 2.3.1",
  "bitflags-serde-legacy",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 dependencies = [
  "bitflags 2.3.1",
  "byteorder",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 dependencies = [
  "color-eyre",
  "jsonrpc-core",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 dependencies = [
  "chrono",
  "futures",
@@ -5828,7 +5828,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 dependencies = [
  "displaydoc",
  "hex",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 dependencies = [
  "bincode",
  "chrono",
@@ -5882,7 +5882,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-test"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 dependencies = [
  "color-eyre",
  "futures",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 dependencies = [
  "color-eyre",
  "hex",
@@ -5930,7 +5930,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "1.0.0-rc.9"
+version = "1.0.0"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ section in the Zebra book for system requirements.
 This command will run our latest release, and sync it to the tip:
 
 ```sh
-docker run zfnd/zebra:1.0.0
+docker run zfnd/zebra:latest
 ```
 
 For more information, read our [Docker documentation](book/src/user/docker.md).

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ section in the Zebra book for system requirements.
 This command will run our latest release, and sync it to the tip:
 
 ```sh
-docker run zfnd/zebra:1.0.0-rc.9
+docker run zfnd/zebra:1.0.0
 ```
 
 For more information, read our [Docker documentation](book/src/user/docker.md).
@@ -101,7 +101,7 @@ Note that the package `clang` includes `libclang` as well as the C++ compiler.
 Once the dependencies are in place, you can build Zebra
 
 ```sh
-cargo install --locked --git https://github.com/ZcashFoundation/zebra --tag v1.0.0-rc.9 zebrad
+cargo install --locked --git https://github.com/ZcashFoundation/zebra --tag v1.0.0 zebrad
 ```
 
 You can start Zebra by

--- a/README.md
+++ b/README.md
@@ -164,8 +164,6 @@ There are a few bugs in Zebra that we're still working on fixing:
 
 ## Future Work
 
-The Zebra team is currently working towards an audited stable release.
-
 We will continue to add new features as part of future network upgrades, and in response to community feedback.
 
 ## Documentation

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -11,13 +11,13 @@ You can deploy Zebra for a daily use with the images available in [Docker Hub](h
 ### Ready to use image
 
 ```shell
-docker run --detach zfnd/zebra:1.0.0-rc.9
+docker run --detach zfnd/zebra:1.0.0
 ```
 
 ### Build it locally
 
 ```shell
-git clone --depth 1 --branch v1.0.0-rc.9 https://github.com/ZcashFoundation/zebra.git
+git clone --depth 1 --branch v1.0.0 https://github.com/ZcashFoundation/zebra.git
 docker build --file docker/Dockerfile --target runtime --tag zebra:local .
 docker run --detach zebra:local
 ```

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -11,7 +11,7 @@ You can deploy Zebra for a daily use with the images available in [Docker Hub](h
 ### Ready to use image
 
 ```shell
-docker run --detach zfnd/zebra:1.0.0
+docker run --detach zfnd/zebra:latest
 ```
 
 ### Build it locally

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -44,8 +44,8 @@ rand = { version = "0.8.5", package = "rand" }
 
 tokio = { version = "1.28.2", features = ["full", "tracing", "test-util"] }
 tokio-test = "0.4.2"
-tower-fallback = { path = "../tower-fallback/"}
+tower-fallback = { path = "../tower-fallback/" }
 tower-test = "0.4.0"
 
-zebra-consensus = { path = "../zebra-consensus/"}
-zebra-test = { path = "../zebra-test/"}
+zebra-consensus = { path = "../zebra-consensus/" }
+zebra-test = { path = "../zebra-test/" }

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -10,6 +10,7 @@ description = "Tower middleware for batch request processing"
 # This code was modified from a 2019 version of:
 # https://github.com/tower-rs/tower/tree/master/tower/src/buffer
 license = "MIT"
+license-file = "LICENSE"
 repository = "https://github.com/ZcashFoundation/zebra"
 edition = "2021"
 

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -43,8 +43,8 @@ rand = { version = "0.8.5", package = "rand" }
 
 tokio = { version = "1.28.2", features = ["full", "tracing", "test-util"] }
 tokio-test = "0.4.2"
-tower-fallback = { path = "../tower-fallback/" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.40" }
 tower-test = "0.4.0"
 
-zebra-consensus = { path = "../zebra-consensus/" }
-zebra-test = { path = "../zebra-test/" }
+zebra-consensus = { path = "../zebra-consensus/", version = "1.0.0-beta.25" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.25" }

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-batch-control"
-version = "0.2.41-beta.1"
+version = "0.2.41-beta.2"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Tower middleware for batch request processing"
 # # Legal

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -10,7 +10,6 @@ description = "Tower middleware for batch request processing"
 # This code was modified from a 2019 version of:
 # https://github.com/tower-rs/tower/tree/master/tower/src/buffer
 license = "MIT"
-license-file = "LICENSE"
 repository = "https://github.com/ZcashFoundation/zebra"
 edition = "2021"
 

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -43,8 +43,8 @@ rand = { version = "0.8.5", package = "rand" }
 
 tokio = { version = "1.28.2", features = ["full", "tracing", "test-util"] }
 tokio-test = "0.4.2"
-tower-fallback = { path = "../tower-fallback/", version = "0.2.40" }
+tower-fallback = { path = "../tower-fallback/"}
 tower-test = "0.4.0"
 
-zebra-consensus = { path = "../zebra-consensus/", version = "1.0.0-beta.25" }
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.25" }
+zebra-consensus = { path = "../zebra-consensus/"}
+zebra-test = { path = "../zebra-test/"}

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-fallback"
-version = "0.2.41-beta.1"
+version = "0.2.41-beta.2"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Tower service combinator that sends requests to a first service, then retries processing on a second fallback service if the first service errors."
 license = "MIT OR Apache-2.0"

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -116,7 +116,7 @@ rand_chacha = { version = "0.3.1", optional = true }
 
 tokio = { version = "1.28.2", features = ["tracing"], optional = true }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.25", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.26", optional = true }
 
 [dev-dependencies]
 # Benchmarks

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Core Zcash data structures"
 license = "MIT OR Apache-2.0"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -65,10 +65,10 @@ zcash_proofs = { version = "0.11.0", features = ["local-prover", "multicore", "d
 tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.1" }
 tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.1" }
 
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.25" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.25" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.25" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.25" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.26" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.26" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.26" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.26" }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Implementation of Zcash consensus checks"
 license = "MIT OR Apache-2.0"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -62,8 +62,8 @@ orchard = "0.4.0"
 
 zcash_proofs = { version = "0.11.0", features = ["local-prover", "multicore", "download-params"] }
 
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.1" }
-tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.1" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.2" }
+tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.2" }
 
 zebra-script = { path = "../zebra-script", version = "1.0.0-beta.26" }
 zebra-state = { path = "../zebra-state", version = "1.0.0-beta.26" }

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -78,7 +78,7 @@ howudoin = { version = "0.1.2", optional = true }
 proptest = { version = "1.2.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.25" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.26" }
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -35,7 +35,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.25"}
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.26"}
 
 # Optional dependencies
 

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-node-services"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The interfaces of some Zebra node services"
 license = "MIT OR Apache-2.0"

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -70,12 +70,12 @@ zcash_address = { version = "0.2.1", optional = true }
 # Test-only feature proptest-impl
 proptest = { version = "1.2.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.25", features = ["json-conversion"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.25" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.25" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.25" }
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.25" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.25" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.26", features = ["json-conversion"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.26" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.26" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.26" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.26" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.26" }
 
 [dev-dependencies]
 insta = { version = "1.29.0", features = ["redactions", "json", "ron"] }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license = "MIT OR Apache-2.0"

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license = "MIT OR Apache-2.0"

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["api-bindings", "cryptography::cryptocurrencies"]
 [dependencies]
 zcash_script = "0.1.12"
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.25" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.26" }
 
 thiserror = "1.0.40"
 displaydoc = "0.2.4"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -69,13 +69,13 @@ tracing = "0.1.37"
 elasticsearch = { version = "8.5.0-alpha.1", package = "elasticsearch", optional = true }
 serde_json = { version = "1.0.96", package = "serde_json", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.25" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.26" }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
 
 # test feature proptest-impl
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.25", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.26", optional = true }
 proptest = { version = "1.2.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "State contextual verification and storage code for Zebra"
 license = "MIT OR Apache-2.0"

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-test"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Test harnesses and test vectors for Zebra"
 license = "MIT OR Apache-2.0"

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -70,11 +70,11 @@ tracing-error = "0.2.0"
 tracing-subscriber = "0.3.17"
 thiserror = "1.0.40"
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.25" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.25" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.26" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.26" }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.25", optional = true }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.26", optional = true }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { version = "0.10.5", optional = true }

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "1.0.0-beta.25"
+version = "1.0.0-beta.26"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Developer tools for Zebra maintenance and testing"
 license = "MIT OR Apache-2.0"

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -116,14 +116,14 @@ test_sync_past_mandatory_checkpoint_mainnet = []
 test_sync_past_mandatory_checkpoint_testnet = []
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.25" }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.25" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.25" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.25" }
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.25" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.25" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.26" }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.26" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.26" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.26" }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.26" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.26" }
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.25", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.26", optional = true }
 
 abscissa_core = "0.7.0"
 clap = { version = "4.3.3", features = ["cargo"] }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "1.0.0-rc.9"
+version = "1.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license = "MIT OR Apache-2.0"

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release started to run.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_113_936;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_121_200;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
# Prepare for the Release

These release steps can be done a week before the release, in separate PRs.
They can be skipped for urgent releases.

## Checkpoints

For performance and security, we want to update the Zebra checkpoints in every release.
- [x] You can copy the latest checkpoints from CI by following [the zebra-checkpoints README](https://github.com/ZcashFoundation/zebra/blob/main/zebra-utils/README.md#zebra-checkpoints).

## Missed Dependency Updates

Sometimes `dependabot` misses some dependency updates, or we accidentally turned them off.

Here's how we make sure we got everything:
- [x] Run `cargo update` on the latest `main` branch, and keep the output
- [x] If needed, update [deny.toml](https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
- [x] Open a separate PR with the changes
- [x] Add the output of `cargo update` to that PR as a comment


# Make Release Changes

These release steps can be done a few days before the release, in the same PR:
- [x] Make sure the PRs with the new checkpoint hashes and missed dependencies are already merged

## Versioning

### How to Increment Versions

Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]

Choose a release level for `zebrad` based on the changes in the release that users will see:
- mainnet network upgrades are `major` releases
- new features, large changes, deprecations, and removals are `minor` releases
- otherwise, it is a `patch` release

Zebra's Rust API doesn't have any support or stability guarantees, so we keep all the `zebra-*` and `tower-*` crates on a beta `pre-release` version.

### Update Crate Versions

<details>

<summary>If you're publishing crates for the first time:</summary>

- [ ] Install `cargo-release`: `cargo install cargo-release`
- [ ] Make sure you are  an owner of the crate or [a member of the Zebra crates.io `owners` group on GitHub](https://github.com/orgs/ZcashFoundation/teams/owners)

</details>

- [x] Update crate versions and do a release dry-run:
    - [x] `cargo release version --verbose --workspace --exclude zebrad beta`
    - [x] `cargo release version --verbose --package zebrad [ major | minor | patch ]`
    - [x] `cargo release publish --verbose --workspace --dry-run`
- [x] Commit the version changes to your release PR branch using `git`: `cargo release commit --verbose --workspace`

## README

README updates can be skipped for urgent releases.

Update the README to:
- [x] Remove any "Known Issues" that have been fixed since the last release.
- [x] Update the "Build and Run Instructions" with any new dependencies.
      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
- [x] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s

You can use a command like:
```sh
fastmod --fixed-strings '1.58' '1.65'
```

## Change Log

**Important**: Any merge into `main` deletes any edits to the draft changelog.
Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.

We use [the Release Drafter workflow](https://github.com/marketplace/actions/release-drafter) to automatically create a [draft changelog](https://github.com/ZcashFoundation/zebra/releases). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.

To create the final change log:
- [x] Copy the **latest** draft changelog into `CHANGELOG.md` (there can be multiple draft releases)
- [x] Delete any trivial changes
    - [x] Put the list of deleted changelog entries in a PR comment to make reviewing easier
- [x] Combine duplicate changes
- [x] Edit change descriptions so they will make sense to Zebra users
- [x] Check the category for each change
  - Prefer the "Fix" category if you're not sure

## Update End of Support

The end of support height is calculated from the current blockchain height:
- [x] Find where the Zcash blockchain tip is now by using a [Zcash explorer](https://zcashblockexplorer.com/blocks) or other tool.
- [x] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.

<details>

<summary>Optional: calculate the release tagging height</summary>

- Add `1152` blocks for each day until the release
- For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height

</details>

### Create the Release PR

- [x] Push the version increments, the updated changelog, and the release constants into a branch,
      for example: `bump-v1.0.0` - this needs to be different to the tag name
- [x] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
- [x] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.


# Release Zebra

## Create the GitHub Pre-Release

- [x] Wait for all the release PRs to be merged
- [x] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
- [x] Set the tag name to the version tag,
      for example: `v1.0.0`
- [x] Set the release to target the `main` branch
- [x] Set the release title to `Zebra ` followed by the version tag,
      for example: `Zebra 1.0.0`
- [x] Replace the prepopulated draft changelog in the release description with the final changelog you created;
      starting just _after_ the title `## [Zebra ...` of the current version being released,
      and ending just _before_ the title of the previous release.
- [x] Mark the release as 'pre-release', until it has been built and tested
- [x] Publish the pre-release to GitHub using "Publish Release"
- [x] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)

## Test the Pre-Release

- [x] Wait until the [Docker binaries have been built on `main`](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-integration-docker.yml), and the quick tests have passed.
      (You can ignore the full sync and `lightwalletd` tests, because they take about a day to run.)
- [x] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-delivery.yml)

## Publish Release

- [x] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"

## Publish Crates

- [x] Run `cargo login`
- [x] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute`
- [x] Check that Zebra can be installed from `crates.io`:
      `cargo install --force --version 1.0.0 zebrad && ~/.cargo/bin/zebrad`

## Publish Docker Images
- [x] Wait until [the Docker images have been published](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml)
- [x] Test the Docker image using `docker run --tty --interactive zfnd/zebra:v1.0.0`,
      and put the output in a comment on the PR. 
      (You can use [gcloud cloud shell](https://console.cloud.google.com/home/dashboard?cloudshell=true))
- [x] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.

## Release Failures

If building or running fails after tagging:

<details>

1. Fix the bug that caused the failure
2. Start a new `patch` release
3. Skip the **Release Preparation**, and start at the **Release Changes** step
4. Update `CHANGELOG.md` with details about the fix
5. Follow the release checklist for the new Zebra version

</details>



Close #6692
Close #6149
Close #6939 

