### PR TITLE
fix(panic): Stop panicking when handling inbound connection handshakes

### DIFF
--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -876,6 +876,10 @@ where
         let relay = self.relay;
         let minimum_peer_version = self.minimum_peer_version.clone();
 
+        // # Security
+        //
+        // `zebra_network::init()` implements a connection timeout on this future.
+        // Any code outside this future does not have a timeout.
         let fut = async move {
             debug!(
                 addr = ?connected_addr,


### PR DESCRIPTION
## Motivation

In PR #6969 which just merged yesterday, I introduced a panic bug when handling some inbound handshake errors.

### Complex Code or Requirements

The lack of `FuturesUnordered` types made bugs like this easy to add and tricky to catch.

## Solution

- Fix the panic by handling errors directly on the futures
- Fix a potential panic on shutdown by logging when tasks are cancelled, rather than panicking unconditionally 
- Prevent panics in other refactors by adding types to errors and FuturesUnordered

Related cleanups:
- Remove a redundant timeout in outbound handshakes

## Review

This could be an urgent fix if it causes panics in other tests or full syncs.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

