### PR TITLE
change(release): Rewrite the release checklist using `cargo release`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -7,17 +7,17 @@ assignees: ''
 
 ---
 
-## Release Preparation
+# Release Preparation
 
 These release steps can be done a week before the release, in separate PRs.
 They can be skipped for urgent releases.
 
-### Checkpoints
+## Checkpoints
 
 For performance and security, we want to update the Zebra checkpoints in every release.
 You can copy the latest checkpoints from CI by following [the zebra-checkpoints README](https://github.com/ZcashFoundation/zebra/blob/main/zebra-utils/README.md#zebra-checkpoints).
 
-### Missed Dependency Updates
+## Missed Dependency Updates
 
 Sometimes `dependabot` misses some dependency updates, or we accidentally turned them off.
 
@@ -28,14 +28,14 @@ Here's how we make sure we got everything:
 - [ ] Add the output of `cargo update` to that PR as a comment
 
 
-## Release Changes
+# Release Changes
 
 These release steps can be done a few days before the release, in the same PR:
 - [ ] Make sure the PRs with the new checkpoint hashes and missed dependencies are already merged
 
-### Crate Versions
+## Versioning
 
-#### Choose the Release Level
+### How to Increment Versions
 
 Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]
 
@@ -46,7 +46,7 @@ Choose a release level for `zebrad` based on the changes in the release that use
 
 Zebra's Rust API doesn't have any support or stability guarantees, so we keep all the `zebra-*` and `tower-*` crates on a beta `pre-release` version.
 
-#### Update Crate Versions
+### Update Crate Versions
 
 <details>
 
@@ -63,9 +63,22 @@ Zebra's Rust API doesn't have any support or stability guarantees, so we keep al
     - [ ] `cargo release publish --verbose --workspace --dry-run`
 - [ ] Commit the version changes to your release PR branch using `git`: `cargo release commit --verbose --workspace`
 
-### Release Documentation
+## README
 
-#### Create Change Log
+README updates can be skipped for urgent releases.
+
+Update the README to:
+- [ ] Remove any "Known Issues" that have been fixed since the last release.
+- [ ] Update the "Build and Run Instructions" with any new dependencies.
+      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
+- [ ] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s
+
+You can use a command like:
+```sh
+fastmod --fixed-strings '1.58' '1.65'
+```
+
+## Change Log
 
 **Important**: Any merge into `main` deletes any edits to the draft changelog.
 Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.
@@ -81,30 +94,16 @@ To create the final change log:
 - [ ] Check the category for each change
   - Prefer the "Fix" category if you're not sure
 
-#### Update README
-
-README updates can be skipped for urgent releases.
-
-Update the README to:
-- [ ] Remove any "Known Issues" that have been fixed since the last release.
-- [ ] Update the "Build and Run Instructions" with any new dependencies.
-      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
-- [ ] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s
-
-You can use a command like:
-```sh
-fastmod --fixed-strings '1.58' '1.65'
-```
-
-### Update End of Support Height
+## Update End of Support
 
 The end of support height is calculated from the current blockchain height:
-- [ ] Find the current Mainnet block height using a [Zcash explorer](https://zcashblockexplorer.com/blocks)
-- [ ] Update `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs)
+- [ ] Find where the Zcash blockchain tip is now by using a [Zcash explorer](https://zcashblockexplorer.com/blocks) or other tool.
+- [ ] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs)
+      with the height you estimate the release will be tagged.
 
 <details>
 
-<summary>Optional: estimate the release tagging height<summary>
+<summary>Optional: calculate the release tagging height<summary>
 
 - Add `1152` blocks for each day until the release
 - For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height
@@ -113,16 +112,16 @@ The end of support height is calculated from the current blockchain height:
 
 ### Create the Release PR
 
-- [ ] Push the version increments, the updated changelog and the release constants into a branch,
+- [ ] Push the version increments, the updated changelog, and the release constants into a branch,
       for example: `bump-v1.0.0` - this needs to be different to the tag name
 - [ ] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
 - [ ] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
 - [ ] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
 
 
-## Releasing Zebra
+# Releasing Zebra
 
-### Tag the Release
+### Create the Release
 
 - [ ] Wait for all the release PRs to be merged
 - [ ] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
@@ -138,12 +137,12 @@ The end of support height is calculated from the current blockchain height:
 - [ ] Publish the pre-release to GitHub using "Publish Release"
 - [ ] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)
 
-### Publish crates
+## Publish crates
 
 - [ ] Run `cargo login`
 - [ ] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute`
 
-### Binary Testing
+## Binary Testing
 
 - [ ] Check that Zebra can be installed from `crates.io`:
       `cargo install --force --version 1.0.0 zebrad && ~/.cargo/bin/zebrad`
@@ -168,6 +167,6 @@ If building or running fails after tagging:
 2. Start a new `patch` release
 3. Skip the **Release Preparation**, and start at the **Release Changes** step
 4. Update `CHANGELOG.md` with details about the fix
-5. Release a new Zebra version
+5. Follow the release checklist for the new Zebra version
 
 </details>

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-# Release Preparation
+# Prepare for the Release
 
 These release steps can be done a week before the release, in separate PRs.
 They can be skipped for urgent releases.
@@ -28,7 +28,7 @@ Here's how we make sure we got everything:
 - [ ] Add the output of `cargo update` to that PR as a comment
 
 
-# Release Changes
+# Make Release Changes
 
 These release steps can be done a few days before the release, in the same PR:
 - [ ] Make sure the PRs with the new checkpoint hashes and missed dependencies are already merged
@@ -98,12 +98,11 @@ To create the final change log:
 
 The end of support height is calculated from the current blockchain height:
 - [ ] Find where the Zcash blockchain tip is now by using a [Zcash explorer](https://zcashblockexplorer.com/blocks) or other tool.
-- [ ] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs)
-      with the height you estimate the release will be tagged.
+- [ ] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.
 
 <details>
 
-<summary>Optional: calculate the release tagging height<summary>
+<summary>Optional: calculate the release tagging height</summary>
 
 - Add `1152` blocks for each day until the release
 - For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height
@@ -119,9 +118,9 @@ The end of support height is calculated from the current blockchain height:
 - [ ] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
 
 
-# Releasing Zebra
+# Release Zebra
 
-### Create the Release
+## Create the GitHub Pre-Release
 
 - [ ] Wait for all the release PRs to be merged
 - [ ] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
@@ -137,18 +136,21 @@ The end of support height is calculated from the current blockchain height:
 - [ ] Publish the pre-release to GitHub using "Publish Release"
 - [ ] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)
 
-## Publish crates
+## Test the Pre-Release
 
-- [ ] Run `cargo login`
-- [ ] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute`
-
-## Binary Testing
-
-- [ ] Check that Zebra can be installed from `crates.io`:
-      `cargo install --force --version 1.0.0 zebrad && ~/.cargo/bin/zebrad`
 - [ ] Wait until the [Docker binaries have been built on `main`](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-integration-docker.yml), and the quick tests have passed.
       (You can ignore the full sync and `lightwalletd` tests, because they take about a day to run.)
 - [ ] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-delivery.yml)
+
+## Publish Crates
+
+- [ ] Run `cargo login`
+- [ ] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute`
+- [ ] Check that Zebra can be installed from `crates.io`:
+      `cargo install --force --version 1.0.0 zebrad && ~/.cargo/bin/zebrad`
+
+## Publish Release & Docker Images
+
 - [ ] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"
 - [ ] Wait until [the Docker images have been published](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml)
 - [ ] Test the Docker image using `docker run --tty --interactive zfnd/zebra:v1.0.0`,

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -142,6 +142,10 @@ The end of support height is calculated from the current blockchain height:
       (You can ignore the full sync and `lightwalletd` tests, because they take about a day to run.)
 - [ ] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-delivery.yml)
 
+## Publish Release
+
+- [ ] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"
+
 ## Publish Crates
 
 - [ ] Run `cargo login`
@@ -149,15 +153,12 @@ The end of support height is calculated from the current blockchain height:
 - [ ] Check that Zebra can be installed from `crates.io`:
       `cargo install --force --version 1.0.0 zebrad && ~/.cargo/bin/zebrad`
 
-## Publish Release & Docker Images
-
-- [ ] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"
+## Publish Docker Images
 - [ ] Wait until [the Docker images have been published](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml)
 - [ ] Test the Docker image using `docker run --tty --interactive zfnd/zebra:v1.0.0`,
       and put the output in a comment on the PR. 
       (You can use [gcloud cloud shell](https://console.cloud.google.com/home/dashboard?cloudshell=true))
 - [ ] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
-
 
 ## Release Failures
 

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -7,87 +7,17 @@ assignees: ''
 
 ---
 
-## Versioning
+## Release Preparation
 
-### How to Increment Versions
+These release steps can be done a week before the release, in separate PRs.
+They can be skipped for urgent releases.
 
-Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR`.`MINOR`.`PATCH[`-`TAG`.`PRE-RELEASE]
-
-The [draft `zebrad` changelog](https://github.com/ZcashFoundation/zebra/releases) will have an automatic version bump. This version is based on [the labels on the PRs in the release](https://github.com/ZcashFoundation/zebra/blob/main/.github/release-drafter.yml).
-
-Check that the automatic `zebrad` version increment matches the changes in the release:
-
-<details>
-
-If we're releasing a mainnet network upgrade, it is a `major` release:
-1. Increment the `major` version of _*all*_ the Zebra crates.
-2. Increment the `patch` version of the tower crates.
-
-If we're not releasing a mainnet network upgrade, check for features, major changes, deprecations, and removals. If this release has any, it is a `minor` release:
-1. Increment the `minor` version of `zebrad`.
-2. Increment the `pre-release` version of the other crates.
-3. Increment the `patch` version of the tower crates.
-
-Otherwise, it is a `patch` release:
-1. Increment the `patch` version of `zebrad`.
-2. Increment the `pre-release` version of the other crates.
-3. Increment the `patch` version of the tower crates.
-
-Zebra's Rust API is not stable or supported, so we keep all the crates on the same beta `pre-release` version.
-
-</details>
-
-### Version Locations
-
-Once you know which versions you want to increment, you can find them in the:
-
-zebrad (rc):
-- [ ] zebrad `Cargo.toml`
-- [ ] `README.md`
-- [ ] `book/src/user/docker.md`
-
-crates (beta):
-- [ ] zebra-* `Cargo.toml`s
-
-tower (patch):
-- [ ] tower-* `Cargo.toml`s
-
-auto-generated:
-- [ ] `Cargo.lock`: run `cargo build` after updating all the `Cargo.toml`s
-
-#### Version Tooling
-
-You can use `fastmod` to interactively find and replace versions.
-
-For example, you can do something like:
-```
-fastmod --extensions rs,toml,md --fixed-strings '1.0.0' '1.1.0' zebrad README.md zebra-network/src/constants.rs book/src/user/docker.md
-fastmod --extensions rs,toml,md --fixed-strings '1.0.0-beta.15' '1.0.0-beta.16' zebra-*
-fastmod --extensions rs,toml,md --fixed-strings '0.2.30' '0.2.31' tower-batch tower-fallback
-cargo build
-```
-
-If you use `fastmod`, don't update versions in `CHANGELOG.md` or `zebra-dependencies-for-audit.md`.
-
-## README
-
-Update the README to:
-- [ ] Remove any "Known Issues" that have been fixed
-- [ ] Update the "Build and Run Instructions" with any new dependencies.
-      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
-- [ ] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s
-
-You can use a command like:
-```sh
-      fastmod --fixed-strings '1.58' '1.65'
-```
-
-## Checkpoints
+### Checkpoints
 
 For performance and security, we want to update the Zebra checkpoints in every release.
 You can copy the latest checkpoints from CI by following [the zebra-checkpoints README](https://github.com/ZcashFoundation/zebra/blob/main/zebra-utils/README.md#zebra-checkpoints).
 
-## Missed Dependency Updates
+### Missed Dependency Updates
 
 Sometimes `dependabot` misses some dependency updates, or we accidentally turned them off.
 
@@ -97,7 +27,45 @@ Here's how we make sure we got everything:
 - [ ] Open a separate PR with the changes
 - [ ] Add the output of `cargo update` to that PR as a comment
 
-## Change Log
+
+## Release Changes
+
+These release steps can be done a few days before the release, in the same PR:
+- [ ] Make sure the PRs with the new checkpoint hashes and missed dependencies are already merged
+
+### Crate Versions
+
+#### Choose the Release Level
+
+Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]
+
+Choose a release level for `zebrad` based on the changes in the release that users will see:
+- mainnet network upgrades are `major` releases
+- new features, large changes, deprecations, and removals are `minor` releases
+- otherwise, it is a `patch` release
+
+Zebra's Rust API doesn't have any support or stability guarantees, so we keep all the `zebra-*` and `tower-*` crates on a beta `pre-release` version.
+
+#### Update Crate Versions
+
+<details>
+
+<summary>If you're publishing crates for the first time:</summary>
+
+- [ ] Install `cargo-release`: `cargo install cargo-release`
+- [ ] Make sure you are  an owner of the crate or [a member of the Zebra crates.io `owners` group on GitHub](https://github.com/orgs/ZcashFoundation/teams/owners)
+
+</details>
+
+- [ ] Update crate versions and do a release dry-run:
+    - [ ] `cargo release version --verbose --workspace --exclude zebrad beta`
+    - [ ] `cargo release version --verbose --package zebrad [ major | minor | patch ]`
+    - [ ] `cargo release publish --verbose --workspace --dry-run`
+- [ ] Commit the version changes to your release PR branch using `git`: `cargo release commit --verbose --workspace`
+
+### Release Documentation
+
+#### Create Change Log
 
 **Important**: Any merge into `main` deletes any edits to the draft changelog.
 Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.
@@ -106,55 +74,58 @@ We use [the Release Drafter workflow](https://github.com/marketplace/actions/rel
 
 To create the final change log:
 - [ ] Copy the **latest** draft changelog into `CHANGELOG.md` (there can be multiple draft releases)
-- [ ] Delete any trivial changes. Keep the list of those, to include in the PR
+- [ ] Delete any trivial changes
+    - [ ] Put the list of deleted changelog entries in a PR comment to make reviewing easier
 - [ ] Combine duplicate changes
-- [ ] Edit change descriptions so they are consistent, and make sense to non-developers
+- [ ] Edit change descriptions so they will make sense to Zebra users
 - [ ] Check the category for each change
   - Prefer the "Fix" category if you're not sure
 
+#### Update README
+
+README updates can be skipped for urgent releases.
+
+Update the README to:
+- [ ] Remove any "Known Issues" that have been fixed since the last release.
+- [ ] Update the "Build and Run Instructions" with any new dependencies.
+      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
+- [ ] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s
+
+You can use a command like:
+```sh
+fastmod --fixed-strings '1.58' '1.65'
+```
+
+### Update End of Support Height
+
+The end of support height is calculated from the current blockchain height:
+- [ ] Find the current Mainnet block height using a [Zcash explorer](https://zcashblockexplorer.com/blocks)
+- [ ] Update `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs)
+
 <details>
 
-#### Change Categories
+<summary>Optional: estimate the release tagging height<summary>
 
-From "Keep a Changelog":
-* `Added` for new features.
-* `Changed` for changes in existing functionality.
-* `Deprecated` for soon-to-be removed features.
-* `Removed` for now removed features.
-* `Fixed` for any bug fixes.
-* `Security` in case of vulnerabilities.
+- Add `1152` blocks for each day until the release
+- For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height
 
 </details>
 
-## Release support constants
-
-Needed for the end of support feature. Please update the following constants [in this file](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs):
-
-- [ ] `ESTIMATED_RELEASE_HEIGHT` (required) - Replace with the estimated height you estimate the release will be tagged.
-      <details>
-      - Find where the Zcash blockchain tip is now by using a [Zcash explorer](https://zcashblockexplorer.com/blocks) or other tool.
-      -  Consider there are aprox `1152` blocks per day (with the current Zcash `75` seconds spacing).
-      - So for example if you think the release will be tagged somewhere in the next 3 days you can add `1152 * 3` to the current tip height and use that value here.
-      </details>
-
-## Create the Release
-
 ### Create the Release PR
 
-After you have the version increments, the updated checkpoints, any missed dependency updates,
-and the updated changelog:
-
-- [ ] Make sure the PRs with the new checkpoint hashes and missed dependencies are already merged
-- [ ] Push the version increments, the updated changelog and the release constants into a branch
-      (for example: `bump-v1.0.0` - this needs to be different to the tag name)
+- [ ] Push the version increments, the updated changelog and the release constants into a branch,
+      for example: `bump-v1.0.0` - this needs to be different to the tag name
 - [ ] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
-  - [ ] Add the list of deleted changelog entries as a comment to make reviewing easier.
 - [ ] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
 - [ ] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
 
-### Create the Release
 
-- [ ] Once the PR has been merged, create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
+## Releasing Zebra
+
+### Tag the Release
+
+- [ ] Wait for all the release PRs to be merged
+- [ ] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
 - [ ] Set the tag name to the version tag,
       for example: `v1.0.0`
 - [ ] Set the release to target the `main` branch
@@ -167,12 +138,12 @@ and the updated changelog:
 - [ ] Publish the pre-release to GitHub using "Publish Release"
 - [ ] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)
 
-## Publish crates
+### Publish crates
 
 - [ ] Run `cargo login`
 - [ ] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute`
 
-## Binary Testing
+### Binary Testing
 
 - [ ] Check that Zebra can be installed from `crates.io`:
       `cargo install --force --version 1.0.0 zebrad && ~/.cargo/bin/zebrad`
@@ -187,10 +158,6 @@ and the updated changelog:
 - [ ] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
 
 
-## Telling Zebra Users
-
-- [ ] Post a summary of the important changes in the release in the `#arborist` and `#communications` Slack channels
-
 ## Release Failures
 
 If building or running fails after tagging:
@@ -198,9 +165,9 @@ If building or running fails after tagging:
 <details>
 
 1. Fix the bug that caused the failure
-2. Increment the patch version again, following these instructions from the start
-3. Update the code and documentation with a **new** git tag
+2. Start a new `patch` release
+3. Skip the **Release Preparation**, and start at the **Release Changes** step
 4. Update `CHANGELOG.md` with details about the fix
-5. Tag a **new** release
+5. Release a new Zebra version
 
 </details>

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -15,7 +15,7 @@ They can be skipped for urgent releases.
 ## Checkpoints
 
 For performance and security, we want to update the Zebra checkpoints in every release.
-You can copy the latest checkpoints from CI by following [the zebra-checkpoints README](https://github.com/ZcashFoundation/zebra/blob/main/zebra-utils/README.md#zebra-checkpoints).
+- [ ] You can copy the latest checkpoints from CI by following [the zebra-checkpoints README](https://github.com/ZcashFoundation/zebra/blob/main/zebra-utils/README.md#zebra-checkpoints).
 
 ## Missed Dependency Updates
 


### PR DESCRIPTION
## Motivation

Using `cargo release` changes how we update crate versions.

## Solution

Reorder release steps:
- Split the checklist into "preparation", "a few days before", "releasing", and "post-release fixes"
- Re-order testing before publishing

`cargo release`:
- Replace most crate versioning with `cargo release`
- Rewrite "how to pick the release level" for stable Zebra releases

Cleanups:
- Delete unused steps, duplicate steps, and extra background info

## Review

This is based on PR #6909.

It will be easier to review as a side-by-side diff, or I can split it up into multiple PRs.

### Reviewer Checklist

  - [x] Are the PR labels correct?
