### PR TITLE
change: Batch tree removal when migrating the database

### DIFF
--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -42,6 +42,8 @@ pub use disk_format::{OutputIndex, OutputLocation, TransactionLocation, MAX_ON_D
 
 pub(super) use zebra_db::ZebraDb;
 
+#[cfg(not(any(test, feature = "proptest-impl")))]
+pub(super) use disk_db::DiskWriteBatch;
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use disk_db::{DiskWriteBatch, WriteDisk};
 

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -113,8 +113,14 @@ pub trait WriteDisk {
         K: IntoDisk + Debug,
         V: IntoDisk;
 
-    /// Remove the given key form rocksdb column family if it exists.
+    /// Remove the given key from rocksdb column family if it exists.
     fn zs_delete<C, K>(&mut self, cf: &C, key: K)
+    where
+        C: rocksdb::AsColumnFamilyRef,
+        K: IntoDisk + Debug;
+
+    /// Remove the given key range from rocksdb column family if it exists.
+    fn zs_delete_range<C, K>(&mut self, cf: &C, from: K, to: K)
     where
         C: rocksdb::AsColumnFamilyRef,
         K: IntoDisk + Debug;
@@ -139,6 +145,16 @@ impl WriteDisk for DiskWriteBatch {
     {
         let key_bytes = key.as_bytes();
         self.batch.delete_cf(cf, key_bytes);
+    }
+
+    fn zs_delete_range<C, K>(&mut self, cf: &C, from: K, to: K)
+    where
+        C: rocksdb::AsColumnFamilyRef,
+        K: IntoDisk + Debug,
+    {
+        let from_bytes = from.as_bytes();
+        let to_bytes = to.as_bytes();
+        self.batch.delete_range_cf(cf, from_bytes, to_bytes);
     }
 }
 

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -420,7 +420,7 @@ impl DiskDb {
     /// Returns an iterator over the items in `cf` in `range`.
     ///
     /// Holding this iterator open might delay block commit transactions.
-    fn zs_range_iter<C, K, V, R>(&self, cf: &C, range: R) -> impl Iterator<Item = (K, V)> + '_
+    pub fn zs_range_iter<C, K, V, R>(&self, cf: &C, range: R) -> impl Iterator<Item = (K, V)> + '_
     where
         C: rocksdb::AsColumnFamilyRef,
         K: IntoDisk + FromDisk,
@@ -465,7 +465,7 @@ impl DiskDb {
             .map(|result| result.expect("unexpected database failure"))
             .map(|(key, value)| (key.to_vec(), value))
             // Handle Excluded start and the end bound
-            .filter(move |(key, _value)| range.contains(key))
+            .take_while(move |(key, _value)| range.contains(key))
             .map(|(key, value)| (K::from_bytes(key), V::from_bytes(value)))
     }
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -308,7 +308,9 @@ impl DbFormatChange {
                 for (height, tree) in
                     db.sapling_tree_by_height_range(sapling_height..initial_tip_height)
                 {
-                    let _ = sapling_tree_tx.send((height, tree));
+                    let _ = sapling_tree_tx
+                        .send((height, tree))
+                        .map_err(|error| warn!(?error, "unexpected send error"));
                 }
             });
 
@@ -320,7 +322,9 @@ impl DbFormatChange {
                 while let Ok((height, tree)) = sapling_tree_rx.recv() {
                     let tree = Some(tree);
                     if prev_sapling_tree != tree {
-                        let _ = unique_sapling_tree_height_tx.send(height);
+                        let _ = unique_sapling_tree_height_tx
+                            .send(height)
+                            .map_err(|error| warn!(?error, "unexpected send error"));
                         prev_sapling_tree = tree;
                     }
                 }
@@ -361,7 +365,9 @@ impl DbFormatChange {
                 for (height, tree) in
                     db.orchard_tree_by_height_range(orchard_height..initial_tip_height)
                 {
-                    let _ = orchard_tree_tx.send((height, tree));
+                    let _ = orchard_tree_tx
+                        .send((height, tree))
+                        .map_err(|error| warn!(?error, "unexpected send error"));
                 }
             });
 
@@ -373,7 +379,9 @@ impl DbFormatChange {
                 while let Ok((height, tree)) = orchard_tree_rx.recv() {
                     let tree = Some(tree);
                     if prev_orchard_tree != tree {
-                        let _ = unique_orchard_tree_height_tx.send(height);
+                        let _ = unique_orchard_tree_height_tx
+                            .send(height)
+                            .map_err(|error| warn!(?error, "unexpected send error"));
                         prev_orchard_tree = tree;
                     }
                 }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -271,8 +271,6 @@ impl DbFormatChange {
         // Check if we need to prune the note commitment trees in the database.
         if older_disk_version < version_for_pruning_trees {
             let mut height = Height(0);
-            let mut prev_sapling_tree = upgrade_db.sapling_tree_by_height(&height);
-            let mut prev_orchard_tree = upgrade_db.orchard_tree_by_height(&height);
             let sapling_cf = upgrade_db
                 .db
                 .cf_handle("sapling_note_commitment_tree")
@@ -304,6 +302,8 @@ impl DbFormatChange {
             height = sapling_height;
             warn!(?height, "Database upgrade is at:");
 
+            let mut prev_sapling_tree = upgrade_db.sapling_tree_by_height(&height);
+
             while height <= orchard_height {
                 let mut batch = DiskWriteBatch::new();
                 for _ in 0..1_000 {
@@ -328,6 +328,8 @@ impl DbFormatChange {
                     height = height.next();
                 }
             }
+
+            let mut prev_orchard_tree = upgrade_db.orchard_tree_by_height(&height);
 
             // Go through every height from genesis to the tip of the old version. If the state was
             // downgraded, some heights might already be upgraded. (Since the upgraded format is

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -339,9 +339,9 @@ impl DbFormatChange {
                         batch.delete_range_sapling_tree(&db, &delete_from, &height);
                         db.write_batch(batch)
                             .expect("Deleting note commitment trees should always succeed.");
-                    } else if num_entries.map_or(false, |n| n == 0) {
+                    } else if num_entries.map_or(false, |n| n == 1) {
                         let mut batch: DiskWriteBatch = DiskWriteBatch::new();
-                        batch.delete_sapling_tree(&db, &height);
+                        batch.delete_sapling_tree(&db, &delete_from);
                         db.write_batch(batch)
                             .expect("Deleting note commitment trees should always succeed.");
                     }
@@ -392,9 +392,9 @@ impl DbFormatChange {
                         batch.delete_range_orchard_tree(&db, &delete_from, &height);
                         db.write_batch(batch)
                             .expect("Deleting note commitment trees should always succeed.");
-                    } else if num_entries.map_or(false, |n| n == 0) {
+                    } else if num_entries.map_or(false, |n| n == 1) {
                         let mut batch: DiskWriteBatch = DiskWriteBatch::new();
-                        batch.delete_orchard_tree(&db, &height);
+                        batch.delete_orchard_tree(&db, &delete_from);
                         db.write_batch(batch)
                             .expect("Deleting note commitment trees should always succeed.");
                     }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -291,8 +291,6 @@ impl DbFormatChange {
                     .write_batch(batch)
                     .expect("Deleting note commitment trees should always succeed.");
 
-                warn!(?sapling_height, "Database upgrade is at:");
-
                 (
                     upgrade_db.sapling_tree_by_height(&Height(0)),
                     upgrade_db.orchard_tree_by_height(&Height(0)),
@@ -351,8 +349,6 @@ impl DbFormatChange {
                     }
 
                     prev_height = height;
-
-                    warn!(?height, "Database upgrade is at:");
                 }
             });
 
@@ -408,8 +404,6 @@ impl DbFormatChange {
                     }
 
                     prev_height = height;
-
-                    warn!(?height, "Database upgrade is at:");
                 }
             });
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -332,12 +332,11 @@ impl DbFormatChange {
                 let mut prev_height = sapling_height;
                 while let Ok(height) = unique_sapling_tree_height_rx.recv() {
                     let delete_from = (prev_height + 1).expect("should be valid height");
-                    let delete_to = (height - 1).expect("should be a valid height");
-                    let num_entries = delete_to.0.checked_sub(delete_from.0);
+                    let num_entries = height.0.checked_sub(delete_from.0);
 
                     if num_entries.map_or(false, |n| n >= 1) {
                         let mut batch: DiskWriteBatch = DiskWriteBatch::new();
-                        batch.delete_range_sapling_tree(&db, &delete_from, &delete_to);
+                        batch.delete_range_sapling_tree(&db, &delete_from, &height);
                         db.write_batch(batch)
                             .expect("Deleting note commitment trees should always succeed.");
                     } else if num_entries.map_or(false, |n| n == 0) {
@@ -386,12 +385,11 @@ impl DbFormatChange {
                 let mut prev_height = orchard_height;
                 while let Ok(height) = unique_orchard_tree_height_rx.recv() {
                     let delete_from = (prev_height + 1).expect("should be valid height");
-                    let delete_to = (height - 1).expect("should be a valid height");
-                    let num_entries = delete_to.0.checked_sub(delete_from.0);
+                    let num_entries = height.0.checked_sub(delete_from.0);
 
                     if num_entries.map_or(false, |n| n >= 1) {
                         let mut batch: DiskWriteBatch = DiskWriteBatch::new();
-                        batch.delete_range_orchard_tree(&db, &delete_from, &delete_to);
+                        batch.delete_range_orchard_tree(&db, &delete_from, &height);
                         db.write_batch(batch)
                             .expect("Deleting note commitment trees should always succeed.");
                     } else if num_entries.map_or(false, |n| n == 0) {

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -54,7 +54,7 @@ pub struct ZebraDb {
     format_change_handle: Option<DbFormatChangeThreadHandle>,
 
     /// The inner low-level database wrapper for the RocksDB database.
-    db: DiskDb,
+    pub db: DiskDb,
 }
 
 impl ZebraDb {

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -389,6 +389,11 @@ impl ZebraDb {
 
         Ok(finalized.verified.hash)
     }
+
+    /// Writes the given batch to the database.
+    pub(crate) fn write_batch(&self, batch: DiskWriteBatch) -> Result<(), rocksdb::Error> {
+        self.db.write(batch)
+    }
 }
 
 /// Lookup the output location for an outpoint.

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -376,7 +376,7 @@ impl DiskWriteBatch {
         self.zs_delete(&orchard_tree_cf, height);
     }
 
-    /// Deletes the range of Orchard note commitment trees at the given [`Height`]s.
+    /// Deletes the range of Orchard note commitment trees at the given [`Height`]s. Doesn't delete the upper bound.
     pub fn delete_range_orchard_tree(&mut self, zebra_db: &ZebraDb, from: &Height, to: &Height) {
         let orchard_tree_cf = zebra_db
             .db
@@ -385,7 +385,7 @@ impl DiskWriteBatch {
         self.zs_delete_range(&orchard_tree_cf, from, to);
     }
 
-    /// Deletes the range of Sapling note commitment trees at the given [`Height`]s.
+    /// Deletes the range of Sapling note commitment trees at the given [`Height`]s. Doesn't delete the upper bound.
     pub fn delete_range_sapling_tree(&mut self, zebra_db: &ZebraDb, from: &Height, to: &Height) {
         let sapling_tree_cf = zebra_db
             .db

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -342,4 +342,24 @@ impl DiskWriteBatch {
     pub fn delete_orchard_tree(&mut self, tree_cf: &impl AsColumnFamilyRef, height: &Height) {
         self.zs_delete(tree_cf, height);
     }
+
+    /// Deletes the range of Orchard note commitment trees at the given [`Height`]s.
+    pub fn delete_range_orchard_tree(
+        &mut self,
+        tree_cf: &impl AsColumnFamilyRef,
+        from: &Height,
+        to: &Height,
+    ) {
+        self.zs_delete_range(tree_cf, from, to);
+    }
+
+    /// Deletes the range of Sapling note commitment trees at the given [`Height`]s.
+    pub fn delete_range_sapling_tree(
+        &mut self,
+        tree_cf: &impl AsColumnFamilyRef,
+        from: &Height,
+        to: &Height,
+    ) {
+        self.zs_delete_range(tree_cf, from, to);
+    }
 }


### PR DESCRIPTION
# Motivation

The migration in PR #7312 is too slow.

## Solution

This PR batches the removals. It provides a speed-up, but we'll need further improvements to make #7312 useful. To quickly implement the batching, I made the inner database in `ZebraDb` `pub`, which violates the API. I'm therefore labeling this PR as a draft for now.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

