### PR TITLE
change(test): Add a recalculate_root() method to trees for tests

### DIFF
--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -345,7 +345,7 @@ impl NoteCommitmentTree {
             Some(root) => root,
             None => {
                 // Compute root and cache it.
-                let root = Root(self.inner.root().0);
+                let root = self.recalculate_root();
                 *write_root = Some(root);
                 root
             }
@@ -359,6 +359,11 @@ impl NoteCommitmentTree {
             .cached_root
             .read()
             .expect("a thread that previously held exclusive lock access panicked")
+    }
+
+    /// Calculates and returns the current root of the tree, ignoring any caching.
+    pub fn recalculate_root(&self) -> Root {
+        Root(self.inner.root().0)
     }
 
     /// Get the Pallas-based Sinsemilla hash / root node of this merkle tree of

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -348,7 +348,7 @@ impl NoteCommitmentTree {
             Some(root) => root,
             None => {
                 // Compute root and cache it.
-                let root = Root::try_from(self.inner.root().0).unwrap();
+                let root = self.recalculate_root();
                 *write_root = Some(root);
                 root
             }
@@ -362,6 +362,11 @@ impl NoteCommitmentTree {
             .cached_root
             .read()
             .expect("a thread that previously held exclusive lock access panicked")
+    }
+
+    /// Calculates and returns the current root of the tree, ignoring any caching.
+    pub fn recalculate_root(&self) -> Root {
+        Root::try_from(self.inner.root().0).unwrap()
     }
 
     /// Gets the Jubjub-based Pedersen hash of root node of this merkle tree of

--- a/zebra-chain/src/sprout/tree.rs
+++ b/zebra-chain/src/sprout/tree.rs
@@ -282,7 +282,7 @@ impl NoteCommitmentTree {
             Some(root) => root,
             None => {
                 // Compute root and cache it.
-                let root = Root(self.inner.root().0);
+                let root = self.recalculate_root();
                 *write_root = Some(root);
                 root
             }
@@ -296,6 +296,11 @@ impl NoteCommitmentTree {
             .cached_root
             .read()
             .expect("a thread that previously held exclusive lock access panicked")
+    }
+
+    /// Calculates and returns the current root of the tree, ignoring any caching.
+    pub fn recalculate_root(&self) -> Root {
+        Root(self.inner.root().0)
     }
 
     /// Returns a hash of the Sprout note commitment tree root.

--- a/zebra-state/src/service/finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/tests/vectors.rs
@@ -4,11 +4,19 @@
 //! We don't need to check empty trees, because the database format snapshot tests
 //! use empty trees.
 
-use halo2::pasta::{group::ff::PrimeField, pallas};
 use hex::FromHex;
 use rand::random;
 
-use zebra_chain::{orchard, sapling, sprout};
+use halo2::pasta::{group::ff::PrimeField, pallas};
+
+use zebra_chain::{
+    orchard::tree::NoteCommitmentTree as OrchardNoteCommitmentTree,
+    sapling::tree::NoteCommitmentTree as SaplingNoteCommitmentTree,
+    sprout::{
+        tree::NoteCommitmentTree as SproutNoteCommitmentTree,
+        NoteCommitment as SproutNoteCommitment,
+    },
+};
 
 use crate::service::finalized_state::disk_format::{FromDisk, IntoDisk};
 
@@ -17,7 +25,7 @@ use crate::service::finalized_state::disk_format::{FromDisk, IntoDisk};
 fn sprout_note_commitment_tree_serialization() {
     let _init_guard = zebra_test::init();
 
-    let mut incremental_tree = sprout::tree::NoteCommitmentTree::default();
+    let mut incremental_tree = SproutNoteCommitmentTree::default();
 
     // Some commitments from zebra-chain/src/sprout/tests/test_vectors.rs
     let hex_commitments = [
@@ -29,7 +37,7 @@ fn sprout_note_commitment_tree_serialization() {
     for (idx, cm_hex) in hex_commitments.iter().enumerate() {
         let bytes = <[u8; 32]>::from_hex(cm_hex).unwrap();
 
-        let cm = sprout::NoteCommitment::from(bytes);
+        let cm = SproutNoteCommitment::from(bytes);
         incremental_tree.append(cm).unwrap();
         if random() {
             info!(?idx, "randomly caching root for note commitment tree index");
@@ -48,7 +56,7 @@ fn sprout_note_commitment_tree_serialization() {
     let serialized_tree = incremental_tree.as_bytes();
     assert_eq!(hex::encode(&serialized_tree), expected_serialized_tree_hex);
 
-    let deserialized_tree = sprout::tree::NoteCommitmentTree::from_bytes(&serialized_tree);
+    let deserialized_tree = SproutNoteCommitmentTree::from_bytes(&serialized_tree);
 
     // This check isn't enough to show that the entire struct is the same, because it just compares
     // the cached serialized/deserialized roots. (NoteCommitmentTree::eq() also just compares
@@ -67,7 +75,7 @@ fn sprout_note_commitment_tree_serialization() {
 fn sprout_note_commitment_tree_serialization_one() {
     let _init_guard = zebra_test::init();
 
-    let mut incremental_tree = sprout::tree::NoteCommitmentTree::default();
+    let mut incremental_tree = SproutNoteCommitmentTree::default();
 
     // Some commitments from zebra-chain/src/sprout/tests/test_vectors.rs
     let hex_commitments = ["836045484077cf6390184ea7cd48b460e2d0f22b2293b69633bb152314a692fb"];
@@ -75,7 +83,7 @@ fn sprout_note_commitment_tree_serialization_one() {
     for (idx, cm_hex) in hex_commitments.iter().enumerate() {
         let bytes = <[u8; 32]>::from_hex(cm_hex).unwrap();
 
-        let cm = sprout::NoteCommitment::from(bytes);
+        let cm = SproutNoteCommitment::from(bytes);
         incremental_tree.append(cm).unwrap();
         if random() {
             info!(?idx, "randomly caching root for note commitment tree index");
@@ -94,7 +102,7 @@ fn sprout_note_commitment_tree_serialization_one() {
     let serialized_tree = incremental_tree.as_bytes();
     assert_eq!(hex::encode(&serialized_tree), expected_serialized_tree_hex);
 
-    let deserialized_tree = sprout::tree::NoteCommitmentTree::from_bytes(&serialized_tree);
+    let deserialized_tree = SproutNoteCommitmentTree::from_bytes(&serialized_tree);
 
     // This check isn't enough to show that the entire struct is the same, because it just compares
     // the cached serialized/deserialized roots. (NoteCommitmentTree::eq() also just compares
@@ -117,7 +125,7 @@ fn sprout_note_commitment_tree_serialization_one() {
 fn sprout_note_commitment_tree_serialization_pow2() {
     let _init_guard = zebra_test::init();
 
-    let mut incremental_tree = sprout::tree::NoteCommitmentTree::default();
+    let mut incremental_tree = SproutNoteCommitmentTree::default();
 
     // Some commitments from zebra-chain/src/sprout/tests/test_vectors.rs
     let hex_commitments = [
@@ -130,7 +138,7 @@ fn sprout_note_commitment_tree_serialization_pow2() {
     for (idx, cm_hex) in hex_commitments.iter().enumerate() {
         let bytes = <[u8; 32]>::from_hex(cm_hex).unwrap();
 
-        let cm = sprout::NoteCommitment::from(bytes);
+        let cm = SproutNoteCommitment::from(bytes);
         incremental_tree.append(cm).unwrap();
         if random() {
             info!(?idx, "randomly caching root for note commitment tree index");
@@ -149,7 +157,7 @@ fn sprout_note_commitment_tree_serialization_pow2() {
     let serialized_tree = incremental_tree.as_bytes();
     assert_eq!(hex::encode(&serialized_tree), expected_serialized_tree_hex);
 
-    let deserialized_tree = sprout::tree::NoteCommitmentTree::from_bytes(&serialized_tree);
+    let deserialized_tree = SproutNoteCommitmentTree::from_bytes(&serialized_tree);
 
     // This check isn't enough to show that the entire struct is the same, because it just compares
     // the cached serialized/deserialized roots. (NoteCommitmentTree::eq() also just compares
@@ -168,7 +176,7 @@ fn sprout_note_commitment_tree_serialization_pow2() {
 fn sapling_note_commitment_tree_serialization() {
     let _init_guard = zebra_test::init();
 
-    let mut incremental_tree = sapling::tree::NoteCommitmentTree::default();
+    let mut incremental_tree = SaplingNoteCommitmentTree::default();
 
     // Some commitments from zebra-chain/src/sapling/tests/test_vectors.rs
     let hex_commitments = [
@@ -199,7 +207,7 @@ fn sapling_note_commitment_tree_serialization() {
     let serialized_tree = incremental_tree.as_bytes();
     assert_eq!(hex::encode(&serialized_tree), expected_serialized_tree_hex);
 
-    let deserialized_tree = sapling::tree::NoteCommitmentTree::from_bytes(&serialized_tree);
+    let deserialized_tree = SaplingNoteCommitmentTree::from_bytes(&serialized_tree);
 
     // This check isn't enough to show that the entire struct is the same, because it just compares
     // the cached serialized/deserialized roots. (NoteCommitmentTree::eq() also just compares
@@ -218,7 +226,7 @@ fn sapling_note_commitment_tree_serialization() {
 fn sapling_note_commitment_tree_serialization_one() {
     let _init_guard = zebra_test::init();
 
-    let mut incremental_tree = sapling::tree::NoteCommitmentTree::default();
+    let mut incremental_tree = SaplingNoteCommitmentTree::default();
 
     // Some commitments from zebra-chain/src/sapling/tests/test_vectors.rs
     let hex_commitments = ["225747f3b5d5dab4e5a424f81f85c904ff43286e0f3fd07ef0b8c6a627b11458"];
@@ -245,7 +253,7 @@ fn sapling_note_commitment_tree_serialization_one() {
     let serialized_tree = incremental_tree.as_bytes();
     assert_eq!(hex::encode(&serialized_tree), expected_serialized_tree_hex);
 
-    let deserialized_tree = sapling::tree::NoteCommitmentTree::from_bytes(&serialized_tree);
+    let deserialized_tree = SaplingNoteCommitmentTree::from_bytes(&serialized_tree);
 
     // This check isn't enough to show that the entire struct is the same, because it just compares
     // the cached serialized/deserialized roots. (NoteCommitmentTree::eq() also just compares
@@ -268,7 +276,7 @@ fn sapling_note_commitment_tree_serialization_one() {
 fn sapling_note_commitment_tree_serialization_pow2() {
     let _init_guard = zebra_test::init();
 
-    let mut incremental_tree = sapling::tree::NoteCommitmentTree::default();
+    let mut incremental_tree = SaplingNoteCommitmentTree::default();
 
     // Some commitments from zebra-chain/src/sapling/tests/test_vectors.rs
     let hex_commitments = [
@@ -304,7 +312,7 @@ fn sapling_note_commitment_tree_serialization_pow2() {
     let serialized_tree = incremental_tree.as_bytes();
     assert_eq!(hex::encode(&serialized_tree), expected_serialized_tree_hex);
 
-    let deserialized_tree = sapling::tree::NoteCommitmentTree::from_bytes(&serialized_tree);
+    let deserialized_tree = SaplingNoteCommitmentTree::from_bytes(&serialized_tree);
 
     // This check isn't enough to show that the entire struct is the same, because it just compares
     // the cached serialized/deserialized roots. (NoteCommitmentTree::eq() also just compares
@@ -323,7 +331,7 @@ fn sapling_note_commitment_tree_serialization_pow2() {
 fn orchard_note_commitment_tree_serialization() {
     let _init_guard = zebra_test::init();
 
-    let mut incremental_tree = orchard::tree::NoteCommitmentTree::default();
+    let mut incremental_tree = OrchardNoteCommitmentTree::default();
 
     // Some commitments from zebra-chain/src/orchard/tests/tree.rs
     let commitments = [
@@ -364,7 +372,7 @@ fn orchard_note_commitment_tree_serialization() {
     let serialized_tree = incremental_tree.as_bytes();
     assert_eq!(hex::encode(&serialized_tree), expected_serialized_tree_hex);
 
-    let deserialized_tree = orchard::tree::NoteCommitmentTree::from_bytes(&serialized_tree);
+    let deserialized_tree = OrchardNoteCommitmentTree::from_bytes(&serialized_tree);
 
     // This check isn't enough to show that the entire struct is the same, because it just compares
     // the cached serialized/deserialized roots. (NoteCommitmentTree::eq() also just compares
@@ -383,7 +391,7 @@ fn orchard_note_commitment_tree_serialization() {
 fn orchard_note_commitment_tree_serialization_one() {
     let _init_guard = zebra_test::init();
 
-    let mut incremental_tree = orchard::tree::NoteCommitmentTree::default();
+    let mut incremental_tree = OrchardNoteCommitmentTree::default();
 
     // Some commitments from zebra-chain/src/orchard/tests/tree.rs
     let commitments = [[
@@ -412,7 +420,7 @@ fn orchard_note_commitment_tree_serialization_one() {
     let serialized_tree = incremental_tree.as_bytes();
     assert_eq!(hex::encode(&serialized_tree), expected_serialized_tree_hex);
 
-    let deserialized_tree = orchard::tree::NoteCommitmentTree::from_bytes(&serialized_tree);
+    let deserialized_tree = OrchardNoteCommitmentTree::from_bytes(&serialized_tree);
 
     // This check isn't enough to show that the entire struct is the same, because it just compares
     // the cached serialized/deserialized roots. (NoteCommitmentTree::eq() also just compares
@@ -435,7 +443,7 @@ fn orchard_note_commitment_tree_serialization_one() {
 fn orchard_note_commitment_tree_serialization_pow2() {
     let _init_guard = zebra_test::init();
 
-    let mut incremental_tree = orchard::tree::NoteCommitmentTree::default();
+    let mut incremental_tree = OrchardNoteCommitmentTree::default();
 
     // Some commitments from zebra-chain/src/orchard/tests/tree.rs
     let commitments = [
@@ -471,7 +479,7 @@ fn orchard_note_commitment_tree_serialization_pow2() {
     let serialized_tree = incremental_tree.as_bytes();
     assert_eq!(hex::encode(&serialized_tree), expected_serialized_tree_hex);
 
-    let deserialized_tree = orchard::tree::NoteCommitmentTree::from_bytes(&serialized_tree);
+    let deserialized_tree = OrchardNoteCommitmentTree::from_bytes(&serialized_tree);
 
     // This check isn't enough to show that the entire struct is the same, because it just compares
     // the cached serialized/deserialized roots. (NoteCommitmentTree::eq() also just compares

--- a/zebra-state/src/service/finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/tests/vectors.rs
@@ -20,6 +20,26 @@ use zebra_chain::{
 
 use crate::service::finalized_state::disk_format::{FromDisk, IntoDisk};
 
+// Currently, these tests check these structs are equal:
+//  * commitments -> tree struct
+//  * commitments -> tree struct -> seralize -> deserialize -> tree struct
+// And these serialized formats are equal:
+//  * fixed serialized test vector
+//  * commitments -> tree struct -> seralize
+//  * commitments -> tree struct -> seralize -> deserialize -> tree struct -> serialize
+//
+// TODO: apply these tests to the new tree structs, and update the serialization format
+//       (keeping the tests for the old format is optional, because the tests below cover it)
+//
+// TODO: test that old and new serializations produce the same format:
+// Tree roots built from the same commitments should match:
+//   * commitments -> old tree struct -> new tree struct -> un-cached root
+//   * commitments -> new tree struct -> un-cached root
+// Even when serialized and deserialized:
+//   * commitments -> old tree struct -> old serialize -> old deserialize -> old tree struct ->  new tree struct -> un-cached root
+//   * commitments -> new tree struct -> new serialize -> new deserialize -> new tree struct -> un-cached root
+//   * commitments -> new tree struct -> un-cached root
+
 /// Check that the sprout tree database serialization format has not changed.
 #[test]
 fn sprout_note_commitment_tree_serialization() {

--- a/zebra-state/src/service/finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/tests/vectors.rs
@@ -22,11 +22,11 @@ use crate::service::finalized_state::disk_format::{FromDisk, IntoDisk};
 
 // Currently, these tests check these structs are equal:
 //  * commitments -> tree struct
-//  * commitments -> tree struct -> seralize -> deserialize -> tree struct
+//  * commitments -> tree struct -> serialize -> deserialize -> tree struct
 // And these serialized formats are equal:
 //  * fixed serialized test vector
-//  * commitments -> tree struct -> seralize
-//  * commitments -> tree struct -> seralize -> deserialize -> tree struct -> serialize
+//  * commitments -> tree struct -> serialize
+//  * commitments -> tree struct -> serialize -> deserialize -> tree struct -> serialize
 //
 // TODO: apply these tests to the new tree structs, and update the serialization format
 //       (keeping the tests for the old format is optional, because the tests below cover it)


### PR DESCRIPTION
## Motivation

We want to write tests that recalculate tree roots, ignoring any cached roots. This PR adds an API to do that, but doesn't add tests.

Part of #7202.

## Solution

Add a tree method that recalculates roots.
Rename some test types to make them easier to change.
Add TODOs for old to new conversion tests.

## Review

This should help with the ECC dependencies upgrade that @oxarbitrage is doing. It can merge before that PR.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Actually write the tests.