### PR TITLE
fix(panic): Stop panicking on shutdown in the syncer and network init

### DIFF
--- a/zebra-network/src/meta_addr/peer_addr.rs
+++ b/zebra-network/src/meta_addr/peer_addr.rs
@@ -3,7 +3,7 @@
 
 use std::{
     fmt,
-    net::SocketAddr,
+    net::{Ipv4Addr, SocketAddr},
     ops::{Deref, DerefMut},
     str::FromStr,
 };
@@ -66,6 +66,11 @@ impl DerefMut for PeerSocketAddr {
 }
 
 impl PeerSocketAddr {
+    /// Returns an unspecified `PeerSocketAddr`, which can't be used for outbound connections.
+    pub fn unspecified() -> Self {
+        Self(SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0))
+    }
+
     /// Return the underlying [`SocketAddr`], which allows sensitive peer address information to
     /// be printed and logged.
     pub fn remove_socket_addr_privacy(&self) -> SocketAddr {


### PR DESCRIPTION
## Motivation

I saw another panic on shutdown in the syncer while preparing for the Zebra showcase.

### Complex Code or Requirements

This is the same kind of bug as the last one: a panic on JoinError::Cancelled, which should just be a log.

## Solution

Log shutdown errors rather than panicking in the syncer and when initialising zebra-network.

## Review

This should be fixed soon, but it's not a release blocker.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

