### PR TITLE
fix(hang): Stop blocking some Zebra futures for up to a minute using a CPU busy-loop, Credit: Ziggurat Team (#6763), james_katz (#7000)

### DIFF
--- a/zebrad/src/components/sync/progress.rs
+++ b/zebrad/src/components/sync/progress.rs
@@ -154,8 +154,8 @@ pub async fn show_block_chain_progress(
                     .desc(network_upgrade.to_string());
             }
 
-            // Skip logging if it isn't time for it yet
-            let elapsed_since_log = last_log_time.saturating_duration_since(instant_now);
+            // Skip logging and status updates if it isn't time for them yet.
+            let elapsed_since_log = instant_now.saturating_duration_since(last_log_time);
             if elapsed_since_log < LOG_INTERVAL {
                 tokio::time::sleep(PROGRESS_BAR_INTERVAL).await;
                 continue;

--- a/zebrad/src/components/sync/progress.rs
+++ b/zebrad/src/components/sync/progress.rs
@@ -144,6 +144,8 @@ pub async fn show_block_chain_progress(
             let network_upgrade = NetworkUpgrade::current(network, current_height);
 
             // Send progress reports for block height
+            //
+            // TODO: split the progress bar height update into its own function.
             #[cfg(feature = "progress-bar")]
             if matches!(howudoin::cancelled(), Some(true)) {
                 block_bar.close();
@@ -162,6 +164,8 @@ pub async fn show_block_chain_progress(
             } else {
                 last_log_time = instant_now;
             }
+
+            // TODO: split logging / status updates into their own function.
 
             // Work out the sync progress towards the estimated tip.
             let sync_progress = f64::from(current_height.0) / f64::from(estimated_height.0);


### PR DESCRIPTION
## Motivation

Since PR #6235 was merged in March 2023, Zebra's progress logging future has been busy-waiting in a loop for at least 55 seconds out of every minute.

Since this loop doesn't call into the `tokio` executor, it never yields, so it blocks all other futures running on that thread.

This is a likely cause for these bugs:
Close #6763
Close #7000 

It might also possibly be causing these bugs, or making them worse:
* #6867
* #5709
* #6922
* #6812

### Specifications

https://docs.rs/tokio/latest/tokio/#cpu-bound-tasks-and-blocking-code

### Complex Code or Requirements

`tokio` uses cooperative multitasking with internal yields, but only `tokio` APIs can yield to `tokio`:
https://docs.rs/tokio/latest/tokio/task/index.html#cooperative-scheduling

## Solution

Sleep before continuing the loop.
Use monotonic `Instant` times, so that changing the computer's clock doesn't cause progress updates to stop.

## Review

This seems like it might be a release blocker, given the number of bugs it impacts.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We should ask users to re-test and see if any of these bugs are still happening.