### PR TITLE
fix(doc): Fix typos in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,6 @@ This release:
 - Starts our work implementing "spend before sync" algorithm for lightwalletd.
 - Contains an automatic database upgrade that reduces the size of Zebra's current cached state from approximately 276GB to 244GB. It does so by automatically pruning unneeded note commitment trees from an existing cache. New Zebra instances will also build their cache without these trees.
 
-### Changed
-
-- Deduplicate note commitment trees stored in the finalized state ([#7312]()https://github.com/ZcashFoundation/zebra/pull/7312, [#7379](https://github.com/ZcashFoundation/zebra/pull/7379))
-- Insert only the first tree in each series of identical trees into finalized state ([#7266](https://github.com/ZcashFoundation/zebra/pull/7266))
-- Our testing framework now uses the ECC lightwalletd fork ([#7307](https://github.com/ZcashFoundation/zebra/pull/7307)). This was needed to start the work of implementing fast spendability. The ECC repo is now the supported implementation in Zebra, documentation was changed to reflect this. ([#7427](https://github.com/ZcashFoundation/zebra/pull/7427))
-
 ### Breaking Changes
 
 `zebrad` 1.2.0 cached states are incompatible with previous `zebrad` versions:
@@ -28,6 +22,12 @@ This release:
 - When earlier versions try to use states upgraded by `zebrad` 1.2.0:
     - `zebrad` versions 1.0.0 and 1.0.1 will respond to some `z_gettreestate` RPC requests with incorrect empty `final_state` fields
     - pre-release `zebrad` versions can panic when verifying shielded transactions, updating the state, or responding to RPC requests
+
+### Changed
+
+- Deduplicate note commitment trees stored in the finalized state ([#7312](https://github.com/ZcashFoundation/zebra/pull/7312), [#7379](https://github.com/ZcashFoundation/zebra/pull/7379))
+- Insert only the first tree in each series of identical trees into finalized state ([#7266](https://github.com/ZcashFoundation/zebra/pull/7266))
+- Our testing framework now uses the ECC lightwalletd fork ([#7307](https://github.com/ZcashFoundation/zebra/pull/7307)). This was needed to start the work of implementing fast spendability. The ECC repo is now the supported implementation in Zebra, documentation was changed to reflect this. ([#7427](https://github.com/ZcashFoundation/zebra/pull/7427))
 
 ### Added
 


### PR DESCRIPTION
## Motivation

1. There's a typo that breaks a link in the changelog
2. Breaking changes are usually at the top, so users notice them

I have already fixed these issues in:
https://github.com/ZcashFoundation/zebra/releases/tag/v1.2.0

## Review

This is a low priority cleanup.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

