### PR TITLE
fix(build): reintroduce `RUST_LOG` info

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,6 +70,9 @@ RUN if [ "$(uname -m)" != "aarch64" ]; then \
 # Build arguments and variables set for tracelog levels and debug information
 #
 # We set defaults to all variables.
+ARG RUST_LOG
+ENV RUST_LOG=${RUST_LOG:-info}
+
 ARG RUST_BACKTRACE
 ENV RUST_BACKTRACE=${RUST_BACKTRACE:-1}
 


### PR DESCRIPTION
## Motivation

Not having the default `info` level causes some tests to not output the needed logs to debug information.

Fix: #7370

## Solution

- Add RUST_LOG `ARG` and `ENV` to the Dockerfile for the whole image

## Review

We should validate the test which gets cancelled is working as expected with this PR

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
