### PR TITLE
fix(handshake): Add extra timeout logging to peer TCP connections

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -320,11 +320,6 @@ impl Config {
             Ok(Ok(ip_addrs)) => {
                 let ip_addrs: Vec<PeerSocketAddr> = ip_addrs.map(canonical_peer_addr).collect();
 
-                // if we're logging at debug level,
-                // the full list of IP addresses will be shown in the log message
-                let debug_span = debug_span!("", remote_ip_addrs = ?ip_addrs);
-                let _span_guard = debug_span.enter();
-
                 // This log is needed for user debugging, but it's annoying during tests.
                 #[cfg(not(test))]
                 info!(seed = ?host, remote_ip_count = ?ip_addrs.len(), "resolved seed peer IP addresses");

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -83,7 +83,10 @@ pub const PEERSET_BUFFER_SIZE: usize = 3;
 /// and receiving a response from a remote peer.
 pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// The timeout for handshakes when connecting to new peers.
+/// The timeout for connections and handshakes when connecting to new peers.
+///
+/// The TCP connect/accept must complete within this timeout,
+/// then the handshake messages get an additional `HANDSHAKE_TIMEOUT` to complete.
 ///
 /// This timeout should remain small, because it helps stop slow peers getting
 /// into the peer set. This is particularly important for network-constrained

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -85,8 +85,9 @@ pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// The timeout for connections and handshakes when connecting to new peers.
 ///
-/// The TCP connect/accept must complete within this timeout,
+/// Outbound TCP connections must complete within this timeout,
 /// then the handshake messages get an additional `HANDSHAKE_TIMEOUT` to complete.
+/// (Inbound TCP accepts can't have a timeout, because they are handled by the OS.)
 ///
 /// This timeout should remain small, because it helps stop slow peers getting
 /// into the peer set. This is particularly important for network-constrained

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -1453,7 +1453,7 @@ async fn init_with_peer_limit<S>(
     default_config: impl Into<Option<Config>>,
 ) -> Arc<std::sync::Mutex<AddressBook>>
 where
-    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + Sync + 'static,
     S::Future: Send + 'static,
 {
     // This test might fail on machines with no configured IPv4 addresses
@@ -1610,6 +1610,7 @@ where
     S: Service<peer::HandshakeRequest<TcpStream>, Response = peer::Client, Error = BoxError>
         + Clone
         + Send
+        + Sync
         + 'static,
     S::Future: Send + 'static,
 {


### PR DESCRIPTION
## Motivation

This PR adds logs for inbound and outbound timeouts, and fixes up some logging inconsistencies.

### Specifications

How TCP connect works in async Rust:
https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html#method.connect

Tokio can yield in any library function:
https://docs.rs/tokio/latest/tokio/task/index.html#cooperative-scheduling

### Complex Code or Requirements

This is async code, but it's just adding (hopefully) redundant timeouts and splitting it into functions.

## Solution

Outbound connections:
- Add an extra 3 second timeout to TCP connect, to see if that's what's timing out

Inbound connections:
- Add an additional 3.5 second timeout to the spawned handshake task, and log if it fails. This will help locate inbound connection hangs.
- Replace the manual span enter with an instrumented macro.

Related cleanups:
- Delete a useless manual span in zebra_network::Config

I checked all the manual spans in zebra_network::AddressBook, they are all in non-async code, and there aren't any sync locks in those functions.

## Review

This is a routine security fix.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [x] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Use these logs to diagnose #6763.
Add extra logs to work out exactly where it's hanging.