### PR TITLE
fix(docs): deploy external and internal docs with the correct path

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Build external docs
         run: |
           # Exclude zebra-utils, it is not for library or app users
-          cargo doc --no-deps --workspace --all-features --exclude zebra-utils --target-dir target/external
+          cargo doc --no-deps --workspace --all-features --exclude zebra-utils --target-dir "$(pwd)"/target/external
         env:
           RUSTDOCFLAGS: '--html-in-header katex-header.html'
 
@@ -197,7 +197,7 @@ jobs:
 
       - name: Build internal docs
         run: |
-          cargo doc --no-deps --workspace --all-features --document-private-items --target-dir target/internal
+          cargo doc --no-deps --workspace --all-features --document-private-items --target-dir "$(pwd)"/target/internal
         env:
           RUSTDOCFLAGS: '--html-in-header katex-header.html'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,7 +110,6 @@ jobs:
     name: Build and Deploy Zebra External Docs
     timeout-minutes: 45
     runs-on: ubuntu-latest
-    environment: docs
     permissions:
       checks: write
       contents: 'read'
@@ -170,7 +169,6 @@ jobs:
     name: Build and Deploy Zebra Internal Docs
     timeout-minutes: 45
     runs-on: ubuntu-latest
-    environment: docs
     permissions:
       checks: write
       contents: 'read'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ on:
       # doc source files
       - 'book/**'
       - '**/firebase.json'
+      - '**/.firebaserc'
       - 'katex-header.html'
       # rustdoc source files
       - '**/*.rs'
@@ -34,6 +35,7 @@ on:
       # doc source files
       - 'book/**'
       - '**/firebase.json'
+      - '**/.firebaserc'
       - 'katex-header.html'
       # rustdoc source files
       - '**/*.rs'
@@ -57,7 +59,6 @@ jobs:
     name: Build and Deploy Zebra Book Docs
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    environment: docs
     permissions:
       checks: write
       contents: 'read'
@@ -91,17 +92,18 @@ jobs:
           service_account: '${{ vars.GCP_FIREBASE_SA }}'
 
       # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed 
-      - run: |
+      - name: Add $GCP_FIREBASE_SA_PATH to env
+        run: |
           # shellcheck disable=SC2002
-          echo "GCP_FIREBASE_SA=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
+          echo "GCP_FIREBASE_SA_PATH=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
 
       - name: Deploy Zebra book to firebase
         uses: FirebaseExtended/action-hosting-deploy@v0.7.1
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA }}
+          firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA_PATH }}
           channelId: ${{ env.FIREBASE_CHANNEL }}
-          projectId: ${{ vars.GCP_PROJECT }}
+          projectId: ${{ vars.GCP_FIREBASE_PROJECT }}
           target: docs-book
 
   build-docs-external:
@@ -150,18 +152,19 @@ jobs:
           service_account: '${{ vars.GCP_FIREBASE_SA }}'
 
       # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed 
-      - run: |
+      - name: Add $GCP_FIREBASE_SA_PATH to env
+        run: |
           # shellcheck disable=SC2002
-          echo "GCP_FIREBASE_SA=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
+          echo "GCP_FIREBASE_SA_PATH=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
 
       - name: Deploy external docs to firebase
         uses: FirebaseExtended/action-hosting-deploy@v0.7.1
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA }}
+          firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA_PATH }}
           channelId: ${{ env.FIREBASE_CHANNEL }}
           target: docs-external
-          projectId: ${{ vars.GCP_PROJECT }}
+          projectId: ${{ vars.GCP_FIREBASE_PROJECT }}
 
   build-docs-internal:
     name: Build and Deploy Zebra Internal Docs
@@ -208,15 +211,16 @@ jobs:
           service_account: '${{ vars.GCP_FIREBASE_SA }}'
 
       # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed 
-      - run: |
+      - name: Add $GCP_FIREBASE_SA_PATH to env
+        run: |
           # shellcheck disable=SC2002
-          echo "GCP_FIREBASE_SA=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
+          echo "GCP_FIREBASE_SA_PATH=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
 
       - name: Deploy internal docs to firebase
         uses: FirebaseExtended/action-hosting-deploy@v0.7.1
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA }}
+          firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA_PATH }}
           channelId: ${{ env.FIREBASE_CHANNEL }}
           target: docs-internal
-          projectId: ${{ vars.GCP_PROJECT }}
+          projectId: ${{ vars.GCP_FIREBASE_PROJECT }}

--- a/firebase.json
+++ b/firebase.json
@@ -1,7 +1,7 @@
 {
   "hosting": [
     {
-      "public": "target/external",
+      "public": "target/external/doc",
       "target": "docs-external",
       "ignore": [
         "firebase.json",
@@ -23,7 +23,7 @@
       ]
     },
     {
-      "public": "target/internal",
+      "public": "target/internal/doc",
       "target": "docs-internal",
       "ignore": [
         "firebase.json",


### PR DESCRIPTION
## Motivation

After changing the docs deploy method, a bug was introduced for internal and external docs.

Also, with the `environment` inclusion, this has made GitHub notifications too noisy.

## Solution

- Create specific variables for Firebase deployment to avoid using an environment
- Target the correct paths for external and internal docs


## Review

This should output the resulting preview URLs 

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

None
