### PR TITLE
change(dev tools): Add an OUTPUT_DATA_LINE_LIMIT to zcash-rpc-diff

### DIFF
--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -22,6 +22,8 @@ JQ="${JQ:-jq}"
 # - Use `-rpccookiefile=your/cookie/file` for a cookie file.
 # - Use `-rpcpassword=your-password` for a password.
 ZCASHD_EXTRA_ARGS="${ZCASHD_EXTRA_ARGS:-}"
+# We show this many lines of data, removing excess lines from the middle of the output.
+OUTPUT_DATA_LINE_LIMIT="${OUTPUT_DATA_LINE_LIMIT:-40}"
 
 if [ $# -lt 2 ]; then
     usage
@@ -114,8 +116,15 @@ $DIFF "$ZEBRAD_RESPONSE" "$ZCASHD_RESPONSE" \
     && ( \
         echo "RPC responses were identical"; \
         echo ; \
-        echo "$ZEBRAD_RESPONSE:"; \
-        cat "$ZEBRAD_RESPONSE"; \
+        echo "$ZEBRAD_RESPONSE, limited to $OUTPUT_DATA_LINE_LIMIT lines:"; \
+        export ZEBRAD_RESPONSE=$ZEBRAD_RESPONSE
+        if [[ $(cat "$ZEBRAD_RESPONSE" | wc -l) -gt $OUTPUT_DATA_LINE_LIMIT ]]; then \
+            cat "$ZEBRAD_RESPONSE" | head -$((OUTPUT_DATA_LINE_LIMIT / 2)) || true; \
+            echo "..."; \
+            cat "$ZEBRAD_RESPONSE" | tail -$((OUTPUT_DATA_LINE_LIMIT / 2)) || true; \
+        else \
+            cat "$ZEBRAD_RESPONSE"; \
+        fi; \
         )
 
 EXIT_STATUS=$?
@@ -159,8 +168,15 @@ $DIFF "$ZEBRAD_CHECK_RESPONSE" "$ZCASHD_CHECK_RESPONSE" \
     && ( \
         echo "RPC check responses were identical"; \
         echo ; \
-        echo "$ZEBRAD_CHECK_RESPONSE:"; \
-        cat "$ZEBRAD_CHECK_RESPONSE"; \
+        echo "$ZEBRAD_CHECK_RESPONSE, limited to $OUTPUT_DATA_LINE_LIMIT lines:"; \
+        export ZEBRAD_CHECK_RESPONSE=$ZEBRAD_CHECK_RESPONSE
+        if [[ $(cat "$ZEBRAD_CHECK_RESPONSE" | wc -l) -gt $OUTPUT_DATA_LINE_LIMIT ]]; then \
+            cat "$ZEBRAD_CHECK_RESPONSE" | head -$((OUTPUT_DATA_LINE_LIMIT / 2)) || true; \
+            echo "..."; \
+            cat "$ZEBRAD_CHECK_RESPONSE" | tail -$((OUTPUT_DATA_LINE_LIMIT / 2)) || true; \
+        else \
+            cat "$ZEBRAD_CHECK_RESPONSE"; \
+        fi; \
         )
 
 CHECK_EXIT_STATUS=$?
@@ -194,8 +210,15 @@ if [ "$1" == "getaddressbalance" ]; then
         && ( \
              echo "RPC balances were identical"; \
              echo ; \
-             echo "$ZEBRAD_NUM_RESPONSE:"; \
-             cat "$ZEBRAD_NUM_RESPONSE"; \
+             echo "$ZEBRAD_NUM_RESPONSE, limited to $OUTPUT_DATA_LINE_LIMIT lines:"; \
+             export ZEBRAD_NUM_RESPONSE=$ZEBRAD_NUM_RESPONSE
+             if [[ $(cat "$ZEBRAD_NUM_RESPONSE" | wc -l) -gt $OUTPUT_DATA_LINE_LIMIT ]]; then \
+                 cat "$ZEBRAD_NUM_RESPONSE" | head -$((OUTPUT_DATA_LINE_LIMIT / 2)) || true; \
+                 echo "..."; \
+                 cat "$ZEBRAD_NUM_RESPONSE" | tail -$((OUTPUT_DATA_LINE_LIMIT / 2)) || true; \
+             else \
+                 cat "$ZEBRAD_NUM_RESPONSE"; \
+             fi; \
         )
 
     COMPARE_EXIT_STATUS=$?


### PR DESCRIPTION
## Motivation

Some RPC outputs are very long, making them hard to paste into GitHub comments.

## Solution

When RPC outputs are identical, only show the first 20 and last 20 lines

`git diff` already limits the length of its outputs. (I think?)

## Review

This is a low priority developer tooling change.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

