### PR TITLE
fix(release): Use correct cargo release manifest key name

### DIFF
--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -28,7 +28,7 @@ rust-version = "1.66"
 default-run = "zebrad"
 
 # `cargo release` settings
-[metadata.release]
+[package.metadata.release]
 pre-release-replacements = [
   {file="../book/src/user/install.md", search="git checkout [a-z0-9\\.-]+", replace="git checkout {{version}}"},
   {file="../book/src/user/install.md", search="--tag [a-z0-9\\.-]+", replace="--tag {{version}}"},


### PR DESCRIPTION
## Motivation

I used the wrong name for the `cargo release` version replacements table.

This makes `cargo` log an "unused manifest key: metadata" warning.

### Specifications

The correct table name is `package.metadata`:
https://doc.rust-lang.org/cargo/reference/manifest.html#the-metadata-table

### Testing

The warning disappears after this fix.

## Review

This is a release blocker, but the other release blockers will take much longer to implement and merge.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

