### PR TITLE
change(ci): Temporally disable `saves_to_disk` in lightwalletd full sync tests

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -599,7 +599,7 @@ jobs:
       is_long_test: true
       needs_zebra_state: true
       needs_lwd_state: false
-      saves_to_disk: true
+      saves_to_disk: false
       force_save_to_disk: ${{ inputs.force_save_to_disk || false }}
       disk_prefix: lwd-cache
       disk_suffix: tip


### PR DESCRIPTION
## Motivation

Step 1 of https://github.com/ZcashFoundation/zebra/pull/7507#pullrequestreview-1619307634

Needed to test the code of that PR. Changes will be reversed in https://github.com/ZcashFoundation/zebra/pull/7507 as part of the other steps of https://github.com/ZcashFoundation/zebra/pull/7507#pullrequestreview-1619307634