### PR TITLE
refactor(consensus): Rename router_verifier to block_verifier_router

### DIFF
--- a/book/src/dev/diagrams/service-dependencies.svg
+++ b/book/src/dev/diagrams/service-dependencies.svg
@@ -74,15 +74,15 @@
 <path fill="none" stroke="#000000" d="M261.2822,-293.6228C291.5824,-281.7662 337.5245,-263.7888 371.0388,-250.6745"/>
 <polygon fill="#000000" stroke="#000000" points="372.5364,-253.847 380.5734,-246.9436 369.9855,-247.3283 372.5364,-253.847"/>
 </g>
-<!-- router_verifier -->
+<!-- block_verifier_router -->
 <a id="node6" class="node" target="_blank" href="https://doc-internal.zebra.zfnd.org/zebra_consensus/chain/index.html">
-<title>router_verifier</title>
+<title>block_verifier_router</title>
 <ellipse fill="transparent" stroke="#000000" cx="244.6515" cy="-234" rx="65.3859" ry="18"/>
-<text text-anchor="middle" x="244.6515" y="-229.8" font-family="'Opens sans', sans-serif" font-size="14.00" fill="#000000">router_verifier</text>
+<text text-anchor="middle" x="244.6515" y="-229.8" font-family="'Opens sans', sans-serif" font-size="14.00" fill="#000000">block_verifier_router</text>
 </a>
-<!-- inbound&#45;&gt;router_verifier -->
+<!-- inbound&#45;&gt;block_verifier_router -->
 <g id="edge9" class="edge">
-<title>inbound&#45;&gt;router_verifier</title>
+<title>inbound&#45;&gt;block_verifier_router</title>
 <path fill="none" stroke="#000000" d="M233.4366,-287.8314C235.0409,-280.131 236.9485,-270.9743 238.7314,-262.4166"/>
 <polygon fill="#000000" stroke="#000000" points="242.2022,-262.9169 240.8154,-252.4133 235.3494,-261.4892 242.2022,-262.9169"/>
 </g>
@@ -104,9 +104,9 @@
 <path fill="none" stroke="#000000" d="M383.846,-360.9895C393.4567,-351.221 404.1854,-338.1106 409.6515,-324 417.2551,-304.3715 417.9695,-280.5065 416.9367,-262.2845"/>
 <polygon fill="#000000" stroke="#000000" points="420.424,-261.9839 416.1656,-252.2825 413.4447,-262.522 420.424,-261.9839"/>
 </g>
-<!-- rpc_server&#45;&gt;router_verifier -->
+<!-- rpc_server&#45;&gt;block_verifier_router -->
 <g id="edge11" class="edge">
-<title>rpc_server&#45;&gt;router_verifier</title>
+<title>rpc_server&#45;&gt;block_verifier_router</title>
 <path fill="none" stroke="#000000" stroke-dasharray="1,5" d="M350.1767,-360.6302C329.2082,-335.4681 290.2442,-288.7112 265.9807,-259.595"/>
 <polygon fill="#000000" stroke="#000000" points="268.6447,-257.3247 259.5541,-251.8831 263.2672,-261.806 268.6447,-257.3247"/>
 </g>
@@ -116,9 +116,9 @@
 <ellipse fill="transparent" stroke="#000000" cx="112.6515" cy="-90" rx="86.7972" ry="18"/>
 <text text-anchor="middle" x="112.6515" y="-85.8" font-family="'Opens sans', sans-serif" font-size="14.00" fill="#000000">checkpoint_verifier</text>
 </a>
-<!-- router_verifier&#45;&gt;checkpoint_verifier -->
+<!-- block_verifier_router&#45;&gt;checkpoint_verifier -->
 <g id="edge6" class="edge">
-<title>router_verifier&#45;&gt;checkpoint_verifier</title>
+<title>block_verifier_router&#45;&gt;checkpoint_verifier</title>
 <path fill="none" stroke="#000000" d="M216.638,-217.5178C201.6091,-207.8136 183.4054,-194.5969 169.6515,-180 151.8569,-161.1147 136.447,-135.8982 126.1523,-116.962"/>
 <polygon fill="#000000" stroke="#000000" points="129.1594,-115.1615 121.3857,-107.9628 122.9735,-118.438 129.1594,-115.1615"/>
 </g>
@@ -128,9 +128,9 @@
 <ellipse fill="transparent" stroke="#000000" cx="244.6515" cy="-162" rx="65.9697" ry="18"/>
 <text text-anchor="middle" x="244.6515" y="-157.8" font-family="'Opens sans', sans-serif" font-size="14.00" fill="#000000">block_verifier</text>
 </a>
-<!-- router_verifier&#45;&gt;block_verifier -->
+<!-- block_verifier_router&#45;&gt;block_verifier -->
 <g id="edge17" class="edge">
-<title>router_verifier&#45;&gt;block_verifier</title>
+<title>block_verifier_router&#45;&gt;block_verifier</title>
 <path fill="none" stroke="#000000" d="M244.6515,-215.8314C244.6515,-208.131 244.6515,-198.9743 244.6515,-190.4166"/>
 <polygon fill="#000000" stroke="#000000" points="248.1516,-190.4132 244.6515,-180.4133 241.1516,-190.4133 248.1516,-190.4132"/>
 </g>
@@ -146,9 +146,9 @@
 <ellipse fill="transparent" stroke="#000000" cx="364.6515" cy="-306" rx="36.4761" ry="18"/>
 <text text-anchor="middle" x="364.6515" y="-301.8" font-family="'Opens sans', sans-serif" font-size="14.00" fill="#000000">syncer</text>
 </a>
-<!-- syncer&#45;&gt;router_verifier -->
+<!-- syncer&#45;&gt;block_verifier_router -->
 <g id="edge10" class="edge">
-<title>syncer&#45;&gt;router_verifier</title>
+<title>syncer&#45;&gt;block_verifier_router</title>
 <path fill="none" stroke="#000000" d="M341.5143,-292.1177C324.2684,-281.7701 300.3887,-267.4423 280.6551,-255.6022"/>
 <polygon fill="#000000" stroke="#000000" points="282.2946,-252.5042 271.9189,-250.3604 278.6931,-258.5067 282.2946,-252.5042"/>
 </g>

--- a/book/src/dev/overview.md
+++ b/book/src/dev/overview.md
@@ -56,18 +56,18 @@ digraph services {
     inbound -> state
     rpc_server -> state
     mempool -> transaction_verifier
-    router_verifier -> checkpoint_verifier
+    block_verifier_router -> checkpoint_verifier
     inbound -> mempool
     rpc_server -> mempool
-    inbound -> router_verifier
-    syncer -> router_verifier
-    rpc_server -> router_verifier [style=dotted]
+    inbound -> block_verifier_router
+    syncer -> block_verifier_router
+    rpc_server -> block_verifier_router [style=dotted]
     syncer -> peer_set
     mempool -> peer_set
     block_verifier -> state
     checkpoint_verifier -> state
     block_verifier -> transaction_verifier
-    router_verifier -> block_verifier
+    block_verifier_router -> block_verifier
     rpc_server -> inbound [style=invis] // for layout of the diagram
 }
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
@@ -98,7 +98,7 @@ pub fn check_miner_address(
 ///
 /// Returns a `getblocktemplate` [`Response`].
 pub async fn validate_block_proposal<BlockVerifierRouter, Tip, SyncStatus>(
-    mut router_verifier: BlockVerifierRouter,
+    mut block_verifier_router: BlockVerifierRouter,
     block_proposal_bytes: Vec<u8>,
     network: Network,
     latest_chain_tip: Tip,
@@ -129,7 +129,7 @@ where
         }
     };
 
-    let router_verifier_response = router_verifier
+    let block_verifier_router_response = block_verifier_router
         .ready()
         .await
         .map_err(|error| Error {
@@ -140,12 +140,12 @@ where
         .call(zebra_consensus::Request::CheckProposal(Arc::new(block)))
         .await;
 
-    Ok(router_verifier_response
+    Ok(block_verifier_router_response
         .map(|_hash| ProposalResponse::Valid)
         .unwrap_or_else(|verify_chain_error| {
             tracing::info!(
                 ?verify_chain_error,
-                "error response from router_verifier in CheckProposal request"
+                "error response from block_verifier_router in CheckProposal request"
             );
 
             ProposalResponse::rejected("invalid proposal", verify_chain_error)

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -85,7 +85,7 @@ pub async fn test_responses<State, ReadState>(
     <ReadState as Service<zebra_state::ReadRequest>>::Future: Send,
 {
     let (
-        router_verifier,
+        block_verifier_router,
         _transaction_verifier,
         _parameter_download_task_handle,
         _max_checkpoint_height,
@@ -145,7 +145,7 @@ pub async fn test_responses<State, ReadState>(
         Buffer::new(mempool.clone(), 1),
         read_state,
         mock_chain_tip.clone(),
-        router_verifier.clone(),
+        block_verifier_router.clone(),
         mock_sync_status.clone(),
         mock_address_book,
     );
@@ -267,7 +267,7 @@ pub async fn test_responses<State, ReadState>(
         Buffer::new(mempool.clone(), 1),
         read_state.clone(),
         mock_chain_tip.clone(),
-        router_verifier,
+        block_verifier_router,
         mock_sync_status.clone(),
         MockAddressBookPeers::default(),
     );
@@ -365,16 +365,16 @@ pub async fn test_responses<State, ReadState>(
 
     snapshot_rpc_getblocktemplate("invalid-proposal", get_block_template, None, &settings);
 
-    // the following snapshots use a mock read_state and router_verifier
+    // the following snapshots use a mock read_state and block_verifier_router
 
-    let mut mock_router_verifier = MockService::build().for_unit_tests();
+    let mut mock_block_verifier_router = MockService::build().for_unit_tests();
     let get_block_template_rpc_mock_state_verifier = GetBlockTemplateRpcImpl::new(
         network,
         mining_config,
         Buffer::new(mempool.clone(), 1),
         read_state.clone(),
         mock_chain_tip,
-        mock_router_verifier.clone(),
+        mock_block_verifier_router.clone(),
         mock_sync_status,
         MockAddressBookPeers::default(),
     );
@@ -387,15 +387,17 @@ pub async fn test_responses<State, ReadState>(
         }),
     );
 
-    let mock_router_verifier_request_handler = async move {
-        mock_router_verifier
+    let mock_block_verifier_router_request_handler = async move {
+        mock_block_verifier_router
             .expect_request_that(|req| matches!(req, zebra_consensus::Request::CheckProposal(_)))
             .await
             .respond(Hash::from([0; 32]));
     };
 
-    let (get_block_template, ..) =
-        tokio::join!(get_block_template_fut, mock_router_verifier_request_handler,);
+    let (get_block_template, ..) = tokio::join!(
+        get_block_template_fut,
+        mock_block_verifier_router_request_handler,
+    );
 
     let get_block_template =
         get_block_template.expect("unexpected error in getblocktemplate RPC call");

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -830,7 +830,7 @@ async fn rpc_getblockcount() {
         zebra_state::populated_state(blocks.clone(), Mainnet).await;
 
     let (
-        router_verifier,
+        block_verifier_router,
         _transaction_verifier,
         _parameter_download_task_handle,
         _max_checkpoint_height,
@@ -849,7 +849,7 @@ async fn rpc_getblockcount() {
         Buffer::new(mempool.clone(), 1),
         read_state,
         latest_chain_tip.clone(),
-        router_verifier,
+        block_verifier_router,
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
     );
@@ -880,7 +880,7 @@ async fn rpc_getblockcount_empty_state() {
         zebra_state::init_test_services(Mainnet);
 
     let (
-        router_verifier,
+        block_verifier_router,
         _transaction_verifier,
         _parameter_download_task_handle,
         _max_checkpoint_height,
@@ -899,7 +899,7 @@ async fn rpc_getblockcount_empty_state() {
         Buffer::new(mempool.clone(), 1),
         read_state,
         latest_chain_tip.clone(),
-        router_verifier,
+        block_verifier_router,
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
     );
@@ -932,7 +932,7 @@ async fn rpc_getpeerinfo() {
         zebra_state::init_test_services(Mainnet);
 
     let (
-        router_verifier,
+        block_verifier_router,
         _transaction_verifier,
         _parameter_download_task_handle,
         _max_checkpoint_height,
@@ -965,7 +965,7 @@ async fn rpc_getpeerinfo() {
         Buffer::new(mempool.clone(), 1),
         read_state,
         latest_chain_tip.clone(),
-        router_verifier,
+        block_verifier_router,
         MockSyncStatus::default(),
         mock_address_book,
     );
@@ -1007,7 +1007,7 @@ async fn rpc_getblockhash() {
         zebra_state::populated_state(blocks.clone(), Mainnet).await;
 
     let (
-        router_verifier,
+        block_verifier_router,
         _transaction_verifier,
         _parameter_download_task_handle,
         _max_checkpoint_height,
@@ -1026,7 +1026,7 @@ async fn rpc_getblockhash() {
         Buffer::new(mempool.clone(), 1),
         read_state,
         latest_chain_tip.clone(),
-        tower::ServiceBuilder::new().service(router_verifier),
+        tower::ServiceBuilder::new().service(block_verifier_router),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
     );
@@ -1195,7 +1195,7 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
     let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
     let read_state = MockService::build().for_unit_tests();
-    let router_verifier = MockService::build().for_unit_tests();
+    let block_verifier_router = MockService::build().for_unit_tests();
 
     let mut mock_sync_status = MockSyncStatus::default();
     mock_sync_status.set_is_close_to_tip(true);
@@ -1236,7 +1236,7 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
         Buffer::new(mempool.clone(), 1),
         read_state.clone(),
         mock_chain_tip,
-        router_verifier,
+        block_verifier_router,
         mock_sync_status.clone(),
         MockAddressBookPeers::default(),
     );
@@ -1481,7 +1481,7 @@ async fn rpc_submitblock_errors() {
 
     // Init RPCs
     let (
-        router_verifier,
+        block_verifier_router,
         _transaction_verifier,
         _parameter_download_task_handle,
         _max_checkpoint_height,
@@ -1500,7 +1500,7 @@ async fn rpc_submitblock_errors() {
         Buffer::new(mempool.clone(), 1),
         read_state,
         latest_chain_tip.clone(),
-        router_verifier,
+        block_verifier_router,
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
     );
@@ -1648,7 +1648,7 @@ async fn rpc_getdifficulty() {
     let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
     let read_state = MockService::build().for_unit_tests();
-    let router_verifier = MockService::build().for_unit_tests();
+    let block_verifier_router = MockService::build().for_unit_tests();
 
     let mut mock_sync_status = MockSyncStatus::default();
     mock_sync_status.set_is_close_to_tip(true);
@@ -1683,7 +1683,7 @@ async fn rpc_getdifficulty() {
         Buffer::new(mempool.clone(), 1),
         read_state.clone(),
         mock_chain_tip,
-        router_verifier,
+        block_verifier_router,
         mock_sync_status.clone(),
         MockAddressBookPeers::default(),
     );

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -84,7 +84,7 @@ impl RpcServer {
         mempool: Buffer<Mempool, mempool::Request>,
         state: State,
         #[cfg_attr(not(feature = "getblocktemplate-rpcs"), allow(unused_variables))]
-        router_verifier: BlockVerifierRouter,
+        block_verifier_router: BlockVerifierRouter,
         #[cfg_attr(not(feature = "getblocktemplate-rpcs"), allow(unused_variables))]
         sync_status: SyncStatus,
         #[cfg_attr(not(feature = "getblocktemplate-rpcs"), allow(unused_variables))]
@@ -149,7 +149,7 @@ impl RpcServer {
                     mempool.clone(),
                     state.clone(),
                     latest_chain_tip.clone(),
-                    router_verifier,
+                    block_verifier_router,
                     sync_status,
                     address_book,
                 );

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -52,7 +52,7 @@ fn rpc_server_spawn(parallel_cpu_threads: bool) {
     rt.block_on(async {
         let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
         let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
-        let mut router_verifier: MockService<_, _, _, BoxError> =
+        let mut block_verifier_router: MockService<_, _, _, BoxError> =
             MockService::build().for_unit_tests();
 
         info!("spawning RPC server...");
@@ -63,7 +63,7 @@ fn rpc_server_spawn(parallel_cpu_threads: bool) {
             "RPC server test",
             Buffer::new(mempool.clone(), 1),
             Buffer::new(state.clone(), 1),
-            Buffer::new(router_verifier.clone(), 1),
+            Buffer::new(block_verifier_router.clone(), 1),
             MockSyncStatus::default(),
             MockAddressBookPeers::default(),
             NoChainTip,
@@ -74,7 +74,7 @@ fn rpc_server_spawn(parallel_cpu_threads: bool) {
 
         mempool.expect_no_requests().await;
         state.expect_no_requests().await;
-        router_verifier.expect_no_requests().await;
+        block_verifier_router.expect_no_requests().await;
 
         // The server and queue tasks should continue without errors or panics
         let rpc_server_task_result = rpc_server_task_handle.now_or_never();
@@ -138,7 +138,7 @@ fn rpc_server_spawn_unallocated_port(parallel_cpu_threads: bool, do_shutdown: bo
     rt.block_on(async {
         let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
         let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
-        let mut router_verifier: MockService<_, _, _, BoxError> =
+        let mut block_verifier_router: MockService<_, _, _, BoxError> =
             MockService::build().for_unit_tests();
 
         info!("spawning RPC server...");
@@ -149,7 +149,7 @@ fn rpc_server_spawn_unallocated_port(parallel_cpu_threads: bool, do_shutdown: bo
             "RPC server test",
             Buffer::new(mempool.clone(), 1),
             Buffer::new(state.clone(), 1),
-            Buffer::new(router_verifier.clone(), 1),
+            Buffer::new(block_verifier_router.clone(), 1),
             MockSyncStatus::default(),
             MockAddressBookPeers::default(),
             NoChainTip,
@@ -160,7 +160,7 @@ fn rpc_server_spawn_unallocated_port(parallel_cpu_threads: bool, do_shutdown: bo
 
         mempool.expect_no_requests().await;
         state.expect_no_requests().await;
-        router_verifier.expect_no_requests().await;
+        block_verifier_router.expect_no_requests().await;
 
         if do_shutdown {
             rpc_server
@@ -217,7 +217,7 @@ fn rpc_server_spawn_port_conflict() {
     let test_task_handle = rt.spawn(async {
         let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
         let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
-        let mut router_verifier: MockService<_, _, _, BoxError> =
+        let mut block_verifier_router: MockService<_, _, _, BoxError> =
             MockService::build().for_unit_tests();
 
         info!("spawning RPC server 1...");
@@ -229,7 +229,7 @@ fn rpc_server_spawn_port_conflict() {
                 "RPC server 1 test",
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
-                Buffer::new(router_verifier.clone(), 1),
+                Buffer::new(block_verifier_router.clone(), 1),
                 MockSyncStatus::default(),
                 MockAddressBookPeers::default(),
                 NoChainTip,
@@ -246,7 +246,7 @@ fn rpc_server_spawn_port_conflict() {
             "RPC server 2 conflict test",
             Buffer::new(mempool.clone(), 1),
             Buffer::new(state.clone(), 1),
-            Buffer::new(router_verifier.clone(), 1),
+            Buffer::new(block_verifier_router.clone(), 1),
             MockSyncStatus::default(),
             MockAddressBookPeers::default(),
             NoChainTip,
@@ -257,7 +257,7 @@ fn rpc_server_spawn_port_conflict() {
 
         mempool.expect_no_requests().await;
         state.expect_no_requests().await;
-        router_verifier.expect_no_requests().await;
+        block_verifier_router.expect_no_requests().await;
 
         // Because there is a panic inside a multi-threaded executor,
         // we can't depend on the exact behaviour of the other tasks,
@@ -325,7 +325,7 @@ fn rpc_server_spawn_port_conflict_parallel_auto() {
     let test_task_handle = rt.spawn(async {
         let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
         let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
-        let mut router_verifier: MockService<_, _, _, BoxError> =
+        let mut block_verifier_router: MockService<_, _, _, BoxError> =
             MockService::build().for_unit_tests();
 
         info!("spawning parallel RPC server 1...");
@@ -337,7 +337,7 @@ fn rpc_server_spawn_port_conflict_parallel_auto() {
                 "RPC server 1 test",
                 Buffer::new(mempool.clone(), 1),
                 Buffer::new(state.clone(), 1),
-                Buffer::new(router_verifier.clone(), 1),
+                Buffer::new(block_verifier_router.clone(), 1),
                 MockSyncStatus::default(),
                 MockAddressBookPeers::default(),
                 NoChainTip,
@@ -354,7 +354,7 @@ fn rpc_server_spawn_port_conflict_parallel_auto() {
             "RPC server 2 conflict test",
             Buffer::new(mempool.clone(), 1),
             Buffer::new(state.clone(), 1),
-            Buffer::new(router_verifier.clone(), 1),
+            Buffer::new(block_verifier_router.clone(), 1),
             MockSyncStatus::default(),
             MockAddressBookPeers::default(),
             NoChainTip,
@@ -365,7 +365,7 @@ fn rpc_server_spawn_port_conflict_parallel_auto() {
 
         mempool.expect_no_requests().await;
         state.expect_no_requests().await;
-        router_verifier.expect_no_requests().await;
+        block_verifier_router.expect_no_requests().await;
 
         // Because there might be a panic inside a multi-threaded executor,
         // we can't depend on the exact behaviour of the other tasks,

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -158,7 +158,7 @@ impl StartCmd {
         .await;
 
         info!("initializing verifiers");
-        let (router_verifier, tx_verifier, consensus_task_handles, max_checkpoint_height) =
+        let (block_verifier_router, tx_verifier, consensus_task_handles, max_checkpoint_height) =
             zebra_consensus::router::init(
                 config.consensus.clone(),
                 config.network.network,
@@ -172,7 +172,7 @@ impl StartCmd {
             &config,
             max_checkpoint_height,
             peer_set.clone(),
-            router_verifier.clone(),
+            block_verifier_router.clone(),
             state.clone(),
             latest_chain_tip.clone(),
         );
@@ -197,7 +197,7 @@ impl StartCmd {
         let setup_data = InboundSetupData {
             address_book: address_book.clone(),
             block_download_peer_set: peer_set.clone(),
-            block_verifier: router_verifier.clone(),
+            block_verifier: block_verifier_router.clone(),
             mempool: mempool.clone(),
             state,
             latest_chain_tip: latest_chain_tip.clone(),
@@ -218,7 +218,7 @@ impl StartCmd {
             app_version(),
             mempool.clone(),
             read_only_state_service,
-            router_verifier,
+            block_verifier_router,
             sync_status.clone(),
             address_book,
             latest_chain_tip.clone(),

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -45,7 +45,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     let (
         chain_sync_future,
         _sync_status,
-        mut router_verifier,
+        mut block_verifier_router,
         mut peer_set,
         mut state_service,
         _mock_chain_tip_sender,
@@ -88,7 +88,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
         .await
         .respond(zn::Response::Blocks(vec![Available(block0.clone())]));
 
-    router_verifier
+    block_verifier_router
         .expect_request(zebra_consensus::Request::Commit(block0))
         .await
         .respond(block0_hash);
@@ -96,7 +96,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     // Check that nothing unexpected happened.
     // We expect more requests to the state service, because the syncer keeps on running.
     peer_set.expect_no_requests().await;
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
 
     // State is checked for genesis again
     state_service
@@ -144,7 +144,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
 
     // Check that nothing unexpected happened.
     peer_set.expect_no_requests().await;
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
 
     // State is checked for all non-tip blocks (blocks 1 & 2) in response order
     state_service
@@ -174,7 +174,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
             .collect();
 
     for _ in 1..=2 {
-        router_verifier
+        block_verifier_router
             .expect_request_that(|req| remaining_blocks.remove(&req.block().hash()).is_some())
             .await
             .respond_with(|req| req.block().hash());
@@ -186,7 +186,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     );
 
     // Check that nothing unexpected happened.
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
     state_service.expect_no_requests().await;
 
     // ChainSync::extend_tips
@@ -217,7 +217,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     }
 
     // Check that nothing unexpected happened.
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
     state_service.expect_no_requests().await;
 
     // Blocks 3 & 4 are fetched in order, then verified concurrently
@@ -238,7 +238,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
             .collect();
 
     for _ in 3..=4 {
-        router_verifier
+        block_verifier_router
             .expect_request_that(|req| remaining_blocks.remove(&req.block().hash()).is_some())
             .await
             .respond_with(|req| req.block().hash());
@@ -250,7 +250,7 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     );
 
     // Check that nothing unexpected happened.
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
     state_service.expect_no_requests().await;
 
     let chain_sync_result = chain_sync_task_handle.now_or_never();
@@ -272,7 +272,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
     let (
         chain_sync_future,
         _sync_status,
-        mut router_verifier,
+        mut block_verifier_router,
         mut peer_set,
         mut state_service,
         _mock_chain_tip_sender,
@@ -315,7 +315,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
         .await
         .respond(zn::Response::Blocks(vec![Available(block0.clone())]));
 
-    router_verifier
+    block_verifier_router
         .expect_request(zebra_consensus::Request::Commit(block0))
         .await
         .respond(block0_hash);
@@ -323,7 +323,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
     // Check that nothing unexpected happened.
     // We expect more requests to the state service, because the syncer keeps on running.
     peer_set.expect_no_requests().await;
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
 
     // State is checked for genesis again
     state_service
@@ -373,7 +373,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
 
     // Check that nothing unexpected happened.
     peer_set.expect_no_requests().await;
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
 
     // State is checked for all non-tip blocks (blocks 1 & 2) in response order
     state_service
@@ -403,7 +403,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
             .collect();
 
     for _ in 1..=2 {
-        router_verifier
+        block_verifier_router
             .expect_request_that(|req| remaining_blocks.remove(&req.block().hash()).is_some())
             .await
             .respond_with(|req| req.block().hash());
@@ -415,7 +415,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
     );
 
     // Check that nothing unexpected happened.
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
     state_service.expect_no_requests().await;
 
     // ChainSync::extend_tips
@@ -448,7 +448,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
     }
 
     // Check that nothing unexpected happened.
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
     state_service.expect_no_requests().await;
 
     // Blocks 3 & 4 are fetched in order, then verified concurrently
@@ -469,7 +469,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
             .collect();
 
     for _ in 3..=4 {
-        router_verifier
+        block_verifier_router
             .expect_request_that(|req| remaining_blocks.remove(&req.block().hash()).is_some())
             .await
             .respond_with(|req| req.block().hash());
@@ -481,7 +481,7 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
     );
 
     // Check that nothing unexpected happened.
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
     state_service.expect_no_requests().await;
 
     let chain_sync_result = chain_sync_task_handle.now_or_never();
@@ -500,7 +500,7 @@ async fn sync_block_lookahead_drop() -> Result<(), crate::BoxError> {
     let (
         chain_sync_future,
         _sync_status,
-        mut router_verifier,
+        mut block_verifier_router,
         mut peer_set,
         mut state_service,
         _mock_chain_tip_sender,
@@ -535,7 +535,7 @@ async fn sync_block_lookahead_drop() -> Result<(), crate::BoxError> {
     // Block is dropped because it is too far ahead of the tip.
     // We expect more requests to the state service, because the syncer keeps on running.
     peer_set.expect_no_requests().await;
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
 
     let chain_sync_result = chain_sync_task_handle.now_or_never();
     assert!(
@@ -555,7 +555,7 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
     let (
         chain_sync_future,
         _sync_status,
-        mut router_verifier,
+        mut block_verifier_router,
         mut peer_set,
         mut state_service,
         _mock_chain_tip_sender,
@@ -597,7 +597,7 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
         .await
         .respond(zn::Response::Blocks(vec![Available(block0.clone())]));
 
-    router_verifier
+    block_verifier_router
         .expect_request(zebra_consensus::Request::Commit(block0))
         .await
         .respond(block0_hash);
@@ -605,7 +605,7 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
     // Check that nothing unexpected happened.
     // We expect more requests to the state service, because the syncer keeps on running.
     peer_set.expect_no_requests().await;
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
 
     // State is checked for genesis again
     state_service
@@ -654,7 +654,7 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
 
     // Check that nothing unexpected happened.
     peer_set.expect_no_requests().await;
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
 
     // State is checked for all non-tip blocks (blocks 982k, 1, 2) in response order
     state_service
@@ -710,7 +710,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
     let (
         chain_sync_future,
         _sync_status,
-        mut router_verifier,
+        mut block_verifier_router,
         mut peer_set,
         mut state_service,
         _mock_chain_tip_sender,
@@ -758,7 +758,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
         .await
         .respond(zn::Response::Blocks(vec![Available(block0.clone())]));
 
-    router_verifier
+    block_verifier_router
         .expect_request(zebra_consensus::Request::Commit(block0))
         .await
         .respond(block0_hash);
@@ -766,7 +766,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
     // Check that nothing unexpected happened.
     // We expect more requests to the state service, because the syncer keeps on running.
     peer_set.expect_no_requests().await;
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
 
     // State is checked for genesis again
     state_service
@@ -814,7 +814,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
 
     // Check that nothing unexpected happened.
     peer_set.expect_no_requests().await;
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
 
     // State is checked for all non-tip blocks (blocks 1 & 2) in response order
     state_service
@@ -844,7 +844,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
             .collect();
 
     for _ in 1..=2 {
-        router_verifier
+        block_verifier_router
             .expect_request_that(|req| remaining_blocks.remove(&req.block().hash()).is_some())
             .await
             .respond_with(|req| req.block().hash());
@@ -856,7 +856,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
     );
 
     // Check that nothing unexpected happened.
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
     state_service.expect_no_requests().await;
 
     // ChainSync::extend_tips
@@ -888,7 +888,7 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
     }
 
     // Check that nothing unexpected happened.
-    router_verifier.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
     state_service.expect_no_requests().await;
 
     // Blocks 3, 4, 982k are fetched in order, then verified concurrently,
@@ -951,7 +951,7 @@ fn setup() -> (
         .with_max_request_delay(MAX_SERVICE_REQUEST_DELAY)
         .for_unit_tests();
 
-    let router_verifier = MockService::build()
+    let block_verifier_router = MockService::build()
         .with_max_request_delay(MAX_SERVICE_REQUEST_DELAY)
         .for_unit_tests();
 
@@ -965,7 +965,7 @@ fn setup() -> (
         &config,
         Height(0),
         peer_set.clone(),
-        router_verifier.clone(),
+        block_verifier_router.clone(),
         state_service.clone(),
         mock_chain_tip,
     );
@@ -975,7 +975,7 @@ fn setup() -> (
     (
         chain_sync_future,
         sync_status,
-        router_verifier,
+        block_verifier_router,
         peer_set,
         state_service,
         mock_chain_tip_sender,


### PR DESCRIPTION
## Motivation

`router_verifier` sounds like something that verifies routes or routers. But what it actually does it route blocks to other verifiers.

## Solution

Do a mass rename to `block_verifier_router` using these commands:

```sh
git ls-tree --full-tree -r --name-only HEAD | xargs sed -i -e 's/router_verifier/block_verifier_router/g'
cargo fmt --all
```

## Review

You can automatically review this code using the review instructions at:
https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/mass-renames.md#universal-renames-with-sed

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

