### PR TITLE
suggestion: Make recent IP splitting more efficient by doing the time calculation once

### DIFF
--- a/zebra-network/src/peer_set/initialize/recent_by_ip.rs
+++ b/zebra-network/src/peer_set/initialize/recent_by_ip.rs
@@ -14,7 +14,7 @@ mod tests;
 #[derive(Debug)]
 /// Stores IPs of recently attempted inbound connections.
 pub struct RecentByIp {
-    /// The list of IPs in increasing connection time order.
+    /// The list of IPs in decreasing connection age order.
     pub by_time: VecDeque<(IpAddr, Instant)>,
 
     /// Stores IPs for recently attempted inbound connections.

--- a/zebra-network/src/peer_set/initialize/recent_by_ip/tests.rs
+++ b/zebra-network/src/peer_set/initialize/recent_by_ip/tests.rs
@@ -1,3 +1,5 @@
+//! Fixed test vectors for recent IP limits.
+
 use std::time::Duration;
 
 use crate::peer_set::initialize::recent_by_ip::RecentByIp;


### PR DESCRIPTION

This is a suggestion for @arya2 for PR #7041:
- make recent IP splitting more efficient by doing the time calculation once
- tweak some comments
