### PR TITLE
fix(ci): allow to set docs build as a required test

### DIFF
--- a/.github/workflows/docs.patch.yml
+++ b/.github/workflows/docs.patch.yml
@@ -1,0 +1,42 @@
+name: Docs
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      # doc source files
+      - 'book/**'
+      - '**/firebase.json'
+      - '**/.firebaserc'
+      - 'katex-header.html'
+      # rustdoc source files
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      # configuration files
+      - '.cargo/config.toml'
+      - '**/clippy.toml'
+      # workflow definitions
+      - '.github/workflows/docs.yml'
+
+jobs:
+  build-docs-book:
+    name: Build and Deploy Zebra Book Docs
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  build-docs-external:
+    name: Build and Deploy Zebra External Docs
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  build-docs-internal:
+    name: Build and Deploy Zebra Internal Docs
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,6 +76,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: r7kamura/rust-problem-matchers@v1.4.0
+
       - name: Setup mdBook
         uses: jontze/action-mdbook@v2.2.1
         with:
@@ -182,6 +184,8 @@ jobs:
         uses: actions/checkout@v3.5.3
         with:
           persist-credentials: false
+
+      - uses: r7kamura/rust-problem-matchers@v1.4.0
 
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v2.0.0

--- a/.github/workflows/lint.patch.yml
+++ b/.github/workflows/lint.patch.yml
@@ -15,9 +15,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
-
-  docs:
-    name: Rust doc
-    runs-on: ubuntu-latest
-    steps:
-      - run: 'echo "No build required"'


### PR DESCRIPTION
## Motivation

When consolidating docs building with docs linting, the linting requirement was removed as a consequence, introducing a bug in CI as it allowed to merge PRs without requiring documentation to pass the linters.

Fixes #7410

### Complex Code or Requirements

Based on a GitHub constrain (https://github.com/orgs/community/discussions/13690) we need to add a `patch` workflow to make a test required in PRs, in case a file not in the `path` is not changed on that PR

## Solution

- Add a patch workflow for documentation building and linting
- Remove an old reference to the previous docs linter

## Review

- After merging this PR, other PRs must be updated
- [x] These jobs must be added as protection rules in the repo settings


### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
