### PR TITLE
fix: prevent progress bar from panicking using workaround

### DIFF
--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -311,9 +311,7 @@ where
         if matches!(howudoin::cancelled(), Some(true)) {
             self.finish_diagnostics();
         } else {
-            self.queued_blocks_bar
-                .set_pos(max_queued_height.0)
-                .set_len(u64::from(self.checkpoint_list.max_height().0));
+            self.queued_blocks_bar.set_pos(max_queued_height.0);
         }
     }
 

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -311,7 +311,9 @@ where
         if matches!(howudoin::cancelled(), Some(true)) {
             self.finish_diagnostics();
         } else {
-            self.queued_blocks_bar.set_pos(max_queued_height.0);
+            self.queued_blocks_bar
+                .set_pos(max_queued_height.0)
+                .set_len(u64::from(self.checkpoint_list.max_height().0));
         }
     }
 

--- a/zebra-network/src/address_book_updater.rs
+++ b/zebra-network/src/address_book_updater.rs
@@ -98,19 +98,14 @@ impl AddressBookUpdater {
                     let address_info = *address_info.borrow_and_update();
 
                     address_bar
-                        .set_pos(u64::try_from(address_info.num_addresses).expect("fits in u64"))
-                        .set_len(u64::try_from(address_info.address_limit).expect("fits in u64"));
+                        .set_pos(u64::try_from(address_info.num_addresses).expect("fits in u64"));
 
                     let never_attempted = address_info.never_attempted_alternate
                         + address_info.never_attempted_gossiped;
 
-                    never_bar
-                        .set_pos(u64::try_from(never_attempted).expect("fits in u64"))
-                        .set_len(u64::try_from(address_info.address_limit).expect("fits in u64"));
+                    never_bar.set_pos(u64::try_from(never_attempted).expect("fits in u64"));
 
-                    failed_bar
-                        .set_pos(u64::try_from(address_info.failed).expect("fits in u64"))
-                        .set_len(u64::try_from(address_info.address_limit).expect("fits in u64"));
+                    failed_bar.set_pos(u64::try_from(address_info.failed).expect("fits in u64"));
                 }
             }
 

--- a/zebra-network/src/address_book_updater.rs
+++ b/zebra-network/src/address_book_updater.rs
@@ -99,13 +99,16 @@ impl AddressBookUpdater {
 
                     address_bar
                         .set_pos(u64::try_from(address_info.num_addresses).expect("fits in u64"));
+                    // .set_len(u64::try_from(address_info.address_limit).expect("fits in u64"));
 
                     let never_attempted = address_info.never_attempted_alternate
                         + address_info.never_attempted_gossiped;
 
                     never_bar.set_pos(u64::try_from(never_attempted).expect("fits in u64"));
+                    // .set_len(u64::try_from(address_info.address_limit).expect("fits in u64"));
 
                     failed_bar.set_pos(u64::try_from(address_info.failed).expect("fits in u64"));
+                    // .set_len(u64::try_from(address_info.address_limit).expect("fits in u64"));
                 }
             }
 

--- a/zebra-network/src/peer_set/limit.rs
+++ b/zebra-network/src/peer_set/limit.rs
@@ -115,8 +115,7 @@ impl ActiveConnectionCounter {
 
         #[cfg(feature = "progress-bar")]
         self.connection_bar
-            .set_pos(u64::try_from(self.count).expect("fits in u64"))
-            .set_len(u64::try_from(self.limit).expect("fits in u64"));
+            .set_pos(u64::try_from(self.count).expect("fits in u64"));
 
         self.count
     }

--- a/zebra-network/src/peer_set/limit.rs
+++ b/zebra-network/src/peer_set/limit.rs
@@ -116,6 +116,7 @@ impl ActiveConnectionCounter {
         #[cfg(feature = "progress-bar")]
         self.connection_bar
             .set_pos(u64::try_from(self.count).expect("fits in u64"));
+        // .set_len(u64::try_from(self.limit).expect("fits in u64"));
 
         self.count
     }

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -662,9 +662,7 @@ impl NonFinalizedState {
                 .best_chain()
                 .map(|chain| chain.non_finalized_root_height().0 - 1);
 
-            chain_count_bar
-                .set_pos(u64::try_from(self.chain_count()).expect("fits in u64"))
-                .set_len(u64::try_from(MAX_NON_FINALIZED_CHAIN_FORKS).expect("fits in u64"));
+            chain_count_bar.set_pos(u64::try_from(self.chain_count()).expect("fits in u64"));
 
             if let Some(finalized_tip_height) = finalized_tip_height {
                 chain_count_bar.desc(format!("Finalized Root {finalized_tip_height}"));
@@ -701,10 +699,7 @@ impl NonFinalizedState {
                 // - the chain this bar was previously assigned to might have changed position.
                 chain_length_bar
                     .label(format!("Fork {fork_height}"))
-                    .set_pos(u64::try_from(chain.len()).expect("fits in u64"))
-                    .set_len(u64::from(
-                        zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY,
-                    ));
+                    .set_pos(u64::try_from(chain.len()).expect("fits in u64"));
 
                 // display work as bits
                 let mut desc = format!(

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -663,6 +663,7 @@ impl NonFinalizedState {
                 .map(|chain| chain.non_finalized_root_height().0 - 1);
 
             chain_count_bar.set_pos(u64::try_from(self.chain_count()).expect("fits in u64"));
+            // .set_len(u64::try_from(MAX_NON_FINALIZED_CHAIN_FORKS).expect("fits in u64"));
 
             if let Some(finalized_tip_height) = finalized_tip_height {
                 chain_count_bar.desc(format!("Finalized Root {finalized_tip_height}"));
@@ -700,6 +701,9 @@ impl NonFinalizedState {
                 chain_length_bar
                     .label(format!("Fork {fork_height}"))
                     .set_pos(u64::try_from(chain.len()).expect("fits in u64"));
+                // .set_len(u64::from(
+                //     zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY,
+                // ));
 
                 // display work as bits
                 let mut desc = format!(

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -701,6 +701,7 @@ impl NonFinalizedState {
                 chain_length_bar
                     .label(format!("Fork {fork_height}"))
                     .set_pos(u64::try_from(chain.len()).expect("fits in u64"));
+                // TODO: should this be MAX_BLOCK_REORG_HEIGHT?
                 // .set_len(u64::from(
                 //     zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY,
                 // ));

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -415,17 +415,25 @@ impl Mempool {
                 / zebra_chain::transaction::MEMPOOL_TRANSACTION_COST_THRESHOLD;
 
             self.queued_count_bar = Some(*howudoin::new().label("Mempool Queue").set_pos(0u64));
+            // .set_len(
+            //     u64::try_from(downloads::MAX_INBOUND_CONCURRENCY).expect("fits in u64"),
+            // ),
 
             self.transaction_count_bar = Some(*howudoin::new().label("Mempool Txs").set_pos(0u64));
+            // .set_len(max_transaction_count),
 
             self.transaction_cost_bar = Some(
                 howudoin::new()
                     .label("Mempool Cost")
                     .set_pos(0u64)
+                    // .set_len(self.config.tx_cost_limit)
                     .fmt_as_bytes(true),
             );
 
             self.rejected_count_bar = Some(*howudoin::new().label("Mempool Rejects").set_pos(0u64));
+            // .set_len(
+            //     u64::try_from(storage::MAX_EVICTION_MEMORY_ENTRIES).expect("fits in u64"),
+            // ),
         }
 
         // Update if the mempool has ever been active

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -411,41 +411,21 @@ impl Mempool {
                 || self.transaction_cost_bar.is_none()
                 || self.rejected_count_bar.is_none())
         {
-            let max_transaction_count = self.config.tx_cost_limit
+            let _max_transaction_count = self.config.tx_cost_limit
                 / zebra_chain::transaction::MEMPOOL_TRANSACTION_COST_THRESHOLD;
 
-            self.queued_count_bar = Some(
-                howudoin::new()
-                    .label("Mempool Queue")
-                    .set_pos(0u64)
-                    .set_len(
-                        u64::try_from(downloads::MAX_INBOUND_CONCURRENCY).expect("fits in u64"),
-                    ),
-            );
+            self.queued_count_bar = Some(*howudoin::new().label("Mempool Queue").set_pos(0u64));
 
-            self.transaction_count_bar = Some(
-                howudoin::new()
-                    .label("Mempool Txs")
-                    .set_pos(0u64)
-                    .set_len(max_transaction_count),
-            );
+            self.transaction_count_bar = Some(*howudoin::new().label("Mempool Txs").set_pos(0u64));
 
             self.transaction_cost_bar = Some(
                 howudoin::new()
                     .label("Mempool Cost")
                     .set_pos(0u64)
-                    .set_len(self.config.tx_cost_limit)
                     .fmt_as_bytes(true),
             );
 
-            self.rejected_count_bar = Some(
-                howudoin::new()
-                    .label("Mempool Rejects")
-                    .set_pos(0u64)
-                    .set_len(
-                        u64::try_from(storage::MAX_EVICTION_MEMORY_ENTRIES).expect("fits in u64"),
-                    ),
-            );
+            self.rejected_count_bar = Some(*howudoin::new().label("Mempool Rejects").set_pos(0u64));
         }
 
         // Update if the mempool has ever been active


### PR DESCRIPTION
## Motivation

Running Zebra with progress bar makes it panic after a while.

This seems to be caused by a bug in `howudoin`/`indicatif` where if a progress bar gets stuck, the ETA keeps growing and growing until it overflows. I'll eventually try to get a simple reproducer and report it, but in the meantime we can do a workaround.

## Solution

This removes the limit on the progress bars that are not guaranteed to complete, which removes the ETA and avoids the panic. The other progress bars (e.g. Blocks) could still panic if the node gets offline but this seems enough for now.

We could copy&paste and modify the `TermLine` implementation from `howudoin` to not display the ETA, but seems more work and would duplicate code.

They look like this with this PR:

```
 | Known Peers: 70                                                                                                    
 | Failed Peers: 3                                                                                                    
 | Inbound Connections: 0                                                                                             
 | Outbound Connections: 39                                                                                           
 / Queued Checkpoint Blocks (6y)
 [=============================>]  99% (2092738/2112016)                                                              
 / Verified Checkpoints (39w)
 [=============================>]  99% (10795/10875)                                                                  
 / Blocks (2h)
 [=============================>]  99% (2091696/2120401) Nu5                                                          
 | Never Attempted Peers: 27                                                             
 ```

Closes https://github.com/ZcashFoundation/zebra/issues/6926

## Review

This is not urgent since progress bars are optional. But I think it would be nice to get this in the stable release so that we can show the progress bars working during demos.

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Need to report the bug in `indicatif` (and maybe propose a PR to fix), will do that later