### PR TITLE
fix(test): Avoid a race condition in testing modified JoinSplits

### DIFF
--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -2153,7 +2153,7 @@ async fn v4_with_joinsplit_is_rejected_for_modification(
             })
             .await;
 
-        if result == expected_error || i >= 10 {
+        if result == expected_error || i >= 100 {
             break result;
         }
 


### PR DESCRIPTION
## Motivation

We recently saw the failure described in #5823, so we reopened the issue. This PR closes #5823.

## Solution

I increased the number of test cases from 10 to 100. If the issue ever shows up again, we shouldn't increase the number of test cases, but accept both test outcomes as correct since increasing the number of test cases would significantly increase the upper bound for the running time of the test.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

