### PR TITLE
fix(ci): Pass the network input to all cached state tests

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -135,6 +135,9 @@ jobs:
 
   # zebrad tests without cached state
 
+  # TODO: make the non-cached-state tests use:
+  # network: ${{ inputs.network || vars.ZCASH_NETWORK }}
+
   # Run all the zebra tests, including tests that are ignored by default.
   # Skips tests that need a cached state disk or a lightwalletd binary.
   #
@@ -309,6 +312,9 @@ jobs:
         env:
           ZEBRA_CONF_PATH: 'zebrad/tests/common/configs/v1.0.0-rc.2.toml'
 
+  # END TODO: make the non-cached-state tests use:
+  # network: ${{ inputs.network || vars.ZCASH_NETWORK }}
+
   # zebrad cached checkpoint state tests
 
   # Regenerate mandatory checkpoint Zebra cached state disks.
@@ -328,6 +334,7 @@ jobs:
       test_id: sync-to-checkpoint
       test_description: Test sync up to mandatory checkpoint
       test_variables: '-e TEST_DISK_REBUILD=1 -e ZEBRA_FORCE_USE_COLOR=1'
+      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       needs_zebra_state: false
       saves_to_disk: true
       disk_suffix: checkpoint
@@ -356,6 +363,7 @@ jobs:
       test_id: sync-past-checkpoint
       test_description: Test full validation sync from a cached state
       test_variables: '-e TEST_CHECKPOINT_SYNC=1 -e ZEBRA_FORCE_USE_COLOR=1'
+      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       needs_zebra_state: true
       saves_to_disk: false
       disk_suffix: checkpoint
@@ -427,6 +435,7 @@ jobs:
       test_id: update-to-tip
       test_description: Test syncing to tip with a Zebra tip state
       test_variables: '-e TEST_UPDATE_SYNC=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache'
+      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       needs_zebra_state: true
       # update the disk on every PR, to increase CI speed
       saves_to_disk: true
@@ -572,7 +581,8 @@ jobs:
       test_id: lwd-full-sync
       test_description: Test lightwalletd full sync
       test_variables: '-e TEST_LWD_FULL_SYNC=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache -e LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache'
-      # This test runs for (just) longer than 6 hours, so it needs multiple jobs
+      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
+      # This test runs for longer than 6 hours, so it needs multiple jobs
       is_long_test: true
       needs_zebra_state: true
       needs_lwd_state: false
@@ -610,6 +620,7 @@ jobs:
       test_id: lwd-update-sync
       test_description: Test lightwalletd update sync with both states
       test_variables: '-e TEST_LWD_UPDATE_SYNC=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache -e LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache'
+      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       needs_zebra_state: true
       needs_lwd_state: true
       # since we do a full sync in every PR, the new cached state will only be a few minutes newer than the original one
@@ -642,6 +653,7 @@ jobs:
       test_id: fully-synced-rpc
       test_description: Test lightwalletd RPC with a Zebra tip state
       test_variables: '-e TEST_LWD_RPC_CALL=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache'
+      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       needs_zebra_state: true
       saves_to_disk: false
       disk_suffix: tip
@@ -667,6 +679,7 @@ jobs:
       test_id: lwd-send-transactions
       test_description: Test sending transactions via lightwalletd
       test_variables: '-e TEST_LWD_TRANSACTIONS=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache -e LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache'
+      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       needs_zebra_state: true
       needs_lwd_state: true
       saves_to_disk: false
@@ -694,6 +707,7 @@ jobs:
       test_id: lwd-grpc-wallet
       test_description: Test gRPC calls via lightwalletd
       test_variables: '-e TEST_LWD_GRPC=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache -e LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache'
+      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       needs_zebra_state: true
       needs_lwd_state: true
       saves_to_disk: false
@@ -725,6 +739,7 @@ jobs:
       test_id: get-block-template
       test_description: Test getblocktemplate RPC method via Zebra's rpc server
       test_variables: '-e TEST_GET_BLOCK_TEMPLATE=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache'
+      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       needs_zebra_state: true
       needs_lwd_state: false
       saves_to_disk: false
@@ -751,6 +766,7 @@ jobs:
       test_id: submit-block
       test_description: Test submitting blocks via Zebra's rpc server
       test_variables: '-e TEST_SUBMIT_BLOCK=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache'
+      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       needs_zebra_state: true
       needs_lwd_state: false
       saves_to_disk: false

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -570,13 +570,91 @@ jobs:
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
           "
 
+
+  # check the logs of the test we just launched for zebrad startup messages
+  #
+  # this step makes sure `zebrad` is running, and configured for `inputs.network`.
+  logs-startup:
+    name: Check startup for ${{ inputs.test_id }}
+    # We run exactly one of without-cached-state or with-cached-state, and we always skip the other one.
+    needs: [ launch-with-cached-state, launch-without-cached-state ]
+    # If the previous job fails, we still want to show the logs.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v3.5.3
+        with:
+          persist-credentials: false
+          fetch-depth: '2'
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
+
+      # Install our SSH secret
+      - name: Install private SSH key
+        uses: shimataro/ssh-key-action@v2.5.1
+        with:
+          key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          name: google_compute_engine
+          known_hosts: unnecessary
+
+      - name: Generate public SSH key
+        run: ssh-keygen -y -f ~/.ssh/google_compute_engine > ~/.ssh/google_compute_engine.pub
+
+      # Setup gcloud CLI
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v1.1.1
+        with:
+          retries: '3'
+          workload_identity_provider: '${{ vars.GCP_WIF }}'
+          service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1.1.1
+
+      # Show all the logs since the container launched,
+      # following until we see zebrad startup messages.
+      #
+      # This check limits the number of log lines, so tests running on the wrong network don't
+      # run until the job timeout. If Zebra does a complete recompile, there are a few hundred log
+      # lines before the startup logs. So that's what we use here.
+      #
+      # The log pipeline ignores the exit status of `docker logs`.
+      # It also ignores the expected 'broken pipe' error from `tee`,
+      # which happens when `grep` finds a matching output and moves on to the next job.
+      #
+      # Errors in the tests are caught by the final test status job.
+      - name: Check startup logs for ${{ inputs.test_id }}
+        run: |
+          gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          --zone ${{ vars.GCP_ZONE }} \
+          --ssh-flag="-o ServerAliveInterval=5" \
+          --ssh-flag="-o ConnectionAttempts=20" \
+          --ssh-flag="-o ConnectTimeout=5" \
+          --command \
+          "\
+          sudo docker logs \
+          --tail all \
+          --follow \
+          ${{ inputs.test_id }} | \
+          head -700 | \
+          tee --output-error=exit /dev/stderr | \
+          grep --max-count=1 --extended-regexp --color=always \
+          -e 'Zcash network: ${{ inputs.network }}' \
+          "
+
   # follow the logs of the test we just launched, up to Canopy activation (or the test finishing)
   #
   # If `inputs.is_long_test` is `false`, this job is skipped.
   logs-heartwood:
     name: Log ${{ inputs.test_id }} test (heartwood)
-    # We run exactly one of without-cached-state or with-cached-state, and we always skip the other one.
-    needs: [ launch-with-cached-state, launch-without-cached-state ]
+    needs: [ logs-startup ]
     # If the previous job fails, we still want to show the logs.
     if: ${{ !cancelled() && inputs.is_long_test }}
     runs-on: ubuntu-latest
@@ -619,12 +697,6 @@ jobs:
 
       # Show all the logs since the container launched,
       # following until Canopy activation (or the test finishes)
-      #
-      # The log pipeline ignores the exit status of `docker logs`.
-      # It also ignores the expected 'broken pipe' error from `tee`,
-      # which happens when `grep` finds a matching output and moves on to the next job.
-      #
-      # Errors in the tests are caught by the final test status job.
       - name: Show logs for ${{ inputs.test_id }} test (heartwood)
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \


### PR DESCRIPTION
## Motivation

Some manual workflow runs can write testnet cache data to mainnet cached state disks. This makes any future jobs that use those cached states run for a long time or fail.

## Solution

- Pass the input network to all the cached state jobs
- Check that the input network matches the network that `zebrad` is using right after it launches

## Review

This is urgent because it's causing CI failures.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We should also apply the network to non-cached-state tests, but that's not urgent.