### PR TITLE
fix(docker): Fix confusing Docker git commit hash default in Zebra logs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,7 +80,9 @@ ARG COLORBT_SHOW_HIDDEN
 ENV COLORBT_SHOW_HIDDEN=${COLORBT_SHOW_HIDDEN:-1}
 
 ARG SHORT_SHA
-ENV SHORT_SHA=${SHORT_SHA:-unknown}
+# If this is not set, it must be the empty string, so Zebra can try an alternative git commit source:
+# https://github.com/ZcashFoundation/zebra/blob/9ebd56092bcdfc1a09062e15a0574c94af37f389/zebrad/src/application.rs#L179-L182
+ENV SHORT_SHA=${SHORT_SHA:-}
 
 ENV CARGO_HOME="/opt/zebrad/.cargo/"
 


### PR DESCRIPTION
## Motivation

PR #7200 adds an incorrect default for the git commit hash in Zebra's logs in Docker builds.

This bug doesn't have a significant impact because vergen uses the `.git` directory, which is currently ignored by `.dockerignore`. So we wouldn't get a fallback hash anyway.

But this change logs "zebrad=unknown" on every single Zebra log line, which could be confusing for users.

## Solution

- Use an empty string if the git commit hash is not specified in Docker

This change will not be user visible if we get this fix merged before the release.

## Review

@arya2 I'm not sure if this is a release blocker or not? What do you think?

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?


