### PR TITLE
change(ci): Automatically open a ticket for main branch failures in the CI Docker workflow

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -782,3 +782,26 @@ jobs:
       root_state_path: '/var/cache'
       zebra_state_dir: 'zebrad-cache'
     secrets: inherit
+
+  failure-issue:
+    name: Open or update issues for main branch failures
+    # When a new test is added to this workflow, add it to this list.
+    #
+    # This list is for reliable tests that are run on the `main` branch.
+    # Testnet jobs are not in this list, because we expect testnet to fail occasionally.
+    needs: [ regenerate-stateful-disks, test-full-sync, lightwalletd-full-sync, test-all, test-all-getblocktemplate-rpcs, test-fake-activation-heights, test-empty-sync, test-lightwalletd-integration, test-configuration-file, test-zebra-conf-path, test-stateful-sync, test-update-sync, generate-checkpoints-mainnet, lightwalletd-update-sync, lightwalletd-rpc-test, lightwalletd-transactions-test, lightwalletd-grpc-test, get-block-template-test, submit-block-test ]
+    # Only open tickets for failed scheduled jobs, manual workflow runs, or `main` branch merges.
+    # (PR statuses are already reported in the PR jobs list, and checked by Mergify.)
+    # TODO: if a job times out, we want to create a ticket. Does failure() do that? Or do we need cancelled()?
+    if: failure() && github.event.pull_request == null
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jayqi/failed-build-issue-action@v1
+        with:
+          title-template: "{{refname}} branch CI failed: {{eventName}} in {{workflow}}"
+          # New failures open an issue with this label.
+          # TODO: do we want a different label for each workflow, or each kind of workflow?
+          label-name: S-ci-fail-auto-issue
+          # If there is already an open issue with this label, any failures become comments on that issue.
+          always-create-new-issue: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

We want to automatically open a ticket when scheduled jobs, main branch merges, or manual workflow runs fail in the CI Docker job.

This implements some of the job kinds in #6864, as a trial of this functionality.

We've been having some issues with cached states, so I wanted to make sure we can see those failures.

### Specifications

https://github.com/marketplace/actions/failed-build-issue

Detailed arguments:
https://github.com/jayqi/failed-build-issue-action/blob/main/action.yml

### Complex Code or Requirements

It's annoying to have to list every job to register failures.

## Solution

Automatically open failure tickets when CI Docker jobs fail, if the job was not run by a PR
If there is already an auto-opened ticket, add a comment to it instead

## Review

This is a routine change.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

See if this works, and then add a similar job to deployments, releases, and scheduled jobs. 