### PR TITLE
fix(cleanup): redundant configuration feature

### DIFF
--- a/zebra-chain/src/block/merkle.rs
+++ b/zebra-chain/src/block/merkle.rs
@@ -9,7 +9,7 @@ use crate::{
     transaction::{self, Transaction, UnminedTx, UnminedTxId, VerifiedUnminedTx},
 };
 
-#[cfg(any(any(test, feature = "proptest-impl"), feature = "proptest-impl"))]
+#[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
 
 /// The root of the Bitcoin-inherited transaction Merkle tree, binding the


### PR DESCRIPTION
## Motivation

Minor mistake a i found which is not causing any issue but it is definitely redundant code.

This has no ticket associated with as it is too small.

## Solution

Fix the redudancy.

Check for other similars: There is no other find for `any(any` in the zebra codebase. 

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

