### PR TITLE
fix(concurrency): Use Arc::into_inner() to avoid potential concurrency issues, needs Rust 1.70

### DIFF
--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -269,9 +269,6 @@ impl ZcashDeserialize for Flags {
         // Consensus rule: "In a version 5 transaction,
         // the reserved bits 2..7 of the flagsOrchard field MUST be zero."
         // https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
-        //
-        // Clippy 1.64 is wrong here, this lazy evaluation is necessary, constructors are functions. This is fixed in 1.66.
-        #[allow(clippy::unnecessary_lazy_evaluations)]
         Flags::from_bits(reader.read_u8()?)
             .ok_or_else(|| SerializationError::Parse("invalid reserved orchard flags"))
     }

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -884,9 +884,6 @@ impl ZcashDeserialize for Transaction {
                 }
                 // Denoted as `nConsensusBranchId` in the spec.
                 // Convert it to a NetworkUpgrade
-                //
-                // Clippy 1.64 is wrong here, this lazy evaluation is necessary, constructors are functions. This is fixed in 1.66.
-                #[allow(clippy::unnecessary_lazy_evaluations)]
                 let network_upgrade =
                     NetworkUpgrade::from_branch_id(limited_reader.read_u32::<LittleEndian>()?)
                         .ok_or_else(|| {

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -280,7 +280,7 @@ where
             check::miner_fees_are_valid(&block, network, block_miner_fees)?;
 
             // Finally, submit the block for contextual verification.
-            let new_outputs = Arc::try_unwrap(known_utxos)
+            let new_outputs = Arc::into_inner(known_utxos)
                 .expect("all verification tasks using known_utxos are complete");
 
             let prepared_block = zs::SemanticallyVerifiedBlock {

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -500,8 +500,6 @@ impl Codec {
     /// Note: zcashd only requires fields up to `address_recv`, but everything up to `relay` is required in Zebra.
     ///       see <https://github.com/zcash/zcash/blob/11d563904933e889a11d9685c3b249f1536cfbe7/src/main.cpp#L6490-L6507>
     fn read_version<R: Read>(&self, mut reader: R) -> Result<Message, Error> {
-        // Clippy 1.64 is wrong here, this lazy evaluation is necessary, constructors are functions. This is fixed in 1.66.
-        #[allow(clippy::unnecessary_lazy_evaluations)]
         Ok(VersionMessage {
             version: Version(reader.read_u32::<LittleEndian>()?),
             // Use from_bits_truncate to discard unknown service bits.

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -399,6 +399,8 @@ impl NonFinalizedState {
             // Pushing a block onto a Chain can launch additional parallel batches.
             // TODO: should we pass _scope into Chain::push()?
             scope.spawn_fifo(|_scope| {
+                // TODO: Replace with Arc::unwrap_or_clone() when it stabilises:
+                // https://github.com/rust-lang/rust/issues/93610
                 let new_chain = Arc::try_unwrap(new_chain)
                     .unwrap_or_else(|shared_chain| (*shared_chain).clone());
                 chain_push_result = Some(new_chain.push(contextual).map(Arc::new));

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -15,6 +15,10 @@ keywords = ["zebra", "zcash"]
 # Must be one of <https://crates.io/category_slugs>
 categories = ["command-line-utilities", "cryptography::cryptocurrencies"]
 
+# Zebra is only supported on the latest stable Rust version. See the README for details.
+# Any Zebra release can break compatibility with older Rust versions.
+rust-version = "1.70"
+
 [[bin]]
 name = "zebra-checkpoints"
 # this setting is required for Zebra's Docker build caches

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 
 # Zebra is only supported on the latest stable Rust version. See the README for details.
 # Any Zebra release can break compatibility with older Rust versions.
-rust-version = "1.66"
+rust-version = "1.70"
 
 # Settings that impact runtime behaviour
 


### PR DESCRIPTION
## Motivation

Some of our code uses an older `Arc` method, which isn't guaranteed to return a value. This can cause hangs or panics in our code if two threads call it at the same time.

### Specifications

The replacement method guarantees that exactly one thread will get the inner value:
https://doc.rust-lang.org/std/sync/struct.Arc.html#method.into_inner

### Complex Code or Requirements

This is a concurrency bug fix, it requires Rust 1.70.

## Solution

Replace `Arc::try_unwrap()` with `Arc::into_inner()`
Update Zebra's Rust version requirement to 1.70

Replacements aren't needed if the code falls back to another method that is guaranteed to be correct.

## Review

This is a routine concurrency fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

