### PR TITLE
add(ci): Run release builds and production Docker image tests on pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -158,10 +158,7 @@ The end of support height is calculated from the current blockchain height:
       and put the output in a comment on the PR.
 
 ## Publish Docker Images
-- [ ] Wait until [the Docker images have been published](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml)
-- [ ] Test the Docker image using `docker run --tty --interactive zfnd/zebra:v1.0.0`,
-      and put the output in a comment on the PR.
-      (You can use [gcloud cloud shell](https://console.cloud.google.com/home/dashboard?cloudshell=true))
+- [ ] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml).
 - [ ] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
 
 ## Release Failures

--- a/.github/workflows/continous-delivery.patch.yml
+++ b/.github/workflows/continous-delivery.patch.yml
@@ -1,0 +1,36 @@
+name: CD
+
+on:
+  # Only patch the Docker image test jobs
+  pull_request:
+    paths-ignore:
+      # code and tests
+      - '**/*.rs'
+      # hard-coded checkpoints and proptest regressions
+      - '**/*.txt'
+      # dependencies
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      # configuration files
+      - '.cargo/config.toml'
+      - '**/clippy.toml'
+      # workflow definitions
+      - 'docker/**'
+      - '.dockerignore'
+      - '.github/workflows/continous-delivery.yml'
+      - '.github/workflows/find-cached-disks.yml'
+
+
+jobs:
+  # Also patched by continous-integration-docker.patch.yml, which has a different paths-ignore
+  build:
+    name: Build CI Docker / Build images
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  test-configuration-file:
+    name: Test Zebra default Docker config file
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -6,9 +6,12 @@ name: CD
 #
 # Since the different event types each use a different Managed Instance Group or instance,
 # we can run different event types concurrently.
+#
+# For pull requests, we only run the tests from this workflow, and don't do any deployments.
+# So an in-progress pull request gets cancelled, just like other tests.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: {{ github.event_name == "pull_request" }}
 
 on:
   workflow_dispatch:
@@ -25,13 +28,51 @@ on:
         required: false
         type: boolean
         default: false
+
   # Temporarily disabled to reduce network load, see #6894.
   #push:
   #  branches:
   #    - main
+  #  paths:
+  #    # code and tests
+  #    - '**/*.rs'
+  #    # hard-coded checkpoints and proptest regressions
+  #    - '**/*.txt'
+  #    # dependencies
+  #    - '**/Cargo.toml'
+  #    - '**/Cargo.lock'
+  #    # configuration files
+  #    - '.cargo/config.toml'
+  #    - '**/clippy.toml'
+  #    # workflow definitions
+  #    - 'docker/**'
+  #    - '.dockerignore'
+  #    - '.github/workflows/continous-delivery.yml'
+  #    - '.github/workflows/build-docker-image.yml'
+
+  # Only runs the Docker image tests, doesn't deploy any instances
+  pull_request:
+    paths:
+      # code and tests
+      - '**/*.rs'
+      # hard-coded checkpoints and proptest regressions
+      - '**/*.txt'
+      # dependencies
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      # configuration files
+      - '.cargo/config.toml'
+      - '**/clippy.toml'
+      # workflow definitions
+      - 'docker/**'
+      - '.dockerignore'
+      - '.github/workflows/continous-delivery.yml'
+      - '.github/workflows/find-cached-disks.yml'
+
   release:
     types:
       - published
+
 
 jobs:
   # If a release was made we want to extract the first part of the semver from the

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -11,7 +11,7 @@ name: CD
 # So an in-progress pull request gets cancelled, just like other tests.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: {{ github.event_name == "pull_request" }}
+  cancel-in-progress: ${{ github.event_name == "pull_request" }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -11,7 +11,7 @@ name: CD
 # So an in-progress pull request gets cancelled, just like other tests.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == "pull_request" }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/continous-integration-docker.patch.yml
+++ b/.github/workflows/continous-integration-docker.patch.yml
@@ -19,8 +19,10 @@ on:
       - '**/clippy.toml'
       # workflow definitions
       - 'docker/**'
+      - '.dockerignore'
       - '.github/workflows/continous-integration-docker.yml'
       - '.github/workflows/deploy-gcp-tests.yml'
+      - '.github/workflows/find-cached-disks.yml'
       - '.github/workflows/build-docker-image.yml'
 
 jobs:

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -80,10 +80,11 @@ on:
       - '**/clippy.toml'
       # workflow definitions
       - 'docker/**'
+      - '.dockerignore'
       - '.github/workflows/continous-integration-docker.yml'
       - '.github/workflows/deploy-gcp-tests.yml'
-      - '.github/workflows/build-docker-image.yml'
       - '.github/workflows/find-cached-disks.yml'
+      - '.github/workflows/build-docker-image.yml'
 
 jobs:
   # to also run a job on Mergify head branches,


### PR DESCRIPTION
## Motivation

Currently we don't run tests on our production images until after the release has been tagged. Tests on `main` branch pushes were accidentally disabled as part of PR #6895.

So if there are any bugs or breaking changes in the release build or docker image, we'll have to tag another bug fix release.

Instead, we can run the release build and tests on every PR. (But not deploy any instances.)

### Complex Code or Requirements

We need a patch workflow to create a branch protection rule, which stops buggy PRs merging.

## Solution

Run the release build and test jobs on PRs when relevant code or configs change. The workflow conditions already restrict deployments to `release`, `workflow_dispatch`, or `main` branch `push` events.

Related fixes:
- Remove the manual docker test from the release checklist
- [Update the workflow run conditions for CI docker tests](https://github.com/ZcashFoundation/zebra/commit/6b7b4261addee7f464dd77fcddf8dd417f0453de), we missed a file that docker uses, and split out a workflow

### Final Tasks

- [x] Admin: Add a branch protection rule for the new test job after this PR merges

## Review

@gustavovalverde this might help with testing PR #7045?

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We might add more tests as part of PR #7045.

After we finish changing the Dockerfile and entrypoint scripts, we could disable the tests on every PR, and enable them on the `main` branch. We could use a GitHub Actions variable to enable/disable PR tests.

We might want to make release builds more efficient, by improving caching.