### PR TITLE
fix(ci): Add extra patch job for `cargo deny` checks

### DIFF
--- a/.github/workflows/continous-integration-os.patch.yml
+++ b/.github/workflows/continous-integration-os.patch.yml
@@ -60,7 +60,7 @@ jobs:
         checks:
           - bans
           - sources
-        features: ['', '--all-features']
+        features: ['', '--features default-release-binaries', '--all-features']
 
     steps:
       - run: 'echo "No build required"'


### PR DESCRIPTION
## Motivation

I added a new `deny.toml` check in a previous PR, but I forgot to update the patch job.

- [x] Admin: add the job to the branch protection rules

## Review

This is a low priority cleanup/fix.

### Reviewer Checklist

  - [x] Are the PR labels correct?
  - [x] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

