### PR TITLE
change(state): Refactor the structure of verified blocks

### DIFF
--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -186,12 +186,12 @@ impl CheckpointVerifiedBlock {
         let new_outputs =
             transparent::new_ordered_outputs_with_height(&block, height, &transaction_hashes);
 
-        Self {
+        Self(SemanticallyVerifiedBlock {
             block,
             hash,
             height,
             new_outputs,
             transaction_hashes,
-        }
+        })
     }
 }

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -21,7 +21,7 @@ use zebra_chain::{
 
 use crate::{
     request::ContextuallyVerifiedBlock, service::watch_receiver::WatchReceiver,
-    CheckpointVerifiedBlock,
+    CheckpointVerifiedBlock, SemanticallyVerifiedBlock,
 };
 
 use TipAction::*;
@@ -109,13 +109,13 @@ impl From<ContextuallyVerifiedBlock> for ChainTipBlock {
 
 impl From<CheckpointVerifiedBlock> for ChainTipBlock {
     fn from(finalized: CheckpointVerifiedBlock) -> Self {
-        let CheckpointVerifiedBlock {
+        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock {
             block,
             hash,
             height,
             transaction_hashes,
             ..
-        } = finalized;
+        }) = finalized;
 
         Self {
             hash,

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -228,7 +228,7 @@ impl FinalizedState {
         contextually_verified_with_trees: ContextuallyVerifiedBlockWithTrees,
         source: &str,
     ) -> Result<block::Hash, BoxError> {
-        let finalized = contextually_verified_with_trees.checkpoint_verified;
+        let finalized = contextually_verified_with_trees.block;
         let committed_tip_hash = self.db.finalized_tip_hash();
         let committed_tip_height = self.db.finalized_tip_height();
 

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -38,7 +38,6 @@ use crate::{
             transparent::{AddressBalanceLocation, OutputLocation},
         },
         zebra_db::{metrics::block_precommit_metrics, ZebraDb},
-        CheckpointVerifiedBlock,
     },
     BoxError, HashOrHeight, SemanticallyVerifiedBlock,
 };
@@ -282,7 +281,7 @@ impl ZebraDb {
     /// - Propagates any errors from updating history and note commitment trees
     pub(in super::super) fn write_block(
         &mut self,
-        finalized: CheckpointVerifiedBlock,
+        finalized: SemanticallyVerifiedBlock,
         history_tree: Arc<HistoryTree>,
         note_commitment_trees: NoteCommitmentTrees,
         network: Network,
@@ -430,7 +429,7 @@ impl DiskWriteBatch {
     pub fn prepare_block_batch(
         &mut self,
         db: &DiskDb,
-        finalized: CheckpointVerifiedBlock,
+        finalized: SemanticallyVerifiedBlock,
         new_outputs_by_out_loc: BTreeMap<OutputLocation, transparent::Utxo>,
         spent_utxos_by_outpoint: HashMap<transparent::OutPoint, transparent::Utxo>,
         spent_utxos_by_out_loc: BTreeMap<OutputLocation, transparent::Utxo>,
@@ -439,12 +438,12 @@ impl DiskWriteBatch {
         note_commitment_trees: NoteCommitmentTrees,
         value_pool: ValueBalance<NonNegative>,
     ) -> Result<(), BoxError> {
-        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock {
+        let SemanticallyVerifiedBlock {
             block,
             hash,
             height,
             ..
-        }) = &finalized;
+        } = &finalized;
 
         // Commit block and transaction data.
         // (Transaction indexes, note commitments, and UTXOs are committed later.)
@@ -495,7 +494,7 @@ impl DiskWriteBatch {
     pub fn prepare_block_header_and_transaction_data_batch(
         &mut self,
         db: &DiskDb,
-        finalized: &CheckpointVerifiedBlock,
+        finalized: &SemanticallyVerifiedBlock,
     ) -> Result<(), BoxError> {
         // Blocks
         let block_header_by_height = db.cf_handle("block_header_by_height").unwrap();
@@ -507,13 +506,13 @@ impl DiskWriteBatch {
         let hash_by_tx_loc = db.cf_handle("hash_by_tx_loc").unwrap();
         let tx_loc_by_hash = db.cf_handle("tx_loc_by_hash").unwrap();
 
-        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock {
+        let SemanticallyVerifiedBlock {
             block,
             hash,
             height,
             transaction_hashes,
             ..
-        }) = finalized;
+        } = finalized;
 
         // Commit block header data
         self.zs_insert(&block_header_by_height, height, &block.header);
@@ -554,9 +553,9 @@ impl DiskWriteBatch {
     pub fn prepare_genesis_batch(
         &mut self,
         db: &DiskDb,
-        finalized: &CheckpointVerifiedBlock,
+        finalized: &SemanticallyVerifiedBlock,
     ) -> bool {
-        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock { block, .. }) = finalized;
+        let SemanticallyVerifiedBlock { block, .. } = finalized;
 
         if block.header.previous_block_hash == GENESIS_PREVIOUS_BLOCK_HASH {
             self.prepare_genesis_note_commitment_tree_batch(db, finalized);

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -26,7 +26,7 @@ use crate::{
         zebra_db::ZebraDb,
         CheckpointVerifiedBlock,
     },
-    BoxError,
+    BoxError, SemanticallyVerifiedBlock,
 };
 
 impl ZebraDb {
@@ -75,7 +75,7 @@ impl DiskWriteBatch {
     ) -> Result<(), BoxError> {
         let history_tree_cf = db.cf_handle("history_tree").unwrap();
 
-        let CheckpointVerifiedBlock { height, .. } = finalized;
+        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock { height, .. }) = finalized;
 
         // Update the tree in state
         let current_tip_height = *height - 1;
@@ -114,7 +114,7 @@ impl DiskWriteBatch {
     ) -> Result<(), BoxError> {
         let tip_chain_value_pool = db.cf_handle("tip_chain_value_pool").unwrap();
 
-        let CheckpointVerifiedBlock { block, .. } = finalized;
+        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock { block, .. }) = finalized;
 
         let new_pool = value_pool.add_block(block.borrow(), &utxos_spent_by_block)?;
         self.zs_insert(&tip_chain_value_pool, (), new_pool);

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -24,7 +24,6 @@ use crate::{
     service::finalized_state::{
         disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
         zebra_db::ZebraDb,
-        CheckpointVerifiedBlock,
     },
     BoxError, SemanticallyVerifiedBlock,
 };
@@ -70,12 +69,12 @@ impl DiskWriteBatch {
     pub fn prepare_history_batch(
         &mut self,
         db: &DiskDb,
-        finalized: &CheckpointVerifiedBlock,
+        finalized: &SemanticallyVerifiedBlock,
         history_tree: Arc<HistoryTree>,
     ) -> Result<(), BoxError> {
         let history_tree_cf = db.cf_handle("history_tree").unwrap();
 
-        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock { height, .. }) = finalized;
+        let SemanticallyVerifiedBlock { height, .. } = finalized;
 
         // Update the tree in state
         let current_tip_height = *height - 1;
@@ -108,13 +107,13 @@ impl DiskWriteBatch {
     pub fn prepare_chain_value_pools_batch(
         &mut self,
         db: &DiskDb,
-        finalized: &CheckpointVerifiedBlock,
+        finalized: &SemanticallyVerifiedBlock,
         utxos_spent_by_block: HashMap<transparent::OutPoint, transparent::Utxo>,
         value_pool: ValueBalance<NonNegative>,
     ) -> Result<(), BoxError> {
         let tip_chain_value_pool = db.cf_handle("tip_chain_value_pool").unwrap();
 
-        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock { block, .. }) = finalized;
+        let SemanticallyVerifiedBlock { block, .. } = finalized;
 
         let new_pool = value_pool.add_block(block.borrow(), &utxos_spent_by_block)?;
         self.zs_insert(&tip_chain_value_pool, (), new_pool);

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -25,7 +25,7 @@ use crate::{
         zebra_db::ZebraDb,
         CheckpointVerifiedBlock,
     },
-    BoxError,
+    BoxError, SemanticallyVerifiedBlock,
 };
 
 impl ZebraDb {
@@ -212,7 +212,7 @@ impl DiskWriteBatch {
         db: &DiskDb,
         finalized: &CheckpointVerifiedBlock,
     ) -> Result<(), BoxError> {
-        let CheckpointVerifiedBlock { block, .. } = finalized;
+        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock { block, .. }) = finalized;
 
         // Index each transaction's shielded data
         for transaction in &block.transactions {
@@ -277,7 +277,7 @@ impl DiskWriteBatch {
         let sapling_note_commitment_tree_cf = db.cf_handle("sapling_note_commitment_tree").unwrap();
         let orchard_note_commitment_tree_cf = db.cf_handle("orchard_note_commitment_tree").unwrap();
 
-        let CheckpointVerifiedBlock { height, .. } = finalized;
+        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock { height, .. }) = finalized;
 
         // Use the cached values that were previously calculated in parallel.
         let sprout_root = note_commitment_trees.sprout.root();
@@ -334,7 +334,7 @@ impl DiskWriteBatch {
         let sapling_note_commitment_tree_cf = db.cf_handle("sapling_note_commitment_tree").unwrap();
         let orchard_note_commitment_tree_cf = db.cf_handle("orchard_note_commitment_tree").unwrap();
 
-        let CheckpointVerifiedBlock { height, .. } = finalized;
+        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock { height, .. }) = finalized;
 
         // Insert empty note commitment trees. Note that these can't be
         // used too early (e.g. the Orchard tree before Nu5 activates)

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -23,7 +23,6 @@ use crate::{
     service::finalized_state::{
         disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
         zebra_db::ZebraDb,
-        CheckpointVerifiedBlock,
     },
     BoxError, SemanticallyVerifiedBlock,
 };
@@ -210,9 +209,9 @@ impl DiskWriteBatch {
     pub fn prepare_shielded_transaction_batch(
         &mut self,
         db: &DiskDb,
-        finalized: &CheckpointVerifiedBlock,
+        finalized: &SemanticallyVerifiedBlock,
     ) -> Result<(), BoxError> {
-        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock { block, .. }) = finalized;
+        let SemanticallyVerifiedBlock { block, .. } = finalized;
 
         // Index each transaction's shielded data
         for transaction in &block.transactions {
@@ -265,7 +264,7 @@ impl DiskWriteBatch {
     pub fn prepare_note_commitment_batch(
         &mut self,
         db: &DiskDb,
-        finalized: &CheckpointVerifiedBlock,
+        finalized: &SemanticallyVerifiedBlock,
         note_commitment_trees: NoteCommitmentTrees,
         history_tree: Arc<HistoryTree>,
     ) -> Result<(), BoxError> {
@@ -277,7 +276,7 @@ impl DiskWriteBatch {
         let sapling_note_commitment_tree_cf = db.cf_handle("sapling_note_commitment_tree").unwrap();
         let orchard_note_commitment_tree_cf = db.cf_handle("orchard_note_commitment_tree").unwrap();
 
-        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock { height, .. }) = finalized;
+        let SemanticallyVerifiedBlock { height, .. } = finalized;
 
         // Use the cached values that were previously calculated in parallel.
         let sprout_root = note_commitment_trees.sprout.root();
@@ -328,13 +327,13 @@ impl DiskWriteBatch {
     pub fn prepare_genesis_note_commitment_tree_batch(
         &mut self,
         db: &DiskDb,
-        finalized: &CheckpointVerifiedBlock,
+        finalized: &SemanticallyVerifiedBlock,
     ) {
         let sprout_note_commitment_tree_cf = db.cf_handle("sprout_note_commitment_tree").unwrap();
         let sapling_note_commitment_tree_cf = db.cf_handle("sapling_note_commitment_tree").unwrap();
         let orchard_note_commitment_tree_cf = db.cf_handle("orchard_note_commitment_tree").unwrap();
 
-        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock { height, .. }) = finalized;
+        let SemanticallyVerifiedBlock { height, .. } = finalized;
 
         // Insert empty note commitment trees. Note that these can't be
         // used too early (e.g. the Orchard tree before Nu5 activates)

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -35,7 +35,7 @@ use crate::{
         },
         zebra_db::ZebraDb,
     },
-    BoxError, CheckpointVerifiedBlock,
+    BoxError, CheckpointVerifiedBlock, SemanticallyVerifiedBlock,
 };
 
 impl ZebraDb {
@@ -375,7 +375,7 @@ impl DiskWriteBatch {
         spent_utxos_by_out_loc: &BTreeMap<OutputLocation, transparent::Utxo>,
         mut address_balances: HashMap<transparent::Address, AddressBalanceLocation>,
     ) -> Result<(), BoxError> {
-        let CheckpointVerifiedBlock { block, height, .. } = finalized;
+        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock { block, height, .. }) = finalized;
 
         // Update created and spent transparent outputs
         self.prepare_new_transparent_outputs_batch(

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -35,7 +35,7 @@ use crate::{
         },
         zebra_db::ZebraDb,
     },
-    BoxError, CheckpointVerifiedBlock, SemanticallyVerifiedBlock,
+    BoxError, SemanticallyVerifiedBlock,
 };
 
 impl ZebraDb {
@@ -369,13 +369,13 @@ impl DiskWriteBatch {
     pub fn prepare_transparent_transaction_batch(
         &mut self,
         db: &DiskDb,
-        finalized: &CheckpointVerifiedBlock,
+        finalized: &SemanticallyVerifiedBlock,
         new_outputs_by_out_loc: &BTreeMap<OutputLocation, transparent::Utxo>,
         spent_utxos_by_outpoint: &HashMap<transparent::OutPoint, transparent::Utxo>,
         spent_utxos_by_out_loc: &BTreeMap<OutputLocation, transparent::Utxo>,
         mut address_balances: HashMap<transparent::Address, AddressBalanceLocation>,
     ) -> Result<(), BoxError> {
-        let CheckpointVerifiedBlock(SemanticallyVerifiedBlock { block, height, .. }) = finalized;
+        let SemanticallyVerifiedBlock { block, height, .. } = finalized;
 
         // Update created and spent transparent outputs
         self.prepare_new_transparent_outputs_batch(

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -214,11 +214,11 @@ fn finalize_pops_from_best_chain_for_network(network: Network) -> Result<()> {
     state.commit_block(child.prepare(), &finalized_state)?;
 
     let finalized_with_trees = state.finalize();
-    let finalized = finalized_with_trees.checkpoint_verified;
+    let finalized = finalized_with_trees.block;
     assert_eq!(block1, finalized.block);
 
     let finalized_with_trees = state.finalize();
-    let finalized = finalized_with_trees.checkpoint_verified;
+    let finalized = finalized_with_trees.block;
     assert_eq!(block2, finalized.block);
 
     assert!(state.best_chain().is_none());


### PR DESCRIPTION
## Motivation & Solution

In preparation for issue #6912, this PR:

- Wraps `SemanticallyVerifiedBlock` as `CheckpointVerifiedBlock` instead of having a standalone `CheckpointVerifiedBlock`. This was straightforward due to PR #6971.
- Uses `SemanticallyVerifiedBlock` in `ContextuallyVerifiedBlockWithTrees`.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests? 

## Follow-Up Work

- #7035