### PR TITLE
fix(ci): Show correct lightwalletd cache heights in CI cached state

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -606,7 +606,7 @@ jobs:
       root_state_path: '/var/cache'
       zebra_state_dir: 'zebrad-cache'
       lwd_state_dir: 'lwd-cache'
-      height_grep_text: '(current_height.*=.*Height.*\()|(Adding block to cache )'
+      height_grep_text: 'Adding block to cache '
     secrets: inherit
     # We want to prevent multiple lightwalletd full syncs running at the same time,
     # but we don't want to cancel running syncs on `main` if a new PR gets merged,
@@ -643,7 +643,7 @@ jobs:
       root_state_path: '/var/cache'
       zebra_state_dir: 'zebrad-cache'
       lwd_state_dir: 'lwd-cache'
-      height_grep_text: '(current_height.*=.*Height.*\()|(Adding block to cache )'
+      height_grep_text: 'Adding block to cache '
     secrets: inherit
 
   # Test that Zebra can answer a synthetic RPC call, using a cached Zebra tip state


### PR DESCRIPTION
## Motivation

`lightwalletd` can have different heights in its logs and cache than Zebra's logs. The tests used to make sure these heights were the same at the end of the test. But that doesn't work with the ECC fork.

This is part of the same underlying problem as ticket #7335, but it's independent of the test fix.

### Specifications

The `height_grep_text` field is used to find the height in the logs, to decide if the cached disk should be replaced. It's also used as a label for the disk.

## Solution

Remove the Zebra log regex and just use the lightwalletd log regex.

## Review

This is a routine fix.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

