### PR TITLE
change(tools): Show zcash-cli version at the start of zcash-rpc-diff

### DIFF
--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -58,7 +58,10 @@ ZCASHD_VERSION=$(cat "$ZCASHD_RELEASE_INFO" | grep '"build"' | cut -d: -f2 | cut
              tr 'A-Z' 'a-z')
 ZCASHD="$ZCASHD_NAME $ZCASHD_VERSION"
 
-echo "Connected to $ZEBRAD (port $ZEBRAD_RPC_PORT) and $ZCASHD ($ZCASH_CLI zcash.conf port)."
+echo
+
+echo "Connected to $ZEBRAD (port $ZEBRAD_RPC_PORT) and $ZCASHD (zcash.conf port)."
+echo "Using '$($ZCASH_CLI -version | head -1)' via command '$ZCASH_CLI'."
 
 echo
 

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -33,6 +33,11 @@ fi
 ZEBRAD_RPC_PORT=$1
 shift
 
+echo "Using '$($ZCASH_CLI -version | head -1)' via command '$ZCASH_CLI'."
+echo "Using bash shell '$BASH_VERSION' launched from '$SHELL'."
+
+echo
+
 # Use an easily identified temp directory name,
 # but fall back to the default temp name if `mktemp` does not understand `--suffix`.
 ZCASH_RPC_TMP_DIR=$(mktemp --suffix=.rpc-diff -d 2>/dev/null || mktemp -d)
@@ -58,11 +63,7 @@ ZCASHD_VERSION=$(cat "$ZCASHD_RELEASE_INFO" | grep '"build"' | cut -d: -f2 | cut
              tr 'A-Z' 'a-z')
 ZCASHD="$ZCASHD_NAME $ZCASHD_VERSION"
 
-echo
-
 echo "Connected to $ZEBRAD (port $ZEBRAD_RPC_PORT) and $ZCASHD (zcash.conf port)."
-echo "Using '$($ZCASH_CLI -version | head -1)' via command '$ZCASH_CLI'."
-echo "Using bash shell '$BASH_VERSION' launched from '$SHELL'."
 
 echo
 

--- a/zebra-utils/zcash-rpc-diff
+++ b/zebra-utils/zcash-rpc-diff
@@ -62,6 +62,7 @@ echo
 
 echo "Connected to $ZEBRAD (port $ZEBRAD_RPC_PORT) and $ZCASHD (zcash.conf port)."
 echo "Using '$($ZCASH_CLI -version | head -1)' via command '$ZCASH_CLI'."
+echo "Using bash shell '$BASH_VERSION' launched from '$SHELL'."
 
 echo
 


### PR DESCRIPTION
## Motivation

We're seeing inconsistent behaviour from `zcash-rpc-diff` on different developers machines.

For example:
https://github.com/ZcashFoundation/zebra/issues/7450#issuecomment-1710717743

## Solution

- Show the `zcash-cli` version when `zcash-rpc-diff` runs
- Show the `bash` shell version when `zcash-rpc-diff` runs

## Review

This is a low priority test tool change.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

