### PR TITLE
fix(state): Avoid temporary failures verifying the first non-finalized block

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -907,6 +907,14 @@ impl Service<Request> for StateService {
             } else {
                 tracing::debug!(len = ?old_len, ?tip, "no utxo requests needed pruning");
             }
+
+            if self.finalized_block_write_sender.is_some()
+                && self
+                    .non_finalized_state_queued_blocks
+                    .has_queued_children(self.finalized_block_write_last_sent_hash)
+            {
+                // TODO: process queue
+            }
         }
 
         poll


### PR DESCRIPTION
## Motivation

This PR fixes a bug where the first block past the final checkpoint will fail verification if it arrives in zebra-state before the final checkpoint block is written to disk.

Close #5125.
Part of #5709.

Depends-On: #6810

## Solution

- Use the finalized tip hash instead of the parent hash when dropping the finalized block write sender

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
