### PR TITLE
change(state): Deduplicate note commitment trees stored in the finalized state

### DIFF
--- a/zebra-chain/src/block/height.rs
+++ b/zebra-chain/src/block/height.rs
@@ -71,6 +71,7 @@ impl Height {
     /// # Panics
     ///
     /// - If the current height is at its maximum.
+    // TODO Return an error instead of panicking #7263.
     pub fn next(self) -> Self {
         (self + 1).expect("Height should not be at its maximum.")
     }
@@ -80,6 +81,7 @@ impl Height {
     /// # Panics
     ///
     /// - If the current height is at its minimum.
+    // TODO Return an error instead of panicking #7263.
     pub fn previous(self) -> Self {
         (self - 1).expect("Height should not be at its minimum.")
     }

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -42,6 +42,8 @@ pub use disk_format::{OutputIndex, OutputLocation, TransactionLocation, MAX_ON_D
 
 pub(super) use zebra_db::ZebraDb;
 
+#[cfg(not(any(test, feature = "proptest-impl")))]
+pub(super) use disk_db::DiskWriteBatch;
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use disk_db::{DiskWriteBatch, WriteDisk};
 

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -113,8 +113,14 @@ pub trait WriteDisk {
         K: IntoDisk + Debug,
         V: IntoDisk;
 
-    /// Remove the given key form rocksdb column family if it exists.
+    /// Remove the given key from rocksdb column family if it exists.
     fn zs_delete<C, K>(&mut self, cf: &C, key: K)
+    where
+        C: rocksdb::AsColumnFamilyRef,
+        K: IntoDisk + Debug;
+
+    /// Remove the given key range from rocksdb column family if it exists.
+    fn zs_delete_range<C, K>(&mut self, cf: &C, from: K, to: K)
     where
         C: rocksdb::AsColumnFamilyRef,
         K: IntoDisk + Debug;
@@ -139,6 +145,16 @@ impl WriteDisk for DiskWriteBatch {
     {
         let key_bytes = key.as_bytes();
         self.batch.delete_cf(cf, key_bytes);
+    }
+
+    fn zs_delete_range<C, K>(&mut self, cf: &C, from: K, to: K)
+    where
+        C: rocksdb::AsColumnFamilyRef,
+        K: IntoDisk + Debug,
+    {
+        let from_bytes = from.as_bytes();
+        let to_bytes = to.as_bytes();
+        self.batch.delete_range_cf(cf, from_bytes, to_bytes);
     }
 }
 

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -94,12 +94,10 @@ pub struct DiskDb {
 //       (DiskDb can be cloned),
 //       and make them accessible via read-only methods
 #[must_use = "batches must be written to the database"]
+#[derive(Default)]
 pub struct DiskWriteBatch {
     /// The inner RocksDB write batch.
     batch: rocksdb::WriteBatch,
-
-    /// The configured network.
-    network: Network,
 }
 
 /// Helper trait for inserting (Key, Value) pairs into rocksdb with a consistently
@@ -395,16 +393,10 @@ impl DiskWriteBatch {
     /// Each block must be written to the state inside a batch, so that:
     /// - concurrent `ReadStateService` queries don't see half-written blocks, and
     /// - if Zebra calls `exit`, panics, or crashes, half-written blocks are rolled back.
-    pub fn new(network: Network) -> Self {
+    pub fn new() -> Self {
         DiskWriteBatch {
             batch: rocksdb::WriteBatch::default(),
-            network,
         }
-    }
-
-    /// Returns the configured network for this write batch.
-    pub fn network(&self) -> Network {
-        self.network
     }
 }
 

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -420,7 +420,7 @@ impl DiskDb {
     /// Returns an iterator over the items in `cf` in `range`.
     ///
     /// Holding this iterator open might delay block commit transactions.
-    fn zs_range_iter<C, K, V, R>(&self, cf: &C, range: R) -> impl Iterator<Item = (K, V)> + '_
+    pub fn zs_range_iter<C, K, V, R>(&self, cf: &C, range: R) -> impl Iterator<Item = (K, V)> + '_
     where
         C: rocksdb::AsColumnFamilyRef,
         K: IntoDisk + FromDisk,
@@ -465,7 +465,7 @@ impl DiskDb {
             .map(|result| result.expect("unexpected database failure"))
             .map(|(key, value)| (key.to_vec(), value))
             // Handle Excluded start and the end bound
-            .filter(move |(key, _value)| range.contains(key))
+            .take_while(move |(key, _value)| range.contains(key))
             .map(|(key, value)| (K::from_bytes(key), V::from_bytes(value)))
     }
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -308,7 +308,9 @@ impl DbFormatChange {
                 for (height, tree) in
                     db.sapling_tree_by_height_range(sapling_height..initial_tip_height)
                 {
-                    let _ = sapling_tree_tx.send((height, tree));
+                    let _ = sapling_tree_tx
+                        .send((height, tree))
+                        .map_err(|error| warn!(?error, "unexpected send error"));
                 }
             });
 
@@ -320,7 +322,9 @@ impl DbFormatChange {
                 while let Ok((height, tree)) = sapling_tree_rx.recv() {
                     let tree = Some(tree);
                     if prev_sapling_tree != tree {
-                        let _ = unique_sapling_tree_height_tx.send(height);
+                        let _ = unique_sapling_tree_height_tx
+                            .send(height)
+                            .map_err(|error| warn!(?error, "unexpected send error"));
                         prev_sapling_tree = tree;
                     }
                 }
@@ -361,7 +365,9 @@ impl DbFormatChange {
                 for (height, tree) in
                     db.orchard_tree_by_height_range(orchard_height..initial_tip_height)
                 {
-                    let _ = orchard_tree_tx.send((height, tree));
+                    let _ = orchard_tree_tx
+                        .send((height, tree))
+                        .map_err(|error| warn!(?error, "unexpected send error"));
                 }
             });
 
@@ -373,7 +379,9 @@ impl DbFormatChange {
                 while let Ok((height, tree)) = orchard_tree_rx.recv() {
                     let tree = Some(tree);
                     if prev_orchard_tree != tree {
-                        let _ = unique_orchard_tree_height_tx.send(height);
+                        let _ = unique_orchard_tree_height_tx
+                            .send(height)
+                            .map_err(|error| warn!(?error, "unexpected send error"));
                         prev_orchard_tree = tree;
                     }
                 }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -271,8 +271,6 @@ impl DbFormatChange {
         // Check if we need to prune the note commitment trees in the database.
         if older_disk_version < version_for_pruning_trees {
             let mut height = Height(0);
-            let mut prev_sapling_tree = upgrade_db.sapling_tree_by_height(&height);
-            let mut prev_orchard_tree = upgrade_db.orchard_tree_by_height(&height);
             let sapling_cf = upgrade_db
                 .db
                 .cf_handle("sapling_note_commitment_tree")
@@ -304,6 +302,8 @@ impl DbFormatChange {
             height = sapling_height;
             warn!(?height, "Database upgrade is at:");
 
+            let mut prev_sapling_tree = upgrade_db.sapling_tree_by_height(&height);
+
             while height <= orchard_height {
                 let mut batch = DiskWriteBatch::new();
                 for _ in 0..1_000 {
@@ -328,6 +328,8 @@ impl DbFormatChange {
                     height = height.next();
                 }
             }
+
+            let mut prev_orchard_tree = upgrade_db.orchard_tree_by_height(&height);
 
             // Go through every height from genesis to the tip of the old version. If the state was
             // downgraded, some heights might already be upgraded. (Since the upgraded format is

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -339,9 +339,9 @@ impl DbFormatChange {
                         batch.delete_range_sapling_tree(&db, &delete_from, &height);
                         db.write_batch(batch)
                             .expect("Deleting note commitment trees should always succeed.");
-                    } else if num_entries.map_or(false, |n| n == 0) {
+                    } else if num_entries.map_or(false, |n| n == 1) {
                         let mut batch: DiskWriteBatch = DiskWriteBatch::new();
-                        batch.delete_sapling_tree(&db, &height);
+                        batch.delete_sapling_tree(&db, &delete_from);
                         db.write_batch(batch)
                             .expect("Deleting note commitment trees should always succeed.");
                     }
@@ -392,9 +392,9 @@ impl DbFormatChange {
                         batch.delete_range_orchard_tree(&db, &delete_from, &height);
                         db.write_batch(batch)
                             .expect("Deleting note commitment trees should always succeed.");
-                    } else if num_entries.map_or(false, |n| n == 0) {
+                    } else if num_entries.map_or(false, |n| n == 1) {
                         let mut batch: DiskWriteBatch = DiskWriteBatch::new();
-                        batch.delete_orchard_tree(&db, &height);
+                        batch.delete_orchard_tree(&db, &delete_from);
                         db.write_batch(batch)
                             .expect("Deleting note commitment trees should always succeed.");
                     }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -339,8 +339,9 @@ impl DbFormatChange {
                     if num_entries.map_or(false, |n| n >= 1) {
                         let mut batch: DiskWriteBatch = DiskWriteBatch::new();
                         batch.delete_range_sapling_tree(&db, &delete_from, &height);
-                        db.write_batch(batch)
-                            .expect("Deleting note commitment trees should always succeed.");
+                        db.write_batch(batch).expect(
+                            "Deleting Sapling note commitment trees should always succeed.",
+                        );
                     }
 
                     prev_height = height;
@@ -390,8 +391,9 @@ impl DbFormatChange {
                     if num_entries.map_or(false, |n| n >= 1) {
                         let mut batch: DiskWriteBatch = DiskWriteBatch::new();
                         batch.delete_range_orchard_tree(&db, &delete_from, &height);
-                        db.write_batch(batch)
-                            .expect("Deleting note commitment trees should always succeed.");
+                        db.write_batch(batch).expect(
+                            "Deleting Orchard note commitment trees should always succeed.",
+                        );
                     }
 
                     prev_height = height;

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -291,8 +291,6 @@ impl DbFormatChange {
                     .write_batch(batch)
                     .expect("Deleting note commitment trees should always succeed.");
 
-                warn!(?sapling_height, "Database upgrade is at:");
-
                 (
                     upgrade_db.sapling_tree_by_height(&Height(0)),
                     upgrade_db.orchard_tree_by_height(&Height(0)),
@@ -351,8 +349,6 @@ impl DbFormatChange {
                     }
 
                     prev_height = height;
-
-                    warn!(?height, "Database upgrade is at:");
                 }
             });
 
@@ -408,8 +404,6 @@ impl DbFormatChange {
                     }
 
                     prev_height = height;
-
-                    warn!(?height, "Database upgrade is at:");
                 }
             });
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -19,7 +19,7 @@ use DbFormatChange::*;
 
 use crate::{
     config::write_database_format_version_to_disk, database_format_version_in_code,
-    database_format_version_on_disk, service::finalized_state::ZebraDb, Config, DiskWriteBatch,
+    database_format_version_on_disk, service::finalized_state::ZebraDb, Config,
 };
 
 /// The kind of database format change we're performing.
@@ -284,30 +284,6 @@ impl DbFormatChange {
                 if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
                     return;
                 }
-
-                let batch = DiskWriteBatch::new();
-
-                for _ in 0..1000 {
-                    if height >= initial_tip_height {
-                        break;
-                    }
-                    let sapling_tree = upgrade_db.sapling_tree_by_height(&height);
-                    let orchard_tree = upgrade_db.orchard_tree_by_height(&height);
-
-                    if prev_sapling_tree == sapling_tree {
-                        batch.delete_sapling_tree(&height);
-                    }
-
-                    if prev_orchard_tree == orchard_tree {
-                        batch.delete_orchard_tree(&height);
-                    }
-
-                    prev_orchard_tree = orchard_tree;
-                    prev_sapling_tree = sapling_tree;
-
-                    height = height.next();
-                }
-                upgrade_db.write(batch);
 
                 let sapling_tree = upgrade_db.sapling_tree_by_height(&height);
                 let orchard_tree = upgrade_db.orchard_tree_by_height(&height);

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -332,12 +332,11 @@ impl DbFormatChange {
                 let mut prev_height = sapling_height;
                 while let Ok(height) = unique_sapling_tree_height_rx.recv() {
                     let delete_from = (prev_height + 1).expect("should be valid height");
-                    let delete_to = (height - 1).expect("should be a valid height");
-                    let num_entries = delete_to.0.checked_sub(delete_from.0);
+                    let num_entries = height.0.checked_sub(delete_from.0);
 
                     if num_entries.map_or(false, |n| n >= 1) {
                         let mut batch: DiskWriteBatch = DiskWriteBatch::new();
-                        batch.delete_range_sapling_tree(&db, &delete_from, &delete_to);
+                        batch.delete_range_sapling_tree(&db, &delete_from, &height);
                         db.write_batch(batch)
                             .expect("Deleting note commitment trees should always succeed.");
                     } else if num_entries.map_or(false, |n| n == 0) {
@@ -386,12 +385,11 @@ impl DbFormatChange {
                 let mut prev_height = orchard_height;
                 while let Ok(height) = unique_orchard_tree_height_rx.recv() {
                     let delete_from = (prev_height + 1).expect("should be valid height");
-                    let delete_to = (height - 1).expect("should be a valid height");
-                    let num_entries = delete_to.0.checked_sub(delete_from.0);
+                    let num_entries = height.0.checked_sub(delete_from.0);
 
                     if num_entries.map_or(false, |n| n >= 1) {
                         let mut batch: DiskWriteBatch = DiskWriteBatch::new();
-                        batch.delete_range_orchard_tree(&db, &delete_from, &delete_to);
+                        batch.delete_range_orchard_tree(&db, &delete_from, &height);
                         db.write_batch(batch)
                             .expect("Deleting note commitment trees should always succeed.");
                     } else if num_entries.map_or(false, |n| n == 0) {

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -2,7 +2,10 @@
 
 use std::{
     cmp::Ordering,
-    sync::{mpsc, Arc},
+    sync::{
+        atomic::{self, AtomicBool},
+        mpsc, Arc,
+    },
     thread::{self, JoinHandle},
 };
 
@@ -68,7 +71,7 @@ pub struct DbFormatChangeThreadHandle {
     update_task: Option<Arc<JoinHandle<()>>>,
 
     /// A channel that tells the running format thread to finish early.
-    cancel_handle: mpsc::SyncSender<CancelFormatChange>,
+    should_cancel_format_change: Arc<AtomicBool>,
 }
 
 /// Marker for cancelling a format upgrade.
@@ -146,24 +149,27 @@ impl DbFormatChange {
         //
         // Cancel handles must use try_send() to avoid blocking waiting for the format change
         // thread to shut down.
-        let (cancel_handle, cancel_receiver) = mpsc::sync_channel(1);
+        let should_cancel_format_change = Arc::new(AtomicBool::new(false));
 
         let span = Span::current();
-        let update_task = thread::spawn(move || {
-            span.in_scope(move || {
-                self.apply_format_change(
-                    config,
-                    network,
-                    initial_tip_height,
-                    upgrade_db,
-                    cancel_receiver,
-                );
+        let update_task = {
+            let should_cancel_format_change = should_cancel_format_change.clone();
+            thread::spawn(move || {
+                span.in_scope(move || {
+                    self.apply_format_change(
+                        config,
+                        network,
+                        initial_tip_height,
+                        upgrade_db,
+                        should_cancel_format_change,
+                    );
+                })
             })
-        });
+        };
 
         let mut handle = DbFormatChangeThreadHandle {
             update_task: Some(Arc::new(update_task)),
-            cancel_handle,
+            should_cancel_format_change,
         };
 
         handle.check_for_panics();
@@ -183,7 +189,7 @@ impl DbFormatChange {
         network: Network,
         initial_tip_height: Option<Height>,
         upgrade_db: ZebraDb,
-        cancel_receiver: mpsc::Receiver<CancelFormatChange>,
+        should_cancel_format_change: Arc<AtomicBool>,
     ) {
         match self {
             // Handled in the rest of this function.
@@ -192,7 +198,7 @@ impl DbFormatChange {
                 network,
                 initial_tip_height,
                 upgrade_db,
-                cancel_receiver,
+                should_cancel_format_change,
             ),
 
             NewlyCreated { .. } => {
@@ -231,7 +237,7 @@ impl DbFormatChange {
         network: Network,
         initial_tip_height: Option<Height>,
         upgrade_db: ZebraDb,
-        _cancel_receiver: mpsc::Receiver<CancelFormatChange>,
+        should_cancel_format_change: Arc<AtomicBool>,
     ) {
         let Upgrade {
             newer_running_version,
@@ -302,10 +308,17 @@ impl DbFormatChange {
 
             // Set up task for reading sapling note commitment trees
             let db = upgrade_db.clone();
+            let should_cancel_flag = should_cancel_format_change.clone();
             let sapling_read_task = std::thread::spawn(move || {
                 for (height, tree) in
                     db.sapling_tree_by_height_range(sapling_height..initial_tip_height)
                 {
+                    // Breaking from this loop and dropping the sapling_tree channel
+                    // will cause the sapling compare and delete tasks to finish.
+                    if should_cancel_flag.load(atomic::Ordering::Relaxed) {
+                        break;
+                    }
+
                     if let Err(error) = sapling_tree_tx.send((height, tree)) {
                         warn!(?error, "unexpected send error")
                     }
@@ -353,10 +366,17 @@ impl DbFormatChange {
 
             // Set up task for reading orchard note commitment trees
             let db = upgrade_db.clone();
+            let should_cancel_flag = should_cancel_format_change;
             let orchard_read_task = std::thread::spawn(move || {
                 for (height, tree) in
                     db.orchard_tree_by_height_range(orchard_height..initial_tip_height)
                 {
+                    // Breaking from this loop and dropping the orchard_tree channel
+                    // will cause the orchard compare and delete tasks to finish.
+                    if should_cancel_flag.load(atomic::Ordering::Relaxed) {
+                        break;
+                    }
+
                     if let Err(error) = orchard_tree_tx.send((height, tree)) {
                         warn!(?error, "unexpected send error")
                     }
@@ -593,7 +613,8 @@ impl DbFormatChangeThreadHandle {
         // There's nothing we can do about errors here.
         // If the channel is disconnected, the task has exited.
         // If it's full, it's already been cancelled.
-        let _ = self.cancel_handle.try_send(CancelFormatChange);
+        self.should_cancel_format_change
+            .store(true, atomic::Ordering::Relaxed);
     }
 
     /// Check for panics in the code running in the spawned thread.

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -341,11 +341,6 @@ impl DbFormatChange {
                         batch.delete_range_sapling_tree(&db, &delete_from, &height);
                         db.write_batch(batch)
                             .expect("Deleting note commitment trees should always succeed.");
-                    } else if num_entries.map_or(false, |n| n == 1) {
-                        let mut batch: DiskWriteBatch = DiskWriteBatch::new();
-                        batch.delete_sapling_tree(&db, &delete_from);
-                        db.write_batch(batch)
-                            .expect("Deleting note commitment trees should always succeed.");
                     }
 
                     prev_height = height;
@@ -395,11 +390,6 @@ impl DbFormatChange {
                     if num_entries.map_or(false, |n| n >= 1) {
                         let mut batch: DiskWriteBatch = DiskWriteBatch::new();
                         batch.delete_range_orchard_tree(&db, &delete_from, &height);
-                        db.write_batch(batch)
-                            .expect("Deleting note commitment trees should always succeed.");
-                    } else if num_entries.map_or(false, |n| n == 1) {
-                        let mut batch: DiskWriteBatch = DiskWriteBatch::new();
-                        batch.delete_orchard_tree(&db, &delete_from);
                         db.write_batch(batch)
                             .expect("Deleting note commitment trees should always succeed.");
                     }

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -54,7 +54,7 @@ pub struct ZebraDb {
     format_change_handle: Option<DbFormatChangeThreadHandle>,
 
     /// The inner low-level database wrapper for the RocksDB database.
-    pub db: DiskDb,
+    db: DiskDb,
 }
 
 impl ZebraDb {

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -54,7 +54,7 @@ pub struct ZebraDb {
     format_change_handle: Option<DbFormatChangeThreadHandle>,
 
     /// The inner low-level database wrapper for the RocksDB database.
-    db: DiskDb,
+    pub db: DiskDb,
 }
 
 impl ZebraDb {

--- a/zebra-state/src/service/finalized_state/zebra_db/arbitrary.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/arbitrary.rs
@@ -2,9 +2,7 @@
 
 use std::ops::Deref;
 
-use zebra_chain::{
-    amount::NonNegative, block::Block, parameters::Network::*, sprout, value_balance::ValueBalance,
-};
+use zebra_chain::{amount::NonNegative, block::Block, sprout, value_balance::ValueBalance};
 
 use crate::service::finalized_state::{
     disk_db::{DiskDb, DiskWriteBatch, WriteDisk},
@@ -31,7 +29,7 @@ impl ZebraDb {
 
     /// Allow to set up a fake value pool in the database for testing purposes.
     pub fn set_finalized_value_pool(&self, fake_value_pool: ValueBalance<NonNegative>) {
-        let mut batch = DiskWriteBatch::new(Mainnet);
+        let mut batch = DiskWriteBatch::new();
         let value_pool_cf = self.db().cf_handle("tip_chain_value_pool").unwrap();
 
         batch.zs_insert(&value_pool_cf, (), fake_value_pool);
@@ -41,7 +39,7 @@ impl ZebraDb {
     /// Artificially prime the note commitment tree anchor sets with anchors
     /// referenced in a block, for testing purposes _only_.
     pub fn populate_with_anchors(&self, block: &Block) {
-        let mut batch = DiskWriteBatch::new(Mainnet);
+        let mut batch = DiskWriteBatch::new();
 
         let sprout_anchors = self.db().cf_handle("sprout_anchors").unwrap();
         let sapling_anchors = self.db().cf_handle("sapling_anchors").unwrap();

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -368,11 +368,12 @@ impl ZebraDb {
                 .filter_map(|address| Some((address, self.address_balance_location(&address)?)))
                 .collect();
 
-        let mut batch = DiskWriteBatch::new(network);
+        let mut batch = DiskWriteBatch::new();
 
         // In case of errors, propagate and do not write the batch.
         batch.prepare_block_batch(
             self,
+            network,
             &finalized,
             new_outputs_by_out_loc,
             spent_utxos_by_outpoint,
@@ -419,12 +420,11 @@ impl DiskWriteBatch {
     /// # Errors
     ///
     /// - Propagates any errors from updating history tree, note commitment trees, or value pools
-    //
-    // TODO: move db, finalized, and maybe other arguments into DiskWriteBatch
     #[allow(clippy::too_many_arguments)]
     pub fn prepare_block_batch(
         &mut self,
         zebra_db: &ZebraDb,
+        network: Network,
         finalized: &SemanticallyVerifiedBlockWithTrees,
         new_outputs_by_out_loc: BTreeMap<OutputLocation, transparent::Utxo>,
         spent_utxos_by_outpoint: HashMap<transparent::OutPoint, transparent::Utxo>,
@@ -454,6 +454,7 @@ impl DiskWriteBatch {
         // Commit transaction indexes
         self.prepare_transparent_transaction_batch(
             db,
+            network,
             &finalized.verified,
             &new_outputs_by_out_loc,
             &spent_utxos_by_outpoint,

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -389,6 +389,11 @@ impl ZebraDb {
 
         Ok(finalized.verified.hash)
     }
+
+    /// Writes the given batch to the database.
+    pub(crate) fn write_batch(&self, batch: DiskWriteBatch) -> Result<(), rocksdb::Error> {
+        self.db.write(batch)
+    }
 }
 
 /// Lookup the output location for an outpoint.

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -120,7 +120,7 @@ fn test_block_db_round_trip_with(
         };
 
         // Skip validation by writing the block directly to the database
-        let mut batch = DiskWriteBatch::new(Mainnet);
+        let mut batch = DiskWriteBatch::new();
         batch
             .prepare_block_header_and_transaction_data_batch(&state.db, &finalized)
             .expect("block is valid for batch");

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -376,7 +376,7 @@ impl DiskWriteBatch {
         self.zs_delete(&orchard_tree_cf, height);
     }
 
-    /// Deletes the range of Orchard note commitment trees at the given [`Height`]s.
+    /// Deletes the range of Orchard note commitment trees at the given [`Height`]s. Doesn't delete the upper bound.
     pub fn delete_range_orchard_tree(&mut self, zebra_db: &ZebraDb, from: &Height, to: &Height) {
         let orchard_tree_cf = zebra_db
             .db
@@ -385,7 +385,7 @@ impl DiskWriteBatch {
         self.zs_delete_range(&orchard_tree_cf, from, to);
     }
 
-    /// Deletes the range of Sapling note commitment trees at the given [`Height`]s.
+    /// Deletes the range of Sapling note commitment trees at the given [`Height`]s. Doesn't delete the upper bound.
     pub fn delete_range_sapling_tree(&mut self, zebra_db: &ZebraDb, from: &Height, to: &Height) {
         let sapling_tree_cf = zebra_db
             .db

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -367,6 +367,15 @@ impl DiskWriteBatch {
         self.zs_delete(&sapling_tree_cf, height);
     }
 
+    /// Deletes the range of Sapling note commitment trees at the given [`Height`]s. Doesn't delete the upper bound.
+    pub fn delete_range_sapling_tree(&mut self, zebra_db: &ZebraDb, from: &Height, to: &Height) {
+        let sapling_tree_cf = zebra_db
+            .db
+            .cf_handle("sapling_note_commitment_tree")
+            .unwrap();
+        self.zs_delete_range(&sapling_tree_cf, from, to);
+    }
+
     /// Deletes the Orchard note commitment tree at the given [`Height`].
     pub fn delete_orchard_tree(&mut self, zebra_db: &ZebraDb, height: &Height) {
         let orchard_tree_cf = zebra_db
@@ -383,14 +392,5 @@ impl DiskWriteBatch {
             .cf_handle("orchard_note_commitment_tree")
             .unwrap();
         self.zs_delete_range(&orchard_tree_cf, from, to);
-    }
-
-    /// Deletes the range of Sapling note commitment trees at the given [`Height`]s. Doesn't delete the upper bound.
-    pub fn delete_range_sapling_tree(&mut self, zebra_db: &ZebraDb, from: &Height, to: &Height) {
-        let sapling_tree_cf = zebra_db
-            .db
-            .cf_handle("sapling_note_commitment_tree")
-            .unwrap();
-        self.zs_delete_range(&sapling_tree_cf, from, to);
     }
 }

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -358,15 +358,6 @@ impl DiskWriteBatch {
         self.prepare_history_batch(db, finalized)
     }
 
-    /// Deletes the Sapling note commitment tree at the given [`Height`].
-    pub fn delete_sapling_tree(&mut self, zebra_db: &ZebraDb, height: &Height) {
-        let sapling_tree_cf = zebra_db
-            .db
-            .cf_handle("sapling_note_commitment_tree")
-            .unwrap();
-        self.zs_delete(&sapling_tree_cf, height);
-    }
-
     /// Deletes the range of Sapling note commitment trees at the given [`Height`]s. Doesn't delete the upper bound.
     pub fn delete_range_sapling_tree(&mut self, zebra_db: &ZebraDb, from: &Height, to: &Height) {
         let sapling_tree_cf = zebra_db
@@ -374,15 +365,6 @@ impl DiskWriteBatch {
             .cf_handle("sapling_note_commitment_tree")
             .unwrap();
         self.zs_delete_range(&sapling_tree_cf, from, to);
-    }
-
-    /// Deletes the Orchard note commitment tree at the given [`Height`].
-    pub fn delete_orchard_tree(&mut self, zebra_db: &ZebraDb, height: &Height) {
-        let orchard_tree_cf = zebra_db
-            .db
-            .cf_handle("orchard_note_commitment_tree")
-            .unwrap();
-        self.zs_delete(&orchard_tree_cf, height);
     }
 
     /// Deletes the range of Orchard note commitment trees at the given [`Height`]s. Doesn't delete the upper bound.

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -338,4 +338,22 @@ impl DiskWriteBatch {
 
         self.prepare_history_batch(db, finalized)
     }
+
+    /// Deletes the Sapling note commitment tree at the given [`Height`].
+    pub fn delete_sapling_tree(&mut self, zebra_db: &ZebraDb, height: &Height) {
+        let sapling_tree_cf = zebra_db
+            .db
+            .cf_handle("sapling_note_commitment_tree")
+            .unwrap();
+        self.zs_delete(&sapling_tree_cf, height);
+    }
+
+    /// Deletes the Orchard note commitment tree at the given [`Height`].
+    pub fn delete_orchard_tree(&mut self, zebra_db: &ZebraDb, height: &Height) {
+        let orchard_tree_cf = zebra_db
+            .db
+            .cf_handle("orchard_note_commitment_tree")
+            .unwrap();
+        self.zs_delete(&orchard_tree_cf, height);
+    }
 }

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -157,6 +157,15 @@ impl ZebraDb {
         Some(Arc::new(tree))
     }
 
+    /// Deletes the Sapling note commitment tree at the given [`Height`].
+    pub fn delete_sapling_tree(&self, height: &Height) {
+        let mut batch = DiskWriteBatch::new();
+        batch.delete_sapling_tree(self, height);
+        self.db
+            .write(batch)
+            .expect("Deleting a Sapling note commitment tree should always succeed.");
+    }
+
     /// Returns the Orchard note commitment tree of the finalized tip
     /// or the empty tree if the state is empty.
     pub fn orchard_tree(&self) -> Arc<orchard::tree::NoteCommitmentTree> {
@@ -197,6 +206,15 @@ impl ZebraDb {
             );
 
         Some(Arc::new(tree))
+    }
+
+    /// Deletes the Sapling note commitment tree at the given [`Height`].
+    pub fn delete_orchard_tree(&self, height: &Height) {
+        let mut batch = DiskWriteBatch::new();
+        batch.delete_orchard_tree(self, height);
+        self.db
+            .write(batch)
+            .expect("Deleting an Orchard note commitment tree should always succeed.");
     }
 
     /// Returns the shielded note commitment trees of the finalized tip

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -142,11 +142,6 @@ impl ZebraDb {
         let sapling_trees = self.db.cf_handle("sapling_note_commitment_tree").unwrap();
 
         // If we know there must be a tree, search backwards for it.
-        //
-        // # Compatibility
-        //
-        // Allow older Zebra versions to read future database formats, after note commitment trees
-        // have been deduplicated. See ticket #6642 for details.
         let (_first_duplicate_height, tree) = self
             .db
             .zs_prev_key_value_back_from(&sapling_trees, height)
@@ -195,9 +190,7 @@ impl ZebraDb {
 
         let orchard_trees = self.db.cf_handle("orchard_note_commitment_tree").unwrap();
 
-        // # Compatibility
-        //
-        // Allow older Zebra versions to read future database formats. See ticket #6642 for details.
+        // If we know there must be a tree, search backwards for it.
         let (_first_duplicate_height, tree) = self
             .db
             .zs_prev_key_value_back_from(&orchard_trees, height)

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -358,6 +358,15 @@ impl DiskWriteBatch {
         self.prepare_history_batch(db, finalized)
     }
 
+    /// Deletes the Sapling note commitment tree at the given [`Height`].
+    pub fn delete_sapling_tree(&mut self, zebra_db: &ZebraDb, height: &Height) {
+        let sapling_tree_cf = zebra_db
+            .db
+            .cf_handle("sapling_note_commitment_tree")
+            .unwrap();
+        self.zs_delete(&sapling_tree_cf, height);
+    }
+
     /// Deletes the range of Sapling note commitment trees at the given [`Height`]s. Doesn't delete the upper bound.
     pub fn delete_range_sapling_tree(&mut self, zebra_db: &ZebraDb, from: &Height, to: &Height) {
         let sapling_tree_cf = zebra_db
@@ -365,6 +374,15 @@ impl DiskWriteBatch {
             .cf_handle("sapling_note_commitment_tree")
             .unwrap();
         self.zs_delete_range(&sapling_tree_cf, from, to);
+    }
+
+    /// Deletes the Orchard note commitment tree at the given [`Height`].
+    pub fn delete_orchard_tree(&mut self, zebra_db: &ZebraDb, height: &Height) {
+        let orchard_tree_cf = zebra_db
+            .db
+            .cf_handle("orchard_note_commitment_tree")
+            .unwrap();
+        self.zs_delete(&orchard_tree_cf, height);
     }
 
     /// Deletes the range of Orchard note commitment trees at the given [`Height`]s. Doesn't delete the upper bound.

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -342,4 +342,24 @@ impl DiskWriteBatch {
     pub fn delete_orchard_tree(&mut self, tree_cf: &impl AsColumnFamilyRef, height: &Height) {
         self.zs_delete(tree_cf, height);
     }
+
+    /// Deletes the range of Orchard note commitment trees at the given [`Height`]s.
+    pub fn delete_range_orchard_tree(
+        &mut self,
+        tree_cf: &impl AsColumnFamilyRef,
+        from: &Height,
+        to: &Height,
+    ) {
+        self.zs_delete_range(tree_cf, from, to);
+    }
+
+    /// Deletes the range of Sapling note commitment trees at the given [`Height`]s.
+    pub fn delete_range_sapling_tree(
+        &mut self,
+        tree_cf: &impl AsColumnFamilyRef,
+        from: &Height,
+        to: &Height,
+    ) {
+        self.zs_delete_range(tree_cf, from, to);
+    }
 }


### PR DESCRIPTION
## Motivation

Close #4784.

Previous PRs that address parts of #4784:

- #7239.
- #7266.

This is a final PR that prunes the trees stored in the database.

## Solution

- Add support for deleting Sapling and Orchard trees in `DiskWriteBatch`.
- Prune duplicate Sapling and Orchard trees starting from the genesis block to the initial tip.
- Zebra doesn't store Sprout trees by height, it keeps only a single tree for the tip, so this PR doesn't prune Sprout trees.
- I kept the database version at 25.1.0, which was introduced in #7266. The reason is that both this PR and #7266 leave the database in the same format&mdash;this PR affects already stored trees, and #7266 affects incoming trees.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?