### PR TITLE
fix(ci): Make CD docker tests accept more progress logs

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -171,7 +171,8 @@ jobs:
           docker logs --tail all --follow testnet-conf-tests | \
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          'net.*=.*Test.*estimated progress to chain tip.*Genesis'
+          -e 'net.*=.*Test.*estimated progress to chain tip.*Genesis' \
+          -e 'net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter'
           docker stop testnet-conf-tests
           # get the exit status from docker
           EXIT_STATUS=$( \


### PR DESCRIPTION
## Motivation

The testnet tests look for Genesis progress, because sometimes that's the only block that can be downloaded on testnet.

But when testnet is running well, the node can get to BeforeOverwinter by the first progress log:
https://github.com/ZcashFoundation/zebra/actions/runs/5385468952/jobs/9774720826?pr=7035#step:5:80
https://github.com/ZcashFoundation/zebra/actions/runs/5385468952/jobs/9774720826?pr=7035#step:5:175
https://github.com/ZcashFoundation/zebra/actions/runs/5385468952/jobs/9774720826?pr=7035#step:5:187

## Solution

This PR accepts either log.

## Review

This is failing some PRs, so it is important to fix.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

