### PR TITLE
change(release): Document the release level for RPC and command-line changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -69,6 +69,8 @@ Zebra follows [semantic versioning](https://semver.org). Semantic versions look 
 Choose a release level for `zebrad`. Release levels are based on user-visible changes from the changelog:
 - Mainnet Network Upgrades are `major` releases
 - significant new features, large changes, deprecations, and removals are `minor` releases
+    - any new, changed, or removed RPC methods or fields are a `minor` release
+    - any new, changed, or removed command-line arguments are a `minor` release
 - otherwise, it is a `patch` release
 
 Zebra's Rust API doesn't have any support or stability guarantees, so we keep all the `zebra-*` and `tower-*` crates on a beta `pre-release` version.

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -68,9 +68,7 @@ Zebra follows [semantic versioning](https://semver.org). Semantic versions look 
 
 Choose a release level for `zebrad`. Release levels are based on user-visible changes from the changelog:
 - Mainnet Network Upgrades are `major` releases
-- significant new features, large changes, deprecations, and removals are `minor` releases
-    - any new, changed, or removed RPC methods or fields are a `minor` release
-    - any new, changed, or removed command-line arguments are a `minor` release
+- significant new features or behaviour changes; changes to RPCs, command-line, or configs; and deprecations or removals are `minor` releases
 - otherwise, it is a `patch` release
 
 Zebra's Rust API doesn't have any support or stability guarantees, so we keep all the `zebra-*` and `tower-*` crates on a beta `pre-release` version.


### PR DESCRIPTION
## Motivation

We talked about which release level to use for RPC and command-line changes in the engineering sync.

### Specifications

Usually we try to follow what `zcashd` does with their versions, because it's easier for users.

## Review

This is a routine change that should get merged before the next release.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We can add more specific release level guidelines as needed.