### PR TITLE
fix(rust): Declare the correct compatibility with older Rust versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Building Zebra requires [Rust](https://www.rust-lang.org/tools/install),
 [pkg-config](http://pkgconf.org/), and a C++ compiler.
 
 Zebra is tested with the latest `stable` Rust version. Earlier versions are not
-supported or tested. Any Zebra version can start depending on new features in the
+supported or tested. Any Zebra release can start depending on new features in the
 latest stable Rust.
 
 Every few weeks, we release a [new Zebra version](https://github.com/ZcashFoundation/zebra/releases).

--- a/README.md
+++ b/README.md
@@ -67,11 +67,10 @@ Building Zebra requires [Rust](https://www.rust-lang.org/tools/install),
 [pkg-config](http://pkgconf.org/), and a C++ compiler.
 
 Zebra is tested with the latest `stable` Rust version. Earlier versions are not
-supported or tested. Note that Zebra's code currently uses features introduced
-in Rust 1.68, or any later stable release.
+supported or tested. Any Zebra version can start depending on new features in the
+latest stable Rust.
 
-Every few weeks, we release a [new Zebra
-version](https://github.com/ZcashFoundation/zebra/releases).
+Every few weeks, we release a [new Zebra version](https://github.com/ZcashFoundation/zebra/releases).
 
 Below are quick summaries for installing the dependencies on your machine.
 

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/ZcashFoundation/zebra"
 # Settings that impact compilation
 edition = "2021"
 
-# Zebra is only supported on the latest stable Rust version. Some earlier versions might work.
-# Zebra's code uses features introduced in Rust 1.68, or any later stable release.
-rust-version = "1.68"
+# Zebra is only supported on the latest stable Rust version. See the README for details.
+# Any Zebra release can break compatibility with older Rust versions.
+rust-version = "1.66"
 
 # Settings that impact runtime behaviour
 


### PR DESCRIPTION
## Motivation

This fixes an unnecessary build failure on Rust 1.66 and 1.67.

### Specifications

https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field


## Solution

- Declare the actual incompatible Rust version
- Document that no specific rust version is supported except stable, don't tempt users to depend on earlier versions

## Review

This should probably make it in the stable release, because it's a serious usability bug for users on older compiler versions.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

