### PR TITLE
fix(ci): Use release images for zcash-params downloads

### DIFF
--- a/docker/zcash-params/Dockerfile
+++ b/docker/zcash-params/Dockerfile
@@ -1,16 +1,19 @@
-# This image is for caching Zcash Sprout and Sapling parameters
+# This image is for caching Zcash Sprout and Sapling parameters.
+# We don't test it automatically in CI due to download server rate-limiting.
+# To manually run it on the PR branch before merging, go to:
+# https://github.com/ZcashFoundation/zebra/actions/workflows/zcash-params.yml
 
 FROM debian:bullseye-slim AS release
 
-# Just use the precompiled zebrad binary from a recent test image.
+# Just use the precompiled zebrad binary from a recent release image.
 #
 # It doesn't matter what build or commit of Zebra we use, because it just calls into the
 # zcash_proofs download code. (Which doesn't change much.)
-# Release image zebrad binaries would also work.
+# Test image zebrad binaries would also work, but it's harder to get a recent tag for them.
 #
 # Compiling the download-params example using `cargo ` is another alternative:
 # `cargo run --locked --release --features default-docker --example download-params`
-COPY --from=us-docker.pkg.dev/zealous-zebra/zebra/zebrad-test /usr/local/bin/zebrad /usr/local/bin
+COPY --from=zfnd/zebra:latest /usr/local/bin/zebrad /usr/local/bin
 
 # Pre-download Zcash Sprout and Sapling parameters
 RUN zebrad download


### PR DESCRIPTION
## Motivation

CI failed on the main branch because PR #7054 couldn't find a zebrad-test Docker image tag.

## Solution

Use the latest release binary instead.

### Testing

I did a manual workflow run:
> #12 241.9 2023-06-28T20:05:50.429642Z  INFO {net="Main"}: zebra_consensus::primitives::groth16::params: Zcash Sapling and Sprout parameters downloaded and/or verified

https://github.com/ZcashFoundation/zebra/actions/runs/5405330596/jobs/9820726921#step:10:299

## Review

This needs to be fixed, but it's only failing this workflow's own main branch commits right now.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

