### PR TITLE
cleanup(clippy): Fix new nightly clippy lints from July and August 2023

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -66,9 +66,6 @@ skip-tree = [
     # wait for rocksdb to upgrade
     { name = "bindgen", version = "=0.65.1" },
 
-    # wait for tempfile to upgrade
-    { name = "rustix", version = "=0.37.23" },
-
     # ZF crates
 
     # wait for indexmap, toml_edit, serde_json, tower to upgrade

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -46,13 +46,13 @@ pub fn coinbase_is_first(block: &Block) -> Result<Arc<transaction::Transaction>,
     // <https://zips.z.cash/protocol/protocol.pdf#coinbasetransactions>
     let mut rest = block.transactions.iter().skip(1);
     if !first.is_coinbase() {
-        return Err(TransactionError::CoinbasePosition)?;
+        Err(TransactionError::CoinbasePosition)?;
     }
     // > A transparent input in a non-coinbase transaction MUST NOT have a null prevout
     //
     // <https://zips.z.cash/protocol/protocol.pdf#txnconsensus>
     if !rest.all(|tx| tx.is_valid_non_coinbase()) {
-        return Err(TransactionError::CoinbaseAfterFirst)?;
+        Err(TransactionError::CoinbaseAfterFirst)?;
     }
 
     Ok(first.clone())
@@ -237,7 +237,7 @@ pub fn miner_fees_are_valid(
     let right = (block_subsidy + block_miner_fees).map_err(|_| SubsidyError::SumOverflow)?;
 
     if left > right {
-        return Err(SubsidyError::InvalidMinerFees)?;
+        Err(SubsidyError::InvalidMinerFees)?;
     }
 
     Ok(())

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -435,7 +435,7 @@ fn validate_expiry_height_max(
 ) -> Result<(), TransactionError> {
     if let Some(expiry_height) = expiry_height {
         if expiry_height > Height::MAX_EXPIRY_HEIGHT {
-            return Err(TransactionError::MaximumExpiryHeight {
+            Err(TransactionError::MaximumExpiryHeight {
                 expiry_height,
                 is_coinbase,
                 block_height: *block_height,
@@ -458,7 +458,7 @@ fn validate_expiry_height_mined(
 ) -> Result<(), TransactionError> {
     if let Some(expiry_height) = expiry_height {
         if *block_height > expiry_height {
-            return Err(TransactionError::ExpiredTransaction {
+            Err(TransactionError::ExpiredTransaction {
                 expiry_height,
                 block_height: *block_height,
                 transaction_hash: transaction.hash(),

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -1216,7 +1216,7 @@ async fn send_periodic_heartbeats_with_shutdown_handle(
     remote_services: PeerServices,
     shutdown_rx: oneshot::Receiver<CancelHeartbeatTask>,
     server_tx: futures::channel::mpsc::Sender<ClientRequest>,
-    mut heartbeat_ts_collector: tokio::sync::mpsc::Sender<MetaAddrChange>,
+    heartbeat_ts_collector: tokio::sync::mpsc::Sender<MetaAddrChange>,
 ) -> Result<(), BoxError> {
     use futures::future::Either;
 
@@ -1277,7 +1277,7 @@ async fn send_periodic_heartbeats_run_loop(
     connected_addr: ConnectedAddr,
     remote_services: PeerServices,
     mut server_tx: futures::channel::mpsc::Sender<ClientRequest>,
-    mut heartbeat_ts_collector: tokio::sync::mpsc::Sender<MetaAddrChange>,
+    heartbeat_ts_collector: tokio::sync::mpsc::Sender<MetaAddrChange>,
 ) -> Result<(), BoxError> {
     // Don't send the first heartbeat immediately - we've just completed the handshake!
     let mut interval = tokio::time::interval_at(

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -1373,7 +1373,7 @@ async fn send_one_heartbeat(
 /// `handle_heartbeat_error`.
 async fn heartbeat_timeout<F, T>(
     fut: F,
-    address_book_updater: &mut tokio::sync::mpsc::Sender<MetaAddrChange>,
+    address_book_updater: &tokio::sync::mpsc::Sender<MetaAddrChange>,
     connected_addr: &ConnectedAddr,
     remote_services: &PeerServices,
 ) -> Result<T, BoxError>
@@ -1407,7 +1407,7 @@ where
 /// If `result.is_err()`, mark `connected_addr` as failed using `address_book_updater`.
 async fn handle_heartbeat_error<T, E>(
     result: Result<T, E>,
-    address_book_updater: &mut tokio::sync::mpsc::Sender<MetaAddrChange>,
+    address_book_updater: &tokio::sync::mpsc::Sender<MetaAddrChange>,
     connected_addr: &ConnectedAddr,
     remote_services: &PeerServices,
 ) -> Result<T, E>
@@ -1438,7 +1438,7 @@ where
 /// Mark `connected_addr` as shut down using `address_book_updater`.
 async fn handle_heartbeat_shutdown(
     peer_error: PeerError,
-    address_book_updater: &mut tokio::sync::mpsc::Sender<MetaAddrChange>,
+    address_book_updater: &tokio::sync::mpsc::Sender<MetaAddrChange>,
     connected_addr: &ConnectedAddr,
     remote_services: &PeerServices,
 ) -> Result<(), BoxError> {

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -1244,7 +1244,7 @@ async fn send_periodic_heartbeats_with_shutdown_handle(
             tracing::trace!("shutting down because Client requested shut down");
             handle_heartbeat_shutdown(
                 PeerError::ClientCancelledHeartbeatTask,
-                &mut heartbeat_ts_collector,
+                &heartbeat_ts_collector,
                 &connected_addr,
                 &remote_services,
             )
@@ -1254,7 +1254,7 @@ async fn send_periodic_heartbeats_with_shutdown_handle(
             tracing::trace!("shutting down because Client was dropped");
             handle_heartbeat_shutdown(
                 PeerError::ClientDropped,
-                &mut heartbeat_ts_collector,
+                &heartbeat_ts_collector,
                 &connected_addr,
                 &remote_services,
             )
@@ -1296,7 +1296,7 @@ async fn send_periodic_heartbeats_run_loop(
         let heartbeat = send_one_heartbeat(&mut server_tx);
         heartbeat_timeout(
             heartbeat,
-            &mut heartbeat_ts_collector,
+            &heartbeat_ts_collector,
             &connected_addr,
             &remote_services,
         )

--- a/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
@@ -438,7 +438,6 @@ pub fn calculate_default_root_hashes(
 ) -> DefaultRoots {
     let (merkle_root, auth_data_root) = calculate_transaction_roots(coinbase_txn, mempool_txs);
 
-    let history_tree = history_tree;
     let chain_history_root = history_tree.hash().expect("history tree can't be empty");
 
     let block_commitments_hash = ChainHistoryBlockTxAuthCommitmentHash::from_commitments(

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -495,7 +495,7 @@ impl DiskDb {
     const MEMTABLE_RAM_CACHE_MEGABYTES: usize = 128;
 
     /// The column families supported by the running database code.
-    const COLUMN_FAMILIES_IN_CODE: &[&'static str] = &[
+    const COLUMN_FAMILIES_IN_CODE: &'static [&'static str] = &[
         // Blocks
         "hash_by_height",
         "height_by_hash",

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -311,7 +311,7 @@ where
                     let tx = match network
                         .oneshot(req)
                         .await
-                        .map_err(|e| TransactionDownloadVerifyError::DownloadFailed(e))?
+                        .map_err(TransactionDownloadVerifyError::DownloadFailed)?
                     {
                         zn::Response::Transactions(mut txs) => txs.pop().ok_or_else(|| {
                             TransactionDownloadVerifyError::DownloadFailed(
@@ -471,7 +471,7 @@ where
         match state
             .ready()
             .await
-            .map_err(|e| TransactionDownloadVerifyError::StateError(e))?
+            .map_err(TransactionDownloadVerifyError::StateError)?
             .call(zs::Request::Transaction(txid.mined_id()))
             .await
         {


### PR DESCRIPTION
## Motivation

This PR fixes new clippy lints added in nightly Rust during July and August 2023.

It also removes an unused duplicate dependency exception in `deny.toml`.

## Review

This is a low priority cleanup.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

