### PR TITLE
fix(net): Reduce maximum number of connections per IP to 1

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -69,7 +69,7 @@ pub const OUTBOUND_PEER_LIMIT_MULTIPLIER: usize = 3;
 
 /// The maximum number of peer connections Zebra will keep for a given IP address
 /// before it drops any additional peer connections with that IP.
-pub const MAX_CONNS_PER_IP: usize = 3;
+pub const MAX_CONNS_PER_IP: usize = 1;
 
 /// The buffer size for the peer set.
 ///

--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -1,6 +1,6 @@
 //! Fixed test vectors for the peer set.
 
-use std::{iter, time::Duration};
+use std::{cmp::max, iter, time::Duration};
 
 use tokio::time::timeout;
 use tower::{Service, ServiceExt};
@@ -12,6 +12,7 @@ use zebra_chain::{
 
 use super::{PeerSetBuilder, PeerVersions};
 use crate::{
+    constants::MAX_CONNS_PER_IP,
     peer::{ClientRequest, MinimumPeerVersion},
     peer_set::inventory_registry::InventoryStatus,
     protocol::external::{types::Version, InventoryHash},
@@ -144,6 +145,7 @@ fn peer_set_ready_multiple_connections() {
         let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
             .with_discover(discovered_peers)
             .with_minimum_peer_version(minimum_peer_version.clone())
+            .max_conns_per_ip(max(3, MAX_CONNS_PER_IP))
             .build();
 
         // Get peerset ready
@@ -257,6 +259,7 @@ fn peer_set_route_inv_empty_registry() {
         let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
             .with_discover(discovered_peers)
             .with_minimum_peer_version(minimum_peer_version.clone())
+            .max_conns_per_ip(max(2, MAX_CONNS_PER_IP))
             .build();
 
         // Get peerset ready
@@ -339,6 +342,7 @@ fn peer_set_route_inv_advertised_registry_order(advertised_first: bool) {
         let (mut peer_set, mut peer_set_guard) = PeerSetBuilder::new()
             .with_discover(discovered_peers)
             .with_minimum_peer_version(minimum_peer_version.clone())
+            .max_conns_per_ip(max(2, MAX_CONNS_PER_IP))
             .build();
 
         // Advertise some inventory
@@ -446,6 +450,7 @@ fn peer_set_route_inv_missing_registry_order(missing_first: bool) {
         let (mut peer_set, mut peer_set_guard) = PeerSetBuilder::new()
             .with_discover(discovered_peers)
             .with_minimum_peer_version(minimum_peer_version.clone())
+            .max_conns_per_ip(max(2, MAX_CONNS_PER_IP))
             .build();
 
         // Mark some inventory as missing


### PR DESCRIPTION
## Motivation

After running PR #6980 over the weekend, I started getting these logs:
> 2023-06-18T22:11:23.779916Z  INFO crawl: zebra_network::peer_set::set: duplicate IP addresses in peer set duplicate_connections=13 duplicated_peers=6 peers=46

This means that 15% of the peer set (7/46) is redundant connections, which seems like a peer set takeover risk.

I'm running 3 nodes locally on 2 IPs, so it's possible that 4 of those connections are from my local setup. But that would still be 11% redundant connections (5/46) from external nodes.

I suggest we aim for 5-10% redundant connections at most.

In my setup:
- 1 peer per IP would be 0% redundant connections. (Unless a peer has multiple IP addresses, which we can't detect.)
- 2 peers per IP would be 9% redundant connections from external nodes (4/46), or 13% from all nodes (6/46).

I don't mind whether we choose 1 or 2, but 3 peers per IP seems to allow too many redundant connections.

### Specifications

`zcashd`'s limit is one connection per IP address:
https://github.com/zcash/zcash/blob/fa3827656df8f97fb4700b22022cc581fbda61fa/src/net.cpp#L1663

## Solution

Limit Zebra to 1 connection per IP address.

Related fixes:
- Fix tests that require more than 1 connection per IP

## Review

This should go in before the next release.

@arya2 wrote the original PR #6980.
### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

