### PR TITLE
change(docs): update docs for new lightwalletd version used in Zebra

### DIFF
--- a/book/src/user/lightwalletd.md
+++ b/book/src/user/lightwalletd.md
@@ -159,7 +159,7 @@ Please refer to [acceptance](https://github.com/ZcashFoundation/zebra/blob/main/
 The final goal is to connect wallets to the lightwalletd service backed by Zebra. 
 
 For demo purposes we used [zecwallet-cli](https://github.com/adityapk00/zecwallet-light-cli) with the [adityapk00/lightwalletd](https://github.com/adityapk00/lightwalletd) fork.
-[zecwallet-cli](https://github.com/adityapk00/zecwallet-light-cli) with [zcash/lightwalletd](https://github.com/zcash/lightwalletd) fork was not yet tested.
+We didn't test [zecwallet-cli](https://github.com/adityapk00/zecwallet-light-cli) with [zcash/lightwalletd](https://github.com/zcash/lightwalletd) yet.
 
 Make sure both `zebrad` and `lightwalletd` are running and listening.
 

--- a/book/src/user/lightwalletd.md
+++ b/book/src/user/lightwalletd.md
@@ -2,7 +2,7 @@
 
 Zebra's RPC methods can support a lightwalletd service backed by zebrad. We
 recommend using
-[adityapk00/lightwalletd](https://github.com/adityapk00/lightwalletd) because we
+[zcash/lightwalletd](https://github.com/zcash/lightwalletd) because we
 use it in testing. Other `lightwalletd` forks have limited support, see the
 [Sync lightwalletd](#sync-lightwalletd) section for more info.
 
@@ -92,14 +92,14 @@ For implementing zebra as a service please see [here](https://github.com/ZcashFo
 ## Download and build lightwalletd
 [#download-and-build-lightwalletd]: #download-and-build-lightwalletd
 
-While you synchronize Zebra you can install [lightwalletd](https://github.com/adityapk00/lightwalletd).
+While you synchronize Zebra you can install [lightwalletd](https://github.com/zcash/lightwalletd).
 
 Before installing, you need to have `go` in place. Please visit the [go install page](https://go.dev/doc/install) with download and installation instructions.
 
 With go installed and in your path, download and install lightwalletd:
 
 ```console
-git clone https://github.com/adityapk00/lightwalletd
+git clone https://github.com/zcash/lightwalletd
 cd lightwalletd
 make
 make install
@@ -112,7 +112,7 @@ If everything went good you should have a `lightwalletd` binary in `~/go/bin/`.
 
 Please make sure you have zebrad running (with RPC endpoint and up to date blockchain) to synchronize lightwalletd.
 
-- `lightwalletd` requires a `zcash.conf` file, however this file can be empty if you are using the default Zebra rpc endpoint (`127.0.0.1:8232`) and the `adityapk00/lightwalletd` fork 
+- `lightwalletd` requires a `zcash.conf` file, however this file can be empty if you are using the default Zebra rpc endpoint (`127.0.0.1:8232`) and the `zcash/lightwalletd` fork.
     - Some `lightwalletd` forks also require a `rpcuser` and `rpcpassword`, but Zebra ignores them if it receives them from `lightwalletd`
     - When using a non-default port, use `rpcport=28232` and `rpcbind=127.0.0.1`
     - When using testnet, use `testnet=1`
@@ -158,7 +158,8 @@ Please refer to [acceptance](https://github.com/ZcashFoundation/zebra/blob/main/
 
 The final goal is to connect wallets to the lightwalletd service backed by Zebra. 
 
-For demo purposes we use [zecwallet-cli](https://github.com/adityapk00/zecwallet-light-cli).
+For demo purposes we used [zecwallet-cli](https://github.com/adityapk00/zecwallet-light-cli) with the [adityapk00/lightwalletd](https://github.com/adityapk00/lightwalletd) fork.
+[zecwallet-cli](https://github.com/adityapk00/zecwallet-light-cli) with [zcash/lightwalletd](https://github.com/zcash/lightwalletd) fork was not yet tested.
 
 Make sure both `zebrad` and `lightwalletd` are running and listening.
 

--- a/zebra-rpc/src/constants.rs
+++ b/zebra-rpc/src/constants.rs
@@ -14,7 +14,7 @@ pub const INVALID_PARAMETERS_ERROR_CODE: ErrorCode = ErrorCode::ServerError(-1);
 /// The RPC error code used by `zcashd` for missing blocks.
 ///
 /// `lightwalletd` expects error code `-8` when a block is not found:
-/// <https://github.com/adityapk00/lightwalletd/blob/c1bab818a683e4de69cd952317000f9bb2932274/common/common.go#L251-L254>
+/// <https://github.com/zcash/lightwalletd/blob/v0.4.16/common/common.go#L287-L290>
 pub const MISSING_BLOCK_ERROR_CODE: ErrorCode = ErrorCode::ServerError(-8);
 
 /// When logging parameter data, only log this much data.

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -288,7 +288,7 @@ async fn rpc_getblock_missing_error() {
     );
 
     // Make sure Zebra returns the correct error code `-8` for missing blocks
-    // https://github.com/adityapk00/lightwalletd/blob/c1bab818a683e4de69cd952317000f9bb2932274/common/common.go#L251-L254
+    // https://github.com/zcash/lightwalletd/blob/v0.4.16/common/common.go#L287-L290
     let block_future = tokio::spawn(rpc.get_block("0".to_string(), Some(0u8)));
 
     // Make the mock service respond with no block

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -57,8 +57,11 @@
 //!
 //! The lightwalletd software is an interface service that uses zebrad or zcashd RPC methods to serve wallets or other applications with blockchain content in an efficient manner.
 //! There are several versions of lightwalled in the form of different forks. The original
-//! repo is <https://github.com/zcash/lightwalletd> but Zecwallet Lite uses a custom fork: <https://github.com/adityapk00/lightwalletd>.
-//! The custom fork from adityapk00 is the one Zebra use for this tests:
+//! repo is <https://github.com/zcash/lightwalletd>, zecwallet Lite uses a custom fork: <https://github.com/adityapk00/lightwalletd>.
+//! Initially this tests were made with `adityapk00/lightwalletd` fork but changes for fast spendability support had
+//! been made to `zcash/lightwalletd` only.
+//!
+//! We expect `adityapk00/lightwalletd` to remain working with Zebra but for this tests we are using `zcash/lightwalletd`.
 //!
 //! Zebra lightwalletd tests are not all marked as ignored but none will run unless
 //! at least the `ZEBRA_TEST_LIGHTWALLETD` environment variable is present:

--- a/zebrad/tests/common/failure_messages.rs
+++ b/zebrad/tests/common/failure_messages.rs
@@ -70,6 +70,8 @@ pub const LIGHTWALLETD_FAILURE_MESSAGES: &[&str] = &[
     "into Go value of type",
     // lightwalletd custom RPC error messages from:
     // https://github.com/adityapk00/lightwalletd/blob/master/common/common.go
+    // TODO: support messages from both implementations if there are differences?
+    // https://github.com/zcash/lightwalletd/blob/v0.4.16/common/common.go
     "block requested is newer than latest block",
     "Cache add failed",
     "error decoding",


### PR DESCRIPTION
## Motivation

Update docs for the switch of lightwalletd made in https://github.com/ZcashFoundation/zebra/pull/7307

Close https://github.com/ZcashFoundation/zebra/issues/7319

## Solution

Originally this changes were done at https://github.com/ZcashFoundation/zebra/pull/7349 with some test changes too.

However the test changes were harder than expected so we decided to split the docs changes in this PR while keeping the test investigation in the older one. 

## Review

Anyone can review, these are just doc changes.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Lightwalletd test changes, updates are not working as expected in CI. https://github.com/ZcashFoundation/zebra/pull/7349