### PR TITLE
Always open a ticket - test for PR #7565

### DIFF
--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -793,12 +793,12 @@ jobs:
     # Only open tickets for failed scheduled jobs, manual workflow runs, or `main` branch merges.
     # (PR statuses are already reported in the PR jobs list, and checked by Mergify.)
     # TODO: if a job times out, we want to create a ticket. Does failure() do that? Or do we need cancelled()?
-    if: failure() && github.event.pull_request == null
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: jayqi/failed-build-issue-action@v1
         with:
-          title-template: "{{refname}} branch CI failed: {{eventName}} in {{workflow}}"
+          title-template: "Test ticket for {{refname}} branch CI failed: {{eventName}} in {{workflow}}"
           # New failures open an issue with this label.
           # TODO: do we want a different label for each workflow, or each kind of workflow?
           label-name: S-ci-fail-auto-issue


### PR DESCRIPTION
## Motivation

This is  test for PR #7565.

Here's what should happen:
- on the first run, a ticket gets opened
- on the second run, a comment gets added to that ticket