### PR TITLE
fix(log): Only show the Zebra logo & intro for the `start` command

### DIFF
--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -422,6 +422,7 @@ impl Application for ZebradApp {
         components.push(Box::new(Tracing::new(
             config.network.network,
             tracing_config,
+            command.cmd().uses_intro(),
         )?));
 
         // Log git metadata and platform info when zebrad starts up

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -64,6 +64,26 @@ impl ZebradCmd {
         }
     }
 
+    /// Returns true if this command shows the Zebra intro logo and text.
+    ///
+    /// For example, `Start` acts as a Zcash node.
+    pub(crate) fn uses_intro(&self) -> bool {
+        // List all the commands, so new commands have to make a choice here
+        match self {
+            // Commands that need an intro
+            Start(_) => true,
+
+            // Utility commands
+            CopyState(_) | Download(_) | Generate(_) | TipHeight(_) => false,
+        }
+    }
+
+    /// Returns true if this command should ignore errors when
+    /// attempting to load a config file.
+    pub(crate) fn should_ignore_load_config_error(&self) -> bool {
+        matches!(self, ZebradCmd::Generate(_) | ZebradCmd::Download(_))
+    }
+
     /// Returns the default log level for this command, based on the `verbose` command line flag.
     ///
     /// Some commands need to be quiet by default.
@@ -86,12 +106,6 @@ impl ZebradCmd {
         } else {
             "debug"
         }
-    }
-
-    /// Returns true if this command should ignore errors when
-    /// attempting to load a config file.
-    pub(crate) fn should_ignore_load_config_error(&self) -> bool {
-        matches!(self, ZebradCmd::Generate(_) | ZebradCmd::Download(_))
     }
 }
 

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -65,9 +65,12 @@ pub struct Tracing {
 }
 
 impl Tracing {
-    /// Try to create a new [`Tracing`] component with the given `filter`.
+    /// Try to create a new [`Tracing`] component with the given `config`.
+    ///
+    /// If `uses_intro` is true, show a welcome message, the `network`,
+    /// and the Zebra logo on startup. (If the terminal supports it.)
     #[allow(clippy::print_stdout, clippy::print_stderr, clippy::unwrap_in_result)]
-    pub fn new(network: Network, config: Config) -> Result<Self, FrameworkError> {
+    pub fn new(network: Network, config: Config, uses_intro: bool) -> Result<Self, FrameworkError> {
         // Only use color if tracing output is being sent to a terminal or if it was explicitly
         // forced to.
         let use_color = config.use_color_stdout();
@@ -76,25 +79,30 @@ impl Tracing {
         let filter = config.filter.unwrap_or_default();
         let flame_root = &config.flamegraph;
 
-        // If it's a terminal and color escaping is enabled: clear screen and
-        // print Zebra logo (here `use_color` is being interpreted as
-        // "use escape codes")
-        if use_color_stderr {
-            // Clear screen
-            eprint!("\x1B[2J");
+        // Only show the intro for user-focused node server commands like `start`
+        if uses_intro {
+            // If it's a terminal and color escaping is enabled: clear screen and
+            // print Zebra logo (here `use_color` is being interpreted as
+            // "use escape codes")
+            if use_color_stderr {
+                // Clear screen
+                eprint!("\x1B[2J");
+                eprintln!(
+                    "{}",
+                    std::str::from_utf8(&ZEBRA_ART)
+                        .expect("should always work on a UTF-8 encoded constant")
+                );
+            }
+
             eprintln!(
-                "{}",
-                std::str::from_utf8(&ZEBRA_ART)
-                    .expect("should always work on a UTF-8 encoded constant")
+                "Thank you for running a {} zebrad {} node!",
+                network.lowercase_name(),
+                build_version()
+            );
+            eprintln!(
+                "You're helping to strengthen the network and contributing to a social good :)"
             );
         }
-
-        eprintln!(
-            "Thank you for running a {} zebrad {} node!",
-            network.lowercase_name(),
-            build_version()
-        );
-        eprintln!("You're helping to strengthen the network and contributing to a social good :)");
 
         let writer = if let Some(log_file) = config.log_file.as_ref() {
             println!("running zebra");

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -105,7 +105,9 @@ impl Tracing {
         }
 
         let writer = if let Some(log_file) = config.log_file.as_ref() {
-            println!("running zebra");
+            if uses_intro {
+                println!("running zebra");
+            }
 
             // Make sure the directory for the log file exists.
             // If the log is configured in the current directory, it won't have a parent directory.
@@ -130,7 +132,9 @@ impl Tracing {
                 }
             }
 
-            println!("sending logs to {log_file:?}...");
+            if uses_intro {
+                println!("sending logs to {log_file:?}...");
+            }
             let log_file = File::options().append(true).create(true).open(log_file)?;
             Box::new(log_file) as BoxWrite
         } else {


### PR DESCRIPTION
## Motivation

We don't need to show the logo when generating a config file.

## Review

This is a usability fix, it is probably a release blocker.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

