### PR TITLE
fix(ci): Temporarily disable panic on subtree validation failure

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -183,7 +183,8 @@ pub fn check(db: &ZebraDb) {
     let check_sapling_subtrees = check_sapling_subtrees(db);
     let check_orchard_subtrees = check_orchard_subtrees(db);
     if !check_sapling_subtrees || !check_orchard_subtrees {
-        panic!("missing or bad subtree(s)");
+        // TODO: make this a panic before releasing the subtree change (#7532)
+        error!("missing or bad subtree(s)");
     }
 }
 


### PR DESCRIPTION
## Motivation

This PR disabled subtree validation panics until we fix subtree bug #7532.

## Solution

Replace a panic with an error

## Review

This is an urgent fix that is blocking unrelated PRs from merging.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

