### PR TITLE
change(devops): Reduce number of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       - 'A-dependencies'
       - 'P-Low :snowflake:'
     groups:
-       ecc:
+        ecc:
           patterns:
             # deliberately include zcash_script
             - "zcash_*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,17 +21,20 @@ updates:
             - "orchard"
             - "halo2*"
             - "incrementalmerkletree"
+            - "equihash"
+            # addresses
             - "bs58"
             - "ripemd"
-            - "equihash"
+        # groups are limited to 10 items
+        crypto:
+          patterns:
             - "bellman"
             - "redjubjub"
             - "reddsa"
             - "jubjub"
             - "group"
             - "bls12_381"
-            - "blake2b_simd"
-            - "blake2s_simd"
+            - "blake*"
             - "secp256k1"
             - "sha2"
         ed25519-zebra:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -127,7 +127,7 @@ updates:
         proptest:
           patterns:
             - "proptest*"
-- package-ecosystem: github-actions
+  - package-ecosystem: github-actions
     directory: '/'
     schedule:
       # tj-actions/changed-files often updates daily, which is too much for us

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: cargo
     directory: '/'
-    # serde, clap, ans other dependencies sometimes have multiple updates in a week
+    # serde, clap, and other dependencies sometimes have multiple updates in a week
     schedule:
       interval: weekly
       timezone: America/New_York
@@ -16,7 +16,7 @@ updates:
     groups:
         ecc:
           patterns:
-            # deliberately include zcash_script
+            # deliberately include zcash_script (even though it is maintained by ZF)
             - "zcash_*"
             - "orchard"
             - "halo2*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,21 +2,138 @@ version: 2
 updates:
   - package-ecosystem: cargo
     directory: '/'
+    # serde, clap, ans other dependencies sometimes have multiple updates in a week
     schedule:
-      interval: daily
+      interval: weekly
       timezone: America/New_York
-    open-pull-requests-limit: 10
+    # Limit dependabot to 2 PRs per reviewer, but assume one reviewer is busy or away
+    open-pull-requests-limit: 8
     labels:
       - 'C-trivial'
       - 'A-rust'
       - 'A-dependencies'
       - 'P-Low :snowflake:'
-  - package-ecosystem: github-actions
+    groups:
+       ecc:
+          patterns:
+            # deliberately include zcash_script
+            - "zcash_*"
+            - "orchard"
+            - "halo2*"
+            - "incrementalmerkletree"
+            - "bs58"
+            - "ripemd"
+            - "equihash"
+            - "bellman"
+            - "redjubjub"
+            - "reddsa"
+            - "jubjub"
+            - "group"
+            - "bls12_381"
+            - "blake2b_simd"
+            - "blake2s_simd"
+            - "secp256k1"
+            - "sha2"
+        ed25519-zebra:
+          patterns:
+            - "ed25519*"
+            - "curve25519*"
+            - "x25519*"
+        tokio:
+          patterns:
+            - "tokio*"
+            - "console-subscriber"
+        tower:
+          patterns:
+            - "tower*"
+        dirs:
+          patterns:
+            - "dirs*"
+            - "directories*"
+            - "tempfile"
+        grpc:
+          patterns:
+            - "prost*"
+            - "tonic*"
+        vergen:
+          patterns:
+            - "vergen"
+            - "git*"
+            - "libgit*"
+        http:
+          patterns:
+            - "hyper*"
+            - "h2"
+            - "reqwest"
+        tracing:
+          patterns:
+            - "tracing*"
+            - "log"
+        error:
+          patterns:
+            - "*eyre*"
+            - "thiserror"
+            - "displaydoc"
+            - "spandoc"
+            - "owo-colors"
+        once-cell:
+          patterns:
+            - "once_cell"
+            - "lazy_static"
+        progress-bar:
+          patterns:
+            - "indicatif"
+            - "howudoin"
+        time:
+          patterns:
+            - "chrono*"
+            - "time*"
+            - "humantime*"
+        cli:
+          patterns:
+            - "abscissa*"
+            - "structopt*"
+            - "clap*"
+            - "atty*"
+        flamegraph:
+          patterns:
+            - "tracing-flame"
+            - "inferno"
+        serde:
+          patterns:
+            - "serde*"
+        futures:
+          patterns:
+            - "futures*"
+        sentry:
+          patterns:
+            - "sentry*"
+        metrics:
+          patterns:
+            - "metrics*"
+        bitflags:
+          patterns:
+            - "bitflags*"
+        jsonrpc:
+          patterns:
+            - "jsonrpc*"
+            - "serde_json"
+        rand:
+          patterns:
+            - "rand*"
+        pin-project:
+          patterns:
+            - "pin-project*"
+        proptest:
+          patterns:
+            - "proptest*"
+- package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: daily
+      # tj-actions/changed-files often updates daily, which is too much for us
+      interval: weekly
       timezone: America/New_York
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 6
     labels:
       - 'C-trivial'
       - 'A-devops'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -178,10 +178,13 @@ jobs:
     if: ${{ needs.changed-files.outputs.workflows == 'true' }}
     steps:
       - uses: actions/checkout@v3.5.3
-      - uses: reviewdog/action-actionlint@v1.37.1
+      - name: actionlint
+        uses: reviewdog/action-actionlint@v1.37.1
         with:
           level: warning
           fail_on_error: false
+      - name: validate-dependabot
+        uses: marocchino/validate-dependabot@v2.1.0
 
   codespell:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

We're getting a lot of dependabot PRs, but some of them don't have a meaningful amount of changes. Others need to be grouped to pass CI.

Close #6547

### Specifications

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

### Complex Code or Requirements

We can update the groups later if they turn out not to work.

## Solution

- Only check for dependency updates weekly on Mondays, rather than daily (some dependencies update multiple times per week)
- Group Rust dependency updates that usually happen together
- Reduce the maximum number of open PRs to `2 * (reviewers - 1)`, because often someone is away or busy

### Testing

- add a validate dependabot step to our existing action lint job

## Review

Let's try this and see how it goes?

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Gustavo (or someone else) might want to group related GitHub Actions dependency updates, but I'm not sure what those groups should be.