### PR TITLE
change(test): Refactor the tests of non-finalized state

### DIFF
--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -349,7 +349,9 @@ impl Arbitrary for Block {
 
     fn arbitrary_with(ledger_state: Self::Parameters) -> Self::Strategy {
         let transactions_strategy =
-            (1..MAX_ARBITRARY_ITEMS).prop_flat_map(move |transaction_count| {
+            // Generate a random number transactions. A coinbase tx is always generated, so if
+            // `transaction_count` is zero, the block will contain only the coinbase tx.
+            (0..MAX_ARBITRARY_ITEMS).prop_flat_map(move |transaction_count| {
                 Transaction::vec_strategy(ledger_state, transaction_count)
             });
 

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -170,14 +170,12 @@ fn forked_equals_pushed_genesis() -> Result<()> {
             empty_tree,
             ValueBalance::zero(),
         );
-        for block in chain.iter().skip(1).cloned() {
+
+        for block in chain.iter().cloned() {
             let block =
             ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, full_chain.unspent_utxos())?;
-            full_chain = full_chain
-                .push(block.clone())
-                .expect("full chain push is valid");
 
-            // Check some other properties of generated chains.
+            // Check some properties of the genesis block and don't push it to the chain.
             if block.height == block::Height(0) {
                 prop_assert_eq!(
                     block
@@ -188,11 +186,13 @@ fn forked_equals_pushed_genesis() -> Result<()> {
                         .filter_map(|i| i.outpoint())
                         .count(),
                     0,
-                    "unexpected transparent prevout input at height {:?}: \
-                            genesis transparent outputs must be ignored, \
-                            so there can not be any spends in the genesis block",
-                    block.height,
+                    "Unexpected transparent prevout input at height 0. Genesis transparent outputs \
+                        must be ignored, so there can not be any spends in the genesis block.",
                 );
+            } else {
+                full_chain = full_chain
+                    .push(block)
+                    .expect("full chain push is valid");
             }
         }
 


### PR DESCRIPTION
## Motivation

I noticed some inaccuracies in our tests of the non-finalized state when I was looking at the test coverage of #7239.

## Solution

- Allow `proptest` to generate blocks containing only the coinbase tx.
- Don't skip some checks of the genesis block in one of the tests.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
