### PR TITLE
OUTDATED: change(state): Add note subtree indexes to the database, and calculate subtrees for existing blocks

### DIFF
--- a/book/src/dev/state-db-upgrades.md
+++ b/book/src/dev/state-db-upgrades.md
@@ -92,10 +92,12 @@ We use the following rocksdb column families:
 | `sapling_nullifiers`               | `sapling::Nullifier`   | `()`                          | Create  |
 | `sapling_anchors`                  | `sapling::tree::Root`  | `()`                          | Create  |
 | `sapling_note_commitment_tree`     | `block::Height`        | `sapling::NoteCommitmentTree` | Create  |
+| `sapling_note_commitment_subtree`  | `block::Height`        | `NoteCommitmentSubtree`       | Create  |
 | *Orchard*                          |                        |                               |         |
 | `orchard_nullifiers`               | `orchard::Nullifier`   | `()`                          | Create  |
 | `orchard_anchors`                  | `orchard::tree::Root`  | `()`                          | Create  |
 | `orchard_note_commitment_tree`     | `block::Height`        | `orchard::NoteCommitmentTree` | Create  |
+| `orchard_note_commitment_subtree`  | `block::Height`        | `NoteCommitmentSubtree`       | Create  |
 | *Chain*                            |                        |                               |         |
 | `history_tree`                     | `block::Height`        | `NonEmptyHistoryTree`         | Delete  |
 | `tip_chain_value_pool`             | `()`                   | `ValueBalance`                | Update  |
@@ -118,6 +120,8 @@ Block and Transaction Data:
   used instead of a `BTreeSet<OutputLocation>` value, to improve database performance
 - `AddressTransaction`: `AddressLocation \|\| TransactionLocation`
   used instead of a `BTreeSet<TransactionLocation>` value, to improve database performance
+- `NoteCommitmentSubtreeIndex`: 16 bits, big-endian, unsigned
+- `NoteCommitmentSubtree`: `Height \|\| {sapling, orchard}::tree::Node`
 
 We use big-endian encoding for keys, to allow database index prefix searches.
 
@@ -333,6 +337,9 @@ So they should not be used for consensus-critical checks.
   state for every height, for the specific pool. Each tree is stored
   as a "Merkle tree frontier" which is basically a (logarithmic) subset of
   the Merkle tree nodes as required to insert new items.
+
+- The `{sapling, orchard}_note_commitment_subtree` stores the completion height and
+  root for every completed level 16 note commitment subtree, for the specific pool.
 
 - `history_tree` stores the ZIP-221 history tree state at the tip of the finalized
   state. There is always a single entry for it. The tree is stored as the set of "peaks"

--- a/book/src/dev/state-db-upgrades.md
+++ b/book/src/dev/state-db-upgrades.md
@@ -92,7 +92,7 @@ We use the following rocksdb column families:
 | `sapling_nullifiers`               | `sapling::Nullifier`   | `()`                          | Create  |
 | `sapling_anchors`                  | `sapling::tree::Root`  | `()`                          | Create  |
 | `sapling_note_commitment_tree`     | `block::Height`        | `sapling::NoteCommitmentTree` | Create  |
-| `sapling_note_commitment_subtree`  | `block::Height`        | `NoteCommitmentSubtree`       | Create  |
+| `sapling_note_commitment_subtree`  | `block::Height`        | `NoteCommitmentSubtreeData`   | Create  |
 | *Orchard*                          |                        |                               |         |
 | `orchard_nullifiers`               | `orchard::Nullifier`   | `()`                          | Create  |
 | `orchard_anchors`                  | `orchard::tree::Root`  | `()`                          | Create  |

--- a/book/src/dev/state-db-upgrades.md
+++ b/book/src/dev/state-db-upgrades.md
@@ -97,7 +97,7 @@ We use the following rocksdb column families:
 | `orchard_nullifiers`               | `orchard::Nullifier`   | `()`                          | Create  |
 | `orchard_anchors`                  | `orchard::tree::Root`  | `()`                          | Create  |
 | `orchard_note_commitment_tree`     | `block::Height`        | `orchard::NoteCommitmentTree` | Create  |
-| `orchard_note_commitment_subtree`  | `block::Height`        | `NoteCommitmentSubtree`       | Create  |
+| `orchard_note_commitment_subtree`  | `block::Height`        | `NoteCommitmentSubtreeData`   | Create  |
 | *Chain*                            |                        |                               |         |
 | `history_tree`                     | `block::Height`        | `NonEmptyHistoryTree`         | Delete  |
 | `tip_chain_value_pool`             | `()`                   | `ValueBalance`                | Update  |
@@ -121,7 +121,7 @@ Block and Transaction Data:
 - `AddressTransaction`: `AddressLocation \|\| TransactionLocation`
   used instead of a `BTreeSet<TransactionLocation>` value, to improve database performance
 - `NoteCommitmentSubtreeIndex`: 16 bits, big-endian, unsigned
-- `NoteCommitmentSubtree`: `Height \|\| {sapling, orchard}::tree::Node`
+- `NoteCommitmentSubtreeData<{sapling, orchard}::tree::Node>`: `Height \|\| {sapling, orchard}::tree::Node`
 
 We use big-endian encoding for keys, to allow database index prefix searches.
 

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -34,6 +34,7 @@ pub mod sapling;
 pub mod serialization;
 pub mod shutdown;
 pub mod sprout;
+pub mod subtree;
 pub mod transaction;
 pub mod transparent;
 pub mod value_balance;

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -184,11 +184,19 @@ impl TryFrom<&[u8]> for Node {
     type Error = &'static str;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Option::<pallas::Base>::from(pallas::Base::from_repr(
-            bytes.try_into().map_err(|_| "wrong byte slice len")?,
-        ))
-        .map(Node)
-        .ok_or("invalid Pallas field element")
+        <[u8; 32]>::try_from(bytes)
+            .map_err(|_| "wrong byte slice len")?
+            .try_into()
+    }
+}
+
+impl TryFrom<[u8; 32]> for Node {
+    type Error = &'static str;
+
+    fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
+        Option::<pallas::Base>::from(pallas::Base::from_repr(bytes))
+            .map(Node)
+            .ok_or("invalid Pallas field element")
     }
 }
 

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -347,6 +347,11 @@ impl NoteCommitmentTree {
         }
     }
 
+    /// Returns frontier of non-empty tree, or None.
+    pub fn frontier(&self) -> Option<&NonEmptyFrontier<Node>> {
+        self.inner.value()
+    }
+
     /// Returns true if the most recently appended leaf completes the subtree
     pub fn is_complete_subtree(tree: &NonEmptyFrontier<Node>) -> bool {
         tree.position()

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -178,18 +178,17 @@ impl Node {
     pub fn to_repr(&self) -> [u8; 32] {
         self.0.to_repr()
     }
+}
 
-    /// Converts a byte representation of a field element into an element of
-    /// this prime field without checking if the input is not canonical
-    pub fn from_repr_unchecked(bytes: &[u8]) -> Self {
-        let mut tmp = [0, 0, 0, 0];
+impl TryFrom<&[u8]> for Node {
+    type Error = &'static str;
 
-        tmp[0] = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
-        tmp[1] = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
-        tmp[2] = u64::from_le_bytes(bytes[16..24].try_into().unwrap());
-        tmp[3] = u64::from_le_bytes(bytes[24..32].try_into().unwrap());
-
-        pallas::Base::from_raw(tmp).into()
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        Option::<pallas::Base>::from(pallas::Base::from_repr(
+            bytes.try_into().map_err(|_| "wrong byte slice len")?,
+        ))
+        .map(Node)
+        .ok_or("invalid Pallas field element")
     }
 }
 

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use bitvec::prelude::*;
-use bridgetree;
+use bridgetree::{self, NonEmptyFrontier};
 use halo2::pasta::{group::ff::PrimeField, pallas};
 use incrementalmerkletree::Hashable;
 use lazy_static::lazy_static;
@@ -31,7 +31,7 @@ use crate::{
     serialization::{
         serde_helpers, ReadZcashExt, SerializationError, ZcashDeserialize, ZcashSerialize,
     },
-    subtree::{TRACKED_SUBTREE_HEIGHT, TRACKED_SUBTREE_SIZE},
+    subtree::TRACKED_SUBTREE_HEIGHT,
 };
 
 pub mod legacy;
@@ -178,6 +178,19 @@ impl Node {
     pub fn to_repr(&self) -> [u8; 32] {
         self.0.to_repr()
     }
+
+    /// Converts a byte representation of a field element into an element of
+    /// this prime field without checking if the input is not canonical
+    pub fn from_repr_unchecked(bytes: &[u8]) -> Self {
+        let mut tmp = [0, 0, 0, 0];
+
+        tmp[0] = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
+        tmp[1] = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
+        tmp[2] = u64::from_le_bytes(bytes[16..24].try_into().unwrap());
+        tmp[3] = u64::from_le_bytes(bytes[24..32].try_into().unwrap());
+
+        pallas::Base::from_raw(tmp).into()
+    }
 }
 
 /// Required to convert [`NoteCommitmentTree`] into [`SerializedTree`].
@@ -231,18 +244,6 @@ impl Hashable for Node {
 impl From<pallas::Base> for Node {
     fn from(x: pallas::Base) -> Self {
         Node(x)
-    }
-}
-
-impl TryFrom<&[u8]> for Node {
-    type Error = &'static str;
-
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Option::<pallas::Base>::from(pallas::Base::from_repr(
-            bytes.try_into().map_err(|_| "wrong byte slice len")?,
-        ))
-        .map(Node)
-        .ok_or("invalid Pallas field element")
     }
 }
 
@@ -340,43 +341,46 @@ impl NoteCommitmentTree {
     }
 
     /// Returns true if the most recently appended leaf completes the subtree
-    pub fn is_complete_subtree(&self) -> bool {
-        self.inner.value().map_or(false, |x| {
-            x.position()
-                .is_complete_subtree(TRACKED_SUBTREE_HEIGHT.into())
-        })
+    pub fn is_complete_subtree(tree: &NonEmptyFrontier<Node>) -> bool {
+        tree.position()
+            .is_complete_subtree(TRACKED_SUBTREE_HEIGHT.into())
     }
 
-    /// Returns subtree index at [`TRACKED_SUBTREE_HEIGHT`]
-    pub fn subtree_index(&self) -> u16 {
-        (self.position() >> TRACKED_SUBTREE_HEIGHT)
-            .try_into()
-            .expect("always within u16")
-    }
-
-    /// Returns subtree root, if any
-    pub fn subtree_root(&self) -> Option<Node> {
-        self.is_complete_subtree().then_some(())?;
-        Some(
-            self.inner
-                .value()?
-                .root(Some(TRACKED_SUBTREE_HEIGHT.into())),
+    /// Returns subtree address at [`TRACKED_SUBTREE_HEIGHT`]
+    pub fn subtree_address(&self) -> incrementalmerkletree::Address {
+        incrementalmerkletree::Address::above_position(
+            TRACKED_SUBTREE_HEIGHT.into(),
+            self.position().into(),
         )
     }
 
-    /// Returns the index of note completing the next subtree
-    pub fn next_complete_subtree_note_index(&self) -> usize {
-        // # Correctness
-        //
-        // 2^16 - (position % 2^16) should always be between 1..=2^16
-        (TRACKED_SUBTREE_SIZE - self.subtree_note_count() - 1)
+    /// Accepts a mutable reference to Orchard notes that are to be appended for a block,
+    /// checks if they will complete the current subtree, and splits off any notes that should
+    /// be appended to the next subtree.
+    ///
+    /// Returns current subtree index and notes in the next subtree if the notes complete
+    /// the current subtree.
+    ///
+    /// Returns None otherwise.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn subtree_index_and_notes_in_next_subtree(
+        &self,
+        notes: &mut Vec<NoteCommitmentUpdate>,
+    ) -> Option<(u16, Vec<NoteCommitmentUpdate>)> {
+        let address = self.subtree_address();
+        let index = || address.index().try_into().expect("should fit in u16");
+        let empty_leaf_count = (u64::from(address.max_position() - self.position()))
             .try_into()
-            .expect("should fit in usize")
+            .expect("should fit in usize");
+
+        (notes.len() > empty_leaf_count).then(|| (index(), notes.split_off(empty_leaf_count)))
     }
 
-    /// Counts of note commitments added to the current subtree, max 2^16
-    fn subtree_note_count(&self) -> u64 {
-        self.count() % TRACKED_SUBTREE_SIZE
+    /// Returns subtree root if the most recently appended leaf completes the subtree
+    pub fn subtree_root(&self) -> Option<Node> {
+        let value = self.inner.value()?;
+        Self::is_complete_subtree(value).then_some(())?;
+        Some(value.root(Some(TRACKED_SUBTREE_HEIGHT.into())))
     }
 
     /// Returns the current root of the tree, used as an anchor in Orchard
@@ -436,7 +440,7 @@ impl NoteCommitmentTree {
 
     /// Position of final leaf added to the tree.
     fn position(&self) -> u64 {
-        self.inner.value().map_or(0, |x| u64::from(x.position()))
+        self.inner.value().map_or(0, |x| x.position().into())
     }
 
     /// Count of note commitments added to the tree.

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -346,40 +346,23 @@ impl NoteCommitmentTree {
     }
 
     /// Returns subtree address at [`TRACKED_SUBTREE_HEIGHT`]
-    pub fn subtree_address(&self) -> incrementalmerkletree::Address {
+    pub fn subtree_address(tree: &NonEmptyFrontier<Node>) -> incrementalmerkletree::Address {
         incrementalmerkletree::Address::above_position(
             TRACKED_SUBTREE_HEIGHT.into(),
-            self.position().into(),
+            tree.position(),
         )
     }
 
-    /// Accepts a mutable reference to Orchard notes that are to be appended for a block,
-    /// checks if they will complete the current subtree, and splits off any notes that should
-    /// be appended to the next subtree.
-    ///
-    /// Returns current subtree index and notes in the next subtree if the notes complete
-    /// the current subtree.
-    ///
-    /// Returns None otherwise.
+    /// Returns subtree index and root if the most recently appended leaf completes the subtree
     #[allow(clippy::unwrap_in_result)]
-    pub fn subtree_index_and_notes_in_next_subtree(
-        &self,
-        notes: &mut Vec<NoteCommitmentUpdate>,
-    ) -> Option<(u16, Vec<NoteCommitmentUpdate>)> {
-        let address = self.subtree_address();
-        let index = || address.index().try_into().expect("should fit in u16");
-        let empty_leaf_count = (u64::from(address.max_position() - self.position()))
-            .try_into()
-            .expect("should fit in usize");
-
-        (notes.len() > empty_leaf_count).then(|| (index(), notes.split_off(empty_leaf_count)))
-    }
-
-    /// Returns subtree root if the most recently appended leaf completes the subtree
-    pub fn subtree_root(&self) -> Option<Node> {
+    pub fn completed_subtree_index_and_root(&self) -> Option<(u16, Node)> {
         let value = self.inner.value()?;
         Self::is_complete_subtree(value).then_some(())?;
-        Some(value.root(Some(TRACKED_SUBTREE_HEIGHT.into())))
+        let address = Self::subtree_address(value);
+        let index = address.index().try_into().expect("should fit in u16");
+        let root = value.root(Some(TRACKED_SUBTREE_HEIGHT.into()));
+
+        Some((index, root))
     }
 
     /// Returns the current root of the tree, used as an anchor in Orchard
@@ -435,11 +418,6 @@ impl NoteCommitmentTree {
     /// Uncommitted^Orchard = I2LEBSP_l_MerkleOrchard(2)
     pub fn uncommitted() -> pallas::Base {
         pallas::Base::one().double()
-    }
-
-    /// Position of final leaf added to the tree.
-    fn position(&self) -> u64 {
-        self.inner.value().map_or(0, |x| x.position().into())
     }
 
     /// Count of note commitments added to the tree.

--- a/zebra-chain/src/sapling/arbitrary.rs
+++ b/zebra-chain/src/sapling/arbitrary.rs
@@ -119,16 +119,30 @@ fn spendauth_verification_key_bytes() -> impl Strategy<Value = ValidatingKey> {
     })
 }
 
+fn jubjub_base_strat() -> BoxedStrategy<jubjub::Base> {
+    (vec(any::<u8>(), 64))
+        .prop_map(|bytes| {
+            let bytes = bytes.try_into().expect("vec is the correct length");
+            jubjub::Base::from_bytes_wide(&bytes)
+        })
+        .boxed()
+}
+
 impl Arbitrary for tree::Root {
     type Parameters = ();
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        (vec(any::<u8>(), 64))
-            .prop_map(|bytes| {
-                let bytes = bytes.try_into().expect("vec is the correct length");
-                tree::Root(jubjub::Base::from_bytes_wide(&bytes))
-            })
-            .boxed()
+        jubjub_base_strat().prop_map(tree::Root).boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl Arbitrary for tree::Node {
+    type Parameters = ();
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        jubjub_base_strat().prop_map(tree::Node::from).boxed()
     }
 
     type Strategy = BoxedStrategy<Self>;

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -332,6 +332,11 @@ impl NoteCommitmentTree {
         }
     }
 
+    /// Returns frontier of non-empty tree, or None.
+    pub fn frontier(&self) -> Option<&NonEmptyFrontier<Node>> {
+        self.inner.value()
+    }
+
     /// Returns true if the most recently appended leaf completes the subtree
     pub fn is_complete_subtree(tree: &NonEmptyFrontier<Node>) -> bool {
         tree.position()

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -168,20 +168,6 @@ impl ZcashDeserialize for Root {
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Node([u8; 32]);
 
-impl Node {
-    /// Converts a little-endian byte representation of
-    /// a Sapling Node without checking if the input is not canonical.
-    pub fn from_repr_unchecked(bytes: &[u8]) -> Self {
-        let mut tmp = [0, 0, 0, 0];
-
-        tmp[0] = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
-        tmp[1] = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
-        tmp[2] = u64::from_le_bytes(bytes[16..24].try_into().unwrap());
-        tmp[3] = u64::from_le_bytes(bytes[24..32].try_into().unwrap());
-
-        jubjub::Fq::from_raw(tmp).into()
-    }
-}
 impl AsRef<[u8; 32]> for Node {
     fn as_ref(&self) -> &[u8; 32] {
         &self.0

--- a/zebra-chain/src/subtree.rs
+++ b/zebra-chain/src/subtree.rs
@@ -7,9 +7,6 @@ use crate::block::Height;
 /// Height at which Zebra tracks subtree roots
 pub const TRACKED_SUBTREE_HEIGHT: u8 = 16;
 
-/// Size of tracked subtrees
-pub const TRACKED_SUBTREE_SIZE: u64 = 1 << TRACKED_SUBTREE_HEIGHT;
-
 /// A subtree index
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct NoteCommitmentSubtreeIndex(pub u16);
@@ -20,7 +17,8 @@ impl From<u16> for NoteCommitmentSubtreeIndex {
     }
 }
 
-/// Subtree of Sapling or Orchard note commitment tree
+/// Subtree root of Sapling or Orchard note commitment tree,
+/// with its associated block height and subtree index.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct NoteCommitmentSubtree<Node> {
     /// Index of this subtree
@@ -39,16 +37,17 @@ impl<Node> NoteCommitmentSubtree<Node> {
     }
 }
 
-/// Partial subtree of Sapling note commitment tree
+/// Subtree root of Sapling or Orchard note commitment tree, with block height, but without the subtree index.
+/// Used for database key-value serialization, where the subtree index is the key, and this struct is the value.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct PartialNoteCommitmentSubtree<Node> {
+pub struct NoteCommitmentSubtreeData<Node> {
     /// End boundary of this subtree, the block height of its last leaf.
     pub end: Height,
     /// Root of this subtree.
     pub node: Node,
 }
 
-impl<Node> PartialNoteCommitmentSubtree<Node> {
+impl<Node> NoteCommitmentSubtreeData<Node> {
     /// Creates new [`PartialNoteCommitmentSubtree`]
     pub fn new(end: Height, node: Node) -> Self {
         Self { end, node }

--- a/zebra-chain/src/subtree.rs
+++ b/zebra-chain/src/subtree.rs
@@ -48,12 +48,12 @@ pub struct NoteCommitmentSubtreeData<Node> {
 }
 
 impl<Node> NoteCommitmentSubtreeData<Node> {
-    /// Creates new [`PartialNoteCommitmentSubtree`]
+    /// Creates new [`NoteCommitmentSubtreeData`]
     pub fn new(end: Height, node: Node) -> Self {
         Self { end, node }
     }
 
-    /// Creates new [`NoteCommitmentSubtree`] from a [`PartialNoteCommitmentSubtree`] and index
+    /// Creates new [`NoteCommitmentSubtree`] from a [`NoteCommitmentSubtreeData`] and index
     pub fn with_index(
         self,
         index: impl Into<NoteCommitmentSubtreeIndex>,

--- a/zebra-chain/src/subtree.rs
+++ b/zebra-chain/src/subtree.rs
@@ -1,0 +1,64 @@
+//! Struct representing Sapling/Orchard note commitment subtrees
+
+use std::sync::Arc;
+
+use crate::block::Height;
+
+/// Height at which Zebra tracks subtree roots
+pub const TRACKED_SUBTREE_HEIGHT: u8 = 16;
+
+/// Size of tracked subtrees
+pub const TRACKED_SUBTREE_SIZE: u64 = 1 << TRACKED_SUBTREE_HEIGHT;
+
+/// A subtree index
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct NoteCommitmentSubtreeIndex(pub u16);
+
+impl From<u16> for NoteCommitmentSubtreeIndex {
+    fn from(value: u16) -> Self {
+        Self(value)
+    }
+}
+
+/// Subtree of Sapling or Orchard note commitment tree
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct NoteCommitmentSubtree<Node> {
+    /// Index of this subtree
+    pub index: NoteCommitmentSubtreeIndex,
+    /// End boundary of this subtree, the block height of its last leaf.
+    pub end: Height,
+    /// Root of this subtree.
+    pub node: Node,
+}
+
+impl<Node> NoteCommitmentSubtree<Node> {
+    /// Creates new [`NoteCommitmentSubtree`]
+    pub fn new(index: impl Into<NoteCommitmentSubtreeIndex>, end: Height, node: Node) -> Arc<Self> {
+        let index = index.into();
+        Arc::new(Self { index, end, node })
+    }
+}
+
+/// Partial subtree of Sapling note commitment tree
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct PartialNoteCommitmentSubtree<Node> {
+    /// End boundary of this subtree, the block height of its last leaf.
+    pub end: Height,
+    /// Root of this subtree.
+    pub node: Node,
+}
+
+impl<Node> PartialNoteCommitmentSubtree<Node> {
+    /// Creates new [`PartialNoteCommitmentSubtree`]
+    pub fn new(end: Height, node: Node) -> Self {
+        Self { end, node }
+    }
+
+    /// Creates new [`NoteCommitmentSubtree`] from a [`PartialNoteCommitmentSubtree`] and index
+    pub fn with_index(
+        self,
+        index: impl Into<NoteCommitmentSubtreeIndex>,
+    ) -> Arc<NoteCommitmentSubtree<Node>> {
+        NoteCommitmentSubtree::new(index, self.end, self.node)
+    }
+}

--- a/zebra-chain/src/subtree.rs
+++ b/zebra-chain/src/subtree.rs
@@ -2,6 +2,9 @@
 
 use std::sync::Arc;
 
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
 use crate::block::Height;
 
 /// Height at which Zebra tracks subtree roots
@@ -35,11 +38,17 @@ impl<Node> NoteCommitmentSubtree<Node> {
         let index = index.into();
         Arc::new(Self { index, end, node })
     }
+
+    /// Converts struct to [`NoteCommitmentSubtreeData`].
+    pub fn into_data(self) -> NoteCommitmentSubtreeData<Node> {
+        NoteCommitmentSubtreeData::new(self.end, self.node)
+    }
 }
 
 /// Subtree root of Sapling or Orchard note commitment tree, with block height, but without the subtree index.
 /// Used for database key-value serialization, where the subtree index is the key, and this struct is the value.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct NoteCommitmentSubtreeData<Node> {
     /// End boundary of this subtree, the block height of its last leaf.
     pub end: Height,

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -354,7 +354,7 @@ impl AddressBook {
     /// See [`AddressBook::is_ready_for_connection_attempt_with_ip`] for more details.
     fn should_update_most_recent_by_ip(&self, updated: MetaAddr) -> bool {
         let Some(most_recent_by_ip) = self.most_recent_by_ip.as_ref() else {
-            return false
+            return false;
         };
 
         if let Some(previous) = most_recent_by_ip.get(&updated.addr.ip()) {
@@ -369,7 +369,7 @@ impl AddressBook {
     /// The entry is checked for an exact match to the IP and port of `addr`.
     fn should_remove_most_recent_by_ip(&self, addr: PeerSocketAddr) -> bool {
         let Some(most_recent_by_ip) = self.most_recent_by_ip.as_ref() else {
-            return false
+            return false;
         };
 
         if let Some(previous) = most_recent_by_ip.get(&addr.ip()) {

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -48,7 +48,7 @@ pub(crate) const DATABASE_FORMAT_VERSION: u64 = 25;
 /// - adding new column families,
 /// - changing the format of a column family in a compatible way, or
 /// - breaking changes with compatibility code in all supported Zebra versions.
-pub(crate) const DATABASE_FORMAT_MINOR_VERSION: u64 = 1;
+pub(crate) const DATABASE_FORMAT_MINOR_VERSION: u64 = 2;
 
 /// The database format patch version, incremented each time the on-disk database format has a
 /// significant format compatibility fix.

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -48,7 +48,7 @@ pub(crate) const DATABASE_FORMAT_VERSION: u64 = 25;
 /// - adding new column families,
 /// - changing the format of a column family in a compatible way, or
 /// - breaking changes with compatibility code in all supported Zebra versions.
-pub(crate) const DATABASE_FORMAT_MINOR_VERSION: u64 = 2;
+pub(crate) const DATABASE_FORMAT_MINOR_VERSION: u64 = 1;
 
 /// The database format patch version, incremented each time the on-disk database format has a
 /// significant format compatibility fix.

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -241,7 +241,9 @@ impl Treestate {
             note_commitment_trees: NoteCommitmentTrees {
                 sprout,
                 sapling,
+                sapling_subtree: None,
                 orchard,
+                orchard_subtree: None,
             },
             history_tree,
         }

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -15,6 +15,7 @@ use zebra_chain::{
     sapling,
     serialization::SerializationError,
     sprout,
+    subtree::NoteCommitmentSubtree,
     transaction::{self, UnminedTx},
     transparent::{self, utxos_from_ordered_utxos},
     value_balance::{ValueBalance, ValueBalanceError},
@@ -235,15 +236,17 @@ impl Treestate {
         sprout: Arc<sprout::tree::NoteCommitmentTree>,
         sapling: Arc<sapling::tree::NoteCommitmentTree>,
         orchard: Arc<orchard::tree::NoteCommitmentTree>,
+        sapling_subtree: Option<Arc<NoteCommitmentSubtree<sapling::tree::Node>>>,
+        orchard_subtree: Option<Arc<NoteCommitmentSubtree<orchard::tree::Node>>>,
         history_tree: Arc<HistoryTree>,
     ) -> Self {
         Self {
             note_commitment_trees: NoteCommitmentTrees {
                 sprout,
                 sapling,
-                sapling_subtree: None,
+                sapling_subtree,
                 orchard,
-                orchard_subtree: None,
+                orchard_subtree,
             },
             history_tree,
         }

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -517,10 +517,12 @@ impl DiskDb {
         "sapling_nullifiers",
         "sapling_anchors",
         "sapling_note_commitment_tree",
+        "sapling_note_commitment_subtree",
         // Orchard
         "orchard_nullifiers",
         "orchard_anchors",
         "orchard_note_commitment_tree",
+        "orchard_note_commitment_subtree",
         // Chain
         "history_tree",
         "tip_chain_value_pool",

--- a/zebra-state/src/service/finalized_state/disk_format/shielded.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/shielded.rs
@@ -10,7 +10,7 @@ use bincode::Options;
 use zebra_chain::{
     block::Height,
     orchard, sapling, sprout,
-    subtree::{NoteCommitmentSubtree, NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
+    subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
 };
 
 use crate::service::finalized_state::disk_format::{FromDisk, IntoDisk};
@@ -171,7 +171,7 @@ impl IntoDisk for orchard::tree::Node {
     }
 }
 
-impl<Node: IntoDisk<Bytes = Vec<u8>>> IntoDisk for NoteCommitmentSubtree<Node> {
+impl<Node: IntoDisk<Bytes = Vec<u8>>> IntoDisk for NoteCommitmentSubtreeData<Node> {
     type Bytes = Vec<u8>;
 
     fn as_bytes(&self) -> Self::Bytes {

--- a/zebra-state/src/service/finalized_state/disk_format/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/prop.rs
@@ -6,6 +6,7 @@ use zebra_chain::{
     amount::{Amount, NonNegative},
     block::{self, Height},
     orchard, sapling, sprout,
+    subtree::NoteCommitmentSubtreeData,
     transaction::{self, Transaction},
     transparent,
     value_balance::ValueBalance,
@@ -361,6 +362,16 @@ fn roundtrip_sapling_tree_root() {
     proptest!(|(val in any::<sapling::tree::Root>())| assert_value_properties(val));
 }
 
+#[test]
+fn roundtrip_sapling_subtree_data() {
+    let _init_guard = zebra_test::init();
+
+    proptest!(|(mut val in any::<NoteCommitmentSubtreeData<sapling::tree::Node>>())| {
+        val.end = val.end.clamp(Height(0), MAX_ON_DISK_HEIGHT);
+        assert_value_properties(val)
+    });
+}
+
 // TODO: test note commitment tree round-trip, after implementing proptest::Arbitrary
 
 // Orchard
@@ -434,6 +445,16 @@ fn roundtrip_orchard_tree_root() {
     let _init_guard = zebra_test::init();
 
     proptest!(|(val in any::<orchard::tree::Root>())| assert_value_properties(val));
+}
+
+#[test]
+fn roundtrip_orchard_subtree_data() {
+    let _init_guard = zebra_test::init();
+
+    proptest!(|(mut val in any::<NoteCommitmentSubtreeData<orchard::tree::Node>>())| {
+        val.end = val.end.clamp(Height(0), MAX_ON_DISK_HEIGHT);
+        assert_value_properties(val)
+    });
 }
 
 // TODO: test note commitment tree round-trip, after implementing proptest::Arbitrary

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/column_family_names.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/column_family_names.snap
@@ -1,6 +1,6 @@
 ---
 source: zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
-assertion_line: 72
+assertion_line: 81
 expression: cf_names
 ---
 [
@@ -12,9 +12,11 @@ expression: cf_names
   "height_by_hash",
   "history_tree",
   "orchard_anchors",
+  "orchard_note_commitment_subtree",
   "orchard_note_commitment_tree",
   "orchard_nullifiers",
   "sapling_anchors",
+  "sapling_note_commitment_subtree",
   "sapling_note_commitment_tree",
   "sapling_nullifiers",
   "sprout_anchors",

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@mainnet_0.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@mainnet_0.snap
@@ -1,14 +1,15 @@
 ---
 source: zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
-assertion_line: 154
 expression: empty_column_families
 ---
 [
   "balance_by_transparent_addr: no entries",
   "history_tree: no entries",
   "orchard_anchors: no entries",
+  "orchard_note_commitment_subtree: no entries",
   "orchard_nullifiers: no entries",
   "sapling_anchors: no entries",
+  "sapling_note_commitment_subtree: no entries",
   "sapling_nullifiers: no entries",
   "sprout_anchors: no entries",
   "sprout_nullifiers: no entries",

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@mainnet_1.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@mainnet_1.snap
@@ -4,7 +4,9 @@ expression: empty_column_families
 ---
 [
   "history_tree: no entries",
+  "orchard_note_commitment_subtree: no entries",
   "orchard_nullifiers: no entries",
+  "sapling_note_commitment_subtree: no entries",
   "sapling_nullifiers: no entries",
   "sprout_nullifiers: no entries",
 ]

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@mainnet_2.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@mainnet_2.snap
@@ -4,7 +4,9 @@ expression: empty_column_families
 ---
 [
   "history_tree: no entries",
+  "orchard_note_commitment_subtree: no entries",
   "orchard_nullifiers: no entries",
+  "sapling_note_commitment_subtree: no entries",
   "sapling_nullifiers: no entries",
   "sprout_nullifiers: no entries",
 ]

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@no_blocks.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@no_blocks.snap
@@ -1,6 +1,6 @@
 ---
 source: zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
-assertion_line: 154
+assertion_line: 166
 expression: empty_column_families
 ---
 [
@@ -11,9 +11,11 @@ expression: empty_column_families
   "height_by_hash: no entries",
   "history_tree: no entries",
   "orchard_anchors: no entries",
+  "orchard_note_commitment_subtree: no entries",
   "orchard_note_commitment_tree: no entries",
   "orchard_nullifiers: no entries",
   "sapling_anchors: no entries",
+  "sapling_note_commitment_subtree: no entries",
   "sapling_note_commitment_tree: no entries",
   "sapling_nullifiers: no entries",
   "sprout_anchors: no entries",

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@testnet_0.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@testnet_0.snap
@@ -1,14 +1,15 @@
 ---
 source: zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
-assertion_line: 154
 expression: empty_column_families
 ---
 [
   "balance_by_transparent_addr: no entries",
   "history_tree: no entries",
   "orchard_anchors: no entries",
+  "orchard_note_commitment_subtree: no entries",
   "orchard_nullifiers: no entries",
   "sapling_anchors: no entries",
+  "sapling_note_commitment_subtree: no entries",
   "sapling_nullifiers: no entries",
   "sprout_anchors: no entries",
   "sprout_nullifiers: no entries",

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@testnet_1.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@testnet_1.snap
@@ -4,7 +4,9 @@ expression: empty_column_families
 ---
 [
   "history_tree: no entries",
+  "orchard_note_commitment_subtree: no entries",
   "orchard_nullifiers: no entries",
+  "sapling_note_commitment_subtree: no entries",
   "sapling_nullifiers: no entries",
   "sprout_nullifiers: no entries",
 ]

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@testnet_2.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@testnet_2.snap
@@ -4,7 +4,9 @@ expression: empty_column_families
 ---
 [
   "history_tree: no entries",
+  "orchard_note_commitment_subtree: no entries",
   "orchard_nullifiers: no entries",
+  "sapling_note_commitment_subtree: no entries",
   "sapling_nullifiers: no entries",
   "sprout_nullifiers: no entries",
 ]

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -27,6 +27,8 @@ use crate::{
     Config,
 };
 
+mod add_subtrees;
+
 /// The kind of database format change we're performing.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DbFormatChange {

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -1,0 +1,168 @@
+//! Fully populate the Sapling and Orchard note commitment subtrees for existing blocks in the database.
+
+use std::sync::{
+    atomic::{self, AtomicBool},
+    Arc,
+};
+
+use zebra_chain::{
+    block::Height, orchard::tree::NoteCommitmentTree as OrchardNoteCommitmentTree,
+    sapling::tree::NoteCommitmentTree as SaplingNoteCommitmentTree, subtree::NoteCommitmentSubtree,
+};
+
+use crate::service::finalized_state::{DiskWriteBatch, ZebraDb};
+
+/// Runs disk format upgrade for adding Sapling and Orchard note commitment subtrees to database.
+pub fn _run(
+    initial_tip_height: Height,
+    upgrade_db: &ZebraDb,
+    should_cancel_format_change: Arc<AtomicBool>,
+) {
+    let mut subtree_count = 0;
+    let mut prev_tree: Option<_> = None;
+    for (height, tree) in upgrade_db.sapling_tree_by_height_range(..initial_tip_height) {
+        if should_cancel_format_change.load(atomic::Ordering::Relaxed) {
+            break;
+        }
+
+        let Some(frontier) = tree.frontier() else {
+            prev_tree = Some(tree);
+            continue
+        };
+
+        // Blocks cannot complete multiple level 16 subtrees,
+        // the subtree index can increase by a maximum of 1 every ~20 blocks.
+        let subtree_address = SaplingNoteCommitmentTree::subtree_address(frontier);
+        if subtree_address.index() <= subtree_count {
+            prev_tree = Some(tree);
+            continue;
+        }
+
+        let (index, node) = if SaplingNoteCommitmentTree::is_complete_subtree(frontier) {
+            tree.completed_subtree_index_and_root()
+                .expect("already checked is_complete_subtree()")
+        } else {
+            let mut sapling_nct = Arc::try_unwrap(
+                prev_tree
+                    .take()
+                    .expect("should have some previous sapling frontier"),
+            )
+            .unwrap_or_else(|shared_tree| (*shared_tree).clone());
+
+            let block = upgrade_db
+                .block(height.into())
+                .expect("height with note commitment tree should have block");
+
+            let sapling_note_commitments: Vec<_> = block
+                .transactions
+                .iter()
+                .flat_map(|tx| tx.sapling_note_commitments())
+                .cloned()
+                .collect();
+
+            for sapling_note_commitment in sapling_note_commitments {
+                sapling_nct
+                    .append(sapling_note_commitment)
+                    .expect("finalized notes should append successfully");
+
+                if sapling_nct
+                    .frontier()
+                    .map_or(false, SaplingNoteCommitmentTree::is_complete_subtree)
+                {
+                    break;
+                }
+            }
+
+            sapling_nct
+                .completed_subtree_index_and_root()
+                .expect("already checked is_complete_subtree()")
+        };
+
+        let subtree = NoteCommitmentSubtree::new(index, height, node);
+
+        let mut batch = DiskWriteBatch::new();
+
+        batch.insert_sapling_subtree(upgrade_db, subtree);
+
+        upgrade_db
+            .write_batch(batch)
+            .expect("writing sapling note commitment subtrees should always succeed.");
+
+        subtree_count += 1;
+        prev_tree = Some(tree);
+    }
+
+    let mut subtree_count = 0;
+    let mut prev_tree: Option<_> = None;
+    for (height, tree) in upgrade_db.orchard_tree_by_height_range(..initial_tip_height) {
+        if should_cancel_format_change.load(atomic::Ordering::Relaxed) {
+            break;
+        }
+
+        let Some(frontier) = tree.frontier() else {
+            prev_tree = Some(tree);
+            continue
+        };
+
+        // Blocks cannot complete multiple level 16 subtrees,
+        // the subtree index can increase by a maximum of 1 every ~20 blocks.
+        let subtree_address = OrchardNoteCommitmentTree::subtree_address(frontier);
+        if subtree_address.index() <= subtree_count {
+            prev_tree = Some(tree);
+            continue;
+        }
+
+        let (index, node) = if OrchardNoteCommitmentTree::is_complete_subtree(frontier) {
+            tree.completed_subtree_index_and_root()
+                .expect("already checked is_complete_subtree()")
+        } else {
+            let mut orchard_nct = Arc::try_unwrap(
+                prev_tree
+                    .take()
+                    .expect("should have some previous orchard frontier"),
+            )
+            .unwrap_or_else(|shared_tree| (*shared_tree).clone());
+
+            let block = upgrade_db
+                .block(height.into())
+                .expect("height with note commitment tree should have block");
+
+            let orchard_note_commitments: Vec<_> = block
+                .transactions
+                .iter()
+                .flat_map(|tx| tx.orchard_note_commitments())
+                .cloned()
+                .collect();
+
+            for orchard_note_commitment in orchard_note_commitments {
+                orchard_nct
+                    .append(orchard_note_commitment)
+                    .expect("finalized notes should append successfully");
+
+                if orchard_nct
+                    .frontier()
+                    .map_or(false, OrchardNoteCommitmentTree::is_complete_subtree)
+                {
+                    break;
+                }
+            }
+
+            orchard_nct
+                .completed_subtree_index_and_root()
+                .expect("already checked is_complete_subtree()")
+        };
+
+        let subtree = NoteCommitmentSubtree::new(index, height, node);
+
+        let mut batch = DiskWriteBatch::new();
+
+        batch.insert_orchard_subtree(upgrade_db, subtree);
+
+        upgrade_db
+            .write_batch(batch)
+            .expect("writing orchard note commitment subtrees should always succeed.");
+
+        subtree_count += 1;
+        prev_tree = Some(tree);
+    }
+}

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -20,7 +20,7 @@ pub fn _run(
 ) {
     let mut subtree_count = 0;
     let mut prev_tree: Option<_> = None;
-    for (height, tree) in upgrade_db.sapling_tree_by_height_range(..initial_tip_height) {
+    for (height, tree) in upgrade_db.sapling_tree_by_height_range(..=initial_tip_height) {
         if should_cancel_format_change.load(atomic::Ordering::Relaxed) {
             break;
         }
@@ -94,7 +94,7 @@ pub fn _run(
 
     let mut subtree_count = 0;
     let mut prev_tree: Option<_> = None;
-    for (height, tree) in upgrade_db.orchard_tree_by_height_range(..initial_tip_height) {
+    for (height, tree) in upgrade_db.orchard_tree_by_height_range(..=initial_tip_height) {
         if should_cancel_format_change.load(atomic::Ordering::Relaxed) {
             break;
         }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -27,7 +27,7 @@ pub fn _run(
 
         let Some(frontier) = tree.frontier() else {
             prev_tree = Some(tree);
-            continue
+            continue;
         };
 
         // Blocks cannot complete multiple level 16 subtrees,
@@ -101,7 +101,7 @@ pub fn _run(
 
         let Some(frontier) = tree.frontier() else {
             prev_tree = Some(tree);
-            continue
+            continue;
         };
 
         // Blocks cannot complete multiple level 16 subtrees,

--- a/zebra-state/src/service/finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/tests/vectors.rs
@@ -10,12 +10,13 @@ use rand::random;
 use halo2::pasta::{group::ff::PrimeField, pallas};
 
 use zebra_chain::{
+    block::Height,
     orchard::{
-        tree::legacy::LegacyNoteCommitmentTree as LegacyOrchardNoteCommitmentTree,
+        self, tree::legacy::LegacyNoteCommitmentTree as LegacyOrchardNoteCommitmentTree,
         tree::NoteCommitmentTree as OrchardNoteCommitmentTree,
     },
     sapling::{
-        tree::legacy::LegacyNoteCommitmentTree as LegacySaplingNoteCommitmentTree,
+        self, tree::legacy::LegacyNoteCommitmentTree as LegacySaplingNoteCommitmentTree,
         tree::NoteCommitmentTree as SaplingNoteCommitmentTree,
     },
     sprout::{
@@ -23,6 +24,7 @@ use zebra_chain::{
         tree::NoteCommitmentTree as SproutNoteCommitmentTree,
         NoteCommitment as SproutNoteCommitment,
     },
+    subtree::{NoteCommitmentSubtree, NoteCommitmentSubtreeData},
 };
 
 use crate::service::finalized_state::disk_format::{FromDisk, IntoDisk};
@@ -172,8 +174,14 @@ fn sapling_note_commitment_tree_serialization() {
     // The purpose of this test is to make sure the serialization format does
     // not change by accident.
     let expected_serialized_tree_hex = "0102007c3ea01a6e3a3d90cf59cd789e467044b5cd78eb2c84cc6816f960746d0e036c0162324ff2c329e99193a74d28a585a3c167a93bf41a255135529c913bd9b1e66601ddaa1ab86de5c153993414f34ba97e9674c459dfadde112b89eeeafa0e5a204c";
+    let expected_serialized_subtree: &str =
+        "0186a0ddaa1ab86de5c153993414f34ba97e9674c459dfadde112b89eeeafa0e5a204c";
 
-    sapling_checks(incremental_tree, expected_serialized_tree_hex);
+    sapling_checks(
+        incremental_tree,
+        expected_serialized_tree_hex,
+        expected_serialized_subtree,
+    );
 }
 
 /// Check that the sapling tree database serialization format has not changed for one commitment.
@@ -205,8 +213,14 @@ fn sapling_note_commitment_tree_serialization_one() {
     // The purpose of this test is to make sure the serialization format does
     // not change by accident.
     let expected_serialized_tree_hex = "010000225747f3b5d5dab4e5a424f81f85c904ff43286e0f3fd07ef0b8c6a627b1145800012c60c7de033d7539d123fb275011edfe08d57431676981d162c816372063bc71";
+    let expected_serialized_subtree: &str =
+        "0186a02c60c7de033d7539d123fb275011edfe08d57431676981d162c816372063bc71";
 
-    sapling_checks(incremental_tree, expected_serialized_tree_hex);
+    sapling_checks(
+        incremental_tree,
+        expected_serialized_tree_hex,
+        expected_serialized_subtree,
+    );
 }
 
 /// Check that the sapling tree database serialization format has not changed when the number of
@@ -251,8 +265,14 @@ fn sapling_note_commitment_tree_serialization_pow2() {
     // The purpose of this test is to make sure the serialization format does
     // not change by accident.
     let expected_serialized_tree_hex = "010701f43e3aac61e5a753062d4d0508c26ceaf5e4c0c58ba3c956e104b5d2cf67c41c3a3661bc12b72646c94bc6c92796e81953985ee62d80a9ec3645a9a95740ac15025991131c5c25911b35fcea2a8343e2dfd7a4d5b45493390e0cb184394d91c349002df68503da9247dfde6585cb8c9fa94897cf21735f8fc1b32116ef474de05c01d23765f3d90dfd97817ed6d995bd253d85967f77b9f1eaef6ecbcb0ef6796812";
+    let expected_serialized_subtree =
+        "0186a0d23765f3d90dfd97817ed6d995bd253d85967f77b9f1eaef6ecbcb0ef6796812";
 
-    sapling_checks(incremental_tree, expected_serialized_tree_hex);
+    sapling_checks(
+        incremental_tree,
+        expected_serialized_tree_hex,
+        expected_serialized_subtree,
+    );
 }
 
 /// Check that the orchard tree database serialization format has not changed.
@@ -298,8 +318,14 @@ fn orchard_note_commitment_tree_serialization() {
     // The purpose of this test is to make sure the serialization format does
     // not change by accident.
     let expected_serialized_tree_hex = "010200ee9488053a30c596b43014105d3477e6f578c89240d1d1ee1743b77bb6adc40a01a34b69a4e4d9ccf954d46e5da1004d361a5497f511aeb4d481d23c0be177813301a0be6dab19bc2c65d8299258c16e14d48ec4d4959568c6412aa85763c222a702";
+    let expected_serialized_subtree =
+        "0186a0a0be6dab19bc2c65d8299258c16e14d48ec4d4959568c6412aa85763c222a702";
 
-    orchard_checks(incremental_tree, expected_serialized_tree_hex);
+    orchard_checks(
+        incremental_tree,
+        expected_serialized_tree_hex,
+        expected_serialized_subtree,
+    );
 }
 
 /// Check that the orchard tree database serialization format has not changed for one commitment.
@@ -333,8 +359,14 @@ fn orchard_note_commitment_tree_serialization_one() {
     // The purpose of this test is to make sure the serialization format does
     // not change by accident.
     let expected_serialized_tree_hex = "01000068135cf49933229099a44ec99a75e1e1cb4640f9b5bdec6b3223856fea16390a000178afd4da59c541e9c2f317f9aff654f1fb38d14dc99431cbbfa93601c7068117";
+    let expected_serialized_subtree =
+        "0186a078afd4da59c541e9c2f317f9aff654f1fb38d14dc99431cbbfa93601c7068117";
 
-    orchard_checks(incremental_tree, expected_serialized_tree_hex);
+    orchard_checks(
+        incremental_tree,
+        expected_serialized_tree_hex,
+        expected_serialized_subtree,
+    );
 }
 
 /// Check that the orchard tree database serialization format has not changed when the number of
@@ -379,8 +411,14 @@ fn orchard_note_commitment_tree_serialization_pow2() {
     // The purpose of this test is to make sure the serialization format does
     // not change by accident.
     let expected_serialized_tree_hex = "01010178315008fb2998b430a5731d6726207dc0f0ec81ea64af5cf612956901e72f0eee9488053a30c596b43014105d3477e6f578c89240d1d1ee1743b77bb6adc40a0001d3d525931005e45f5a29bc82524e871e5ee1b6d77839deb741a6e50cd99fdf1a";
+    let expected_serialized_subtree =
+        "0186a0d3d525931005e45f5a29bc82524e871e5ee1b6d77839deb741a6e50cd99fdf1a";
 
-    orchard_checks(incremental_tree, expected_serialized_tree_hex);
+    orchard_checks(
+        incremental_tree,
+        expected_serialized_tree_hex,
+        expected_serialized_subtree,
+    );
 }
 
 fn sprout_checks(incremental_tree: SproutNoteCommitmentTree, expected_serialized_tree_hex: &str) {
@@ -433,8 +471,12 @@ fn sprout_checks(incremental_tree: SproutNoteCommitmentTree, expected_serialized
     assert_eq!(re_serialized_legacy_tree, re_serialized_tree);
 }
 
-fn sapling_checks(incremental_tree: SaplingNoteCommitmentTree, expected_serialized_tree_hex: &str) {
-    let serialized_tree = incremental_tree.as_bytes();
+fn sapling_checks(
+    incremental_tree: SaplingNoteCommitmentTree,
+    expected_serialized_tree_hex: &str,
+    expected_serialized_subtree: &str,
+) {
+    let serialized_tree: Vec<u8> = incremental_tree.as_bytes();
 
     assert_eq!(hex::encode(&serialized_tree), expected_serialized_tree_hex);
 
@@ -481,9 +523,37 @@ fn sapling_checks(incremental_tree: SaplingNoteCommitmentTree, expected_serializ
 
     assert_eq!(serialized_tree, re_serialized_tree);
     assert_eq!(re_serialized_legacy_tree, re_serialized_tree);
+
+    // Check subtree format
+
+    let subtree = NoteCommitmentSubtree::new(
+        0,
+        Height(100000),
+        sapling::tree::Node::from_bytes(incremental_tree.hash()),
+    );
+
+    let serialized_subtree = subtree.as_bytes();
+
+    assert_eq!(
+        hex::encode(&serialized_subtree),
+        expected_serialized_subtree
+    );
+
+    let deserialized_subtree =
+        NoteCommitmentSubtreeData::<sapling::tree::Node>::from_bytes(&serialized_subtree)
+            .with_index(0);
+
+    assert_eq!(
+        subtree, deserialized_subtree,
+        "(de)serialization should not modify subtree value"
+    );
 }
 
-fn orchard_checks(incremental_tree: OrchardNoteCommitmentTree, expected_serialized_tree_hex: &str) {
+fn orchard_checks(
+    incremental_tree: OrchardNoteCommitmentTree,
+    expected_serialized_tree_hex: &str,
+    expected_serialized_subtree: &str,
+) {
     let serialized_tree = incremental_tree.as_bytes();
 
     assert_eq!(hex::encode(&serialized_tree), expected_serialized_tree_hex);
@@ -531,4 +601,28 @@ fn orchard_checks(incremental_tree: OrchardNoteCommitmentTree, expected_serializ
 
     assert_eq!(serialized_tree, re_serialized_tree);
     assert_eq!(re_serialized_legacy_tree, re_serialized_tree);
+
+    // Check subtree format
+
+    let subtree = NoteCommitmentSubtree::new(
+        0,
+        Height(100000),
+        orchard::tree::Node::from_bytes(incremental_tree.hash()),
+    );
+
+    let serialized_subtree = subtree.as_bytes();
+
+    assert_eq!(
+        hex::encode(&serialized_subtree),
+        expected_serialized_subtree
+    );
+
+    let deserialized_subtree =
+        NoteCommitmentSubtreeData::<orchard::tree::Node>::from_bytes(&serialized_subtree)
+            .with_index(0);
+
+    assert_eq!(
+        subtree, deserialized_subtree,
+        "(de)serialization should not modify subtree value"
+    );
 }

--- a/zebra-state/src/service/finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/tests/vectors.rs
@@ -24,7 +24,7 @@ use zebra_chain::{
         tree::NoteCommitmentTree as SproutNoteCommitmentTree,
         NoteCommitment as SproutNoteCommitment,
     },
-    subtree::{NoteCommitmentSubtree, NoteCommitmentSubtreeData},
+    subtree::NoteCommitmentSubtreeData,
 };
 
 use crate::service::finalized_state::disk_format::{FromDisk, IntoDisk};
@@ -526,8 +526,7 @@ fn sapling_checks(
 
     // Check subtree format
 
-    let subtree = NoteCommitmentSubtree::new(
-        0,
+    let subtree = NoteCommitmentSubtreeData::new(
         Height(100000),
         sapling::tree::Node::from_bytes(incremental_tree.hash()),
     );
@@ -540,8 +539,7 @@ fn sapling_checks(
     );
 
     let deserialized_subtree =
-        NoteCommitmentSubtreeData::<sapling::tree::Node>::from_bytes(&serialized_subtree)
-            .with_index(0);
+        NoteCommitmentSubtreeData::<sapling::tree::Node>::from_bytes(&serialized_subtree);
 
     assert_eq!(
         subtree, deserialized_subtree,
@@ -604,8 +602,7 @@ fn orchard_checks(
 
     // Check subtree format
 
-    let subtree = NoteCommitmentSubtree::new(
-        0,
+    let subtree = NoteCommitmentSubtreeData::new(
         Height(100000),
         orchard::tree::Node::from_bytes(incremental_tree.hash()),
     );
@@ -618,8 +615,7 @@ fn orchard_checks(
     );
 
     let deserialized_subtree =
-        NoteCommitmentSubtreeData::<orchard::tree::Node>::from_bytes(&serialized_subtree)
-            .with_index(0);
+        NoteCommitmentSubtreeData::<orchard::tree::Node>::from_bytes(&serialized_subtree);
 
     assert_eq!(
         subtree, deserialized_subtree,

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -397,11 +397,11 @@ impl DiskWriteBatch {
         }
 
         if let Some(subtree) = trees.sapling_subtree {
-            self.zs_insert(&sapling_subtree_cf, subtree.index, subtree);
+            self.zs_insert(&sapling_subtree_cf, subtree.index, subtree.into_data());
         }
 
         if let Some(subtree) = trees.orchard_subtree {
-            self.zs_insert(&orchard_subtree_cf, subtree.index, subtree);
+            self.zs_insert(&orchard_subtree_cf, subtree.index, subtree.into_data());
         }
 
         self.prepare_history_batch(db, finalized)

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -407,6 +407,19 @@ impl DiskWriteBatch {
         self.prepare_history_batch(db, finalized)
     }
 
+    /// Inserts the Sapling note commitment subtree.
+    pub fn insert_sapling_subtree(
+        &mut self,
+        zebra_db: &ZebraDb,
+        subtree: Arc<NoteCommitmentSubtree<sapling::tree::Node>>,
+    ) {
+        let sapling_subtree_cf = zebra_db
+            .db
+            .cf_handle("sapling_note_commitment_subtree")
+            .unwrap();
+        self.zs_insert(&sapling_subtree_cf, subtree.index, subtree.into_data());
+    }
+
     /// Deletes the Sapling note commitment tree at the given [`Height`].
     pub fn delete_sapling_tree(&mut self, zebra_db: &ZebraDb, height: &Height) {
         let sapling_tree_cf = zebra_db
@@ -423,6 +436,19 @@ impl DiskWriteBatch {
             .cf_handle("sapling_note_commitment_tree")
             .unwrap();
         self.zs_delete_range(&sapling_tree_cf, from, to);
+    }
+
+    /// Inserts the Orchard note commitment subtree.
+    pub fn insert_orchard_subtree(
+        &mut self,
+        zebra_db: &ZebraDb,
+        subtree: Arc<NoteCommitmentSubtree<orchard::tree::Node>>,
+    ) {
+        let orchard_subtree_cf = zebra_db
+            .db
+            .cf_handle("orchard_note_commitment_subtree")
+            .unwrap();
+        self.zs_insert(&orchard_subtree_cf, subtree.index, subtree.into_data());
     }
 
     /// Deletes the Orchard note commitment tree at the given [`Height`].

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -348,8 +348,8 @@ impl DiskWriteBatch {
         let sapling_tree_cf = db.cf_handle("sapling_note_commitment_tree").unwrap();
         let orchard_tree_cf = db.cf_handle("orchard_note_commitment_tree").unwrap();
 
-        let sapling_subtree_cf = db.cf_handle("sapling_note_commitment_subtree").unwrap();
-        let orchard_subtree_cf = db.cf_handle("orchard_note_commitment_subtree").unwrap();
+        let _sapling_subtree_cf = db.cf_handle("sapling_note_commitment_subtree").unwrap();
+        let _orchard_subtree_cf = db.cf_handle("orchard_note_commitment_subtree").unwrap();
 
         let height = finalized.verified.height;
         let trees = finalized.treestate.note_commitment_trees.clone();
@@ -396,13 +396,15 @@ impl DiskWriteBatch {
             self.zs_insert(&orchard_tree_cf, height, trees.orchard);
         }
 
-        if let Some(subtree) = trees.sapling_subtree {
-            self.zs_insert(&sapling_subtree_cf, subtree.index, subtree.into_data());
-        }
+        // TODO: Increment DATABASE_FORMAT_MINOR_VERSION and uncomment these insertions
 
-        if let Some(subtree) = trees.orchard_subtree {
-            self.zs_insert(&orchard_subtree_cf, subtree.index, subtree.into_data());
-        }
+        // if let Some(subtree) = trees.sapling_subtree {
+        //     self.zs_insert(&sapling_subtree_cf, subtree.index, subtree.into_data());
+        // }
+
+        // if let Some(subtree) = trees.orchard_subtree {
+        //     self.zs_insert(&orchard_subtree_cf, subtree.index, subtree.into_data());
+        // }
 
         self.prepare_history_batch(db, finalized)
     }

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -193,9 +193,9 @@ impl ZebraDb {
             .cf_handle("sapling_note_commitment_subtree")
             .unwrap();
 
-        let partial_subtree: NoteCommitmentSubtreeData<sapling::tree::Node> =
+        let subtree_data: NoteCommitmentSubtreeData<sapling::tree::Node> =
             self.db.zs_get(&sapling_subtrees, &index.into())?;
-        Some(partial_subtree.with_index(index))
+        Some(subtree_data.with_index(index))
     }
 
     /// Returns the Orchard note commitment tree of the finalized tip
@@ -221,9 +221,9 @@ impl ZebraDb {
             .cf_handle("orchard_note_commitment_subtree")
             .unwrap();
 
-        let partial_subtree: NoteCommitmentSubtreeData<orchard::tree::Node> =
+        let subtree_data: NoteCommitmentSubtreeData<orchard::tree::Node> =
             self.db.zs_get(&orchard_subtrees, &index.into())?;
-        Some(partial_subtree.with_index(index))
+        Some(subtree_data.with_index(index))
     }
 
     /// Returns the Orchard note commitment tree matching the given block height,

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -224,7 +224,9 @@ impl ZebraDb {
         NoteCommitmentTrees {
             sprout: self.sprout_tree(),
             sapling: self.sapling_tree(),
+            sapling_subtree: None,
             orchard: self.orchard_tree(),
+            orchard_subtree: None,
         }
     }
 }

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -348,8 +348,8 @@ impl DiskWriteBatch {
         let sapling_tree_cf = db.cf_handle("sapling_note_commitment_tree").unwrap();
         let orchard_tree_cf = db.cf_handle("orchard_note_commitment_tree").unwrap();
 
-        let _sapling_subtree_cf = db.cf_handle("sapling_note_commitment_subtree").unwrap();
-        let _orchard_subtree_cf = db.cf_handle("orchard_note_commitment_subtree").unwrap();
+        let sapling_subtree_cf = db.cf_handle("sapling_note_commitment_subtree").unwrap();
+        let orchard_subtree_cf = db.cf_handle("orchard_note_commitment_subtree").unwrap();
 
         let height = finalized.verified.height;
         let trees = finalized.treestate.note_commitment_trees.clone();
@@ -396,15 +396,13 @@ impl DiskWriteBatch {
             self.zs_insert(&orchard_tree_cf, height, trees.orchard);
         }
 
-        // TODO: Increment DATABASE_FORMAT_MINOR_VERSION and uncomment these insertions
+        if let Some(subtree) = trees.sapling_subtree {
+            self.zs_insert(&sapling_subtree_cf, subtree.index, subtree.into_data());
+        }
 
-        // if let Some(subtree) = trees.sapling_subtree {
-        //     self.zs_insert(&sapling_subtree_cf, subtree.index, subtree.into_data());
-        // }
-
-        // if let Some(subtree) = trees.orchard_subtree {
-        //     self.zs_insert(&orchard_subtree_cf, subtree.index, subtree.into_data());
-        // }
+        if let Some(subtree) = trees.orchard_subtree {
+            self.zs_insert(&orchard_subtree_cf, subtree.index, subtree.into_data());
+        }
 
         self.prepare_history_batch(db, finalized)
     }

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -1251,7 +1251,9 @@ impl Chain {
         let mut nct = NoteCommitmentTrees {
             sprout: self.sprout_note_commitment_tree(),
             sapling: self.sapling_note_commitment_tree(),
+            sapling_subtree: None,
             orchard: self.orchard_note_commitment_tree(),
+            orchard_subtree: None,
         };
 
         let mut tree_result = None;

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -3,7 +3,7 @@
 
 use std::{
     cmp::Ordering,
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     ops::{Deref, RangeInclusive},
     sync::Arc,
 };
@@ -20,6 +20,7 @@ use zebra_chain::{
     parameters::Network,
     primitives::Groth16Proof,
     sapling, sprout,
+    subtree::{NoteCommitmentSubtree, NoteCommitmentSubtreeIndex},
     transaction::Transaction::*,
     transaction::{self, Transaction},
     transparent,
@@ -133,6 +134,8 @@ pub struct Chain {
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
     /// This extra root is removed when the first non-finalized block is committed.
     pub(crate) sapling_anchors_by_height: BTreeMap<block::Height, sapling::tree::Root>,
+    /// A list of Sapling subtrees completed in the non-finalized state
+    pub(crate) sapling_subtrees: VecDeque<Arc<NoteCommitmentSubtree<sapling::tree::Node>>>,
 
     /// The Orchard anchors created by `blocks`.
     ///
@@ -144,6 +147,8 @@ pub struct Chain {
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
     /// This extra root is removed when the first non-finalized block is committed.
     pub(crate) orchard_anchors_by_height: BTreeMap<block::Height, orchard::tree::Root>,
+    /// A list of Orchard subtrees completed in the non-finalized state
+    pub(crate) orchard_subtrees: VecDeque<Arc<NoteCommitmentSubtree<orchard::tree::Node>>>,
 
     // Nullifiers
     //
@@ -221,9 +226,11 @@ impl Chain {
             sapling_anchors: MultiSet::new(),
             sapling_anchors_by_height: Default::default(),
             sapling_trees_by_height: Default::default(),
+            sapling_subtrees: Default::default(),
             orchard_anchors: MultiSet::new(),
             orchard_anchors_by_height: Default::default(),
             orchard_trees_by_height: Default::default(),
+            orchard_subtrees: Default::default(),
             sprout_nullifiers: Default::default(),
             sapling_nullifiers: Default::default(),
             orchard_nullifiers: Default::default(),
@@ -342,6 +349,14 @@ impl Chain {
         let treestate = self
             .treestate(block_height.into())
             .expect("The treestate must be present for the root height.");
+
+        if treestate.note_commitment_trees.sapling_subtree.is_some() {
+            self.sapling_subtrees.pop_front();
+        }
+
+        if treestate.note_commitment_trees.orchard_subtree.is_some() {
+            self.orchard_subtrees.pop_front();
+        }
 
         // Remove the lowest height block from `self.blocks`.
         let block = self
@@ -663,6 +678,33 @@ impl Chain {
             .map(|(_height, tree)| tree.clone())
     }
 
+    /// Returns the Sapling [`NoteCommitmentSubtree`] specified
+    /// by an index, if it exists in the non-finalized [`Chain`].
+    pub fn sapling_subtree(
+        &self,
+        hash_or_height: HashOrHeight,
+    ) -> Option<Arc<NoteCommitmentSubtree<sapling::tree::Node>>> {
+        let height =
+            hash_or_height.height_or_else(|hash| self.height_by_hash.get(&hash).cloned())?;
+
+        self.sapling_subtrees
+            .iter()
+            .find(|subtree| subtree.end == height)
+            .cloned()
+    }
+
+    /// Returns the Sapling [`NoteCommitmentSubtree`](sapling::tree::NoteCommitmentSubtree) specified
+    /// by a [`HashOrHeight`], if it exists in the non-finalized [`Chain`].
+    pub fn sapling_subtree_by_index(
+        &self,
+        index: NoteCommitmentSubtreeIndex,
+    ) -> Option<Arc<NoteCommitmentSubtree<sapling::tree::Node>>> {
+        self.sapling_subtrees
+            .iter()
+            .find(|subtree| subtree.index == index)
+            .cloned()
+    }
+
     /// Adds the Sapling `tree` to the tree and anchor indexes at `height`.
     ///
     /// `height` can be either:
@@ -810,6 +852,33 @@ impl Chain {
             .range(..=height)
             .next_back()
             .map(|(_height, tree)| tree.clone())
+    }
+
+    /// Returns the Orchard [`NoteCommitmentSubtree`](orchard::tree::NoteCommitmentSubtree) specified
+    /// by a [`HashOrHeight`], if it exists in the non-finalized [`Chain`].
+    pub fn orchard_subtree(
+        &self,
+        hash_or_height: HashOrHeight,
+    ) -> Option<Arc<NoteCommitmentSubtree<orchard::tree::Node>>> {
+        let height =
+            hash_or_height.height_or_else(|hash| self.height_by_hash.get(&hash).cloned())?;
+
+        self.orchard_subtrees
+            .iter()
+            .find(|subtree| subtree.end == height)
+            .cloned()
+    }
+
+    /// Returns the Orchard [`NoteCommitmentSubtree`] specified
+    /// by an index, if it exists in the non-finalized [`Chain`].
+    pub fn orchard_subtree_by_index(
+        &self,
+        index: NoteCommitmentSubtreeIndex,
+    ) -> Option<Arc<NoteCommitmentSubtree<orchard::tree::Node>>> {
+        self.orchard_subtrees
+            .iter()
+            .find(|subtree| subtree.index == index)
+            .cloned()
     }
 
     /// Adds the Orchard `tree` to the tree and anchor indexes at `height`.
@@ -1004,11 +1073,15 @@ impl Chain {
         let sapling_tree = self.sapling_tree(hash_or_height)?;
         let orchard_tree = self.orchard_tree(hash_or_height)?;
         let history_tree = self.history_tree(hash_or_height)?;
+        let sapling_subtree = self.sapling_subtree(hash_or_height);
+        let orchard_subtree = self.orchard_subtree(hash_or_height);
 
         Some(Treestate::new(
             sprout_tree,
             sapling_tree,
             orchard_tree,
+            sapling_subtree,
+            orchard_subtree,
             history_tree,
         ))
     }
@@ -1279,6 +1352,13 @@ impl Chain {
         self.add_sprout_tree_and_anchor(height, nct.sprout);
         self.add_sapling_tree_and_anchor(height, nct.sapling);
         self.add_orchard_tree_and_anchor(height, nct.orchard);
+
+        if let Some(subtree) = nct.sapling_subtree {
+            self.sapling_subtrees.push_back(subtree)
+        }
+        if let Some(subtree) = nct.orchard_subtree {
+            self.orchard_subtrees.push_back(subtree)
+        }
 
         let sapling_root = self.sapling_note_commitment_tree().root();
         let orchard_root = self.orchard_note_commitment_tree().root();


### PR DESCRIPTION
## Motivation

This is needed to support "spend before sync" in lightwalletd.

Closes #6953.

Depends-On #7334.

TODO: Add state validity test.

## Solution

- Add subtrees below initial tip height

## Review

Not yet ready for review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- Add state service requests for reading subtrees