### PR TITLE
change(support): Move macOS to tier 3 support: no builds

### DIFF
--- a/book/src/user/supported-platforms.md
+++ b/book/src/user/supported-platforms.md
@@ -32,7 +32,6 @@ For the full requirements, see [Tier 2 platform policy](platform-tier-policy.md#
 
 | platform | os | notes | rust | artifacts
 | -------|-------|-------|-------|-------
-| `x86_64-apple-darwin` | [GitHub macos-latest](https://github.com/actions/virtual-environments#available-environments) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A
 | `x86_64-unknown-linux-gnu` | [GitHub ubuntu-latest](https://github.com/actions/virtual-environments#available-environments) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A
 | `x86_64-unknown-linux-gnu` | [GitHub ubuntu-latest](https://github.com/actions/virtual-environments#available-environments) | 64-bit | [latest beta release](https://github.com/rust-lang/rust/blob/beta/src/version) | N/A
 
@@ -47,3 +46,5 @@ For the full requirements, see [Tier 3 platform policy](platform-tier-policy.md#
 | platform | os | notes | rust | artifacts
 | -------|-------|-------|-------|-------
 | `aarch64-unknown-linux-gnu` | [Debian 11](https://www.debian.org/releases/bullseye/) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A
+| `x86_64-apple-darwin` | [GitHub macos-latest](https://github.com/actions/virtual-environments#available-environments) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A
+


### PR DESCRIPTION
## Motivation

When we disabled macOS tests, we also disabled macOS builds. So this makes macOS a tier 3 support platform.

## Solution

Move macOS to the tier 3 list

## Review

This is a routine documentation fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the change do what the ticket and PR says?

## Follow Up Work

If we re-enable builds, we can move macOS back to tier 2. But that needs to be a separate ticket.