### PR TITLE
fix(ci): Stop requiring testnet job for CI to pass

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -120,8 +120,7 @@ jobs:
       zebra_skip_ipv6_tests: '1'
       rust_log: info
 
-  # Test that Zebra works using the default config with the latest Zebra version,
-  # and test reconfiguring the docker image for testnet.
+  # Test that Zebra works using the default config with the latest Zebra version.
   test-configuration-file:
     name: Test Zebra CD Docker config file
     timeout-minutes: 15
@@ -160,6 +159,20 @@ jobs:
           exit 0
           fi
           exit "$EXIT_STATUS"
+
+  # Test reconfiguring the docker image for testnet.
+  test-configuration-file-testnet:
+    name: Test testnet Zebra CD Docker config file
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: r7kamura/rust-problem-matchers@v1.3.0
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 7
 
       # Make sure Zebra can sync the genesis block on testnet
       - name: Run tests using a testnet config


### PR DESCRIPTION
## Motivation

Testnet is down and we can't merge any PRs, because one of our required CI tests has a step that runs on testnet.


## Solution

Move the testnet step into its own job, so main branch merges just depend on mainnet.

## Review

This is urgent, PRs can't merge without this fix.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
