### PR TITLE
fix(Docker): Set default `RPC_PORT`

### DIFF
--- a/docker/runtime-entrypoint.sh
+++ b/docker/runtime-entrypoint.sh
@@ -31,6 +31,11 @@ fi
 : "${TRACING_ENDPOINT_PORT:=3000}"
 # [rpc]
 : "${RPC_LISTEN_ADDR:=0.0.0.0}"
+if [[ "${NETWORK}" = "Mainnet" ]]; then
+: "${RPC_PORT:=8232}"
+elif [[ "${NETWORK}" = "Testnet" ]]; then
+: "${RPC_PORT:=18232}"
+fi
 
 
 # Populate `zebrad.toml` before starting zebrad, using the environmental


### PR DESCRIPTION
## Motivation

I noticed we were using an unset `RPC_PORT` in the runtime entry point.

## Solution

The `runtime-entrypoint.sh` uses the `RPC_PORT` env var when the user
specifies the `getblocktemplate-rpc` feature, but this env var is unset
unless the user sets it. This commit sets the default values for
`RPC_PORT` depending on `NETWORK`.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?


