### PR TITLE
fix(ci): Use correct name for CD build patch job

### DIFF
--- a/.github/workflows/continous-delivery.patch.yml
+++ b/.github/workflows/continous-delivery.patch.yml
@@ -22,9 +22,8 @@ on:
 
 
 jobs:
-  # Also patched by continous-integration-docker.patch.yml, which has a different paths-ignore
   build:
-    name: Build CI Docker / Build images
+    name: Build CD Docker / Build images
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'


### PR DESCRIPTION
## Motivation

I can't set up a branch protection rule for this CD build job because the patch job name is wrong:

<img width="893" alt="Screenshot 2023-06-27 at 12 27 22" src="https://github.com/ZcashFoundation/zebra/assets/8951843/f6e65bb2-ea05-42a1-98c0-fd7fb44dcfeb">

- [x] Admin: add the job to the branch protection rules

## Review

This would be good to get fixed but it's not a blocker.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

