### PR TITLE
fix(state): Compare subtrees in non-finalized chains when evaluating chain equality

### DIFF
--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -281,6 +281,10 @@ impl Chain {
             // history trees
             self.history_trees_by_height == other.history_trees_by_height &&
 
+            // note commitment subtrees
+            self.sapling_subtrees == other.sapling_subtrees &&
+            self.orchard_subtrees == other.orchard_subtrees &&
+
             // anchors
             self.sprout_anchors == other.sprout_anchors &&
             self.sprout_anchors_by_height == other.sprout_anchors_by_height &&

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -624,6 +624,10 @@ fn different_blocks_different_chains() -> Result<()> {
                 chain1.sapling_trees_by_height = chain2.sapling_trees_by_height.clone();
                 chain1.orchard_trees_by_height = chain2.orchard_trees_by_height.clone();
 
+                // note commitment subtrees
+                chain1.sapling_subtrees = chain2.sapling_subtrees.clone();
+                chain1.orchard_subtrees = chain2.orchard_subtrees.clone();
+
                 // history trees
                 chain1.history_trees_by_height = chain2.history_trees_by_height.clone();
 


### PR DESCRIPTION
## Motivation

Close #7447.

## Solution

- Compare the subtrees in [eq_internal_state](https://github.com/zcashfoundation/zebra/blob/6f503049c631804aca7d99615becb8be5cc1bd7a/zebra-state/src/service/non_finalized_state/chain.rs#L263).
- This fix turned out to be trivial since none of our tests create subtrees in non-finalized chains.
- I thought of moving the chain comparison to `Eq`, but we already use `Eq` for another purpose, so I left the comparison as it is.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?