### PR TITLE
fix(state): Avoid panics and history tree consensus database concurrency bugs 

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -110,6 +110,44 @@ impl FromDisk for () {
     }
 }
 
+/// Access database keys or values as raw bytes.
+/// Mainly for use in tests, runtime checks, or format compatibility code.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct RawBytes(Vec<u8>);
+
+// Note: don't implement From or Into for RawBytes, because it makes it harder to spot in reviews.
+// Instead, implement IntoDisk and FromDisk on the original type, or a specific wrapper type.
+
+impl RawBytes {
+    /// Create a new raw byte key or data.
+    ///
+    /// Mainly for use in tests or runtime checks.
+    /// These methods
+    pub fn new_raw_bytes(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    /// Create a new raw byte key or data.
+    /// Mainly for use in tests.
+    pub fn raw_bytes(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+impl IntoDisk for RawBytes {
+    type Bytes = Vec<u8>;
+
+    fn as_bytes(&self) -> Self::Bytes {
+        self.raw_bytes().clone()
+    }
+}
+
+impl FromDisk for RawBytes {
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
+        Self::new_raw_bytes(bytes.as_ref().to_vec())
+    }
+}
+
 // Serialization Modification Functions
 
 /// Truncates `mem_bytes` to `disk_len`, by removing zero bytes from the start of the slice.


### PR DESCRIPTION
## Scheduling

This PR should probably get in before the 1.3.0 release, because it fixes a panic bug.

## Motivation

1. We've been seeing "missing sprout tree" panics in CI and on local machines (but users haven't reported them yet)
2. A similar concurrency bug exists in history trees, but it causes invalid empty history tree data to be returned from the state

Close #7581

### Zebra Designs

These are the only column families that:
1. Delete the old height and insert the new height
2. Don't have code that handles the height changing in the middle of reading the height & data

https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/state-db-upgrades.md#current-state-database-format

(The UTXOs get deleted, but missing UTXOs are handled correctly, and their keys are never updated.)

### Complex Code or Requirements

This fix to the tree reading code is compatible with the permanent fix in PR #7392: changing to the key format to an empty key, so the trees get overwritten rather than deleted and re-inserted.

## Solution

- Always read the last sprout tree, regardless of the key value or format
- Always read the last history tree, regardless of the key value or format
- Add a RawData database serialization type

## Review

This PR should probably get in before the 1.3.0 release, because it fixes a panic bug.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Permanent format fix in PR #7392.