### PR TITLE
fix(ci): Use correct testnet checkpoint job height regex

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -570,7 +570,7 @@ jobs:
       disk_suffix: tip
       root_state_path: '/var/cache'
       zebra_state_dir: 'zebrad-cache'
-      height_grep_text: 'current_height.*=.*Height.*\('
+      height_grep_text: 'zebra_tip_height.*=.*Height.*\('
     secrets: inherit
 
   # lightwalletd cached tip state tests


### PR DESCRIPTION
## Motivation

The testnet checkpoint job is the only testnet job that runs regularly, so it needs to save the checkpoint cached state disk. But it doesn't show the `zebrad` logs, to make checkpoints easier to find and copy.

So we need to look for the line where the test harness logs the `zebrad` height instead.

## Solution

Find this line:
https://github.com/ZcashFoundation/zebra/actions/runs/6029885728/job/16362255999?pr=7431#step:13:269

Instead of the `zebrad` progress log line.

## Review

This is a routine fix but it's showing some failures on PRs. Those failures don't block merging but they are confusing.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

