### PR TITLE
change(doc): Refactor docs for feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ You can also build Zebra with additional [Cargo features](https://doc.rust-lang.
 - `prometheus` for [Prometheus metrics](https://zebra.zfnd.org/user/metrics.html)
 - `progress-bar` [experimental progress bars](https://zfnd.org/experimental-zebra-progress-bars/)
 - `sentry` for [Sentry monitoring](https://zebra.zfnd.org/user/tracing.html#sentry-production-monitoring)
+- `elasticsearch` for [experimental Elasticsearch support](https://zebra.zfnd.org/user/elasticsearch.html)
 
 You can combine multiple features by listing them as parameters of the `--features` flag:
 

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ sections in the book for more details.
 
 You can also build Zebra with additional [Cargo features](https://doc.rust-lang.org/cargo/reference/features.html#command-line-feature-options):
 
-- `sentry` for [Sentry monitoring](https://zebra.zfnd.org/user/requirements.html#sentry-production-monitoring)
-- `journald` for [`journald` logging](https://zebra.zfnd.org/user/tracing.html#journald-logging)
-- `prometheus` for [Prometheus metrics](https://doc.zebra.zfnd.org/zebrad/#metrics)
 - `getblocktemplate-rpcs` for [mining support](https://zebra.zfnd.org/user/mining.html)
+- `prometheus` for [Prometheus metrics](https://zebra.zfnd.org/user/metrics.html)
+- `progress-bar` [experimental progress bars](https://zfnd.org/experimental-zebra-progress-bars/)
+- `sentry` for [Sentry monitoring](https://zebra.zfnd.org/user/tracing.html#sentry-production-monitoring)
 
 You can combine multiple features by listing them as parameters of the `--features` flag:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
   - [Docker](#docker)
   - [Building Zebra](#building-zebra)
     - [Optional Features](#optional-features)
-  - [Network Ports](#network-ports)
 - [Known Issues](#known-issues)
 - [Future Work](#future-work)
 - [Documentation](#documentation)
@@ -138,17 +137,6 @@ documentation](https://doc.zebra.zfnd.org/zebrad/index.html#zebra-feature-flags)
 Some debugging and monitoring features are disabled in release builds to increase
 performance.
 
-### Network Ports
-
-Zebra uses the following inbound and outbound TCP ports:
-
-- 8233 on Mainnet
-- 18233 on Testnet
-
-Please see the [Network
-Requirements](https://zebra.zfnd.org/user/requirements.html#network-requirements-and-ports)
-section of the Zebra book for more details.
-
 ## Known Issues
 
 There are a few bugs in Zebra that we're still working on fixing:
@@ -164,7 +152,6 @@ There are a few bugs in Zebra that we're still working on fixing:
 - No Windows support [#3801](https://github.com/ZcashFoundation/zebra/issues/3801). We used to test with Windows Server 2019, but not any more; see the issue for details.
 
 - Experimental Tor support is disabled until [Zebra upgrades to the latest `arti-client`](https://github.com/ZcashFoundation/zebra/issues/5492). This happened due to a Rust dependency conflict, which could only be resolved by `arti` upgrading to a version of `x25519-dalek` with the dependency fix.
-
 
 ## Future Work
 

--- a/book/src/user/requirements.md
+++ b/book/src/user/requirements.md
@@ -54,7 +54,3 @@ so some version upgrades might require a full download of the whole chain.
 Zebra needs some peers which have a round-trip latency of 2 seconds or less. If
 this is a problem for you, please [open a
 ticket.](https://github.com/ZcashFoundation/zebra/issues/new/choose)
-
-## Sentry Production Monitoring
-
-Compile Zebra with `--features sentry` to monitor it using Sentry in production.

--- a/book/src/user/tracing.md
+++ b/book/src/user/tracing.md
@@ -32,9 +32,9 @@ Zebra can generate [flamegraphs] of tracing spans.
 Activate flamegraphs using the `flamegraph` compile-time feature,
 and the [`flamegraph`][flamegraph] runtime config option.
 
-[tracing_section]: https://doc.zebra.zfnd.org/zebrad/config/struct.TracingSection.html
-[filter]: https://doc.zebra.zfnd.org/zebrad/config/struct.TracingSection.html#structfield.filter
-[flamegraph]: https://doc.zebra.zfnd.org/zebrad/config/struct.TracingSection.html#structfield.flamegraph
+[tracing_section]: https://doc.zebra.zfnd.org/zebrad/components/tracing/struct.Config.html
+[filter]: https://doc.zebra.zfnd.org/zebrad/components/tracing/struct.Config.html#structfield.filter
+[flamegraph]: https://doc.zebra.zfnd.org/zebrad/components/tracing/struct.Config.html#structfield.flamegraph
 [flamegraphs]: http://www.brendangregg.com/flamegraphs.html
 [systemd_journald]: https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
-[use_journald]: https://doc.zebra.zfnd.org/zebrad/config/struct.TracingSection.html#structfield.use_journald
+[use_journald]: https://doc.zebra.zfnd.org/zebrad/components/tracing/struct.Config.html#structfield.use_journald

--- a/book/src/user/tracing.md
+++ b/book/src/user/tracing.md
@@ -32,9 +32,14 @@ Zebra can generate [flamegraphs] of tracing spans.
 Activate flamegraphs using the `flamegraph` compile-time feature,
 and the [`flamegraph`][flamegraph] runtime config option.
 
+## Sentry Production Monitoring
+
+Compile Zebra with `--features sentry` to monitor it using [Sentry][sentry] in production.
+
 [tracing_section]: https://doc.zebra.zfnd.org/zebrad/components/tracing/struct.Config.html
 [filter]: https://doc.zebra.zfnd.org/zebrad/components/tracing/struct.Config.html#structfield.filter
 [flamegraph]: https://doc.zebra.zfnd.org/zebrad/components/tracing/struct.Config.html#structfield.flamegraph
 [flamegraphs]: http://www.brendangregg.com/flamegraphs.html
 [systemd_journald]: https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
 [use_journald]: https://doc.zebra.zfnd.org/zebrad/components/tracing/struct.Config.html#structfield.use_journald
+[sentry]: https://sentry.io/welcome/


### PR DESCRIPTION
## Motivation

When reviewing #7552, I noticed a few bugs in our docs for users.
 
## Solution

- Update links in the Tracing Zebra section.
- Move Sentry to the Tracing Zebra section.
- Keep only the most relevant features in `README.md` (this is a subjective change).
- Remove the section on networking from `README.md`. The rationale for this change is in the commit description.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?