### PR TITLE
change(state): Prepare for in-place database format upgrades, but don't make any format changes yet

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -437,7 +437,7 @@ jobs:
       needs_zebra_state: true
       # update the disk on every PR, to increase CI speed
       saves_to_disk: true
-      force_save_to_disk: ${{ github.event.inputs.force_save_to_disk }}
+      force_save_to_disk: ${{ inputs.force_save_to_disk }}
       disk_suffix: tip
       root_state_path: '/var/cache'
       zebra_state_dir: 'zebrad-cache'
@@ -510,7 +510,7 @@ jobs:
       is_long_test: true
       needs_zebra_state: false
       saves_to_disk: true
-      force_save_to_disk: ${{ github.event.inputs.force_save_to_disk }}
+      force_save_to_disk: ${{ inputs.force_save_to_disk }}
       disk_suffix: tip
       height_grep_text: 'current_height.*=.*Height.*\('
     secrets: inherit
@@ -554,7 +554,7 @@ jobs:
       # update the disk on every PR, to increase CI speed
       # we don't have a test-update-sync-testnet job, so we need to update the disk here
       saves_to_disk: true
-      force_save_to_disk: ${{ github.event.inputs.force_save_to_disk }}
+      force_save_to_disk: ${{ inputs.force_save_to_disk }}
       disk_suffix: tip
       root_state_path: '/var/cache'
       zebra_state_dir: 'zebrad-cache'
@@ -587,7 +587,7 @@ jobs:
       needs_zebra_state: true
       needs_lwd_state: false
       saves_to_disk: true
-      force_save_to_disk: ${{ github.event.inputs.force_save_to_disk }}
+      force_save_to_disk: ${{ inputs.force_save_to_disk }}
       disk_prefix: lwd-cache
       disk_suffix: tip
       root_state_path: '/var/cache'

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -35,6 +35,11 @@ on:
         default: false
         description: 'Just run a lightwalletd full sync and update tip disks'
         required: true
+      force_save_to_disk:
+        required: false
+        type: boolean
+        default: false
+        description: 'Force tests to always create a cached state disk, if they already create disks'
       no_cache:
         description: 'Disable the Docker cache for this build'
         required: false
@@ -330,6 +335,7 @@ jobs:
       test_variables: '-e TEST_DISK_REBUILD=1 -e ZEBRA_FORCE_USE_COLOR=1'
       needs_zebra_state: false
       saves_to_disk: true
+      force_save_to_disk: ${{ github.event.inputs.force_save_to_disk }}
       disk_suffix: checkpoint
       height_grep_text: 'flushing database to disk .*height.*=.*Height.*\('
     secrets: inherit
@@ -391,6 +397,7 @@ jobs:
       is_long_test: true
       needs_zebra_state: false
       saves_to_disk: true
+      force_save_to_disk: ${{ github.event.inputs.force_save_to_disk }}
       disk_suffix: tip
       height_grep_text: 'current_height.*=.*Height.*\('
     secrets: inherit
@@ -430,6 +437,7 @@ jobs:
       needs_zebra_state: true
       # update the disk on every PR, to increase CI speed
       saves_to_disk: true
+      force_save_to_disk: ${{ github.event.inputs.force_save_to_disk }}
       disk_suffix: tip
       root_state_path: '/var/cache'
       zebra_state_dir: 'zebrad-cache'
@@ -502,6 +510,7 @@ jobs:
       is_long_test: true
       needs_zebra_state: false
       saves_to_disk: true
+      force_save_to_disk: ${{ github.event.inputs.force_save_to_disk }}
       disk_suffix: tip
       height_grep_text: 'current_height.*=.*Height.*\('
     secrets: inherit
@@ -545,6 +554,7 @@ jobs:
       # update the disk on every PR, to increase CI speed
       # we don't have a test-update-sync-testnet job, so we need to update the disk here
       saves_to_disk: true
+      force_save_to_disk: ${{ github.event.inputs.force_save_to_disk }}
       disk_suffix: tip
       root_state_path: '/var/cache'
       zebra_state_dir: 'zebrad-cache'
@@ -577,6 +587,7 @@ jobs:
       needs_zebra_state: true
       needs_lwd_state: false
       saves_to_disk: true
+      force_save_to_disk: ${{ github.event.inputs.force_save_to_disk }}
       disk_prefix: lwd-cache
       disk_suffix: tip
       root_state_path: '/var/cache'

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -335,7 +335,7 @@ jobs:
       test_variables: '-e TEST_DISK_REBUILD=1 -e ZEBRA_FORCE_USE_COLOR=1'
       needs_zebra_state: false
       saves_to_disk: true
-      force_save_to_disk: ${{ github.event.inputs.force_save_to_disk }}
+      force_save_to_disk: ${{ inputs.force_save_to_disk || false }}
       disk_suffix: checkpoint
       height_grep_text: 'flushing database to disk .*height.*=.*Height.*\('
     secrets: inherit
@@ -397,7 +397,7 @@ jobs:
       is_long_test: true
       needs_zebra_state: false
       saves_to_disk: true
-      force_save_to_disk: ${{ github.event.inputs.force_save_to_disk }}
+      force_save_to_disk: ${{ inputs.force_save_to_disk || false }}
       disk_suffix: tip
       height_grep_text: 'current_height.*=.*Height.*\('
     secrets: inherit
@@ -437,7 +437,7 @@ jobs:
       needs_zebra_state: true
       # update the disk on every PR, to increase CI speed
       saves_to_disk: true
-      force_save_to_disk: ${{ inputs.force_save_to_disk }}
+      force_save_to_disk: ${{ inputs.force_save_to_disk || false }}
       disk_suffix: tip
       root_state_path: '/var/cache'
       zebra_state_dir: 'zebrad-cache'
@@ -510,7 +510,7 @@ jobs:
       is_long_test: true
       needs_zebra_state: false
       saves_to_disk: true
-      force_save_to_disk: ${{ inputs.force_save_to_disk }}
+      force_save_to_disk: ${{ inputs.force_save_to_disk || false }}
       disk_suffix: tip
       height_grep_text: 'current_height.*=.*Height.*\('
     secrets: inherit
@@ -554,7 +554,7 @@ jobs:
       # update the disk on every PR, to increase CI speed
       # we don't have a test-update-sync-testnet job, so we need to update the disk here
       saves_to_disk: true
-      force_save_to_disk: ${{ inputs.force_save_to_disk }}
+      force_save_to_disk: ${{ inputs.force_save_to_disk || false }}
       disk_suffix: tip
       root_state_path: '/var/cache'
       zebra_state_dir: 'zebrad-cache'
@@ -587,7 +587,7 @@ jobs:
       needs_zebra_state: true
       needs_lwd_state: false
       saves_to_disk: true
-      force_save_to_disk: ${{ inputs.force_save_to_disk }}
+      force_save_to_disk: ${{ inputs.force_save_to_disk || false }}
       disk_prefix: lwd-cache
       disk_suffix: tip
       root_state_path: '/var/cache'

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1719,6 +1719,96 @@ jobs:
           echo "UPDATE_SUFFIX=$UPDATE_SUFFIX" >> "$GITHUB_ENV"
           echo "TIME_SUFFIX=$TIME_SUFFIX" >> "$GITHUB_ENV"
 
+      # Get the full initial and running database versions from the test logs.
+      # These versions are used as part of the disk description and labels.
+      #
+      # If these versions are missing from the logs, the job fails.
+      #
+      # Typically, the database versions are around line 20 in the logs..
+      # But we check the first 1000 log lines, just in case the test harness recompiles all the
+      # dependencies before running the test. (This can happen if the cache is invalid.)
+      #
+      # Passes the versions to subsequent steps using the $INITIAL_DISK_DB_VERSION,
+      # $RUNNING_DB_VERSION, and $DB_VERSION_SUMMARY env variables.
+      - name: Get database versions from logs
+        run: |
+          INITIAL_DISK_DB_VERSION=""
+          RUNNING_DB_VERSION=""
+          DB_VERSION_SUMMARY=""
+
+          DOCKER_LOGS=$( \
+          gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          --zone ${{ vars.GCP_ZONE }} \
+          --ssh-flag="-o ServerAliveInterval=5" \
+          --ssh-flag="-o ConnectionAttempts=20" \
+          --ssh-flag="-o ConnectTimeout=5" \
+          --command=" \
+          sudo docker logs ${{ inputs.test_id }} | head +1000 \
+          ")
+
+          # either a semantic version or "creating new database"
+          INITIAL_DISK_DB_VERSION=$( \
+          echo "$DOCKER_LOGS" | \
+          grep --extended-regexp --only-matching 'initial disk state version: [0-9a-z\. ]+' | \
+          grep --extended-regexp --only-matching '[0-9a-z\. ]+' | \
+          tail -1 || \
+          [[ $? == 1 ]] \
+          )
+
+          if [[ -z "$INITIAL_DISK_DB_VERSION" ]]; then
+              echo "Checked logs:"
+              echo ""
+              echo "$DOCKER_LOGS"
+              echo ""
+              echo "Missing initial disk database version in logs: $INITIAL_DISK_DB_VERSION"
+              # Fail the tests, because Zebra didn't log the initial disk database version,
+              # or the regex in this step is wrong.
+              false
+          fi
+
+          if [[ "$INITIAL_DISK_DB_VERSION" = "creating new database" ]]; then
+              INITIAL_DISK_DB_VERSION="new"
+          else
+              INITIAL_DISK_DB_VERSION="v${INITIAL_DISK_DB_VERSION//./-}"
+          fi
+
+          echo "Found initial disk database version in logs: $INITIAL_DISK_DB_VERSION"
+          echo "INITIAL_DISK_DB_VERSION=$INITIAL_DISK_DB_VERSION" >> "$INITIAL_DISK_DB_VERSION"
+
+          RUNNING_DB_VERSION=$( \
+          echo "$DOCKER_LOGS" | \
+          grep --extended-regexp --only-matching 'running state version: [0-9\.]+' | \
+          grep --extended-regexp --only-matching '[0-9\.]+' | \
+          tail -1 || \
+          [[ $? == 1 ]] \
+          )
+
+          if [[ -z "$RUNNING_DB_VERSION" ]]; then
+              echo "Checked logs:"
+              echo ""
+              echo "$DOCKER_LOGS"
+              echo ""
+              echo "Missing running database version in logs: $RUNNING_DB_VERSION"
+              # Fail the tests, because Zebra didn't log the running database version,
+              # or the regex in this step is wrong.
+              false
+          fi
+
+          RUNNING_DB_VERSION="v${RUNNING_DB_VERSION//./-}"
+          echo "Found running database version in logs: $RUNNING_DB_VERSION"
+          echo "RUNNING_DB_VERSION=$RUNNING_DB_VERSION" >> "$RUNNING_DB_VERSION"
+
+          if [[ "$INITIAL_DISK_DB_VERSION" = "$RUNNING_DB_VERSION" ]]; then
+              DB_VERSION_SUMMARY="$RUNNING_DB_VERSION"
+          elif [[ "$INITIAL_DISK_DB_VERSION" = "new" ]]; then
+              DB_VERSION_SUMMARY="$RUNNING_DB_VERSION in new database"
+          else
+              DB_VERSION_SUMMARY="$INITIAL_DISK_DB_VERSION upgrading to $RUNNING_DB_VERSION"
+          fi
+
+          echo "Summarised database versions from logs: $DB_VERSION_SUMMARY"
+          echo "DB_VERSION_SUMMARY=$DB_VERSION_SUMMARY" >> "$DB_VERSION_SUMMARY"
+
       # Get the sync height from the test logs, which is later used as part of the
       # disk description and labels.
       #
@@ -1728,7 +1818,7 @@ jobs:
       #
       # If the sync height is missing from the logs, the job fails.
       #
-      # Passes the sync height to subsequent steps using $SYNC_HEIGHT env variable.
+      # Passes the sync height to subsequent steps using the $SYNC_HEIGHT env variable.
       - name: Get sync height from logs
         run: |
           SYNC_HEIGHT=""
@@ -1746,12 +1836,16 @@ jobs:
           SYNC_HEIGHT=$( \
           echo "$DOCKER_LOGS" | \
           grep --extended-regexp --only-matching '${{ inputs.height_grep_text }}[0-9]+' | \
-          grep --extended-regexp --only-matching  '[0-9]+' | \
+          grep --extended-regexp --only-matching '[0-9]+' | \
           tail -1 || \
           [[ $? == 1 ]] \
           )
 
           if [[ -z "$SYNC_HEIGHT" ]]; then
+              echo "Checked logs:"
+              echo ""
+              echo "$DOCKER_LOGS"
+              echo ""
               echo "Missing sync height in logs: $SYNC_HEIGHT"
               # Fail the tests, because Zebra and lightwalletd didn't log their sync heights,
               # or the CI workflow sync height regex is wrong.
@@ -1820,8 +1914,8 @@ jobs:
               --source-disk=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} \
               --source-disk-zone=${{ vars.GCP_ZONE }} \
               --storage-location=us \
-              --description="Created from commit ${{ env.GITHUB_SHA_SHORT }} with height ${{ env.SYNC_HEIGHT }}" \
-              --labels="height=${{ env.SYNC_HEIGHT }},purpose=${{ inputs.disk_prefix }},commit=${{ env.GITHUB_SHA_SHORT }},state-version=${{ env.STATE_VERSION }},network=${NETWORK},target-height-kind=${{ inputs.disk_suffix }},update-flag=${UPDATE_SUFFIX},updated-from-height=${ORIGINAL_HEIGHT},test-id=${{ inputs.test_id }},app-name=${{ inputs.app_name }}"
+              --description="Created from commit ${{ env.GITHUB_SHA_SHORT }} with height ${{ env.SYNC_HEIGHT }} and database format ${{ env.DB_VERSION_SUMMARY }}" \
+              --labels="height=${{ env.SYNC_HEIGHT }},purpose=${{ inputs.disk_prefix }},commit=${{ env.GITHUB_SHA_SHORT }},state-version=${{ env.STATE_VERSION }},state-running-version=${{ env.RUNNING_DB_VERSION }},initial-state-disk-version=${{ env.INITIAL_DISK_DB_VERSION }},network=${NETWORK},target-height-kind=${{ inputs.disk_suffix }},update-flag=${UPDATE_SUFFIX},updated-from-height=${ORIGINAL_HEIGHT},test-id=${{ inputs.test_id }},app-name=${{ inputs.app_name }}"
           else
               echo "Skipped cached state update because the new sync height $SYNC_HEIGHT was less than $CACHED_STATE_UPDATE_LIMIT blocks above the original height $ORIGINAL_HEIGHT"
           fi

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1754,8 +1754,8 @@ jobs:
           # either a semantic version or "creating new database"
           INITIAL_DISK_DB_VERSION=$( \
           echo "$DOCKER_LOGS" | \
-          grep --extended-regexp --only-matching 'initial disk state version: [0-9a-z\. ]+' | \
-          grep --extended-regexp --only-matching '[0-9a-z\. ]+' | \
+          grep --extended-regexp --only-matching 'initial disk state version: [0-9a-z\.]+' | \
+          grep --extended-regexp --only-matching '[0-9a-z\.]+' | \
           tail -1 || \
           [[ $? == 1 ]] \
           )
@@ -1771,7 +1771,7 @@ jobs:
               false
           fi
 
-          if [[ "$INITIAL_DISK_DB_VERSION" = "creating new database" ]]; then
+          if [[ "$INITIAL_DISK_DB_VERSION" = "creating.new.database" ]]; then
               INITIAL_DISK_DB_VERSION="new"
           else
               INITIAL_DISK_DB_VERSION="v${INITIAL_DISK_DB_VERSION//./-}"

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -79,7 +79,12 @@ on:
       saves_to_disk:
         required: true
         type: boolean
-        description: 'Does the test create a new cached state disk?'
+        description: 'Can this test create new or updated cached state disks?'
+      force_save_to_disk:
+        required: false
+        type: boolean
+        default: false
+        description: 'Force this test to create a new or updated cached state disk'
       app_name:
         required: false
         type: string
@@ -1630,7 +1635,7 @@ jobs:
     # We run exactly one of without-cached-state or with-cached-state, and we always skip the other one.
     # Normally, if a job is skipped, all the jobs that depend on it are also skipped.
     # So we need to override the default success() check to make this job run.
-    if: ${{ !cancelled() && !failure() && inputs.saves_to_disk }}
+    if: ${{ !cancelled() && !failure() && (inputs.saves_to_disk || inputs.force_save_to_disk) }}
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -1907,7 +1912,7 @@ jobs:
       - name: Create image from state disk
         run: |
           MINIMUM_UPDATE_HEIGHT=$((ORIGINAL_HEIGHT+CACHED_STATE_UPDATE_LIMIT))
-          if [[ -z "$UPDATE_SUFFIX" ]] || [[ "$SYNC_HEIGHT" -gt "$MINIMUM_UPDATE_HEIGHT" ]]; then
+          if [[ -z "$UPDATE_SUFFIX" ]] || [[ "$SYNC_HEIGHT" -gt "$MINIMUM_UPDATE_HEIGHT" ]] || [[ "${{ inputs.force_save_to_disk }}" == "true" ]]; then
              gcloud compute images create \
               "${{ inputs.disk_prefix }}-${SHORT_GITHUB_REF}-${{ env.GITHUB_SHA_SHORT }}-v${{ env.STATE_VERSION }}-${NETWORK}-${{ inputs.disk_suffix }}${UPDATE_SUFFIX}-${TIME_SUFFIX}" \
               --force \
@@ -1915,7 +1920,7 @@ jobs:
               --source-disk-zone=${{ vars.GCP_ZONE }} \
               --storage-location=us \
               --description="Created from commit ${{ env.GITHUB_SHA_SHORT }} with height ${{ env.SYNC_HEIGHT }} and database format ${{ env.DB_VERSION_SUMMARY }}" \
-              --labels="height=${{ env.SYNC_HEIGHT }},purpose=${{ inputs.disk_prefix }},commit=${{ env.GITHUB_SHA_SHORT }},state-version=${{ env.STATE_VERSION }},state-running-version=${{ env.RUNNING_DB_VERSION }},initial-state-disk-version=${{ env.INITIAL_DISK_DB_VERSION }},network=${NETWORK},target-height-kind=${{ inputs.disk_suffix }},update-flag=${UPDATE_SUFFIX},updated-from-height=${ORIGINAL_HEIGHT},test-id=${{ inputs.test_id }},app-name=${{ inputs.app_name }}"
+              --labels="height=${{ env.SYNC_HEIGHT }},purpose=${{ inputs.disk_prefix }},commit=${{ env.GITHUB_SHA_SHORT }},state-version=${{ env.STATE_VERSION }},state-running-version=${{ env.RUNNING_DB_VERSION }},initial-state-disk-version=${{ env.INITIAL_DISK_DB_VERSION }},network=${NETWORK},target-height-kind=${{ inputs.disk_suffix }},update-flag=${UPDATE_SUFFIX},force-save=${{ inputs.force_save_to_disk }},updated-from-height=${ORIGINAL_HEIGHT},test-id=${{ inputs.test_id }},app-name=${{ inputs.app_name }}"
           else
               echo "Skipped cached state update because the new sync height $SYNC_HEIGHT was less than $CACHED_STATE_UPDATE_LIMIT blocks above the original height $ORIGINAL_HEIGHT"
           fi

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1808,7 +1808,7 @@ jobs:
           elif [[ "$INITIAL_DISK_DB_VERSION" = "new" ]]; then
               DB_VERSION_SUMMARY="$RUNNING_DB_VERSION in new database"
           else
-              DB_VERSION_SUMMARY="$INITIAL_DISK_DB_VERSION upgrading to $RUNNING_DB_VERSION"
+              DB_VERSION_SUMMARY="$INITIAL_DISK_DB_VERSION changing to $RUNNING_DB_VERSION"
           fi
 
           echo "Summarised database versions from logs: $DB_VERSION_SUMMARY"

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1920,7 +1920,7 @@ jobs:
               --source-disk-zone=${{ vars.GCP_ZONE }} \
               --storage-location=us \
               --description="Created from commit ${{ env.GITHUB_SHA_SHORT }} with height ${{ env.SYNC_HEIGHT }} and database format ${{ env.DB_VERSION_SUMMARY }}" \
-              --labels="height=${{ env.SYNC_HEIGHT }},purpose=${{ inputs.disk_prefix }},commit=${{ env.GITHUB_SHA_SHORT }},state-version=${{ env.STATE_VERSION }},state-running-version=${{ env.RUNNING_DB_VERSION }},initial-state-disk-version=${{ env.INITIAL_DISK_DB_VERSION }},network=${NETWORK},target-height-kind=${{ inputs.disk_suffix }},update-flag=${UPDATE_SUFFIX},force-save=${{ inputs.force_save_to_disk }},updated-from-height=${ORIGINAL_HEIGHT},test-id=${{ inputs.test_id }},app-name=${{ inputs.app_name }}"
+              --labels="height=${{ env.SYNC_HEIGHT }},purpose=${{ inputs.disk_prefix }},commit=${{ env.GITHUB_SHA_SHORT }},state-version=${{ env.STATE_VERSION }},state-running-version=${RUNNING_DB_VERSION},initial-state-disk-version=${INITIAL_DISK_DB_VERSION},network=${NETWORK},target-height-kind=${{ inputs.disk_suffix }},update-flag=${UPDATE_SUFFIX},force-save=${{ inputs.force_save_to_disk }},updated-from-height=${ORIGINAL_HEIGHT},test-id=${{ inputs.test_id }},app-name=${{ inputs.app_name }}"
           else
               echo "Skipped cached state update because the new sync height $SYNC_HEIGHT was less than $CACHED_STATE_UPDATE_LIMIT blocks above the original height $ORIGINAL_HEIGHT"
           fi

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1743,7 +1743,7 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command=" \
-          sudo docker logs ${{ inputs.test_id }} | head +1000 \
+          sudo docker logs ${{ inputs.test_id }} | head -1000 \
           ")
 
           # either a semantic version or "creating new database"

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -1778,7 +1778,7 @@ jobs:
           fi
 
           echo "Found initial disk database version in logs: $INITIAL_DISK_DB_VERSION"
-          echo "INITIAL_DISK_DB_VERSION=$INITIAL_DISK_DB_VERSION" >> "$INITIAL_DISK_DB_VERSION"
+          echo "INITIAL_DISK_DB_VERSION=$INITIAL_DISK_DB_VERSION" >> "$GITHUB_ENV"
 
           RUNNING_DB_VERSION=$( \
           echo "$DOCKER_LOGS" | \
@@ -1801,7 +1801,7 @@ jobs:
 
           RUNNING_DB_VERSION="v${RUNNING_DB_VERSION//./-}"
           echo "Found running database version in logs: $RUNNING_DB_VERSION"
-          echo "RUNNING_DB_VERSION=$RUNNING_DB_VERSION" >> "$RUNNING_DB_VERSION"
+          echo "RUNNING_DB_VERSION=$RUNNING_DB_VERSION" >> "$GITHUB_ENV"
 
           if [[ "$INITIAL_DISK_DB_VERSION" = "$RUNNING_DB_VERSION" ]]; then
               DB_VERSION_SUMMARY="$RUNNING_DB_VERSION"
@@ -1812,7 +1812,7 @@ jobs:
           fi
 
           echo "Summarised database versions from logs: $DB_VERSION_SUMMARY"
-          echo "DB_VERSION_SUMMARY=$DB_VERSION_SUMMARY" >> "$DB_VERSION_SUMMARY"
+          echo "DB_VERSION_SUMMARY=$DB_VERSION_SUMMARY" >> "$GITHUB_ENV"
 
       # Get the sync height from the test logs, which is later used as part of the
       # disk description and labels.

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -175,6 +175,7 @@ impl Default for Config {
 }
 
 // Cleaning up old database versions
+// TODO: put this in a different module?
 
 /// Spawns a task that checks if there are old database folders,
 /// and deletes them from the filesystem.
@@ -291,6 +292,8 @@ fn parse_version_number(dir_name: &str) -> Option<u64> {
         .strip_prefix('v')
         .and_then(|version| version.parse().ok())
 }
+
+// TODO: move these to the format upgrade module
 
 /// Returns the full semantic version of the currently running database format code.
 ///

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -52,7 +52,7 @@ pub const DATABASE_FORMAT_MINOR_VERSION: u64 = 0;
 
 /// The database format patch version, incremented each time the on-disk database format has a
 /// significant format compatibility fix.
-pub const DATABASE_FORMAT_PATCH_VERSION: u64 = 1;
+pub const DATABASE_FORMAT_PATCH_VERSION: u64 = 2;
 
 /// The name of the file containing the minor and patch database versions.
 pub const DATABASE_FORMAT_VERSION_FILE_NAME: &str = "version";

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 
 // For doc comment links
 #[allow(unused_imports)]
-use crate::config::{database_format_version_in_code, database_format_version_on_disk};
+use crate::config::{self, Config};
 
 pub use zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
 
@@ -37,9 +37,9 @@ pub const MAX_BLOCK_REORG_HEIGHT: u32 = MIN_TRANSPARENT_COINBASE_MATURITY - 1;
 /// - we previously added compatibility code, and
 /// - it's available in all supported Zebra versions.
 ///
-/// Use [`database_format_version_in_code()`] or [`database_format_version_on_disk()`]
-/// to get the full semantic format version.
-pub const DATABASE_FORMAT_VERSION: u64 = 25;
+/// Use [`config::database_format_version_in_code()`] or
+/// [`config::database_format_version_on_disk()`] to get the full semantic format version.
+pub(crate) const DATABASE_FORMAT_VERSION: u64 = 25;
 
 /// The database format minor version, incremented each time the on-disk database format has a
 /// significant data format change.
@@ -48,14 +48,16 @@ pub const DATABASE_FORMAT_VERSION: u64 = 25;
 /// - adding new column families,
 /// - changing the format of a column family in a compatible way, or
 /// - breaking changes with compatibility code in all supported Zebra versions.
-pub const DATABASE_FORMAT_MINOR_VERSION: u64 = 0;
+pub(crate) const DATABASE_FORMAT_MINOR_VERSION: u64 = 0;
 
 /// The database format patch version, incremented each time the on-disk database format has a
 /// significant format compatibility fix.
-pub const DATABASE_FORMAT_PATCH_VERSION: u64 = 2;
+pub(crate) const DATABASE_FORMAT_PATCH_VERSION: u64 = 2;
 
 /// The name of the file containing the minor and patch database versions.
-pub const DATABASE_FORMAT_VERSION_FILE_NAME: &str = "version";
+///
+/// Use [`Config::version_file_path()`] to get the path to this file.
+pub(crate) const DATABASE_FORMAT_VERSION_FILE_NAME: &str = "version";
 
 /// The maximum number of blocks to check for NU5 transactions,
 /// before we assume we are on a pre-NU5 legacy chain.

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -29,7 +29,10 @@ mod service;
 #[cfg(test)]
 mod tests;
 
-pub use config::{check_and_delete_old_databases, Config};
+pub use config::{
+    check_and_delete_old_databases, database_format_version_in_code,
+    database_format_version_on_disk, Config,
+};
 pub use constants::MAX_BLOCK_REORG_HEIGHT;
 pub use error::{
     BoxError, CloneError, CommitSemanticallyVerifiedError, DuplicateNullifierError,

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -60,4 +60,7 @@ pub use service::{
     init_test, init_test_services, ReadStateService,
 };
 
+#[cfg(any(test, feature = "proptest-impl"))]
+pub use config::write_database_format_version_to_disk;
+
 pub(crate) use request::ContextuallyVerifiedBlock;

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1179,6 +1179,8 @@ impl Service<ReadRequest> for ReadStateService {
             }
         }
 
+        self.db.check_for_panics();
+
         Poll::Ready(Ok(()))
     }
 

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -10,7 +10,13 @@
 //! The [`crate::constants::DATABASE_FORMAT_VERSION`] constants must
 //! be incremented each time the database format (column, serialization, etc) changes.
 
-use std::{fmt::Debug, path::Path, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt::Debug,
+    ops::RangeBounds,
+    path::Path,
+    sync::Arc,
+};
 
 use itertools::Itertools;
 use rlimit::increase_nofile_limit;

--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -11,6 +11,7 @@ pub mod block;
 pub mod chain;
 pub mod shielded;
 pub mod transparent;
+pub mod upgrade;
 
 #[cfg(test)]
 mod tests;

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -1,0 +1,138 @@
+//! In-place format upgrades for the Zebra state database.
+
+use std::cmp::Ordering;
+
+use semver::Version;
+
+use zebra_chain::parameters::Network;
+use DbFormatChange::*;
+
+use crate::{config::write_database_format_version_to_disk, Config};
+
+/// The kind of database format change we're performing.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DbFormatChange {
+    /// Upgrading the format from `disk_version` to `running_version`.
+    ///
+    /// Until this upgrade is complete, the format is a mixture of both versions.
+    Upgrade {
+        disk_version: Version,
+        running_version: Version,
+    },
+
+    /// Marking the format as downgraded from `disk_version` to `running_version`.
+    ///
+    /// Until the state is upgraded to `disk_version` by a later Zebra version,
+    /// the format will be a mixture of both versions.
+    Downgrade {
+        disk_version: Version,
+        running_version: Version,
+    },
+}
+
+impl DbFormatChange {
+    /// Check if loading `disk_version` into `running_version` needs a format change,
+    /// and if it does, return the required format change.
+    ///
+    /// Also logs the kind of change at info level.
+    ///
+    /// If `disk_version` is `None`, Zebra is creating a new database.
+    pub fn new(running_version: Version, disk_version: Option<Version>) -> Option<Self> {
+        let Some(disk_version) = disk_version else {
+            info!(
+                ?running_version,
+                "creating new database with the current format"
+            );
+
+            return None;
+        };
+
+        match disk_version.cmp(&running_version) {
+            Ordering::Less => {
+                info!(
+                    ?running_version,
+                    ?disk_version,
+                    "trying to open older database format: launching upgrade task"
+                );
+
+                Some(Upgrade {
+                    disk_version,
+                    running_version,
+                })
+            }
+            Ordering::Greater => {
+                info!(
+                    ?running_version,
+                    ?disk_version,
+                    "trying to open newer database format: data should be compatible"
+                );
+
+                Some(Downgrade {
+                    disk_version,
+                    running_version,
+                })
+            }
+            Ordering::Equal => {
+                info!(
+                    ?running_version,
+                    "trying to open compatible database format"
+                );
+
+                None
+            }
+        }
+    }
+
+    /// Returns true if this change is an upgrade.
+    pub fn is_upgrade(&self) -> bool {
+        matches!(self, Upgrade { .. })
+    }
+
+    /// Apply this format change to the database.
+    /// Format changes should be launched in an independent `std::thread`.
+    //
+    // New format changes must be added to the *end* of this method.
+    pub fn apply_format_change(&self, config: &Config, network: Network) {
+        if !self.is_upgrade() {
+            // # Correctness
+            //
+            // At the start of a format downgrade, the database must be marked as partially or
+            // fully downgraded.
+            Self::mark_as_changed(config, network);
+
+            // Older supported versions just assume they can read newer formats,
+            // because they can't predict all changes a newer Zebra version could make.
+            //
+            // The resposibility of staying backwards-compatible is on the newer version.
+            // We do this on a best-effort basis for versions that are still supported.
+            return;
+        }
+
+        // # TODO: link to format upgrade instructions doc here
+
+        // # Correctness
+        //
+        // New code goes above this comment!
+        //
+        // Run the latest format upgrade code after the other upgrades are complete,
+        // but before marking the format as upgraded.
+
+        // At the end of a format upgrade, the database is marked as fully upgraded.
+        // Upgrades can be run more than once if Zebra is restarted, so this is just a performance
+        // optimisation.
+        Self::mark_as_changed(config, network);
+    }
+
+    /// Mark the database as fully upgraded.
+    /// This should be called after database format is up-to-date.
+    ///
+    /// # Concurrency
+    ///
+    /// The version must only be updated while RocksDB is holding the database
+    /// directory lock. This prevents multiple Zebra instances corrupting the version
+    /// file.
+    fn mark_as_changed(config: &Config, network: Network) {
+        write_database_format_version_to_disk(config, network)
+            .expect("unable to write database format version file to disk");
+    }
+}

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -247,10 +247,9 @@ impl DbFormatChange {
             Self::mark_as_upgraded_to(&database_format_version_in_code(), &config, network);
 
             info!(
-                ?initial_tip_height,
                 ?newer_running_version,
                 ?older_disk_version,
-                "database is fully upgraded"
+                "empty database is fully upgraded"
             );
 
             return;
@@ -339,14 +338,14 @@ impl DbFormatChange {
              running: {running_version}"
         );
 
+        write_database_format_version_to_disk(&running_version, config, network)
+            .expect("unable to write database format version file to disk");
+
         info!(
             ?running_version,
             ?disk_version,
-            "marking database format as newly created"
+            "marked database format as newly created"
         );
-
-        write_database_format_version_to_disk(&running_version, config, network)
-            .expect("unable to write database format version file to disk");
     }
 
     /// Mark the database as upgraded to `format_upgrade_version`.
@@ -400,15 +399,15 @@ impl DbFormatChange {
              running: {running_version}"
         );
 
+        write_database_format_version_to_disk(format_upgrade_version, config, network)
+            .expect("unable to write database format version file to disk");
+
         info!(
             ?running_version,
             ?format_upgrade_version,
             ?disk_version,
-            "marking database format as upgraded"
+            "marked database format as upgraded"
         );
-
-        write_database_format_version_to_disk(format_upgrade_version, config, network)
-            .expect("unable to write database format version file to disk");
     }
 
     /// Mark the database as downgraded to the running database version.
@@ -439,14 +438,14 @@ impl DbFormatChange {
              running: {running_version}"
         );
 
+        write_database_format_version_to_disk(&running_version, config, network)
+            .expect("unable to write database format version file to disk");
+
         info!(
             ?running_version,
             ?disk_version,
-            "marking database format as downgraded"
+            "marked database format as downgraded"
         );
-
-        write_database_format_version_to_disk(&running_version, config, network)
-            .expect("unable to write database format version file to disk");
     }
 }
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -108,7 +108,7 @@ impl DbFormatChange {
                 })
             }
             Ordering::Equal => {
-                info!(?running_version, "trying to open matching database format");
+                info!(?running_version, "trying to open current database format");
 
                 None
             }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -187,7 +187,7 @@ impl DbFormatChange {
                 // Older supported versions just assume they can read newer formats,
                 // because they can't predict all changes a newer Zebra version could make.
                 //
-                // The resposibility of staying backwards-compatible is on the newer version.
+                // The responsibility of staying backwards-compatible is on the newer version.
                 // We do this on a best-effort basis for versions that are still supported.
             }
         }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -175,8 +175,6 @@ impl DbFormatChange {
 
             NewlyCreated { .. } => {
                 Self::mark_as_newly_created(&config, network);
-
-                return;
             }
             Downgrade { .. } => {
                 // # Correctness
@@ -191,7 +189,6 @@ impl DbFormatChange {
                 //
                 // The resposibility of staying backwards-compatible is on the newer version.
                 // We do this on a best-effort basis for versions that are still supported.
-                return;
             }
         }
     }
@@ -230,6 +227,14 @@ impl DbFormatChange {
             );
 
             Self::mark_as_upgraded_to(&database_format_version_in_code(), &config, network);
+
+            info!(
+                ?initial_tip_height,
+                ?newer_running_version,
+                ?older_disk_version,
+                "database is fully upgraded"
+            );
+
             return;
         };
 
@@ -278,6 +283,12 @@ impl DbFormatChange {
         // Run the latest format upgrade code after the other upgrades are complete,
         // then mark the format as upgraded. The code should check `cancel_receiver`
         // every time it runs its inner update loop.
+        info!(
+            ?initial_tip_height,
+            ?newer_running_version,
+            ?older_disk_version,
+            "database is fully upgraded"
+        );
     }
 
     /// Mark a newly created database with the current format version.

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -1372,6 +1372,11 @@ impl<T> TestOutput<T> {
     fn was_killed(&self) -> bool {
         self.output.status.signal() == Some(9)
     }
+
+    /// Takes the generic `dir` paramter out of this `TestOutput`.
+    pub fn take_dir(&mut self) -> Option<T> {
+        self.dir.take()
+    }
 }
 
 /// Add context to an error report

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -1373,7 +1373,7 @@ impl<T> TestOutput<T> {
         self.output.status.signal() == Some(9)
     }
 
-    /// Takes the generic `dir` paramter out of this `TestOutput`.
+    /// Takes the generic `dir` parameter out of this `TestOutput`.
     pub fn take_dir(&mut self) -> Option<T> {
         self.dir.take()
     }

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -540,7 +540,9 @@ impl<T> TestChild<T> {
         // Read unread child output.
         //
         // This checks for failure logs, and prevents some test hangs and deadlocks.
-        if self.child.is_some() || self.stdout.is_some() {
+        //
+        // TODO: this could block if stderr is full and stdout is waiting for stderr to be read.
+        if self.stdout.is_some() {
             let wrote_lines =
                 self.wait_for_stdout_line(format!("\n{} Child Stdout:", self.command_path));
 
@@ -552,7 +554,7 @@ impl<T> TestChild<T> {
             }
         }
 
-        if self.child.is_some() || self.stderr.is_some() {
+        if self.stderr.is_some() {
             let wrote_lines =
                 self.wait_for_stderr_line(format!("\n{} Child Stderr:", self.command_path));
 
@@ -564,6 +566,56 @@ impl<T> TestChild<T> {
         }
 
         kill_result
+    }
+
+    /// Kill the process, and return all its remaining standard output and standard error output.
+    ///
+    /// If `ignore_exited` is `true`, log "can't kill an exited process" errors,
+    /// rather than returning them.
+    ///
+    /// Returns `Ok(output)`, or an error if the kill failed.
+    pub fn kill_and_return_output(&mut self, ignore_exited: bool) -> Result<String> {
+        self.apply_failure_regexes_to_outputs();
+
+        // Prevent a hang when consuming output,
+        // by making sure the child's output actually finishes.
+        let kill_result = self.kill(ignore_exited);
+
+        // Read unread child output.
+        let mut stdout_buf = String::new();
+        let mut stderr_buf = String::new();
+
+        // This also checks for failure logs, and prevents some test hangs and deadlocks.
+        loop {
+            let mut remaining_output = false;
+
+            if let Some(stdout) = self.stdout.as_mut() {
+                if let Some(line) =
+                    Self::wait_and_return_output_line(stdout, self.bypass_test_capture)
+                {
+                    stdout_buf.push_str(&line);
+                    remaining_output = true;
+                }
+            }
+
+            if let Some(stderr) = self.stderr.as_mut() {
+                if let Some(line) =
+                    Self::wait_and_return_output_line(stderr, self.bypass_test_capture)
+                {
+                    stderr_buf.push_str(&line);
+                    remaining_output = true;
+                }
+            }
+
+            if !remaining_output {
+                break;
+            }
+        }
+
+        let mut output = stdout_buf;
+        output.push_str(&stderr_buf);
+
+        kill_result.map(|()| output)
     }
 
     /// Waits until a line of standard output is available, then consumes it.
@@ -632,15 +684,40 @@ impl<T> TestChild<T> {
         false
     }
 
+    /// Waits until a line of `output` is available, then returns it.
+    ///
+    /// If there is a line, and `write_context` is `Some`, writes the context to the test logs.
+    /// Always writes the line to the test logs.
+    ///
+    /// Returns `true` if a line was available,
+    /// or `false` if the standard output has finished.
+    #[allow(clippy::unwrap_in_result)]
+    fn wait_and_return_output_line(
+        mut output: impl Iterator<Item = std::io::Result<String>>,
+        bypass_test_capture: bool,
+    ) -> Option<String> {
+        if let Some(line_result) = output.next() {
+            let line_result = line_result.expect("failure reading test process logs");
+
+            Self::write_to_test_logs(&line_result, bypass_test_capture);
+
+            return Some(line_result);
+        }
+
+        None
+    }
+
     /// Waits for the child process to exit, then returns its output.
+    ///
+    /// # Correctness
     ///
     /// The other test child output methods take one or both outputs,
     /// making them unavailable to this method.
     ///
     /// Ignores any configured timeouts.
     ///
-    /// Returns an error if the child has already been taken,
-    /// or both outputs have already been taken.
+    /// Returns an error if the child has already been taken.
+    /// TODO: return an error if both outputs have already been taken.
     #[spandoc::spandoc]
     pub fn wait_with_output(mut self) -> Result<TestOutput<T>> {
         let child = match self.child.take() {
@@ -708,6 +785,8 @@ impl<T> TestChild<T> {
     ///
     /// Kills the child on error, or after the configured timeout has elapsed.
     /// See [`Self::expect_line_matching_regex_set`] for details.
+    //
+    // TODO: these methods could block if stderr is full and stdout is waiting for stderr to be read
     #[instrument(skip(self))]
     #[allow(clippy::unwrap_in_result)]
     pub fn expect_stdout_line_matches<R>(&mut self, success_regex: R) -> Result<String>

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -266,7 +266,8 @@ impl Application for ZebradApp {
         let disk_db_version =
             match database_format_version_on_disk(&config.state, config.network.network) {
                 Ok(Some(version)) => version.to_string(),
-                Ok(None) => "creating new database".to_string(),
+                // This "version" is specially formatted to match a relaxed version regex in CI
+                Ok(None) => "creating.new.database".to_string(),
                 Err(error) => {
                     let mut error = format!("error: {error:?}");
                     error.truncate(100);

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2419,6 +2419,9 @@ async fn new_state_format() -> Result<()> {
 
 /// Check that outdated states are updated to the current state format version,
 /// and that restarting `zebrad` doesn't change the updated format version.
+///
+/// TODO: test partial updates, once we have some updates that take a while.
+///       (or just add a delay during tests)
 #[tokio::test]
 async fn update_state_format() -> Result<()> {
     let mut fake_version = database_format_version_in_code();

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -136,6 +136,7 @@
 //! ```
 
 use std::{
+    cmp::Ordering,
     collections::HashSet,
     env, fs, panic,
     path::PathBuf,
@@ -2526,10 +2527,10 @@ async fn state_format_test(
 
         let running_version = database_format_version_in_code();
 
-        if fake_version < &running_version {
-            expect_older_version = true;
-        } else if fake_version > &running_version {
-            expect_newer_version = true;
+        match fake_version.cmp(&running_version) {
+            Ordering::Less => expect_older_version = true,
+            Ordering::Equal => {}
+            Ordering::Greater => expect_newer_version = true,
         }
     }
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2484,6 +2484,9 @@ async fn state_format_test(
     zebrad.expect_stdout_line_matches("creating new database with the current format")?;
     zebrad.expect_stdout_line_matches("loaded Zebra state cache")?;
 
+    // Give Zebra enough time to actually write the database to disk.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
     let logs = zebrad.kill_and_return_output(false)?;
 
     assert!(
@@ -2525,6 +2528,9 @@ async fn state_format_test(
         zebra_state::write_database_format_version_to_disk(fake_version, &config.state, network)
             .expect("can't write fake database version to disk");
 
+        // Give zebra_state enough time to actually write the database version to disk.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
         let running_version = database_format_version_in_code();
 
         match fake_version.cmp(&running_version) {
@@ -2560,6 +2566,9 @@ async fn state_format_test(
             zebrad.expect_stdout_line_matches("trying to open current database format")?;
             zebrad.expect_stdout_line_matches("loaded Zebra state cache")?;
         }
+
+        // Give Zebra enough time to actually write the database to disk.
+        tokio::time::sleep(Duration::from_secs(1)).await;
 
         let logs = zebrad.kill_and_return_output(false)?;
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2487,12 +2487,12 @@ async fn state_format_test(
     let logs = zebrad.kill_and_return_output(false)?;
 
     assert!(
-        !logs.contains("marking database format as upgraded"),
+        !logs.contains("marked database format as upgraded"),
         "unexpected format upgrade in logs:\n\
          {logs}"
     );
     assert!(
-        !logs.contains("marking database format as downgraded"),
+        !logs.contains("marked database format as downgraded"),
         "unexpected format downgrade in logs:\n\
          {logs}"
     );
@@ -2551,11 +2551,11 @@ async fn state_format_test(
 
         if expect_older_version {
             zebrad.expect_stdout_line_matches("trying to open older database format")?;
-            zebrad.expect_stdout_line_matches("marking database format as upgraded")?;
+            zebrad.expect_stdout_line_matches("marked database format as upgraded")?;
             zebrad.expect_stdout_line_matches("database is fully upgraded")?;
         } else if expect_newer_version {
             zebrad.expect_stdout_line_matches("trying to open newer database format")?;
-            zebrad.expect_stdout_line_matches("marking database format as downgraded")?;
+            zebrad.expect_stdout_line_matches("marked database format as downgraded")?;
         } else {
             zebrad.expect_stdout_line_matches("trying to open current database format")?;
             zebrad.expect_stdout_line_matches("loaded Zebra state cache")?;
@@ -2565,7 +2565,7 @@ async fn state_format_test(
 
         if !expect_older_version {
             assert!(
-                !logs.contains("marking database format as upgraded"),
+                !logs.contains("marked database format as upgraded"),
                 "unexpected format upgrade in logs:\n\
                  {logs}"
             );
@@ -2573,7 +2573,7 @@ async fn state_format_test(
 
         if !expect_newer_version {
             assert!(
-                !logs.contains("marking database format as downgraded"),
+                !logs.contains("marked database format as downgraded"),
                 "unexpected format downgrade in logs:\n\
                  {logs}"
             );

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2416,7 +2416,7 @@ pub(crate) async fn new_state_format() -> Result<()> {
 
     // # Create a new state and check it has the current version
 
-    let zebrad = spawn_zebrad_without_rpc(network, test_name, false, false, None)?;
+    let zebrad = spawn_zebrad_without_rpc(network, test_name, false, false, false, None)?;
 
     // Skip the test unless it has the required state and environmental variables.
     let Some(mut zebrad) = zebrad else {
@@ -2455,7 +2455,7 @@ pub(crate) async fn new_state_format() -> Result<()> {
 
     let test_name = "new_state_format_test/reopen";
 
-    let mut zebrad = spawn_zebrad_without_rpc(network, test_name, false, false, dir)?
+    let mut zebrad = spawn_zebrad_without_rpc(network, test_name, false, false, false, dir)?
         .expect("unexpectedly missing required state or env vars");
 
     tracing::info!(?network, "running {} using zebrad", test_name);

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2416,7 +2416,7 @@ pub(crate) async fn new_state_format() -> Result<()> {
 
     // # Create a new state and check it has the current version
 
-    let zebrad = spawn_zebrad_without_rpc(network, test_name, false, false, false, None)?;
+    let zebrad = spawn_zebrad_without_rpc(network, test_name, false, false, None, false)?;
 
     // Skip the test unless it has the required state and environmental variables.
     let Some(mut zebrad) = zebrad else {
@@ -2455,7 +2455,7 @@ pub(crate) async fn new_state_format() -> Result<()> {
 
     let test_name = "new_state_format_test/reopen";
 
-    let mut zebrad = spawn_zebrad_without_rpc(network, test_name, false, false, false, dir)?
+    let mut zebrad = spawn_zebrad_without_rpc(network, test_name, false, false, dir, false)?
         .expect("unexpectedly missing required state or env vars");
 
     tracing::info!(?network, "running {} using zebrad", test_name);

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2089,7 +2089,7 @@ fn zebra_state_conflict() -> Result<()> {
         dir_conflict_full.push("state");
         dir_conflict_full.push(format!(
             "v{}",
-            zebra_state::constants::DATABASE_FORMAT_VERSION
+            zebra_state::database_format_version_in_code().major,
         ));
         dir_conflict_full.push(config.network.network.to_string().to_lowercase());
         format!(

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2408,11 +2408,18 @@ async fn generate_checkpoints_testnet() -> Result<()> {
 /// Check that new states are created with the current state format version,
 /// and that restarting `zebrad` doesn't change the format version.
 #[tokio::test]
-pub(crate) async fn new_state_format() -> Result<()> {
+async fn new_state_format() -> Result<()> {
+    for network in [Mainnet, Testnet] {
+        state_format_test("new_state_format_test", network).await?;
+    }
+
+    Ok(())
+}
+
+async fn state_format_test(base_test_name: &str, network: Network) -> Result<()> {
     let _init_guard = zebra_test::init();
 
-    let test_name = "new_state_format_test/new";
-    let network = Network::Mainnet;
+    let test_name = &format!("{base_test_name}/new");
 
     // # Create a new state and check it has the current version
 
@@ -2423,7 +2430,7 @@ pub(crate) async fn new_state_format() -> Result<()> {
         return Ok(());
     };
 
-    tracing::info!(?network, "running {} using zebrad", test_name);
+    tracing::info!(?network, "running {test_name} using zebrad");
 
     zebrad.expect_stdout_line_matches("creating new database with the current format")?;
     zebrad.expect_stdout_line_matches("loaded Zebra state cache")?;
@@ -2455,12 +2462,12 @@ pub(crate) async fn new_state_format() -> Result<()> {
 
     // # Reopen that state and check the version hasn't changed
 
-    let test_name = "new_state_format_test/reopen";
+    let test_name = &format!("{base_test_name}/reopen");
 
     let mut zebrad = spawn_zebrad_without_rpc(network, test_name, false, false, dir, false)?
         .expect("unexpectedly missing required state or env vars");
 
-    tracing::info!(?network, "running {} using zebrad", test_name);
+    tracing::info!(?network, "running {test_name} using zebrad");
 
     zebrad.expect_stdout_line_matches("trying to open current database format")?;
     zebrad.expect_stdout_line_matches("loaded Zebra state cache")?;

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2426,6 +2426,8 @@ pub(crate) async fn new_state_format() -> Result<()> {
     tracing::info!(?network, "running {} using zebrad", test_name);
 
     zebrad.expect_stdout_line_matches("creating new database with the current format")?;
+    zebrad.expect_stdout_line_matches("loaded Zebra state cache")?;
+
     let logs = zebrad.kill_and_return_output(false)?;
 
     assert!(
@@ -2461,6 +2463,8 @@ pub(crate) async fn new_state_format() -> Result<()> {
     tracing::info!(?network, "running {} using zebrad", test_name);
 
     zebrad.expect_stdout_line_matches("trying to open current database format")?;
+    zebrad.expect_stdout_line_matches("loaded Zebra state cache")?;
+
     let logs = zebrad.kill_and_return_output(false)?;
 
     assert!(

--- a/zebrad/tests/common/cached_state.rs
+++ b/zebrad/tests/common/cached_state.rs
@@ -11,8 +11,6 @@ use std::{
 };
 
 use color_eyre::eyre::{eyre, Result};
-use tempfile::TempDir;
-use tokio::fs;
 use tower::{util::BoxService, Service};
 
 use zebra_chain::{
@@ -25,7 +23,6 @@ use zebra_node_services::rpc_client::RpcRequestClient;
 use zebra_state::{ChainTipChange, LatestChainTip, MAX_BLOCK_REORG_HEIGHT};
 
 use crate::common::{
-    config::testdir,
     launch::spawn_zebrad_for_rpc,
     sync::{check_sync_logs_until, MempoolBehavior, SYNC_FINISHED_REGEX},
     test_type::TestType,
@@ -76,83 +73,6 @@ pub async fn load_tip_height_from_state_directory(
         .ok_or_else(|| eyre!("State directory doesn't have a chain tip block"))?;
 
     Ok(chain_tip_height)
-}
-
-/// Recursively copy a chain state database directory into a new temporary directory.
-pub async fn copy_state_directory(network: Network, source: impl AsRef<Path>) -> Result<TempDir> {
-    // Copy the database files for this state and network, excluding testnet and other state versions
-    let source = source.as_ref();
-    let state_config = zebra_state::Config {
-        cache_dir: source.into(),
-        ..Default::default()
-    };
-    let source_net_dir = state_config.db_path(network);
-    let source_net_dir = source_net_dir.as_path();
-    let state_suffix = source_net_dir
-        .strip_prefix(source)
-        .expect("db_path() is a subdirectory");
-
-    let destination = testdir()?;
-    let destination_net_dir = destination.path().join(state_suffix);
-
-    tracing::info!(
-        ?source,
-        ?source_net_dir,
-        ?state_suffix,
-        ?destination,
-        ?destination_net_dir,
-        "copying cached state files (this may take some time)...",
-    );
-
-    let mut remaining_directories = vec![PathBuf::from(source_net_dir)];
-
-    while let Some(directory) = remaining_directories.pop() {
-        let sub_directories =
-            copy_directory(&directory, source_net_dir, destination_net_dir.as_ref()).await?;
-
-        remaining_directories.extend(sub_directories);
-    }
-
-    Ok(destination)
-}
-
-/// Copy the contents of a directory, and return the sub-directories it contains.
-///
-/// Copies all files from the `directory` into the destination specified by the concatenation of
-/// the `base_destination_path` and `directory` stripped of its `prefix`.
-#[tracing::instrument]
-async fn copy_directory(
-    directory: &Path,
-    prefix: &Path,
-    base_destination_path: &Path,
-) -> Result<Vec<PathBuf>> {
-    let mut sub_directories = Vec::new();
-    let mut entries = fs::read_dir(directory).await?;
-
-    let destination =
-        base_destination_path.join(directory.strip_prefix(prefix).expect("Invalid path prefix"));
-
-    fs::create_dir_all(&destination).await?;
-
-    while let Some(entry) = entries.next_entry().await? {
-        let entry_path = entry.path();
-        let file_type = entry.file_type().await?;
-
-        if file_type.is_file() {
-            let file_name = entry_path.file_name().expect("Missing file name");
-            let destination_path = destination.join(file_name);
-
-            fs::copy(&entry_path, destination_path).await?;
-        } else if file_type.is_dir() {
-            sub_directories.push(entry_path);
-        } else if file_type.is_symlink() {
-            unimplemented!("Symbolic link support is currently not necessary");
-        } else {
-            panic!("Unknown file type");
-        }
-    }
-
-    Ok(sub_directories)
 }
 
 /// Accepts a network, test_type, test_name, and num_blocks (how many blocks past the finalized tip to try getting)

--- a/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
@@ -66,7 +66,7 @@ pub(crate) async fn run() -> Result<()> {
     let network = Network::Mainnet;
 
     // Skip the test unless the user specifically asked for it and there is a zebrad_state_path
-    if !can_spawn_zebrad_for_test_type(test_name, test_type) {
+    if !can_spawn_zebrad_for_test_type(test_name, test_type, true) {
         return Ok(());
     }
 

--- a/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
@@ -21,7 +21,7 @@ use zebra_rpc::methods::get_block_template_rpcs::{
 };
 
 use crate::common::{
-    launch::{can_spawn_zebrad_for_rpc, spawn_zebrad_for_rpc},
+    launch::{can_spawn_zebrad_for_test_type, spawn_zebrad_for_rpc},
     sync::{check_sync_logs_until, MempoolBehavior, SYNC_FINISHED_REGEX},
     test_type::TestType,
 };
@@ -66,7 +66,7 @@ pub(crate) async fn run() -> Result<()> {
     let network = Network::Mainnet;
 
     // Skip the test unless the user specifically asked for it and there is a zebrad_state_path
-    if !can_spawn_zebrad_for_rpc(test_name, test_type) {
+    if !can_spawn_zebrad_for_test_type(test_name, test_type) {
         return Ok(());
     }
 

--- a/zebrad/tests/common/get_block_template_rpcs/get_peer_info.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_peer_info.rs
@@ -21,7 +21,7 @@ pub(crate) async fn run() -> Result<()> {
     let network = Network::Mainnet;
 
     // Skip the test unless the user specifically asked for it and there is a zebrad_state_path
-    if !can_spawn_zebrad_for_test_type(test_name, test_type) {
+    if !can_spawn_zebrad_for_test_type(test_name, test_type, true) {
         return Ok(());
     }
 

--- a/zebrad/tests/common/get_block_template_rpcs/get_peer_info.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_peer_info.rs
@@ -7,7 +7,7 @@ use zebra_node_services::rpc_client::RpcRequestClient;
 use zebra_rpc::methods::get_block_template_rpcs::types::peer_info::PeerInfo;
 
 use crate::common::{
-    launch::{can_spawn_zebrad_for_rpc, spawn_zebrad_for_rpc},
+    launch::{can_spawn_zebrad_for_test_type, spawn_zebrad_for_rpc},
     test_type::TestType,
 };
 
@@ -21,7 +21,7 @@ pub(crate) async fn run() -> Result<()> {
     let network = Network::Mainnet;
 
     // Skip the test unless the user specifically asked for it and there is a zebrad_state_path
-    if !can_spawn_zebrad_for_rpc(test_name, test_type) {
+    if !can_spawn_zebrad_for_test_type(test_name, test_type) {
         return Ok(());
     }
 
@@ -29,7 +29,7 @@ pub(crate) async fn run() -> Result<()> {
 
     let (mut zebrad, zebra_rpc_address) =
         spawn_zebrad_for_rpc(network, test_name, test_type, true)?
-            .expect("Already checked zebra state path with can_spawn_zebrad_for_rpc");
+            .expect("Already checked zebra state path with can_spawn_zebrad_for_test_type");
 
     let rpc_address = zebra_rpc_address.expect("getpeerinfo test must have RPC port");
 

--- a/zebrad/tests/common/get_block_template_rpcs/submit_block.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/submit_block.rs
@@ -31,7 +31,7 @@ pub(crate) async fn run() -> Result<()> {
     let network = Network::Mainnet;
 
     // Skip the test unless the user specifically asked for it and there is a zebrad_state_path
-    if !can_spawn_zebrad_for_test_type(test_name, test_type) {
+    if !can_spawn_zebrad_for_test_type(test_name, test_type, true) {
         return Ok(());
     }
 

--- a/zebrad/tests/common/get_block_template_rpcs/submit_block.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/submit_block.rs
@@ -15,7 +15,7 @@ use zebra_node_services::rpc_client::RpcRequestClient;
 
 use crate::common::{
     cached_state::get_raw_future_blocks,
-    launch::{can_spawn_zebrad_for_rpc, spawn_zebrad_for_rpc},
+    launch::{can_spawn_zebrad_for_test_type, spawn_zebrad_for_rpc},
     test_type::TestType,
 };
 
@@ -31,7 +31,7 @@ pub(crate) async fn run() -> Result<()> {
     let network = Network::Mainnet;
 
     // Skip the test unless the user specifically asked for it and there is a zebrad_state_path
-    if !can_spawn_zebrad_for_rpc(test_name, test_type) {
+    if !can_spawn_zebrad_for_test_type(test_name, test_type) {
         return Ok(());
     }
 
@@ -50,7 +50,7 @@ pub(crate) async fn run() -> Result<()> {
     let should_sync = false;
     let (mut zebrad, zebra_rpc_address) =
         spawn_zebrad_for_rpc(network, test_name, test_type, should_sync)?
-            .expect("Already checked zebra state path with can_spawn_zebrad_for_rpc");
+            .expect("Already checked zebra state path with can_spawn_zebrad_for_test_type");
 
     let rpc_address = zebra_rpc_address.expect("submitblock test must have RPC port");
 

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -229,7 +229,7 @@ pub fn spawn_zebrad_for_rpc<S: AsRef<str> + std::fmt::Debug>(
     let test_name = test_name.as_ref();
 
     // Skip the test unless the user specifically asked for it
-    if !can_spawn_zebrad_for_rpc(test_name, test_type) {
+    if !can_spawn_zebrad_for_test_type(test_name, test_type) {
         return Ok(None);
     }
 
@@ -256,7 +256,7 @@ pub fn spawn_zebrad_for_rpc<S: AsRef<str> + std::fmt::Debug>(
 
 /// Returns `true` if a zebrad test for `test_type` has everything it needs to run.
 #[tracing::instrument]
-pub fn can_spawn_zebrad_for_rpc<S: AsRef<str> + std::fmt::Debug>(
+pub fn can_spawn_zebrad_for_test_type<S: AsRef<str> + std::fmt::Debug>(
     test_name: S,
     test_type: TestType,
 ) -> bool {

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -229,7 +229,7 @@ pub fn spawn_zebrad_for_rpc<S: AsRef<str> + std::fmt::Debug>(
     let test_name = test_name.as_ref();
 
     // Skip the test unless the user specifically asked for it
-    if !can_spawn_zebrad_for_test_type(test_name, test_type) {
+    if !can_spawn_zebrad_for_test_type(test_name, test_type, use_internet_connection) {
         return Ok(None);
     }
 
@@ -287,7 +287,7 @@ pub fn spawn_zebrad_without_rpc<S: AsRef<str> + std::fmt::Debug>(
     };
 
     // Skip the test unless the user specifically asked for it
-    if !can_spawn_zebrad_for_test_type(test_name, test_type) {
+    if !can_spawn_zebrad_for_test_type(test_name, test_type, use_internet_connection) {
         return Ok(None);
     }
 
@@ -317,8 +317,9 @@ pub fn spawn_zebrad_without_rpc<S: AsRef<str> + std::fmt::Debug>(
 pub fn can_spawn_zebrad_for_test_type<S: AsRef<str> + std::fmt::Debug>(
     test_name: S,
     test_type: TestType,
+    use_internet_connection: bool,
 ) -> bool {
-    if zebra_test::net::zebra_skip_network_tests() {
+    if use_internet_connection && zebra_test::net::zebra_skip_network_tests() {
         return false;
     }
 

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -236,7 +236,7 @@ pub fn spawn_zebrad_for_rpc<S: AsRef<str> + Debug>(
 
     // Get the zebrad config
     let mut config = test_type
-        .zebrad_config(test_name, use_internet_connection)
+        .zebrad_config(test_name, use_internet_connection, true)
         .expect("already checked config")?;
 
     config.network.network = network;
@@ -276,6 +276,7 @@ pub fn spawn_zebrad_without_rpc<Str, Dir>(
     test_name: Str,
     use_cached_state: bool,
     use_internet_connection: bool,
+    ephemeral: bool,
     reuse_state_path: Dir,
 ) -> Result<Option<TestChild<TempDir>>>
 where
@@ -301,7 +302,7 @@ where
 
     // Get the zebrad config
     let mut config = test_type
-        .zebrad_config(test_name, use_internet_connection)
+        .zebrad_config(test_name, use_internet_connection, ephemeral)
         .expect("already checked config")?;
 
     config.network.network = network;
@@ -342,8 +343,9 @@ pub fn can_spawn_zebrad_for_test_type<S: AsRef<str> + Debug>(
         return false;
     }
 
-    // Check if we have any necessary cached states for the zebrad config
-    test_type.zebrad_config(test_name, true).is_some()
+    // Check if we have any necessary cached states for the zebrad config.
+    // The ephemeral value doesn't matter here.
+    test_type.zebrad_config(test_name, true, true).is_some()
 }
 
 /// Panics if `$pred` is false, with an error report containing:

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -286,13 +286,16 @@ where
     use TestType::*;
 
     let test_name = test_name.as_ref();
+    let reuse_state_path = reuse_state_path.into();
 
     let test_type = if use_cached_state {
         UpdateZebraCachedStateNoRpc
-    } else {
+    } else if ephemeral || reuse_state_path.is_none() {
         LaunchWithEmptyState {
             launches_lightwalletd: false,
         }
+    } else {
+        UseAnyState
     };
 
     // Skip the test unless the user specifically asked for it
@@ -310,7 +313,6 @@ where
     let (zebrad_failure_messages, zebrad_ignore_messages) = test_type.zebrad_failure_messages();
 
     let testdir = reuse_state_path
-        .into()
         .unwrap_or_else(|| testdir().expect("failed to create test temporary directory"));
 
     // Writes a configuration that does not have RPC listen_addr set.

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -13,7 +13,6 @@ use std::{
 };
 
 use color_eyre::eyre::Result;
-use indexmap::IndexSet;
 use tempfile::TempDir;
 
 use zebra_chain::parameters::Network;
@@ -236,19 +235,10 @@ pub fn spawn_zebrad_for_rpc<S: AsRef<str> + std::fmt::Debug>(
 
     // Get the zebrad config
     let mut config = test_type
-        .zebrad_config(test_name)
+        .zebrad_config(test_name, use_internet_connection)
         .expect("already checked config")?;
 
-    // TODO: move this into zebrad_config()
     config.network.network = network;
-    if !use_internet_connection {
-        config.network.initial_mainnet_peers = IndexSet::new();
-        config.network.initial_testnet_peers = IndexSet::new();
-        // Avoid re-using cached peers from disk when we're supposed to be a disconnected instance
-        config.network.cache_dir = CacheDir::disabled();
-
-        config.mempool.debug_enable_at_height = Some(0);
-    }
 
     let (zebrad_failure_messages, zebrad_ignore_messages) = test_type.zebrad_failure_messages();
 
@@ -282,7 +272,7 @@ pub fn can_spawn_zebrad_for_rpc<S: AsRef<str> + std::fmt::Debug>(
     }
 
     // Check if we have any necessary cached states for the zebrad config
-    test_type.zebrad_config(test_name).is_some()
+    test_type.zebrad_config(test_name, true).is_some()
 }
 
 /// Panics if `$pred` is false, with an error report containing:

--- a/zebrad/tests/common/lightwalletd/send_transaction_test.rs
+++ b/zebrad/tests/common/lightwalletd/send_transaction_test.rs
@@ -30,7 +30,7 @@ use zebrad::components::mempool::downloads::MAX_INBOUND_CONCURRENCY;
 
 use crate::common::{
     cached_state::get_future_blocks,
-    launch::{can_spawn_zebrad_for_rpc, spawn_zebrad_for_rpc},
+    launch::{can_spawn_zebrad_for_test_type, spawn_zebrad_for_rpc},
     lightwalletd::{
         can_spawn_lightwalletd_for_rpc, spawn_lightwalletd_for_rpc,
         sync::wait_for_zebrad_and_lightwalletd_sync,
@@ -62,7 +62,7 @@ pub async fn run() -> Result<()> {
     let network = Mainnet;
 
     // Skip the test unless the user specifically asked for it
-    if !can_spawn_zebrad_for_rpc(test_name, test_type) {
+    if !can_spawn_zebrad_for_test_type(test_name, test_type) {
         return Ok(());
     }
 

--- a/zebrad/tests/common/lightwalletd/send_transaction_test.rs
+++ b/zebrad/tests/common/lightwalletd/send_transaction_test.rs
@@ -62,7 +62,7 @@ pub async fn run() -> Result<()> {
     let network = Mainnet;
 
     // Skip the test unless the user specifically asked for it
-    if !can_spawn_zebrad_for_test_type(test_name, test_type) {
+    if !can_spawn_zebrad_for_test_type(test_name, test_type, true) {
         return Ok(());
     }
 

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -5,10 +5,7 @@
 //! Test functions in this file will not be run.
 //! This file is only for test library code.
 
-use std::{
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::{path::PathBuf, time::Duration};
 
 use color_eyre::eyre::Result;
 use tempfile::TempDir;
@@ -19,7 +16,6 @@ use zebrad::{components::sync, config::ZebradConfig};
 use zebra_test::{args, prelude::*};
 
 use super::{
-    cached_state::copy_state_directory,
     config::{persistent_test_config, testdir},
     launch::ZebradTestDirExt,
 };
@@ -339,30 +335,6 @@ pub fn check_sync_logs_until(
     zebrad.expect_stdout_line_matches(stop_regex)?;
 
     Ok(zebrad)
-}
-
-/// Runs a zebrad instance to synchronize the chain to the network tip.
-///
-/// The zebrad instance is executed on a copy of the partially synchronized chain state. This copy
-/// is returned afterwards, containing the fully synchronized chain state.
-#[allow(dead_code)]
-#[tracing::instrument]
-pub async fn copy_state_and_perform_full_sync(
-    network: Network,
-    partial_sync_path: &Path,
-) -> Result<TempDir> {
-    let fully_synced_path = copy_state_directory(network, &partial_sync_path).await?;
-
-    sync_until(
-        Height::MAX,
-        network,
-        SYNC_FINISHED_REGEX,
-        FINISH_PARTIAL_SYNC_TIMEOUT,
-        fully_synced_path,
-        MempoolBehavior::ShouldAutomaticallyActivate,
-        true,
-        false,
-    )
 }
 
 /// Returns a test config for caching Zebra's state up to the mandatory checkpoint.

--- a/zebrad/tests/common/test_type.rs
+++ b/zebrad/tests/common/test_type.rs
@@ -155,12 +155,15 @@ impl TestType {
 
     /// Returns a Zebra config for this test.
     ///
+    /// `ephemeral` is ignored if the test is using a cached state.
+    ///
     /// Returns `None` if the test should be skipped,
     /// and `Some(Err(_))` if the config could not be created.
-    pub fn zebrad_config<S: AsRef<str>>(
+    pub fn zebrad_config<Str: AsRef<str>>(
         &self,
-        test_name: S,
+        test_name: Str,
         use_internet_connection: bool,
+        ephemeral: bool,
     ) -> Option<Result<ZebradConfig>> {
         let config = if self.needs_zebra_rpc_server() {
             // This is what we recommend our users configure.
@@ -201,6 +204,7 @@ impl TestType {
         );
 
         if !self.needs_zebra_cached_state() {
+            config.state.ephemeral = ephemeral;
             return Some(Ok(config));
         }
 


### PR DESCRIPTION
## Motivation

We need a way to upgrade the on-disk database format, without re-syncing the whole chain.

Close #6955

### Complex Code or Requirements

This is concurrent code, we need to be careful to shut down correctly, and regularly check for panics in the inner thread.

A lot of this code is modified from the block write task. We could refactor that task to use a generic `ThreadHandle` type in a future PR.

## Solution

Implementation:
- [Move format upgrades to their own module and enum](https://github.com/ZcashFoundation/zebra/pull/7031/commits/451f97cc1e7ac2a26cdeff72f7d8f799b3f21d11)
- [Launch a format change thread if needed](https://github.com/ZcashFoundation/zebra/pull/7031/commits/79f0fbbe86215e0e7df47dc2c5dd27b98c080d01)
- Shut down the format change thread when Zebra is shutting down
- [Regularly check for panics in the state upgrade task](https://github.com/ZcashFoundation/zebra/pull/7031/commits/c82aa581331f7031150163f6f1617ea6080ddc51)
- [Increment database format to 25.0.2](https://github.com/ZcashFoundation/zebra/pull/7031/commits/2dbc6cee00536d5f40d10f95d35a51f67c429d65)

Logging:
- [Log the running and initial disk database format versions on startup](https://github.com/ZcashFoundation/zebra/pull/7031/commits/d7572cb304fa116ba958506cc961942b80101888)

### Testing

`zebrad` tests:
- Test that a newly created state is the current version, and re-opening it doesn't upgrade or downgrade the version
- Test that a fake older state gets upgraded to the current version
- Test that a fake newer state gets downgraded to the current version
- Add extra test support functions and rename some existing functions

CI:
- [Add initial disk and running state versions to cached state images in CI](https://github.com/ZcashFoundation/zebra/pull/7031/commits/de2453596ad7cb25174488727c9be1476e6e9a6f)
    - This also tests `zebrad` logging the state versions
- [Add a force_save_to_disk argument to the CI workflow](https://github.com/ZcashFoundation/zebra/pull/7031/commits/5a50516773dd3738b727171b6f413bf77202329d)

Related changes:
- [Add some TODOs and remove a redundant timer](https://github.com/ZcashFoundation/zebra/pull/7031/commits/6633f2f68d1890189c790f4823b1644b21a24c86)

## Review

This is a large PR, so I'm happy to do a video review, or split the test harness refactor and the CI changes into separate PRs.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

See #6955:
- documentation for format upgrades
- optional format upgrade debugging log file
- optional refactors
