### PR TITLE
fix(ci): Disable scheduled testnet full sync by default

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -488,7 +488,7 @@ jobs:
     name: Zebra tip on testnet
     needs: [ build, get-available-disks-testnet ]
     uses: ./.github/workflows/deploy-gcp-tests.yml
-    if: ${{ github.event_name == 'schedule' || !fromJSON(needs.get-available-disks-testnet.outputs.zebra_tip_disk) || (github.event.inputs.run-full-sync == 'true' && github.event.inputs.network == 'Testnet') }}
+    if: ${{ (github.event_name == 'schedule' && vars.SCHEDULE_TESTNET_FULL_SYNC == 'true') || !fromJSON(needs.get-available-disks-testnet.outputs.zebra_tip_disk) || (github.event.inputs.run-full-sync == 'true' && github.event.inputs.network == 'Testnet') }}
     with:
       app_name: zebrad
       test_id: full-sync-to-tip-testnet


### PR DESCRIPTION
## Motivation

The testnet full sync is currently extremely slow, we should stop running it until the network recovers:
https://github.com/ZcashFoundation/zebra/actions/runs/5240305921/jobs/9476158691#step:8:2240

## Solution

Disable the scheduled testnet full sync job unless the `SCHEDULE_TESTNET_FULL_SYNC` actions variable is set to `true`.

## Review

This needs to be merged before the scheduled job runs on Friday midday UTC.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

If the full sync job needs fixes, we should fix it in another ticket.
If Zebra needs fixes on testnet, that should also be another ticket.