### PR TITLE
Keep links within the zebra book whenever possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This command will run our latest release, and sync it to the tip:
 docker run zfnd/zebra:1.0.0-rc.9
 ```
 
-For more information, read our [Docker documentation](book/src/user/docker.md).
+For more information, read our [Docker documentation](https://zebra.zfnd.org/user/docker.html).
 
 ### Building Zebra
 

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -1,6 +1,6 @@
 # Installing Zebra
 
-Follow the [Docker or compilation instructions in the README](https://github.com/ZcashFoundation/zebra#getting-started).
+Follow the [Docker or compilation instructions](https://zebra.zfnd.org/index.html#getting-started).
 
 #### ARM
 


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

There's a number of links in the README and the zebra book that refer back to files on github.com instead of the book itself. These should ideally remain in the zebra book.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
If this is a large change, list commits of key functional changes here.
-->
Replace links out to github.com with their zebra.zfnd.org equivalents
## Review

<!--
Is this PR blocking any other work?
If you want specific reviewers for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
