### PR TITLE
fix(db): use the correct state version for databases without a state version file

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -22,6 +22,7 @@ use DbFormatChange::*;
 
 use crate::{
     config::write_database_format_version_to_disk,
+    constants::DATABASE_FORMAT_VERSION,
     database_format_version_in_code, database_format_version_on_disk,
     service::finalized_state::{DiskWriteBatch, ZebraDb},
     Config,
@@ -478,8 +479,12 @@ impl DbFormatChange {
             .expect("unable to read database format version file path");
         let running_version = database_format_version_in_code();
 
+        let default_new_version = Some(Version::new(DATABASE_FORMAT_VERSION, 0, 0));
+
+        // The database version isn't empty any more, because we've created the RocksDB database
+        // and acquired its lock. (If it is empty, we have a database locking bug.)
         assert_eq!(
-            disk_version, None,
+            disk_version, default_new_version,
             "can't overwrite the format version in an existing database:\n\
              disk: {disk_version:?}\n\
              running: {running_version}"

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -71,6 +71,10 @@ impl ZebraDb {
         // Open the database and do initial checks.
         let mut db = ZebraDb {
             format_change_handle: None,
+            // After the database directory is created, a newly created database temporarily
+            // changes to the default database version. Then we set the correct version in the
+            // upgrade thread. We need to do the version change in this order, because the version
+            // file can only be changed while we hold the RocksDB database lock.
             db: DiskDb::new(config, network),
         };
 


### PR DESCRIPTION
## Motivation

When Zebra opens a state cache that has never been upgraded, it was reporting the cache as a newly created state, then marking it with the current state version. This incorrectly skips all format upgrades.

Instead, all upgrades should be performed on the state.

### Specifications

https://doc.rust-lang.org/std/fs/struct.Metadata.html#method.is_dir

### Complex Code or Requirements

We missed this bug because there weren't enough tests for state version changes or state upgrades. But there are tests in PR #7379 now.

## Solution

If there's a database directory wit no version file, report its version as `25.0.0`. (Compatible but with no upgrades.)

## Review

This bug fix blocks all the finalized state format changes.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

