### PR TITLE
change(deps): Change dependabot actions schedule and tweak groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     # serde, clap, and other dependencies sometimes have multiple updates in a week
     schedule:
       interval: weekly
+      day: monday
       timezone: America/New_York
     # Limit dependabot to 2 PRs per reviewer, but assume one reviewer is busy or away
     open-pull-requests-limit: 8
@@ -120,7 +121,6 @@ updates:
         jsonrpc:
           patterns:
             - "jsonrpc*"
-            - "serde_json"
         rand:
           patterns:
             - "rand*"
@@ -135,6 +135,7 @@ updates:
     schedule:
       # tj-actions/changed-files often updates daily, which is too much for us
       interval: weekly
+      day: wednesday
       timezone: America/New_York
     open-pull-requests-limit: 6
     labels:


### PR DESCRIPTION
## Motivation

Currently we open Rust and GitHub Actions dependabot PRs on the same day, but it would be easier to review them in two separate groups. It would also stop us hitting Google Cloud rate limits.

serde_json is in two groups, so it opens two PRs when it updates.

## Review

This is a routine fix.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
