### PR TITLE
Suggestion for Fix the deduplication of note commitment trees

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -148,6 +148,8 @@ impl WriteDisk for DiskWriteBatch {
         self.batch.delete_cf(cf, key_bytes);
     }
 
+    // TODO: convert zs_delete_range() to take std::ops::RangeBounds
+    //       see zs_range_iter() for an example of the edge cases
     fn zs_delete_range<C, K>(&mut self, cf: &C, from: K, to: K)
     where
         C: rocksdb::AsColumnFamilyRef,

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -12,9 +12,7 @@ use tracing::Span;
 use zebra_chain::{
     block::Height,
     diagnostic::task::{CheckForPanics, WaitForPanics},
-    orchard,
     parameters::Network,
-    sapling,
 };
 
 use DbFormatChange::*;
@@ -282,37 +280,52 @@ impl DbFormatChange {
         // Check if we need to prune the note commitment trees in the database.
         if older_disk_version < version_for_pruning_trees {
             // Prune duplicate Sapling note commitment trees.
-            let mut last_tree = db.sapling_tree_by_height(&Height(0)).expect(
-                "The Sapling note commitment tree for the genesis block should be in the database.",
-            );
-            let mut last_height = Height(1);
 
-            // We use this dummy cap in the loop below. It resolves an edge case when the pruning
-            // reaches the `initial_tip_height`.
-            let dummy_cap = Some((
-                initial_tip_height.next(),
-                Arc::new(sapling::tree::NoteCommitmentTree::default()),
-            ))
-            .into_iter();
+            // The last unique tree's height. Genesis is always unique.
+            let mut last_unique_height = Height(0);
+            // The last unique tree's data.
+            let mut last_unique_tree = db
+                .sapling_tree_by_height(&Height(0))
+                .expect("Checked above that the genesis block is in the database.");
 
-            // Run through all the trees in the finalized chain.
-            for (height, tree) in db
-                .sapling_tree_by_height_range(Height(1)..=initial_tip_height)
-                .chain(dummy_cap)
+            // Run through all the possible duplicate trees in the finalized chain.
+            // The block after genesis is the first possible duplicate.
+            for (next_height, next_tree) in
+                db.sapling_tree_by_height_range(Height(1)..=initial_tip_height)
             {
                 // Return early if there is a cancel signal.
                 if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
                     return;
                 }
+
                 // We delete duplicate trees in batches. A batch is a (possibly empty) series of
-                // identical trees excluding the first tree. We exclude the first tree so that we
-                // don't prune it. We get a batch if we encounter a tree that differs from the
-                // previous one. We get an empty batch if there are two consecutive differing trees.
-                // The dummy cap ensures we don't skip the last batch if the tree at
-                // `initial_tip_height` doesn't differ from the previous one.
-                if last_tree != tree || height == initial_tip_height {
-                    // Compute the size of the batch.
-                    let batch_size = height - last_height;
+                // identical trees. We start a batch after first unique tree, so that we don't
+                // prune it. We end a batch if we encounter a tree that differs from the previous
+                // one, or if we reach the end of the possible duplicates. We get an empty batch if
+                // there are two consecutive differing trees.
+
+                // Work out if we've found a batch, and what its end is.
+                let next_unique_height = if last_unique_tree != next_tree {
+                    // We've found a unique tree that isn't in this batch.
+                    Some(next_height)
+                } else if next_height == initial_tip_height {
+                    // We've reached the end of the possible duplicates without finding a unique
+                    // tree, so the initial tip is a duplicate which must be deleted.
+                    Some(next_height.next())
+                } else {
+                    // We're in the middle of a range of duplicate trees.
+                    None
+                };
+
+                if let Some(next_unique_height) = next_unique_height {
+                    // Start the batch at height just above the height of the last unique tree.
+                    // This excludes the unique tree from the next batch so that we keep the tree
+                    // in the database. This is only a duplicate if the batch has trees in it.
+                    let first_duplicate_height = last_unique_height.next();
+
+                    // TODO: convert zs_delete_range() to take std::ops::RangeBounds
+                    let batch_size = next_unique_height - first_duplicate_height;
+
                     // Check if we have a non-empty batch. In other words, check if there's at least
                     // one duplicate tree between the last tree and the new one.
                     if batch_size > 0 {
@@ -320,15 +333,21 @@ impl DbFormatChange {
 
                         // Delete the batch.
                         //
-                        // The current tree at height `height` doesn't belong to the current batch
+                        // The tree at `next_unique_height` doesn't belong to the current batch
                         // since it differs from the trees in the batch.
                         if batch_size == 1 {
                             // # Optimization
                             //
                             // Use a faster method if we're deleting a single tree.
-                            batch.delete_sapling_tree(&db, &last_height);
+                            batch.delete_sapling_tree(&db, &first_duplicate_height);
                         } else {
-                            batch.delete_range_sapling_tree(&db, &last_height, &height);
+                            // This is an exclusive end range.
+                            // TODO: convert zs_delete_range() to take std::ops::RangeBounds
+                            batch.delete_range_sapling_tree(
+                                &db,
+                                &first_duplicate_height,
+                                &next_unique_height,
+                            );
                         }
 
                         db.write_batch(batch).expect(
@@ -336,47 +355,62 @@ impl DbFormatChange {
                         );
                     }
 
-                    // Use the current tree to find the end of the next batch.
-                    last_tree = tree;
-                    // Start the next batch at height just above the height of the current tree.
-                    // This excludes the current tree from the next batch so that we keep the tree
-                    // in the database.
-                    last_height = height.next();
+                    // Record the height of this unique tree, so we can start a batch after it.
+                    //
+                    // This loop terminates before we get to the tree after the initial tip, so it
+                    // doesn't matter what value we use. (It's handled by the standard write code.)
+                    last_unique_height = next_unique_height;
+
+                    // Compare against this unique tree to find the end of the next batch.
+                    last_unique_tree = next_tree;
                 }
             }
 
-            // Prune duplicate Orchard note commitment trees.
-            let mut last_tree = db.orchard_tree_by_height(&Height(0)).expect(
-                "The Orchard note commitment tree for the genesis block should be in the database.",
-            );
-            let mut last_height = Height(1);
+            // The last unique tree's height. Genesis is always unique.
+            let mut last_unique_height = Height(0);
+            // The last unique tree's data.
+            let mut last_unique_tree = db
+                .orchard_tree_by_height(&Height(0))
+                .expect("Checked above that the genesis block is in the database.");
 
-            // We use this dummy cap in the loop below. It resolves an edge case when the pruning
-            // reaches the `initial_tip_height`.
-            let dummy_cap = Some((
-                initial_tip_height.next(),
-                Arc::new(orchard::tree::NoteCommitmentTree::default()),
-            ))
-            .into_iter();
-
-            // Run through all the trees in the finalized chain.
-            for (height, tree) in db
-                .orchard_tree_by_height_range(Height(1)..=initial_tip_height)
-                .chain(dummy_cap)
+            // Run through all the possible duplicate trees in the finalized chain.
+            // The block after genesis is the first possible duplicate.
+            for (next_height, next_tree) in
+                db.orchard_tree_by_height_range(Height(1)..=initial_tip_height)
             {
                 // Return early if there is a cancel signal.
                 if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
                     return;
                 }
+
                 // We delete duplicate trees in batches. A batch is a (possibly empty) series of
-                // identical trees excluding the first tree. We exclude the first tree so that we
-                // don't prune it. We get a batch if we encounter a tree that differs from the
-                // previous one. We get an empty batch if there are two consecutive differing trees.
-                // The dummy cap ensures we don't skip the last batch if the tree at
-                // `initial_tip_height` doesn't differ from the previous one.
-                if last_tree != tree {
-                    // Compute the size of the batch.
-                    let batch_size = height - last_height;
+                // identical trees. We start a batch after first unique tree, so that we don't
+                // prune it. We end a batch if we encounter a tree that differs from the previous
+                // one, or if we reach the end of the possible duplicates. We get an empty batch if
+                // there are two consecutive differing trees.
+
+                // Work out if we've found a batch, and what its end is.
+                let next_unique_height = if last_unique_tree != next_tree {
+                    // We've found a unique tree that isn't in this batch.
+                    Some(next_height)
+                } else if next_height == initial_tip_height {
+                    // We've reached the end of the possible duplicates without finding a unique
+                    // tree, so the initial tip is a duplicate which must be deleted.
+                    Some(next_height.next())
+                } else {
+                    // We're in the middle of a range of duplicate trees.
+                    None
+                };
+
+                if let Some(next_unique_height) = next_unique_height {
+                    // Start the batch at height just above the height of the last unique tree.
+                    // This excludes the unique tree from the next batch so that we keep the tree
+                    // in the database. This is only a duplicate if the batch has trees in it.
+                    let first_duplicate_height = last_unique_height.next();
+
+                    // TODO: convert zs_delete_range() to take std::ops::RangeBounds
+                    let batch_size = next_unique_height - first_duplicate_height;
+
                     // Check if we have a non-empty batch. In other words, check if there's at least
                     // one duplicate tree between the last tree and the new one.
                     if batch_size > 0 {
@@ -384,15 +418,21 @@ impl DbFormatChange {
 
                         // Delete the batch.
                         //
-                        // The current tree at height `height` doesn't belong to the current batch
+                        // The tree at `next_unique_height` doesn't belong to the current batch
                         // since it differs from the trees in the batch.
                         if batch_size == 1 {
                             // # Optimization
                             //
                             // Use a faster method if we're deleting a single tree.
-                            batch.delete_orchard_tree(&db, &last_height);
+                            batch.delete_orchard_tree(&db, &first_duplicate_height);
                         } else {
-                            batch.delete_range_orchard_tree(&db, &last_height, &height);
+                            // This is an exclusive end range.
+                            // TODO: convert zs_delete_range() to take std::ops::RangeBounds
+                            batch.delete_range_orchard_tree(
+                                &db,
+                                &first_duplicate_height,
+                                &next_unique_height,
+                            );
                         }
 
                         db.write_batch(batch).expect(
@@ -400,12 +440,14 @@ impl DbFormatChange {
                         );
                     }
 
-                    // Use the current tree to find the end of the next batch.
-                    last_tree = tree;
-                    // Start the next batch at height just above the height of the current tree.
-                    // This excludes the current tree from the next batch so that we keep the tree
-                    // in the database.
-                    last_height = height.next();
+                    // Record the height of this unique tree, so we can start a batch after it.
+                    //
+                    // This loop terminates before we get to the tree after the initial tip, so it
+                    // doesn't matter what value we use. (It's handled by the standard write code.)
+                    last_unique_height = next_unique_height;
+
+                    // Compare against this unique tree to find the end of the next batch.
+                    last_unique_tree = next_tree;
                 }
             }
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -281,174 +281,56 @@ impl DbFormatChange {
         if older_disk_version < version_for_pruning_trees {
             // Prune duplicate Sapling note commitment trees.
 
-            // The last unique tree's height. Genesis is always unique.
-            let mut last_unique_height = Height(0);
-            // The last unique tree's data.
-            let mut last_unique_tree = db
+            // The last tree we checked.
+            let mut last_tree = db
                 .sapling_tree_by_height(&Height(0))
                 .expect("Checked above that the genesis block is in the database.");
 
             // Run through all the possible duplicate trees in the finalized chain.
             // The block after genesis is the first possible duplicate.
-            for (next_height, next_tree) in
-                db.sapling_tree_by_height_range(Height(1)..=initial_tip_height)
-            {
+            for (height, tree) in db.sapling_tree_by_height_range(Height(1)..=initial_tip_height) {
                 // Return early if there is a cancel signal.
                 if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
                     return;
                 }
 
-                // We delete duplicate trees in batches. A batch is a (possibly empty) series of
-                // identical trees. We start a batch after first unique tree, so that we don't
-                // prune it. We end a batch if we encounter a tree that differs from the previous
-                // one, or if we reach the end of the possible duplicates. We get an empty batch if
-                // there are two consecutive differing trees.
-
-                // Work out if we've found a batch, and what its end is.
-                let next_unique_height = if last_unique_tree != next_tree {
-                    // We've found a unique tree that isn't in this batch.
-                    Some(next_height)
-                } else if next_height == initial_tip_height {
-                    // We've reached the end of the possible duplicates without finding a unique
-                    // tree, so the initial tip is a duplicate which must be deleted.
-                    Some(next_height.next())
-                } else {
-                    // We're in the middle of a range of duplicate trees.
-                    None
-                };
-
-                if let Some(next_unique_height) = next_unique_height {
-                    // Start the batch at height just above the height of the last unique tree.
-                    // This excludes the unique tree from the next batch so that we keep the tree
-                    // in the database. This is only a duplicate if the batch has trees in it.
-                    let first_duplicate_height = last_unique_height.next();
-
-                    // TODO: convert zs_delete_range() to take std::ops::RangeBounds
-                    let batch_size = next_unique_height - first_duplicate_height;
-
-                    // Check if we have a non-empty batch. In other words, check if there's at least
-                    // one duplicate tree between the last tree and the new one.
-                    if batch_size > 0 {
-                        let mut batch = DiskWriteBatch::new();
-
-                        // Delete the batch.
-                        //
-                        // The tree at `next_unique_height` doesn't belong to the current batch
-                        // since it differs from the trees in the batch.
-                        if batch_size == 1 {
-                            // # Optimization
-                            //
-                            // Use a faster method if we're deleting a single tree.
-                            batch.delete_sapling_tree(&db, &first_duplicate_height);
-                        } else {
-                            // This is an exclusive end range.
-                            // TODO: convert zs_delete_range() to take std::ops::RangeBounds
-                            batch.delete_range_sapling_tree(
-                                &db,
-                                &first_duplicate_height,
-                                &next_unique_height,
-                            );
-                        }
-
-                        db.write_batch(batch).expect(
-                            "Deleting Sapling note commitment trees should always succeed.",
-                        );
-                    }
-
-                    // Record the height of this unique tree, so we can start a batch after it.
-                    //
-                    // This loop terminates before we get to the tree after the initial tip, so it
-                    // doesn't matter what value we use. (It's handled by the standard write code.)
-                    last_unique_height = next_unique_height;
-
-                    // Compare against this unique tree to find the end of the next batch.
-                    last_unique_tree = next_tree;
+                // Delete any duplicate trees.
+                if tree == last_tree {
+                    let mut batch = DiskWriteBatch::new();
+                    batch.delete_sapling_tree(&db, &height);
+                    db.write_batch(batch)
+                        .expect("Deleting Sapling note commitment trees should always succeed.");
                 }
+
+                // Compare against the last tree to find unique trees.
+                last_tree = tree;
             }
 
-            // The last unique tree's height. Genesis is always unique.
-            let mut last_unique_height = Height(0);
-            // The last unique tree's data.
-            let mut last_unique_tree = db
+            // Prune duplicate Orchard note commitment trees.
+
+            // The last tree we checked.
+            let mut last_tree = db
                 .orchard_tree_by_height(&Height(0))
                 .expect("Checked above that the genesis block is in the database.");
 
             // Run through all the possible duplicate trees in the finalized chain.
             // The block after genesis is the first possible duplicate.
-            for (next_height, next_tree) in
-                db.orchard_tree_by_height_range(Height(1)..=initial_tip_height)
-            {
+            for (height, tree) in db.orchard_tree_by_height_range(Height(1)..=initial_tip_height) {
                 // Return early if there is a cancel signal.
                 if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
                     return;
                 }
 
-                // We delete duplicate trees in batches. A batch is a (possibly empty) series of
-                // identical trees. We start a batch after first unique tree, so that we don't
-                // prune it. We end a batch if we encounter a tree that differs from the previous
-                // one, or if we reach the end of the possible duplicates. We get an empty batch if
-                // there are two consecutive differing trees.
-
-                // Work out if we've found a batch, and what its end is.
-                let next_unique_height = if last_unique_tree != next_tree {
-                    // We've found a unique tree that isn't in this batch.
-                    Some(next_height)
-                } else if next_height == initial_tip_height {
-                    // We've reached the end of the possible duplicates without finding a unique
-                    // tree, so the initial tip is a duplicate which must be deleted.
-                    Some(next_height.next())
-                } else {
-                    // We're in the middle of a range of duplicate trees.
-                    None
-                };
-
-                if let Some(next_unique_height) = next_unique_height {
-                    // Start the batch at height just above the height of the last unique tree.
-                    // This excludes the unique tree from the next batch so that we keep the tree
-                    // in the database. This is only a duplicate if the batch has trees in it.
-                    let first_duplicate_height = last_unique_height.next();
-
-                    // TODO: convert zs_delete_range() to take std::ops::RangeBounds
-                    let batch_size = next_unique_height - first_duplicate_height;
-
-                    // Check if we have a non-empty batch. In other words, check if there's at least
-                    // one duplicate tree between the last tree and the new one.
-                    if batch_size > 0 {
-                        let mut batch = DiskWriteBatch::new();
-
-                        // Delete the batch.
-                        //
-                        // The tree at `next_unique_height` doesn't belong to the current batch
-                        // since it differs from the trees in the batch.
-                        if batch_size == 1 {
-                            // # Optimization
-                            //
-                            // Use a faster method if we're deleting a single tree.
-                            batch.delete_orchard_tree(&db, &first_duplicate_height);
-                        } else {
-                            // This is an exclusive end range.
-                            // TODO: convert zs_delete_range() to take std::ops::RangeBounds
-                            batch.delete_range_orchard_tree(
-                                &db,
-                                &first_duplicate_height,
-                                &next_unique_height,
-                            );
-                        }
-
-                        db.write_batch(batch).expect(
-                            "Deleting Orchard note commitment trees should always succeed.",
-                        );
-                    }
-
-                    // Record the height of this unique tree, so we can start a batch after it.
-                    //
-                    // This loop terminates before we get to the tree after the initial tip, so it
-                    // doesn't matter what value we use. (It's handled by the standard write code.)
-                    last_unique_height = next_unique_height;
-
-                    // Compare against this unique tree to find the end of the next batch.
-                    last_unique_tree = next_tree;
+                // Delete any duplicate trees.
+                if tree == last_tree {
+                    let mut batch = DiskWriteBatch::new();
+                    batch.delete_orchard_tree(&db, &height);
+                    db.write_batch(batch)
+                        .expect("Deleting Orchard note commitment trees should always succeed.");
                 }
+
+                // Compare against the last tree to find unique trees.
+                last_tree = tree;
             }
 
             // Before marking the state as upgraded, check that the upgrade completed successfully.

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -379,6 +379,8 @@ impl DiskWriteBatch {
             .db
             .cf_handle("sapling_note_commitment_tree")
             .unwrap();
+
+        // TODO: convert zs_delete_range() to take std::ops::RangeBounds
         self.zs_delete_range(&sapling_tree_cf, from, to);
     }
 
@@ -397,6 +399,8 @@ impl DiskWriteBatch {
             .db
             .cf_handle("orchard_note_commitment_tree")
             .unwrap();
+
+        // TODO: convert zs_delete_range() to take std::ops::RangeBounds
         self.zs_delete_range(&orchard_tree_cf, from, to);
     }
 }

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -374,6 +374,7 @@ impl DiskWriteBatch {
     }
 
     /// Deletes the range of Sapling note commitment trees at the given [`Height`]s. Doesn't delete the upper bound.
+    #[allow(dead_code)]
     pub fn delete_range_sapling_tree(&mut self, zebra_db: &ZebraDb, from: &Height, to: &Height) {
         let sapling_tree_cf = zebra_db
             .db
@@ -394,6 +395,7 @@ impl DiskWriteBatch {
     }
 
     /// Deletes the range of Orchard note commitment trees at the given [`Height`]s. Doesn't delete the upper bound.
+    #[allow(dead_code)]
     pub fn delete_range_orchard_tree(&mut self, zebra_db: &ZebraDb, from: &Height, to: &Height) {
         let orchard_tree_cf = zebra_db
             .db


### PR DESCRIPTION
## Motivation

This PR contains two different suggestions to fix bugs in PR #7379.

## Alternative Solutions

### Minimal Changes

Commit d70a23304268bc3e9e73aafbd373515efbde74ee contains a minor refactor that simplifies the code to handle the initial tip edge case, regardless of whether it is the same as the genesis tree or not. It also renames some variables to make them clearer.

### Complete Rewrite

Commit b97303f73211df3d87a62e90e7744a6998f239ff rewrites and simplifies the inner loop so these edge cases never occur, by removing the range deletes entirely.

This performs almost as well as ranged deletes on a legacy state with 1719530 blocks, taking 16 seconds to do the upgrade:
```
2023-08-28T01:29:44.261735Z  INFO zebra_state::service::finalized_state::disk_format::upgrade: trying to open older database format: launching upgrade task running_version=Version { major: 25, minor: 1, 
patch: 1 } disk_version=Version { major: 25, minor: 0, patch: 0 }             
...
2023-08-28T01:30:01.122526Z  INFO zebra_state::service::finalized_state::disk_format::upgrade: marked database format as upgraded running_version=Version { major: 25, minor: 1, patch: 1 } format_upgrade_
version=Version { major: 25, minor: 1, patch: 1 } disk_version=Version { major: 25, minor: 0, patch: 0 }
```

## Review

This PR is a suggestion for @upbqdn on PR #7379.

Feel free to choose either suggestion!