### PR TITLE
fix(network): Limit number of peer connections per IP address, Ignore new peer connections from the same IP and port

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -67,7 +67,7 @@ pub const INBOUND_PEER_LIMIT_MULTIPLIER: usize = 5;
 /// See [`INBOUND_PEER_LIMIT_MULTIPLIER`] for details.
 pub const OUTBOUND_PEER_LIMIT_MULTIPLIER: usize = 3;
 
-/// The maximum number of peer connections Zebra will for a given IP address
+/// The maximum number of peer connections Zebra will keep for a given IP address
 /// before it drops any additional peer connections with that IP.
 pub const MAX_CONNS_PER_IP: usize = 3;
 

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -67,6 +67,10 @@ pub const INBOUND_PEER_LIMIT_MULTIPLIER: usize = 5;
 /// See [`INBOUND_PEER_LIMIT_MULTIPLIER`] for details.
 pub const OUTBOUND_PEER_LIMIT_MULTIPLIER: usize = 3;
 
+/// The maximum number of peer connections Zebra will for a given IP address
+/// before it drops any additional peer connections with that IP.
+pub const MAX_CONNS_PER_IP: usize = 3;
+
 /// The buffer size for the peer set.
 ///
 /// This should be greater than 1 to avoid sender contention, but also reasonably

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -179,6 +179,7 @@ where
         inv_receiver,
         address_metrics,
         MinimumPeerVersion::new(latest_chain_tip, config.network),
+        None,
     );
     let peer_set = Buffer::new(BoxService::new(peer_set), constants::PEERSET_BUFFER_SIZE);
 

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -541,7 +541,7 @@ where
                     //
                     // drop the new peer if there are already `MAX_CONNS_PER_IP` peers with
                     // the same IP address in the peer set.
-                    if self.num_peers_with_ip(key.ip()) > self.max_conns_per_ip {
+                    if self.num_peers_with_ip(key.ip()) >= self.max_conns_per_ip {
                         std::mem::drop(svc);
                         continue;
                     }

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -507,13 +507,15 @@ where
                     // - always do the same checks on every ready peer, and
                     // - check for any errors that happened right after the handshake
                     trace!(?key, "got Change::Insert from Discover");
-                    self.remove(&key);
 
+                    // # Security
+                    //
                     // drop the new peer if there are already `MAX_CONNS_PER_IP` peers with
                     // the same IP address in the peer set
                     // this is skipped for tests so we can mock peer connections
                     #[cfg(not(test))]
                     if self.num_peers_with_ip(key.ip()) > crate::constants::MAX_CONNS_PER_IP {
+                        std::mem::drop(svc);
                         continue;
                     }
 

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -509,7 +509,8 @@ where
                     trace!(?key, "got Change::Insert from Discover");
                     self.remove(&key);
 
-                    // drop the new peer if its IP is in cancel_handles or ready_services,
+                    // drop the new peer if there are already `MAX_CONNS_PER_IP` peers with
+                    // the same IP address in the peer set
                     // this is skipped for tests so we can mock peer connections
                     #[cfg(not(test))]
                     if self.num_peers_with_ip(key.ip()) > crate::constants::MAX_CONNS_PER_IP {

--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -117,6 +117,7 @@ struct PeerSetBuilder<D, C> {
     inv_stream: Option<broadcast::Receiver<InventoryChange>>,
     address_book: Option<Arc<std::sync::Mutex<AddressBook>>>,
     minimum_peer_version: Option<MinimumPeerVersion<C>>,
+    max_conns_per_ip: Option<usize>,
 }
 
 impl PeerSetBuilder<(), ()> {
@@ -137,6 +138,7 @@ impl<D, C> PeerSetBuilder<D, C> {
             inv_stream: self.inv_stream,
             address_book: self.address_book,
             minimum_peer_version: self.minimum_peer_version,
+            max_conns_per_ip: self.max_conns_per_ip,
         }
     }
 
@@ -146,13 +148,33 @@ impl<D, C> PeerSetBuilder<D, C> {
         minimum_peer_version: MinimumPeerVersion<NewC>,
     ) -> PeerSetBuilder<D, NewC> {
         PeerSetBuilder {
-            minimum_peer_version: Some(minimum_peer_version),
             config: self.config,
             discover: self.discover,
             demand_signal: self.demand_signal,
             handle_rx: self.handle_rx,
             inv_stream: self.inv_stream,
             address_book: self.address_book,
+            minimum_peer_version: Some(minimum_peer_version),
+            max_conns_per_ip: self.max_conns_per_ip,
+        }
+    }
+
+    /// Use the provided [`MinimumPeerVersion`] instance when constructing the [`PeerSet`] instance.
+    pub fn max_conns_per_ip(self, max_conns_per_ip: usize) -> PeerSetBuilder<D, C> {
+        assert!(
+            max_conns_per_ip > 0,
+            "max_conns_per_ip must be greater than zero"
+        );
+
+        PeerSetBuilder {
+            config: self.config,
+            discover: self.discover,
+            demand_signal: self.demand_signal,
+            handle_rx: self.handle_rx,
+            inv_stream: self.inv_stream,
+            address_book: self.address_book,
+            minimum_peer_version: self.minimum_peer_version,
+            max_conns_per_ip: Some(max_conns_per_ip),
         }
     }
 }
@@ -175,6 +197,7 @@ where
         let minimum_peer_version = self
             .minimum_peer_version
             .expect("`minimum_peer_version` must be set");
+        let max_conns_per_ip = self.max_conns_per_ip;
 
         let demand_signal = self
             .demand_signal
@@ -196,6 +219,7 @@ where
             inv_stream,
             address_metrics,
             minimum_peer_version,
+            max_conns_per_ip,
         );
 
         (peer_set, guard)

--- a/zebra-network/src/peer_set/set/tests/prop.rs
+++ b/zebra-network/src/peer_set/set/tests/prop.rs
@@ -42,6 +42,7 @@ proptest! {
             let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
                 .with_discover(discovered_peers)
                 .with_minimum_peer_version(minimum_peer_version)
+                .max_conns_per_ip(usize::MAX)
                 .build();
 
             check_if_only_up_to_date_peers_are_live(
@@ -72,6 +73,7 @@ proptest! {
             let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
                 .with_discover(discovered_peers)
                 .with_minimum_peer_version(minimum_peer_version.clone())
+                .max_conns_per_ip(usize::MAX)
                 .build();
 
             check_if_only_up_to_date_peers_are_live(
@@ -122,6 +124,7 @@ proptest! {
             let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
                 .with_discover(discovered_peers)
                 .with_minimum_peer_version(minimum_peer_version.clone())
+                .max_conns_per_ip(usize::MAX)
                 .build();
 
             // Get the total number of active peers
@@ -197,6 +200,7 @@ proptest! {
             let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
                 .with_discover(discovered_peers)
                 .with_minimum_peer_version(minimum_peer_version.clone())
+                .max_conns_per_ip(usize::MAX)
                 .build();
 
             // Remove peers, test broadcast until there is only 1 peer left in the peerset
@@ -267,6 +271,7 @@ proptest! {
             let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
                 .with_discover(discovered_peers)
                 .with_minimum_peer_version(minimum_peer_version.clone())
+                .max_conns_per_ip(usize::MAX)
                 .build();
 
             // Remove peers


### PR DESCRIPTION
## Motivation

This PR drops additional peer connections from a given IP after there are already `MAX_CONNS_PER_IP` in the peer set.

Closes #6936.

## Solution

- Define `MAX_CONNS_PER_IP`
- Count the number of keys in `PeerSet.ready_services` and `PeerSet.cancel_handles` before inserting new connections into the peer set
- Drop new connections when there are already `MAX_CONNS_PER_IP`

## Review

This is a routine security fix.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [x] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [x] Does it change concurrent code, unsafe code, or consensus rules?
  - [x] How do you know it works? Does it have tests?

## Follow Up Work

- #6981 
- #6982