### PR TITLE
fix(docker): Improve Dockerfile cache use by making build commands match exactly

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -107,10 +107,11 @@ COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/lightwalletd /opt/lightwalletd
 #
 # This is the caching Docker layer for Rust!
 #
-# TODO: is it faster to use --tests here?
-RUN cargo chef cook --release --features "${TEST_FEATURES} ${FEATURES}" --workspace --recipe-path recipe.json
+# TODO: add --locked when cargo-chef supports it
+RUN cargo chef cook --tests --release --features "${TEST_FEATURES} ${FEATURES}" --workspace --recipe-path recipe.json
 
 COPY . .
+# Test Zebra
 RUN cargo test --locked --release --features "${TEST_FEATURES} ${FEATURES}" --workspace --no-run
 RUN cp /opt/zebrad/target/release/zebrad /usr/local/bin
 RUN cp /opt/zebrad/target/release/zebra-checkpoints /usr/local/bin
@@ -127,10 +128,12 @@ ENTRYPOINT [ "/entrypoint.sh" ]
 # `test` stage. This step is a dependency for the `runtime` stage, which uses the resulting
 # zebrad binary from this step.
 FROM deps AS release
-RUN cargo chef cook --release --features "${FEATURES}" --recipe-path recipe.json
+
+# TODO: add --locked when cargo-chef supports it
+RUN cargo chef cook --release --features "${FEATURES}" --package zebrad --bin zebrad --recipe-path recipe.json
 
 COPY . .
-# Build zebra
+# Build zebrad
 RUN cargo build --locked --release --features "${FEATURES}" --package zebrad --bin zebrad
 
 COPY ./docker/runtime-entrypoint.sh /


### PR DESCRIPTION
## Motivation

I think Docker builds are slow because the cook and build/test commands are using different settings.

## Solution

Use exactly the same settings for cook and build/test
Add a TODO for --locked once it is supported 

## Review

This is important but not a release blocker.

We might want to merge it separately to PR #6934, so we can see the cache speed improvement. The full speed improvement won't be visible until this PR merges to `main`.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?


