### PR TITLE
0. Add note commitment subtree types to zebra-chain

### DIFF
--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -34,6 +34,7 @@ pub mod sapling;
 pub mod serialization;
 pub mod shutdown;
 pub mod sprout;
+pub mod subtree;
 pub mod transaction;
 pub mod transparent;
 pub mod value_balance;

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -178,18 +178,17 @@ impl Node {
     pub fn to_repr(&self) -> [u8; 32] {
         self.0.to_repr()
     }
+}
 
-    /// Converts a byte representation of a field element into an element of
-    /// this prime field without checking if the input is not canonical
-    pub fn from_repr_unchecked(bytes: &[u8]) -> Self {
-        let mut tmp = [0, 0, 0, 0];
+impl TryFrom<&[u8]> for Node {
+    type Error = &'static str;
 
-        tmp[0] = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
-        tmp[1] = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
-        tmp[2] = u64::from_le_bytes(bytes[16..24].try_into().unwrap());
-        tmp[3] = u64::from_le_bytes(bytes[24..32].try_into().unwrap());
-
-        pallas::Base::from_raw(tmp).into()
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        Option::<pallas::Base>::from(pallas::Base::from_repr(
+            bytes.try_into().map_err(|_| "wrong byte slice len")?,
+        ))
+        .map(Node)
+        .ok_or("invalid Pallas field element")
     }
 }
 

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use bitvec::prelude::*;
-use bridgetree;
+use bridgetree::{self, NonEmptyFrontier};
 use halo2::pasta::{group::ff::PrimeField, pallas};
 use incrementalmerkletree::Hashable;
 use lazy_static::lazy_static;
@@ -31,7 +31,7 @@ use crate::{
     serialization::{
         serde_helpers, ReadZcashExt, SerializationError, ZcashDeserialize, ZcashSerialize,
     },
-    subtree::{TRACKED_SUBTREE_HEIGHT, TRACKED_SUBTREE_SIZE},
+    subtree::TRACKED_SUBTREE_HEIGHT,
 };
 
 pub mod legacy;
@@ -178,6 +178,19 @@ impl Node {
     pub fn to_repr(&self) -> [u8; 32] {
         self.0.to_repr()
     }
+
+    /// Converts a byte representation of a field element into an element of
+    /// this prime field without checking if the input is not canonical
+    pub fn from_repr_unchecked(bytes: &[u8]) -> Self {
+        let mut tmp = [0, 0, 0, 0];
+
+        tmp[0] = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
+        tmp[1] = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
+        tmp[2] = u64::from_le_bytes(bytes[16..24].try_into().unwrap());
+        tmp[3] = u64::from_le_bytes(bytes[24..32].try_into().unwrap());
+
+        pallas::Base::from_raw(tmp).into()
+    }
 }
 
 /// Required to convert [`NoteCommitmentTree`] into [`SerializedTree`].
@@ -231,18 +244,6 @@ impl Hashable for Node {
 impl From<pallas::Base> for Node {
     fn from(x: pallas::Base) -> Self {
         Node(x)
-    }
-}
-
-impl TryFrom<&[u8]> for Node {
-    type Error = &'static str;
-
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Option::<pallas::Base>::from(pallas::Base::from_repr(
-            bytes.try_into().map_err(|_| "wrong byte slice len")?,
-        ))
-        .map(Node)
-        .ok_or("invalid Pallas field element")
     }
 }
 
@@ -340,43 +341,46 @@ impl NoteCommitmentTree {
     }
 
     /// Returns true if the most recently appended leaf completes the subtree
-    pub fn is_complete_subtree(&self) -> bool {
-        self.inner.value().map_or(false, |x| {
-            x.position()
-                .is_complete_subtree(TRACKED_SUBTREE_HEIGHT.into())
-        })
+    pub fn is_complete_subtree(tree: &NonEmptyFrontier<Node>) -> bool {
+        tree.position()
+            .is_complete_subtree(TRACKED_SUBTREE_HEIGHT.into())
     }
 
-    /// Returns subtree index at [`TRACKED_SUBTREE_HEIGHT`]
-    pub fn subtree_index(&self) -> u16 {
-        (self.position() >> TRACKED_SUBTREE_HEIGHT)
-            .try_into()
-            .expect("always within u16")
-    }
-
-    /// Returns subtree root, if any
-    pub fn subtree_root(&self) -> Option<Node> {
-        self.is_complete_subtree().then_some(())?;
-        Some(
-            self.inner
-                .value()?
-                .root(Some(TRACKED_SUBTREE_HEIGHT.into())),
+    /// Returns subtree address at [`TRACKED_SUBTREE_HEIGHT`]
+    pub fn subtree_address(&self) -> incrementalmerkletree::Address {
+        incrementalmerkletree::Address::above_position(
+            TRACKED_SUBTREE_HEIGHT.into(),
+            self.position().into(),
         )
     }
 
-    /// Returns the index of note completing the next subtree
-    pub fn next_complete_subtree_note_index(&self) -> usize {
-        // # Correctness
-        //
-        // 2^16 - (position % 2^16) should always be between 1..=2^16
-        (TRACKED_SUBTREE_SIZE - self.subtree_note_count() - 1)
+    /// Accepts a mutable reference to Orchard notes that are to be appended for a block,
+    /// checks if they will complete the current subtree, and splits off any notes that should
+    /// be appended to the next subtree.
+    ///
+    /// Returns current subtree index and notes in the next subtree if the notes complete
+    /// the current subtree.
+    ///
+    /// Returns None otherwise.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn subtree_index_and_notes_in_next_subtree(
+        &self,
+        notes: &mut Vec<NoteCommitmentUpdate>,
+    ) -> Option<(u16, Vec<NoteCommitmentUpdate>)> {
+        let address = self.subtree_address();
+        let index = || address.index().try_into().expect("should fit in u16");
+        let empty_leaf_count = (u64::from(address.max_position() - self.position()))
             .try_into()
-            .expect("should fit in usize")
+            .expect("should fit in usize");
+
+        (notes.len() > empty_leaf_count).then(|| (index(), notes.split_off(empty_leaf_count)))
     }
 
-    /// Counts of note commitments added to the current subtree, max 2^16
-    fn subtree_note_count(&self) -> u64 {
-        self.count() % TRACKED_SUBTREE_SIZE
+    /// Returns subtree root if the most recently appended leaf completes the subtree
+    pub fn subtree_root(&self) -> Option<Node> {
+        let value = self.inner.value()?;
+        Self::is_complete_subtree(value).then_some(())?;
+        Some(value.root(Some(TRACKED_SUBTREE_HEIGHT.into())))
     }
 
     /// Returns the current root of the tree, used as an anchor in Orchard
@@ -436,7 +440,7 @@ impl NoteCommitmentTree {
 
     /// Position of final leaf added to the tree.
     fn position(&self) -> u64 {
-        self.inner.value().map_or(0, |x| u64::from(x.position()))
+        self.inner.value().map_or(0, |x| x.position().into())
     }
 
     /// Count of note commitments added to the tree.

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -346,40 +346,23 @@ impl NoteCommitmentTree {
     }
 
     /// Returns subtree address at [`TRACKED_SUBTREE_HEIGHT`]
-    pub fn subtree_address(&self) -> incrementalmerkletree::Address {
+    pub fn subtree_address(tree: &NonEmptyFrontier<Node>) -> incrementalmerkletree::Address {
         incrementalmerkletree::Address::above_position(
             TRACKED_SUBTREE_HEIGHT.into(),
-            self.position().into(),
+            tree.position(),
         )
     }
 
-    /// Accepts a mutable reference to Orchard notes that are to be appended for a block,
-    /// checks if they will complete the current subtree, and splits off any notes that should
-    /// be appended to the next subtree.
-    ///
-    /// Returns current subtree index and notes in the next subtree if the notes complete
-    /// the current subtree.
-    ///
-    /// Returns None otherwise.
+    /// Returns subtree index and root if the most recently appended leaf completes the subtree
     #[allow(clippy::unwrap_in_result)]
-    pub fn subtree_index_and_notes_in_next_subtree(
-        &self,
-        notes: &mut Vec<NoteCommitmentUpdate>,
-    ) -> Option<(u16, Vec<NoteCommitmentUpdate>)> {
-        let address = self.subtree_address();
-        let index = || address.index().try_into().expect("should fit in u16");
-        let empty_leaf_count = (u64::from(address.max_position() - self.position()))
-            .try_into()
-            .expect("should fit in usize");
-
-        (notes.len() > empty_leaf_count).then(|| (index(), notes.split_off(empty_leaf_count)))
-    }
-
-    /// Returns subtree root if the most recently appended leaf completes the subtree
-    pub fn subtree_root(&self) -> Option<Node> {
+    pub fn completed_subtree_index_and_root(&self) -> Option<(u16, Node)> {
         let value = self.inner.value()?;
         Self::is_complete_subtree(value).then_some(())?;
-        Some(value.root(Some(TRACKED_SUBTREE_HEIGHT.into())))
+        let address = Self::subtree_address(value);
+        let index = address.index().try_into().expect("should fit in u16");
+        let root = value.root(Some(TRACKED_SUBTREE_HEIGHT.into()));
+
+        Some((index, root))
     }
 
     /// Returns the current root of the tree, used as an anchor in Orchard
@@ -435,11 +418,6 @@ impl NoteCommitmentTree {
     /// Uncommitted^Orchard = I2LEBSP_l_MerkleOrchard(2)
     pub fn uncommitted() -> pallas::Base {
         pallas::Base::one().double()
-    }
-
-    /// Position of final leaf added to the tree.
-    fn position(&self) -> u64 {
-        self.inner.value().map_or(0, |x| x.position().into())
     }
 
     /// Count of note commitments added to the tree.

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -168,20 +168,6 @@ impl ZcashDeserialize for Root {
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Node([u8; 32]);
 
-impl Node {
-    /// Converts a little-endian byte representation of
-    /// a Sapling Node without checking if the input is not canonical.
-    pub fn from_repr_unchecked(bytes: &[u8]) -> Self {
-        let mut tmp = [0, 0, 0, 0];
-
-        tmp[0] = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
-        tmp[1] = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
-        tmp[2] = u64::from_le_bytes(bytes[16..24].try_into().unwrap());
-        tmp[3] = u64::from_le_bytes(bytes[24..32].try_into().unwrap());
-
-        jubjub::Fq::from_raw(tmp).into()
-    }
-}
 impl AsRef<[u8; 32]> for Node {
     fn as_ref(&self) -> &[u8; 32] {
         &self.0

--- a/zebra-chain/src/subtree.rs
+++ b/zebra-chain/src/subtree.rs
@@ -7,9 +7,6 @@ use crate::block::Height;
 /// Height at which Zebra tracks subtree roots
 pub const TRACKED_SUBTREE_HEIGHT: u8 = 16;
 
-/// Size of tracked subtrees
-pub const TRACKED_SUBTREE_SIZE: u64 = 1 << TRACKED_SUBTREE_HEIGHT;
-
 /// A subtree index
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct NoteCommitmentSubtreeIndex(pub u16);
@@ -20,7 +17,8 @@ impl From<u16> for NoteCommitmentSubtreeIndex {
     }
 }
 
-/// Subtree of Sapling or Orchard note commitment tree
+/// Subtree root of Sapling or Orchard note commitment tree,
+/// with its associated block height and subtree index.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct NoteCommitmentSubtree<Node> {
     /// Index of this subtree
@@ -39,16 +37,17 @@ impl<Node> NoteCommitmentSubtree<Node> {
     }
 }
 
-/// Partial subtree of Sapling note commitment tree
+/// Subtree root of Sapling or Orchard note commitment tree, with block height, but without the subtree index.
+/// Used for database key-value serialization, where the subtree index is the key, and this struct is the value.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct PartialNoteCommitmentSubtree<Node> {
+pub struct NoteCommitmentSubtreeData<Node> {
     /// End boundary of this subtree, the block height of its last leaf.
     pub end: Height,
     /// Root of this subtree.
     pub node: Node,
 }
 
-impl<Node> PartialNoteCommitmentSubtree<Node> {
+impl<Node> NoteCommitmentSubtreeData<Node> {
     /// Creates new [`PartialNoteCommitmentSubtree`]
     pub fn new(end: Height, node: Node) -> Self {
         Self { end, node }

--- a/zebra-chain/src/subtree.rs
+++ b/zebra-chain/src/subtree.rs
@@ -48,12 +48,12 @@ pub struct NoteCommitmentSubtreeData<Node> {
 }
 
 impl<Node> NoteCommitmentSubtreeData<Node> {
-    /// Creates new [`PartialNoteCommitmentSubtree`]
+    /// Creates new [`NoteCommitmentSubtreeData`]
     pub fn new(end: Height, node: Node) -> Self {
         Self { end, node }
     }
 
-    /// Creates new [`NoteCommitmentSubtree`] from a [`PartialNoteCommitmentSubtree`] and index
+    /// Creates new [`NoteCommitmentSubtree`] from a [`NoteCommitmentSubtreeData`] and index
     pub fn with_index(
         self,
         index: impl Into<NoteCommitmentSubtreeIndex>,

--- a/zebra-chain/src/subtree.rs
+++ b/zebra-chain/src/subtree.rs
@@ -1,0 +1,64 @@
+//! Struct representing Sapling/Orchard note commitment subtrees
+
+use std::sync::Arc;
+
+use crate::block::Height;
+
+/// Height at which Zebra tracks subtree roots
+pub const TRACKED_SUBTREE_HEIGHT: u8 = 16;
+
+/// Size of tracked subtrees
+pub const TRACKED_SUBTREE_SIZE: u64 = 1 << TRACKED_SUBTREE_HEIGHT;
+
+/// A subtree index
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct NoteCommitmentSubtreeIndex(pub u16);
+
+impl From<u16> for NoteCommitmentSubtreeIndex {
+    fn from(value: u16) -> Self {
+        Self(value)
+    }
+}
+
+/// Subtree of Sapling or Orchard note commitment tree
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct NoteCommitmentSubtree<Node> {
+    /// Index of this subtree
+    pub index: NoteCommitmentSubtreeIndex,
+    /// End boundary of this subtree, the block height of its last leaf.
+    pub end: Height,
+    /// Root of this subtree.
+    pub node: Node,
+}
+
+impl<Node> NoteCommitmentSubtree<Node> {
+    /// Creates new [`NoteCommitmentSubtree`]
+    pub fn new(index: impl Into<NoteCommitmentSubtreeIndex>, end: Height, node: Node) -> Arc<Self> {
+        let index = index.into();
+        Arc::new(Self { index, end, node })
+    }
+}
+
+/// Partial subtree of Sapling note commitment tree
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct PartialNoteCommitmentSubtree<Node> {
+    /// End boundary of this subtree, the block height of its last leaf.
+    pub end: Height,
+    /// Root of this subtree.
+    pub node: Node,
+}
+
+impl<Node> PartialNoteCommitmentSubtree<Node> {
+    /// Creates new [`PartialNoteCommitmentSubtree`]
+    pub fn new(end: Height, node: Node) -> Self {
+        Self { end, node }
+    }
+
+    /// Creates new [`NoteCommitmentSubtree`] from a [`PartialNoteCommitmentSubtree`] and index
+    pub fn with_index(
+        self,
+        index: impl Into<NoteCommitmentSubtreeIndex>,
+    ) -> Arc<NoteCommitmentSubtree<Node>> {
+        NoteCommitmentSubtree::new(index, self.end, self.node)
+    }
+}

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -241,7 +241,9 @@ impl Treestate {
             note_commitment_trees: NoteCommitmentTrees {
                 sprout,
                 sapling,
+                sapling_subtree: None,
                 orchard,
+                orchard_subtree: None,
             },
             history_tree,
         }

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -224,7 +224,9 @@ impl ZebraDb {
         NoteCommitmentTrees {
             sprout: self.sprout_tree(),
             sapling: self.sapling_tree(),
+            sapling_subtree: None,
             orchard: self.orchard_tree(),
+            orchard_subtree: None,
         }
     }
 }

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -1251,7 +1251,9 @@ impl Chain {
         let mut nct = NoteCommitmentTrees {
             sprout: self.sprout_note_commitment_tree(),
             sapling: self.sapling_note_commitment_tree(),
+            sapling_subtree: None,
             orchard: self.orchard_note_commitment_tree(),
+            orchard_subtree: None,
         };
 
         let mut tree_result = None;


### PR DESCRIPTION
## Motivation

We want to review and merge the data structure and cryptographic changes to the subtree code separately.

This is part of ticket #6953.

### PR Construction Process

I made this PR by checking out the zebra-chain changes from @arya2's `subtree-boundaries` branch:
```sh
git checkout -b subtree-boundaries-zebra-chain main
git checkout origin/subtree-boundaries zebra-chain
git commit
```

And then temporarily fixing the compiler errors by using `None` for all the new subtree fields. (Since those fields aren't read by the state yet, any value is ok.)

### Complex Code or Requirements

There's cryptographic code here that I don't fully understand. But we can fix it later during testing if any bugs come up.

## Solution

Add subtree data structures
Add methods for working with subtrees
Add methods for deserialising nodes

## Review

This PR is the first PR for ticket #6953, it blocks all the others.

Teor can't approve this PR, because they opened it based on Arya's branch.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Revert the temporary `None` values for subtree fields.