### PR TITLE
change(merge): Require 2 reviews for PRs with an extra-reviews label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -29,34 +29,67 @@ queue_rules:
     conditions:
       - base=main
 
+# These rules are checked in order, the first one to be satisfied applies
 pull_request_rules:
-  - name: move to urgent queue when CI passes with 1 review and not WIP targeting main
+  - name: move to urgent queue when CI passes with multiple reviews
     conditions:
-      # This queue handles a PR if:
-      # - it targets main
-      # - is not in draft
-      # - does not include the do-not-merge label
-      # - is labeled with Critical priority
-      - base=main
-      - -draft
-      - label!=do-not-merge
+      # This queue handles a PR if it:
+      # has multiple approving reviewers
+      - "#approved-reviews-by>=2"
+      # is labeled with Critical priority
       - 'label~=^P-Critical'
+      # and satisfies the standard merge conditions:
+      # targets main
+      - base=main
+      # is not in draft
+      - -draft
+      # does not include the do-not-merge label
+      - label!=do-not-merge
     actions:
       queue:
         name: urgent
         method: squash
 
-  - name: move to batched queue when CI passes with 1 review and not WIP targeting main
+  - name: move to urgent queue when CI passes with 1 review
     conditions:
-      # This queue handles a PR if:
-      # - it targets main
-      # - is not in draft
-      # - does not include the do-not-merge label
-      # - is labeled with any other priority except Critical, or does not have a priority label,
-      #   including automated dependabot PRs.
-      #
-      # We don't need to check priority labels here, because the rules are evaluated in order:
-      # https://docs.mergify.com/configuration/#pull-request-rules      
+      # This queue handles a PR if it:
+      # has at least one approving reviewer (branch protection rule)
+      # does not need extra reviews
+      - 'label!=extra-reviews'
+      # is labeled with Critical priority
+      - 'label~=^P-Critical'
+      # and satisfies the standard merge conditions:
+      - base=main
+      - -draft
+      - label!=do-not-merge
+    actions:
+      queue:
+        name: urgent
+        method: squash
+
+  - name: move to batched queue when CI passes with multiple reviews
+    conditions:
+      # This queue handles a PR if it:
+      # has multiple approving reviewers
+      - "#approved-reviews-by>=2"
+      # is labeled with any other priority (rules are checked in order)
+      # and satisfies the standard merge conditions:
+      - base=main
+      - -draft
+      - label!=do-not-merge
+    actions:
+      queue:
+        name: batched
+        method: squash
+
+  - name: move to batched queue when CI passes with 1 review
+    conditions:
+      # This queue handles a PR if it:
+      # has at least one approving reviewer (branch protection rule)
+      # does not need extra reviews
+      - 'label!=extra-reviews'
+      # is labeled with any other priority (rules are checked in order)
+      # and satisfies the standard merge conditions:
       - base=main
       - -draft
       - label!=do-not-merge

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,11 +11,24 @@ autolabeler:
       - '/secur/i'
     title:
       - '/secur/i'
+      - '/crash/i'
+      - '/destr/i'
+      - '/unsafe/i'
   - label: 'C-deprecated'
     branch:
       - '/deprecat/i'
     title:
       - '/deprecat/i'
+  - label: 'extra-reviews'
+    branch:
+      - '/remov/i'
+      - '/deprecat/i'
+    title:
+      - '/remov/i'
+      - '/deprecat/i'
+      - '/crash/i'
+      - '/destr/i'
+      - '/unsafe/i'
   - label: 'C-feature'
     branch:
       - '/feat/i'
@@ -23,10 +36,8 @@ autolabeler:
       - '/feat/i'
   - label: 'C-bug'
     branch:
-      - '/fix/i'
       - '/bug/i'
     title:
-      - '/fix/i'
       - '/bug/i'
   # Changes that are almost always trivial for users
   - label: 'C-trivial'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,11 +11,6 @@ autolabeler:
       - '/secur/i'
     title:
       - '/secur/i'
-  - label: 'C-removed'
-    branch:
-      - '/remov/i'
-    title:
-      - '/remov/i'
   - label: 'C-deprecated'
     branch:
       - '/deprecat/i'
@@ -23,16 +18,9 @@ autolabeler:
       - '/deprecat/i'
   - label: 'C-feature'
     branch:
-      - '/add/i'
       - '/feat/i'
     title:
-      - '/add/i'
       - '/feat/i'
-  - label: 'C-enhancement'
-    branch:
-      - '/chang/i'
-    title:
-      - '/chang/i'
   - label: 'C-bug'
     branch:
       - '/fix/i'
@@ -46,16 +34,24 @@ autolabeler:
       - '/clean/i'
       - '/chore/i'
       - '/clippy/i'
+      - '/test/i'
     title:
       - '/clean/i'
       - '/chore/i'
       - '/clippy/i'
+      - '/test/i'
+      - '/(ci)/i'
+      - '/(cd)/i'
+      - '/job/i'
+      - '/patch/i'
+      - '/actions/i'
     files:
       # Regular changes that don't need to go in the CHANGELOG
       - 'CHANGELOG.md'
       - 'zebra-consensus/src/checkpoint/*-checkpoints.txt'
       # Developer-only changes
       - '.gitignore'
+      - '.dockerignore'
       # Test-only changes
       - 'zebra-test'
       - '.cargo/config.toml'
@@ -80,8 +76,7 @@ categories:
     labels:
       - 'C-security'
       # Other labels that are usually security issues
-      - 'I-bad-code'
-      - 'I-bad-data'
+      - 'I-invalid-data'
       - 'I-consensus'
       - 'I-crash'
       - 'I-destructive'
@@ -90,11 +85,10 @@ categories:
       - 'I-privacy'
       - 'I-remote-node-overload'
       - 'I-unbounded-growth'
-      - 'I-unsound'
+      - 'I-memory-safety'
   - title: 'Removed'
     labels:
       - 'C-removal'
-      - 'C-breaking'
   - title: 'Deprecated'
     labels:
       - 'C-deprecation'
@@ -164,9 +158,9 @@ template: |
   ### Breaking Changes
   
   This release has the following breaking changes:
-  - *TODO*: Check the `Removed` section for any breaking changes
+  - *TODO*: Check the `Removed` and  `Deprecated` sections for any breaking changes
   - *TODO*: Add a short description of the user impact of each breaking change, and any actions users need to take
-    
+  
   $CHANGES
   
   ### Contributors

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -169,7 +169,7 @@ template: |
   ### Breaking Changes
   
   This release has the following breaking changes:
-  - *TODO*: Check the `Removed` and  `Deprecated` sections for any breaking changes
+  - *TODO*: Check the `Removed` and `Deprecated` sections for any breaking changes
   - *TODO*: Add a short description of the user impact of each breaking change, and any actions users need to take
   
   $CHANGES


### PR DESCRIPTION
## Motivation

This PR makes sure we do two reviews on PRs with the `extra-reviews` label.

Closes #5996

### Specifications

https://docs.mergify.com/examples/#using-labels-to-enable-disable-merge

## Solution

- Require 2 reviews if the `extra-reviews` label is on a PR
- Automatically add an `extra-reviews` label with release drafter to PRs with titles with:
  - remov*
  - deprecat*
  - crash*
  - destr*
  - unsafe*
- Clean up the auto-labelling in release-drafter.yml

## Review

This would be good to have for PR #7053.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

