### PR TITLE
fix(network): Rate-limit inbound connections per IP.

### DIFF
--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -615,6 +615,9 @@ where
                 // Too many open inbound connections or pending handshakes already.
                 // Close the connection.
                 std::mem::drop(tcp_stream);
+                // Allow invalid connections to be cleared quickly,
+                // but still put a limit on our CPU and network usage from failed connections.
+                tokio::time::sleep(constants::MIN_INBOUND_PEER_FAILED_CONNECTION_INTERVAL).await;
                 continue;
             }
 

--- a/zebra-network/src/peer_set/initialize/recent_by_ip.rs
+++ b/zebra-network/src/peer_set/initialize/recent_by_ip.rs
@@ -53,9 +53,7 @@ impl RecentByIp {
     /// Returns true if the recently attempted inbound connection count is past the configured limit.
     pub fn is_past_limit_or_add(&mut self, ip: IpAddr) -> bool {
         let now = Instant::now();
-        if self.by_ip.contains_key(&ip) {
-            self.prune_by_time(now);
-        }
+        self.prune_by_time(now);
 
         let count = self.by_ip.entry(ip).or_default();
         if *count >= self.max_connections_per_ip {

--- a/zebra-network/src/peer_set/initialize/recent_by_ip.rs
+++ b/zebra-network/src/peer_set/initialize/recent_by_ip.rs
@@ -8,6 +8,9 @@ use std::{
 
 use crate::constants;
 
+#[cfg(test)]
+mod tests;
+
 #[derive(Debug)]
 /// Stores IPs of recently attempted inbound connections.
 pub struct RecentByIp {
@@ -50,7 +53,9 @@ impl RecentByIp {
     /// Returns true if there was a recently attempted inbound connection.
     pub fn is_past_limit_or_add(&mut self, ip: IpAddr) -> bool {
         let now = Instant::now();
-        self.prune_by_time(now);
+        if self.by_ip.contains_key(&ip) {
+            self.prune_by_time(now);
+        }
 
         let count = self.by_ip.entry(ip).or_default();
         if *count >= self.max_connections_per_ip {
@@ -64,81 +69,22 @@ impl RecentByIp {
 
     /// Prunes entries older than `time_limit`, decrementing or removing their counts in `by_ip`.
     fn prune_by_time(&mut self, now: Instant) {
-        while let Some((ip, time)) = self.by_time.pop_front() {
-            if now.saturating_duration_since(time) <= self.time_limit {
-                return self.by_time.push_front((ip, time));
-            }
+        // `by_time` must be sorted for this to work.
+        let split_off_idx = self
+            .by_time
+            .partition_point(|&(_, time)| now.saturating_duration_since(time) > self.time_limit);
 
-            if let Some(count) = self.by_ip.get_mut(&ip) {
+        let updated_by_time = self.by_time.split_off(split_off_idx);
+
+        for (ip, _) in &self.by_time {
+            if let Some(count) = self.by_ip.get_mut(ip) {
                 *count -= 1;
                 if *count == 0 {
-                    self.by_ip.remove(&ip);
+                    self.by_ip.remove(ip);
                 }
             }
         }
+
+        self.by_time = updated_by_time;
     }
-}
-
-#[test]
-fn old_connection_attempts_are_pruned() {
-    const TEST_TIME_LIMIT: Duration = Duration::from_secs(5);
-
-    let _init_guard = zebra_test::init();
-
-    let mut recent_connections = RecentByIp::new(Some(TEST_TIME_LIMIT), None);
-    let ip = "127.0.0.1".parse().expect("should parse");
-
-    assert!(
-        !recent_connections.is_past_limit_or_add(ip),
-        "should not be past limit"
-    );
-    assert!(
-        recent_connections.is_past_limit_or_add(ip),
-        "should be past max_connections_per_ip limit"
-    );
-
-    std::thread::sleep(TEST_TIME_LIMIT / 3);
-
-    assert!(
-        recent_connections.is_past_limit_or_add(ip),
-        "should still contain entry after a third of the time limit"
-    );
-
-    std::thread::sleep(3 * TEST_TIME_LIMIT / 4);
-
-    assert!(
-        !recent_connections.is_past_limit_or_add(ip),
-        "should prune entry after 13/12 * time_limit"
-    );
-
-    const TEST_MAX_CONNS_PER_IP: usize = 3;
-
-    let mut recent_connections =
-        RecentByIp::new(Some(TEST_TIME_LIMIT), Some(TEST_MAX_CONNS_PER_IP));
-
-    for _ in 0..TEST_MAX_CONNS_PER_IP {
-        assert!(
-            !recent_connections.is_past_limit_or_add(ip),
-            "should not be past limit"
-        );
-    }
-
-    assert!(
-        recent_connections.is_past_limit_or_add(ip),
-        "should be past max_connections_per_ip limit"
-    );
-
-    std::thread::sleep(TEST_TIME_LIMIT / 3);
-
-    assert!(
-        recent_connections.is_past_limit_or_add(ip),
-        "should still be past limit after a third of the reconnection delay"
-    );
-
-    std::thread::sleep(3 * TEST_TIME_LIMIT / 4);
-
-    assert!(
-        !recent_connections.is_past_limit_or_add(ip),
-        "should prune entry after 13/12 * time_limit"
-    );
 }

--- a/zebra-network/src/peer_set/initialize/recent_by_ip.rs
+++ b/zebra-network/src/peer_set/initialize/recent_by_ip.rs
@@ -1,50 +1,79 @@
 //! A set of IPs from recent connection attempts.
 
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::{HashMap, VecDeque},
     net::IpAddr,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use crate::constants;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 /// Stores IPs of recently attempted inbound connections.
 pub struct RecentByIp {
     /// The list of IPs in increasing connection time order.
     pub by_time: VecDeque<(IpAddr, Instant)>,
 
-    /// Stores a set of IPs for recently attempted inbound connections.
-    // TODO: Replace with `HashMap<IpAddr, usize>` to support
-    //       configured `max_connections_per_ip` greater than 1.
-    pub by_ip: HashSet<IpAddr>,
+    /// Stores IPs for recently attempted inbound connections.
+    pub by_ip: HashMap<IpAddr, usize>,
+
+    /// The maximum number of peer connections Zebra will keep for a given IP address
+    /// before it drops any additional peer connections with that IP.
+    pub max_connections_per_ip: usize,
+
+    /// The duration to wait after an entry is added before removing it.
+    pub time_limit: Duration,
+}
+
+impl Default for RecentByIp {
+    fn default() -> Self {
+        Self::new(None, None)
+    }
 }
 
 impl RecentByIp {
+    pub fn new(time_limit: Option<Duration>, max_connections_per_ip: Option<usize>) -> Self {
+        let (by_time, by_ip) = Default::default();
+        Self {
+            by_time,
+            by_ip,
+            time_limit: time_limit.unwrap_or(constants::MIN_PEER_RECONNECTION_DELAY),
+            max_connections_per_ip: max_connections_per_ip
+                .unwrap_or(constants::DEFAULT_MAX_CONNS_PER_IP),
+        }
+    }
+
     /// Prunes outdated entries, checks if there's a recently attempted inbound connection with
     /// this IP, and adds the entry to `by_time` if it wasn't already in `by_ip`.
     ///
     /// Returns true if there was a recently attempted inbound connection.
-    #[allow(dead_code)]
-    pub fn has_or_add(&mut self, ip: IpAddr) -> bool {
-        self.prune_by_time();
-        if self.by_ip.insert(ip) {
-            self.by_time.push_back((ip, Instant::now()));
-            false
-        } else {
+    pub fn is_past_limit_or_add(&mut self, ip: IpAddr) -> bool {
+        let now = Instant::now();
+        self.prune_by_time(now);
+
+        let count = self.by_ip.entry(ip).or_default();
+        if *count >= self.max_connections_per_ip {
             true
+        } else {
+            *count += 1;
+            self.by_time.push_back((ip, now));
+            false
         }
     }
 
     /// Prunes entries older than [`constants::MIN_PEER_RECONNECTION_DELAY`].
-    #[allow(dead_code)]
-    fn prune_by_time(&mut self) {
-        let now = Instant::now();
+    fn prune_by_time(&mut self, now: Instant) {
         while let Some((ip, time)) = self.by_time.pop_front() {
             if now.saturating_duration_since(time) <= constants::MIN_PEER_RECONNECTION_DELAY {
                 return self.by_time.push_front((ip, time));
             }
-            self.by_ip.remove(&ip);
+
+            if let Some(count) = self.by_ip.get_mut(&ip) {
+                *count -= 1;
+                if *count == 0 {
+                    self.by_ip.remove(&ip);
+                }
+            }
         }
     }
 }
@@ -56,22 +85,57 @@ fn old_connection_attempts_are_pruned() {
     let ip = "127.0.0.1".parse().expect("should parse");
 
     assert!(
-        !recent_connections.has_or_add(ip),
-        "new RecentConnections should be empty"
+        !recent_connections.is_past_limit_or_add(ip),
+        "should not be past limit"
     );
-    assert!(recent_connections.has_or_add(ip), "should now contain ip");
+    assert!(
+        recent_connections.is_past_limit_or_add(ip),
+        "should be past max_connections_per_ip limit"
+    );
 
     std::thread::sleep(constants::MIN_PEER_RECONNECTION_DELAY / 3);
 
     assert!(
-        recent_connections.has_or_add(ip),
+        recent_connections.is_past_limit_or_add(ip),
         "should still contain entry after a third of the reconnection delay"
     );
 
     std::thread::sleep(3 * constants::MIN_PEER_RECONNECTION_DELAY / 4);
 
     assert!(
-        !recent_connections.has_or_add(ip),
+        !recent_connections.is_past_limit_or_add(ip),
         "should prune entry after 13/12 * MIN_PEER_RECONNECTION_DELAY"
+    );
+
+    const TEST_MAX_CONNS_PER_IP: usize = 3;
+    const TEST_TIME_LIMIT: Duration = Duration::from_secs(5);
+
+    let mut recent_connections =
+        RecentByIp::new(Some(TEST_TIME_LIMIT), Some(TEST_MAX_CONNS_PER_IP));
+
+    for _ in 0..TEST_MAX_CONNS_PER_IP {
+        assert!(
+            !recent_connections.is_past_limit_or_add(ip),
+            "should not be past limit"
+        );
+    }
+
+    assert!(
+        recent_connections.is_past_limit_or_add(ip),
+        "should be past max_connections_per_ip limit"
+    );
+
+    std::thread::sleep(TEST_TIME_LIMIT / 3);
+
+    assert!(
+        recent_connections.is_past_limit_or_add(ip),
+        "should still be past limit after a third of the reconnection delay"
+    );
+
+    std::thread::sleep(3 * TEST_TIME_LIMIT / 4);
+
+    assert!(
+        !recent_connections.is_past_limit_or_add(ip),
+        "should prune entry after 13/12 * time_limit"
     );
 }

--- a/zebra-network/src/peer_set/initialize/recent_by_ip.rs
+++ b/zebra-network/src/peer_set/initialize/recent_by_ip.rs
@@ -1,0 +1,77 @@
+//! A set of IPs from recent connection attempts.
+
+use std::{
+    collections::{HashSet, VecDeque},
+    net::IpAddr,
+    time::Instant,
+};
+
+use crate::constants;
+
+#[derive(Debug, Default)]
+/// Stores IPs of recently attempted inbound connections.
+pub struct RecentByIp {
+    /// The list of IPs in increasing connection time order.
+    pub by_time: VecDeque<(IpAddr, Instant)>,
+
+    /// Stores a set of IPs for recently attempted inbound connections.
+    // TODO: Replace with `HashMap<IpAddr, usize>` to support
+    //       configured `max_connections_per_ip` greater than 1.
+    pub by_ip: HashSet<IpAddr>,
+}
+
+impl RecentByIp {
+    /// Prunes outdated entries, checks if there's a recently attempted inbound connection with
+    /// this IP, and adds the entry to `by_time` if it wasn't already in `by_ip`.
+    ///
+    /// Returns true if there was a recently attempted inbound connection.
+    #[allow(dead_code)]
+    pub fn has_or_add(&mut self, ip: IpAddr) -> bool {
+        self.prune_by_time();
+        if self.by_ip.insert(ip) {
+            self.by_time.push_back((ip, Instant::now()));
+            false
+        } else {
+            true
+        }
+    }
+
+    /// Prunes entries older than [`constants::MIN_PEER_RECONNECTION_DELAY`].
+    #[allow(dead_code)]
+    fn prune_by_time(&mut self) {
+        let now = Instant::now();
+        while let Some((ip, time)) = self.by_time.pop_front() {
+            if now.saturating_duration_since(time) <= constants::MIN_PEER_RECONNECTION_DELAY {
+                return self.by_time.push_front((ip, time));
+            }
+            self.by_ip.remove(&ip);
+        }
+    }
+}
+
+#[test]
+fn old_connection_attempts_are_pruned() {
+    let _init_guard = zebra_test::init();
+    let mut recent_connections = RecentByIp::default();
+    let ip = "127.0.0.1".parse().expect("should parse");
+
+    assert!(
+        !recent_connections.has_or_add(ip),
+        "new RecentConnections should be empty"
+    );
+    assert!(recent_connections.has_or_add(ip), "should now contain ip");
+
+    std::thread::sleep(constants::MIN_PEER_RECONNECTION_DELAY / 3);
+
+    assert!(
+        recent_connections.has_or_add(ip),
+        "should still contain entry after a third of the reconnection delay"
+    );
+
+    std::thread::sleep(3 * constants::MIN_PEER_RECONNECTION_DELAY / 4);
+
+    assert!(
+        !recent_connections.has_or_add(ip),
+        "should prune entry after 13/12 * MIN_PEER_RECONNECTION_DELAY"
+    );
+}

--- a/zebra-network/src/peer_set/initialize/recent_by_ip.rs
+++ b/zebra-network/src/peer_set/initialize/recent_by_ip.rs
@@ -48,9 +48,9 @@ impl RecentByIp {
     }
 
     /// Prunes outdated entries, checks if there's a recently attempted inbound connection with
-    /// this IP, and adds the entry to `by_time` if it wasn't already in `by_ip`.
+    /// this IP, and adds the entry to `by_time`, and `by_ip` if needed.
     ///
-    /// Returns true if there was a recently attempted inbound connection.
+    /// Returns true if the recently attempted inbound connection count is past the configured limit.
     pub fn is_past_limit_or_add(&mut self, ip: IpAddr) -> bool {
         let now = Instant::now();
         if self.by_ip.contains_key(&ip) {

--- a/zebra-network/src/peer_set/initialize/recent_by_ip.rs
+++ b/zebra-network/src/peer_set/initialize/recent_by_ip.rs
@@ -14,7 +14,7 @@ mod tests;
 #[derive(Debug)]
 /// Stores IPs of recently attempted inbound connections.
 pub struct RecentByIp {
-    /// The list of IPs in increasing connection time order.
+    /// The list of IPs in decreasing connection age order.
     pub by_time: VecDeque<(IpAddr, Instant)>,
 
     /// Stores IPs for recently attempted inbound connections.

--- a/zebra-network/src/peer_set/initialize/recent_by_ip/tests.rs
+++ b/zebra-network/src/peer_set/initialize/recent_by_ip/tests.rs
@@ -1,0 +1,67 @@
+use std::time::Duration;
+
+use crate::peer_set::initialize::recent_by_ip::RecentByIp;
+
+#[test]
+fn old_connection_attempts_are_pruned() {
+    const TEST_TIME_LIMIT: Duration = Duration::from_secs(5);
+
+    let _init_guard = zebra_test::init();
+
+    let mut recent_connections = RecentByIp::new(Some(TEST_TIME_LIMIT), None);
+    let ip = "127.0.0.1".parse().expect("should parse");
+
+    assert!(
+        !recent_connections.is_past_limit_or_add(ip),
+        "should not be past limit"
+    );
+    assert!(
+        recent_connections.is_past_limit_or_add(ip),
+        "should be past max_connections_per_ip limit"
+    );
+
+    std::thread::sleep(TEST_TIME_LIMIT / 3);
+
+    assert!(
+        recent_connections.is_past_limit_or_add(ip),
+        "should still contain entry after a third of the time limit"
+    );
+
+    std::thread::sleep(3 * TEST_TIME_LIMIT / 4);
+
+    assert!(
+        !recent_connections.is_past_limit_or_add(ip),
+        "should prune entry after 13/12 * time_limit"
+    );
+
+    const TEST_MAX_CONNS_PER_IP: usize = 3;
+
+    let mut recent_connections =
+        RecentByIp::new(Some(TEST_TIME_LIMIT), Some(TEST_MAX_CONNS_PER_IP));
+
+    for _ in 0..TEST_MAX_CONNS_PER_IP {
+        assert!(
+            !recent_connections.is_past_limit_or_add(ip),
+            "should not be past limit"
+        );
+    }
+
+    assert!(
+        recent_connections.is_past_limit_or_add(ip),
+        "should be past max_connections_per_ip limit"
+    );
+
+    std::thread::sleep(TEST_TIME_LIMIT / 3);
+
+    assert!(
+        recent_connections.is_past_limit_or_add(ip),
+        "should still be past limit after a third of the reconnection delay"
+    );
+
+    std::thread::sleep(3 * TEST_TIME_LIMIT / 4);
+
+    assert!(
+        !recent_connections.is_past_limit_or_add(ip),
+        "should prune entry after 13/12 * time_limit"
+    );
+}

--- a/zebra-network/src/peer_set/initialize/recent_by_ip/tests.rs
+++ b/zebra-network/src/peer_set/initialize/recent_by_ip/tests.rs
@@ -1,3 +1,5 @@
+//! Fixed test vectors for recent IP limits.
+
 use std::time::Duration;
 
 use crate::peer_set::initialize::recent_by_ip::RecentByIp;


### PR DESCRIPTION
## Motivation

This prevents some kinds of attacks by making Zebra skip the handshake for these inbound connections.

Closes #6981.

## Solution

- Count recent inbound connection attempts by IP
- Drop connections if there were already `max_connections_per_ip` recent inbound connections from their IP
 
## Review

Part of regular scheduled work.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

