### PR TITLE
fix(deps): Replace openssl with rustls in tests and experimental features

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -38,7 +38,7 @@ on:
       # https://github.com/ZcashFoundation/zebra/blob/main/docker/Dockerfile#L83
       features:
         required: false
-        default: "default-docker"
+        default: "default-release-binaries"
         type: string
       test_features:
         required: false

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -38,7 +38,7 @@ on:
       # https://github.com/ZcashFoundation/zebra/blob/main/docker/Dockerfile#L83
       features:
         required: false
-        default: "sentry"
+        default: "default-docker"
         type: string
       test_features:
         required: false

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -261,7 +261,7 @@ jobs:
         # We don't need to check `--no-default-features` here, because (except in very rare cases):
         # - disabling features isn't going to add duplicate dependencies
         # - disabling features isn't going to add more crate sources
-        features: ['', '--features default-docker', '--all-features']
+        features: ['', '--features default-release-binaries', '--all-features']
       # Always run the --all-features job, to get accurate "skip tree root was not found" warnings
       fail-fast: false
 

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -262,7 +262,7 @@ jobs:
         # - disabling features isn't going to add duplicate dependencies
         # - disabling features isn't going to add more crate sources
         features: ['', '--all-features']
-      # We always want to run the --all-features job, because it gives accurate "skip tree root was not found" warnings
+      # Always run the --all-features job, to get accurate "skip tree root was not found" warnings
       fail-fast: false
 
     # Prevent sudden announcement of a new advisory from failing ci:
@@ -274,13 +274,15 @@ jobs:
           persist-credentials: false
       - uses: r7kamura/rust-problem-matchers@v1.3.0
 
-      # The --all-features job is the only job that gives accurate "skip tree root was not found" warnings.
-      # In other jobs, we expect some of these warnings, due to disabled features.
       - name: Check ${{ matrix.checks }} with features ${{ matrix.features }}
         uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check ${{ matrix.checks }}
-          arguments: --workspace ${{ matrix.features }}
+          # --all-features spuriously activates openssl, but we want to ban that dependency in
+          # all of zebrad's real features for security reasons. But the --all-features job is the
+          # only job that gives accurate "skip tree root was not found" warnings.
+          # In other jobs, we expect some of these warnings, due to disabled features.
+          arguments: --workspace ${{ matrix.features == '--all-features' && '--all-features --allow banned' || format('{0} --allow unmatched-skip-root', matrix.features) }}
 
   unused-deps:
     name: Check for unused dependencies

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -261,7 +261,7 @@ jobs:
         # We don't need to check `--no-default-features` here, because (except in very rare cases):
         # - disabling features isn't going to add duplicate dependencies
         # - disabling features isn't going to add more crate sources
-        features: ['', '--all-features']
+        features: ['', '--features default-docker', '--all-features']
       # Always run the --all-features job, to get accurate "skip tree root was not found" warnings
       fail-fast: false
 
@@ -278,8 +278,8 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@v1
         with:
           # --all-features spuriously activates openssl, but we want to ban that dependency in
-          # all of zebrad's real features for security reasons. But the --all-features job is the
-          # only job that gives accurate "skip tree root was not found" warnings.
+          # all of zebrad's production features for security reasons. But the --all-features job is
+          # the only job that gives accurate "skip tree root was not found" warnings.
           # In other jobs, we expect some of these warnings, due to disabled features.
           command: check ${{ matrix.checks }} ${{ matrix.features == '--all-features' && '--allow banned' || '--allow unmatched-skip-root' }}
           arguments: --workspace ${{ matrix.features }}

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -277,11 +277,11 @@ jobs:
       - name: Check ${{ matrix.checks }} with features ${{ matrix.features }}
         uses: EmbarkStudios/cargo-deny-action@v1
         with:
-          command: check ${{ matrix.checks }} ${{ matrix.features == '--all-features' && '--allow banned' || '--allow unmatched-skip-root' }}
           # --all-features spuriously activates openssl, but we want to ban that dependency in
           # all of zebrad's real features for security reasons. But the --all-features job is the
           # only job that gives accurate "skip tree root was not found" warnings.
           # In other jobs, we expect some of these warnings, due to disabled features.
+          command: check ${{ matrix.checks }} ${{ matrix.features == '--all-features' && '--allow banned' || '--allow unmatched-skip-root' }}
           arguments: --workspace ${{ matrix.features }}
 
   unused-deps:

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -277,12 +277,12 @@ jobs:
       - name: Check ${{ matrix.checks }} with features ${{ matrix.features }}
         uses: EmbarkStudios/cargo-deny-action@v1
         with:
-          command: check ${{ matrix.checks }}
+          command: check ${{ matrix.checks }} ${{ matrix.features == '--all-features' && '--allow banned' || '--allow unmatched-skip-root' }}
           # --all-features spuriously activates openssl, but we want to ban that dependency in
           # all of zebrad's real features for security reasons. But the --all-features job is the
           # only job that gives accurate "skip tree root was not found" warnings.
           # In other jobs, we expect some of these warnings, due to disabled features.
-          arguments: --workspace ${{ matrix.features == '--all-features' && '--all-features --allow banned' || format('{0} --allow unmatched-skip-root', matrix.features) }}
+          arguments: --workspace ${{ matrix.features }}
 
   unused-deps:
     name: Check for unused dependencies

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -44,7 +44,7 @@ jobs:
       tag_suffix: .experimental
       network: Testnet
       rpc_port: '18232'
-      features: "sentry getblocktemplate-rpcs"
+      features: "default-docker getblocktemplate-rpcs"
       test_features: ""
       rust_backtrace: '1'
       zebra_skip_ipv6_tests: '1'

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -44,7 +44,7 @@ jobs:
       tag_suffix: .experimental
       network: Testnet
       rpc_port: '18232'
-      features: "default-docker getblocktemplate-rpcs"
+      features: "default-release-binaries getblocktemplate-rpcs"
       test_features: ""
       rust_backtrace: '1'
       zebra_skip_ipv6_tests: '1'

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,13 @@
 [bans]
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "deny"
+
+# Don't allow wildcard ("any version") dependencies
+wildcards = "deny"
+# Allow private and dev wildcard dependencies.
+# Switch this to `false` when #6924 is implemented.
+allow-wildcard-paths = true
+
 # The graph highlighting used when creating dotgraphs for crates
 # with multiple versions
 # * lowest-version - The path to the lowest versioned duplicate is highlighted
@@ -17,11 +24,17 @@ multiple-versions = "deny"
 # * all - Both lowest-version and simplest-path are used
 highlight = "all"
 
-# We don't use this for Zebra.
-#
 # List of crates that are allowed. Use with care!
 #allow = [
 #]
+
+# List of crates that can never become Zebra dependencies.
+deny = [
+    # Often has memory safety vulerabilities.
+    # Enabled by --all-features, use the `cargo hack` script in the deny.toml CI job instead.
+    { name = "openssl" },
+    { name = "openssl-sys" },
+]
 
 # We only use this for some `librustzcash` and `orchard` crates.
 # If we add a crate here, duplicate dependencies of that crate are still shown.
@@ -47,6 +60,9 @@ skip-tree = [
     # wait for criterion to upgrade
     { name = "itertools", version = "=0.10.5" },
 
+    # wait for backtrace and multiple dependents to upgrade
+    { name = "miniz_oxide", version = "=0.6.2" },
+
     # ZF crates
 
     # wait for zcashd and zcash_script to upgrade
@@ -70,6 +86,9 @@ skip-tree = [
 
     # wait for zcash_address to upgrade
     { name = "bs58", version = "=0.4.0" },
+
+    # wait for minreq and zcash_proofs to upgrade
+    { name = "rustls", version = "=0.20.8" },
 
     # zebra-utils dependencies
 

--- a/deny.toml
+++ b/deny.toml
@@ -30,7 +30,7 @@ highlight = "all"
 
 # List of crates that can never become Zebra dependencies.
 deny = [
-    # Often has memory safety vulerabilities.
+    # Often has memory safety vulnerabilities.
     # Enabled by --all-features, use the `cargo hack` script in the deny.toml CI job instead.
     { name = "openssl" },
     { name = "openssl-sys" },

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,7 +81,7 @@ ENV ZEBRA_SKIP_IPV6_TESTS ${ZEBRA_SKIP_IPV6_TESTS:-1}
 # Build zebrad with these features
 # Keep these in sync with:
 # https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/build-docker-image.yml#L42
-ARG FEATURES="sentry"
+ARG FEATURES="default-docker"
 ARG TEST_FEATURES="lightwalletd-grpc-tests zebra-checkpoints"
 # Use ENTRYPOINT_FEATURES to override the specific features used to run tests in entrypoint.sh,
 # separately from the test and production image builds.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,7 +81,7 @@ ENV ZEBRA_SKIP_IPV6_TESTS ${ZEBRA_SKIP_IPV6_TESTS:-1}
 # Build zebrad with these features
 # Keep these in sync with:
 # https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/build-docker-image.yml#L42
-ARG FEATURES="default-docker"
+ARG FEATURES="default-release-binaries"
 ARG TEST_FEATURES="lightwalletd-grpc-tests zebra-checkpoints"
 # Use ENTRYPOINT_FEATURES to override the specific features used to run tests in entrypoint.sh,
 # separately from the test and production image builds.

--- a/docker/zcash-params/Dockerfile
+++ b/docker/zcash-params/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -qq update && \
 
 ENV CARGO_HOME /opt/zebrad/.cargo/
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --features default-docker --package zebrad --recipe-path recipe.json
+RUN cargo chef cook --release --features default-release-binaries --package zebrad --recipe-path recipe.json
 
 ARG RUST_BACKTRACE=0
 ENV RUST_BACKTRACE ${RUST_BACKTRACE}
@@ -36,4 +36,4 @@ ENV COLORBT_SHOW_HIDDEN ${COLORBT_SHOW_HIDDEN}
 
 COPY . .
 # Pre-download Zcash Sprout and Sapling parameters
-RUN cargo run --locked --release --features default-docker --package zebrad --bin zebrad download
+RUN cargo run --locked --release --features default-release-binaries --package zebrad --bin zebrad download

--- a/docker/zcash-params/Dockerfile
+++ b/docker/zcash-params/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -qq update && \
 
 ENV CARGO_HOME /opt/zebrad/.cargo/
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --features sentry --package zebrad --recipe-path recipe.json
+RUN cargo chef cook --release --features default-docker --package zebrad --recipe-path recipe.json
 
 ARG RUST_BACKTRACE=0
 ENV RUST_BACKTRACE ${RUST_BACKTRACE}
@@ -36,4 +36,4 @@ ENV COLORBT_SHOW_HIDDEN ${COLORBT_SHOW_HIDDEN}
 
 COPY . .
 # Pre-download Zcash Sprout and Sapling parameters
-RUN cargo run --locked --release --features sentry --package zebrad --bin zebrad download
+RUN cargo run --locked --release --features default-docker --package zebrad --bin zebrad download

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -42,7 +42,8 @@ zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.26"}
 # Tool and test feature rpc-client
 color-eyre = { version = "0.6.2", optional = true }
 jsonrpc-core = { version = "18.0.0", optional = true }
-reqwest = { version = "0.11.18", optional = true }
+# Security: avoid default dependency on openssl
+reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls"], optional = true }
 serde = { version = "1.0.164", optional = true }
 serde_json = { version = "1.0.97", optional = true }
 
@@ -50,6 +51,6 @@ serde_json = { version = "1.0.97", optional = true }
 
 color-eyre = "0.6.2"
 jsonrpc-core = "18.0.0"
-reqwest = "0.11.18"
+reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls"] }
 serde = "1.0.164"
 serde_json = "1.0.97"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -67,7 +67,8 @@ tower = { version = "0.4.13", features = ["buffer", "util"] }
 tracing = "0.1.37"
 
 # elasticsearch specific dependencies.
-elasticsearch = { version = "8.5.0-alpha.1", package = "elasticsearch", optional = true }
+# Security: avoid default dependency on openssl
+elasticsearch = { version = "8.5.0-alpha.1", default-features = false, features = ["rustls-tls"], optional = true }
 serde_json = { version = "1.0.97", package = "serde_json", optional = true }
 
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.26" }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -39,6 +39,9 @@ pre-release-replacements = [
 # In release builds, don't compile debug logging code, to improve performance.
 default = ["release_max_level_info"]
 
+# Default features for Docker release builds
+default-docker = ["default", "sentry"]
+
 # Production features that activate extra dependencies, or extra features in dependencies
 
 # Experimental mining RPC support

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -39,8 +39,8 @@ pre-release-replacements = [
 # In release builds, don't compile debug logging code, to improve performance.
 default = ["release_max_level_info"]
 
-# Default features for Docker release builds
-default-docker = ["default", "sentry"]
+# Default features for official ZF binary release builds
+default-release-binaries = ["default", "sentry"]
 
 # Production features that activate extra dependencies, or extra features in dependencies
 


### PR DESCRIPTION
## Motivation

OpenSSL continues to have memory safety vulnerabilities:
https://github.com/advisories/GHSA-xcf7-rvmh-g6q4

`zebrad` isn't impacted by this one in production, because openssl is only a dependency of our tests and experimental features. But it could accidentally become a production dependency when we stabilise features or add new dependencies.

### Reference

GitHub Actions ternary expressions:
https://docs.github.com/en/actions/learn-github-actions/expressions#example

### Complex Code or Requirements

`--all-features` activates the openssl dependency, because it's an optional dependency of some of Zebra's dependencies. So I changed the CI check to ignore banned crates for `--all-features`. (And ignore missing dependencies for default features.)

## Solution

- Ban `openssl` as a Zebra dependency
- Make CI check that openssl is not used in default production builds and production Docker images

Related fixes:
- Add a `default-release-binaries` feature to `zebrad` and use it in Docker files and production/prod test workflows
- Ignore expected warnings for default features and `default-release-binaries`
- Ban wildcard ("any version") dependencies, except in tests

## Review

This is a low priority security fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

It would be good to automate keeping the duplicate dependency exception list up to date.