### PR TITLE
fix(state): Handle a subtree comparison edge case correctly

### DIFF
--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -440,7 +440,12 @@ impl NoteCommitmentTree {
             return self.is_complete_subtree();
         }
 
-        // If `self` is the next index, check for spurious index differences.
+        // If `self` is the next index, check if the last note completed a subtree.
+        if self.is_complete_subtree() {
+            return true;
+        }
+
+        // Then check for spurious index differences.
         //
         // There is one new subtree somewhere in the trees. It is either:
         // - a new subtree at the end of the previous tree, or

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -421,7 +421,12 @@ impl NoteCommitmentTree {
             return self.is_complete_subtree();
         }
 
-        // If `self` is the next index, check for spurious index differences.
+        // If `self` is the next index, check if the last note completed a subtree.
+        if self.is_complete_subtree() {
+            return true;
+        }
+
+        // Then check for spurious index differences.
         //
         // There is one new subtree somewhere in the trees. It is either:
         // - a new subtree at the end of the previous tree, or


### PR DESCRIPTION
## Motivation

There are two edge cases in the subtree code which we don't currently handle correctly:
> 1. The method returns false here when prev_tree is empty, so prev_index is -1, but self is a complete subtree with index 0. I think the returned value should be true for this case. This case was covered correctly before the refactor.
> 
> 2. The method returns false here when index_difference is 1, and both prev_tree and self are complete subtrees. This case was covered correctly before the refactor.

https://github.com/ZcashFoundation/zebra/pull/7566#discussion_r1330320840

This doesn't impact Zebra because the bug isn't triggered by the way we currently use this code:
1. I'm not sure why this case isn't triggered by the current code, but we have specific tests for this subtree
2. We always pass adjacent trees, so it's not possible for both subtrees to complete a subtree (the block size/output limit prevents it)

### Complex Code or Requirements

This code is a bit complex and it would be nice to refactor it, but we'd have to do a full subtree rebuild to test that the refactor works.

## Solution

Check the "empty subtree" and "completed previous subtree" edge cases after checking for the current subtree being completed.

## Review

This is a fix for @upbqdn's review of PR #7566.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

