### PR TITLE
fix(deployment): Fix log file path and log colour

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -18,7 +18,7 @@ on:
         description: 'Network to deploy: Mainnet or Testnet'
         required: true
       log_file:
-        default: ${{ vars.CD_LOG_FILE }}
+        default: ''
         description: 'Log to a file path rather than standard output'
       no_cache:
         description: 'Disable the Docker cache for this build'

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -18,6 +18,7 @@ on:
         description: 'Network to deploy: Mainnet or Testnet'
         required: true
       log_file:
+        default: ${{ vars.CD_LOG_FILE }}
         description: 'Log to a file path rather than standard output'
       no_cache:
         description: 'Disable the Docker cache for this build'
@@ -318,7 +319,7 @@ jobs:
           --container-stdin \
           --container-tty \
           --container-image ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
-          --container-env "NETWORK=${{ inputs.network }},LOG_FILE=${{ inputs.log_file || vars.CD_LOG_FILE }},SENTRY_DSN=${{ vars.SENTRY_DSN }},SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}" \
+          --container-env "NETWORK=${{ inputs.network }},LOG_FILE=${{ inputs.log_file }},SENTRY_DSN=${{ vars.SENTRY_DSN }},SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}" \
           --create-disk=auto-delete=yes,size=300GB,type=pd-ssd \
           --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},auto-delete=yes,size=300GB,type=pd-ssd \
           --container-mount-disk=mount-path='/zebrad-cache',name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK} \

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -218,7 +218,7 @@ jobs:
           --user-output-enabled \
           --metadata google-logging-enabled=true,google-logging-use-fluentbit=true \
           --container-image ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
-          --container-env "NETWORK=${{ matrix.network }},LOG_FILE=${{ vars.CD_LOG_FILE }},SENTRY_DSN=${{ vars.SENTRY_DSN }},SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}" \
+          --container-env "NETWORK=${{ matrix.network }},LOG_FILE=${{ vars.CD_LOG_FILE }},LOG_COLOR=false,SENTRY_DSN=${{ vars.SENTRY_DSN }},SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}" \
           --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},auto-delete=yes,size=300GB,type=pd-ssd \
           --container-mount-disk=mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK} \
           --machine-type ${{ vars.GCP_SMALL_MACHINE }} \
@@ -319,7 +319,7 @@ jobs:
           --container-stdin \
           --container-tty \
           --container-image ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
-          --container-env "NETWORK=${{ inputs.network }},LOG_FILE=${{ inputs.log_file }},SENTRY_DSN=${{ vars.SENTRY_DSN }},SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}" \
+          --container-env "NETWORK=${{ inputs.network }},LOG_FILE=${{ inputs.log_file }},LOG_COLOR=false,SENTRY_DSN=${{ vars.SENTRY_DSN }},SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}" \
           --create-disk=auto-delete=yes,size=300GB,type=pd-ssd \
           --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},auto-delete=yes,size=300GB,type=pd-ssd \
           --container-mount-disk=mount-path='/zebrad-cache',name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -162,6 +162,12 @@ ENV RPC_PORT ${RPC_PORT}
 ARG LOG_FILE
 ENV LOG_FILE ${LOG_FILE}
 
+# Zebra automatically detects if it is attached to a terminal, and uses colored output.
+# Set this to 'true' to force using color even if the output is not a terminal.
+# Set this to 'false' to disable using color even if the output is a terminal.
+ARG LOG_COLOR
+ENV LOG_COLOR ${LOG_COLOR}
+
 # Expose configured ports
 
 EXPOSE 8233 18233 $RPC_PORT

--- a/docker/runtime-entrypoint.sh
+++ b/docker/runtime-entrypoint.sh
@@ -72,7 +72,7 @@ if [[ "$LOG_COLOR" = "true" ]]; then
 cat <<EOF >> "$ZEBRA_CONF_PATH"
 force_use_color = true
 EOF
-else if [[ "$LOG_COLOR" = "false" ]]; then
+elif [[ "$LOG_COLOR" = "false" ]]; then
 cat <<EOF >> "$ZEBRA_CONF_PATH"
 use_color = false
 EOF

--- a/docker/runtime-entrypoint.sh
+++ b/docker/runtime-entrypoint.sh
@@ -53,13 +53,28 @@ listen_addr = "0.0.0.0:${RPC_PORT}"
 EOF
 fi
 
+if [[ -n "$LOG_FILE" ]] || [[ -n "$LOG_COLOR" ]]; then
+cat <<EOF >> "$ZEBRA_CONF_PATH"
+[tracing]
+#endpoint_addr = "0.0.0.0:3000"
+EOF
+fi
+
 if [[ -n "$LOG_FILE" ]]; then
 mkdir -p $(dirname "$LOG_FILE")
 
 cat <<EOF >> "$ZEBRA_CONF_PATH"
-[tracing]
 log_file = "${LOG_FILE}"
-#endpoint_addr = "0.0.0.0:3000"
+EOF
+fi
+
+if [[ "$LOG_COLOR" = "true" ]]; then
+cat <<EOF >> "$ZEBRA_CONF_PATH"
+force_use_color = true
+EOF
+else if [[ "$LOG_COLOR" = "false" ]]; then
+cat <<EOF >> "$ZEBRA_CONF_PATH"
+use_color = false
 EOF
 fi
 


### PR DESCRIPTION
## Motivation

I can't say "no log file" for manually deployed instances.

Google Cloud logs have colour escapes in them.

## Solution

Only use the GItHub repository variable for auto-deployments.
Allow colours to be forced on or off.

## Review

This is a routine fix.

Please check I spelt color the North American way in the PR code.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

