### PR TITLE
fix(state): Fix the deduplication of note commitment trees

### DIFF
--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -52,7 +52,7 @@ pub(crate) const DATABASE_FORMAT_MINOR_VERSION: u64 = 1;
 
 /// The database format patch version, incremented each time the on-disk database format has a
 /// significant format compatibility fix.
-pub(crate) const DATABASE_FORMAT_PATCH_VERSION: u64 = 0;
+pub(crate) const DATABASE_FORMAT_PATCH_VERSION: u64 = 1;
 
 /// The name of the file containing the minor and patch database versions.
 ///

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -119,7 +119,8 @@ pub trait WriteDisk {
         C: rocksdb::AsColumnFamilyRef,
         K: IntoDisk + Debug;
 
-    /// Remove the given key range from rocksdb column family if it exists.
+    /// Deletes the given key range from rocksdb column family if it exists, including `from` and
+    /// excluding `to`.
     fn zs_delete_range<C, K>(&mut self, cf: &C, from: K, to: K)
     where
         C: rocksdb::AsColumnFamilyRef,

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -148,6 +148,8 @@ impl WriteDisk for DiskWriteBatch {
         self.batch.delete_cf(cf, key_bytes);
     }
 
+    // TODO: convert zs_delete_range() to take std::ops::RangeBounds
+    //       see zs_range_iter() for an example of the edge cases
     fn zs_delete_range<C, K>(&mut self, cf: &C, from: K, to: K)
     where
         C: rocksdb::AsColumnFamilyRef,

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -330,20 +330,6 @@ impl DbFormatChange {
                 }
             }
 
-            // The Sapling note commitment trees are pruned if `last_height` has reached the height
-            // right after `initial_tip_height`. If `last_height` has not reached that height, they
-            // have been pruned in a previous upgrade, so the inclusive range between `last_height`
-            // and `initial_tip_height` must be empty. If it is not, there is an error, and the
-            // current upgrade did not succeed.
-            if last_height != initial_tip_height.next()
-                && db
-                    .sapling_tree_by_height_range(last_height..=initial_tip_height)
-                    .next()
-                    .is_some()
-            {
-                panic!("Zebra could not prune all Sapling trees.");
-            }
-
             // Prune duplicate Orchard note commitment trees.
             let mut last_tree = db.orchard_tree_by_height(&Height(0)).expect(
                 "The Orchard note commitment tree for the genesis block should be in the database.",
@@ -393,20 +379,6 @@ impl DbFormatChange {
                     // in the database.
                     last_height = height.next();
                 }
-            }
-
-            // The Sapling note commitment trees are pruned if `last_height` has reached the height
-            // right after `initial_tip_height`. If `last_height` has not reached that height, they
-            // have been pruned in a previous upgrade, so the inclusive range between `last_height`
-            // and `initial_tip_height` must be empty. If it is not, there is an error, and the
-            // current upgrade did not succeed.
-            if last_height != initial_tip_height.next()
-                && db
-                    .orchard_tree_by_height_range(last_height..=initial_tip_height)
-                    .next()
-                    .is_some()
-            {
-                panic!("Zebra could not prune all Orchard trees.");
             }
 
             // Before marking the state as upgraded, check that the upgrade completed successfully.

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -341,8 +341,7 @@ impl DbFormatChange {
                     .next()
                     .is_some()
             {
-                warn!("Zebra could not prune all Sapling trees.");
-                return;
+                panic!("Zebra could not prune all Sapling trees.");
             }
 
             // Prune duplicate Orchard note commitment trees.
@@ -407,8 +406,7 @@ impl DbFormatChange {
                     .next()
                     .is_some()
             {
-                warn!("Zebra could not prune all Orchard trees.");
-                return;
+                panic!("Zebra could not prune all Orchard trees.");
             }
 
             // Before marking the state as upgraded, check that the upgrade completed successfully.

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -272,7 +272,7 @@ impl DbFormatChange {
         // Start of a database upgrade task.
 
         let version_for_pruning_trees =
-            Version::parse("25.1.0").expect("Hardcoded version string should be valid.");
+            Version::parse("25.1.1").expect("Hardcoded version string should be valid.");
 
         // Check if we need to prune the note commitment trees in the database.
         if older_disk_version < version_for_pruning_trees {

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -179,8 +179,8 @@ impl DbFormatChange {
 
     /// Apply this format change to the database.
     ///
-    /// Format changes should be launched in an independent `std::thread`, which runs until the
-    /// upgrade is finished.
+    /// Format changes are launched in an independent `std::thread` by `apply_format_upgrade()`.
+    /// This thread runs until the upgrade is finished.
     ///
     /// See `apply_format_upgrade()` for details.
     fn apply_format_change(
@@ -192,7 +192,7 @@ impl DbFormatChange {
         should_cancel_format_change: Arc<AtomicBool>,
     ) {
         match self {
-            // Handled in the rest of this function.
+            // Perform any required upgrades, then mark the state as upgraded.
             Upgrade { .. } => self.apply_format_upgrade(
                 config,
                 network,

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -102,6 +102,11 @@ impl ZebraDb {
             );
 
             db.format_change_handle = Some(format_change_handle);
+        } else {
+            // If we're re-opening a previously upgraded or newly created database,
+            // the trees should already be de-duplicated.
+            // (There's no format change here, so the format change checks won't run.)
+            DbFormatChange::check_for_duplicate_trees(db.clone());
         }
 
         db

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -425,11 +425,14 @@ impl DiskWriteBatch {
     }
 
     /// Deletes the range of Sapling note commitment trees at the given [`Height`]s. Doesn't delete the upper bound.
+    #[allow(dead_code)]
     pub fn delete_range_sapling_tree(&mut self, zebra_db: &ZebraDb, from: &Height, to: &Height) {
         let sapling_tree_cf = zebra_db
             .db
             .cf_handle("sapling_note_commitment_tree")
             .unwrap();
+
+        // TODO: convert zs_delete_range() to take std::ops::RangeBounds
         self.zs_delete_range(&sapling_tree_cf, from, to);
     }
 
@@ -443,11 +446,14 @@ impl DiskWriteBatch {
     }
 
     /// Deletes the range of Orchard note commitment trees at the given [`Height`]s. Doesn't delete the upper bound.
+    #[allow(dead_code)]
     pub fn delete_range_orchard_tree(&mut self, zebra_db: &ZebraDb, from: &Height, to: &Height) {
         let orchard_tree_cf = zebra_db
             .db
             .cf_handle("orchard_note_commitment_tree")
             .unwrap();
+
+        // TODO: convert zs_delete_range() to take std::ops::RangeBounds
         self.zs_delete_range(&orchard_tree_cf, from, to);
     }
 }

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -68,6 +68,8 @@ impl ZebraDb {
         self.db.zs_contains(&orchard_anchors, &orchard_anchor)
     }
 
+    // # Sprout trees
+
     /// Returns the Sprout note commitment tree of the finalized tip
     /// or the empty tree if the state is empty.
     pub fn sprout_tree(&self) -> Arc<sprout::tree::NoteCommitmentTree> {
@@ -112,6 +114,8 @@ impl ZebraDb {
             .zs_items_in_range_unordered(&sprout_anchors_handle, ..)
     }
 
+    // # Sapling trees
+
     /// Returns the Sapling note commitment tree of the finalized tip or the empty tree if the state
     /// is empty.
     pub fn sapling_tree(&self) -> Arc<sapling::tree::NoteCommitmentTree> {
@@ -124,35 +128,8 @@ impl ZebraDb {
             .expect("Sapling note commitment tree must exist if there is a finalized tip")
     }
 
-    /// Returns the Orchard note commitment trees starting from the given block height up to the chain tip
-    #[allow(clippy::unwrap_in_result)]
-    pub fn orchard_tree_by_height_range<R>(
-        &self,
-        range: R,
-    ) -> impl Iterator<Item = (Height, Arc<orchard::tree::NoteCommitmentTree>)> + '_
-    where
-        R: std::ops::RangeBounds<Height>,
-    {
-        let orchard_trees = self.db.cf_handle("orchard_note_commitment_tree").unwrap();
-        self.db.zs_range_iter(&orchard_trees, range)
-    }
-
-    /// Returns the Sapling note commitment tree matching the given block height,
-    /// or `None` if the height is above the finalized tip.
-    #[allow(clippy::unwrap_in_result)]
-    pub fn sapling_tree_by_height_range<R>(
-        &self,
-        range: R,
-    ) -> impl Iterator<Item = (Height, Arc<sapling::tree::NoteCommitmentTree>)> + '_
-    where
-        R: std::ops::RangeBounds<Height>,
-    {
-        let sapling_trees = self.db.cf_handle("sapling_note_commitment_tree").unwrap();
-        self.db.zs_range_iter(&sapling_trees, range)
-    }
-
-    /// Returns the Sapling note commitment tree matching the given block height,
-    /// or `None` if the height is above the finalized tip.
+    /// Returns the Sapling note commitment tree matching the given block height, or `None` if the
+    /// height is above the finalized tip.
     #[allow(clippy::unwrap_in_result)]
     pub fn sapling_tree_by_height(
         &self,
@@ -179,8 +156,23 @@ impl ZebraDb {
         Some(Arc::new(tree))
     }
 
-    /// Returns the Orchard note commitment tree of the finalized tip
-    /// or the empty tree if the state is empty.
+    /// Returns the Sapling note commitment trees in the supplied range.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn sapling_tree_by_height_range<R>(
+        &self,
+        range: R,
+    ) -> impl Iterator<Item = (Height, Arc<sapling::tree::NoteCommitmentTree>)> + '_
+    where
+        R: std::ops::RangeBounds<Height>,
+    {
+        let sapling_trees = self.db.cf_handle("sapling_note_commitment_tree").unwrap();
+        self.db.zs_range_iter(&sapling_trees, range)
+    }
+
+    // Orchard trees
+
+    /// Returns the Orchard note commitment tree of the finalized tip or the empty tree if the state
+    /// is empty.
     pub fn orchard_tree(&self) -> Arc<orchard::tree::NoteCommitmentTree> {
         let height = match self.finalized_tip_height() {
             Some(h) => h,
@@ -191,8 +183,8 @@ impl ZebraDb {
             .expect("Orchard note commitment tree must exist if there is a finalized tip")
     }
 
-    /// Returns the Orchard note commitment tree matching the given block height,
-    /// or `None` if the height is above the finalized tip.
+    /// Returns the Orchard note commitment tree matching the given block height, or `None` if the
+    /// height is above the finalized tip.
     #[allow(clippy::unwrap_in_result)]
     pub fn orchard_tree_by_height(
         &self,
@@ -217,6 +209,19 @@ impl ZebraDb {
             );
 
         Some(Arc::new(tree))
+    }
+
+    /// Returns the Orchard note commitment trees in the supplied range.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn orchard_tree_by_height_range<R>(
+        &self,
+        range: R,
+    ) -> impl Iterator<Item = (Height, Arc<orchard::tree::NoteCommitmentTree>)> + '_
+    where
+        R: std::ops::RangeBounds<Height>,
+    {
+        let orchard_trees = self.db.cf_handle("orchard_note_commitment_tree").unwrap();
+        self.db.zs_range_iter(&orchard_trees, range)
     }
 
     /// Returns the shielded note commitment trees of the finalized tip

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -112,7 +112,8 @@ impl ZebraDb {
             .zs_items_in_range_unordered(&sprout_anchors_handle, ..)
     }
 
-    /// Returns the Sapling note commitment trees starting from the given block height up to the chain tip
+    /// Returns the Sapling note commitment tree of the finalized tip or the empty tree if the state
+    /// is empty.
     pub fn sapling_tree(&self) -> Arc<sapling::tree::NoteCommitmentTree> {
         let height = match self.finalized_tip_height() {
             Some(h) => h,


### PR DESCRIPTION
## Motivation & Solution

- Refactor the deduplication.
- Include a test that checks that there are no duplicates.

This PR merges #7365.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?