### PR TITLE
fix(build): Suppress warnings about doc links pointing to private items

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -55,12 +55,6 @@ rustflags = [
     # Documentation
     "-Wmissing_docs",
 
-    # These rustdoc -A and -W settings must be the same as the RUSTDOCFLAGS in:
-    # https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/lint.yml#L152
-
-    # Links in public docs can point to private items.
-    "-Arustdoc::private_intra_doc_links",
-
     # TODOs:
     # `cargo fix` might help do these fixes,
     # or add a config.toml to sub-directories which should allow these lints,
@@ -81,4 +75,13 @@ rustflags = [
 
     # fix hidden lifetime parameters
     #"-Wrust_2018_idioms",
+]
+
+[build]
+rustdocflags = [
+    # The -A and -W settings must be the same as the `RUSTDOCFLAGS` in:
+    # https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/lint.yml#L151
+
+    # Links in public docs can point to private items.
+    "-Arustdoc::private_intra_doc_links",
 ]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -145,8 +145,8 @@ jobs:
     # cargo doc doesn't support '--  -D warnings', so we have to add it here
     # https://github.com/rust-lang/cargo/issues/8424#issuecomment-774662296
     #
-    # These -A and -W settings must be the same as the rustdoc settings in:
-    # https://github.com/ZcashFoundation/zebra/blob/main/.cargo/config.toml#L53
+    # The -A and -W settings must be the same as the `rustdocflags` in:
+    # https://github.com/ZcashFoundation/zebra/blob/main/.cargo/config.toml#L87
     env:
       RUSTDOCFLAGS: -D warnings -A rustdoc::private_intra_doc_links
 


### PR DESCRIPTION
## Motivation

I was checking if things work before the upcoming release, and I noticed compiling the docs with 

``` bash
cargo doc --no-deps --document-private-items --all-features
``` 

produces lots of warnings because our documentation for some public items contains links to private items. We thought we had these warnings suppressed in `Cargo.toml`, but it wasn't correct. Note that these warnings show up only locally because CI uses its own config.

## Solution

This PR (hopefully) correctly suppresses the warnings and updates CI.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [x] How do you know it works? Does it have tests?

