### PR TITLE
change(state): Use `OrderedUtxo` in `CheckpointVerifiedBlock`

### DIFF
--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -183,7 +183,8 @@ impl CheckpointVerifiedBlock {
         height: block::Height,
     ) -> Self {
         let transaction_hashes: Arc<[_]> = block.transactions.iter().map(|tx| tx.hash()).collect();
-        let new_outputs = transparent::new_outputs_with_height(&block, height, &transaction_hashes);
+        let new_outputs =
+            transparent::new_ordered_outputs_with_height(&block, height, &transaction_hashes);
 
         Self {
             block,

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -235,7 +235,7 @@ pub struct CheckpointVerifiedBlock {
     /// earlier transaction.
     ///
     /// This field can also contain unrelated outputs, which are ignored.
-    pub(crate) new_outputs: HashMap<transparent::OutPoint, transparent::Utxo>,
+    pub(crate) new_outputs: HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
     /// A precomputed list of the hashes of the transactions in this block,
     /// in the same order as `block.transactions`.
     pub transaction_hashes: Arc<[transaction::Hash]>,
@@ -369,7 +369,7 @@ impl CheckpointVerifiedBlock {
             .coinbase_height()
             .expect("coinbase height was already checked");
         let transaction_hashes: Arc<[_]> = block.transactions.iter().map(|tx| tx.hash()).collect();
-        let new_outputs = transparent::new_outputs(&block, &transaction_hashes);
+        let new_outputs = transparent::new_ordered_outputs(&block, &transaction_hashes);
 
         Self {
             block,
@@ -405,7 +405,7 @@ impl From<ContextuallyVerifiedBlock> for CheckpointVerifiedBlock {
             block,
             hash,
             height,
-            new_outputs: utxos_from_ordered_utxos(new_outputs),
+            new_outputs,
             transaction_hashes,
         }
     }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -976,7 +976,8 @@ impl Service<Request> for StateService {
                 // even though it is redundant for most finalized blocks.
                 // (Finalized blocks are verified using block hash checkpoints
                 // and transaction merkle tree block header commitments.)
-                self.pending_utxos.check_against(&finalized.new_outputs);
+                self.pending_utxos
+                    .check_against_ordered(&finalized.new_outputs);
 
                 // # Performance
                 //

--- a/zebra-state/src/service/pending_utxos.rs
+++ b/zebra-state/src/service/pending_utxos.rs
@@ -60,14 +60,6 @@ impl PendingUtxos {
         }
     }
 
-    /// Check the list of pending UTXO requests against the supplied [`transparent::Utxo`] index.
-    #[inline]
-    pub fn check_against(&mut self, utxos: &HashMap<transparent::OutPoint, transparent::Utxo>) {
-        for (outpoint, utxo) in utxos.iter() {
-            self.respond(outpoint, utxo.clone())
-        }
-    }
-
     /// Scan the set of waiting utxo requests for channels where all receivers
     /// have been dropped and remove the corresponding sender.
     pub fn prune(&mut self) {

--- a/zebra-state/src/service/queued_blocks.rs
+++ b/zebra-state/src/service/queued_blocks.rs
@@ -279,8 +279,9 @@ impl SentHashes {
         let outpoints = block
             .new_outputs
             .iter()
-            .map(|(outpoint, utxo)| {
-                self.known_utxos.insert(*outpoint, utxo.clone());
+            .map(|(outpoint, ordered_utxo)| {
+                self.known_utxos
+                    .insert(*outpoint, ordered_utxo.utxo.clone());
                 outpoint
             })
             .cloned()

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -419,7 +419,7 @@ proptest! {
             // the genesis block has a zero-valued transparent output,
             // which is not included in the UTXO set
             if block.height > block::Height(0) {
-                let utxos = &block.new_outputs;
+                let utxos = &block.new_outputs.iter().map(|(k, ordered_utxo)| (*k, ordered_utxo.utxo.clone())).collect();
                 let block_value_pool = &block.block.chain_value_pool_change(utxos)?;
                 expected_finalized_value_pool += *block_value_pool;
             }


### PR DESCRIPTION
## Motivation

After looking into #6912, I realized `CheckpointVerifiedBlock` and `SemanticallyVerifiedBlock` are the same, except that the first contains `Utxo`, and the second `OrderedUtxo`. This PR makes `CheckpointVerifiedBlock` use `OrderedUtxo` as well. This makes the block types the same, which will make the refactor of `ContextuallyVerifiedBlockWithTrees` simpler since `ContextuallyVerifiedBlock` uses `OrderedUtxo` as well.

## Solution

Use `OrderedUtxo` instead of `Utxo` in `CheckpointVerifiedBlock`.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- #7025