### PR TITLE
fix(cd): Rename a CD job with the same name as a CI job

### DIFF
--- a/.github/workflows/continous-delivery.patch.yml
+++ b/.github/workflows/continous-delivery.patch.yml
@@ -30,7 +30,7 @@ jobs:
       - run: 'echo "No build required"'
 
   test-configuration-file:
-    name: Test Zebra default Docker config file
+    name: Test Zebra CD Docker config file
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -123,7 +123,7 @@ jobs:
   # Test that Zebra works using the default config with the latest Zebra version,
   # and test reconfiguring the docker image for testnet.
   test-configuration-file:
-    name: Test Zebra default Docker config file
+    name: Test Zebra CD Docker config file
     timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
## Motivation

One of our CD test jobs has the same name as a CI test job, so we could merge a PR if either one of them passes. (We want both to pass.)

## Solution

Rename the CD job

- [x] Admin: add a branch protection rule for the new name after merging this PR

## Review

This should be merged before merging PRT #7045, because it tests that PR.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

