### PR TITLE
fix(ci): Increase peer cache startup wait time and test time

### DIFF
--- a/zebra-network/src/peer_cache_updater.rs
+++ b/zebra-network/src/peer_cache_updater.rs
@@ -25,7 +25,7 @@ pub async fn peer_cache_updater(
     //
     // TODO: turn the initial sleep time into a parameter of this function,
     //       and allow it to be set in tests
-    sleep(DNS_LOOKUP_TIMEOUT * 2).await;
+    sleep(DNS_LOOKUP_TIMEOUT * 4).await;
 
     loop {
         // Ignore errors because updating the cache is optional.

--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -39,7 +39,7 @@ pub const LAUNCH_DELAY: Duration = Duration::from_secs(15);
 
 /// After we launch `zebrad`, wait this long in extended tests.
 /// See [`LAUNCH_DELAY`] for details.
-pub const EXTENDED_LAUNCH_DELAY: Duration = Duration::from_secs(25);
+pub const EXTENDED_LAUNCH_DELAY: Duration = Duration::from_secs(45);
 
 /// After we launch `lightwalletd`, wait this long for the command to start up,
 /// take the actions expected by the quick tests, and log the expected logs.


### PR DESCRIPTION
## Motivation

The peer cache tests sometimes fail because the task doesn't wait long enough for the seed peer DNS queries:
https://github.com/ZcashFoundation/zebra/actions/runs/5481072579/jobs/9984955195?pr=7152#step:15:4516

I've seen this happen two or three times in the past week. 

## Solution

Wait longer for the DNS timeout and initial peer connections, before writing peers to disk
Make the test timeout longer as well

## Review

This is causing CI failures so it would be good to get it fixed.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We could wait for the peers to actually be put in the address book instead. But in production it doesn't matter because they just get written to disk the next time the task runs.