### PR TITLE
cleanup(workflow): Remove an outdated TODO in release-binaries.yml

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -41,7 +41,6 @@ jobs:
       dockerfile_path: ./docker/Dockerfile
       dockerfile_target: runtime
       image_name: zebra
-      # TODO: change this to `-experimental` when we release Zebra `1.0.0`
       tag_suffix: .experimental
       network: Testnet
       rpc_port: '18232'


### PR DESCRIPTION
## Motivation

We don't need to do this TODO comment any more.

## Review

This is a low priority cleanup.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?

