### PR TITLE
fix(compatibility): Replace or add RPC content type header when applicable

### DIFF
--- a/zebra-node-services/src/rpc_client.rs
+++ b/zebra-node-services/src/rpc_client.rs
@@ -43,7 +43,7 @@ impl RpcRequestClient {
             .await
     }
 
-    /// Builds rpc request with a variable `content-type`. Used only for testing.
+    /// Builds rpc request with a variable `content-type`.
     pub async fn call_with_content_type(
         &self,
         method: impl AsRef<str>,
@@ -59,6 +59,24 @@ impl RpcRequestClient {
                 r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":123 }}"#
             ))
             .header("Content-Type", content_type)
+            .send()
+            .await
+    }
+
+    /// Builds rpc request with no content type.
+    pub async fn call_with_no_content_type(
+        &self,
+        method: impl AsRef<str>,
+        params: impl AsRef<str>,
+    ) -> reqwest::Result<reqwest::Response> {
+        let method = method.as_ref();
+        let params = params.as_ref();
+
+        self.client
+            .post(format!("http://{}", &self.rpc_address))
+            .body(format!(
+                r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":123 }}"#
+            ))
             .send()
             .await
     }

--- a/zebra-node-services/src/rpc_client.rs
+++ b/zebra-node-services/src/rpc_client.rs
@@ -43,6 +43,26 @@ impl RpcRequestClient {
             .await
     }
 
+    /// Builds rpc request with a variable `content-type`. Used only for testing.
+    pub async fn call_with_content_type(
+        &self,
+        method: impl AsRef<str>,
+        params: impl AsRef<str>,
+        content_type: String,
+    ) -> reqwest::Result<reqwest::Response> {
+        let method = method.as_ref();
+        let params = params.as_ref();
+
+        self.client
+            .post(format!("http://{}", &self.rpc_address))
+            .body(format!(
+                r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":123 }}"#
+            ))
+            .header("Content-Type", content_type)
+            .send()
+            .await
+    }
+
     /// Builds rpc request and gets text from response
     pub async fn text_from_call(
         &self,

--- a/zebra-rpc/src/server/http_request_compatibility.rs
+++ b/zebra-rpc/src/server/http_request_compatibility.rs
@@ -111,6 +111,16 @@ impl FixHttpRequestMiddleware {
     /// `application/json` is the only `content-type` accepted by the Zebra rpc endpoint:
     ///
     /// <https://github.com/paritytech/jsonrpc/blob/38af3c9439aa75481805edf6c05c6622a5ab1e70/http/src/handler.rs#L582-L584>
+    ///
+    /// # Security
+    ///
+    /// - `content-type` headers exist so that applications know they are speaking the correct protocol with the correct format.
+    /// We can be a bit flexible, but there are some types (such as binary) we shouldn't allow.
+    /// In particular, the "application/x-www-form-urlencoded" header should be rejected, so browser forms can't be used to attack
+    /// a local RPC port. See "The Role of Routers in the CSRF Attack" in
+    /// <https://www.invicti.com/blog/web-security/importance-content-type-header-http-requests/>
+    /// - Checking all the headers is secure, but only because hyper has custom code that just reads the first content-type header.
+    /// <https://github.com/hyperium/headers/blob/f01cc90cf8d601a716856bc9d29f47df92b779e4/src/common/content_type.rs#L102-L108>
     pub fn insert_or_replace_content_type_header(headers: &mut hyper::header::HeaderMap) {
         if !headers.contains_key(hyper::header::CONTENT_TYPE)
             || headers

--- a/zebra-rpc/src/server/http_request_compatibility.rs
+++ b/zebra-rpc/src/server/http_request_compatibility.rs
@@ -44,7 +44,7 @@ impl RequestMiddleware for FixHttpRequestMiddleware {
         tracing::trace!(?request, "original HTTP request");
 
         // Fix the request headers
-        FixHttpRequestMiddleware::add_missing_content_type_header(request.headers_mut());
+        FixHttpRequestMiddleware::add_content_type_header(request.headers_mut());
 
         // Fix the request body
         let request = request.map(|body| {
@@ -106,7 +106,7 @@ impl FixHttpRequestMiddleware {
     /// Ignore client supplied `content-type` HTTP header if any and always send requests with `application/json`.
     ///
     /// `application/json` is the only `content-type` accepted by the Zebra rpc endpoint.
-    pub fn add_missing_content_type_header(headers: &mut hyper::header::HeaderMap) {
+    pub fn add_content_type_header(headers: &mut hyper::header::HeaderMap) {
         headers.insert(
             hyper::header::CONTENT_TYPE,
             hyper::header::HeaderValue::from_static("application/json"),

--- a/zebra-rpc/src/server/http_request_compatibility.rs
+++ b/zebra-rpc/src/server/http_request_compatibility.rs
@@ -103,11 +103,13 @@ impl FixHttpRequestMiddleware {
             .replace(", \"jsonrpc\": \"1.0\"", "")
     }
 
-    /// If the `content-type` HTTP header is not present,
-    /// add an `application/json` content type header.
+    /// Ignore client supplied `content-type` HTTP header if any and always send requests with `application/json`.
+    ///
+    /// `application/json` is the only `content-type` accepted by the Zebra rpc endpoint.
     pub fn add_missing_content_type_header(headers: &mut hyper::header::HeaderMap) {
-        headers
-            .entry(hyper::header::CONTENT_TYPE)
-            .or_insert(hyper::header::HeaderValue::from_static("application/json"));
+        headers.insert(
+            hyper::header::CONTENT_TYPE,
+            hyper::header::HeaderValue::from_static("application/json"),
+        );
     }
 }

--- a/zebra-rpc/src/server/http_request_compatibility.rs
+++ b/zebra-rpc/src/server/http_request_compatibility.rs
@@ -106,7 +106,10 @@ impl FixHttpRequestMiddleware {
     /// Insert or replace client supplied `content-type` HTTP header to `application/json` in the following cases:
     ///
     /// - no `content-type` supplied.
-    /// - supplied `content-type` is `text/plain`.
+    /// - supplied `content-type` start with `text/plain`, for example:
+    ///   - `text/plain`
+    ///   - `text/plain;`
+    ///   - `text/plain; charset=utf-8`
     ///
     /// `application/json` is the only `content-type` accepted by the Zebra rpc endpoint:
     ///
@@ -125,7 +128,13 @@ impl FixHttpRequestMiddleware {
         if !headers.contains_key(hyper::header::CONTENT_TYPE)
             || headers
                 .get(hyper::header::CONTENT_TYPE)
-                .filter(|value| value.to_str().ok() == Some("text/plain"))
+                .filter(|value| {
+                    value
+                        .to_str()
+                        .ok()
+                        .unwrap_or_default()
+                        .starts_with("text/plain")
+                })
                 .is_some()
         {
             headers.insert(

--- a/zebra-rpc/src/server/http_request_compatibility.rs
+++ b/zebra-rpc/src/server/http_request_compatibility.rs
@@ -112,27 +112,16 @@ impl FixHttpRequestMiddleware {
     ///
     /// <https://github.com/paritytech/jsonrpc/blob/38af3c9439aa75481805edf6c05c6622a5ab1e70/http/src/handler.rs#L582-L584>
     pub fn insert_or_replace_content_type_header(headers: &mut hyper::header::HeaderMap) {
-        match headers.entry(hyper::header::CONTENT_TYPE) {
-            hyper::header::Entry::Vacant(_) => {
-                headers.insert(
-                    hyper::header::CONTENT_TYPE,
-                    hyper::header::HeaderValue::from_static("application/json"),
-                );
-            }
-            hyper::header::Entry::Occupied(header_data) => {
-                if header_data
-                    .iter()
-                    .filter_map(|x| x.to_str().ok())
-                    .map(|s| s == "text/plain")
-                    .next()
-                    .unwrap_or(false)
-                {
-                    headers.insert(
-                        hyper::header::CONTENT_TYPE,
-                        hyper::header::HeaderValue::from_static("application/json"),
-                    );
-                }
-            }
-        };
+        if !headers.contains_key(hyper::header::CONTENT_TYPE)
+            || headers
+                .get(hyper::header::CONTENT_TYPE)
+                .filter(|value| value.to_str().ok() == Some("text/plain"))
+                .is_some()
+        {
+            headers.insert(
+                hyper::header::CONTENT_TYPE,
+                hyper::header::HeaderValue::from_static("application/json"),
+            );
+        }
     }
 }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -221,6 +221,7 @@ color-eyre = { version = "0.6.2" }
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
 zebra-consensus = { path = "../zebra-consensus", features = ["proptest-impl"] }
 zebra-network = { path = "../zebra-network", features = ["proptest-impl"] }
+zebra-rpc = { path = "../zebra-rpc", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
 
 zebra-node-services = { path = "../zebra-node-services", features = ["rpc-client"] }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -221,7 +221,6 @@ color-eyre = { version = "0.6.2" }
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
 zebra-consensus = { path = "../zebra-consensus", features = ["proptest-impl"] }
 zebra-network = { path = "../zebra-network", features = ["proptest-impl"] }
-zebra-rpc = { path = "../zebra-rpc", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
 
 zebra-node-services = { path = "../zebra-node-services", features = ["rpc-client"] }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1494,12 +1494,20 @@ async fn rpc_endpoint_ignore_client_content_type() -> Result<()> {
     // Create an http client
     let client = RpcRequestClient::new(config.rpc.listen_addr.unwrap());
 
-    // Make the call to the `getinfo` RPC method
+    // Make the call to the `getinfo` RPC method with a `text/plain` content type as the zcashd rpc docs.
     let res = client
-        .call_with_content_type("getinfo", "[]".to_string(), "text/plain;".to_string())
+        .call_with_content_type("getinfo", "[]".to_string(), "text/plain".to_string())
         .await?;
 
-    // Test rpc endpoint response
+    // Test if rpc endpoint respond
+    assert!(res.status().is_success());
+
+    // Make the call to the `getinfo` RPC method with a random string as content type.
+    let res = client
+        .call_with_content_type("getinfo", "[]".to_string(), "whatever".to_string())
+        .await?;
+
+    // Test if rpc endpoint respond
     assert!(res.status().is_success());
 
     Ok(())

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1502,9 +1502,29 @@ async fn rpc_endpoint_client_content_type() -> Result<()> {
     // Zebra will insert valid `application/json` content type and succeed.
     assert!(res.status().is_success());
 
-    // Call to `getinfo` RPC method with a `text/plain` content type as the zcashd rpc docs.
+    // Call to `getinfo` RPC method with a `text/plain`.
     let res = client
         .call_with_content_type("getinfo", "[]".to_string(), "text/plain".to_string())
+        .await?;
+
+    // Zebra will replace to the valid `application/json` content type and succeed.
+    assert!(res.status().is_success());
+
+    // Call to `getinfo` RPC method with a `text/plain` content type as the zcashd rpc docs.
+    let res = client
+        .call_with_content_type("getinfo", "[]".to_string(), "text/plain;".to_string())
+        .await?;
+
+    // Zebra will replace to the valid `application/json` content type and succeed.
+    assert!(res.status().is_success());
+
+    // Call to `getinfo` RPC method with a `text/plain; other string` content type.
+    let res = client
+        .call_with_content_type(
+            "getinfo",
+            "[]".to_string(),
+            "text/plain; other string".to_string(),
+        )
         .await?;
 
     // Zebra will replace to the valid `application/json` content type and succeed.

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1512,7 +1512,7 @@ async fn rpc_endpoint_client_content_type() -> Result<()> {
 
     // Call to `getinfo` RPC method with a valid `application/json` content type.
     let res = client
-        .call_with_content_type("getinfo", "[]".to_string(), "text/plain".to_string())
+        .call_with_content_type("getinfo", "[]".to_string(), "application/json".to_string())
         .await?;
 
     // Zebra will not replace valid content type and succeed.


### PR DESCRIPTION
## Motivation

We want Zebra to support the curl examples from the zcashd rpc documentation like https://zcash.github.io/rpc/getblockchaininfo.html where the content type header is `text/plain`.

Close https://github.com/ZcashFoundation/zebra/issues/6363

## Solution

The solution here actually ignores any content type sent by the client and always use `application/json` which is the only type we support. I could be wrong here.

## Review

Anyone can review.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [x] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [x] Does it change concurrent code, unsafe code, or consensus rules?
  - [x] How do you know it works? Does it have tests?

