### PR TITLE
fix(rpc): Match zcashd's getblockchaininfo capitalisation for NU5

### DIFF
--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -45,8 +45,9 @@ pub enum NetworkUpgrade {
     Canopy,
     /// The Zcash protocol after the Nu5 upgrade.
     ///
-    /// Note: Network Upgrade 5 includes the Orchard Shielded Protocol, and
-    /// other changes. The Nu5 code name has not been chosen yet.
+    /// Note: Network Upgrade 5 includes the Orchard Shielded Protocol, non-malleable transaction
+    /// IDs, and other changes. There is no special code name for Nu5.
+    #[serde(rename = "NU5")]
     Nu5,
 }
 

--- a/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@mainnet_10.snap
@@ -34,7 +34,7 @@ expression: info
       "status": "pending"
     },
     "c2d6d0b4": {
-      "name": "Nu5",
+      "name": "NU5",
       "activationheight": 1687104,
       "status": "pending"
     }

--- a/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@testnet_10.snap
@@ -34,7 +34,7 @@ expression: info
       "status": "pending"
     },
     "c2d6d0b4": {
-      "name": "Nu5",
+      "name": "NU5",
       "activationheight": 1842420,
       "status": "pending"
     }


### PR DESCRIPTION
## Motivation

Our `getblockchaininfo` RPC is using a different capitalisation of NU5 to `zcashd`:
```
Querying zebrad v1.2.0+38.g7ca6974 main chain at height >=2214736...                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
Querying zcashd v5.6.1-gb7af08e90de main chain at height >=2214738...    
...
Response diff between zebrad v1.2.0+38.g7ca6974 and zcashd v5.6.1-gb7af08e90de:                                                                                                                            
--- /run/user/1000/tmp.Xom0Z8v18C.rpc-diff/zebrad-main-2214736-getblockchaininfo.json   2023-09-04 11:52:17.632123229 +1000                                                                                
+++ /run/user/1000/tmp.Xom0Z8v18C.rpc-diff/zcashd-main-2214738-getblockchaininfo.json   2023-09-04 11:52:17.655123021 +1000      
     "c2d6d0b4": {                                                                                                                                                                                         
-      "name": "Nu5",                                                                                                                                                                                      
+      "name": "NU5",                                                                                                                                                                                      
       "activationheight": 1687104,                                                                                                                                                                        
-      "status": "active"                                                                                                                                                                                  
+      "status": "active",                                                                                                                                                                                 
+      "info": "See https://z.cash/upgrade/nu5/ for details."                                                                                                                                              
     }                                                                                                                                                                                                     
   },                                                                                                                                                                                                      
   "consensus": {  
```

This is unlikely to matter because `lightwalletd` ignores this field, but it seemed easy to fix.

### Specifications

This is unspecified behaviour:
https://zcash.github.io/rpc/getblockchaininfo.html

## Solution

Tell Zebra to serialize and deserialize as "NU5" instead
Update snapshot tests

## Review

This is an optional RPC fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

