### PR TITLE
imp(doc): add missing Docker variables and examples

### DIFF
--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -28,12 +28,15 @@ See [Building Zebra](https://github.com/ZcashFoundation/zebra#building-zebra) fo
 
 ## Advanced usage
 
-You're able to specify various parameters when building or launching the Docker image, which are meant to be used by developers and CI pipelines. For example, specifying the Network where Zebra will run (Mainnet, Testnet, etc), or enabling features like mining.
+You're able to specify various parameters when building or launching the Docker image, which are meant to be used by developers and CI pipelines. For example, specifying the Network where Zebra will run (Mainnet, Testnet, etc), or enabling features like metrics with Prometheus.
 
-For example, if we'd like to enable mining on the image, we'd build it using the following `build-arg`:
+For example, if we'd like to enable metrics on the image, we'd build it using the following `build-arg`:
+
+> [!WARNING]
+> To fully use and display the metrics, you'll need to run a Prometheus and Grafana server, and configure it to scrape and visualize the metrics endpoint. This is explained in more detailed in the [Metrics](https://zebra.zfnd.org/user/metrics.html#zebra-metrics) section of the User Guide.
 
 ```shell
-docker build -f ./docker/Dockerfile --target runtime --build-arg FEATURES='default-release-binaries getblocktemplate-rpcs' --tag local/zebra.mining:latest .
+docker build -f ./docker/Dockerfile --target runtime --build-arg FEATURES='default-release-binaries prometheus' --tag local/zebra.mining:latest .
 ```
 
 To increase the log output we can optionally add these `build-arg`s:
@@ -42,13 +45,13 @@ To increase the log output we can optionally add these `build-arg`s:
 --build-arg RUST_BACKTRACE=full --build-arg RUST_LOG=debug --build-arg COLORBT_SHOW_HIDDEN=1
 ```
 
-And after our image has been built, we can run it on `Mainnet` with the following command:
+And after our image has been built, we can run it on `Mainnet` with the following command, which will expose the metrics endpoint on port `9999` and force the logs to be colored:
 
 ```shell
-docker run --env NETWORK="Mainnet" --env RPC_PORT="8232" --env MINER_ADDRESS="t1XhG6pT9xRqRQn3BHP7heUou1RuYrbcrCc" -p 8232:8232 local/zebra.mining
+docker run --env LOG_COLOR="true" -p 9999:9999 local/zebra.mining
 ```
 
-Based on our actual `entrypoint.sh` script, the following configuration file will be generated (on the fly, at startup) and used by Zebra:
+Based on our actual `runtime-entrypoint.sh` script, the following configuration file will be generated (on the fly, at startup) and used by Zebra:
 
 ```toml
 [network]
@@ -56,12 +59,8 @@ network = "Mainnet"
 listen_addr = "0.0.0.0"
 [state]
 cache_dir = "/var/cache/zebrad-cache"
-[rpc]
-listen_addr = "0.0.0.0:8232"
-[tracing]
-use_color = false
-[mining]
-miner_address = "t1XhG6pT9xRqRQn3BHP7heUou1RuYrbcrCc"
+[metrics]
+endpoint_addr = "127.0.0.1:9999"
 ```
 
 ### Build time arguments
@@ -81,7 +80,7 @@ miner_address = "t1XhG6pT9xRqRQn3BHP7heUou1RuYrbcrCc"
 
 - `TEST_FEATURES`: Specifies the features for tests. Example: `"lightwalletd-grpc-tests zebra-checkpoints"`
 - `ZEBRA_SKIP_IPV6_TESTS`: Skips IPv6 tests. Example: `1`
-- `ENTRYPOINT_FEATURES`: Overrides the specific features used to run tests in `entrypoint.sh`. Example: `"default-release-binaries lightwalletd-grpc-tests"`
+- `ENTRYPOINT_FEATURES`: Overrides the specific features used to run tests in `runtime-entrypoint.sh`. Example: `"default-release-binaries lightwalletd-grpc-tests"`
 
 #### CI/CD
 

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -68,51 +68,51 @@ miner_address = "t1XhG6pT9xRqRQn3BHP7heUou1RuYrbcrCc"
 
 #### Configuration
 
-- **FEATURES**: Specifies the features to build `zebrad` with. Example: `"default-release-binaries getblocktemplate-rpcs"`
+- `FEATURES`: Specifies the features to build `zebrad` with. Example: `"default-release-binaries getblocktemplate-rpcs"`
 
 #### Logging
 
-- **RUST_LOG**: Sets the trace log level. Example: `"debug"`
-- **RUST_BACKTRACE**: Enables or disables backtraces. Example: `"full"`
-- **RUST_LIB_BACKTRACE**: Enables or disables library backtraces. Example: `1`
-- **COLORBT_SHOW_HIDDEN**: Enables or disables showing hidden backtraces. Example: `1`
+- `RUST_LOG`: Sets the trace log level. Example: `"debug"`
+- `RUST_BACKTRACE`: Enables or disables backtraces. Example: `"full"`
+- `RUST_LIB_BACKTRACE`: Enables or disables library backtraces. Example: `1`
+- `COLORBT_SHOW_HIDDEN`: Enables or disables showing hidden backtraces. Example: `1`
 
 #### Tests
 
-- **TEST_FEATURES**: Specifies the features for tests. Example: `"lightwalletd-grpc-tests zebra-checkpoints"`
-- **ZEBRA_SKIP_IPV6_TESTS**: Skips IPv6 tests. Example: `1`
-- **ENTRYPOINT_FEATURES**: Overrides the specific features used to run tests in `entrypoint.sh`. Example: `"default-release-binaries lightwalletd-grpc-tests"`
+- `TEST_FEATURES`: Specifies the features for tests. Example: `"lightwalletd-grpc-tests zebra-checkpoints"`
+- `ZEBRA_SKIP_IPV6_TESTS`: Skips IPv6 tests. Example: `1`
+- `ENTRYPOINT_FEATURES`: Overrides the specific features used to run tests in `entrypoint.sh`. Example: `"default-release-binaries lightwalletd-grpc-tests"`
 
 #### CI/CD
 
-- **SHORT_SHA**: Represents the short SHA of the commit. Example: `"a1b2c3d"`
+- `SHORT_SHA`: Represents the short SHA of the commit. Example: `"a1b2c3d"`
 
 ### Run time variables
 
 #### Network
 
-- **NETWORK**: Specifies the network type. Example: `"Mainnet"`
+- `NETWORK`: Specifies the network type. Example: `"Mainnet"`
 
 #### Zebra Configuration
 
-- **ZEBRA_CHECKPOINT_SYNC**: Enables or disables checkpoint sync. Example: `true`
-- **ZEBRA_LISTEN_ADDR**: Address for Zebra to listen on. Example: `"0.0.0.0"`
-- **ZEBRA_CACHED_STATE_DIR**: Directory for cached state. Example: `"/var/cache/zebrad-cache"`
+- `ZEBRA_CHECKPOINT_SYNC`: Enables or disables checkpoint sync. Example: `true`
+- `ZEBRA_LISTEN_ADDR`: Address for Zebra to listen on. Example: `"0.0.0.0"`
+- `ZEBRA_CACHED_STATE_DIR`: Directory for cached state. Example: `"/var/cache/zebrad-cache"`
 
 #### Mining Configuration
 
-- **RPC_LISTEN_ADDR**: Address for RPC to listen on. Example: `"0.0.0.0"`
-- **RPC_PORT**: Port for RPC. Example: `8232`
-- **MINER_ADDRESS**: Address for the miner. Example: `"t1XhG6pT9xRqRQn3BHP7heUou1RuYrbcrCc"`
+- `RPC_LISTEN_ADDR`: Address for RPC to listen on. Example: `"0.0.0.0"`
+- `RPC_PORT`: Port for RPC. Example: `8232`
+- `MINER_ADDRESS`: Address for the miner. Example: `"t1XhG6pT9xRqRQn3BHP7heUou1RuYrbcrCc"`
 
 #### Other Configuration
 
-- **METRICS_ENDPOINT_ADDR**: Address for metrics endpoint. Example: `"0.0.0.0"`
-- **METRICS_ENDPOINT_PORT**: Port for metrics endpoint. Example: `9999`
-- **LOG_FILE**: Path to the log file. Example: `"/path/to/log/file.log"`
-- **LOG_COLOR**: Enables or disables log color. Example: `false`
-- **TRACING_ENDPOINT_ADDR**: Address for tracing endpoint. Example: `"0.0.0.0"`
-- **TRACING_ENDPOINT_PORT**: Port for tracing endpoint. Example: `3000`
+- `METRICS_ENDPOINT_ADDR`: Address for metrics endpoint. Example: `"0.0.0.0"`
+- `METRICS_ENDPOINT_PORT`: Port for metrics endpoint. Example: `9999`
+- `LOG_FILE`: Path to the log file. Example: `"/path/to/log/file.log"`
+- `LOG_COLOR`: Enables or disables log color. Example: `false`
+- `TRACING_ENDPOINT_ADDR`: Address for tracing endpoint. Example: `"0.0.0.0"`
+- `TRACING_ENDPOINT_PORT`: Port for tracing endpoint. Example: `3000`
 
 ## Registries
 

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -66,31 +66,53 @@ miner_address = "t1XhG6pT9xRqRQn3BHP7heUou1RuYrbcrCc"
 
 ### Build time arguments
 
+#### Configuration
+
 - **FEATURES**: Specifies the features to build `zebrad` with. Example: `"default-release-binaries getblocktemplate-rpcs"`
-- **TEST_FEATURES**: Specifies the features for tests. Example: `"lightwalletd-grpc-tests zebra-checkpoints"`
+
+#### Logging
+
 - **RUST_LOG**: Sets the trace log level. Example: `"debug"`
 - **RUST_BACKTRACE**: Enables or disables backtraces. Example: `"full"`
 - **RUST_LIB_BACKTRACE**: Enables or disables library backtraces. Example: `1`
 - **COLORBT_SHOW_HIDDEN**: Enables or disables showing hidden backtraces. Example: `1`
-- **SHORT_SHA**: Represents the short SHA of the commit. Example: `"a1b2c3d"`
+
+#### Tests
+
+- **TEST_FEATURES**: Specifies the features for tests. Example: `"lightwalletd-grpc-tests zebra-checkpoints"`
 - **ZEBRA_SKIP_IPV6_TESTS**: Skips IPv6 tests. Example: `1`
 - **ENTRYPOINT_FEATURES**: Overrides the specific features used to run tests in `entrypoint.sh`. Example: `"default-release-binaries lightwalletd-grpc-tests"`
 
+#### CI/CD
+
+- **SHORT_SHA**: Represents the short SHA of the commit. Example: `"a1b2c3d"`
+
 ### Run time variables
 
+#### Network
+
 - **NETWORK**: Specifies the network type. Example: `"Mainnet"`
-- **ZEBRA_LISTEN_ADDR**: Address for Zebra to listen on. Example: `"0.0.0.0"`
+
+#### Zebra Configuration
+
 - **ZEBRA_CHECKPOINT_SYNC**: Enables or disables checkpoint sync. Example: `true`
+- **ZEBRA_LISTEN_ADDR**: Address for Zebra to listen on. Example: `"0.0.0.0"`
 - **ZEBRA_CACHED_STATE_DIR**: Directory for cached state. Example: `"/var/cache/zebrad-cache"`
+
+#### Mining Configuration
+
+- **RPC_LISTEN_ADDR**: Address for RPC to listen on. Example: `"0.0.0.0"`
+- **RPC_PORT**: Port for RPC. Example: `8232`
+- **MINER_ADDRESS**: Address for the miner. Example: `"t1XhG6pT9xRqRQn3BHP7heUou1RuYrbcrCc"`
+
+#### Other Configuration
+
 - **METRICS_ENDPOINT_ADDR**: Address for metrics endpoint. Example: `"0.0.0.0"`
 - **METRICS_ENDPOINT_PORT**: Port for metrics endpoint. Example: `9999`
+- **LOG_FILE**: Path to the log file. Example: `"/path/to/log/file.log"`
 - **LOG_COLOR**: Enables or disables log color. Example: `false`
 - **TRACING_ENDPOINT_ADDR**: Address for tracing endpoint. Example: `"0.0.0.0"`
 - **TRACING_ENDPOINT_PORT**: Port for tracing endpoint. Example: `3000`
-- **RPC_LISTEN_ADDR**: Address for RPC to listen on. Example: `"0.0.0.0"`
-- **RPC_PORT**: Port for RPC. Example: `8232`
-- **LOG_FILE**: Path to the log file. Example: `"/path/to/log/file.log"`
-- **MINER_ADDRESS**: Address for the miner. Example: `"t1XhG6pT9xRqRQn3BHP7heUou1RuYrbcrCc"`
 
 ## Registries
 

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -33,7 +33,7 @@ You're able to specify various parameters when building or launching the Docker 
 For example, if we'd like to enable mining on the image, we'd build it using the following `build-arg`:
 
 ```shell
-docker build -f ./docker/Dockerfile --target runtime --build-arg FEATURES='default-release-binaries getblocktemplate-rpcs'  --tag local/zebra.mining:latest .
+docker build -f ./docker/Dockerfile --target runtime --build-arg FEATURES='default-release-binaries getblocktemplate-rpcs' --tag local/zebra.mining:latest .
 ```
 
 To increase the log output we can optionally add these `build-arg`s:
@@ -42,10 +42,10 @@ To increase the log output we can optionally add these `build-arg`s:
 --build-arg RUST_BACKTRACE=full --build-arg RUST_LOG=debug --build-arg COLORBT_SHOW_HIDDEN=1
 ```
 
-And after our image has been built, we can run it in the `Mainnet` with the following command:
+And after our image has been built, we can run it on `Mainnet` with the following command:
 
 ```shell
-docker run -e NETWORK="Mainnet" -e RPC_PORT="8232" -e MINER_ADDRESS="t1XhG6pT9xRqRQn3BHP7heUou1RuYrbcrCc" -p 8232:8232 local/zebra.mining
+docker run --env NETWORK="Mainnet" --env RPC_PORT="8232" --env MINER_ADDRESS="t1XhG6pT9xRqRQn3BHP7heUou1RuYrbcrCc" -p 8232:8232 local/zebra.mining
 ```
 
 Based on our actual `entrypoint.sh` script, the following configuration file will be generated (on the fly, at startup) and used by Zebra:


### PR DESCRIPTION
## Motivation

We did not have documentation on the new variables and arguments which were introduced and changed in:
- #7200

Closes: #7008 

## Solution
- Document these arguments and variables
- Add examples for each one, and a mining example using some of these values

## Review

@upbqdn might want to have a look at this one

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We should have a `docker-compose.yml` with some scenarios already set-up so it's easier for people to have a running node, for example, with non-volatile storage for their cache state.