### PR TITLE
change(docs): Add `cargo clean` step to crate publishing steps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -149,6 +149,7 @@ The end of support height is calculated from the current blockchain height:
 ## Publish Crates
 
 - [ ] Run `cargo login`
+- [ ] Run `cargo clean` in the zebra repo
 - [ ] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute`
 - [ ] Check that Zebra can be installed from `crates.io`:
       `cargo install --force --version 1.0.0 zebrad && ~/.cargo/bin/zebrad`


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request.
How does this change improve Zebra?
-->

It really sucks to run out of storage space in the middle of publishing a bunch of crates.

## Solution

<!--
Summarize the changes in this PR.
Does it close any issues?
If this is a large change, list commits of key functional changes here.
-->

Suggest a `cargo clean` in the zebra workspace before attempting `cargo release publish`. I ran out of storage space mid-release, so

## Review

<!--
Is this PR blocking any other work?
If you want specific reviewers for this PR, tag them here.
-->

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?


