### PR TITLE
fix(test): Update expected log in lightwalletd_full_sync test

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1831,10 +1831,11 @@ fn lightwalletd_integration_test(test_type: TestType) -> Result<()> {
         }
 
         if test_type.needs_lightwalletd_cached_state() {
-            lightwalletd.expect_stdout_line_matches("Found [0-9]{7} blocks in cache")?;
+            lightwalletd
+                .expect_stdout_line_matches("Done reading [0-9]{7} blocks from disk cache")?;
         } else if !test_type.allow_lightwalletd_cached_state() {
             // Timeout the test if we're somehow accidentally using a cached state in our temp dir
-            lightwalletd.expect_stdout_line_matches("Found 0 blocks in cache")?;
+            lightwalletd.expect_stdout_line_matches("Done reading 0 blocks from disk cache")?;
         }
 
         // getblock with the first Sapling block in Zebra's state


### PR DESCRIPTION
## Motivation

This may be causing problems in CI. 

## Solution

- Update the expected logs from lightwalletd in the full sync test

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
