### PR TITLE
change(commands): Ignore error from loading config if running the 'generate' or 'download' commands

### DIFF
--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -14,7 +14,7 @@ use zebra_network::constants::PORT_IN_USE_ERROR;
 use zebra_state::constants::{DATABASE_FORMAT_VERSION, LOCK_FILE_ERROR};
 
 use crate::{
-    commands::{EntryPoint, ZebradCmd},
+    commands::EntryPoint,
     components::{sync::end_of_support::EOS_PANIC_MESSAGE_HEADER, tracing::Tracing},
     config::ZebradConfig,
 };
@@ -237,11 +237,11 @@ impl Application for ZebradApp {
         // Load config *after* framework components so that we can
         // report an error to the terminal if it occurs (unless used with the 'generate' cmd).
         let config = match command.config_path() {
-            Some(path) => match (&command.cmd, self.load_config(&path)) {
-                (_, Ok(config)) => config,
-                // Ignore errors loading the config when generating a default config.
-                (&Some(ZebradCmd::Generate(_)), Err(_e)) => Default::default(),
-                (_, Err(e)) => {
+            Some(path) => match self.load_config(&path) {
+                Ok(config) => config,
+                // Ignore errors loading the config for some commands.
+                Err(_e) if command.cmd().should_ignore_load_config_error() => Default::default(),
+                Err(e) => {
                     status_err!("Zebra could not parse the provided config file. This might mean you are using a deprecated format of the file. You can generate a valid config by running \"zebrad generate\", and diff it against yours to examine any format inconsistencies.");
                     return Err(e);
                 }

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -235,10 +235,11 @@ impl Application for ZebradApp {
         let mut components = self.framework_components(command)?;
 
         // Load config *after* framework components so that we can
-        // report an error to the terminal if it occurs.
+        // report an error to the terminal if it occurs (unless used with the 'generate' cmd).
         let config = match command.config_path() {
             Some(path) => match (&command.cmd, self.load_config(&path)) {
                 (_, Ok(config)) => config,
+                // Ignore errors loading the config when generating a default config.
                 (&Some(ZebradCmd::Generate(_)), Err(_e)) => Default::default(),
                 (_, Err(e)) => {
                     status_err!("Zebra could not parse the provided config file. This might mean you are using a deprecated format of the file. You can generate a valid config by running \"zebrad generate\", and diff it against yours to examine any format inconsistencies.");

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -235,7 +235,7 @@ impl Application for ZebradApp {
         let mut components = self.framework_components(command)?;
 
         // Load config *after* framework components so that we can
-        // report an error to the terminal if it occurs (unless used with the 'generate' cmd).
+        // report an error to the terminal if it occurs (unless used with a command that doesn't need the config).
         let config = match command.config_path() {
             Some(path) => match self.load_config(&path) {
                 Ok(config) => config,

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -87,6 +87,12 @@ impl ZebradCmd {
             "debug"
         }
     }
+
+    /// Returns true if this command should ignore errors when
+    /// attempting to load a config file.
+    pub(crate) fn should_ignore_load_config_error(&self) -> bool {
+        matches!(self, ZebradCmd::Generate(_) | ZebradCmd::Download(_))
+    }
 }
 
 impl Runnable for ZebradCmd {


### PR DESCRIPTION
## Motivation

Zebra should ignore errors from loading the config when generating a default config.

## Solution

- Ignore error from `load_config()` when the command is `Generate` and use default config

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
