### PR TITLE
fix(changelog): Fix a broken link in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Please report bugs to [the Zebra GitHub repository](https://github.com/ZcashFoun
 
 ### Changed
 
-- Publish to [crates.io](https://crates.io/crates/zebrad) ([#6908(https://github.com/ZcashFoundation/zebra/pull/6908))
+- Publish to [crates.io](https://crates.io/crates/zebrad) ([#6908](https://github.com/ZcashFoundation/zebra/pull/6908))
 - Rename tower-batch to tower-batch-control ([#6907](https://github.com/ZcashFoundation/zebra/pull/6907))
 - Upgrade to ed25519-zebra 4.0.0 ([#6881](https://github.com/ZcashFoundation/zebra/pull/6881))
 


### PR DESCRIPTION
## Motivation

There's a broken link in the CHANGELOG.

I already fixed it in the release notes at https://github.com/ZcashFoundation/zebra/releases/tag/v1.0.0

## Review

This is a low priority fix.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the change do what the ticket and PR says?

