### PR TITLE
cleanup(deps): Bump sha2 and secp256k1 to remove duplicate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "rand 0.8.5",
- "sha2 0.10.6",
+ "sha2",
  "unicode-normalization",
  "zeroize",
 ]
@@ -509,15 +509,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -553,7 +544,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
- "sha2 0.10.6",
+ "sha2",
  "tinyvec",
 ]
 
@@ -1039,7 +1030,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
  "platforms",
  "rustc_version 0.4.0",
@@ -1182,20 +1173,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
  "subtle",
 ]
@@ -1260,7 +1242,7 @@ dependencies = [
  "hex",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.6",
+ "sha2",
  "zeroize",
 ]
 
@@ -1779,7 +1761,7 @@ dependencies = [
  "lazy_static",
  "rand_core 0.6.4",
  "ring",
- "secp256k1 0.26.0",
+ "secp256k1",
  "thiserror",
 ]
 
@@ -1828,7 +1810,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2980,7 +2962,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "password-hash",
 ]
 
@@ -3037,7 +3019,7 @@ checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.6",
+ "sha2",
 ]
 
 [[package]]
@@ -3689,7 +3671,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3875,30 +3857,12 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
-dependencies = [
- "secp256k1-sys 0.4.2",
- "serde",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
 dependencies = [
- "secp256k1-sys 0.8.1",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
-dependencies = [
- "cc",
+ "secp256k1-sys",
+ "serde",
 ]
 
 [[package]]
@@ -4167,26 +4131,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -5616,8 +5567,8 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "ripemd",
- "secp256k1 0.26.0",
- "sha2 0.10.6",
+ "secp256k1",
+ "sha2",
  "subtle",
  "zcash_address",
  "zcash_encoding",
@@ -5722,12 +5673,12 @@ dependencies = [
  "reddsa",
  "redjubjub",
  "ripemd",
- "secp256k1 0.21.3",
+ "secp256k1",
  "serde",
  "serde-big-array",
  "serde_json",
  "serde_with 3.0.0",
- "sha2 0.9.9",
+ "sha2",
  "spandoc",
  "static_assertions",
  "thiserror",

--- a/deny.toml
+++ b/deny.toml
@@ -68,25 +68,10 @@ skip-tree = [
 
     # ZF crates
 
-    # wait for zcashd and zcash_script to upgrade
-    # https://github.com/ZcashFoundation/zcash_script/pulls
-    { name = "sha2", version = "=0.9.9" },
-
     # wait for indexmap, toml_edit, serde_json, tower to upgrade
     { name = "hashbrown", version = "=0.12.3" },
-    # wait for metrics-exporter-prometheus to upgrade
-    { name = "hashbrown", version = "=0.13.2" },
-
-    # wait for zebra-chain to upgrade
-    { name = "secp256k1", version = "=0.21.3" },
-
-    # wait for zebra-chain to upgrade `secp256k1`
-    { name = "secp256k1-sys", version = "=0.4.2" },
 
     # ECC crates
-
-    # wait for zcash_primitives to remove duplicated dependencies
-    { name = "block-buffer", version = "=0.9.0" },
 
     # wait for minreq and zcash_proofs to upgrade
     { name = "rustls", version = "=0.20.8" },

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -66,8 +66,8 @@ primitive-types = "0.11.1"
 rand_core = "0.6.4"
 ripemd = "0.1.3"
 # Matches version used by hdwallet
-secp256k1 = { version = "0.21.3", features = ["serde"] }
-sha2 = { version = "0.9.9", features = ["compress"] }
+secp256k1 = { version = "0.26.0", features = ["serde"] }
+sha2 = { version = "0.10.7", features = ["compress"] }
 uint = "0.9.5"
 x25519-dalek = { version = "2.0.0-rc.3", features = ["serde"] }
 

--- a/zebra-chain/src/serialization/sha256d.rs
+++ b/zebra-chain/src/serialization/sha256d.rs
@@ -14,7 +14,7 @@ impl Writer {
     /// Consume the Writer and produce the hash result.
     pub fn finish(self) -> [u8; 32] {
         let result1 = self.hash.finalize();
-        let result2 = Sha256::digest(&result1);
+        let result2 = Sha256::digest(result1);
         let mut buffer = [0u8; 32];
         buffer[0..32].copy_from_slice(&result2[0..32]);
         buffer
@@ -39,7 +39,7 @@ pub struct Checksum(pub [u8; 4]);
 impl<'a> From<&'a [u8]> for Checksum {
     fn from(bytes: &'a [u8]) -> Self {
         let hash1 = Sha256::digest(bytes);
-        let hash2 = Sha256::digest(&hash1);
+        let hash2 = Sha256::digest(hash1);
         let mut checksum = [0u8; 4];
         checksum[0..4].copy_from_slice(&hash2[0..4]);
         Self(checksum)

--- a/zebra-chain/src/transparent/address.rs
+++ b/zebra-chain/src/transparent/address.rs
@@ -4,7 +4,6 @@ use std::{fmt, io};
 
 use ripemd::{Digest, Ripemd160};
 use secp256k1::PublicKey;
-use sha2::Digest as Sha256Digest;
 use sha2::Sha256;
 
 use crate::{


### PR DESCRIPTION
## Motivation

This PR removes duplicate dependencies in Zebra where possible. 

Close #6638.

## Solution

- Use latest versions of sha2 and secp256k1 in zebra-chain
- Update deny.toml

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
