### PR TITLE
add(metrics): Track mempool actions and size bucketed by weight

### DIFF
--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -337,6 +337,13 @@ pub struct VerifiedUnminedTx {
     /// transparent inputs and outputs.
     pub legacy_sigop_count: u64,
 
+    /// The number of conventional actions for `transaction`, as defined by [ZIP-317].
+    ///
+    /// The number of actions is limited by [`MAX_BLOCK_BYTES`], so it fits in a u32.
+    ///
+    /// [ZIP-317]: https://zips.z.cash/zip-0317#block-production
+    pub conventional_actions: u32,
+
     /// The number of unpaid actions for `transaction`,
     /// as defined by [ZIP-317] for block production.
     ///
@@ -381,6 +388,7 @@ impl VerifiedUnminedTx {
         legacy_sigop_count: u64,
     ) -> Result<Self, zip317::Error> {
         let fee_weight_ratio = zip317::conventional_fee_weight_ratio(&transaction, miner_fee);
+        let conventional_actions = zip317::conventional_actions(&transaction.transaction);
         let unpaid_actions = zip317::unpaid_actions(&transaction, miner_fee);
 
         zip317::mempool_checks(unpaid_actions, miner_fee, transaction.size)?;
@@ -390,6 +398,7 @@ impl VerifiedUnminedTx {
             miner_fee,
             legacy_sigop_count,
             fee_weight_ratio,
+            conventional_actions,
             unpaid_actions,
         })
     }

--- a/zebra-chain/src/transaction/unmined/zip317.rs
+++ b/zebra-chain/src/transaction/unmined/zip317.rs
@@ -133,7 +133,7 @@ pub fn conventional_fee_weight_ratio(
 /// as defined by [ZIP-317].
 ///
 /// [ZIP-317]: https://zips.z.cash/zip-0317#fee-calculation
-fn conventional_actions(transaction: &Transaction) -> u32 {
+pub fn conventional_actions(transaction: &Transaction) -> u32 {
     let tx_in_total_size: usize = transaction
         .inputs()
         .iter()

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1170,7 +1170,7 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
         block::{Hash, MAX_BLOCK_BYTES, ZCASH_BLOCK_VERSION},
         chain_sync_status::MockSyncStatus,
         serialization::DateTime32,
-        transaction::VerifiedUnminedTx,
+        transaction::{zip317, VerifiedUnminedTx},
         work::difficulty::{CompactDifficulty, ExpandedDifficulty, U256},
     };
     use zebra_consensus::MAX_BLOCK_SIGOPS;
@@ -1425,10 +1425,13 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
         conventional_fee: 0.try_into().unwrap(),
     };
 
+    let conventional_actions = zip317::conventional_actions(&unmined_tx.transaction);
+
     let verified_unmined_tx = VerifiedUnminedTx {
         transaction: unmined_tx,
         miner_fee: 0.try_into().unwrap(),
         legacy_sigop_count: 0,
+        conventional_actions,
         unpaid_actions: 0,
         fee_weight_ratio: 1.0,
     };


### PR DESCRIPTION
## Motivation

It is useful to have insight into the composition of the mempool along the axes used for the default block construction algorithm. The algorithm from the now-deployed [ZIP 317](https://zips.z.cash/zip-0317) takes into account both a transaction's weight, and the number of "unpaid actions" it contains.

## Solution

This PR adds the following new metrics:

- (gauge) `zcash.mempool.actions.unpaid { "bk" = ["< 0.2", "< 0.4", "< 0.6", "< 0.8", "< 1"] }`
- (gauge) `zcash.mempool.actions.paid`
- (gauge) `zcash.mempool.size.weighted { "bk" = ["< 1", "1", "> 1", "> 2", "> 3"] }`

These are proposed as common Zcash metrics (with a `zcash.` prefix). The corresponding `zcashd` PR is https://github.com/zcash/zcash/pull/6632.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
