### PR TITLE
change(docs): Explicitly invoke --execute when bumping crate versions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -58,9 +58,9 @@ Zebra's Rust API doesn't have any support or stability guarantees, so we keep al
 </details>
 
 - [ ] Update crate versions and do a release dry-run:
-    - [ ] `cargo release version --execute --verbose --workspace --exclude zebrad beta`
-    - [ ] `cargo release version --execute --verbose --package zebrad [ major | minor | patch ]`
-    - [ ] `cargo release publish --verbose --workspace --dry-run`
+    - [ ] `cargo release version --verbose --execute --workspace --exclude zebrad beta`
+    - [ ] `cargo release version --verbose --execute --package zebrad [ major | minor | patch ]`
+    - [ ] `cargo release publish --verbose --dry-run --workspace`
 - [ ] Commit the version changes to your release PR branch using `git`: `cargo release commit --verbose --workspace`
 
 ## README

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -58,8 +58,8 @@ Zebra's Rust API doesn't have any support or stability guarantees, so we keep al
 </details>
 
 - [ ] Update crate versions and do a release dry-run:
-    - [ ] `cargo release version --verbose --workspace --exclude zebrad beta`
-    - [ ] `cargo release version --verbose --package zebrad [ major | minor | patch ]`
+    - [ ] `cargo release version --execute --verbose --workspace --exclude zebrad beta`
+    - [ ] `cargo release version --execute --verbose --package zebrad [ major | minor | patch ]`
     - [ ] `cargo release publish --verbose --workspace --dry-run`
 - [ ] Commit the version changes to your release PR branch using `git`: `cargo release commit --verbose --workspace`
 

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -61,7 +61,7 @@ Zebra's Rust API doesn't have any support or stability guarantees, so we keep al
     - [ ] `cargo release version --verbose --execute --workspace --exclude zebrad beta`
     - [ ] `cargo release version --verbose --execute --package zebrad [ major | minor | patch ]`
     - [ ] `cargo release publish --verbose --dry-run --workspace`
-- [ ] Commit the version changes to your release PR branch using `git`: `cargo release commit --verbose --workspace`
+- [ ] Commit the version changes to your release PR branch using `git`: `cargo release commit --verbose --execute --workspace`
 
 ## README
 


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

We need to tell `cargo-release` explicitly to `--execute` when bumping crate versions.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
If this is a large change, list commits of key functional changes here.
-->

Pass `--execute` to our `cargo release version` commands in the checklist.

## Review

<!--
Is this PR blocking any other work?
If you want specific reviewers for this PR, tag them here.
-->

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?

