### PR TITLE
RPC testing branch with `z_getsubtreesbyindex` RPC and state data

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -2,6 +2,8 @@
 
 use std::{collections::HashMap, fmt, ops::Neg, sync::Arc};
 
+use halo2::pasta::pallas;
+
 use crate::{
     amount::NegativeAllowed,
     block::merkle::AuthDataRoot,
@@ -152,16 +154,30 @@ impl Block {
 
     /// Access the [`orchard::Nullifier`]s from all transactions in this block.
     pub fn orchard_nullifiers(&self) -> impl Iterator<Item = &orchard::Nullifier> {
-        // Work around a compiler panic (ICE) with flat_map():
-        // https://github.com/rust-lang/rust/issues/105044
-        #[allow(clippy::needless_collect)]
-        let nullifiers: Vec<_> = self
-            .transactions
+        self.transactions
             .iter()
             .flat_map(|transaction| transaction.orchard_nullifiers())
-            .collect();
+    }
 
-        nullifiers.into_iter()
+    /// Access the [`sprout::NoteCommitment`]s from all transactions in this block.
+    pub fn sprout_note_commitments(&self) -> impl Iterator<Item = &sprout::NoteCommitment> {
+        self.transactions
+            .iter()
+            .flat_map(|transaction| transaction.sprout_note_commitments())
+    }
+
+    /// Access the [sapling note commitments](jubjub::Fq) from all transactions in this block.
+    pub fn sapling_note_commitments(&self) -> impl Iterator<Item = &jubjub::Fq> {
+        self.transactions
+            .iter()
+            .flat_map(|transaction| transaction.sapling_note_commitments())
+    }
+
+    /// Access the [orchard note commitments](pallas::Base) from all transactions in this block.
+    pub fn orchard_note_commitments(&self) -> impl Iterator<Item = &pallas::Base> {
+        self.transactions
+            .iter()
+            .flat_map(|transaction| transaction.orchard_note_commitments())
     }
 
     /// Count how many Sapling transactions exist in a block,

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -364,6 +364,7 @@ impl NoteCommitmentTree {
     }
 
     /// Returns the subtree index at [`TRACKED_SUBTREE_HEIGHT`].
+    /// This is the number of complete or incomplete subtrees that are currently in the tree.
     /// Returns `None` if the tree is empty.
     #[allow(clippy::unwrap_in_result)]
     pub fn subtree_index(&self) -> Option<NoteCommitmentSubtreeIndex> {

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -347,6 +347,11 @@ impl NoteCommitmentTree {
         }
     }
 
+    /// Returns frontier of non-empty tree, or None.
+    pub fn frontier(&self) -> Option<&NonEmptyFrontier<Node>> {
+        self.inner.value()
+    }
+
     /// Returns true if the most recently appended leaf completes the subtree
     pub fn is_complete_subtree(tree: &NonEmptyFrontier<Node>) -> bool {
         tree.position()

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -31,7 +31,7 @@ use crate::{
     serialization::{
         serde_helpers, ReadZcashExt, SerializationError, ZcashDeserialize, ZcashSerialize,
     },
-    subtree::TRACKED_SUBTREE_HEIGHT,
+    subtree::{NoteCommitmentSubtreeIndex, TRACKED_SUBTREE_HEIGHT},
 };
 
 pub mod legacy;
@@ -376,7 +376,7 @@ impl NoteCommitmentTree {
 
     /// Returns subtree index and root if the most recently appended leaf completes the subtree
     #[allow(clippy::unwrap_in_result)]
-    pub fn completed_subtree_index_and_root(&self) -> Option<(u16, Node)> {
+    pub fn completed_subtree_index_and_root(&self) -> Option<(NoteCommitmentSubtreeIndex, Node)> {
         if !self.is_complete_subtree() {
             return None;
         }

--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -347,33 +347,43 @@ impl NoteCommitmentTree {
         }
     }
 
-    /// Returns frontier of non-empty tree, or None.
-    pub fn frontier(&self) -> Option<&NonEmptyFrontier<Node>> {
+    /// Returns frontier of non-empty tree, or `None` if the tree is empty.
+    fn frontier(&self) -> Option<&NonEmptyFrontier<Node>> {
         self.inner.value()
     }
 
     /// Returns true if the most recently appended leaf completes the subtree
-    pub fn is_complete_subtree(tree: &NonEmptyFrontier<Node>) -> bool {
+    pub fn is_complete_subtree(&self) -> bool {
+        let Some(tree) = self.frontier() else {
+            // An empty tree can't be a complete subtree.
+            return false;
+        };
+
         tree.position()
             .is_complete_subtree(TRACKED_SUBTREE_HEIGHT.into())
     }
 
-    /// Returns subtree address at [`TRACKED_SUBTREE_HEIGHT`]
-    pub fn subtree_address(tree: &NonEmptyFrontier<Node>) -> incrementalmerkletree::Address {
-        incrementalmerkletree::Address::above_position(
+    /// Returns the subtree address at [`TRACKED_SUBTREE_HEIGHT`].
+    /// Returns `None` if the tree is empty.
+    pub fn subtree_address(&self) -> Option<incrementalmerkletree::Address> {
+        let tree = self.frontier()?;
+
+        Some(incrementalmerkletree::Address::above_position(
             TRACKED_SUBTREE_HEIGHT.into(),
             tree.position(),
-        )
+        ))
     }
 
     /// Returns subtree index and root if the most recently appended leaf completes the subtree
     #[allow(clippy::unwrap_in_result)]
     pub fn completed_subtree_index_and_root(&self) -> Option<(u16, Node)> {
-        let value = self.inner.value()?;
-        Self::is_complete_subtree(value).then_some(())?;
-        let address = Self::subtree_address(value);
+        if !self.is_complete_subtree() {
+            return None;
+        }
+
+        let address = self.subtree_address()?;
         let index = address.index().try_into().expect("should fit in u16");
-        let root = value.root(Some(TRACKED_SUBTREE_HEIGHT.into()));
+        let root = self.frontier()?.root(Some(TRACKED_SUBTREE_HEIGHT.into()));
 
         Some((index, root))
     }

--- a/zebra-chain/src/parallel/tree.rs
+++ b/zebra-chain/src/parallel/tree.rs
@@ -69,24 +69,9 @@ impl NoteCommitmentTrees {
             ..
         } = self.clone();
 
-        let sprout_note_commitments: Vec<_> = block
-            .transactions
-            .iter()
-            .flat_map(|tx| tx.sprout_note_commitments())
-            .cloned()
-            .collect();
-        let sapling_note_commitments: Vec<_> = block
-            .transactions
-            .iter()
-            .flat_map(|tx| tx.sapling_note_commitments())
-            .cloned()
-            .collect();
-        let orchard_note_commitments: Vec<_> = block
-            .transactions
-            .iter()
-            .flat_map(|tx| tx.orchard_note_commitments())
-            .cloned()
-            .collect();
+        let sprout_note_commitments: Vec<_> = block.sprout_note_commitments().cloned().collect();
+        let sapling_note_commitments: Vec<_> = block.sapling_note_commitments().cloned().collect();
+        let orchard_note_commitments: Vec<_> = block.orchard_note_commitments().cloned().collect();
 
         let mut sprout_result = None;
         let mut sapling_result = None;

--- a/zebra-chain/src/parallel/tree.rs
+++ b/zebra-chain/src/parallel/tree.rs
@@ -4,7 +4,11 @@ use std::sync::Arc;
 
 use thiserror::Error;
 
-use crate::{block::Block, orchard, sapling, sprout, subtree::NoteCommitmentSubtree};
+use crate::{
+    block::Block,
+    orchard, sapling, sprout,
+    subtree::{NoteCommitmentSubtree, NoteCommitmentSubtreeIndex},
+};
 
 /// An argument wrapper struct for note commitment trees.
 #[derive(Clone, Debug)]
@@ -163,7 +167,7 @@ impl NoteCommitmentTrees {
     ) -> Result<
         (
             Arc<sapling::tree::NoteCommitmentTree>,
-            Option<(u16, sapling::tree::Node)>,
+            Option<(NoteCommitmentSubtreeIndex, sapling::tree::Node)>,
         ),
         NoteCommitmentTreeError,
     > {
@@ -202,7 +206,7 @@ impl NoteCommitmentTrees {
     ) -> Result<
         (
             Arc<orchard::tree::NoteCommitmentTree>,
-            Option<(u16, orchard::tree::Node)>,
+            Option<(NoteCommitmentSubtreeIndex, orchard::tree::Node)>,
         ),
         NoteCommitmentTreeError,
     > {

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -32,7 +32,7 @@ use crate::{
     serialization::{
         serde_helpers, ReadZcashExt, SerializationError, ZcashDeserialize, ZcashSerialize,
     },
-    subtree::TRACKED_SUBTREE_HEIGHT,
+    subtree::{NoteCommitmentSubtreeIndex, TRACKED_SUBTREE_HEIGHT},
 };
 
 pub mod legacy;
@@ -361,7 +361,7 @@ impl NoteCommitmentTree {
 
     /// Returns subtree index and root if the most recently appended leaf completes the subtree
     #[allow(clippy::unwrap_in_result)]
-    pub fn completed_subtree_index_and_root(&self) -> Option<(u16, Node)> {
+    pub fn completed_subtree_index_and_root(&self) -> Option<(NoteCommitmentSubtreeIndex, Node)> {
         if !self.is_complete_subtree() {
             return None;
         }

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -348,26 +348,30 @@ impl NoteCommitmentTree {
             .is_complete_subtree(TRACKED_SUBTREE_HEIGHT.into())
     }
 
-    /// Returns the subtree address at [`TRACKED_SUBTREE_HEIGHT`].
+    /// Returns the subtree index at [`TRACKED_SUBTREE_HEIGHT`].
     /// Returns `None` if the tree is empty.
-    pub fn subtree_address(&self) -> Option<incrementalmerkletree::Address> {
+    #[allow(clippy::unwrap_in_result)]
+    pub fn subtree_index(&self) -> Option<NoteCommitmentSubtreeIndex> {
         let tree = self.frontier()?;
 
-        Some(incrementalmerkletree::Address::above_position(
+        let index = incrementalmerkletree::Address::above_position(
             TRACKED_SUBTREE_HEIGHT.into(),
             tree.position(),
-        ))
+        )
+        .index()
+        .try_into()
+        .expect("fits in u16");
+
+        Some(index)
     }
 
     /// Returns subtree index and root if the most recently appended leaf completes the subtree
-    #[allow(clippy::unwrap_in_result)]
     pub fn completed_subtree_index_and_root(&self) -> Option<(NoteCommitmentSubtreeIndex, Node)> {
         if !self.is_complete_subtree() {
             return None;
         }
 
-        let address = self.subtree_address()?;
-        let index = address.index().try_into().expect("should fit in u16");
+        let index = self.subtree_index()?;
         let root = self.frontier()?.root(Some(TRACKED_SUBTREE_HEIGHT.into()));
 
         Some((index, root))

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -349,6 +349,7 @@ impl NoteCommitmentTree {
     }
 
     /// Returns the subtree index at [`TRACKED_SUBTREE_HEIGHT`].
+    /// This is the number of complete or incomplete subtrees that are currently in the tree.
     /// Returns `None` if the tree is empty.
     #[allow(clippy::unwrap_in_result)]
     pub fn subtree_index(&self) -> Option<NoteCommitmentSubtreeIndex> {

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -332,6 +332,11 @@ impl NoteCommitmentTree {
         }
     }
 
+    /// Returns frontier of non-empty tree, or None.
+    pub fn frontier(&self) -> Option<&NonEmptyFrontier<Node>> {
+        self.inner.value()
+    }
+
     /// Returns true if the most recently appended leaf completes the subtree
     pub fn is_complete_subtree(tree: &NonEmptyFrontier<Node>) -> bool {
         tree.position()

--- a/zebra-chain/src/subtree.rs
+++ b/zebra-chain/src/subtree.rs
@@ -1,6 +1,6 @@
 //! Struct representing Sapling/Orchard note commitment subtrees
 
-use std::sync::Arc;
+use std::{num::TryFromIntError, sync::Arc};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
@@ -17,6 +17,14 @@ pub struct NoteCommitmentSubtreeIndex(pub u16);
 impl From<u16> for NoteCommitmentSubtreeIndex {
     fn from(value: u16) -> Self {
         Self(value)
+    }
+}
+
+impl TryFrom<u64> for NoteCommitmentSubtreeIndex {
+    type Error = TryFromIntError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        u16::try_from(value).map(Self)
     }
 }
 

--- a/zebra-chain/src/subtree.rs
+++ b/zebra-chain/src/subtree.rs
@@ -28,6 +28,14 @@ impl TryFrom<u64> for NoteCommitmentSubtreeIndex {
     }
 }
 
+// If we want to automatically convert NoteCommitmentSubtreeIndex to the generic integer literal
+// type, we can only implement conversion into u64. (Or u16, but not both.)
+impl From<NoteCommitmentSubtreeIndex> for u64 {
+    fn from(value: NoteCommitmentSubtreeIndex) -> Self {
+        value.0.into()
+    }
+}
+
 /// Subtree root of Sapling or Orchard note commitment tree,
 /// with its associated block height and subtree index.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/zebra-chain/src/subtree.rs
+++ b/zebra-chain/src/subtree.rs
@@ -11,7 +11,7 @@ use crate::block::Height;
 pub const TRACKED_SUBTREE_HEIGHT: u8 = 16;
 
 /// A subtree index
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct NoteCommitmentSubtreeIndex(pub u16);
 
 impl From<u16> for NoteCommitmentSubtreeIndex {

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -25,13 +25,21 @@ use zebra_chain::{
     parameters::{ConsensusBranchId, Network, NetworkUpgrade},
     sapling,
     serialization::{SerializationError, ZcashDeserialize},
+    subtree::NoteCommitmentSubtreeIndex,
     transaction::{self, SerializedTransaction, Transaction, UnminedTx},
     transparent::{self, Address},
 };
 use zebra_node_services::mempool;
 use zebra_state::{HashOrHeight, MinedTx, OutputIndex, OutputLocation, TransactionLocation};
 
-use crate::{constants::MISSING_BLOCK_ERROR_CODE, queue::Queue};
+use crate::{
+    constants::{INVALID_PARAMETERS_ERROR_CODE, MISSING_BLOCK_ERROR_CODE},
+    methods::trees::{GetSubtrees, SubtreeRpcData},
+    queue::Queue,
+};
+
+// We don't use a types/ module here, because it is redundant.
+pub mod trees;
 
 #[cfg(feature = "getblocktemplate-rpcs")]
 pub mod get_block_template_rpcs;
@@ -171,6 +179,31 @@ pub trait Rpc {
     /// negative heights.
     #[rpc(name = "z_gettreestate")]
     fn z_get_treestate(&self, hash_or_height: String) -> BoxFuture<Result<GetTreestate>>;
+
+    /// Returns information about a range of Sapling or Orchard subtrees.
+    ///
+    /// zcashd reference: [`z_getsubtreesbyindex`](https://zcash.github.io/rpc/z_getsubtreesbyindex.html)
+    ///
+    /// # Parameters
+    ///
+    /// - `pool`: (string, required) The pool from which subtrees should be returned.
+    ///           Either "sapling" or "orchard".
+    /// - `start_index`: (numeric, required) The index of the first 2^16-leaf subtree to return.
+    /// - `limit`: (numeric, optional) The maximum number of subtree values to return.
+    ///
+    /// # Notes
+    ///
+    /// While Zebra is doing its initial subtree index rebuild, subtrees will become available
+    /// starting at the chain tip. This RPC will return an empty list if the `start_index` subtree
+    /// exists, but has not been rebuilt yet. This matches `zcashd`'s behaviour when subtrees aren't
+    /// available yet. (But `zcashd` does its rebuild before syncing any blocks.)
+    #[rpc(name = "z_getsubtreesbyindex")]
+    fn z_get_subtrees_by_index(
+        &self,
+        pool: String,
+        start_index: NoteCommitmentSubtreeIndex,
+        limit: Option<NoteCommitmentSubtreeIndex>,
+    ) -> BoxFuture<Result<GetSubtrees>>;
 
     /// Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
     ///
@@ -1104,6 +1137,88 @@ where
                     },
                 },
             })
+        }
+        .boxed()
+    }
+
+    fn z_get_subtrees_by_index(
+        &self,
+        pool: String,
+        start_index: NoteCommitmentSubtreeIndex,
+        limit: Option<NoteCommitmentSubtreeIndex>,
+    ) -> BoxFuture<Result<GetSubtrees>> {
+        let mut state = self.state.clone();
+
+        async move {
+            const POOL_LIST: &[&str] = &["sapling", "orchard"];
+
+            if pool == "sapling" {
+                let request = zebra_state::ReadRequest::SaplingSubtrees { start_index, limit };
+                let response = state
+                    .ready()
+                    .and_then(|service| service.call(request))
+                    .await
+                    .map_err(|error| Error {
+                        code: ErrorCode::ServerError(0),
+                        message: error.to_string(),
+                        data: None,
+                    })?;
+
+                let subtrees = match response {
+                    zebra_state::ReadResponse::SaplingSubtrees(subtrees) => subtrees,
+                    _ => unreachable!("unmatched response to a subtrees request"),
+                };
+
+                let subtrees = subtrees
+                    .values()
+                    .map(|subtree| SubtreeRpcData {
+                        node: subtree.node.encode_hex(),
+                        end: subtree.end,
+                    })
+                    .collect();
+
+                Ok(GetSubtrees {
+                    pool,
+                    start_index,
+                    subtrees,
+                })
+            } else if pool == "orchard" {
+                let request = zebra_state::ReadRequest::OrchardSubtrees { start_index, limit };
+                let response = state
+                    .ready()
+                    .and_then(|service| service.call(request))
+                    .await
+                    .map_err(|error| Error {
+                        code: ErrorCode::ServerError(0),
+                        message: error.to_string(),
+                        data: None,
+                    })?;
+
+                let subtrees = match response {
+                    zebra_state::ReadResponse::OrchardSubtrees(subtrees) => subtrees,
+                    _ => unreachable!("unmatched response to a subtrees request"),
+                };
+
+                let subtrees = subtrees
+                    .values()
+                    .map(|subtree| SubtreeRpcData {
+                        node: subtree.node.encode_hex(),
+                        end: subtree.end,
+                    })
+                    .collect();
+
+                Ok(GetSubtrees {
+                    pool,
+                    start_index,
+                    subtrees,
+                })
+            } else {
+                Err(Error {
+                    code: INVALID_PARAMETERS_ERROR_CODE,
+                    message: format!("invalid pool name, must be one of: {:?}", POOL_LIST),
+                    data: None,
+                })
+            }
         }
         .boxed()
     }

--- a/zebra-rpc/src/methods/trees.rs
+++ b/zebra-rpc/src/methods/trees.rs
@@ -1,0 +1,31 @@
+//! Types and functions for note commitment tree RPCs.
+//
+// TODO: move the *Tree and *Commitment types into this module.
+
+use zebra_chain::subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex};
+
+/// A subtree data type that can hold Sapling or Orchard subtree roots.
+pub type SubtreeRpcData = NoteCommitmentSubtreeData<String>;
+
+/// Response to a `z_getsubtreesbyindex` RPC request.
+///
+/// Contains the Sapling or Orchard pool label, the index of the first subtree in the list,
+/// and a list of subtree roots and end heights.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+pub struct GetSubtrees {
+    /// The shielded pool to which the subtrees belong.
+    //
+    // TODO: consider an enum with a string conversion?
+    pub pool: String,
+
+    /// The index of the first subtree.
+    pub start_index: NoteCommitmentSubtreeIndex,
+
+    /// A sequential list of complete subtrees, in `index` order.
+    ///
+    /// The generic subtree root type is a hex-encoded Sapling or Orchard subtree root string.
+    //
+    // TODO: is this needed?
+    //#[serde(skip_serializing_if = "Vec::is_empty")]
+    pub subtrees: Vec<SubtreeRpcData>,
+}

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -48,11 +48,11 @@ pub(crate) const DATABASE_FORMAT_VERSION: u64 = 25;
 /// - adding new column families,
 /// - changing the format of a column family in a compatible way, or
 /// - breaking changes with compatibility code in all supported Zebra versions.
-pub(crate) const DATABASE_FORMAT_MINOR_VERSION: u64 = 1;
+pub(crate) const DATABASE_FORMAT_MINOR_VERSION: u64 = 2;
 
 /// The database format patch version, incremented each time the on-disk database format has a
 /// significant format compatibility fix.
-pub(crate) const DATABASE_FORMAT_PATCH_VERSION: u64 = 1;
+pub(crate) const DATABASE_FORMAT_PATCH_VERSION: u64 = 0;
 
 /// The name of the file containing the minor and patch database versions.
 ///

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -98,7 +98,7 @@ impl FinalizedState {
         network: Network,
         #[cfg(feature = "elasticsearch")] elastic_db: Option<elasticsearch::Elasticsearch>,
     ) -> Self {
-        let db = ZebraDb::new(config, network);
+        let db = ZebraDb::new(config, network, false);
 
         #[cfg(feature = "elasticsearch")]
         let new_state = Self {

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -25,6 +25,8 @@ use crate::{
     Config,
 };
 
+mod add_subtrees;
+
 /// The kind of database format change we're performing.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DbFormatChange {

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -226,7 +226,7 @@ impl DbFormatChange {
         // - since this Zebra code knows how to de-duplicate trees, downgrades using this code
         //   still know how to make sure trees are unique
         Self::check_for_duplicate_trees(upgrade_db.clone());
-        add_subtrees::check(&upgrade_db, &cancel_receiver)?;
+        add_subtrees::check(&upgrade_db);
 
         Ok(())
     }
@@ -359,7 +359,7 @@ impl DbFormatChange {
             add_subtrees::run(initial_tip_height, &db, cancel_receiver)?;
 
             // Before marking the state as upgraded, check that the upgrade completed successfully.
-            add_subtrees::check(&db, cancel_receiver)?;
+            add_subtrees::check(&db);
 
             // Mark the database as upgraded. Zebra won't repeat the upgrade anymore once the
             // database is marked, so the upgrade MUST be complete at this point.

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -366,11 +366,6 @@ impl DbFormatChange {
             Self::mark_as_upgraded_to(&version_for_adding_subtrees, &config, network);
         }
 
-        info!(
-            ?newer_running_version,
-            "Zebra automatically upgraded the database format to:"
-        );
-
         // # New Upgrades Usually Go Here
         //
         // New code goes above this comment!
@@ -378,6 +373,11 @@ impl DbFormatChange {
         // Run the latest format upgrade code after the other upgrades are complete,
         // then mark the format as upgraded. The code should check `cancel_receiver`
         // every time it runs its inner update loop.
+
+        info!(
+            ?newer_running_version,
+            "Zebra automatically upgraded the database format to:"
+        );
 
         Ok(())
     }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -341,10 +341,6 @@ impl DbFormatChange {
 
             // Mark the database as upgraded. Zebra won't repeat the upgrade anymore once the
             // database is marked, so the upgrade MUST be complete at this point.
-            info!(
-                ?newer_running_version,
-                "Zebra automatically upgraded the database format to:"
-            );
             Self::mark_as_upgraded_to(&version_for_pruning_trees, &config, network);
         }
 
@@ -364,12 +360,13 @@ impl DbFormatChange {
 
             // Mark the database as upgraded. Zebra won't repeat the upgrade anymore once the
             // database is marked, so the upgrade MUST be complete at this point.
-            info!(
-                ?newer_running_version,
-                "Zebra automatically upgraded the database format to:"
-            );
             Self::mark_as_upgraded_to(&version_for_adding_subtrees, &config, network);
         }
+
+        info!(
+            ?newer_running_version,
+            "Zebra automatically upgraded the database format to:"
+        );
 
         // # New Upgrades Usually Go Here
         //

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -25,7 +25,7 @@ use crate::{
     Config,
 };
 
-mod add_subtrees;
+pub(crate) mod add_subtrees;
 
 /// The kind of database format change we're performing.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -220,11 +220,12 @@ impl DbFormatChange {
             }
         }
 
-        // This check should pass for all format changes:
-        // - upgrades should de-duplicate trees if needed (and they already do this check)
-        // - an empty state doesn't have any trees, so it can't have duplicate trees
-        // - since this Zebra code knows how to de-duplicate trees, downgrades using this code
-        //   still know how to make sure trees are unique
+        // These checks should pass for all format changes:
+        // - upgrades should produce a valid format (and they already do that check)
+        // - an empty state should pass all the format checks
+        // - since the running Zebra code knows how to upgrade the database to this format,
+        //   downgrades using this running code still know how to create a valid database
+        //   (unless a future upgrade breaks these format checks)
         Self::check_for_duplicate_trees(upgrade_db.clone());
         add_subtrees::check(&upgrade_db);
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -191,14 +191,20 @@ pub fn check(db: &ZebraDb) {
 ///
 /// If a note commitment subtree is missing or incorrect.
 fn check_sapling_subtrees(db: &ZebraDb) -> bool {
-    let Some(NoteCommitmentSubtreeIndex(last_subtree_index)) = db.sapling_tree().subtree_index()
+    let Some(NoteCommitmentSubtreeIndex(mut first_incomplete_subtree_index)) =
+        db.sapling_tree().subtree_index()
     else {
         return true;
     };
 
+    // If there are no incomplete subtrees in the tree, also expect a subtree for the final index.
+    if db.sapling_tree().is_complete_subtree() {
+        first_incomplete_subtree_index += 1;
+    }
+
     let mut is_valid = true;
-    for index in 0..last_subtree_index {
-        // Check that there's a continuous range of subtrees from index [0, last_subtree_index)
+    for index in 0..first_incomplete_subtree_index {
+        // Check that there's a continuous range of subtrees from index [0, first_incomplete_subtree_index)
         let Some(subtree) = db.sapling_subtree_by_index(index) else {
             warn!(index, "missing subtree");
             is_valid = false;
@@ -295,14 +301,20 @@ fn check_sapling_subtrees(db: &ZebraDb) -> bool {
 ///
 /// If a note commitment subtree is missing or incorrect.
 fn check_orchard_subtrees(db: &ZebraDb) -> bool {
-    let Some(NoteCommitmentSubtreeIndex(last_subtree_index)) = db.orchard_tree().subtree_index()
+    let Some(NoteCommitmentSubtreeIndex(mut first_incomplete_subtree_index)) =
+        db.orchard_tree().subtree_index()
     else {
         return true;
     };
 
+    // If there are no incomplete subtrees in the tree, also expect a subtree for the final index.
+    if db.orchard_tree().is_complete_subtree() {
+        first_incomplete_subtree_index += 1;
+    }
+
     let mut is_valid = true;
-    for index in 0..last_subtree_index {
-        // Check that there's a continuous range of subtrees from index [0, last_subtree_index)
+    for index in 0..first_incomplete_subtree_index {
+        // Check that there's a continuous range of subtrees from index [0, first_incomplete_subtree_index)
         let Some(subtree) = db.orchard_subtree_by_index(index) else {
             warn!(index, "missing subtree");
             is_valid = false;

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -34,12 +34,19 @@ pub fn run(
 
         // Blocks cannot complete multiple level 16 subtrees,
         // the subtree index can increase by a maximum of 1 every ~20 blocks.
-        if subtree_address.index() <= subtree_count {
+        // If this block does complete a subtree, the subtree is either completed by a note before
+        // the final note (so the final note is in the next subtree), or by the final note
+        // (so the final note is the end of this subtree).
+        if subtree_address.index() <= subtree_count && !tree.is_complete_subtree() {
             prev_tree = Some(tree);
             continue;
         }
 
         if let Some((index, node)) = tree.completed_subtree_index_and_root() {
+            assert_eq!(
+                index, subtree_count,
+                "trees are inserted in order with no gaps"
+            );
             write_sapling_subtree(upgrade_db, index, height, node);
         } else {
             let mut prev_tree = prev_tree
@@ -75,6 +82,10 @@ pub fn run(
                  and that the block must complete a subtree",
             );
 
+            assert_eq!(
+                index, subtree_count,
+                "trees are inserted in order with no gaps"
+            );
             write_sapling_subtree(upgrade_db, index, height, node);
         };
 
@@ -96,14 +107,19 @@ pub fn run(
             continue;
         };
 
-        // Blocks cannot complete multiple level 16 subtrees,
-        // the subtree index can increase by a maximum of 1 every ~20 blocks.
-        if subtree_address.index() <= subtree_count {
+        // Blocks cannot complete multiple level 16 subtrees.
+        // If a block does complete a subtree, it is either inside the block, or at the end.
+        // (See the detailed comment for Sapling.)
+        if subtree_address.index() <= subtree_count && !tree.is_complete_subtree() {
             prev_tree = Some(tree);
             continue;
         }
 
         if let Some((index, node)) = tree.completed_subtree_index_and_root() {
+            assert_eq!(
+                index, subtree_count,
+                "trees are inserted in order with no gaps"
+            );
             write_orchard_subtree(upgrade_db, index, height, node);
         } else {
             let mut prev_tree = prev_tree
@@ -139,6 +155,10 @@ pub fn run(
                  and that the block must complete a subtree",
             );
 
+            assert_eq!(
+                index, subtree_count,
+                "trees are inserted in order with no gaps"
+            );
             write_orchard_subtree(upgrade_db, index, height, node);
         };
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -398,10 +398,10 @@ fn write_orchard_subtree(
         .write_batch(batch)
         .expect("writing orchard note commitment subtrees should always succeed.");
 
-    // This log happens about once per second on recent machines with SSD disks.
-    if index.0 % 100 == 0 {
+    if index.0 % 300 == 0 {
         info!(?height, index = ?index.0, "calculated and added orchard subtree");
     }
+    // This log happens about 3 times per second on recent machines with SSD disks.
     debug!(?height, index = ?index.0, ?node, "calculated and added orchard subtree");
 }
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -206,14 +206,14 @@ fn check_sapling_subtrees(db: &ZebraDb) -> bool {
     for index in 0..first_incomplete_subtree_index {
         // Check that there's a continuous range of subtrees from index [0, first_incomplete_subtree_index)
         let Some(subtree) = db.sapling_subtree_by_index(index) else {
-            warn!(index, "missing subtree");
+            error!(index, "missing subtree");
             is_valid = false;
             continue;
         };
 
         // Check that there was a sapling note at the subtree's end height.
         let Some(tree) = db.sapling_tree_by_height(&subtree.end) else {
-            warn!(?subtree.end, "missing note commitment tree at subtree completion height");
+            error!(?subtree.end, "missing note commitment tree at subtree completion height");
             is_valid = false;
             continue;
         };
@@ -221,19 +221,19 @@ fn check_sapling_subtrees(db: &ZebraDb) -> bool {
         // Check the index and root if the sapling note commitment tree at this height is a complete subtree.
         if let Some((index, node)) = tree.completed_subtree_index_and_root() {
             if subtree.index != index {
-                warn!("completed subtree indexes should match");
+                error!("completed subtree indexes should match");
                 is_valid = false;
             }
 
             if subtree.node != node {
-                warn!("completed subtree roots should match");
+                error!("completed subtree roots should match");
                 is_valid = false;
             }
         }
         // Check that the final note has a greater subtree index if it didn't complete a subtree.
         else {
             let Some(prev_tree) = db.sapling_tree_by_height(&subtree.end.previous()) else {
-                warn!(?subtree.end, "missing note commitment tree at subtree completion height");
+                error!(?subtree.end, "missing note commitment tree at subtree completion height");
                 is_valid = false;
                 continue;
             };
@@ -241,7 +241,7 @@ fn check_sapling_subtrees(db: &ZebraDb) -> bool {
             let prev_subtree_index = prev_tree.subtree_index();
             let subtree_index = tree.subtree_index();
             if subtree_index <= prev_subtree_index {
-                warn!(
+                error!(
                     ?subtree_index,
                     ?prev_subtree_index,
                     "note commitment tree at end height should have incremented subtree index"
@@ -265,31 +265,31 @@ fn check_sapling_subtrees(db: &ZebraDb) -> bool {
         })
     {
         let Some(subtree) = db.sapling_subtree_by_index(index) else {
-            warn!(?index, "missing subtree");
+            error!(?index, "missing subtree");
             is_valid = false;
             continue;
         };
 
         if subtree.index != index {
-            warn!("completed subtree indexes should match");
+            error!("completed subtree indexes should match");
             is_valid = false;
         }
 
         if subtree.end != height {
-            warn!(?subtree.end, "bad subtree end height");
+            error!(?subtree.end, "bad subtree end height");
             is_valid = false;
         }
 
         if let Some((_index, node)) = tree.completed_subtree_index_and_root() {
             if subtree.node != node {
-                warn!("completed subtree roots should match");
+                error!("completed subtree roots should match");
                 is_valid = false;
             }
         }
     }
 
     if !is_valid {
-        warn!("missing or bad sapling subtrees");
+        error!("missing or bad sapling subtrees");
     }
 
     is_valid
@@ -316,14 +316,14 @@ fn check_orchard_subtrees(db: &ZebraDb) -> bool {
     for index in 0..first_incomplete_subtree_index {
         // Check that there's a continuous range of subtrees from index [0, first_incomplete_subtree_index)
         let Some(subtree) = db.orchard_subtree_by_index(index) else {
-            warn!(index, "missing subtree");
+            error!(index, "missing subtree");
             is_valid = false;
             continue;
         };
 
         // Check that there was a orchard note at the subtree's end height.
         let Some(tree) = db.orchard_tree_by_height(&subtree.end) else {
-            warn!(?subtree.end, "missing note commitment tree at subtree completion height");
+            error!(?subtree.end, "missing note commitment tree at subtree completion height");
             is_valid = false;
             continue;
         };
@@ -331,19 +331,19 @@ fn check_orchard_subtrees(db: &ZebraDb) -> bool {
         // Check the index and root if the orchard note commitment tree at this height is a complete subtree.
         if let Some((index, node)) = tree.completed_subtree_index_and_root() {
             if subtree.index != index {
-                warn!("completed subtree indexes should match");
+                error!("completed subtree indexes should match");
                 is_valid = false;
             }
 
             if subtree.node != node {
-                warn!("completed subtree roots should match");
+                error!("completed subtree roots should match");
                 is_valid = false;
             }
         }
         // Check that the final note has a greater subtree index if it didn't complete a subtree.
         else {
             let Some(prev_tree) = db.orchard_tree_by_height(&subtree.end.previous()) else {
-                warn!(?subtree.end, "missing note commitment tree at subtree completion height");
+                error!(?subtree.end, "missing note commitment tree at subtree completion height");
                 is_valid = false;
                 continue;
             };
@@ -351,7 +351,7 @@ fn check_orchard_subtrees(db: &ZebraDb) -> bool {
             let prev_subtree_index = prev_tree.subtree_index();
             let subtree_index = tree.subtree_index();
             if subtree_index <= prev_subtree_index {
-                warn!(
+                error!(
                     ?subtree_index,
                     ?prev_subtree_index,
                     "note commitment tree at end height should have incremented subtree index"
@@ -375,31 +375,31 @@ fn check_orchard_subtrees(db: &ZebraDb) -> bool {
         })
     {
         let Some(subtree) = db.orchard_subtree_by_index(index) else {
-            warn!(?index, "missing subtree");
+            error!(?index, "missing subtree");
             is_valid = false;
             continue;
         };
 
         if subtree.index != index {
-            warn!("completed subtree indexes should match");
+            error!("completed subtree indexes should match");
             is_valid = false;
         }
 
         if subtree.end != height {
-            warn!(?subtree.end, "bad subtree end height");
+            error!(?subtree.end, "bad subtree end height");
             is_valid = false;
         }
 
         if let Some((_index, node)) = tree.completed_subtree_index_and_root() {
             if subtree.node != node {
-                warn!("completed subtree roots should match");
+                error!("completed subtree roots should match");
                 is_valid = false;
             }
         }
     }
 
     if !is_valid {
-        warn!("missing or bad orchard subtrees");
+        error!("missing or bad orchard subtrees");
     }
 
     is_valid

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -27,7 +27,7 @@ pub fn run(
         }
 
         // Empty note commitment trees can't contain subtrees.
-        let Some(subtree_address) = tree.subtree_address() else {
+        let Some(end_of_block_subtree_index) = tree.subtree_index() else {
             prev_tree = Some(tree);
             continue;
         };
@@ -37,14 +37,14 @@ pub fn run(
         // If this block does complete a subtree, the subtree is either completed by a note before
         // the final note (so the final note is in the next subtree), or by the final note
         // (so the final note is the end of this subtree).
-        if subtree_address.index() <= subtree_count && !tree.is_complete_subtree() {
+        if end_of_block_subtree_index.0 <= subtree_count && !tree.is_complete_subtree() {
             prev_tree = Some(tree);
             continue;
         }
 
         if let Some((index, node)) = tree.completed_subtree_index_and_root() {
             assert_eq!(
-                index, subtree_count,
+                index.0, subtree_count,
                 "trees are inserted in order with no gaps"
             );
             write_sapling_subtree(upgrade_db, index, height, node);
@@ -83,7 +83,7 @@ pub fn run(
             );
 
             assert_eq!(
-                index, subtree_count,
+                index.0, subtree_count,
                 "trees are inserted in order with no gaps"
             );
             write_sapling_subtree(upgrade_db, index, height, node);
@@ -102,7 +102,7 @@ pub fn run(
         }
 
         // Empty note commitment trees can't contain subtrees.
-        let Some(subtree_address) = tree.subtree_address() else {
+        let Some(end_of_block_subtree_index) = tree.subtree_index() else {
             prev_tree = Some(tree);
             continue;
         };
@@ -110,14 +110,14 @@ pub fn run(
         // Blocks cannot complete multiple level 16 subtrees.
         // If a block does complete a subtree, it is either inside the block, or at the end.
         // (See the detailed comment for Sapling.)
-        if subtree_address.index() <= subtree_count && !tree.is_complete_subtree() {
+        if end_of_block_subtree_index.0 <= subtree_count && !tree.is_complete_subtree() {
             prev_tree = Some(tree);
             continue;
         }
 
         if let Some((index, node)) = tree.completed_subtree_index_and_root() {
             assert_eq!(
-                index, subtree_count,
+                index.0, subtree_count,
                 "trees are inserted in order with no gaps"
             );
             write_orchard_subtree(upgrade_db, index, height, node);
@@ -156,7 +156,7 @@ pub fn run(
             );
 
             assert_eq!(
-                index, subtree_count,
+                index.0, subtree_count,
                 "trees are inserted in order with no gaps"
             );
             write_orchard_subtree(upgrade_db, index, height, node);

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -189,7 +189,11 @@ fn write_sapling_subtree(
         .write_batch(batch)
         .expect("writing sapling note commitment subtrees should always succeed.");
 
-    info!(?height, index = ?index.0, "calculated and added sapling subtree");
+    if index.0 % 100 == 0 {
+        info!(?height, index = ?index.0, "calculated and added sapling subtree");
+    }
+    // This log happens about once per second on recent machines with SSD disks.
+    debug!(?height, index = ?index.0, ?node, "calculated and added sapling subtree");
 }
 
 /// Writes a Orchard note commitment subtree to `upgrade_db`.
@@ -209,5 +213,9 @@ fn write_orchard_subtree(
         .write_batch(batch)
         .expect("writing orchard note commitment subtrees should always succeed.");
 
-    info!(?height, index = ?index.0, "calculated and added orchard subtree");
+    // This log happens about once per second on recent machines with SSD disks.
+    if index.0 % 100 == 0 {
+        info!(?height, index = ?index.0, "calculated and added orchard subtree");
+    }
+    debug!(?height, index = ?index.0, ?node, "calculated and added orchard subtree");
 }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -178,7 +178,7 @@ fn write_sapling_subtree(
 
     let mut batch = DiskWriteBatch::new();
 
-    batch.insert_sapling_subtree(upgrade_db, subtree);
+    batch.insert_sapling_subtree(upgrade_db, &subtree);
 
     upgrade_db
         .write_batch(batch)
@@ -196,7 +196,7 @@ fn write_orchard_subtree(
 
     let mut batch = DiskWriteBatch::new();
 
-    batch.insert_orchard_subtree(upgrade_db, subtree);
+    batch.insert_orchard_subtree(upgrade_db, &subtree);
 
     upgrade_db
         .write_batch(batch)

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -51,21 +51,14 @@ pub fn run(
                 .block(height.into())
                 .expect("height with note commitment tree should have block");
 
-            let sapling_note_commitments: Vec<_> = block
-                .transactions
-                .iter()
-                .flat_map(|tx| tx.sapling_note_commitments())
-                .cloned()
-                .collect();
-
-            for sapling_note_commitment in sapling_note_commitments {
+            for sapling_note_commitment in block.sapling_note_commitments() {
                 // Return early if there is a cancel signal.
                 if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
                     return;
                 }
 
                 sapling_nct
-                    .append(sapling_note_commitment)
+                    .append(*sapling_note_commitment)
                     .expect("finalized notes should append successfully");
 
                 // The loop always breaks on this condition,
@@ -122,21 +115,14 @@ pub fn run(
                 .block(height.into())
                 .expect("height with note commitment tree should have block");
 
-            let orchard_note_commitments: Vec<_> = block
-                .transactions
-                .iter()
-                .flat_map(|tx| tx.orchard_note_commitments())
-                .cloned()
-                .collect();
-
-            for orchard_note_commitment in orchard_note_commitments {
+            for orchard_note_commitment in block.orchard_note_commitments() {
                 // Return early if there is a cancel signal.
                 if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
                     return;
                 }
 
                 orchard_nct
-                    .append(orchard_note_commitment)
+                    .append(*orchard_note_commitment)
                     .expect("finalized notes should append successfully");
 
                 // The loop always breaks on this condition,

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -183,6 +183,8 @@ fn write_sapling_subtree(
     upgrade_db
         .write_batch(batch)
         .expect("writing sapling note commitment subtrees should always succeed.");
+
+    info!(?height, index = ?index.0, "calculated and added sapling subtree");
 }
 
 /// Writes a Orchard note commitment subtree to `upgrade_db`.
@@ -201,4 +203,6 @@ fn write_orchard_subtree(
     upgrade_db
         .write_batch(batch)
         .expect("writing orchard note commitment subtrees should always succeed.");
+
+    info!(?height, index = ?index.0, "calculated and added orchard subtree");
 }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -39,12 +39,10 @@ pub fn run(
             tree.completed_subtree_index_and_root()
                 .expect("already checked is_complete_subtree()")
         } else {
-            let mut sapling_nct = Arc::try_unwrap(
-                prev_tree
-                    .take()
-                    .expect("should have some previous sapling frontier"),
-            )
-            .unwrap_or_else(|shared_tree| (*shared_tree).clone());
+            let mut prev_tree = prev_tree
+                .take()
+                .expect("should have some previous sapling frontier");
+            let sapling_nct = Arc::make_mut(&mut prev_tree);
 
             let block = upgrade_db
                 .block(height.into())
@@ -121,12 +119,10 @@ pub fn run(
             tree.completed_subtree_index_and_root()
                 .expect("already checked is_complete_subtree()")
         } else {
-            let mut orchard_nct = Arc::try_unwrap(
-                prev_tree
-                    .take()
-                    .expect("should have some previous orchard frontier"),
-            )
-            .unwrap_or_else(|shared_tree| (*shared_tree).clone());
+            let mut prev_tree = prev_tree
+                .take()
+                .expect("should have some previous orchard frontier");
+            let orchard_nct = Arc::make_mut(&mut prev_tree);
 
             let block = upgrade_db
                 .block(height.into())

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -19,7 +19,7 @@ use crate::service::finalized_state::{
 pub fn run(
     initial_tip_height: Height,
     upgrade_db: &ZebraDb,
-    cancel_receiver: mpsc::Receiver<CancelFormatChange>,
+    cancel_receiver: &mpsc::Receiver<CancelFormatChange>,
 ) -> Result<(), CancelFormatChange> {
     let mut subtree_count = 0;
     let mut prev_tree: Option<_> = None;
@@ -172,6 +172,191 @@ pub fn run(
     Ok(())
 }
 
+/// Check that note commitment subtrees were correctly added.
+///
+/// # Panics
+///
+/// If a note commitment subtree is missing or incorrect.
+pub fn check(
+    upgrade_db: &ZebraDb,
+    cancel_receiver: &mpsc::Receiver<CancelFormatChange>,
+) -> Result<(), CancelFormatChange> {
+    let mut is_valid = true;
+
+    let mut subtree_count = 0;
+    let mut prev_tree: Option<_> = None;
+    for (height, tree) in upgrade_db.sapling_tree_by_height_range(..) {
+        // Return early if there is a cancel signal.
+        if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
+            return Err(CancelFormatChange);
+        }
+
+        // Empty note commitment trees can't contain subtrees.
+        let Some(end_of_block_subtree_index) = tree.subtree_index() else {
+            prev_tree = Some(tree);
+            continue;
+        };
+
+        // Blocks cannot complete multiple level 16 subtrees,
+        // the subtree index can increase by a maximum of 1 every ~20 blocks.
+        // If this block does complete a subtree, the subtree is either completed by a note before
+        // the final note (so the final note is in the next subtree), or by the final note
+        // (so the final note is the end of this subtree).
+        if end_of_block_subtree_index.0 <= subtree_count && !tree.is_complete_subtree() {
+            prev_tree = Some(tree);
+            continue;
+        }
+
+        if let Some((index, node)) = tree.completed_subtree_index_and_root() {
+            assert_eq!(
+                index.0, subtree_count,
+                "trees are inserted in order with no gaps"
+            );
+
+            if !sapling_subtree_exists(upgrade_db, index, height, node) {
+                error!(?height, ?index, "missing sapling subtree");
+                is_valid = false;
+            }
+        } else {
+            let mut prev_tree = prev_tree
+                .take()
+                .expect("should have some previous sapling frontier");
+            let sapling_nct = Arc::make_mut(&mut prev_tree);
+
+            let block = upgrade_db
+                .block(height.into())
+                .expect("height with note commitment tree should have block");
+
+            for sapling_note_commitment in block.sapling_note_commitments() {
+                // Return early if there is a cancel signal.
+                if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
+                    return Err(CancelFormatChange);
+                }
+
+                sapling_nct
+                    .append(*sapling_note_commitment)
+                    .expect("finalized notes should append successfully");
+
+                // The loop always breaks on this condition,
+                // because we checked the block has enough commitments,
+                // and that the final commitment in the block doesn't complete a subtree.
+                if sapling_nct.is_complete_subtree() {
+                    break;
+                }
+            }
+
+            let (index, node) = sapling_nct.completed_subtree_index_and_root().expect(
+                "block should have completed a subtree before its final note commitment: \
+                 already checked is_complete_subtree(),\
+                 and that the block must complete a subtree",
+            );
+
+            assert_eq!(
+                index.0, subtree_count,
+                "trees are inserted in order with no gaps"
+            );
+
+            if !sapling_subtree_exists(upgrade_db, index, height, node) {
+                error!(?height, ?index, "missing sapling subtree");
+                is_valid = false;
+            }
+        };
+
+        subtree_count += 1;
+        prev_tree = Some(tree);
+    }
+
+    let mut subtree_count = 0;
+    let mut prev_tree: Option<_> = None;
+    for (height, tree) in upgrade_db.orchard_tree_by_height_range(..) {
+        // Return early if there is a cancel signal.
+        if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
+            return Err(CancelFormatChange);
+        }
+
+        // Empty note commitment trees can't contain subtrees.
+        let Some(end_of_block_subtree_index) = tree.subtree_index() else {
+            prev_tree = Some(tree);
+            continue;
+        };
+
+        // Blocks cannot complete multiple level 16 subtrees.
+        // If a block does complete a subtree, it is either inside the block, or at the end.
+        // (See the detailed comment for Sapling.)
+        if end_of_block_subtree_index.0 <= subtree_count && !tree.is_complete_subtree() {
+            prev_tree = Some(tree);
+            continue;
+        }
+
+        if let Some((index, node)) = tree.completed_subtree_index_and_root() {
+            assert_eq!(
+                index.0, subtree_count,
+                "trees are inserted in order with no gaps"
+            );
+
+            if !orchard_subtree_exists(upgrade_db, index, height, node) {
+                error!(?height, ?index, "missing orchard subtree");
+                is_valid = false;
+            }
+        } else {
+            let mut prev_tree = prev_tree
+                .take()
+                .expect("should have some previous orchard frontier");
+            let orchard_nct = Arc::make_mut(&mut prev_tree);
+
+            let block = upgrade_db
+                .block(height.into())
+                .expect("height with note commitment tree should have block");
+
+            for orchard_note_commitment in block.orchard_note_commitments() {
+                // Return early if there is a cancel signal.
+                if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
+                    return Err(CancelFormatChange);
+                }
+
+                orchard_nct
+                    .append(*orchard_note_commitment)
+                    .expect("finalized notes should append successfully");
+
+                // The loop always breaks on this condition,
+                // because we checked the block has enough commitments,
+                // and that the final commitment in the block doesn't complete a subtree.
+                if orchard_nct.is_complete_subtree() {
+                    break;
+                }
+            }
+
+            let (index, node) = orchard_nct.completed_subtree_index_and_root().expect(
+                "block should have completed a subtree before its final note commitment: \
+                 already checked is_complete_subtree(),\
+                 and that the block must complete a subtree",
+            );
+
+            assert_eq!(
+                index.0, subtree_count,
+                "trees are inserted in order with no gaps"
+            );
+
+            if !orchard_subtree_exists(upgrade_db, index, height, node) {
+                error!(?height, ?index, "missing orchard subtree");
+                is_valid = false;
+            }
+        };
+
+        subtree_count += 1;
+        prev_tree = Some(tree);
+    }
+
+    if !is_valid {
+        panic!(
+            "found duplicate sapling or orchard trees \
+                     after running de-duplicate tree upgrade"
+        );
+    }
+
+    Ok(())
+}
+
 /// Writes a Sapling note commitment subtree to `upgrade_db`.
 fn write_sapling_subtree(
     upgrade_db: &ZebraDb,
@@ -218,4 +403,26 @@ fn write_orchard_subtree(
         info!(?height, index = ?index.0, "calculated and added orchard subtree");
     }
     debug!(?height, index = ?index.0, ?node, "calculated and added orchard subtree");
+}
+
+/// Checks that a Sapling note commitment subtree exists in `upgrade_db`.
+fn sapling_subtree_exists(
+    upgrade_db: &ZebraDb,
+    index: NoteCommitmentSubtreeIndex,
+    height: Height,
+    node: sapling::tree::Node,
+) -> bool {
+    upgrade_db.sapling_subtree_by_index(index)
+        == Some(NoteCommitmentSubtree::new(index, height, node))
+}
+
+/// Checks that a Orchard note commitment subtree exists in `upgrade_db`.
+fn orchard_subtree_exists(
+    upgrade_db: &ZebraDb,
+    index: NoteCommitmentSubtreeIndex,
+    height: Height,
+    node: orchard::tree::Node,
+) -> bool {
+    upgrade_db.orchard_subtree_by_index(index)
+        == Some(NoteCommitmentSubtree::new(index, height, node))
 }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -1,0 +1,168 @@
+//! Fully populate the Sapling and Orchard note commitment subtrees for existing blocks in the database.
+
+use std::sync::{
+    atomic::{self, AtomicBool},
+    Arc,
+};
+
+use zebra_chain::{
+    block::Height, orchard::tree::NoteCommitmentTree as OrchardNoteCommitmentTree,
+    sapling::tree::NoteCommitmentTree as SaplingNoteCommitmentTree, subtree::NoteCommitmentSubtree,
+};
+
+use crate::service::finalized_state::{DiskWriteBatch, ZebraDb};
+
+/// Runs disk format upgrade for adding Sapling and Orchard note commitment subtrees to database.
+pub fn _run(
+    initial_tip_height: Height,
+    upgrade_db: &ZebraDb,
+    should_cancel_format_change: Arc<AtomicBool>,
+) {
+    let mut subtree_count = 0;
+    let mut prev_tree: Option<_> = None;
+    for (height, tree) in upgrade_db.sapling_tree_by_height_range(..=initial_tip_height) {
+        if should_cancel_format_change.load(atomic::Ordering::Relaxed) {
+            break;
+        }
+
+        let Some(frontier) = tree.frontier() else {
+            prev_tree = Some(tree);
+            continue;
+        };
+
+        // Blocks cannot complete multiple level 16 subtrees,
+        // the subtree index can increase by a maximum of 1 every ~20 blocks.
+        let subtree_address = SaplingNoteCommitmentTree::subtree_address(frontier);
+        if subtree_address.index() <= subtree_count {
+            prev_tree = Some(tree);
+            continue;
+        }
+
+        let (index, node) = if SaplingNoteCommitmentTree::is_complete_subtree(frontier) {
+            tree.completed_subtree_index_and_root()
+                .expect("already checked is_complete_subtree()")
+        } else {
+            let mut sapling_nct = Arc::try_unwrap(
+                prev_tree
+                    .take()
+                    .expect("should have some previous sapling frontier"),
+            )
+            .unwrap_or_else(|shared_tree| (*shared_tree).clone());
+
+            let block = upgrade_db
+                .block(height.into())
+                .expect("height with note commitment tree should have block");
+
+            let sapling_note_commitments: Vec<_> = block
+                .transactions
+                .iter()
+                .flat_map(|tx| tx.sapling_note_commitments())
+                .cloned()
+                .collect();
+
+            for sapling_note_commitment in sapling_note_commitments {
+                sapling_nct
+                    .append(sapling_note_commitment)
+                    .expect("finalized notes should append successfully");
+
+                if sapling_nct
+                    .frontier()
+                    .map_or(false, SaplingNoteCommitmentTree::is_complete_subtree)
+                {
+                    break;
+                }
+            }
+
+            sapling_nct
+                .completed_subtree_index_and_root()
+                .expect("already checked is_complete_subtree()")
+        };
+
+        let subtree = NoteCommitmentSubtree::new(index, height, node);
+
+        let mut batch = DiskWriteBatch::new();
+
+        batch.insert_sapling_subtree(upgrade_db, subtree);
+
+        upgrade_db
+            .write_batch(batch)
+            .expect("writing sapling note commitment subtrees should always succeed.");
+
+        subtree_count += 1;
+        prev_tree = Some(tree);
+    }
+
+    let mut subtree_count = 0;
+    let mut prev_tree: Option<_> = None;
+    for (height, tree) in upgrade_db.orchard_tree_by_height_range(..=initial_tip_height) {
+        if should_cancel_format_change.load(atomic::Ordering::Relaxed) {
+            break;
+        }
+
+        let Some(frontier) = tree.frontier() else {
+            prev_tree = Some(tree);
+            continue;
+        };
+
+        // Blocks cannot complete multiple level 16 subtrees,
+        // the subtree index can increase by a maximum of 1 every ~20 blocks.
+        let subtree_address = OrchardNoteCommitmentTree::subtree_address(frontier);
+        if subtree_address.index() <= subtree_count {
+            prev_tree = Some(tree);
+            continue;
+        }
+
+        let (index, node) = if OrchardNoteCommitmentTree::is_complete_subtree(frontier) {
+            tree.completed_subtree_index_and_root()
+                .expect("already checked is_complete_subtree()")
+        } else {
+            let mut orchard_nct = Arc::try_unwrap(
+                prev_tree
+                    .take()
+                    .expect("should have some previous orchard frontier"),
+            )
+            .unwrap_or_else(|shared_tree| (*shared_tree).clone());
+
+            let block = upgrade_db
+                .block(height.into())
+                .expect("height with note commitment tree should have block");
+
+            let orchard_note_commitments: Vec<_> = block
+                .transactions
+                .iter()
+                .flat_map(|tx| tx.orchard_note_commitments())
+                .cloned()
+                .collect();
+
+            for orchard_note_commitment in orchard_note_commitments {
+                orchard_nct
+                    .append(orchard_note_commitment)
+                    .expect("finalized notes should append successfully");
+
+                if orchard_nct
+                    .frontier()
+                    .map_or(false, OrchardNoteCommitmentTree::is_complete_subtree)
+                {
+                    break;
+                }
+            }
+
+            orchard_nct
+                .completed_subtree_index_and_root()
+                .expect("already checked is_complete_subtree()")
+        };
+
+        let subtree = NoteCommitmentSubtree::new(index, height, node);
+
+        let mut batch = DiskWriteBatch::new();
+
+        batch.insert_orchard_subtree(upgrade_db, subtree);
+
+        upgrade_db
+            .write_batch(batch)
+            .expect("writing orchard note commitment subtrees should always succeed.");
+
+        subtree_count += 1;
+        prev_tree = Some(tree);
+    }
+}

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -22,13 +22,14 @@ pub fn run(
             return;
         }
 
-        // Blocks cannot complete multiple level 16 subtrees,
-        // the subtree index can increase by a maximum of 1 every ~20 blocks.
+        // Empty note commitment trees can't contain subtrees.
         let Some(subtree_address) = tree.subtree_address() else {
             prev_tree = Some(tree);
             continue;
         };
 
+        // Blocks cannot complete multiple level 16 subtrees,
+        // the subtree index can increase by a maximum of 1 every ~20 blocks.
         if subtree_address.index() <= subtree_count {
             prev_tree = Some(tree);
             continue;
@@ -75,8 +76,9 @@ pub fn run(
             }
 
             sapling_nct.completed_subtree_index_and_root().expect(
-                "already checked is_complete_subtree(),\
-                     and that the block must complete a subtree",
+                "block should have completed a subtree before its final note commitment: \
+                 already checked is_complete_subtree(),\
+                 and that the block must complete a subtree",
             )
         };
 
@@ -102,13 +104,14 @@ pub fn run(
             return;
         }
 
-        // Blocks cannot complete multiple level 16 subtrees,
-        // the subtree index can increase by a maximum of 1 every ~20 blocks.
+        // Empty note commitment trees can't contain subtrees.
         let Some(subtree_address) = tree.subtree_address() else {
             prev_tree = Some(tree);
             continue;
         };
 
+        // Blocks cannot complete multiple level 16 subtrees,
+        // the subtree index can increase by a maximum of 1 every ~20 blocks.
         if subtree_address.index() <= subtree_count {
             prev_tree = Some(tree);
             continue;
@@ -155,8 +158,9 @@ pub fn run(
             }
 
             orchard_nct.completed_subtree_index_and_root().expect(
-                "already checked is_complete_subtree(),\
-                     and that the block must complete a subtree",
+                "block should have completed a subtree before its final note commitment: \
+                 already checked is_complete_subtree(),\
+                 and that the block must complete a subtree",
             )
         };
 

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -19,7 +19,7 @@ use crate::{
         disk_db::DiskDb,
         disk_format::{
             block::MAX_ON_DISK_HEIGHT,
-            upgrade::{DbFormatChange, DbFormatChangeThreadHandle},
+            upgrade::{self, DbFormatChange, DbFormatChangeThreadHandle},
         },
     },
     Config,
@@ -108,9 +108,10 @@ impl ZebraDb {
             db.format_change_handle = Some(format_change_handle);
         } else {
             // If we're re-opening a previously upgraded or newly created database,
-            // the trees should already be de-duplicated.
+            // the database format should be valid.
             // (There's no format change here, so the format change checks won't run.)
             DbFormatChange::check_for_duplicate_trees(db.clone());
+            upgrade::add_subtrees::check(&db.clone());
         }
 
         db

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -26,7 +26,7 @@ use zebra_chain::{
 use zebra_test::vectors::{MAINNET_BLOCKS, TESTNET_BLOCKS};
 
 use crate::{
-    service::finalized_state::{disk_db::DiskWriteBatch, FinalizedState},
+    service::finalized_state::{disk_db::DiskWriteBatch, ZebraDb},
     CheckpointVerifiedBlock, Config,
 };
 
@@ -77,11 +77,11 @@ fn test_block_db_round_trip_with(
 ) {
     let _init_guard = zebra_test::init();
 
-    let state = FinalizedState::new(
+    let state = ZebraDb::new(
         &Config::ephemeral(),
         network,
-        #[cfg(feature = "elasticsearch")]
-        None,
+        // The raw database accesses in this test create invalid database formats.
+        true,
     );
 
     // Check that each block round-trips to the database

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -180,15 +180,39 @@ impl ZebraDb {
         self.db.zs_range_iter(&sapling_trees, range)
     }
 
+    /// Returns the Sapling note commitment subtree at this `index`.
+    ///
+    /// # Correctness
+    ///
+    /// This method should not be used to get subtrees for RPC responses,
+    /// because those subtree lists require that the start subtree is present in the list.
+    /// Instead, use `sapling_subtrees_by_index()`.
+    #[allow(clippy::unwrap_in_result)]
+    pub(in super::super) fn sapling_subtree_by_index(
+        &self,
+        index: impl Into<NoteCommitmentSubtreeIndex> + Copy,
+    ) -> Option<NoteCommitmentSubtree<sapling::tree::Node>> {
+        let sapling_subtrees = self
+            .db
+            .cf_handle("sapling_note_commitment_subtree")
+            .unwrap();
+
+        let subtree_data: NoteCommitmentSubtreeData<sapling::tree::Node> =
+            self.db.zs_get(&sapling_subtrees, &index.into())?;
+
+        Some(subtree_data.with_index(index))
+    }
+
     /// Returns a list of Sapling [`NoteCommitmentSubtree`]s starting at `start_index`.
     /// If `limit` is provided, the list is limited to `limit` entries.
     ///
     /// If there is no subtree at `start_index`, the returned list is empty.
     /// Otherwise, subtrees are continuous up to the finalized tip.
     ///
-    /// There is no API for retrieving single subtrees by index, because it can accidentally be used
-    /// to create an inconsistent list of subtrees after concurrent non-finalized and finalized
-    /// updates.
+    /// # Correctness
+    ///
+    /// This method is specifically designed for the `z_getsubtreesbyindex` state request.
+    /// It might not work for other RPCs or state checks.
     #[allow(clippy::unwrap_in_result)]
     pub fn sapling_subtrees_by_index(
         &self,
@@ -289,15 +313,39 @@ impl ZebraDb {
         self.db.zs_range_iter(&orchard_trees, range)
     }
 
+    /// Returns the Orchard note commitment subtree at this `index`.
+    ///
+    /// # Correctness
+    ///
+    /// This method should not be used to get subtrees for RPC responses,
+    /// because those subtree lists require that the start subtree is present in the list.
+    /// Instead, use `orchard_subtrees_by_index()`.
+    #[allow(clippy::unwrap_in_result)]
+    pub(in super::super) fn orchard_subtree_by_index(
+        &self,
+        index: impl Into<NoteCommitmentSubtreeIndex> + Copy,
+    ) -> Option<NoteCommitmentSubtree<orchard::tree::Node>> {
+        let orchard_subtrees = self
+            .db
+            .cf_handle("orchard_note_commitment_subtree")
+            .unwrap();
+
+        let subtree_data: NoteCommitmentSubtreeData<orchard::tree::Node> =
+            self.db.zs_get(&orchard_subtrees, &index.into())?;
+
+        Some(subtree_data.with_index(index))
+    }
+
     /// Returns a list of Orchard [`NoteCommitmentSubtree`]s starting at `start_index`.
     /// If `limit` is provided, the list is limited to `limit` entries.
     ///
     /// If there is no subtree at `start_index`, the returned list is empty.
     /// Otherwise, subtrees are continuous up to the finalized tip.
     ///
-    /// There is no API for retrieving single subtrees by index, because it can accidentally be used
-    /// to create an inconsistent list of subtrees after concurrent non-finalized and finalized
-    /// updates.
+    /// # Correctness
+    ///
+    /// This method is specifically designed for the `z_getsubtreesbyindex` state request.
+    /// It might not work for other RPCs or state checks.
     #[allow(clippy::unwrap_in_result)]
     pub fn orchard_subtrees_by_index(
         &self,

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -354,9 +354,6 @@ impl DiskWriteBatch {
         let sapling_tree_cf = db.cf_handle("sapling_note_commitment_tree").unwrap();
         let orchard_tree_cf = db.cf_handle("orchard_note_commitment_tree").unwrap();
 
-        let sapling_subtree_cf = db.cf_handle("sapling_note_commitment_subtree").unwrap();
-        let orchard_subtree_cf = db.cf_handle("orchard_note_commitment_subtree").unwrap();
-
         let height = finalized.verified.height;
         let trees = finalized.treestate.note_commitment_trees.clone();
 
@@ -403,11 +400,11 @@ impl DiskWriteBatch {
         }
 
         if let Some(subtree) = trees.sapling_subtree {
-            self.zs_insert(&sapling_subtree_cf, subtree.index, subtree.into_data());
+            self.insert_sapling_subtree(zebra_db, subtree);
         }
 
         if let Some(subtree) = trees.orchard_subtree {
-            self.zs_insert(&orchard_subtree_cf, subtree.index, subtree.into_data());
+            self.insert_orchard_subtree(zebra_db, subtree);
         }
 
         self.prepare_history_batch(db, finalized)

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -186,7 +186,7 @@ impl ZebraDb {
     ///
     /// This method should not be used to get subtrees for RPC responses,
     /// because those subtree lists require that the start subtree is present in the list.
-    /// Instead, use `sapling_subtrees_by_index()`.
+    /// Instead, use `sapling_subtree_list_by_index_for_rpc()`.
     #[allow(clippy::unwrap_in_result)]
     pub(in super::super) fn sapling_subtree_by_index(
         &self,
@@ -214,7 +214,7 @@ impl ZebraDb {
     /// This method is specifically designed for the `z_getsubtreesbyindex` state request.
     /// It might not work for other RPCs or state checks.
     #[allow(clippy::unwrap_in_result)]
-    pub fn sapling_subtrees_by_index(
+    pub fn sapling_subtree_list_by_index_for_rpc(
         &self,
         start_index: NoteCommitmentSubtreeIndex,
         limit: Option<NoteCommitmentSubtreeIndex>,
@@ -319,7 +319,7 @@ impl ZebraDb {
     ///
     /// This method should not be used to get subtrees for RPC responses,
     /// because those subtree lists require that the start subtree is present in the list.
-    /// Instead, use `orchard_subtrees_by_index()`.
+    /// Instead, use `orchard_subtree_list_by_index_for_rpc()`.
     #[allow(clippy::unwrap_in_result)]
     pub(in super::super) fn orchard_subtree_by_index(
         &self,
@@ -347,7 +347,7 @@ impl ZebraDb {
     /// This method is specifically designed for the `z_getsubtreesbyindex` state request.
     /// It might not work for other RPCs or state checks.
     #[allow(clippy::unwrap_in_result)]
-    pub fn orchard_subtrees_by_index(
+    pub fn orchard_subtree_list_by_index_for_rpc(
         &self,
         start_index: NoteCommitmentSubtreeIndex,
         limit: Option<NoteCommitmentSubtreeIndex>,

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -400,11 +400,11 @@ impl DiskWriteBatch {
         }
 
         if let Some(subtree) = trees.sapling_subtree {
-            self.insert_sapling_subtree(zebra_db, subtree);
+            self.insert_sapling_subtree(zebra_db, &subtree);
         }
 
         if let Some(subtree) = trees.orchard_subtree {
-            self.insert_orchard_subtree(zebra_db, subtree);
+            self.insert_orchard_subtree(zebra_db, &subtree);
         }
 
         self.prepare_history_batch(db, finalized)
@@ -416,7 +416,7 @@ impl DiskWriteBatch {
     pub fn insert_sapling_subtree(
         &mut self,
         zebra_db: &ZebraDb,
-        subtree: Arc<NoteCommitmentSubtree<sapling::tree::Node>>,
+        subtree: &NoteCommitmentSubtree<sapling::tree::Node>,
     ) {
         let sapling_subtree_cf = zebra_db
             .db
@@ -452,7 +452,7 @@ impl DiskWriteBatch {
     pub fn insert_orchard_subtree(
         &mut self,
         zebra_db: &ZebraDb,
-        subtree: Arc<NoteCommitmentSubtree<orchard::tree::Node>>,
+        subtree: &NoteCommitmentSubtree<orchard::tree::Node>,
     ) {
         let orchard_subtree_cf = zebra_db
             .db

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -682,6 +682,11 @@ impl Chain {
 
     /// Returns the Sapling [`NoteCommitmentSubtree`] that was completed at a block with
     /// [`HashOrHeight`], if it exists in the non-finalized [`Chain`].
+    ///
+    /// # Concurrency
+    ///
+    /// This method should not be used to get subtrees in concurrent code by height,
+    /// because the same heights in different chain forks can have different subtrees.
     pub fn sapling_subtree(
         &self,
         hash_or_height: HashOrHeight,
@@ -872,6 +877,11 @@ impl Chain {
 
     /// Returns the Orchard [`NoteCommitmentSubtree`] that was completed at a block with
     /// [`HashOrHeight`], if it exists in the non-finalized [`Chain`].
+    ///
+    /// # Concurrency
+    ///
+    /// This method should not be used to get subtrees in concurrent code by height,
+    /// because the same heights in different chain forks can have different subtrees.
     pub fn orchard_subtree(
         &self,
         hash_or_height: HashOrHeight,

--- a/zebra-state/src/service/read/tree.rs
+++ b/zebra-state/src/service/read/tree.rs
@@ -74,7 +74,7 @@ where
     // In that case, we ignore all the trees in `chain` after the first inconsistent tree,
     // because we know they will be inconsistent as well. (It is cryptographically impossible
     // for tree roots to be equal once the leaves have diverged.)
-    let mut db_list = db.sapling_subtrees_by_index(start_index, limit);
+    let mut db_list = db.sapling_subtree_list_by_index_for_rpc(start_index, limit);
 
     // If there's no chain, then we have the complete list.
     let Some(chain) = chain else {
@@ -162,7 +162,7 @@ where
     // In that case, we ignore all the trees in `chain` after the first inconsistent tree,
     // because we know they will be inconsistent as well. (It is cryptographically impossible
     // for tree roots to be equal once the leaves have diverged.)
-    let mut db_list = db.orchard_subtrees_by_index(start_index, limit);
+    let mut db_list = db.orchard_subtree_list_by_index_for_rpc(start_index, limit);
 
     // If there's no chain, then we have the complete list.
     let Some(chain) = chain else {


### PR DESCRIPTION
## Motivation

This is a branch that we can use to test the `z_getsubtreesbyindex ` RPC method with real state data.

We can:
- do manual tests on this branch, or
- write snapshot or integration tests based on this branch