### PR TITLE
Log errors and panic if duplicate trees are found after the de-duplicating upgrade

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -179,8 +179,8 @@ impl DbFormatChange {
 
     /// Apply this format change to the database.
     ///
-    /// Format changes should be launched in an independent `std::thread`, which runs until the
-    /// upgrade is finished.
+    /// Format changes are launched in an independent `std::thread` by `apply_format_upgrade()`.
+    /// This thread runs until the upgrade is finished.
     ///
     /// See `apply_format_upgrade()` for details.
     fn apply_format_change(
@@ -192,7 +192,7 @@ impl DbFormatChange {
         should_cancel_format_change: Arc<AtomicBool>,
     ) {
         match self {
-            // Handled in the rest of this function.
+            // Perform any required upgrades, then mark the state as upgraded.
             Upgrade { .. } => self.apply_format_upgrade(
                 config,
                 network,

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -102,6 +102,11 @@ impl ZebraDb {
             );
 
             db.format_change_handle = Some(format_change_handle);
+        } else {
+            // If we're re-opening a previously upgraded or newly created database,
+            // the trees should already be de-duplicated.
+            // (There's no format change here, so the format change checks won't run.)
+            DbFormatChange::check_for_duplicate_trees(db.clone());
         }
 
         db


### PR DESCRIPTION
## Motivation

There are some duplicate trees left after the version `25.1.0` state upgrade, which de-duplicates note commitment trees.

### Complex Code or Requirements

There seem to be some off-by-one errors in the code that's been merged to the `main` branch, see my upcoming review on PR #7312.

## Solution

This PR just detects the bug, by checking for duplicates after the upgrade has run. (Or if there isn't any upgrade, when the state is opened.)

## Review

This is part of a conversation with @upbqdn, but I'm happy to do any fixes.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Actually fix the bug.