### PR TITLE
fix(ci): Increase test launch and shutdown times to fix CI failures

### DIFF
--- a/zebrad/tests/common/launch.rs
+++ b/zebrad/tests/common/launch.rs
@@ -35,7 +35,7 @@ use crate::common::{
 ///
 /// Previously, this value was 3 seconds, which caused rare
 /// metrics or tracing test failures in Windows CI.
-pub const LAUNCH_DELAY: Duration = Duration::from_secs(15);
+pub const LAUNCH_DELAY: Duration = Duration::from_secs(20);
 
 /// After we launch `zebrad`, wait this long in extended tests.
 /// See [`LAUNCH_DELAY`] for details.
@@ -52,7 +52,7 @@ pub const LIGHTWALLETD_DELAY: Duration = Duration::from_secs(60);
 ///
 /// We use a longer time to make sure the first node has launched before the second starts,
 /// even if CI is under load.
-pub const BETWEEN_NODES_DELAY: Duration = Duration::from_secs(5);
+pub const BETWEEN_NODES_DELAY: Duration = Duration::from_secs(20);
 
 /// The amount of time we wait for lightwalletd to update to the tip.
 ///


### PR DESCRIPTION
## Motivation

I've seen at least 3 CI failures due to slow Zebra startup or shutdown over the last few days:
- rpc_conflict_test
- non_blocking_logger

In one of these failures, the RPC sever task doesn't seem to run at all, so I added extra logging to help diagnose that.

Close #7498.
(If this fix doesn't work we can re-open that ticket.)

## Solution

- Make the tests wait longer for startup and shutdown
- Add logs to the start command for every spawned and shut down task

## Review

This is causing CI failures every 1-2 days, so it's urgent.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
