### PR TITLE
fix(deploy): allow the container to raise in MIGs

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -211,15 +211,18 @@ jobs:
       - name: Create instance template for ${{ matrix.network }}
         run: |
           gcloud compute instance-templates create-with-container zebrad-${{ needs.versioning.outputs.major_version || env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-${NETWORK} \
+          --boot-disk-size 300GB \
           --boot-disk-type=pd-ssd \
           --image-project=cos-cloud \
           --image-family=cos-stable \
           --user-output-enabled \
-          --metadata google-logging-enabled=true,google-logging-use-fluentbit=true \
+          --metadata google-logging-enabled=true,google-logging-use-fluentbit=true,google-monitoring-enabled=true \
+          --container-stdin \
+          --container-tty \
           --container-image ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
-          --container-env "NETWORK=${{ matrix.network }},LOG_FILE=${{ vars.CD_LOG_FILE }},SENTRY_DSN=${{ vars.SENTRY_DSN }},SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}" \
-          --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},auto-delete=yes,size=300GB,type=pd-ssd \
-          --container-mount-disk=mount-path="/zebrad-cache",name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK} \
+          --container-env "NETWORK=${{ matrix.network }},ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache,LOG_FILE=${{ vars.CD_LOG_FILE }},SENTRY_DSN=${{ vars.SENTRY_DSN }},SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}" \
+          --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},device-name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},auto-delete=yes,size=300GB,type=pd-ssd,mode=rw \
+          --container-mount-disk=mount-path='/var/cache/zebrad-cache',name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},mode=rw \
           --machine-type ${{ vars.GCP_SMALL_MACHINE }} \
           --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \
           --service-account ${{ vars.GCP_DEPLOYMENTS_SA }} \
@@ -314,14 +317,13 @@ jobs:
           --image-project=cos-cloud \
           --image-family=cos-stable \
           --user-output-enabled \
-          --metadata google-logging-enabled=true,google-logging-use-fluentbit=true \
+          --metadata google-logging-enabled=true,google-logging-use-fluentbit=true,google-monitoring-enabled=true \
           --container-stdin \
           --container-tty \
           --container-image ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
-          --container-env "NETWORK=${{ inputs.network }},LOG_FILE=${{ inputs.log_file || vars.CD_LOG_FILE }},SENTRY_DSN=${{ vars.SENTRY_DSN }},SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}" \
-          --create-disk=auto-delete=yes,size=300GB,type=pd-ssd \
-          --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},auto-delete=yes,size=300GB,type=pd-ssd \
-          --container-mount-disk=mount-path='/zebrad-cache',name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK} \
+          --container-env "NETWORK=${{ inputs.network }},ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache,LOG_FILE=${{ inputs.log_file || vars.CD_LOG_FILE }},SENTRY_DSN=${{ vars.SENTRY_DSN }},SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}" \
+          --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},device-name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},auto-delete=yes,size=300GB,type=pd-ssd,mode=rw \
+          --container-mount-disk=mount-path='/var/cache/zebrad-cache',name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},mode=rw \
           --machine-type ${{ vars.GCP_SMALL_MACHINE }} \
           --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \
           --service-account ${{ vars.GCP_DEPLOYMENTS_SA }} \

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -220,7 +220,7 @@ jobs:
           --container-stdin \
           --container-tty \
           --container-image ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
-          --container-env "NETWORK=${{ matrix.network }},ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache,LOG_FILE=${{ vars.CD_LOG_FILE }},SENTRY_DSN=${{ vars.SENTRY_DSN }},SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}" \
+          --container-env "NETWORK=${{ matrix.network }},LOG_FILE=${{ vars.CD_LOG_FILE }},SENTRY_DSN=${{ vars.SENTRY_DSN }},SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}" \
           --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},device-name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},auto-delete=yes,size=300GB,type=pd-ssd,mode=rw \
           --container-mount-disk=mount-path='/var/cache/zebrad-cache',name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},mode=rw \
           --machine-type ${{ vars.GCP_SMALL_MACHINE }} \
@@ -321,7 +321,7 @@ jobs:
           --container-stdin \
           --container-tty \
           --container-image ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
-          --container-env "NETWORK=${{ inputs.network }},ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache,LOG_FILE=${{ inputs.log_file || vars.CD_LOG_FILE }},SENTRY_DSN=${{ vars.SENTRY_DSN }},SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}" \
+          --container-env "NETWORK=${{ inputs.network }},LOG_FILE=${{ inputs.log_file || vars.CD_LOG_FILE }},SENTRY_DSN=${{ vars.SENTRY_DSN }},SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}" \
           --create-disk=name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},device-name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},auto-delete=yes,size=300GB,type=pd-ssd,mode=rw \
           --container-mount-disk=mount-path='/var/cache/zebrad-cache',name=zebrad-cache-${{ env.GITHUB_SHA_SHORT }}-${NETWORK},mode=rw \
           --machine-type ${{ vars.GCP_SMALL_MACHINE }} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -162,6 +162,10 @@ ENV RPC_PORT ${RPC_PORT}
 ARG LOG_FILE
 ENV LOG_FILE ${LOG_FILE}
 
+# Set this to change the default cached state directory
+ARG ZEBRA_CACHED_STATE_DIR
+ENV ZEBRA_CACHED_STATE_DIR ${ZEBRA_CACHED_STATE_DIR:-/var/cache/zebrad-cache}
+
 # Expose configured ports
 
 EXPOSE 8233 18233 $RPC_PORT

--- a/docker/runtime-entrypoint.sh
+++ b/docker/runtime-entrypoint.sh
@@ -40,7 +40,7 @@ network = "$NETWORK"
 listen_addr = "0.0.0.0"
 
 [state]
-cache_dir = "/zebrad-cache"
+cache_dir = "$ZEBRA_CACHED_STATE_DIR"
 
 [metrics]
 #endpoint_addr = "0.0.0.0:9999"


### PR DESCRIPTION
## Motivation

The Managed Instance Groups in GCP were not raising the container as those were expecting the device name and the correct RW/RO mode to match between the created disk and the disk we're mounting in the container.

This also fixes monitoring, and uses the same caching directory as in CI, as the Container Optimized Image does not allow mounting in non-standard linux paths for security reasons.

Fixes: #5644
Fixes: #6861  

### Specifications

See: https://cloud.google.com/sdk/gcloud/reference/compute/instance-templates/create-with-container#--container-mount-disk

## Solution

- Add the missing `--boot-disk-size 300GB` to the MIGs template, just as we have on CI and Single instance deploy
- Allow user output and container `stdin` and `tty` to standardize with other approaches
- Enable Google Monitoring for single and long-live instances (MIGs)
- Use `ZEBRA_CACHED_STATE_DIR` with `/var/cache/zebrad-cache` as we do on CI, as the `cos-cloud` doesn't behave correctly with non-standard paths.

## Review

Anyone from DevOps

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We should make further changes in a following PR:

- For releases, it should sync from scratch (1). Currently it's 2-4 weeks between releases, so a 3 day mainnet sync is ok.

- For `main` branch pushes, it should have a cached state (2 or 3, whatever is easier or more reliable). We merge new PRs multiple times a day, so a cached state is needed.