### PR TITLE
fix(log): Refactor terminal color checks, fix force_color on panic logs

### DIFF
--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -160,11 +160,6 @@ pub struct ZebradApp {
 }
 
 impl ZebradApp {
-    /// Are standard output and standard error both connected to ttys?
-    fn outputs_are_ttys() -> bool {
-        atty::is(atty::Stream::Stdout) && atty::is(atty::Stream::Stderr)
-    }
-
     /// Returns the git commit for this build, if available.
     ///
     ///
@@ -209,8 +204,7 @@ impl Application for ZebradApp {
         //       of the `color_eyre::install` part of `Terminal::new` without
         //       ColorChoice::Never?
 
-        // The Tracing component uses stdout directly and will apply colors
-        // `if Self::outputs_are_ttys() && config.tracing.use_colors`
+        // The Tracing component uses stdout directly and will apply colors automatically.
         //
         // Note: It's important to use `ColorChoice::Never` here to avoid panicking in
         //       `register_components()` below if `color_eyre::install()` is called
@@ -249,7 +243,7 @@ impl Application for ZebradApp {
 
         let config = command.process_config(config)?;
 
-        let theme = if Self::outputs_are_ttys() && config.tracing.use_color {
+        let theme = if config.tracing.use_color_stdout_and_stderr() {
             color_eyre::config::Theme::dark()
         } else {
             color_eyre::config::Theme::new()

--- a/zebrad/src/components/tracing.rs
+++ b/zebrad/src/components/tracing.rs
@@ -131,6 +131,21 @@ pub struct Config {
     pub use_journald: bool,
 }
 
+impl Config {
+    /// Returns `true` if standard output should use color escapes.
+    /// Automatically checks if Zebra is running in a terminal.
+    pub fn use_color_stdout(&self) -> bool {
+        self.force_use_color || (self.use_color && atty::is(atty::Stream::Stdout))
+    }
+
+    /// Returns `true` if output that could go to standard output or standard error
+    /// should use color escapes. Automatically checks if Zebra is running in a terminal.
+    pub fn use_color_stdout_and_stderr(&self) -> bool {
+        self.force_use_color
+            || (self.use_color && atty::is(atty::Stream::Stdout) && atty::is(atty::Stream::Stderr))
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
         #[cfg(feature = "progress-bar")]

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -54,6 +54,10 @@ impl Tracing {
     /// Try to create a new [`Tracing`] component with the given `filter`.
     #[allow(clippy::print_stdout, clippy::print_stderr)]
     pub fn new(config: Config) -> Result<Self, FrameworkError> {
+        // Only use color if tracing output is being sent to a terminal or if it was explicitly
+        // forced to.
+        let use_color = config.use_color_stdout();
+
         let filter = config.filter.unwrap_or_default();
         let flame_root = &config.flamegraph;
 
@@ -97,11 +101,6 @@ impl Tracing {
         let (non_blocking, worker_guard) = NonBlockingBuilder::default()
             .buffered_lines_limit(config.buffer_limit.max(100))
             .finish(writer);
-
-        // Only use color if tracing output is being sent to a terminal or if it was explicitly
-        // forced to.
-        let use_color =
-            config.force_use_color || (config.use_color && atty::is(atty::Stream::Stdout));
 
         // Construct a format subscriber with the supplied global logging filter,
         // and optionally enable reloading.


### PR DESCRIPTION
## Motivation

Panic logs aren't being shown in colour when `force_use_color` is set.

## Solution

- Refactor all terminal colour checks onto `tracing::Config`
- Use the new config methods to set tracing and color_eyre colours

## Review

@conradoplg might want to review this for PR #6945.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

