### PR TITLE
fix(state): Replace a chain length assertion with a NotReadyToBeCommitted error

### DIFF
--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -51,7 +51,7 @@ pub struct CommitSemanticallyVerifiedError(#[from] ValidateContextError);
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum ValidateContextError {
-    #[error("block parent not found in any chain")]
+    #[error("block parent not found in any chain, or not enough blocks in chain")]
     #[non_exhaustive]
     NotReadyToBeCommitted,
 


### PR DESCRIPTION
## Motivation

The auditors were concerned about the possibility of a panic in a state verification check.

## Solution

Replace the assertion with a block verification error.

## Review

This is a low-priority audit cleanup.

### Reviewer Checklist

  - [x] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We should change the tests that currently check for success to check for this error instead, and remove the test workaround.