### PR TITLE
change(devops): Tweak dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,18 +50,20 @@ updates:
             - "reqwest"
             - "futures*"
             - "pin-project*"
-        log:
+        log-time:
           patterns:
             - "tracing*"
             - "log"
             - "*eyre*"
             - "thiserror"
-            - "displaydoc"
-            - "spandoc"
+            # displaydoc, spandoc
+            - "*doc"
             - "owo-colors"
             - "sentry*"
             - "metrics*"
-            - "inferno"
+            # time, humantime
+            - "*time*"
+            - "chrono*"
         concurrency:
           patterns:
             - "once_cell"
@@ -73,11 +75,6 @@ updates:
           patterns:
             - "indicatif"
             - "howudoin"
-        time:
-          patterns:
-            - "chrono*"
-            - "time*"
-            - "humantime*"
         app:
           patterns:
             - "abscissa*"
@@ -118,9 +115,12 @@ updates:
             - "insta"
             - "prost*"
             - "tonic*"
+            # depends on tonic and prost
+            - "console-subscriber"
             - "tempfile"
             - "static_assertions"
             - "criterion"
+            - "inferno"
   - package-ecosystem: github-actions
     directory: '/'
     schedule:


### PR DESCRIPTION
## Motivation

We're still getting multiple dependabot PRs that could have been combined, and some dependabot PRs have resolvable errors:
https://github.com/ZcashFoundation/zebra/actions/runs/6075525215/job/16481878156?pr=7459#step:5:29

Let's see if these changes fix that.

### Specifications

Groups are limited to 10 patterns.

## Solution

- combine the log and time groups
- add console-subscriber to the test group (as well as the async group)
    - this might mean we get 2 PRs when it changes, let's see
- move inferno to the test group

## Review

This is a low priority cleanup.

We'll see if it works next Monday with the next round of updates.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
