### PR TITLE
cleanup(test): Make test debugging output more readable

### DIFF
--- a/zebra-chain/src/fmt.rs
+++ b/zebra-chain/src/fmt.rs
@@ -162,7 +162,7 @@ where
 }
 
 /// Wrapper to override `Debug`, redirecting it to hex-encode the type.
-/// The type must be hex-encodable.
+/// The type must implement `AsRef<[u8]>`.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 #[serde(transparent)]

--- a/zebra-chain/src/sprout/joinsplit.rs
+++ b/zebra-chain/src/sprout/joinsplit.rs
@@ -1,6 +1,6 @@
 //! Sprout funds transfers using [`JoinSplit`]s.
 
-use std::io;
+use std::{fmt, io};
 
 use serde::{Deserialize, Serialize};
 
@@ -49,7 +49,7 @@ impl From<&RandomSeed> for [u8; 32] {
 /// A _JoinSplit Description_, as described in [protocol specification §7.2][ps].
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#joinsplitencoding
-#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct JoinSplit<P: ZkSnarkProof> {
     /// A value that the JoinSplit transfer removes from the transparent value
     /// pool.
@@ -79,6 +79,23 @@ pub struct JoinSplit<P: ZkSnarkProof> {
     pub zkproof: P,
     /// A ciphertext component for this output note.
     pub enc_ciphertexts: [note::EncryptedNote; 2],
+}
+
+impl<P: ZkSnarkProof> fmt::Debug for JoinSplit<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JoinSplit")
+            .field("vpub_old", &self.vpub_old)
+            .field("vpub_new", &self.vpub_new)
+            .field("anchor", &self.anchor)
+            .field("nullifiers", &self.nullifiers)
+            .field("commitments", &self.commitments)
+            .field("ephemeral_key", &HexDebug(self.ephemeral_key.as_bytes()))
+            .field("random_seed", &self.random_seed)
+            .field("vmacs", &self.vmacs)
+            .field("zkproof", &self.zkproof)
+            .field("enc_ciphertexts", &self.enc_ciphertexts)
+            .finish()
+    }
 }
 
 impl<P: ZkSnarkProof> ZcashSerialize for JoinSplit<P> {

--- a/zebra-chain/src/transaction/joinsplit.rs
+++ b/zebra-chain/src/transaction/joinsplit.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     amount::{self, Amount, NegativeAllowed},
+    fmt::HexDebug,
     primitives::{ed25519, ZkSnarkProof},
     sprout::{self, JoinSplit, Nullifier},
 };
@@ -16,7 +17,7 @@ use crate::{
 /// description with the required signature data, so that an
 /// `Option<JoinSplitData>` correctly models the presence or absence of any
 /// JoinSplit data.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JoinSplitData<P: ZkSnarkProof> {
     /// The first JoinSplit description in the transaction,
     /// using proofs of type `P`.
@@ -46,6 +47,17 @@ pub struct JoinSplitData<P: ZkSnarkProof> {
     pub pub_key: ed25519::VerificationKeyBytes,
     /// The JoinSplit signature, denoted as `joinSplitSig` in the spec.
     pub sig: ed25519::Signature,
+}
+
+impl<P: ZkSnarkProof> fmt::Debug for JoinSplitData<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JoinSplitData")
+            .field("first", &self.first)
+            .field("rest", &self.rest)
+            .field("pub_key", &self.pub_key)
+            .field("sig", &HexDebug(&self.sig.to_bytes()))
+            .finish()
+    }
 }
 
 impl<P: ZkSnarkProof> fmt::Display for JoinSplitData<P> {

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -11,7 +11,7 @@ use tower::{buffer::Buffer, util::BoxService};
 
 use zebra_chain::{
     block::{self, Block},
-    fmt::DisplayToDebug,
+    fmt::{DisplayToDebug, TypeNameToDebug},
     parameters::{Network, NetworkUpgrade},
     serialization::ZcashDeserializeInto,
     transaction::VerifiedUnminedTx,
@@ -103,7 +103,7 @@ proptest! {
         network in any::<Network>(),
         mut previous_chain_tip in any::<DisplayToDebug<ChainTipBlock>>(),
         mut transactions in vec(any::<DisplayToDebug<VerifiedUnminedTx>>(), 0..CHAIN_LENGTH),
-        fake_chain_tips in vec(any::<DisplayToDebug<FakeChainTip>>(), 0..CHAIN_LENGTH),
+        fake_chain_tips in vec(any::<TypeNameToDebug<FakeChainTip>>(), 0..CHAIN_LENGTH),
     ) {
         let (runtime, _init_guard) = zebra_test::init_async();
 


### PR DESCRIPTION
## Motivation

Sometimes Zebra produces 30,000 lines of debug output from a single test:
https://github.com/ZcashFoundation/zebra/actions/runs/5321638950/jobs/9636992835?pr=7019#step:10:4911

Some Zebra structs have debug impls which print arrays of u8, rather than hex-encoded strings.

## Solution

Hide the extremely long debug output.

Manually implement the debug impls to use hex encoded strings.

## Review

This is a low priority cleanup.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

