### PR TITLE
fix(network): Avoid initiating outbound handshakes with IPs for which Zebra already has an active peer.

### DIFF
--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -78,7 +78,7 @@ pub struct AddressBook {
     ///
     /// This is used to avoid initiating outbound connections past [`Config::max_connections_per_ip`](crate::config::Config), and
     /// currently only supports a `max_connections_per_ip` of 1, and must be `None` when used with a greater `max_connections_per_ip`.
-    // TODO: Replace with `by_ip` to support configured `max_connections_per_ip`
+    // TODO: Replace with `by_ip: HashMap<IpAddr, BTreeMap<DateTime32, MetaAddr>>` to support configured `max_connections_per_ip` greater than 1
     most_recent_by_ip: Option<HashMap<IpAddr, MetaAddr>>,
 
     /// The local listener address.

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -533,7 +533,7 @@ impl AddressBook {
     }
 
     /// Is this IP ready for a new outbound connection attempt?
-    /// Checks if the most recently updated address with this IP `was_recently_updated()`.
+    /// Checks if the most recently updated outbound address with this IP `was_recently_updated()`.
     ///
     /// Note: last_response times may remain live for a long time if the local clock is changed to an earlier time.
     fn is_ready_for_connection_attempt_with_ip(

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -203,6 +203,12 @@ impl AddressBook {
         for (socket_addr, meta_addr) in addrs {
             // overwrite any duplicate addresses
             new_book.by_addr.insert(socket_addr, meta_addr);
+            // Add the address to `most_recent_by_ip` if it has responded
+            if new_book.should_update_most_recent_by_ip(meta_addr) {
+                new_book
+                    .most_recent_by_ip
+                    .insert(socket_addr.ip(), meta_addr);
+            }
             // exit as soon as we get enough addresses
             if new_book.by_addr.len() >= addr_limit {
                 break;
@@ -435,7 +441,7 @@ impl AddressBook {
                 self.by_addr.remove(&surplus_peer.addr);
 
                 // Check if this surplus peer's addr matches that in `most_recent_by_ip`
-                // for this the surplus peer's ip.
+                // for this the surplus peer's ip to remove it there as well.
                 if self.is_addr_most_recent_by_ip(surplus_peer.addr) {
                     self.most_recent_by_ip.remove(&surplus_peer.addr.ip());
                 }

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -358,9 +358,10 @@ impl AddressBook {
         };
 
         if let Some(previous) = most_recent_by_ip.get(&updated.addr.ip()) {
-            updated.last_response() > previous.last_response()
+            updated.last_connection_state == PeerAddrState::Responded
+                && updated.last_response() > previous.last_response()
         } else {
-            true
+            updated.last_connection_state == PeerAddrState::Responded
         }
     }
 

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -73,7 +73,8 @@ pub struct AddressBook {
     /// [`OrderedMap`] sorts in descending order.
     by_addr: OrderedMap<PeerSocketAddr, MetaAddr, Reverse<MetaAddr>>,
 
-    /// The address with a last_connection_state of [`Responded`] and the most recent `last_response` time by IP.
+    /// The address with a last_connection_state of [`PeerAddrState::Responded`] and
+    /// the most recent `last_response` time by IP.
     most_recent_by_ip: HashMap<IpAddr, MetaAddr>,
 
     /// The local listener address.

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -330,7 +330,9 @@ impl AddressBook {
         meta_addr
     }
 
-    /// Returns true if there are no existing entries in the address book with this IP,
+    /// Returns true if `updated` needs to be applied to the recent outbound peer connection IP cache.
+    ///
+    /// Checks if there are no existing entries in the address book with this IP,
     /// or if `updated` has a more recent update requiring the outbound connector to wait
     /// longer before initiating handshakes with peers at this IP.
     ///
@@ -526,13 +528,14 @@ impl AddressBook {
     }
 
     /// Is this IP ready for a new outbound connection attempt?
+    /// Checks if the most recently updated address with this IP `was_recently_updated()`.
     fn is_ready_for_connection_attempt_with_ip(
         &self,
         ip: &IpAddr,
         instant_now: Instant,
         chrono_now: chrono::DateTime<Utc>,
     ) -> bool {
-        self.most_recent_by_ip.get(ip).map_or(false, |peer| {
+        self.most_recent_by_ip.get(ip).map_or(true, |peer| {
             !peer.was_recently_updated(instant_now, chrono_now)
         })
     }

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -566,12 +566,12 @@ impl AddressBook {
         let Some(most_recent_by_ip) = self.most_recent_by_ip.as_ref() else {
             // if we're not checking IPs, any connection is allowed
             return true;
-        }
+        };
         
         let Some(same_ip_peer) = most_recent_by_ip.get(ip) else {
             // If there's no entry for this IP, any connection is allowed
             return true;
-        }
+        };
         
         !same_ip_peer.has_connection_recently_responded(chrono_now)
     }

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -75,6 +75,10 @@ pub struct AddressBook {
 
     /// The address with a last_connection_state of [`PeerAddrState::Responded`] and
     /// the most recent `last_response` time by IP.
+    ///
+    /// This is used to avoid initiating outbound connections past [`Config::max_connections_per_ip`](crate::config::Config),
+    /// and currently only supports a `max_connections_per_ip` of 1.
+    // TODO: Replace with `by_ip` to support configured `max_connections_per_ip`
     most_recent_by_ip: HashMap<IpAddr, MetaAddr>,
 
     /// The local listener address.

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -567,12 +567,10 @@ impl AddressBook {
             // if we're not checking IPs, any connection is allowed
             return true;
         };
-        
         let Some(same_ip_peer) = most_recent_by_ip.get(ip) else {
             // If there's no entry for this IP, any connection is allowed
             return true;
         };
-        
         !same_ip_peer.has_connection_recently_responded(chrono_now)
     }
 

--- a/zebra-network/src/address_book/tests/prop.rs
+++ b/zebra-network/src/address_book/tests/prop.rs
@@ -9,7 +9,7 @@ use tracing::Span;
 use zebra_chain::{parameters::Network::*, serialization::Duration32};
 
 use crate::{
-    constants::{MAX_ADDRS_IN_ADDRESS_BOOK, MAX_PEER_ACTIVE_FOR_GOSSIP},
+    constants::{DEFAULT_MAX_CONNS_PER_IP, MAX_ADDRS_IN_ADDRESS_BOOK, MAX_PEER_ACTIVE_FOR_GOSSIP},
     meta_addr::{arbitrary::MAX_META_ADDR, MetaAddr, MetaAddrChange},
     AddressBook,
 };
@@ -30,6 +30,7 @@ proptest! {
         let address_book = AddressBook::new_with_addrs(
             local_listener,
             Mainnet,
+            DEFAULT_MAX_CONNS_PER_IP,
             MAX_ADDRS_IN_ADDRESS_BOOK,
             Span::none(),
             addresses
@@ -59,6 +60,7 @@ proptest! {
         let address_book = AddressBook::new_with_addrs(
             local_listener,
             Mainnet,
+            DEFAULT_MAX_CONNS_PER_IP,
             MAX_ADDRS_IN_ADDRESS_BOOK,
             Span::none(),
             addresses
@@ -97,6 +99,7 @@ proptest! {
         let mut address_book = AddressBook::new_with_addrs(
             local_listener,
             Mainnet,
+            DEFAULT_MAX_CONNS_PER_IP,
             addr_limit,
             Span::none(),
             initial_addrs.clone(),
@@ -119,6 +122,7 @@ proptest! {
         let mut address_book = AddressBook::new_with_addrs(
             local_listener,
             Mainnet,
+            DEFAULT_MAX_CONNS_PER_IP,
             addr_limit,
             Span::none(),
             initial_addrs,

--- a/zebra-network/src/address_book/tests/vectors.rs
+++ b/zebra-network/src/address_book/tests/vectors.rs
@@ -112,7 +112,7 @@ fn address_book_peer_order() {
 }
 
 /// Check that `reconnection_peers` skips addresses with IPs for which
-/// Zebra already has recently updated peers.
+/// Zebra already has recently updated outbound peers.
 #[test]
 fn reconnection_peers_skips_recently_updated_ip() {
     test_reconnection_peers_skips_recently_updated_ip(MetaAddr::new_reconnect);

--- a/zebra-network/src/address_book/tests/vectors.rs
+++ b/zebra-network/src/address_book/tests/vectors.rs
@@ -11,14 +11,21 @@ use zebra_chain::{
 };
 
 use crate::{
-    constants::MAX_ADDRS_IN_ADDRESS_BOOK, meta_addr::MetaAddr,
-    protocol::external::types::PeerServices, AddressBook,
+    constants::{DEFAULT_MAX_CONNS_PER_IP, MAX_ADDRS_IN_ADDRESS_BOOK},
+    meta_addr::MetaAddr,
+    protocol::external::types::PeerServices,
+    AddressBook,
 };
 
 /// Make sure an empty address book is actually empty.
 #[test]
 fn address_book_empty() {
-    let address_book = AddressBook::new("0.0.0.0:0".parse().unwrap(), Mainnet, Span::current());
+    let address_book = AddressBook::new(
+        "0.0.0.0:0".parse().unwrap(),
+        Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
+        Span::current(),
+    );
 
     assert_eq!(
         address_book
@@ -48,6 +55,7 @@ fn address_book_peer_order() {
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
         MAX_ADDRS_IN_ADDRESS_BOOK,
         Span::current(),
         addrs,
@@ -64,6 +72,7 @@ fn address_book_peer_order() {
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
         MAX_ADDRS_IN_ADDRESS_BOOK,
         Span::current(),
         addrs,
@@ -83,6 +92,7 @@ fn address_book_peer_order() {
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
         MAX_ADDRS_IN_ADDRESS_BOOK,
         Span::current(),
         addrs,
@@ -99,6 +109,7 @@ fn address_book_peer_order() {
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
         MAX_ADDRS_IN_ADDRESS_BOOK,
         Span::current(),
         addrs,
@@ -152,6 +163,7 @@ fn test_reconnection_peers_skips_recently_updated_ip<
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
         MAX_ADDRS_IN_ADDRESS_BOOK,
         Span::current(),
         addrs,

--- a/zebra-network/src/address_book/tests/vectors.rs
+++ b/zebra-network/src/address_book/tests/vectors.rs
@@ -129,7 +129,8 @@ fn reconnection_peers_skips_live_ip() {
         DateTime32::MIN.saturating_add(Duration32::from_seconds(1)),
     );
 
-    // Regardless of the order of insertion, the most recent address should be chosen first
+    // The second address should be skipped because the first address has a
+    // recent `last_response` time and the two addresses have the same IP.
     let addrs = vec![meta_addr1, meta_addr2];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),

--- a/zebra-network/src/address_book/tests/vectors.rs
+++ b/zebra-network/src/address_book/tests/vectors.rs
@@ -115,10 +115,14 @@ fn address_book_peer_order() {
 /// Zebra already has recently updated outbound peers.
 #[test]
 fn reconnection_peers_skips_recently_updated_ip() {
+    // tests that reconnection_peers() skips addresses where there's a connection at that IP with a recent:
+    // - `last_attempt`
     test_reconnection_peers_skips_recently_updated_ip(MetaAddr::new_reconnect);
+    // - `last_response`
     test_reconnection_peers_skips_recently_updated_ip(|addr| {
         MetaAddr::new_responded(addr, &PeerServices::NODE_NETWORK)
     });
+    // - `last_failure`
     test_reconnection_peers_skips_recently_updated_ip(|addr| {
         MetaAddr::new_errored(addr, PeerServices::NODE_NETWORK)
     });

--- a/zebra-network/src/address_book_updater.rs
+++ b/zebra-network/src/address_book_updater.rs
@@ -51,6 +51,7 @@ impl AddressBookUpdater {
         let address_book = AddressBook::new(
             local_listener,
             config.network,
+            config.max_connections_per_ip,
             span!(Level::TRACE, "address book"),
         );
         let address_metrics = address_book.address_metrics_watcher();

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -159,11 +159,11 @@ pub struct Config {
     ///
     /// The default and minimum value are 1.
     ///
-    /// Note: Zebra will currently avoid initiating outbound connections where it
-    ///       has already recently sent or received a message to or from an address
-    ///       with that IP. Zebra will not initiate more than 1 outbound connection
-    ///       to an IP based on this configuration, but it will accept more inbound
-    ///       connections to an IP.
+    /// Note: Zebra currently requires this to be set to 1 in order to avoid initiating
+    ///       additional outbound handshakes. It will otherwise still initiate outbound handshakes
+    ///       beyond this limit. Zebra will also currently still accept more inbound connections
+    ///       per IP. In cases where additional handshakes are permitted beyond this limit,
+    ///       connections will be dropped when attempting to add them to the peer set.
     pub max_connections_per_ip: usize,
 }
 

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -681,7 +681,7 @@ impl<'de> Deserialize<'de> for Config {
         ].map(|(field_name, non_zero_config_field, default_config_value)| {
             if non_zero_config_field == Some(0) {
                 warn!(
-                    ?field_name, 
+                    ?field_name,
                     ?non_zero_config_field,
                     "{field_name} should be greater than 0, using default value of {default_config_value} instead"
                 );

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -158,6 +158,12 @@ pub struct Config {
     /// before it drops any additional peer connections with that IP.
     ///
     /// The default and minimum value are 1.
+    ///
+    /// Note: Zebra will currently avoid initiating outbound connections where it
+    ///       has already recently sent or received a message to or from an address
+    ///       with that IP. Zebra will not initiate more than 1 outbound connection
+    ///       to an IP based on this configuration, but it will accept more inbound
+    ///       connections to an IP.
     pub max_connections_per_ip: usize,
 }
 

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -160,11 +160,19 @@ pub struct Config {
     ///
     /// The default and minimum value are 1.
     ///
-    /// Note: Zebra currently requires this to be set to 1 in order to avoid initiating
-    ///       additional outbound handshakes. It will otherwise still initiate outbound handshakes
-    ///       beyond this limit. Zebra will also currently still accept more inbound connections
-    ///       per IP. In cases where additional handshakes are permitted beyond this limit,
-    ///       connections will be dropped when attempting to add them to the peer set.
+    /// # Security
+    ///
+    /// Increasing this config above 1 reduces Zebra's network security.
+    ///
+    /// If this config is greater than 1, Zebra can initiate multiple outbound handshakes to the same
+    /// IP address.
+    ///
+    /// This config does not currently limit the number of inbound connections that Zebra will accept
+    /// from the same IP address.
+    ///
+    /// If Zebra makes multiple inbound or outbound connections to the same IP, they will be dropped
+    /// after the handshake, but before adding them to the peer set. The total numbers of inbound and
+    /// outbound connections are also limited to a multiple of `peerset_initial_target_size`.
     pub max_connections_per_ip: usize,
 }
 

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -71,6 +71,12 @@ pub const OUTBOUND_PEER_LIMIT_MULTIPLIER: usize = 3;
 /// before it drops any additional peer connections with that IP.
 ///
 /// This will be used as Config.max_connections_per_ip if no value is provided.
+///
+/// Note: Zebra will currently avoid initiating outbound connections where it
+///       has already recently sent or received a message to or from an address
+///       with that IP. Zebra will not initiate more than 1 outbound connection
+///       to an IP based on this configuration, but it will accept more inbound
+///       connections to an IP.
 pub const DEFAULT_MAX_CONNS_PER_IP: usize = 1;
 
 /// The buffer size for the peer set.

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -70,7 +70,7 @@ pub const OUTBOUND_PEER_LIMIT_MULTIPLIER: usize = 3;
 /// The default maximum number of peer connections Zebra will keep for a given IP address
 /// before it drops any additional peer connections with that IP.
 ///
-/// This will be used as Config.max_connections_per_ip if no value is provided.
+/// This will be used as `Config.max_connections_per_ip` if no valid value is provided.
 ///
 /// Note: Zebra will currently avoid initiating outbound connections where it
 ///       has already recently sent or received a message to or from an address
@@ -78,6 +78,11 @@ pub const OUTBOUND_PEER_LIMIT_MULTIPLIER: usize = 3;
 ///       to an IP based on this configuration, but it will accept more inbound
 ///       connections to an IP.
 pub const DEFAULT_MAX_CONNS_PER_IP: usize = 1;
+
+/// The default peerset target size.
+///
+/// This will be used as `Config.peerset_initial_target_size` if no valid value is provided.
+pub const DEFAULT_PEERSET_INITIAL_TARGET_SIZE: usize = 25;
 
 /// The buffer size for the peer set.
 ///

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -73,9 +73,9 @@ pub const OUTBOUND_PEER_LIMIT_MULTIPLIER: usize = 3;
 /// This will be used as `Config.max_connections_per_ip` if no valid value is provided.
 ///
 /// Note: Zebra will currently avoid initiating outbound connections where it
-///       has already recently sent or received a message to or from an address
-///       with that IP. Zebra will not initiate more than 1 outbound connection
-///       to an IP based on this configuration, but it will accept more inbound
+///       has recently had a successful handshake with any address
+///       on that IP. Zebra will not initiate more than 1 outbound connection
+///       to an IP based on the default configuration, but it will accept more inbound
 ///       connections to an IP.
 pub const DEFAULT_MAX_CONNS_PER_IP: usize = 1;
 

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -483,46 +483,6 @@ impl MetaAddr {
         self.last_failure
     }
 
-    /// Returns the shortest duration that's passed since last_response,
-    /// last_attempt, or last_failure.
-    #[allow(clippy::unwrap_in_result)]
-    pub fn most_recent_update(
-        &self,
-        now: Instant,
-        chrono_now: chrono::DateTime<Utc>,
-    ) -> Option<zebra_chain::serialization::Duration32> {
-        let last_response = self
-            .last_response
-            .map(|last_response| last_response.saturating_elapsed(chrono_now));
-
-        // Use the later instant and ignore any `None` fields.
-        let Some(last_attempt_or_failure) = self.last_attempt.max(self.last_failure) else {
-            return last_response
-        };
-
-        let last_attempt_or_failure: zebra_chain::serialization::Duration32 = now
-            .saturating_duration_since(last_attempt_or_failure)
-            .try_into()
-            .expect("will succeed until 2038");
-
-        let Some(last_response) = last_response else {
-            return Some(last_attempt_or_failure)
-        };
-
-        // Use the shorter duration
-        Some(last_attempt_or_failure.min(last_response))
-    }
-
-    /// Returns true if `self` has a greater `most_recent_update`.
-    pub fn gt_most_recent_update(
-        &self,
-        previous: &MetaAddr,
-        now: Instant,
-        chrono_now: chrono::DateTime<Utc>,
-    ) -> bool {
-        self.most_recent_update(now, chrono_now) > previous.most_recent_update(now, chrono_now)
-    }
-
     /// Have we had any recently messages from this peer?
     ///
     /// Returns `true` if the peer is likely connected and responsive in the peer

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -483,6 +483,46 @@ impl MetaAddr {
         self.last_failure
     }
 
+    /// Returns the shortest duration that's passed since last_response,
+    /// last_attempt, or last_failure.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn most_recent_update(
+        &self,
+        now: Instant,
+        chrono_now: chrono::DateTime<Utc>,
+    ) -> Option<zebra_chain::serialization::Duration32> {
+        let last_response = self
+            .last_response
+            .map(|last_response| last_response.saturating_elapsed(chrono_now));
+
+        // Use the later instant and ignore any `None` fields.
+        let Some(last_attempt_or_failure) = self.last_attempt.max(self.last_failure) else {
+            return last_response
+        };
+
+        let last_attempt_or_failure: zebra_chain::serialization::Duration32 = now
+            .saturating_duration_since(last_attempt_or_failure)
+            .try_into()
+            .expect("will succeed until 2038");
+
+        let Some(last_response) = last_response else {
+            return Some(last_attempt_or_failure)
+        };
+
+        // Use the shorter duration
+        Some(last_attempt_or_failure.min(last_response))
+    }
+
+    /// Returns true if `self` has a greater `most_recent_update`.
+    pub fn gt_most_recent_update(
+        &self,
+        previous: &MetaAddr,
+        now: Instant,
+        chrono_now: chrono::DateTime<Utc>,
+    ) -> bool {
+        self.most_recent_update(now, chrono_now) > previous.most_recent_update(now, chrono_now)
+    }
+
     /// Have we had any recently messages from this peer?
     ///
     /// Returns `true` if the peer is likely connected and responsive in the peer
@@ -561,6 +601,17 @@ impl MetaAddr {
         }
     }
 
+    /// Returns true if any messages were recently sent to or received from this address.
+    pub fn was_recently_updated(
+        &self,
+        instant_now: Instant,
+        chrono_now: chrono::DateTime<Utc>,
+    ) -> bool {
+        self.has_connection_recently_responded(chrono_now)
+            || self.was_connection_recently_attempted(instant_now)
+            || self.has_connection_recently_failed(instant_now)
+    }
+
     /// Is this address ready for a new outbound connection attempt?
     pub fn is_ready_for_connection_attempt(
         &self,
@@ -569,9 +620,7 @@ impl MetaAddr {
         network: Network,
     ) -> bool {
         self.last_known_info_is_valid_for_outbound(network)
-            && !self.has_connection_recently_responded(chrono_now)
-            && !self.was_connection_recently_attempted(instant_now)
-            && !self.has_connection_recently_failed(instant_now)
+            && !self.was_recently_updated(instant_now, chrono_now)
             && self.is_probably_reachable(chrono_now)
     }
 

--- a/zebra-network/src/meta_addr/tests/prop.rs
+++ b/zebra-network/src/meta_addr/tests/prop.rs
@@ -10,7 +10,10 @@ use tracing::Span;
 use zebra_chain::{parameters::Network::*, serialization::DateTime32};
 
 use crate::{
-    constants::{MAX_ADDRS_IN_ADDRESS_BOOK, MAX_RECENT_PEER_AGE, MIN_PEER_RECONNECTION_DELAY},
+    constants::{
+        DEFAULT_MAX_CONNS_PER_IP, MAX_ADDRS_IN_ADDRESS_BOOK, MAX_RECENT_PEER_AGE,
+        MIN_PEER_RECONNECTION_DELAY,
+    },
     meta_addr::{
         arbitrary::{MAX_ADDR_CHANGE, MAX_META_ADDR},
         MetaAddr, MetaAddrChange,
@@ -156,6 +159,7 @@ proptest! {
         let address_book = AddressBook::new_with_addrs(
             local_listener,
             Mainnet,
+            DEFAULT_MAX_CONNS_PER_IP,
             MAX_ADDRS_IN_ADDRESS_BOOK,
             Span::none(),
             address_book_addrs
@@ -214,6 +218,7 @@ proptest! {
             let mut address_book = AddressBook::new_with_addrs(
                 local_listener,
                 Mainnet,
+                DEFAULT_MAX_CONNS_PER_IP,
                 1,
                 Span::none(),
                 Vec::new(),
@@ -327,6 +332,7 @@ proptest! {
         let address_book = Arc::new(std::sync::Mutex::new(AddressBook::new_with_addrs(
             SocketAddr::from_str("0.0.0.0:0").unwrap(),
             Mainnet,
+            DEFAULT_MAX_CONNS_PER_IP,
             MAX_ADDRS_IN_ADDRESS_BOOK,
             Span::none(),
             addrs,

--- a/zebra-network/src/peer_set/candidate_set/tests/prop.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/prop.rs
@@ -19,7 +19,7 @@ use zebra_chain::{parameters::Network::*, serialization::DateTime32};
 
 use crate::{
     canonical_peer_addr,
-    constants::MIN_OUTBOUND_PEER_CONNECTION_INTERVAL,
+    constants::{DEFAULT_MAX_CONNS_PER_IP, MIN_OUTBOUND_PEER_CONNECTION_INTERVAL},
     meta_addr::{MetaAddr, MetaAddrChange},
     protocol::types::PeerServices,
     AddressBook, BoxError, Request, Response,
@@ -72,7 +72,7 @@ proptest! {
         });
 
         // Since the address book is empty, there won't be any available peers
-        let address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Mainnet, Span::none());
+        let address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Mainnet, DEFAULT_MAX_CONNS_PER_IP, Span::none());
 
         let mut candidate_set = CandidateSet::new(Arc::new(std::sync::Mutex::new(address_book)), peer_service);
 
@@ -114,7 +114,7 @@ proptest! {
             unreachable!("Mock peer service is never used");
         });
 
-        let mut address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Mainnet, Span::none());
+        let mut address_book = AddressBook::new(SocketAddr::from_str("0.0.0.0:0").unwrap(), Mainnet, DEFAULT_MAX_CONNS_PER_IP, Span::none());
         address_book.extend(peers);
 
         let mut candidate_set = CandidateSet::new(Arc::new(std::sync::Mutex::new(address_book)), peer_service);

--- a/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests/vectors.rs
@@ -15,7 +15,7 @@ use zebra_chain::{parameters::Network::*, serialization::DateTime32};
 use zebra_test::mock_service::{MockService, PanicAssertion};
 
 use crate::{
-    constants::{GET_ADDR_FANOUT, MIN_PEER_GET_ADDR_INTERVAL},
+    constants::{DEFAULT_MAX_CONNS_PER_IP, GET_ADDR_FANOUT, MIN_PEER_GET_ADDR_INTERVAL},
     types::{MetaAddr, PeerServices},
     AddressBook, Request, Response,
 };
@@ -141,6 +141,7 @@ fn candidate_set_updates_are_rate_limited() {
     let address_book = AddressBook::new(
         SocketAddr::from_str("0.0.0.0:0").unwrap(),
         Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
         Span::none(),
     );
     let mut peer_service = MockService::build().for_unit_tests();
@@ -186,6 +187,7 @@ fn candidate_set_update_after_update_initial_is_rate_limited() {
     let address_book = AddressBook::new(
         SocketAddr::from_str("0.0.0.0:0").unwrap(),
         Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
         Span::none(),
     );
     let mut peer_service = MockService::build().for_unit_tests();

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -107,13 +107,6 @@ where
     S::Future: Send + 'static,
     C: ChainTip + Clone + Send + Sync + 'static,
 {
-    // If we want Zebra to operate with no network,
-    // we should implement a `zebrad` command that doesn't use `zebra-network`.
-    assert!(
-        config.peerset_initial_target_size > 0,
-        "Zebra must be allowed to connect to at least one peer"
-    );
-
     let (tcp_listener, listen_addr) = open_listener(&config.clone()).await;
 
     let (address_book, address_book_updater, address_metrics, address_book_updater_guard) =

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -1509,7 +1509,12 @@ where
     }
 
     // Manually initialize an address book without a timestamp tracker.
-    let mut address_book = AddressBook::new(config.listen_addr, config.network, Span::current());
+    let mut address_book = AddressBook::new(
+        config.listen_addr,
+        config.network,
+        config.max_connections_per_ip,
+        Span::current(),
+    );
 
     // Add enough fake peers to go over the limit, even if the limit is zero.
     let over_limit_peers = config.peerset_outbound_connection_limit() * 2 + 1;

--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -23,6 +23,7 @@ use zebra_chain::{
 
 use crate::{
     address_book::AddressMetrics,
+    constants::DEFAULT_MAX_CONNS_PER_IP,
     peer::{ClientTestHarness, LoadTrackedClient, MinimumPeerVersion},
     peer_set::{set::MorePeers, InventoryChange, PeerSet},
     protocol::external::types::Version,
@@ -333,7 +334,12 @@ impl PeerSetGuard {
         let local_listener = "127.0.0.1:1000"
             .parse()
             .expect("Invalid local listener address");
-        let address_book = AddressBook::new(local_listener, Network::Mainnet, Span::none());
+        let address_book = AddressBook::new(
+            local_listener,
+            Network::Mainnet,
+            DEFAULT_MAX_CONNS_PER_IP,
+            Span::none(),
+        );
 
         Arc::new(std::sync::Mutex::new(address_book))
     }

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -23,7 +23,9 @@ use zebra_chain::{
     transaction::{UnminedTx, UnminedTxId, VerifiedUnminedTx},
 };
 use zebra_consensus::{error::TransactionError, transaction, Config as ConsensusConfig};
-use zebra_network::{AddressBook, InventoryResponse, Request, Response};
+use zebra_network::{
+    constants::DEFAULT_MAX_CONNS_PER_IP, AddressBook, InventoryResponse, Request, Response,
+};
 use zebra_node_services::mempool;
 use zebra_state::{ChainTipChange, Config as StateConfig, CHAIN_TIP_UPDATE_WAIT_LIMIT};
 use zebra_test::mock_service::{MockService, PanicAssertion};
@@ -771,6 +773,7 @@ async fn setup(
     let address_book = AddressBook::new(
         SocketAddr::from_str("0.0.0.0:0").unwrap(),
         Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
         Span::none(),
     );
     let address_book = Arc::new(std::sync::Mutex::new(address_book));


### PR DESCRIPTION
## Motivation

This prevents some kinds of attacks.

Closes #6982.

## Solution

- Adds a `most_recent_by_ip` field to `AddressBook`.
- Updates the new field when there's an update with a later `last_response` time, or when addresses are removed.
- Adds `&& !self.has_active_peer_with_ip()` to the filter in `reconnection_peers()`. 
- Tests that the iterator from `reconnection_peers()` skips over address when there's already a live address with the same IP.
 
## Review

Part of regular scheduled work.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- #7040