### PR TITLE
fix(docs): redundant links in state

### DIFF
--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -693,7 +693,7 @@ impl Chain {
             .cloned()
     }
 
-    /// Returns the Sapling [`NoteCommitmentSubtree`](sapling::tree::NoteCommitmentSubtree) specified
+    /// Returns the Sapling [`NoteCommitmentSubtree`] specified
     /// by a [`HashOrHeight`], if it exists in the non-finalized [`Chain`].
     pub fn sapling_subtree_by_index(
         &self,
@@ -854,7 +854,7 @@ impl Chain {
             .map(|(_height, tree)| tree.clone())
     }
 
-    /// Returns the Orchard [`NoteCommitmentSubtree`](orchard::tree::NoteCommitmentSubtree) specified
+    /// Returns the Orchard [`NoteCommitmentSubtree`] specified
     /// by a [`HashOrHeight`], if it exists in the non-finalized [`Chain`].
     pub fn orchard_subtree(
         &self,

--- a/zebra-state/src/service/read/tree.rs
+++ b/zebra-state/src/service/read/tree.rs
@@ -45,7 +45,7 @@ where
 }
 
 /// Returns the Sapling
-/// [`NoteCommitmentSubtree`](NoteCommitmentSubtree) specified by an
+/// [`NoteCommitmentSubtree`] specified by an
 /// index, if it exists in the non-finalized `chain` or finalized `db`.
 #[allow(unused)]
 pub fn sapling_subtree<C>(
@@ -87,8 +87,7 @@ where
         .or_else(|| db.orchard_tree_by_hash_or_height(hash_or_height))
 }
 
-/// Returns the Orchard
-/// [`NoteCommitmentSubtree`](NoteCommitmentSubtree) specified by an
+/// Returns the Orchard [`NoteCommitmentSubtree`] specified by an
 /// index, if it exists in the non-finalized `chain` or finalized `db`.
 #[allow(unused)]
 pub fn orchard_subtree<C>(


### PR DESCRIPTION
## Motivation

Doc builds are failing by redundant doc links recently introduced.

## Solution

Fix the issues.

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
