### PR TITLE
fix(tests): Place coinbase tx as the first tx in fake child blocks

### DIFF
--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -41,7 +41,7 @@ impl FakeChainHelper for Arc<Block> {
             _ => panic!("block must have a coinbase height to create a child"),
         }
 
-        child.transactions.push(tx);
+        child.transactions.insert(0, tx);
         Arc::make_mut(&mut child.header).previous_block_hash = parent_hash;
 
         Arc::new(child)


### PR DESCRIPTION
## Motivation

I noticed we weren't making fake child blocks correctly. The issue was that we weren't placing the updated coinbase tx as the first one in the block. All tests using the `make_fake_child` function were working fine because they all use blocks with only one tx. 

## Solution

Place the updated coinbase tx as the first one in the block.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
