### PR TITLE
fix(logs): Avoid grouping logs for separate tasks

### DIFF
--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -603,8 +603,7 @@ where
             );
 
             let connected_addr = peer::ConnectedAddr::new_inbound_direct(addr);
-            let accept_span = info_span!("listen_accept", peer = ?connected_addr);
-            let _guard = accept_span.enter();
+            info!(peer = ?connected_addr, "listen_accept");
 
             debug!("got incoming connection");
             handshaker.ready().await?;

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -611,7 +611,7 @@ where
             // # Correctness
             //
             // Holding the drop guard returned by Span::enter across .await points will
-            // result in incorrect traces if the executor yields.
+            // result in incorrect traces if it yields.
             //
             // This await is okay because the handshaker's `poll_ready` method always returns Ready.
             handshaker.ready().await?;

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -603,9 +603,17 @@ where
             );
 
             let connected_addr = peer::ConnectedAddr::new_inbound_direct(addr);
-            info!(peer = ?connected_addr, "listen_accept");
+            let accept_span = info_span!("listen_accept", peer = ?connected_addr);
+            let _guard = accept_span.enter();
 
             debug!("got incoming connection");
+
+            // # Correctness
+            //
+            // Holding the drop guard returned by Span::enter across .await points will
+            // result in incorrect traces if the executor yields.
+            //
+            // This await is okay because the handshaker's `poll_ready` method always returns Ready.
             handshaker.ready().await?;
             // TODO: distinguish between proxied listeners and direct listeners
             let handshaker_span = info_span!("listen_handshaker", peer = ?connected_addr);
@@ -636,6 +644,9 @@ where
 
                 handshakes.push(Box::pin(handshake_task));
             }
+
+            // We need to drop the guard before yielding.
+            std::mem::drop(_guard);
 
             // Rate-limit inbound connection handshakes.
             // But sleep longer after a successful connection,


### PR DESCRIPTION
## Motivation

We've seen some malformed logs from the `peer_cache_updater` task:

> 2023-06-11T22:18:21.656595Z INFO {net="Test"}:accept_inbound_connections{min_inbound_peer_connection_interval=1s listener_addr=Ok(0.0.0.0:18233)}:listen_accept{peer=In("v4redacted:41812")}:crawl: zebra_network::peer_set::candidate_set: timeout waiting for peer service readiness or peer responses
> accept_inbound_connections{min_inbound_peer_connection_interval=1s listener_addr=Ok(0.0.0.0:18233)}:listen_accept{peer=In("v4redacted:47028")}: zebra_network::config: updated cached peer IP addresses cached_ip_count=11 peer_cache_file="/root/.cache/zebra/network/testnet.peers

## Solution

- Drop `Entered` guard in `accept_inbound_connections()` before yielding

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
