### PR TITLE
add(docs): add missing elasticsearch flag feature to lib docs

### DIFF
--- a/book/src/user/elasticsearch.md
+++ b/book/src/user/elasticsearch.md
@@ -4,7 +4,7 @@ The goal here is to export block data from Zebra into an [elasticsearch](https:/
 
 **Attention:** This is an experimental feature tested only in the Zcash Testnet.
 
-Elasticsearch support for zebra was introduced to Zebra in [pull request #6274](https://github.com/ZcashFoundation/zebra/pull/6274).
+Elasticsearch support was introduced to Zebra in [pull request #6274](https://github.com/ZcashFoundation/zebra/pull/6274).
 
 ## Download, build and run Elasticsearch
 

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -93,6 +93,11 @@
 //!
 //! * `proptest-impl`: enable randomised test data generation.
 //! * `lightwalletd-grpc-tests`: enable Zebra JSON-RPC tests that query `lightwalletd` using gRPC.
+//!
+//! ### Experimental
+//!
+//! * `elasticsearch`: save block data into elasticsearch database. Read the [elasticsearch](https://zebra.zfnd.org/user/elasticsearch.html)
+//! section of the book for more details.
 
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]


### PR DESCRIPTION
## Motivation

It was noticed by @upbqdn [here](https://github.com/ZcashFoundation/zebra/pull/7567#discussion_r1327857916) that the `elasticsearch` feafure is undocumented.

## Solution

- document the feature.
- fix a small redundancy in the elasticsearch book page.

## Review

Anyone can review, this is low priority.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
