### PR TITLE
fix(state): Fix marking format upgrades

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -287,18 +287,18 @@ impl DbFormatChange {
 
                 upgrade_height = (upgrade_height + 1).expect("task exits before maximum height");
             }
-        }
 
-        // At the end of each format upgrade, the database is marked as upgraded to that version.
-        // Upgrades can be run more than once if Zebra is restarted, so this is just a performance
-        // optimisation.
-        info!(
-            ?initial_tip_height,
-            ?newer_running_version,
-            ?older_disk_version,
-            "marking database as upgraded"
-        );
-        Self::mark_as_upgraded_to(&database_format_add_format_change_task, &config, network);
+            // At the end of each format upgrade, the database is marked as upgraded to that version.
+            // Upgrades can be run more than once if Zebra is restarted, so this is just a performance
+            // optimisation.
+            info!(
+                ?initial_tip_height,
+                ?newer_running_version,
+                ?older_disk_version,
+                "marking database as upgraded"
+            );
+            Self::mark_as_upgraded_to(&database_format_add_format_change_task, &config, network);
+        }
 
         // End of example format change.
 


### PR DESCRIPTION
## Motivation

PR #7266 bumps the state minor version, which triggers the recent framework for upgrading the database. There is a function that marks the database as upgraded, even though no upgrade is actually run. This function contains an assert that checks that the new format is strictly greater than the format on disk, which is false, and the assert fails.

## Solution

- Move the marking function inside the dummy upgrade so that it's called only when the upgrade takes place.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
