### PR TITLE
change(state): Refactor the structure of finalizable blocks

### DIFF
--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -273,7 +273,7 @@ pub enum FinalizableBlock {
 }
 
 impl FinalizableBlock {
-    /// Create a new `FinalizedBlock` given a `ContextuallyVerifiedBlock`.
+    /// Create a new [`FinalizableBlock`] given a [`ContextuallyVerifiedBlock`].
     pub fn new(contextually_verified: ContextuallyVerifiedBlock, treestate: Treestate) -> Self {
         Self::Contextual {
             contextually_verified,
@@ -282,7 +282,7 @@ impl FinalizableBlock {
     }
 
     #[cfg(test)]
-    /// Extract a `Block` from a `FinalizedBlock` variant.
+    /// Extract a [`Block`] from a [`FinalizableBlock`] variant.
     pub fn inner_block(&self) -> Arc<Block> {
         match self {
             FinalizableBlock::Checkpoint {

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -273,6 +273,7 @@ pub enum FinalizableBlock {
 }
 
 impl FinalizableBlock {
+    /// Create a new `FinalizedBlock` given a `ContextuallyVerifiedBlock`.
     pub fn new(contextually_verified: ContextuallyVerifiedBlock, treestate: Treestate) -> Self {
         Self::Contextual {
             contextually_verified,
@@ -281,6 +282,7 @@ impl FinalizableBlock {
     }
 
     #[cfg(test)]
+    /// Extract a `Block` from a `FinalizedBlock` variant.
     pub fn inner_block(&self) -> Arc<Block> {
         match self {
             FinalizableBlock::Checkpoint {

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -262,6 +262,10 @@ pub struct SemanticallyVerifiedBlockWithTrees {
     pub treestate: Treestate,
 }
 
+/// Contains a block ready to be committed.
+///
+/// Zebra's state service passes this `enum` over to the finalized state
+ /// when committing a block.
 pub enum FinalizableBlock {
     Checkpoint {
         checkpoint_verified: CheckpointVerifiedBlock,

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -255,7 +255,7 @@ impl Treestate {
 /// when committing a block. The associated treestate is passed so that the
 /// finalized state does not have to retrieve the previous treestate from the
 /// database and recompute a new one.
-pub struct ContextuallyVerifiedBlockWithTrees {
+pub struct SemanticallyVerifiedBlockWithTrees {
     /// A block ready to be committed.
     pub verified: SemanticallyVerifiedBlock,
     /// The tresstate associated with the block.

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -265,7 +265,7 @@ pub struct SemanticallyVerifiedBlockWithTrees {
 /// Contains a block ready to be committed.
 ///
 /// Zebra's state service passes this `enum` over to the finalized state
- /// when committing a block.
+/// when committing a block.
 pub enum FinalizableBlock {
     Checkpoint {
         checkpoint_verified: CheckpointVerifiedBlock,

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -236,7 +236,7 @@ impl FinalizedState {
                 // treestate of the finalized tip from the database and update it for the block
                 // being committed, assuming the retrieved treestate is the parent block's
                 // treestate. Later on, this function proves this assumption by asserting that the
-                // finalized tip is the parent block of the block being commited.
+                // finalized tip is the parent block of the block being committed.
 
                 let block = checkpoint_verified.block.clone();
                 let mut history_tree = self.db.history_tree();

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -339,8 +339,8 @@ impl FinalizedState {
             // TODO: move the stop height check to the syncer (#3442)
             if self.is_at_stop_height(height) {
                 tracing::info!(
-                    height = ?height,
-                    hash = ?hash,
+                    ?height,
+                    ?hash,
                     block_source = ?source,
                     "stopping at configured height, flushing database to disk"
                 );

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -23,7 +23,7 @@ use std::{
 use zebra_chain::{block, parameters::Network};
 
 use crate::{
-    request::ContextuallyVerifiedBlockWithTrees,
+    request::{ContextuallyVerifiedBlockWithTrees, FinalizableBlock, Treestate},
     service::{check, QueuedCheckpointVerified},
     BoxError, CheckpointVerifiedBlock, CloneError, Config,
 };
@@ -225,53 +225,22 @@ impl FinalizedState {
     #[allow(clippy::unwrap_in_result)]
     pub fn commit_finalized_direct(
         &mut self,
-        contextually_verified_with_trees: ContextuallyVerifiedBlockWithTrees,
+        finalizable_block: FinalizableBlock,
         source: &str,
     ) -> Result<block::Hash, BoxError> {
-        let finalized = contextually_verified_with_trees.block;
-        let committed_tip_hash = self.db.finalized_tip_hash();
-        let committed_tip_height = self.db.finalized_tip_height();
+        let (height, hash, finalized) = match finalizable_block {
+            FinalizableBlock::Checkpoint {
+                checkpoint_verified,
+            } => {
+                // Checkpoint-verified blocks don't have an associated treestate, so we get the most
+                // recent one from the database and update it for the block being committed.
 
-        // Assert that callers (including unit tests) get the chain order correct
-        if self.db.is_empty() {
-            assert_eq!(
-                committed_tip_hash, finalized.block.header.previous_block_hash,
-                "the first block added to an empty state must be a genesis block, source: {source}",
-            );
-            assert_eq!(
-                block::Height(0),
-                finalized.height,
-                "cannot commit genesis: invalid height, source: {source}",
-            );
-        } else {
-            assert_eq!(
-                committed_tip_height.expect("state must have a genesis block committed") + 1,
-                Some(finalized.height),
-                "committed block height must be 1 more than the finalized tip height, source: {source}",
-            );
-
-            assert_eq!(
-                committed_tip_hash, finalized.block.header.previous_block_hash,
-                "committed block must be a child of the finalized tip, source: {source}",
-            );
-        }
-
-        let (history_tree, note_commitment_trees) = match contextually_verified_with_trees.treestate
-        {
-            // If the treestate associated with the block was supplied, use it
-            // without recomputing it.
-            Some(ref treestate) => (
-                treestate.history_tree.clone(),
-                treestate.note_commitment_trees.clone(),
-            ),
-            // If the treestate was not supplied, retrieve a previous treestate
-            // from the database, and update it for the block being committed.
-            None => {
+                let block = checkpoint_verified.block.clone();
                 let mut history_tree = self.db.history_tree();
                 let mut note_commitment_trees = self.db.note_commitment_trees();
 
                 // Update the note commitment trees.
-                note_commitment_trees.update_trees_parallel(&finalized.block)?;
+                note_commitment_trees.update_trees_parallel(&block)?;
 
                 // Check the block commitment if the history tree was not
                 // supplied by the non-finalized state. Note that we don't do
@@ -291,7 +260,7 @@ impl FinalizedState {
                 // TODO: run this CPU-intensive cryptography in a parallel rayon
                 // thread, if it shows up in profiles
                 check::block_commitment_is_valid_for_chain_history(
-                    finalized.block.clone(),
+                    block.clone(),
                     self.network,
                     &history_tree,
                 )?;
@@ -303,27 +272,67 @@ impl FinalizedState {
                 let history_tree_mut = Arc::make_mut(&mut history_tree);
                 let sapling_root = note_commitment_trees.sapling.root();
                 let orchard_root = note_commitment_trees.orchard.root();
-                history_tree_mut.push(
-                    self.network(),
-                    finalized.block.clone(),
-                    sapling_root,
-                    orchard_root,
-                )?;
+                history_tree_mut.push(self.network(), block.clone(), sapling_root, orchard_root)?;
 
-                (history_tree, note_commitment_trees)
+                (
+                    checkpoint_verified.height,
+                    checkpoint_verified.hash,
+                    ContextuallyVerifiedBlockWithTrees {
+                        verified: checkpoint_verified.0,
+                        treestate: Treestate {
+                            note_commitment_trees,
+                            history_tree,
+                        },
+                    },
+                )
             }
+            FinalizableBlock::Contextual {
+                contextually_verified,
+                treestate,
+            } => (
+                contextually_verified.height,
+                contextually_verified.hash,
+                ContextuallyVerifiedBlockWithTrees {
+                    verified: contextually_verified.into(),
+                    treestate,
+                },
+            ),
         };
 
-        let finalized_height = finalized.height;
-        let finalized_hash = finalized.hash;
+        let committed_tip_hash = self.db.finalized_tip_hash();
+        let committed_tip_height = self.db.finalized_tip_height();
+
+        // Assert that callers (including unit tests) get the chain order correct
+        if self.db.is_empty() {
+            assert_eq!(
+                committed_tip_hash, finalized.verified.block.header.previous_block_hash,
+                "the first block added to an empty state must be a genesis block, source: {source}",
+            );
+            assert_eq!(
+                block::Height(0),
+                height,
+                "cannot commit genesis: invalid height, source: {source}",
+            );
+        } else {
+            assert_eq!(
+                committed_tip_height.expect("state must have a genesis block committed") + 1,
+                Some(height),
+                "committed block height must be 1 more than the finalized tip height, source: {source}",
+            );
+
+            assert_eq!(
+                committed_tip_hash, finalized.verified.block.header.previous_block_hash,
+                "committed block must be a child of the finalized tip, source: {source}",
+            );
+        }
 
         #[cfg(feature = "elasticsearch")]
-        let finalized_block = finalized.block.clone();
+        let finalized_block = finalized.verified.block.clone();
 
         let result = self.db.write_block(
-            finalized,
-            history_tree,
-            note_commitment_trees,
+            finalized.verified,
+            finalized.treestate.history_tree,
+            finalized.treestate.note_commitment_trees,
             self.network,
             source,
         );
@@ -334,10 +343,10 @@ impl FinalizedState {
             self.elasticsearch(&finalized_block);
 
             // TODO: move the stop height check to the syncer (#3442)
-            if self.is_at_stop_height(finalized_height) {
+            if self.is_at_stop_height(height) {
                 tracing::info!(
-                    height = ?finalized_height,
-                    hash = ?finalized_hash,
+                    height = ?height,
+                    hash = ?hash,
                     block_source = ?source,
                     "stopping at configured height, flushing database to disk"
                 );

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -329,13 +329,7 @@ impl FinalizedState {
         #[cfg(feature = "elasticsearch")]
         let finalized_block = finalized.verified.block.clone();
 
-        let result = self.db.write_block(
-            finalized.verified,
-            finalized.treestate.history_tree,
-            finalized.treestate.note_commitment_trees,
-            self.network,
-            source,
-        );
+        let result = self.db.write_block(finalized, self.network, source);
 
         if result.is_ok() {
             // Save blocks to elasticsearch if the feature is enabled.

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -23,7 +23,7 @@ use std::{
 use zebra_chain::{block, parameters::Network};
 
 use crate::{
-    request::{ContextuallyVerifiedBlockWithTrees, FinalizableBlock, Treestate},
+    request::{FinalizableBlock, SemanticallyVerifiedBlockWithTrees, Treestate},
     service::{check, QueuedCheckpointVerified},
     BoxError, CheckpointVerifiedBlock, CloneError, Config,
 };
@@ -278,7 +278,7 @@ impl FinalizedState {
                 (
                     checkpoint_verified.height,
                     checkpoint_verified.hash,
-                    ContextuallyVerifiedBlockWithTrees {
+                    SemanticallyVerifiedBlockWithTrees {
                         verified: checkpoint_verified.0,
                         treestate: Treestate {
                             note_commitment_trees,
@@ -293,7 +293,7 @@ impl FinalizedState {
             } => (
                 contextually_verified.height,
                 contextually_verified.hash,
-                ContextuallyVerifiedBlockWithTrees {
+                SemanticallyVerifiedBlockWithTrees {
                     verified: contextually_verified.into(),
                     treestate,
                 },

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -232,8 +232,9 @@ impl FinalizedState {
             FinalizableBlock::Checkpoint {
                 checkpoint_verified,
             } => {
-                // Checkpoint-verified blocks don't have an associated treestate, so we get the most
-                // recent one from the database and update it for the block being committed.
+                // Checkpoint-verified blocks don't have an associated treestate, so we get the parent
+                // block treestate from the database and update it for the block being committed.
+                // We check that the treestate is the parent block in an assert later in this function.
 
                 let block = checkpoint_verified.block.clone();
                 let mut history_tree = self.db.history_tree();

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -232,9 +232,11 @@ impl FinalizedState {
             FinalizableBlock::Checkpoint {
                 checkpoint_verified,
             } => {
-                // Checkpoint-verified blocks don't have an associated treestate, so we get the parent
-                // block treestate from the database and update it for the block being committed.
-                // We check that the treestate is the parent block in an assert later in this function.
+                // Checkpoint-verified blocks don't have an associated treestate, so we retrieve the
+                // treestate of the finalized tip from the database and update it for the block
+                // being committed, assuming the retrieved treestate is the parent block's
+                // treestate. Later on, this function proves this assumption by asserting that the
+                // finalized tip is the parent block of the block being commited.
 
                 let block = checkpoint_verified.block.clone();
                 let mut history_tree = self.db.history_tree();

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -29,7 +29,7 @@ use zebra_chain::{
 };
 
 use crate::{
-    request::ContextuallyVerifiedBlockWithTrees,
+    request::SemanticallyVerifiedBlockWithTrees,
     service::finalized_state::{
         disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
         disk_format::{
@@ -280,7 +280,7 @@ impl ZebraDb {
     /// - Propagates any errors from updating history and note commitment trees
     pub(in super::super) fn write_block(
         &mut self,
-        finalized: ContextuallyVerifiedBlockWithTrees,
+        finalized: SemanticallyVerifiedBlockWithTrees,
         network: Network,
         source: &str,
     ) -> Result<block::Hash, BoxError> {
@@ -427,7 +427,7 @@ impl DiskWriteBatch {
     pub fn prepare_block_batch(
         &mut self,
         db: &DiskDb,
-        finalized: &ContextuallyVerifiedBlockWithTrees,
+        finalized: &SemanticallyVerifiedBlockWithTrees,
         new_outputs_by_out_loc: BTreeMap<OutputLocation, transparent::Utxo>,
         spent_utxos_by_outpoint: HashMap<transparent::OutPoint, transparent::Utxo>,
         spent_utxos_by_out_loc: BTreeMap<OutputLocation, transparent::Utxo>,

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -21,6 +21,7 @@ use zebra_chain::{
 };
 
 use crate::{
+    request::ContextuallyVerifiedBlockWithTrees,
     service::finalized_state::{
         disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
         zebra_db::ZebraDb,
@@ -69,15 +70,14 @@ impl DiskWriteBatch {
     pub fn prepare_history_batch(
         &mut self,
         db: &DiskDb,
-        finalized: &SemanticallyVerifiedBlock,
-        history_tree: Arc<HistoryTree>,
+        finalized: &ContextuallyVerifiedBlockWithTrees,
     ) -> Result<(), BoxError> {
         let history_tree_cf = db.cf_handle("history_tree").unwrap();
 
-        let SemanticallyVerifiedBlock { height, .. } = finalized;
+        let height = finalized.verified.height;
 
         // Update the tree in state
-        let current_tip_height = *height - 1;
+        let current_tip_height = height - 1;
         if let Some(h) = current_tip_height {
             self.zs_delete(&history_tree_cf, h);
         }
@@ -87,7 +87,7 @@ impl DiskWriteBatch {
         // Otherwise, the ReadStateService could access a height
         // that was just deleted by a concurrent StateService write.
         // This requires a database version update.
-        if let Some(history_tree) = history_tree.as_ref().as_ref() {
+        if let Some(history_tree) = finalized.treestate.history_tree.as_ref().as_ref() {
             self.zs_insert(&history_tree_cf, height, history_tree);
         }
 

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -21,7 +21,7 @@ use zebra_chain::{
 };
 
 use crate::{
-    request::ContextuallyVerifiedBlockWithTrees,
+    request::SemanticallyVerifiedBlockWithTrees,
     service::finalized_state::{
         disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
         zebra_db::ZebraDb,
@@ -70,7 +70,7 @@ impl DiskWriteBatch {
     pub fn prepare_history_batch(
         &mut self,
         db: &DiskDb,
-        finalized: &ContextuallyVerifiedBlockWithTrees,
+        finalized: &SemanticallyVerifiedBlockWithTrees,
     ) -> Result<(), BoxError> {
         let history_tree_cf = db.cf_handle("history_tree").unwrap();
 

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -15,11 +15,12 @@
 use std::sync::Arc;
 
 use zebra_chain::{
-    block::Height, history_tree::HistoryTree, orchard, parallel::tree::NoteCommitmentTrees,
-    sapling, sprout, transaction::Transaction,
+    block::Height, orchard, parallel::tree::NoteCommitmentTrees, sapling, sprout,
+    transaction::Transaction,
 };
 
 use crate::{
+    request::ContextuallyVerifiedBlockWithTrees,
     service::finalized_state::{
         disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
         zebra_db::ZebraDb,
@@ -264,9 +265,7 @@ impl DiskWriteBatch {
     pub fn prepare_note_commitment_batch(
         &mut self,
         db: &DiskDb,
-        finalized: &SemanticallyVerifiedBlock,
-        note_commitment_trees: NoteCommitmentTrees,
-        history_tree: Arc<HistoryTree>,
+        finalized: &ContextuallyVerifiedBlockWithTrees,
     ) -> Result<(), BoxError> {
         let sprout_anchors = db.cf_handle("sprout_anchors").unwrap();
         let sapling_anchors = db.cf_handle("sapling_anchors").unwrap();
@@ -276,7 +275,8 @@ impl DiskWriteBatch {
         let sapling_note_commitment_tree_cf = db.cf_handle("sapling_note_commitment_tree").unwrap();
         let orchard_note_commitment_tree_cf = db.cf_handle("orchard_note_commitment_tree").unwrap();
 
-        let SemanticallyVerifiedBlock { height, .. } = finalized;
+        let height = finalized.verified.height;
+        let note_commitment_trees = finalized.treestate.note_commitment_trees.clone();
 
         // Use the cached values that were previously calculated in parallel.
         let sprout_root = note_commitment_trees.sprout.root();
@@ -290,7 +290,7 @@ impl DiskWriteBatch {
         self.zs_insert(&orchard_anchors, orchard_root, ());
 
         // Delete the previously stored Sprout note commitment tree.
-        let current_tip_height = *height - 1;
+        let current_tip_height = height - 1;
         if let Some(h) = current_tip_height {
             self.zs_delete(&sprout_note_commitment_tree_cf, h);
         }
@@ -317,7 +317,7 @@ impl DiskWriteBatch {
             note_commitment_trees.orchard,
         );
 
-        self.prepare_history_batch(db, finalized, history_tree)
+        self.prepare_history_batch(db, finalized)
     }
 
     /// Prepare a database batch containing the initial note commitment trees,

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -20,7 +20,7 @@ use zebra_chain::{
 };
 
 use crate::{
-    request::ContextuallyVerifiedBlockWithTrees,
+    request::SemanticallyVerifiedBlockWithTrees,
     service::finalized_state::{
         disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
         zebra_db::ZebraDb,
@@ -265,7 +265,7 @@ impl DiskWriteBatch {
     pub fn prepare_note_commitment_batch(
         &mut self,
         db: &DiskDb,
-        finalized: &ContextuallyVerifiedBlockWithTrees,
+        finalized: &SemanticallyVerifiedBlockWithTrees,
     ) -> Result<(), BoxError> {
         let sprout_anchors = db.cf_handle("sprout_anchors").unwrap();
         let sapling_anchors = db.cf_handle("sapling_anchors").unwrap();

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -16,7 +16,7 @@ use zebra_chain::{
 
 use crate::{
     constants::MAX_NON_FINALIZED_CHAIN_FORKS,
-    request::{ContextuallyVerifiedBlock, ContextuallyVerifiedBlockWithTrees},
+    request::{ContextuallyVerifiedBlock, FinalizableBlock},
     service::{check, finalized_state::ZebraDb},
     SemanticallyVerifiedBlock, ValidateContextError,
 };
@@ -174,7 +174,7 @@ impl NonFinalizedState {
 
     /// Finalize the lowest height block in the non-finalized portion of the best
     /// chain and update all side-chains to match.
-    pub fn finalize(&mut self) -> ContextuallyVerifiedBlockWithTrees {
+    pub fn finalize(&mut self) -> FinalizableBlock {
         // Chain::cmp uses the partial cumulative work, and the hash of the tip block.
         // Neither of these fields has interior mutability.
         // (And when the tip block is dropped for a chain, the chain is also dropped.)
@@ -226,7 +226,7 @@ impl NonFinalizedState {
         self.update_metrics_for_chains();
 
         // Add the treestate to the finalized block.
-        ContextuallyVerifiedBlockWithTrees::new(best_chain_root, root_treestate)
+        FinalizableBlock::new(best_chain_root, root_treestate)
     }
 
     /// Commit block to the non-finalized state, on top of:

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -213,13 +213,12 @@ fn finalize_pops_from_best_chain_for_network(network: Network) -> Result<()> {
     state.commit_block(block2.clone().prepare(), &finalized_state)?;
     state.commit_block(child.prepare(), &finalized_state)?;
 
-    let finalized_with_trees = state.finalize();
-    let finalized = finalized_with_trees.block;
-    assert_eq!(block1, finalized.block);
+    let finalized = state.finalize().inner_block();
 
-    let finalized_with_trees = state.finalize();
-    let finalized = finalized_with_trees.block;
-    assert_eq!(block2, finalized.block);
+    assert_eq!(block1, finalized);
+
+    let finalized = state.finalize().inner_block();
+    assert_eq!(block2, finalized);
 
     assert!(state.best_chain().is_none());
 


### PR DESCRIPTION
## Motivation

Close #6912.

## Solution

- Create `FinalizableBlock` and use it instead of `ContextuallyVerifiedBlockWithTrees` in `commit_finalized_direct()`.
- Pass `ContextuallyVerifiedBlockWithTrees` instead of passing separate `finalized`, `history_tree`, and `note_commitment_trees` when storing blocks in the finalized state. This also simplifies the internal API when storing blocks since the parameter list is shorter.

This PR is based on PR #7025.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

