### PR TITLE
fix(deploy): Stop doing another full sync on every main branch push

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -24,10 +24,10 @@ on:
         required: false
         type: boolean
         default: false
-
-  push:
-    branches:
-      - main
+  # Temporarily disabled to reduce network load, see #6894.
+  #push:
+  #  branches:
+  #    - main
   release:
     types:
       - published


### PR DESCRIPTION
## Motivation

PR #6893 actually enables Zebra deployment instances, but we don't want to deploy them on every main branch push until we've fixed caching in ticket #6894.

## Solution

Temporarily disable deployments on every main branch push.

It's ok to do a full sync after a release. (It's not ideal, but it doesn't put too much load on the network.)

## Review

This needs to go in at the same time as PR #6894.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?


