### PR TITLE
change(readme): Install from crates.io not git in the README, automate release version replacements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,6 @@ members = [
 # Use the edition 2021 dependency resolver in the workspace, to match the crates
 resolver = "2"
 
-# Release settings
-
-[package.metadata.release]
-pre-release-replacements = [
-  {file="book/src/user/install.md", search="git checkout [a-z0-9\\.-]+", replace="git checkout {{version}}"} ,
-  {file="book/src/user/install.md", search="--tag [a-z0-9\\.-]+", replace="--tag {{version}}"} ,
-  {file="book/src/user/docker.md", search="--branch [a-z0-9\\.-]+", replace="--branch {{version}}"} ,
-]
-
 # Compilation settings
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,17 @@ members = [
 # Use the edition 2021 dependency resolver in the workspace, to match the crates
 resolver = "2"
 
+# Release settings
+
+[package.metadata.release]
+pre-release-replacements = [
+  {file="book/src/user/install.md", search="git checkout [a-z0-9\\.-]+", replace="git checkout {{version}}"} ,
+  {file="book/src/user/install.md", search="--tag [a-z0-9\\.-]+", replace="--tag {{version}}"} ,
+  {file="book/src/user/docker.md", search="--branch [a-z0-9\\.-]+", replace="--branch {{version}}"} ,
+]
+
+# Compilation settings
+
 [profile.dev]
 panic = "abort"
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Below are quick summaries for installing the dependencies on your machine.
 
 <details>
 
-<summary>General instructions for installing dependencies</summary>
+<summary><h4>General instructions for installing dependencies</h4></summary>
 
 1. Install [`cargo` and `rustc`](https://www.rust-lang.org/tools/install).
 
@@ -92,7 +92,7 @@ Below are quick summaries for installing the dependencies on your machine.
 
 <details>
 
-<summary>Dependencies on Arch</summary>
+<summary><h4>Dependencies on Arch</h4></summary>
 
 ```sh
 sudo pacman -S rust clang pkgconf

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Every few weeks, we release a [new Zebra version](https://github.com/ZcashFounda
 
 Below are quick summaries for installing the dependencies on your machine.
 
-<details><summary><h4>General instructions for installing dependencies</h4></summary>
+<details>
+
+<summary>General instructions for installing dependencies</summary>
 
 1. Install [`cargo` and `rustc`](https://www.rust-lang.org/tools/install).
 
@@ -88,7 +90,9 @@ Below are quick summaries for installing the dependencies on your machine.
 
 </details>
 
-<details><summary><h4>Dependencies on Arch</h4></summary>
+<details>
+
+<summary>Dependencies on Arch</summary>
 
 ```sh
 sudo pacman -S rust clang pkgconf
@@ -98,10 +102,10 @@ Note that the package `clang` includes `libclang` as well as the C++ compiler.
 
 </details>
 
-Once the dependencies are in place, you can build Zebra
+Once the dependencies are in place, you can build and install Zebra:
 
 ```sh
-cargo install --locked --git https://github.com/ZcashFoundation/zebra --tag v1.0.0 zebrad
+cargo install --locked zebrad
 ```
 
 You can start Zebra by
@@ -110,8 +114,8 @@ You can start Zebra by
 zebrad start
 ```
 
-See the [Running Zebra](https://zebra.zfnd.org/user/run.html) section in the
-book for more details.
+See the [Installing Zebra](https://zebra.zfnd.org/user/install.html) and [Running Zebra](https://zebra.zfnd.org/user/run.html)
+sections in the book for more details.
 
 #### Optional Features
 

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -6,17 +6,10 @@ Follow the [Docker or compilation instructions](https://zebra.zfnd.org/index.htm
 
 To compile Zebra from source, you will need to [install some dependencies.](https://zebra.zfnd.org/index.html#building-zebra).
 
-During compilation, `cargo` downloads all the other required dependencies.
-Zebra primarily depends on pure Rust crates, and some Rust/C++ crates:
-
-- [rocksdb](https://crates.io/crates/rocksdb)
-- [zcash_script](https://crates.io/crates/zcash_script)
-
-They will be automatically built along with `zebrad`.
 
 ## Alternative Compilation Methods
 
-### Compiling from git
+### Compiling Manually from git
 
 To compile Zebra directly from GitHub, or from a GitHub release source archive:
 
@@ -30,14 +23,14 @@ cd zebra
 git checkout v1.0.0
 ```
 
-3. Build `zebrad`
+3. Build and Run `zebrad`
 
 ```sh
 cargo build --release --bin zebrad
 target/release/zebrad start
 ```
 
-#### Compiling from git using cargo install
+### Compiling from git using cargo install
 
 ```sh
 cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.0.0 zebrad

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -2,19 +2,71 @@
 
 Follow the [Docker or compilation instructions](https://zebra.zfnd.org/index.html#getting-started).
 
-#### ARM
+## Installing Dependencies
+
+To compile Zebra from source, you will need to [install some dependencies.](https://zebra.zfnd.org/index.html#building-zebra).
+
+During compilation, `cargo` downloads all the other required dependencies.
+Zebra primarily depends on pure Rust crates, and some Rust/C++ crates:
+
+- [rocksdb](https://crates.io/crates/rocksdb)
+- [zcash_script](https://crates.io/crates/zcash_script)
+
+They will be automatically built along with `zebrad`.
+
+## Alternative Compilation Methods
+
+### Compiling from git
+
+To compile Zebra directly from GitHub, or from a GitHub release source archive:
+
+1. Install the dependencies (see above)
+
+2. Get the source code using `git` or from a GitHub source package
+
+```sh
+git clone https://github.com/ZcashFoundation/zebra.git
+cd zebra
+git checkout [release tag or branch name]
+```
+
+3. Build `zebrad`
+
+```sh
+cargo build --release --bin zebrad
+target/release/zebrad start
+```
+
+#### Compiling from git using cargo install
+
+```sh
+cargo install --git https://github.com/ZcashFoundation/zebra --tag [release tag or branch name] zebrad
+```
+
+### Compiling on ARM
 
 If you're using an ARM machine, [install the Rust compiler for
 ARM](https://rust-lang.github.io/rustup/installation/other.html). If you build
 using the x86_64 tools, Zebra might run really slowly.
 
-#### Build Troubleshooting
+## Build Troubleshooting
 
 If you're having trouble with:
 
-Dependencies:
+### Compilers
+
+- **clang:** install both `libclang` and `clang` - they are usually different packages
+- **libclang:** check out the [clang-sys documentation](https://github.com/KyleMayes/clang-sys#dependencies)
+- **g++ or MSVC++:** try using clang or Xcode instead
+- **rustc:** use the latest stable `rustc` and `cargo` versions
+  - Zebra does not have a minimum supported Rust version (MSRV) policy: any release can update the required Rust version.
+
+### Dependencies
 
 - use `cargo install` without `--locked` to build with the latest versions of each dependency
+
+#### Optional Tor feature
+
 - **sqlite linker errors:** libsqlite3 is an optional dependency of the `zebra-network/tor` feature.
   If you don't have it installed, you might see errors like `note: /usr/bin/ld: cannot find -lsqlite3`.
   [Follow the arti instructions](https://gitlab.torproject.org/tpo/core/arti/-/blob/main/CONTRIBUTING.md#setting-up-your-development-environment)
@@ -25,19 +77,4 @@ cargo build
 cargo build -p zebrad --all-features
 ```
 
-Compilers:
 
-- **clang:** install both `libclang` and `clang` - they are usually different packages
-- **libclang:** check out the [clang-sys documentation](https://github.com/KyleMayes/clang-sys#dependencies)
-- **g++ or MSVC++:** try using clang or Xcode instead
-- **rustc:** use rustc 1.65 or later
-  - Zebra does not have a minimum supported Rust version (MSRV) policy: any release can update the required Rust version.
-
-### Dependencies
-
-Zebra primarily depends on pure Rust crates, and some Rust/C++ crates:
-
-- [rocksdb](https://crates.io/crates/rocksdb)
-- [zcash_script](https://crates.io/crates/zcash_script)
-
-They will be automatically built along with `zebrad`.

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -27,7 +27,7 @@ To compile Zebra directly from GitHub, or from a GitHub release source archive:
 ```sh
 git clone https://github.com/ZcashFoundation/zebra.git
 cd zebra
-git checkout [release tag or branch name]
+git checkout v1.0.0
 ```
 
 3. Build `zebrad`
@@ -40,7 +40,7 @@ target/release/zebrad start
 #### Compiling from git using cargo install
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag [release tag or branch name] zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.0.0 zebrad
 ```
 
 ### Compiling on ARM

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -34,6 +34,14 @@ keywords = ["zebra", "zcash"]
 # Must be one of <https://crates.io/category_slugs>
 categories = ["command-line-utilities", "cryptography::cryptocurrencies"]
 
+# Release settings
+[metadata.release]
+pre-release-replacements = [
+  {file="../book/src/user/install.md", search="git checkout [a-z0-9\\.-]+", replace="git checkout {{version}}"},
+  {file="../book/src/user/install.md", search="--tag [a-z0-9\\.-]+", replace="--tag {{version}}"},
+  {file="../book/src/user/docker.md", search="--branch [a-z0-9\\.-]+", replace="--branch {{version}}"},
+]
+
 [features]
 # In release builds, don't compile debug logging code, to improve performance.
 default = ["release_max_level_info"]
@@ -255,12 +263,3 @@ zebra-test = { path = "../zebra-test" }
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
 zebra-utils = { path = "../zebra-utils" }
-
-# Release settings
-# This needs to be at the end of the file to avoid including other tables.
-[package.metadata.release]
-pre-release-replacements = [
-  {file="../book/src/user/install.md", search="git checkout [a-z0-9\\.-]+", replace="git checkout {{version}}"} ,
-  {file="../book/src/user/install.md", search="--tag [a-z0-9\\.-]+", replace="--tag {{version}}"} ,
-  {file="../book/src/user/docker.md", search="--branch [a-z0-9\\.-]+", replace="--branch {{version}}"} ,
-]

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -34,14 +34,6 @@ keywords = ["zebra", "zcash"]
 # Must be one of <https://crates.io/category_slugs>
 categories = ["command-line-utilities", "cryptography::cryptocurrencies"]
 
-# Release settings
-[package.metadata.release]
-pre-release-replacements = [
-  {file="../book/src/user/install.md", search="git checkout [a-z0-9\\.-]+", replace="git checkout {{version}}"} ,
-  {file="../book/src/user/install.md", search="--tag [a-z0-9\\.-]+", replace="--tag {{version}}"} ,
-  {file="../book/src/user/docker.md", search="--branch [a-z0-9\\.-]+", replace="--branch {{version}}"} ,
-]
-
 [features]
 # In release builds, don't compile debug logging code, to improve performance.
 default = ["release_max_level_info"]
@@ -263,3 +255,12 @@ zebra-test = { path = "../zebra-test" }
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
 zebra-utils = { path = "../zebra-utils" }
+
+# Release settings
+# This needs to be at the end of the file to avoid including other tables.
+[package.metadata.release]
+pre-release-replacements = [
+  {file="../book/src/user/install.md", search="git checkout [a-z0-9\\.-]+", replace="git checkout {{version}}"} ,
+  {file="../book/src/user/install.md", search="--tag [a-z0-9\\.-]+", replace="--tag {{version}}"} ,
+  {file="../book/src/user/docker.md", search="--branch [a-z0-9\\.-]+", replace="--branch {{version}}"} ,
+]

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/ZcashFoundation/zebra"
 readme = "../README.md"
 homepage = "https://zfnd.org/zebra/"
 # crates.io is limited to 5 keywords and categories
-keywords = ["zebra", "zcash", "node"]
+keywords = ["zebra", "zcash"]
 # Must be one of <https://crates.io/category_slugs>
 categories = ["command-line-utilities", "cryptography::cryptocurrencies"]
 
@@ -27,14 +27,7 @@ rust-version = "1.66"
 # when run in the workspace directory
 default-run = "zebrad"
 
-readme = "../README.md"
-homepage = "https://zfnd.org/zebra/"
-# crates.io is limited to 5 keywords and categories
-keywords = ["zebra", "zcash"]
-# Must be one of <https://crates.io/category_slugs>
-categories = ["command-line-utilities", "cryptography::cryptocurrencies"]
-
-# Release settings
+# `cargo release` settings
 [metadata.release]
 pre-release-replacements = [
   {file="../book/src/user/install.md", search="git checkout [a-z0-9\\.-]+", replace="git checkout {{version}}"},

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -7,6 +7,22 @@ description = "The Zcash Foundation's independent, consensus-compatible implemen
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ZcashFoundation/zebra"
 
+readme = "../README.md"
+homepage = "https://zfnd.org/zebra/"
+# crates.io is limited to 5 keywords and categories
+keywords = ["zebra", "zcash", "node"]
+# Must be one of <https://crates.io/category_slugs>
+categories = ["command-line-utilities", "cryptography::cryptocurrencies"]
+
+# Release settings
+
+[package.metadata.release]
+pre-release-replacements = [
+  {file="../book/src/user/install.md", search="git checkout [a-z0-9\\.-]+", replace="git checkout {{version}}"} ,
+  {file="../book/src/user/install.md", search="--tag [a-z0-9\\.-]+", replace="--tag {{version}}"} ,
+  {file="../book/src/user/docker.md", search="--branch [a-z0-9\\.-]+", replace="--branch {{version}}"} ,
+]
+
 # Settings that impact compilation
 edition = "2021"
 

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -14,15 +14,6 @@ keywords = ["zebra", "zcash", "node"]
 # Must be one of <https://crates.io/category_slugs>
 categories = ["command-line-utilities", "cryptography::cryptocurrencies"]
 
-# Release settings
-
-[package.metadata.release]
-pre-release-replacements = [
-  {file="../book/src/user/install.md", search="git checkout [a-z0-9\\.-]+", replace="git checkout {{version}}"} ,
-  {file="../book/src/user/install.md", search="--tag [a-z0-9\\.-]+", replace="--tag {{version}}"} ,
-  {file="../book/src/user/docker.md", search="--branch [a-z0-9\\.-]+", replace="--branch {{version}}"} ,
-]
-
 # Settings that impact compilation
 edition = "2021"
 
@@ -42,6 +33,14 @@ homepage = "https://zfnd.org/zebra/"
 keywords = ["zebra", "zcash"]
 # Must be one of <https://crates.io/category_slugs>
 categories = ["command-line-utilities", "cryptography::cryptocurrencies"]
+
+# Release settings
+[package.metadata.release]
+pre-release-replacements = [
+  {file="../book/src/user/install.md", search="git checkout [a-z0-9\\.-]+", replace="git checkout {{version}}"} ,
+  {file="../book/src/user/install.md", search="--tag [a-z0-9\\.-]+", replace="--tag {{version}}"} ,
+  {file="../book/src/user/docker.md", search="--branch [a-z0-9\\.-]+", replace="--branch {{version}}"} ,
+]
 
 [features]
 # In release builds, don't compile debug logging code, to improve performance.


### PR DESCRIPTION
## Motivation

Our README release instructions should be consistent with other install instructions.

We need to update the Zebra version in documentation before every release, the manual replacements were already  deleted from the release checklist. (This was an accident.)

## Solution

Documentation:
- Install from crates.io not git in the README (this removes all versions from the readme)
- Move crates.io git install to `install.md`
- Add `git checkout` install to `install.md`
- Reorder `install.md` so the steps are in the order that users will do them

Release:
- Automate version replacements in `docker.md` and `install.md` with `cargo release`
- Put release metadata in the same place as other crates

Versions were already removed from zebra-network/src/constants.rs by a previous PR.

Related fixes:
- Try to fix formatting issues in summary/details headings in rendered docs, the headers come after the triangles in: https://zebra.zfnd.org/#general-instructions-for-installing-dependencies 

## Review

This is a routine docs and release update.

### Reviewer Checklist

  - [x] Are the PR labels correct?
  - [ ] Do the docs do what the ticket and PR says?
  - [ ] How do you know it works?

## Follow Up Work

I will check that these replacements work when I do the next release.

