### PR TITLE
fix(rpc): Format subtree roots in little-endian order

### DIFF
--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -182,12 +182,9 @@ impl Node {
 
     /// Return the node bytes in big-endian byte-order suitable for printing out byte by byte.
     ///
-    /// Zebra displays note commitment tree nodes in big-endian byte-order,
-    /// following the u256 convention set by Bitcoin and zcashd.
+    /// `zcashd`'s `z_getsubtreesbyindex` does not reverse the byte order of subtree roots.
     pub fn bytes_in_display_order(&self) -> [u8; 32] {
-        let mut reversed_bytes = self.0.to_repr();
-        reversed_bytes.reverse();
-        reversed_bytes
+        self.to_repr()
     }
 }
 

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -190,14 +190,11 @@ impl fmt::Debug for Node {
 }
 
 impl Node {
-    /// Return the node bytes in big-endian byte-order suitable for printing out byte by byte.
+    /// Return the node bytes in little-endian byte order suitable for printing out byte by byte.
     ///
-    /// Zebra displays note commitment tree nodes in big-endian byte-order,
-    /// following the u256 convention set by Bitcoin and zcashd.
+    /// `zcashd`'s `z_getsubtreesbyindex` does not reverse the byte order of subtree roots.
     pub fn bytes_in_display_order(&self) -> [u8; 32] {
-        let mut reversed_bytes = self.0;
-        reversed_bytes.reverse();
-        reversed_bytes
+        self.0
     }
 }
 


### PR DESCRIPTION
## Motivation

I assumed that subtree roots would be in big-endian order, but `zcashd` formats them in little-endian order.

### Logs

<details>

<summary>detailed logs showing a diff with reversed byte order</summary>

```
$ zcash-rpc-diff 28232 z_getsubtreesbyindex sapling 0 3                            
Checking first node release info...                                                                  
Checking second node release info...            
Connected to zebrad v1.2.0+40.gb3d5aac (port 28232) and zcashd v5.6.1-gb7af08e90de (zcash-cli zcash.conf port).
                                                                                                     
Checking zebrad v1.2.0+40.gb3d5aac network and tip height... 
Checking zcashd v5.6.1-gb7af08e90de network and tip height...
                                                                                                     
WARNING: comparing RPC responses from different heights:                                  
zebrad v1.2.0+40.gb3d5aac is at: 2215759                                                                                                                                                                   
zcashd v5.6.1-gb7af08e90de is at: 1867054                                                                                                                                                                  
                                                                                                                                                                                                           
Request:                                                                                                                                                                                                   
z_getsubtreesbyindex sapling 0 3                                                                     
                                                                                                     
Querying zebrad v1.2.0+40.gb3d5aac main chain at height >=2215759...                           
                                                                                                     
real    0m0.021s                                                                                     
user    0m0.004s                                                                                                                                                                                           
sys     0m0.003s                                                                                                                                                                                           
                                                                                                     
Querying zcashd v5.6.1-gb7af08e90de main chain at height >=1867054...                                                                                                                                      
                                                                                                                                                                                                           
real    0m0.149s                                                                                                                                                                                           
user    0m0.004s                                                                                     
sys     0m0.004s                                                                                     
                                                                                                     
                                                                                                     
Response diff between zebrad v1.2.0+40.gb3d5aac and zcashd v5.6.1-gb7af08e90de:      
--- /run/user/1000/tmp.KsyUuhrBLV.rpc-diff/zebrad-main-2215759-z_getsubtreesbyindex.json        2023-09-05 09:11:38.020957578 +1000
+++ /run/user/1000/tmp.KsyUuhrBLV.rpc-diff/zcashd-main-1867054-z_getsubtreesbyindex.json        2023-09-05 09:11:38.169956040 +1000
@@ -3,15 +3,15 @@                                                                                    
   "start_index": 0,                                                                                 
   "subtrees": [                                                                                     
     {                                                                                               
-      "root": "135b6b010c0e34cc03201d2c0fc09df5bb090f6467f3dda731d242ea93b54b75",  
+      "root": "754bb593ea42d231a7ddf367640f09bbf59dc00f2c1d2003cc340e0c016b5b13",  
       "end_height": 558822                                                                          
     },                                                                                              
     {                                                                                               
-      "root": "2de068fd9781368579478af3f41096e2ea06b6776dcf22e1939bbbac3e4c6503",   
+      "root": "03654c3eacbb9b93e122cf6d77b606eae29610f4f38a477985368197fd68e02d",  
       "end_height": 670209                                                                          
     },                      
     {      
-      "root": "6051548b74a88a94a6e02b8a962aa891c1d5e1a5110d56da440bc15a8f69bfe2",
+      "root": "e2bf698f5ac10b44da560d11a5e1d5c191a82a968a2be0a6948aa8748b545160",
       "end_height": 780364                                                                                                                                                                                
     }                                                                                               
   ]                                    
```

</details>

### Specifications

The RPC spec is unclear on the byte order:
https://github.com/zcash/zcash/pull/6677/files#diff-decae4be02fb8a47ab4557fe74a9cb853bdfa3ec0fa1b515c0a1e5de91f4ad0bR1458-R1475

## Solution

Stop reversing the byte order.

## Review

This is urgent because most other tests for this RPC will fail without this fix.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

