### PR TITLE
fix: Fix a new `cargo fmt` warning

### DIFF
--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -354,7 +354,7 @@ impl AddressBook {
     /// See [`AddressBook::is_ready_for_connection_attempt_with_ip`] for more details.
     fn should_update_most_recent_by_ip(&self, updated: MetaAddr) -> bool {
         let Some(most_recent_by_ip) = self.most_recent_by_ip.as_ref() else {
-            return false
+            return false;
         };
 
         if let Some(previous) = most_recent_by_ip.get(&updated.addr.ip()) {
@@ -369,7 +369,7 @@ impl AddressBook {
     /// The entry is checked for an exact match to the IP and port of `addr`.
     fn should_remove_most_recent_by_ip(&self, addr: PeerSocketAddr) -> bool {
         let Some(most_recent_by_ip) = self.most_recent_by_ip.as_ref() else {
-            return false
+            return false;
         };
 
         if let Some(previous) = most_recent_by_ip.get(&addr.ip()) {


### PR DESCRIPTION
## Motivation & Solution

- Fix a new `cargo fmt` error: https://github.com/ZcashFoundation/zebra/actions/runs/5965090963/job/16181739018?pr=7379#step:6:11.

This is the new change in rustfmt: https://github.com/rust-lang/rustfmt/pull/5690

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?