### PR TITLE
fix(panic): Stop panicking on async task cancellation on shutdown in network and state futures

### DIFF
--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -24,6 +24,11 @@ json-conversion = [
     "serde_json",
 ]
 
+# Async error handling convenience traits
+async-error = [
+    "tokio",
+]
+
 # Experimental mining RPC support
 getblocktemplate-rpcs = [
     "zcash_address",
@@ -39,7 +44,7 @@ proptest-impl = [
     "proptest-derive",
     "rand",
     "rand_chacha",
-    "tokio",
+    "tokio/tracing",
     "zebra-test",
 ]
 
@@ -107,6 +112,9 @@ reddsa = "0.5.0"
 # Production feature json-conversion
 serde_json = { version = "1.0.100", optional = true }
 
+# Production feature async-error and testing feature proptest-impl
+tokio = { version = "1.29.1", optional = true }
+
 # Experimental feature getblocktemplate-rpcs
 zcash_address = { version = "0.2.1", optional = true }
 
@@ -116,8 +124,6 @@ proptest-derive = { version = "0.3.0", optional = true }
 
 rand = { version = "0.8.5", optional = true }
 rand_chacha = { version = "0.3.1", optional = true }
-
-tokio = { version = "1.29.1", features = ["tracing"], optional = true }
 
 zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.27", optional = true }
 

--- a/zebra-chain/src/diagnostic.rs
+++ b/zebra-chain/src/diagnostic.rs
@@ -1,6 +1,15 @@
-//! Tracing the execution time of functions.
-//!
-//! TODO: also trace polling time for futures, using a `Future` wrapper
+//! Diagnostic types and functions for Zebra:
+//! - code performance
+//! - task handling
+//! - errors and panics
+
+pub mod task;
+
+// Tracing the execution time of functions.
+//
+// TODO:
+// - move this to a `timing` submodule
+// - also trace polling time for futures, using a `Future` wrapper
 
 use std::time::{Duration, Instant};
 

--- a/zebra-chain/src/diagnostic/task.rs
+++ b/zebra-chain/src/diagnostic/task.rs
@@ -13,11 +13,56 @@ pub trait CheckForPanics {
     /// The output type, after removing panics from `Self`.
     type Output;
 
-    /// Check if `self` contains a panic payload, and resume that panic.
+    /// Check if `self` contains a panic payload or an unexpected termination, then panic.
     /// Otherwise, return the non-panic part of `self`.
     ///
     /// # Panics
     ///
-    /// If `self` contains a panic payload.
+    /// If `self` contains a panic payload or an unexpected termination.
+    #[track_caller]
     fn check_for_panics(self) -> Self::Output;
+}
+
+/// A trait that waits for a task to finish, then handles panics and cancellations.
+pub trait WaitForTermination {
+    /// The underlying task output, after removing panics and unwrapping termination results.
+    type UnwrappedOutput;
+
+    /// The underlying task output, after removing panics,
+    /// and replacing expected terminations with a default value.
+    ///
+    /// This is typically a `Result` containing the underlying task output type.
+    type ResultOutput;
+
+    /// Waits for `self` to finish, then check if its output is:
+    /// - a panic payload: resume that panic,
+    /// - an unexpected termination: panic with that error,
+    /// - an expected termination: hang waiting for shutdown.
+    ///
+    /// Otherwise, returns the task return value of `self`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` contains a panic payload or an unexpected termination.
+    ///
+    /// # Hangs
+    ///
+    /// If `self` contains an expected termination, and we're shutting down anyway.
+    #[track_caller]
+    fn panic_on_early_termination(self) -> Self::UnwrappedOutput;
+
+    /// Waits for `self` to finish, then check if its output is:
+    /// - a panic payload: resume that panic,
+    /// - an unexpected termination: return that error,
+    /// - an expected termination: return the provided `expected_termination_value`.
+    ///
+    /// Otherwise, returns the task return value of `self`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` contains a panic payload.
+    #[track_caller]
+    fn error_on_early_termination<D>(self, expected_termination_value: D) -> Self::ResultOutput
+    where
+        D: Into<Self::ResultOutput> + Send + 'static;
 }

--- a/zebra-chain/src/diagnostic/task.rs
+++ b/zebra-chain/src/diagnostic/task.rs
@@ -7,3 +7,17 @@
 pub mod future;
 
 pub mod thread;
+
+/// A trait that checks a task's return value for panics.
+pub trait CheckForPanics {
+    /// The output type, after removing panics from `Self`.
+    type Output;
+
+    /// Check if `self` contains a panic payload, and resume that panic.
+    /// Otherwise, return the non-panic part of `self`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` contains a panic payload.
+    fn check_for_panics(self) -> Self::Output;
+}

--- a/zebra-chain/src/diagnostic/task.rs
+++ b/zebra-chain/src/diagnostic/task.rs
@@ -24,15 +24,9 @@ pub trait CheckForPanics {
 }
 
 /// A trait that waits for a task to finish, then handles panics and cancellations.
-pub trait WaitForTermination {
+pub trait WaitForPanics {
     /// The underlying task output, after removing panics and unwrapping termination results.
-    type UnwrappedOutput;
-
-    /// The underlying task output, after removing panics,
-    /// and replacing expected terminations with a default value.
-    ///
-    /// This is typically a `Result` containing the underlying task output type.
-    type ResultOutput;
+    type Output;
 
     /// Waits for `self` to finish, then check if its output is:
     /// - a panic payload: resume that panic,
@@ -49,20 +43,5 @@ pub trait WaitForTermination {
     ///
     /// If `self` contains an expected termination, and we're shutting down anyway.
     #[track_caller]
-    fn panic_on_early_termination(self) -> Self::UnwrappedOutput;
-
-    /// Waits for `self` to finish, then check if its output is:
-    /// - a panic payload: resume that panic,
-    /// - an unexpected termination: return that error,
-    /// - an expected termination: return the provided `expected_termination_value`.
-    ///
-    /// Otherwise, returns the task return value of `self`.
-    ///
-    /// # Panics
-    ///
-    /// If `self` contains a panic payload.
-    #[track_caller]
-    fn error_on_early_termination<D>(self, expected_termination_value: D) -> Self::ResultOutput
-    where
-        D: Into<Self::ResultOutput> + Send + 'static;
+    fn wait_for_panics(self) -> Self::Output;
 }

--- a/zebra-chain/src/diagnostic/task.rs
+++ b/zebra-chain/src/diagnostic/task.rs
@@ -1,0 +1,9 @@
+//! Diagnostic types and functions for Zebra tasks:
+//! - OS thread handling
+//! - async future task handling
+//! - errors and panics
+
+#[cfg(feature = "async-error")]
+pub mod future;
+
+pub mod thread;

--- a/zebra-chain/src/diagnostic/task/future.rs
+++ b/zebra-chain/src/diagnostic/task/future.rs
@@ -1,3 +1,61 @@
 //! Diagnostic types and functions for Zebra async future tasks:
 //! - task handles
 //! - errors and panics
+
+use std::panic;
+
+use tokio::task;
+
+use crate::shutdown::is_shutting_down;
+
+use super::CheckForPanics;
+
+// Only for doc links.
+#[allow(unused_imports)]
+use tokio::task::JoinHandle;
+
+/// This is the return type of the [`JoinHandle`] future.
+impl<T> CheckForPanics for Result<T, task::JoinError> {
+    /// The [`JoinHandle`]'s task output, after resuming any panics,
+    /// and ignoring task cancellations on shutdown.
+    type Output = Result<T, task::JoinError>;
+
+    /// Returns the task result if the task finished normally.
+    /// Otherwise, resumes any panics, logs unexpected errors, and ignores any expected errors.
+    ///
+    /// If the task finished normally, returns `Some(T)`.
+    /// If the task was cancelled, returns `None`.
+    fn check_for_panics(self) -> Self::Output {
+        match self {
+            Ok(task_output) => Ok(task_output),
+            Err(join_error) => Err(join_error.check_for_panics()),
+        }
+    }
+}
+
+impl CheckForPanics for task::JoinError {
+    /// The [`JoinError`] after resuming any panics, and logging any unexpected task cancellations.
+    type Output = task::JoinError;
+
+    /// Resume any panics and panic on unexpected task cancellations.
+    /// Always returns [`JoinError::Cancelled`].
+    fn check_for_panics(self) -> Self::Output {
+        match self.try_into_panic() {
+            Ok(panic_payload) => panic::resume_unwind(panic_payload),
+
+            // We could ignore this error, but then we'd have to change the return type.
+            Err(task_cancelled) if is_shutting_down() => {
+                debug!(
+                    ?task_cancelled,
+                    "ignoring cancelled task because Zebra is shutting down"
+                );
+
+                task_cancelled
+            }
+
+            Err(task_cancelled) => {
+                panic!("task cancelled during normal Zebra operation: {task_cancelled:?}");
+            }
+        }
+    }
+}

--- a/zebra-chain/src/diagnostic/task/future.rs
+++ b/zebra-chain/src/diagnostic/task/future.rs
@@ -2,29 +2,27 @@
 //! - task handles
 //! - errors and panics
 
-use std::panic;
+use std::{future, panic};
 
-use tokio::task;
+use futures::future::{BoxFuture, FutureExt};
+use tokio::task::{JoinError, JoinHandle};
 
 use crate::shutdown::is_shutting_down;
 
-use super::CheckForPanics;
-
-// Only for doc links.
-#[allow(unused_imports)]
-use tokio::task::JoinHandle;
+use super::{CheckForPanics, WaitForTermination};
 
 /// This is the return type of the [`JoinHandle`] future.
-impl<T> CheckForPanics for Result<T, task::JoinError> {
+impl<T> CheckForPanics for Result<T, JoinError> {
     /// The [`JoinHandle`]'s task output, after resuming any panics,
     /// and ignoring task cancellations on shutdown.
-    type Output = Result<T, task::JoinError>;
+    type Output = Result<T, JoinError>;
 
     /// Returns the task result if the task finished normally.
     /// Otherwise, resumes any panics, logs unexpected errors, and ignores any expected errors.
     ///
     /// If the task finished normally, returns `Some(T)`.
     /// If the task was cancelled, returns `None`.
+    #[track_caller]
     fn check_for_panics(self) -> Self::Output {
         match self {
             Ok(task_output) => Ok(task_output),
@@ -33,12 +31,13 @@ impl<T> CheckForPanics for Result<T, task::JoinError> {
     }
 }
 
-impl CheckForPanics for task::JoinError {
+impl CheckForPanics for JoinError {
     /// The [`JoinError`] after resuming any panics, and logging any unexpected task cancellations.
-    type Output = task::JoinError;
+    type Output = JoinError;
 
     /// Resume any panics and panic on unexpected task cancellations.
-    /// Always returns [`JoinError::Cancelled`].
+    /// Always returns [`JoinError::Cancelled`](JoinError::is_cancelled).
+    #[track_caller]
     fn check_for_panics(self) -> Self::Output {
         match self.try_into_panic() {
             Ok(panic_payload) => panic::resume_unwind(panic_payload),
@@ -57,5 +56,102 @@ impl CheckForPanics for task::JoinError {
                 panic!("task cancelled during normal Zebra operation: {task_cancelled:?}");
             }
         }
+    }
+}
+
+impl<T> WaitForTermination for JoinHandle<T>
+where
+    T: Send + 'static,
+{
+    type UnwrappedOutput = BoxFuture<'static, T>;
+
+    type ResultOutput = BoxFuture<'static, Result<T, JoinError>>;
+
+    /// Returns a future which waits for `self` to finish, then checks if its output is:
+    /// - a panic payload: resume that panic,
+    /// - an unexpected termination: panic with that error,
+    /// - an expected termination: hang waiting for shutdown.
+    ///
+    /// Otherwise, returns the task return value of `self`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` contains a panic payload, or [`JoinHandle::abort()`] has been called on `self`.
+    ///
+    /// # Hangs
+    ///
+    /// If `self` contains an expected termination, and we're shutting down anyway.
+    /// Futures hang by returning `Pending` and not setting a waker, so this uses minimal resources.
+    #[track_caller]
+    fn panic_on_early_termination(self) -> Self::UnwrappedOutput {
+        async move {
+            let join_error = match self.await {
+                Ok(task_output) => return task_output,
+                Err(join_error) => join_error,
+            };
+
+            match join_error.try_into_panic() {
+                Ok(panic_payload) => panic::resume_unwind(panic_payload),
+
+                // We can ignore this error by making the future wait forever.
+                // Waiting forever is only correct when Zebra is shutting down,
+                // otherwise it could lead to hangs.
+                Err(task_cancelled) if is_shutting_down() => {
+                    debug!(
+                        ?task_cancelled,
+                        "ignoring cancelled task because Zebra is shutting down"
+                    );
+
+                    future::pending().await
+                }
+
+                Err(task_cancelled) => {
+                    panic!("task cancelled during normal Zebra operation: {task_cancelled:?}");
+                }
+            }
+        }
+        .boxed()
+    }
+
+    /// Returns a future which waits for `self` to finish, then checks if its output is:
+    /// - a panic payload: resume that panic,
+    /// - an unexpected termination: return that error,
+    /// - an expected termination: return the provided `expected_termination_value`.
+    ///
+    /// Otherwise, returns the task return value of `self`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` contains a panic payload.
+    #[track_caller]
+    fn error_on_early_termination<D>(self, expected_termination_value: D) -> Self::ResultOutput
+    where
+        D: Into<Self::ResultOutput> + Send + 'static,
+    {
+        async move {
+            let task_result = self.await;
+
+            let Err(join_error) = task_result else {
+                // Always `Ok`
+                return task_result;
+            };
+
+            match join_error.try_into_panic() {
+                Ok(panic_payload) => panic::resume_unwind(panic_payload),
+
+                // Substitute the default value
+                Err(task_cancelled) if is_shutting_down() => {
+                    debug!(
+                        ?task_cancelled,
+                        "ignoring cancelled task because Zebra is shutting down"
+                    );
+
+                    expected_termination_value.into().await
+                }
+
+                Err(task_cancelled) => Err(task_cancelled),
+            }
+        }
+        .boxed()
     }
 }

--- a/zebra-chain/src/diagnostic/task/future.rs
+++ b/zebra-chain/src/diagnostic/task/future.rs
@@ -1,0 +1,3 @@
+//! Diagnostic types and functions for Zebra async future tasks:
+//! - task handles
+//! - errors and panics

--- a/zebra-chain/src/diagnostic/task/thread.rs
+++ b/zebra-chain/src/diagnostic/task/thread.rs
@@ -70,9 +70,7 @@ impl<T> CheckForPanics for &mut Option<Arc<JoinHandle<T>>> {
     ///
     /// If the thread has not finished, or this is not the final `Arc`, returns `None`.
     fn check_for_panics(self) -> Self::Output {
-        let Some(handle) = self.take() else {
-            return None;
-        };
+        let handle = self.take()?;
 
         if handle.is_finished() {
             // This is the same as calling `self.wait_for_panics()`, but we can't do that,
@@ -95,13 +93,9 @@ impl<T> WaitForPanics for &mut Option<Arc<JoinHandle<T>>> {
     ///
     /// If this is not the final `Arc`, drops the handle and returns `None`.
     fn wait_for_panics(self) -> Self::Output {
-        let Some(handle) = self.take() else {
-            return None;
-        };
-
         // This is more readable as an expanded statement.
         #[allow(clippy::manual_map)]
-        if let Some(output) = handle.wait_for_panics() {
+        if let Some(output) = self.take()?.wait_for_panics() {
             Some(output)
         } else {
             // Some other task has a reference, so we should give up ours to let them use it.

--- a/zebra-chain/src/diagnostic/task/thread.rs
+++ b/zebra-chain/src/diagnostic/task/thread.rs
@@ -13,7 +13,7 @@ use super::{CheckForPanics, WaitForPanics};
 impl<T> CheckForPanics for thread::Result<T> {
     type Output = T;
 
-    /// Waits for the thread to finish, then panics if the thread panicked.
+    /// Panics if the thread panicked.
     ///
     /// Threads can't be cancelled except by using a panic, so there are no thread errors here.
     #[track_caller]

--- a/zebra-chain/src/diagnostic/task/thread.rs
+++ b/zebra-chain/src/diagnostic/task/thread.rs
@@ -1,3 +1,21 @@
 //! Diagnostic types and functions for Zebra OS thread tasks:
 //! - task handles
 //! - errors and panics
+
+use std::{panic, thread};
+
+use super::CheckForPanics;
+
+impl<T> CheckForPanics for thread::Result<T> {
+    type Output = T;
+
+    fn check_for_panics(self) -> Self::Output {
+        match self {
+            // The value returned by the thread when it finished.
+            Ok(thread_output) => thread_output,
+
+            // A thread error is always a panic.
+            Err(panic_payload) => panic::resume_unwind(panic_payload),
+        }
+    }
+}

--- a/zebra-chain/src/diagnostic/task/thread.rs
+++ b/zebra-chain/src/diagnostic/task/thread.rs
@@ -1,0 +1,3 @@
+//! Diagnostic types and functions for Zebra OS thread tasks:
+//! - task handles
+//! - errors and panics

--- a/zebra-chain/src/diagnostic/task/thread.rs
+++ b/zebra-chain/src/diagnostic/task/thread.rs
@@ -4,11 +4,15 @@
 
 use std::{panic, thread};
 
-use super::CheckForPanics;
+use super::{CheckForPanics, WaitForTermination};
 
 impl<T> CheckForPanics for thread::Result<T> {
     type Output = T;
 
+    /// Waits for the thread to finish, then panics if the thread panicked.
+    ///
+    /// Threads can't be cancelled except by using a panic, so there are no thread errors here.
+    #[track_caller]
     fn check_for_panics(self) -> Self::Output {
         match self {
             // The value returned by the thread when it finished.
@@ -17,5 +21,28 @@ impl<T> CheckForPanics for thread::Result<T> {
             // A thread error is always a panic.
             Err(panic_payload) => panic::resume_unwind(panic_payload),
         }
+    }
+}
+
+impl<T> WaitForTermination for thread::JoinHandle<T> {
+    type UnwrappedOutput = T;
+
+    type ResultOutput = thread::Result<T>;
+
+    /// Waits for the thread to finish, then panics if the thread panicked.
+    #[track_caller]
+    fn panic_on_early_termination(self) -> Self::UnwrappedOutput {
+        self.join().check_for_panics()
+    }
+
+    /// Waits for the thread to finish, then panics if the thread panicked.
+    ///
+    /// Threads can't be cancelled except by using a panic, so the returned result is always `Ok`.
+    #[track_caller]
+    fn error_on_early_termination<D>(self, _expected_termination_value: D) -> Self::ResultOutput
+    where
+        D: Into<Self::ResultOutput> + 'static,
+    {
+        Ok(self.panic_on_early_termination())
     }
 }

--- a/zebra-chain/src/diagnostic/task/thread.rs
+++ b/zebra-chain/src/diagnostic/task/thread.rs
@@ -45,6 +45,7 @@ impl<T> WaitForPanics for Arc<JoinHandle<T>> {
     /// panicked. Otherwise, returns the thread's return value.
     ///
     /// If this is not the final `Arc`, drops the handle and immediately returns `None`.
+    #[track_caller]
     fn wait_for_panics(self) -> Self::Output {
         // If we are the last Arc with a reference to this handle,
         // we can wait for it and propagate any panics.
@@ -69,6 +70,7 @@ impl<T> CheckForPanics for &mut Option<Arc<JoinHandle<T>>> {
     /// panicked. Otherwise, returns the thread's return value.
     ///
     /// If the thread has not finished, or this is not the final `Arc`, returns `None`.
+    #[track_caller]
     fn check_for_panics(self) -> Self::Output {
         let handle = self.take()?;
 
@@ -92,6 +94,7 @@ impl<T> WaitForPanics for &mut Option<Arc<JoinHandle<T>>> {
     /// panicked. Otherwise, returns the thread's return value.
     ///
     /// If this is not the final `Arc`, drops the handle and returns `None`.
+    #[track_caller]
     fn wait_for_panics(self) -> Self::Output {
         // This is more readable as an expanded statement.
         #[allow(clippy::manual_map)]

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -83,7 +83,7 @@ howudoin = { version = "0.1.2", optional = true }
 proptest = { version = "1.2.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.27" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.27", features = ["async-error"] }
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -8,7 +8,7 @@ use tokio::time::{sleep_until, timeout, Instant};
 use tower::{Service, ServiceExt};
 use tracing::Span;
 
-use zebra_chain::serialization::DateTime32;
+use zebra_chain::{diagnostic::task::WaitForTermination, serialization::DateTime32};
 
 use crate::{
     constants, meta_addr::MetaAddrChange, peer_set::set::MorePeers, types::MetaAddr, AddressBook,
@@ -348,8 +348,8 @@ where
         tokio::task::spawn_blocking(move || {
             span.in_scope(|| address_book.lock().unwrap().extend(addrs))
         })
+        .panic_on_early_termination()
         .await
-        .expect("panic in new peers address book update task");
     }
 
     /// Returns the next candidate for a connection attempt, if any are available.
@@ -403,8 +403,8 @@ where
         // Correctness: Spawn address book accesses on a blocking thread, to avoid deadlocks (see #1976).
         let span = Span::current();
         let next_peer = tokio::task::spawn_blocking(move || span.in_scope(next_peer))
-            .await
-            .expect("panic in next peer address book task")?;
+            .panic_on_early_termination()
+            .await?;
 
         // Security: rate-limit new outbound peer connections
         sleep_until(self.min_next_handshake).await;

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -71,7 +71,7 @@ tracing = "0.1.37"
 elasticsearch = { version = "8.5.0-alpha.1", default-features = false, features = ["rustls-tls"], optional = true }
 serde_json = { version = "1.0.100", package = "serde_json", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.27" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.27", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -32,6 +32,9 @@ pub enum Response {
     Depth(Option<u32>),
 
     /// Response to [`Request::Tip`] with the current best chain tip.
+    //
+    // TODO: remove this request, and replace it with a call to
+    //       `LatestChainTip::best_tip_height_and_hash()`
     Tip(Option<(block::Height, block::Hash)>),
 
     /// Response to [`Request::BlockLocator`] with a block locator object.

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -43,7 +43,7 @@ use tower::buffer::Buffer;
 
 use zebra_chain::{
     block::{self, CountedHeader, HeightDiff},
-    diagnostic::CodeTimer,
+    diagnostic::{task::WaitForTermination, CodeTimer},
     parameters::{Network, NetworkUpgrade},
 };
 
@@ -1209,8 +1209,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::Tip(tip))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::Tip"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // Used by the StateService.
@@ -1231,8 +1230,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::Depth(depth))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::Depth"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // Used by the StateService.
@@ -1255,10 +1253,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::BestChainNextMedianTimePast(median_time_past?))
                     })
                 })
-                .map(|join_result| {
-                    join_result.expect("panic in ReadRequest::BestChainNextMedianTimePast")
-                })
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // Used by the get_block (raw) RPC and the StateService.
@@ -1283,8 +1278,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::Block(block))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::Block"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // For the get_raw_transaction RPC and the StateService.
@@ -1302,8 +1296,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::Transaction(response))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::Transaction"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // Used by the getblock (verbose) RPC.
@@ -1332,10 +1325,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::TransactionIdsForBlock(transaction_ids))
                     })
                 })
-                .map(|join_result| {
-                    join_result.expect("panic in ReadRequest::TransactionIdsForBlock")
-                })
-                .boxed()
+                .panic_on_early_termination()
             }
 
             ReadRequest::UnspentBestChainUtxo(outpoint) => {
@@ -1359,8 +1349,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::UnspentBestChainUtxo(utxo))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::UnspentBestChainUtxo"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // Manually used by the StateService to implement part of AwaitUtxo.
@@ -1381,8 +1370,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::AnyChainUtxo(utxo))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::AnyChainUtxo"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // Used by the StateService.
@@ -1405,8 +1393,7 @@ impl Service<ReadRequest> for ReadStateService {
                         ))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::BlockLocator"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // Used by the StateService.
@@ -1433,8 +1420,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::BlockHashes(block_hashes))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::FindBlockHashes"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // Used by the StateService.
@@ -1466,8 +1452,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::BlockHeaders(block_headers))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::FindBlockHeaders"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             ReadRequest::SaplingTree(hash_or_height) => {
@@ -1491,8 +1476,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::SaplingTree(sapling_tree))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::SaplingTree"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             ReadRequest::OrchardTree(hash_or_height) => {
@@ -1516,8 +1500,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::OrchardTree(orchard_tree))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::OrchardTree"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // For the get_address_balance RPC.
@@ -1542,8 +1525,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::AddressBalance(balance))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::AddressBalance"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // For the get_address_tx_ids RPC.
@@ -1576,10 +1558,7 @@ impl Service<ReadRequest> for ReadStateService {
                         tx_ids.map(ReadResponse::AddressesTransactionIds)
                     })
                 })
-                .map(|join_result| {
-                    join_result.expect("panic in ReadRequest::TransactionIdsByAddresses")
-                })
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // For the get_address_utxos RPC.
@@ -1605,8 +1584,7 @@ impl Service<ReadRequest> for ReadStateService {
                         utxos.map(ReadResponse::AddressUtxos)
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::UtxosByAddresses"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             ReadRequest::CheckBestChainTipNullifiersAndAnchors(unmined_tx) => {
@@ -1639,11 +1617,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::ValidBestChainTipNullifiersAndAnchors)
                     })
                 })
-                .map(|join_result| {
-                    join_result
-                        .expect("panic in ReadRequest::CheckBestChainTipNullifiersAndAnchors")
-                })
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // Used by the get_block and get_block_hash RPCs.
@@ -1672,8 +1646,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::BlockHash(hash))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::BestChainBlockHash"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // Used by get_block_template RPC.
@@ -1712,8 +1685,7 @@ impl Service<ReadRequest> for ReadStateService {
                         get_block_template_info.map(ReadResponse::ChainInfo)
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::ChainInfo"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             // Used by getmininginfo, getnetworksolps, and getnetworkhashps RPCs.
@@ -1766,8 +1738,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::SolutionRate(solution_rate))
                     })
                 })
-                .map(|join_result| join_result.expect("panic in ReadRequest::SolutionRate"))
-                .boxed()
+                .panic_on_early_termination()
             }
 
             #[cfg(feature = "getblocktemplate-rpcs")]
@@ -1815,10 +1786,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::ValidBlockProposal)
                     })
                 })
-                .map(|join_result| {
-                    join_result.expect("panic in ReadRequest::CheckBlockProposalValidity")
-                })
-                .boxed()
+                .panic_on_early_termination()
             }
         }
     }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -43,7 +43,7 @@ use tower::buffer::Buffer;
 
 use zebra_chain::{
     block::{self, CountedHeader, HeightDiff},
-    diagnostic::{task::WaitForTermination, CodeTimer},
+    diagnostic::{task::WaitForPanics, CodeTimer},
     parameters::{Network, NetworkUpgrade},
 };
 
@@ -1209,7 +1209,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::Tip(tip))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // Used by the StateService.
@@ -1230,7 +1230,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::Depth(depth))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // Used by the StateService.
@@ -1253,7 +1253,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::BestChainNextMedianTimePast(median_time_past?))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // Used by the get_block (raw) RPC and the StateService.
@@ -1278,7 +1278,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::Block(block))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // For the get_raw_transaction RPC and the StateService.
@@ -1296,7 +1296,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::Transaction(response))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // Used by the getblock (verbose) RPC.
@@ -1325,7 +1325,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::TransactionIdsForBlock(transaction_ids))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             ReadRequest::UnspentBestChainUtxo(outpoint) => {
@@ -1349,7 +1349,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::UnspentBestChainUtxo(utxo))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // Manually used by the StateService to implement part of AwaitUtxo.
@@ -1370,7 +1370,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::AnyChainUtxo(utxo))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // Used by the StateService.
@@ -1393,7 +1393,7 @@ impl Service<ReadRequest> for ReadStateService {
                         ))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // Used by the StateService.
@@ -1420,7 +1420,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::BlockHashes(block_hashes))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // Used by the StateService.
@@ -1452,7 +1452,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::BlockHeaders(block_headers))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             ReadRequest::SaplingTree(hash_or_height) => {
@@ -1476,7 +1476,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::SaplingTree(sapling_tree))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             ReadRequest::OrchardTree(hash_or_height) => {
@@ -1500,7 +1500,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::OrchardTree(orchard_tree))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // For the get_address_balance RPC.
@@ -1525,7 +1525,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::AddressBalance(balance))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // For the get_address_tx_ids RPC.
@@ -1558,7 +1558,7 @@ impl Service<ReadRequest> for ReadStateService {
                         tx_ids.map(ReadResponse::AddressesTransactionIds)
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // For the get_address_utxos RPC.
@@ -1584,7 +1584,7 @@ impl Service<ReadRequest> for ReadStateService {
                         utxos.map(ReadResponse::AddressUtxos)
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             ReadRequest::CheckBestChainTipNullifiersAndAnchors(unmined_tx) => {
@@ -1617,7 +1617,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::ValidBestChainTipNullifiersAndAnchors)
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // Used by the get_block and get_block_hash RPCs.
@@ -1646,7 +1646,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::BlockHash(hash))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // Used by get_block_template RPC.
@@ -1685,7 +1685,7 @@ impl Service<ReadRequest> for ReadStateService {
                         get_block_template_info.map(ReadResponse::ChainInfo)
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             // Used by getmininginfo, getnetworksolps, and getnetworkhashps RPCs.
@@ -1738,7 +1738,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::SolutionRate(solution_rate))
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
 
             #[cfg(feature = "getblocktemplate-rpcs")]
@@ -1786,7 +1786,7 @@ impl Service<ReadRequest> for ReadStateService {
                         Ok(ReadResponse::ValidBlockProposal)
                     })
                 })
-                .panic_on_early_termination()
+                .wait_for_panics()
             }
         }
     }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -10,7 +10,7 @@ use std::{
 use semver::Version;
 use tracing::Span;
 
-use zebra_chain::{block::Height, parameters::Network};
+use zebra_chain::{block::Height, diagnostic::task::PanicOnTermination, parameters::Network};
 
 use DbFormatChange::*;
 


### PR DESCRIPTION
## Motivation

We want to stop Zebra panicking on shutdown.

Close #7170

### Specifications

Threads:
https://doc.rust-lang.org/std/thread/struct.JoinHandle.html#method.is_finished

Async tasks:
https://docs.rs/tokio/latest/tokio/task/struct.JoinHandle.html#impl-Future-for-JoinHandle%3CT%3E
https://docs.rs/tokio/latest/tokio/task/struct.JoinError.html#method.try_into_panic

### Complex Code or Requirements

This PR replaces a bunch of complex panic-handling code with consistent trait methods.

## Solution

- Create generic traits for checking and waiting for panics
- Implement those traits on OS threads and async tasks
- Use those trait impls to fix the panic and cancel bugs
- Replace existing manual implementations with the trait impls

### Testing

I've changed enough impls in this PR that any bugs should show up in the tests as they shut Zebra down.

## Review

This is a routine bug fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We can use these methods on `JoinError` and `JoinHandle` throughout Zebra, or maybe create our own `JoinHandle` and `JoinError` types that automatically use these methods.