### PR TITLE
fix(net): Reduce inbound service overloads and add a timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5759,6 +5759,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "metrics 0.21.0",
+ "num-integer",
  "ordered-map",
  "pin-project",
  "proptest",

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -46,6 +46,7 @@ humantime-serde = "1.1.1"
 indexmap = { version = "1.9.3", features = ["serde"] }
 itertools = "0.10.5"
 lazy_static = "1.4.0"
+num-integer = "0.1.45"
 ordered-map = "0.4.2"
 pin-project = "1.1.0"
 rand = { version = "0.8.5", package = "rand" }

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -349,7 +349,7 @@ pub const MIN_OVERLOAD_DROP_PROBABILITY: f32 = 0.05;
 
 /// The maximum probability of dropping a peer connection when it receives an
 /// [`Overloaded`](crate::PeerError::Overloaded) error.
-pub const MAX_OVERLOAD_DROP_PROBABILITY: f32 = 0.95;
+pub const MAX_OVERLOAD_DROP_PROBABILITY: f32 = 0.5;
 
 /// The minimum interval between logging peer set status updates.
 pub const MIN_PEER_SET_LOG_INTERVAL: Duration = Duration::from_secs(60);

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -1283,6 +1283,12 @@ where
         // before sending the next inbound request.
         tokio::task::yield_now().await;
 
+        // # Security
+        //
+        // Holding buffer slots for a long time can cause hangs:
+        // <https://docs.rs/tower/latest/tower/buffer/struct.Buffer.html#a-note-on-choosing-a-bound>
+        //
+        // The inbound service must be called immediately after a buffer slot is reserved.
         if self.svc.ready().await.is_err() {
             self.fail_with(PeerError::ServiceShutdown).await;
             return;

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -1464,7 +1464,7 @@ where
             metrics::counter!("pool.closed.loadshed", 1);
 
             tracing::info!(
-                drop_connection_probability,
+                drop_connection_probability = format!("{drop_connection_probability:.3}"),
                 remote_user_agent = ?self.connection_info.remote.user_agent,
                 negotiated_version = ?self.connection_info.negotiated_version,
                 peer = ?self.metrics_label,

--- a/zebra-network/src/peer/connection/tests/vectors.rs
+++ b/zebra-network/src/peer/connection/tests/vectors.rs
@@ -687,11 +687,11 @@ fn overload_probability_reduces_over_time() {
     let drop_probability = overload_drop_connection_probability(now, Some(prev));
     assert!(
         drop_probability <= MAX_OVERLOAD_DROP_PROBABILITY,
-        "if the overloads are very close together, drops can optionally decrease",
+        "if the overloads are very close together, drops can optionally decrease: {drop_probability} <= {MAX_OVERLOAD_DROP_PROBABILITY}",
     );
     assert!(
         MAX_OVERLOAD_DROP_PROBABILITY - drop_probability < 0.001,
-        "if the overloads are very close together, drops can only decrease slightly",
+        "if the overloads are very close together, drops can only decrease slightly: {drop_probability}",
     );
     let last_probability = drop_probability;
 
@@ -700,11 +700,11 @@ fn overload_probability_reduces_over_time() {
     let drop_probability = overload_drop_connection_probability(now, Some(prev));
     assert!(
         drop_probability < last_probability,
-        "if the overloads decrease, drops should decrease",
+        "if the overloads decrease, drops should decrease: {drop_probability} < {last_probability}",
     );
     assert!(
         MAX_OVERLOAD_DROP_PROBABILITY - drop_probability < 0.001,
-        "if the overloads are very close together, drops can only decrease slightly",
+        "if the overloads are very close together, drops can only decrease slightly: {drop_probability}",
     );
     let last_probability = drop_probability;
 
@@ -713,11 +713,11 @@ fn overload_probability_reduces_over_time() {
     let drop_probability = overload_drop_connection_probability(now, Some(prev));
     assert!(
         drop_probability < last_probability,
-        "if the overloads decrease, drops should decrease",
+        "if the overloads decrease, drops should decrease: {drop_probability} < {last_probability}",
     );
     assert!(
         MAX_OVERLOAD_DROP_PROBABILITY - drop_probability < 0.001,
-        "if the overloads are very close together, drops can only decrease slightly",
+        "if the overloads are very close together, drops can only decrease slightly: {drop_probability}",
     );
     let last_probability = drop_probability;
 
@@ -726,11 +726,11 @@ fn overload_probability_reduces_over_time() {
     let drop_probability = overload_drop_connection_probability(now, Some(prev));
     assert!(
         drop_probability < last_probability,
-        "if the overloads decrease, drops should decrease",
+        "if the overloads decrease, drops should decrease: {drop_probability} < {last_probability}",
     );
     assert!(
         MAX_OVERLOAD_DROP_PROBABILITY - drop_probability < 0.01,
-        "if the overloads are very close together, drops can only decrease slightly",
+        "if the overloads are very close together, drops can only decrease slightly: {drop_probability}",
     );
     let last_probability = drop_probability;
 
@@ -739,11 +739,11 @@ fn overload_probability_reduces_over_time() {
     let drop_probability = overload_drop_connection_probability(now, Some(prev));
     assert!(
         drop_probability < last_probability,
-        "if the overloads decrease, drops should decrease",
+        "if the overloads decrease, drops should decrease: {drop_probability} < {last_probability}",
     );
     assert!(
-        MAX_OVERLOAD_DROP_PROBABILITY - drop_probability > 0.5,
-        "if the overloads are distant, drops should decrease a lot",
+        MAX_OVERLOAD_DROP_PROBABILITY - drop_probability > 0.4,
+        "if the overloads are distant, drops should decrease a lot: {drop_probability}",
     );
     let last_probability = drop_probability;
 
@@ -752,11 +752,11 @@ fn overload_probability_reduces_over_time() {
     let drop_probability = overload_drop_connection_probability(now, Some(prev));
     assert!(
         drop_probability < last_probability,
-        "if the overloads decrease, drops should decrease",
+        "if the overloads decrease, drops should decrease: {drop_probability} < {last_probability}",
     );
-    assert!(
-        MAX_OVERLOAD_DROP_PROBABILITY - drop_probability > 0.7,
-        "if the overloads are distant, drops should decrease a lot",
+    assert_eq!(
+        drop_probability, MIN_OVERLOAD_DROP_PROBABILITY,
+        "if overloads are far apart, drops should have minimum drop probability: {drop_probability}",
     );
     let _last_probability = drop_probability;
 
@@ -765,14 +765,14 @@ fn overload_probability_reduces_over_time() {
     let drop_probability = overload_drop_connection_probability(now, Some(prev));
     assert_eq!(
         drop_probability, MIN_OVERLOAD_DROP_PROBABILITY,
-        "if overloads are far apart, drops should have minimum drop probability",
+        "if overloads are far apart, drops should have minimum drop probability: {drop_probability}",
     );
 
     // Base case: no previous overload
     let drop_probability = overload_drop_connection_probability(now, None);
     assert_eq!(
         drop_probability, MIN_OVERLOAD_DROP_PROBABILITY,
-        "if there is no previous overload time, overloads should have minimum drop probability",
+        "if there is no previous overload time, overloads should have minimum drop probability: {drop_probability}",
     );
 }
 

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -82,6 +82,11 @@ pub enum PeerError {
     #[error("Internal services over capacity")]
     Overloaded,
 
+    /// This peer request's caused an internal service timeout, so the connection was dropped
+    /// to shed load or prevent attacks.
+    #[error("Internal services timed out")]
+    InboundTimeout,
+
     /// This node's internal services are no longer able to service requests.
     #[error("Internal services have failed or shutdown")]
     ServiceShutdown,
@@ -142,6 +147,7 @@ impl PeerError {
             PeerError::Serialization(inner) => format!("Serialization({inner})").into(),
             PeerError::DuplicateHandshake => "DuplicateHandshake".into(),
             PeerError::Overloaded => "Overloaded".into(),
+            PeerError::InboundTimeout => "InboundTimeout".into(),
             PeerError::ServiceShutdown => "ServiceShutdown".into(),
             PeerError::NotFoundResponse(_) => "NotFoundResponse".into(),
             PeerError::NotFoundRegistry(_) => "NotFoundRegistry".into(),

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -111,6 +111,7 @@ use futures::{
     stream::FuturesUnordered,
 };
 use itertools::Itertools;
+use num_integer::div_ceil;
 use tokio::{
     sync::{broadcast, oneshot::error::TryRecvError, watch},
     task::JoinHandle,
@@ -808,9 +809,11 @@ where
     /// Given a number of ready peers calculate to how many of them Zebra will
     /// actually send the request to. Return this number.
     pub(crate) fn number_of_peers_to_broadcast(&self) -> usize {
-        // We are currently sending broadcast messages to half of the total peers.
+        // We are currently sending broadcast messages to a third of the total peers.
+        const PEER_FRACTION_TO_BROADCAST: usize = 3;
+
         // Round up, so that if we have one ready peer, it gets the request.
-        (self.ready_services.len() + 1) / 2
+        div_ceil(self.ready_services.len(), PEER_FRACTION_TO_BROADCAST)
     }
 
     /// Returns the list of addresses in the peer set.

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -84,7 +84,7 @@ use zebra_rpc::server::RpcServer;
 use crate::{
     application::{app_version, user_agent},
     components::{
-        inbound::{self, InboundSetupData},
+        inbound::{self, InboundSetupData, MAX_INBOUND_RESPONSE_TIME},
         mempool::{self, Mempool},
         sync::{self, show_block_chain_progress, VERIFICATION_PIPELINE_SCALING_MULTIPLIER},
         tokio::{RuntimeRun, TokioComponent},
@@ -143,6 +143,7 @@ impl StartCmd {
         let inbound = ServiceBuilder::new()
             .load_shed()
             .buffer(inbound::downloads::MAX_INBOUND_CONCURRENCY)
+            .timeout(MAX_INBOUND_RESPONSE_TIME)
             .service(Inbound::new(
                 config.sync.full_verify_concurrency_limit,
                 setup_rx,

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -132,6 +132,13 @@ impl StartCmd {
         // The service that our node uses to respond to requests by peers. The
         // load_shed middleware ensures that we reduce the size of the peer set
         // in response to excess load.
+        //
+        // # Security
+        //
+        // This layer stack is security-sensitive, modifying it can cause hangs,
+        // or enable denial of service attacks.
+        //
+        // See `zebra_network::Connection::drive_peer_request()` for details.
         let (setup_tx, setup_rx) = oneshot::channel();
         let inbound = ServiceBuilder::new()
             .load_shed()

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -18,6 +18,7 @@ use futures::{
     future::{FutureExt, TryFutureExt},
     stream::Stream,
 };
+use num_integer::div_ceil;
 use tokio::sync::oneshot::{self, error::TryRecvError};
 use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, Service, ServiceExt};
 
@@ -374,10 +375,7 @@ impl Service<zn::Request> for Inbound {
                     let mut peers = peers.sanitized(now);
 
                     // Truncate the list
-                    //
-                    // TODO: replace with div_ceil once it stabilises
-                    //       https://github.com/rust-lang/rust/issues/88581
-                    let address_limit = (peers.len() + ADDR_RESPONSE_LIMIT_DENOMINATOR - 1) / ADDR_RESPONSE_LIMIT_DENOMINATOR;
+                    let address_limit = div_ceil(peers.len(), ADDR_RESPONSE_LIMIT_DENOMINATOR);
                     let address_limit = MAX_ADDRS_IN_MESSAGE.min(address_limit);
                     peers.truncate(address_limit);
 

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -11,6 +11,7 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
+    time::Duration,
 };
 
 use chrono::Utc;
@@ -50,6 +51,12 @@ pub(crate) mod downloads;
 mod tests;
 
 use downloads::Downloads as BlockDownloads;
+
+/// The maximum amount of time an inbound service response can take.
+///
+/// If the response takes longer than this time, it will be cancelled,
+/// and the peer might be disconnected.
+pub const MAX_INBOUND_RESPONSE_TIME: Duration = Duration::from_secs(5);
 
 /// The number of bytes the [`Inbound`] service will queue in response to a single block or
 /// transaction request, before ignoring any additional block or transaction IDs in that request.

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -49,7 +49,7 @@ type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// Since Zebra keeps an `inv` index, inbound downloads for malicious blocks
 /// will be directed to the malicious node that originally gossiped the hash.
 /// Therefore, this attack can be carried out by a single malicious node.
-pub const MAX_INBOUND_CONCURRENCY: usize = 20;
+pub const MAX_INBOUND_CONCURRENCY: usize = 30;
 
 /// The action taken in response to a peer's gossiped block hash.
 pub enum DownloadAction {


### PR DESCRIPTION
## Motivation

Sometimes Zebra's inbound service gets overloaded and drops a whole lot of connections at the same time.

Close #6911

### Complex Code or Requirements

This is concurrent code.

## Solution

Timeouts:
- Add a timeout to inbound service requests, there is currently no timeout on those requests. This is a security issue.
- Treat inbound timeouts like queue overloads

Overloads:
- Increase the inbound concurrency limit, to reduce overloads at the cost of slightly more memory
- Reduce the peer broadcast fraction, to reduce network load
- Reduce maximum connection drop probability, to reduce the number of disconnections that happen at the same time

Related changes:
- Document security requirements of inbound peer overload handling

## Review

This is an important security fix, it should go in early in the next release.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Work out which requests are slow (or numerous), and make them faster. This PR adds logging for inbound request timeouts.