### PR TITLE
change(state): Restrict access to types for database writes

### DIFF
--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -66,7 +66,7 @@ pub use response::GetBlockTemplateChainInfo;
 pub use service::{
     arbitrary::{populated_state, CHAIN_TIP_UPDATE_WAIT_LIMIT},
     chain_tip::{ChainTipBlock, ChainTipSender},
-    finalized_state::{DiskWriteBatch, WriteDisk, MAX_ON_DISK_HEIGHT},
+    finalized_state::MAX_ON_DISK_HEIGHT,
     init_test, init_test_services, ReadStateService,
 };
 

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -42,10 +42,7 @@ pub use disk_format::{OutputIndex, OutputLocation, TransactionLocation, MAX_ON_D
 
 pub(super) use zebra_db::ZebraDb;
 
-#[cfg(not(any(test, feature = "proptest-impl")))]
-pub(super) use disk_db::DiskWriteBatch;
-#[cfg(any(test, feature = "proptest-impl"))]
-pub use disk_db::{DiskWriteBatch, WriteDisk};
+use disk_db::DiskWriteBatch;
 
 /// The finalized part of the chain state, stored in the db.
 ///

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -95,7 +95,7 @@ pub struct DiskDb {
 //       and make them accessible via read-only methods
 #[must_use = "batches must be written to the database"]
 #[derive(Default)]
-pub struct DiskWriteBatch {
+pub(crate) struct DiskWriteBatch {
     /// The inner RocksDB write batch.
     batch: rocksdb::WriteBatch,
 }
@@ -605,7 +605,7 @@ impl DiskDb {
     // Low-level write methods are located in the WriteDisk trait
 
     /// Writes `batch` to the database.
-    pub fn write(&self, batch: DiskWriteBatch) -> Result<(), rocksdb::Error> {
+    pub(crate) fn write(&self, batch: DiskWriteBatch) -> Result<(), rocksdb::Error> {
         self.db.write(batch.batch)
     }
 


### PR DESCRIPTION
## Motivation

Close #7418.

Depends-On: #7437 

## Solution

This is a quick fix that makes `DiskWriteBatch` and `WriteDisk` available only in the finalized state.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
