### PR TITLE
change(release): Add deny.toml update details to release-checklist.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -23,7 +23,8 @@ Sometimes `dependabot` misses some dependency updates, or we accidentally turned
 
 Here's how we make sure we got everything:
 - [ ] Run `cargo update` on the latest `main` branch, and keep the output
-- [ ] If needed, update [deny.toml](https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
+- [ ] If needed, [add duplicate dependency exceptions to deny.toml](https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
+- [ ] If needed, remove resolved duplicate dependencies from `deny.toml`
 - [ ] Open a separate PR with the changes
 - [ ] Add the output of `cargo update` to that PR as a comment
 


### PR DESCRIPTION
## Motivation

We don't tell release coordinators what to do with `deny.toml` in the release checklist. This was a late audit finding:
> The release process includes a step specifying “If needed, update deny.toml”. During the
> re-test, it was observed that deny.toml contains several exceptions, with justification, for
> multiple version detection. Many suggest that version numbers should be updated in the
> future, but this work is not explicitly tracked elsewhere. Thus, the basic instructions to
> update deny.toml if needed may not make the work required in this task clear. The
> documented process could be strengthened with more detailed instructions or
> requirements.

## Solution

Explain what to add or remove, and when it's needed.

## Review

This is a low priority release checklist change.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the checklist do what the ticket and PR says?

