### PR TITLE
Reduce disk reads by caching trees.

### DIFF
--- a/zebra-state/src/service/check/tests/nullifier.rs
+++ b/zebra-state/src/service/check/tests/nullifier.rs
@@ -85,7 +85,7 @@ proptest! {
         // randomly choose to commit the block to the finalized or non-finalized state
         if use_finalized_state {
             let block1 = CheckpointVerifiedBlock::from(Arc::new(block1));
-            let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(), "test");
+            let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(), None, "test");
 
             // the block was committed
             prop_assert_eq!(Some((Height(1), block1.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
@@ -352,7 +352,7 @@ proptest! {
         // randomly choose to commit the next block to the finalized or non-finalized state
         if duplicate_in_finalized_state {
             let block1 = CheckpointVerifiedBlock::from(Arc::new(block1));
-            let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(), "test");
+            let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(), None, "test");
 
             prop_assert_eq!(Some((Height(1), block1.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
             prop_assert!(commit_result.is_ok());
@@ -452,7 +452,7 @@ proptest! {
         // randomly choose to commit the block to the finalized or non-finalized state
         if use_finalized_state {
             let block1 = CheckpointVerifiedBlock::from(Arc::new(block1));
-            let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(), "test");
+            let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(),None,  "test");
 
             prop_assert_eq!(Some((Height(1), block1.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
             prop_assert!(commit_result.is_ok());
@@ -634,7 +634,7 @@ proptest! {
         // randomly choose to commit the next block to the finalized or non-finalized state
         if duplicate_in_finalized_state {
             let block1 = CheckpointVerifiedBlock::from(Arc::new(block1));
-            let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(), "test");
+            let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(),None,  "test");
 
             prop_assert_eq!(Some((Height(1), block1.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
             prop_assert!(commit_result.is_ok());
@@ -732,7 +732,7 @@ proptest! {
         // randomly choose to commit the block to the finalized or non-finalized state
         if use_finalized_state {
             let block1 = CheckpointVerifiedBlock::from(Arc::new(block1));
-            let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(), "test");
+            let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(), None, "test");
 
             prop_assert_eq!(Some((Height(1), block1.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
             prop_assert!(commit_result.is_ok());
@@ -923,7 +923,7 @@ proptest! {
         // randomly choose to commit the next block to the finalized or non-finalized state
         if duplicate_in_finalized_state {
             let block1 = CheckpointVerifiedBlock::from(Arc::new(block1));
-            let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(), "test");
+            let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(), None, "test");
 
             prop_assert_eq!(Some((Height(1), block1.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
             prop_assert!(commit_result.is_ok());

--- a/zebra-state/src/service/check/tests/utxo.rs
+++ b/zebra-state/src/service/check/tests/utxo.rs
@@ -185,7 +185,7 @@ proptest! {
         // randomly choose to commit the block to the finalized or non-finalized state
         if use_finalized_state {
             let block1 = CheckpointVerifiedBlock::from(Arc::new(block1));
-            let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(), "test");
+            let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(), None, "test");
 
             // the block was committed
             prop_assert_eq!(Some((Height(1), block1.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
@@ -273,7 +273,7 @@ proptest! {
 
         if use_finalized_state_spend {
             let block2 = CheckpointVerifiedBlock::from(Arc::new(block2));
-            let commit_result = finalized_state.commit_finalized_direct(block2.clone().into(), "test");
+            let commit_result = finalized_state.commit_finalized_direct(block2.clone().into(),None,  "test");
 
             // the block was committed
             prop_assert_eq!(Some((Height(2), block2.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
@@ -612,7 +612,7 @@ proptest! {
 
         if use_finalized_state_spend {
             let block2 = CheckpointVerifiedBlock::from(block2.clone());
-            let commit_result = finalized_state.commit_finalized_direct(block2.clone().into(), "test");
+            let commit_result = finalized_state.commit_finalized_direct(block2.clone().into(), None, "test");
 
             // the block was committed
             prop_assert_eq!(Some((Height(2), block2.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
@@ -884,7 +884,8 @@ fn new_state_with_mainnet_transparent_data(
 
     if use_finalized_state {
         let block1 = CheckpointVerifiedBlock::from(block1.clone());
-        let commit_result = finalized_state.commit_finalized_direct(block1.clone().into(), "test");
+        let commit_result =
+            finalized_state.commit_finalized_direct(block1.clone().into(), None, "test");
 
         // the block was committed
         assert_eq!(

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
@@ -103,7 +103,7 @@ fn test_raw_rocksdb_column_families_with_network(network: Network) {
             .expect("test data deserializes");
 
         state
-            .commit_finalized_direct(block.into(), "snapshot tests")
+            .commit_finalized_direct(block.into(), None, "snapshot tests")
             .expect("test block is valid");
 
         let mut settings = insta::Settings::clone_current();

--- a/zebra-state/src/service/finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/tests/prop.rs
@@ -29,12 +29,13 @@ fn blocks_with_v5_transactions() -> Result<()> {
             // use `count` to minimize test failures, so they are easier to diagnose
             for block in chain.iter().take(count) {
                 let checkpoint_verified = CheckpointVerifiedBlock::from(block.block.clone());
-                let hash = state.commit_finalized_direct(
+                let (hash, _) = state.commit_finalized_direct(
                     checkpoint_verified.into(),
+                    None,
                     "blocks_with_v5_transactions test"
-                );
+                ).unwrap();
                 prop_assert_eq!(Some(height), state.finalized_tip_height());
-                prop_assert_eq!(hash.unwrap(), block.hash);
+                prop_assert_eq!(hash, block.hash);
                 height = Height(height.0 + 1);
             }
     });
@@ -86,6 +87,7 @@ fn all_upgrades_and_wrong_commitments_with_fake_activation_heights() -> Result<(
                             let checkpoint_verified = CheckpointVerifiedBlock::from(block);
                             state.commit_finalized_direct(
                                 checkpoint_verified.into(),
+                                None,
                                 "all_upgrades test"
                             ).expect_err("Must fail commitment check");
                             failure_count += 1;
@@ -93,8 +95,9 @@ fn all_upgrades_and_wrong_commitments_with_fake_activation_heights() -> Result<(
                     _ => {},
                 }
                 let checkpoint_verified = CheckpointVerifiedBlock::from(block.block.clone());
-                let hash = state.commit_finalized_direct(
+                let (hash, _) = state.commit_finalized_direct(
                     checkpoint_verified.into(),
+                    None,
                     "all_upgrades test"
                 ).unwrap();
                 prop_assert_eq!(Some(height), state.finalized_tip_height());

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
@@ -197,7 +197,7 @@ fn test_block_and_transaction_data_with_network(network: Network) {
             .expect("test data deserializes");
 
         state
-            .commit_finalized_direct(block.into(), "snapshot tests")
+            .commit_finalized_direct(block.into(), None, "snapshot tests")
             .expect("test block is valid");
 
         let mut settings = insta::Settings::clone_current();

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -140,6 +140,7 @@ pub fn write_blocks_from_channels(
     non_finalized_state_sender: watch::Sender<NonFinalizedState>,
 ) {
     let mut last_zebra_mined_log_height = None;
+    let mut prev_note_commitment_trees = None;
 
     // Write all the finalized blocks sent by the state,
     // until the state closes the finalized block channel's sender.
@@ -178,9 +179,10 @@ pub fn write_blocks_from_channels(
         }
 
         // Try committing the block
-        match finalized_state.commit_finalized(ordered_block) {
-            Ok(finalized) => {
+        match finalized_state.commit_finalized(ordered_block, prev_note_commitment_trees.take()) {
+            Ok((finalized, note_commitment_trees)) => {
                 let tip_block = ChainTipBlock::from(finalized);
+                prev_note_commitment_trees = Some(note_commitment_trees);
 
                 log_if_mined_by_zebra(&tip_block, &mut last_zebra_mined_log_height);
 
@@ -289,11 +291,11 @@ pub fn write_blocks_from_channels(
         while non_finalized_state.best_chain_len() > MAX_BLOCK_REORG_HEIGHT {
             tracing::trace!("finalizing block past the reorg limit");
             let contextually_verified_with_trees = non_finalized_state.finalize();
-            finalized_state
-                        .commit_finalized_direct(contextually_verified_with_trees, "commit contextually-verified request")
+            prev_note_commitment_trees = finalized_state
+                        .commit_finalized_direct(contextually_verified_with_trees, prev_note_commitment_trees.take(), "commit contextually-verified request")
                         .expect(
                             "unexpected finalized block commit error: note commitment and history trees were already checked by the non-finalized state",
-                        );
+                        ).1.into();
         }
 
         // Update the metrics if semantic and contextual validation passes

--- a/zebra-state/src/tests/setup.rs
+++ b/zebra-state/src/tests/setup.rs
@@ -107,7 +107,7 @@ pub(crate) fn new_state_with_mainnet_genesis(
 
     let genesis = CheckpointVerifiedBlock::from(genesis);
     finalized_state
-        .commit_finalized_direct(genesis.clone().into(), "test")
+        .commit_finalized_direct(genesis.clone().into(), None, "test")
         .expect("unexpected invalid genesis block test vector");
 
     assert_eq!(


### PR DESCRIPTION
This is a suggestion for #7266 to cache the finalized tip's note commitment trees in the write block task:

- Caches note commitment trees of finalized tip in memory when writing blocks to disk
- Skips disk reads when there's a cached copy of the note commitment trees