### PR TITLE
refactor(issues): Include DevOps template and improve others

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: Bug report
+name: ":bug: Bug report"
 description: Create a report to help us improve
 title: '[User reported bug]: '
 labels: C-bug, S-needs-triage

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Zcash Community Support
+    url: https://forum.zcashcommunity.com/
+    about: You're invited to ask questions about the ecosystem, community and Zebra
+  - name: ❓ General Questions about Zebra
+    url: https://github.com/ZcashFoundation/zebra/discussions/categories/q-a
+    about: Please ask and answer questions about Zebra as a discussion threads

--- a/.github/ISSUE_TEMPLATE/devops_report.md
+++ b/.github/ISSUE_TEMPLATE/devops_report.md
@@ -12,7 +12,7 @@ body:
       Thank you for taking the time to report a bug in Zebra!
 
       Please fill out the sections below to help us reproduce and fix the bug.
-      If you have a question, please ask on [Discord](https://discord.gg/na6mU7m) or [GitHub Discussions](
+      If you have a question, please ask on [Discord](https://discord.gg/fP2JGmhm) or [GitHub Discussions](https://github.com/ZcashFoundation/zebra/discussions)
 - type: textarea
 id: description
 attributes:

--- a/.github/ISSUE_TEMPLATE/devops_report.md
+++ b/.github/ISSUE_TEMPLATE/devops_report.md
@@ -1,5 +1,4 @@
 ---
-
 name: ":octocat: DevOps Report"
 description: Issues related to the Zebra build, test, or release process.
 title: "(short issue description)"

--- a/.github/ISSUE_TEMPLATE/devops_report.md
+++ b/.github/ISSUE_TEMPLATE/devops_report.md
@@ -1,4 +1,5 @@
 ---
+
 name: ":octocat: DevOps Report"
 description: Issues related to the Zebra build, test, or release process.
 title: "(short issue description)"
@@ -67,4 +68,3 @@ attributes:
     label: Is this happening on the main branch?
 validations:
     required: true
----

--- a/.github/ISSUE_TEMPLATE/devops_report.md
+++ b/.github/ISSUE_TEMPLATE/devops_report.md
@@ -1,0 +1,70 @@
+---
+name: ":octocat: DevOps Report"
+description: Issues related to the Zebra build, test, or release process.
+title: "(short issue description)"
+labels: [A-devops, C-bug, S-needs-triage]
+assignees: []
+body:
+
+- type: markdown
+  attributes:
+    value: |
+      Thank you for taking the time to report a bug in Zebra!
+
+      Please fill out the sections below to help us reproduce and fix the bug.
+      If you have a question, please ask on [Discord](https://discord.gg/na6mU7m) or [GitHub Discussions](
+- type: textarea
+id: description
+attributes:
+    label: Describe the issue or request
+    description: What is the problem? A clear and concise description of the bug.
+validations:
+    required: true
+- type: textarea
+id: expected
+attributes:
+    label: Expected Behavior
+    description: |
+    What did you expect to happen?
+validations:
+    required: true
+- type: textarea
+id: current
+attributes:
+    label: Current Behavior
+    description: |
+    What actually happened?
+
+    Please include full errors, uncaught exceptions, stack traces, and relevant logs.
+    Links to the faulty logs in GitHub Actions or other places are also welcomed.
+validations:
+    required: true
+- type: textarea
+id: solution
+attributes:
+    label: Possible Solution
+    description: |
+    Suggest a fix/reason for the bug
+validations:
+    required: false
+- type: textarea
+id: context
+attributes:
+    label: Additional Information/Context
+    description: |
+    Anything else that might be relevant for troubleshooting this bug. Providing context helps us come up with a solution that is most useful for the community.
+validations:
+    required: false
+- type: input
+id: on-prs
+attributes:
+    label: Is this happening on PRs?
+validations:
+    required: true
+- type: input
+id: on-main
+attributes:
+    label: Is this happening on the main branch?
+validations:
+    required: true
+---

--- a/.github/ISSUE_TEMPLATE/devops_report.yml
+++ b/.github/ISSUE_TEMPLATE/devops_report.yml
@@ -3,7 +3,6 @@ name: ":octocat: DevOps Report"
 description: Issues related to the Zebra build, test, or release process.
 title: "(short issue description)"
 labels: [A-devops, C-bug, S-needs-triage]
-assignees: []
 body:
 
 - type: markdown
@@ -14,56 +13,56 @@ body:
       Please fill out the sections below to help us reproduce and fix the bug.
       If you have a question, please ask on [Discord](https://discord.gg/fP2JGmhm) or [GitHub Discussions](https://github.com/ZcashFoundation/zebra/discussions)
 - type: textarea
-id: description
-attributes:
+  id: description
+  attributes:
     label: Describe the issue or request
     description: What is the problem? A clear and concise description of the bug.
-validations:
+  validations:
     required: true
 - type: textarea
-id: expected
-attributes:
+  id: expected
+  attributes:
     label: Expected Behavior
     description: |
     What did you expect to happen?
-validations:
+  validations:
     required: true
 - type: textarea
-id: current
-attributes:
+  id: current
+  attributes:
     label: Current Behavior
     description: |
     What actually happened?
 
     Please include full errors, uncaught exceptions, stack traces, and relevant logs.
     Links to the faulty logs in GitHub Actions or other places are also welcomed.
-validations:
+  validations:
     required: true
 - type: textarea
-id: solution
-attributes:
+  id: solution
+  attributes:
     label: Possible Solution
     description: |
     Suggest a fix/reason for the bug
-validations:
+  validations:
     required: false
 - type: textarea
-id: context
-attributes:
+  id: context
+  attributes:
     label: Additional Information/Context
     description: |
     Anything else that might be relevant for troubleshooting this bug. Providing context helps us come up with a solution that is most useful for the community.
-validations:
+  validations:
     required: false
 - type: input
-id: on-prs
-attributes:
+  id: on-prs
+  attributes:
     label: Is this happening on PRs?
-validations:
+  validations:
     required: true
 - type: input
-id: on-main
-attributes:
+  id: on-main
+  attributes:
     label: Is this happening on the main branch?
-validations:
+  validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/devops_report.yml
+++ b/.github/ISSUE_TEMPLATE/devops_report.yml
@@ -24,7 +24,7 @@ body:
   attributes:
     label: Expected Behavior
     description: |
-    What did you expect to happen?
+     What did you expect to happen?
   validations:
     required: true
 - type: textarea
@@ -32,10 +32,10 @@ body:
   attributes:
     label: Current Behavior
     description: |
-    What actually happened?
+     What actually happened?
 
-    Please include full errors, uncaught exceptions, stack traces, and relevant logs.
-    Links to the faulty logs in GitHub Actions or other places are also welcomed.
+     Please include full errors, uncaught exceptions, stack traces, and relevant logs.
+     Links to the faulty logs in GitHub Actions or other places are also welcomed.
   validations:
     required: true
 - type: textarea
@@ -43,7 +43,7 @@ body:
   attributes:
     label: Possible Solution
     description: |
-    Suggest a fix/reason for the bug
+     Suggest a fix/reason for the bug
   validations:
     required: false
 - type: textarea
@@ -51,7 +51,7 @@ body:
   attributes:
     label: Additional Information/Context
     description: |
-    Anything else that might be relevant for troubleshooting this bug. Providing context helps us come up with a solution that is most useful for the community.
+     Anything else that might be relevant for troubleshooting this bug. Providing context helps us come up with a solution that is most useful for the community.
   validations:
     required: false
 - type: input

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Change request
+name: ":construction: Change request"
 about: Suggest a feature or change for this project
 title: ''
 labels: C-enhancement, S-needs-triage

--- a/.github/ISSUE_TEMPLATE/private_security_issue.yml
+++ b/.github/ISSUE_TEMPLATE/private_security_issue.yml
@@ -1,5 +1,5 @@
 ---
-name: Private Security Issue
+name: ":unlock: Private Security Issue"
 about: Zebra team use only
 title: 'Security Issue #NNN'
 labels: C-security, S-needs-triage

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,5 +1,5 @@
 ---
-name: 'Zebra Release'
+name: ":rocket: Zebra Release"
 about: 'Zebra team use only'
 title: 'Publish next Zebra release: (version)'
 labels: 'A-release, C-trivial, P-Medium :zap:'

--- a/.github/ISSUE_TEMPLATE/usability_testing_plan.md
+++ b/.github/ISSUE_TEMPLATE/usability_testing_plan.md
@@ -1,5 +1,5 @@
 ---
-name: Usability Testing Plan
+name: ":clipboard: Usability Testing Plan"
 about: Create a Usability Testing Plan
 title: 'Usability Testing Plan'
 labels: C-research


### PR DESCRIPTION
## Motivation

We needed a way to report DevOps tickets and make the reports more structured.

Fixes #6668 

## Solution

- Create a DevOps template with a specified structure and required information
- Add visual feedback to all issue templates
- Add Zebra and Community links for questions and discussions

## Review

Anyone can review this. And @dconnolly for the emojis audit ✒️  

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

None, or adapting other issue templates