### PR TITLE
fix(ci): handle `tee` trying to write to a closed pipe

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -592,6 +592,9 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command=' \
           set -e;
+          set -o pipefail;
+          trap '' PIPE;
+
           sudo docker logs \
           --tail all \
           --follow \
@@ -599,11 +602,13 @@ jobs:
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           "test result: .*ok.* [1-9][0-9]* passed.*finished in"; \
+
           EXIT_STATUS=$( \
           sudo docker wait ${{ inputs.test_id }} || \
           sudo docker inspect --format "{{.State.ExitCode}}" ${{ inputs.test_id }} || \
           echo "missing container, or missing exit status for container" \
           ); \
+
           echo "sudo docker exit status: $EXIT_STATUS"; \
           exit "$EXIT_STATUS" \
           '


### PR DESCRIPTION
## Motivation
This issue happens even if there's not an actual failure in integration tests.

```
tee: 'standard output': Broken pipe
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 44 filtered out; finished in 2.11s
sudo docker exit status: 101
Error: Process completed with exit code 101.
```

Fixes #7564

### Complex Code or Requirements

`trap '' PIPE` is a not a very intuitive command.

## Solution

Use `trap '' PIPE` as a command in the pipeline might exit early and we want the script to continue executing, as using `grep --max-count=1` might exit after finding the first match, causing a broken pipe error with `tee`. This is being combined with  `set -o pipefail` to have strict error handling, as we want the script to fail if any command in the pipeline fails.

## Review

We should confirm this part of CI is being tested and passes as expected.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

N/A
