### PR TITLE
change(docker): Replace the zcash-params Dockerfile build with a zebrad binary copy

### DIFF
--- a/.github/workflows/zcash-params.yml
+++ b/.github/workflows/zcash-params.yml
@@ -22,10 +22,12 @@ on:
     paths:
       # parameter download code
       - 'zebra-consensus/src/primitives/groth16/params.rs'
-      - 'zebra-consensus/src/chain.rs'
+      - 'zebra-consensus/src/router.rs'
+      - 'zebrad/src/commands/download.rs'
       - 'zebrad/src/commands/start.rs'
       # workflow definitions
       - 'docker/zcash-params/Dockerfile'
+      - '.dockerignore'
       - '.github/workflows/zcash-params.yml'
       - '.github/workflows/build-docker-image.yml'
 

--- a/docker/zcash-params/Dockerfile
+++ b/docker/zcash-params/Dockerfile
@@ -1,39 +1,16 @@
-# This steps implement cargo-chef for docker layer caching
 # This image is for caching Zcash Sprout and Sapling parameters
-FROM rust:bullseye as chef
-RUN cargo install cargo-chef --locked
-WORKDIR /opt/zebrad
 
-FROM chef AS planner
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
+FROM debian:bullseye-slim AS release
 
-FROM chef AS release
-COPY --from=planner /opt/zebrad/recipe.json recipe.json
+# Just use the precompiled zebrad binary from a recent test image.
+#
+# It doesn't matter what build or commit of Zebra we use, because it just calls into the
+# zcash_proofs download code. (Which doesn't change much.)
+# Release image zebrad binaries would also work.
+#
+# Compiling the download-params example using `cargo ` is another alternative:
+# `cargo run --locked --release --features default-docker --example download-params`
+COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/zebrad-test /usr/local/bin/zebrad /usr/local/bin
 
-# Install zebra build deps
-RUN apt-get -qq update && \
-    apt-get -qq install -y --no-install-recommends \
-    llvm \
-    libclang-dev \
-    clang \
-    ca-certificates \
-    ; \
-    rm -rf /var/lib/apt/lists/* /tmp/*
-
-ENV CARGO_HOME /opt/zebrad/.cargo/
-# Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --features default-release-binaries --package zebrad --recipe-path recipe.json
-
-ARG RUST_BACKTRACE=0
-ENV RUST_BACKTRACE ${RUST_BACKTRACE}
-
-ARG RUST_LIB_BACKTRACE=0
-ENV RUST_LIB_BACKTRACE ${RUST_LIB_BACKTRACE}
-
-ARG COLORBT_SHOW_HIDDEN=0
-ENV COLORBT_SHOW_HIDDEN ${COLORBT_SHOW_HIDDEN}
-
-COPY . .
 # Pre-download Zcash Sprout and Sapling parameters
-RUN cargo run --locked --release --features default-release-binaries --package zebrad --bin zebrad download
+RUN zebrad download


### PR DESCRIPTION
## Motivation

We currently build `zebrad` in both docker/Dockerfile and docker/zcash-params/Dockerfile.

But we don't need to build `zebrad` again, we can just re-use the test or release binaries.

### Complex Code or Requirements

This slightly increases the risk we break the `zebrad download` command and don't notice for a while.

## Solution

- Instead of building `zebrad`, copy any recently built `zebrad` test binary

Related fixes:
- Update the workflow run files for the zcash-params.yml workflow

## Review

This is a low priority cleanup.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

