### PR TITLE
ref(docs): consolidate docs linting and publishing

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -80,7 +80,7 @@ rustflags = [
 [build]
 rustdocflags = [
     # The -A and -W settings must be the same as the `RUSTDOCFLAGS` in:
-    # https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/lint.yml#L151
+    # https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/docs.yml#L61
 
     # Links in public docs can point to private items.
     "-Arustdoc::private_intra_doc_links",

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Build external docs
         run: |
           # Exclude zebra-utils, it is not for library or app users
-          cargo doc --no-deps --workspace --all-features --exclude zebra-utils --target-dir target/external
+          cargo doc --no-deps --workspace --all-features --exclude zebra-utils --target-dir "$(pwd)"/target/external
         env:
           RUSTDOCFLAGS: '--html-in-header katex-header.html'
 
@@ -197,7 +197,7 @@ jobs:
 
       - name: Build internal docs
         run: |
-          cargo doc --no-deps --workspace --all-features --document-private-items --target-dir target/internal
+          cargo doc --no-deps --workspace --all-features --document-private-items --target-dir "$(pwd)"/target/internal
         env:
           RUSTDOCFLAGS: '--html-in-header katex-header.html'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,7 +110,6 @@ jobs:
     name: Build and Deploy Zebra External Docs
     timeout-minutes: 45
     runs-on: ubuntu-latest
-    environment: docs
     permissions:
       checks: write
       contents: 'read'
@@ -170,7 +169,6 @@ jobs:
     name: Build and Deploy Zebra Internal Docs
     timeout-minutes: 45
     runs-on: ubuntu-latest
-    environment: docs
     permissions:
       checks: write
       contents: 'read'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,6 @@ env:
   # https://github.com/ZcashFoundation/zebra/blob/main/.cargo/config.toml#L87
   RUSTDOCFLAGS: --html-in-header katex-header.html -D warnings -A rustdoc::private_intra_doc_links
 
-
 jobs:
   build-docs-book:
     name: Build and Deploy Zebra Book Docs
@@ -98,7 +97,7 @@ jobs:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_FIREBASE_SA }}'
 
-      # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed 
+      # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed
       - name: Add $GCP_FIREBASE_SA_PATH to env
         run: |
           # shellcheck disable=SC2002
@@ -155,7 +154,7 @@ jobs:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_FIREBASE_SA }}'
 
-      # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed 
+      # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed
       - name: Add $GCP_FIREBASE_SA_PATH to env
         run: |
           # shellcheck disable=SC2002
@@ -211,7 +210,7 @@ jobs:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_FIREBASE_SA }}'
 
-      # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed 
+      # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed
       - name: Add $GCP_FIREBASE_SA_PATH to env
         run: |
           # shellcheck disable=SC2002

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,6 +53,13 @@ env:
   RUST_LIB_BACKTRACE: ${{ vars.RUST_LIB_BACKTRACE }}
   COLORBT_SHOW_HIDDEN: ${{ vars.COLORBT_SHOW_HIDDEN }}
   FIREBASE_CHANNEL: ${{ github.event_name == 'pull_request' && 'preview' || 'live' }}
+  # cargo doc doesn't support '--  -D warnings', so we have to add it here
+  # https://github.com/rust-lang/cargo/issues/8424#issuecomment-774662296
+  #
+  # The -A and -W settings must be the same as the `rustdocflags` in:
+  # https://github.com/ZcashFoundation/zebra/blob/main/.cargo/config.toml#L87
+  RUSTDOCFLAGS: --html-in-header katex-header.html -D warnings -A rustdoc::private_intra_doc_links
+
 
 jobs:
   build-docs-book:
@@ -138,8 +145,6 @@ jobs:
         run: |
           # Exclude zebra-utils, it is not for library or app users
           cargo doc --no-deps --workspace --all-features --exclude zebra-utils --target-dir "$(pwd)"/target/external
-        env:
-          RUSTDOCFLAGS: '--html-in-header katex-header.html'
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
@@ -196,8 +201,6 @@ jobs:
       - name: Build internal docs
         run: |
           cargo doc --no-deps --workspace --all-features --document-private-items --target-dir "$(pwd)"/target/internal
-        env:
-          RUSTDOCFLAGS: '--html-in-header katex-header.html'
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ on:
       # doc source files
       - 'book/**'
       - '**/firebase.json'
+      - '**/.firebaserc'
       - 'katex-header.html'
       # rustdoc source files
       - '**/*.rs'
@@ -34,6 +35,7 @@ on:
       # doc source files
       - 'book/**'
       - '**/firebase.json'
+      - '**/.firebaserc'
       - 'katex-header.html'
       # rustdoc source files
       - '**/*.rs'
@@ -57,7 +59,6 @@ jobs:
     name: Build and Deploy Zebra Book Docs
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    environment: docs
     permissions:
       checks: write
       contents: 'read'
@@ -91,17 +92,18 @@ jobs:
           service_account: '${{ vars.GCP_FIREBASE_SA }}'
 
       # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed 
-      - run: |
+      - name: Add $GCP_FIREBASE_SA_PATH to env
+        run: |
           # shellcheck disable=SC2002
-          echo "GCP_FIREBASE_SA=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
+          echo "GCP_FIREBASE_SA_PATH=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
 
       - name: Deploy Zebra book to firebase
         uses: FirebaseExtended/action-hosting-deploy@v0.7.1
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA }}
+          firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA_PATH }}
           channelId: ${{ env.FIREBASE_CHANNEL }}
-          projectId: ${{ vars.GCP_PROJECT }}
+          projectId: ${{ vars.GCP_FIREBASE_PROJECT }}
           target: docs-book
 
   build-docs-external:
@@ -150,18 +152,19 @@ jobs:
           service_account: '${{ vars.GCP_FIREBASE_SA }}'
 
       # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed 
-      - run: |
+      - name: Add $GCP_FIREBASE_SA_PATH to env
+        run: |
           # shellcheck disable=SC2002
-          echo "GCP_FIREBASE_SA=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
+          echo "GCP_FIREBASE_SA_PATH=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
 
       - name: Deploy external docs to firebase
         uses: FirebaseExtended/action-hosting-deploy@v0.7.1
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA }}
+          firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA_PATH }}
           channelId: ${{ env.FIREBASE_CHANNEL }}
           target: docs-external
-          projectId: ${{ vars.GCP_PROJECT }}
+          projectId: ${{ vars.GCP_FIREBASE_PROJECT }}
 
   build-docs-internal:
     name: Build and Deploy Zebra Internal Docs
@@ -208,15 +211,16 @@ jobs:
           service_account: '${{ vars.GCP_FIREBASE_SA }}'
 
       # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed 
-      - run: |
+      - name: Add $GCP_FIREBASE_SA_PATH to env
+        run: |
           # shellcheck disable=SC2002
-          echo "GCP_FIREBASE_SA=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
+          echo "GCP_FIREBASE_SA_PATH=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
 
       - name: Deploy internal docs to firebase
         uses: FirebaseExtended/action-hosting-deploy@v0.7.1
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA }}
+          firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA_PATH }}
           channelId: ${{ env.FIREBASE_CHANNEL }}
           target: docs-internal
-          projectId: ${{ vars.GCP_PROJECT }}
+          projectId: ${{ vars.GCP_FIREBASE_PROJECT }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -106,7 +106,6 @@ jobs:
       - name: Deploy Zebra book to firebase
         uses: FirebaseExtended/action-hosting-deploy@v0.7.1
         with:
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA_PATH }}
           channelId: ${{ env.FIREBASE_CHANNEL }}
           projectId: ${{ vars.GCP_FIREBASE_PROJECT }}
@@ -163,7 +162,6 @@ jobs:
       - name: Deploy external docs to firebase
         uses: FirebaseExtended/action-hosting-deploy@v0.7.1
         with:
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA_PATH }}
           channelId: ${{ env.FIREBASE_CHANNEL }}
           target: docs-external
@@ -219,7 +217,6 @@ jobs:
       - name: Deploy internal docs to firebase
         uses: FirebaseExtended/action-hosting-deploy@v0.7.1
         with:
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA_PATH }}
           channelId: ${{ env.FIREBASE_CHANNEL }}
           target: docs-internal

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -136,41 +136,6 @@ jobs:
       - run: |
           cargo fmt --all -- --check
 
-  docs:
-    name: Rust doc
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    needs: changed-files
-    if: ${{ needs.changed-files.outputs.rust == 'true' }}
-    # cargo doc doesn't support '--  -D warnings', so we have to add it here
-    # https://github.com/rust-lang/cargo/issues/8424#issuecomment-774662296
-    #
-    # The -A and -W settings must be the same as the `rustdocflags` in:
-    # https://github.com/ZcashFoundation/zebra/blob/main/.cargo/config.toml#L87
-    env:
-      RUSTDOCFLAGS: -D warnings -A rustdoc::private_intra_doc_links
-
-    steps:
-      - uses: actions/checkout@v3.5.3
-        with:
-          persist-credentials: false
-      - uses: r7kamura/rust-problem-matchers@v1.4.0
-
-      - name: Install last version of Protoc
-        uses: arduino/setup-protoc@v2.0.0
-        with:
-          # TODO: increase to latest version after https://github.com/arduino/setup-protoc/issues/33 is fixed
-          version: '23.x'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Setup Rust with stable toolchain and default profile
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
-
-      - run: |
-          cargo doc --no-deps --document-private-items --all-features
-
   actionlint:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/firebase.json
+++ b/firebase.json
@@ -1,7 +1,7 @@
 {
   "hosting": [
     {
-      "public": "target/external",
+      "public": "target/external/doc",
       "target": "docs-external",
       "ignore": [
         "firebase.json",
@@ -23,7 +23,7 @@
       ]
     },
     {
-      "public": "target/internal",
+      "public": "target/internal/doc",
       "target": "docs-internal",
       "ignore": [
         "firebase.json",


### PR DESCRIPTION
## Motivation

We were not linting before publishing

Depends-On: #7338

## Solution

- Consolidate linting errors with the docs build and publish steps

## Review

This should fail if there are  Rust `Warnings` while building the docs. And those should be fixed in this PR

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

None