### PR TITLE
change(ci): Update CI to run tests with zcash/lightwalletd instead of adityapk00/lightwalletd

### DIFF
--- a/.github/workflows/zcash-lightwalletd.yml
+++ b/.github/workflows/zcash-lightwalletd.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.3
         with:
-          repository: adityapk00/lightwalletd
+          repository: zcash/lightwalletd
           ref: 'master'
           persist-credentials: false
 


### PR DESCRIPTION
## Motivation

[adityapk00/lightwalletd](https://github.com/adityapk00/lightwalletd) does not include new code added by the ECC to support new functionality.

We want to switch to the ECC version to use its new features.

Closes #7292.

## Solution

- Update CI workflow to use zcash/lightwalletd repo instead of adityapk00/lightwalletd

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
