### PR TITLE
fix(chain): Return errors instead of panicking in methods for `Height`s

### DIFF
--- a/zebra-chain/src/block/height.rs
+++ b/zebra-chain/src/block/height.rs
@@ -27,7 +27,7 @@ pub struct Height(pub u32);
 
 #[derive(Error, Debug)]
 pub enum HeightError {
-    #[error("The resulting height would ovferflow Height::MAX.")]
+    #[error("The resulting height would overflow Height::MAX.")]
     Overflow,
     #[error("The resulting height would underflow Height::MIN.")]
     Underflow,

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -356,7 +356,7 @@ fn check_sapling_subtrees(db: &ZebraDb) -> Result<(), &'static str> {
             let prev_height = subtree
                 .end
                 .previous()
-                .expect("Height should not underflow here.");
+                .expect("underflow is impossible: Sapling activation is a long way from genesis");
 
             let Some(prev_tree) = db.sapling_tree_by_height(&prev_height) else {
                 result = Err("missing note commitment tree below subtree completion height");

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -356,7 +356,7 @@ fn check_sapling_subtrees(db: &ZebraDb) -> Result<(), &'static str> {
             let prev_height = subtree
                 .end
                 .previous()
-                .expect("underflow is impossible: Sapling activation is a long way from genesis");
+                .expect("Note commitment subtrees should not end at the minimal height.");
 
             let Some(prev_tree) = db.sapling_tree_by_height(&prev_height) else {
                 result = Err("missing note commitment tree below subtree completion height");
@@ -473,7 +473,7 @@ fn check_orchard_subtrees(db: &ZebraDb) -> Result<(), &'static str> {
             let prev_height = subtree
                 .end
                 .previous()
-                .expect("Height should not underflow here.");
+                .expect("Note commitment subtrees should not end at the minimal height.");
 
             let Some(prev_tree) = db.orchard_tree_by_height(&prev_height) else {
                 result = Err("missing note commitment tree below subtree completion height");

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -353,7 +353,12 @@ fn check_sapling_subtrees(db: &ZebraDb) -> Result<(), &'static str> {
         }
         // Check that the final note has a greater subtree index if it didn't complete a subtree.
         else {
-            let Some(prev_tree) = db.sapling_tree_by_height(&subtree.end.previous()) else {
+            let prev_height = subtree
+                .end
+                .previous()
+                .expect("Height should not underflow here.");
+
+            let Some(prev_tree) = db.sapling_tree_by_height(&prev_height) else {
                 result = Err("missing note commitment tree below subtree completion height");
                 error!(?result, ?subtree.end);
                 continue;
@@ -465,7 +470,12 @@ fn check_orchard_subtrees(db: &ZebraDb) -> Result<(), &'static str> {
         }
         // Check that the final note has a greater subtree index if it didn't complete a subtree.
         else {
-            let Some(prev_tree) = db.orchard_tree_by_height(&subtree.end.previous()) else {
+            let prev_height = subtree
+                .end
+                .previous()
+                .expect("Height should not underflow here.");
+
+            let Some(prev_tree) = db.orchard_tree_by_height(&prev_height) else {
                 result = Err("missing note commitment tree below subtree completion height");
                 error!(?result, ?subtree.end);
                 continue;

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -645,7 +645,9 @@ impl Chain {
         // it will always violate the invariant. We restore the invariant by storing the highest
         // (rightmost) removed tree just above `height` if there is no tree at that height.
         if !self.is_empty() && height < self.non_finalized_tip_height() {
-            let next_height = height.next().expect("Height should not overflow here.");
+            let next_height = height
+                .next()
+                .expect("Zebra should never reach the max height in normal operation.");
 
             if self.sprout_trees_by_height.get(&next_height).is_none() {
                 // TODO: Use `try_insert` once it stabilises.
@@ -844,7 +846,9 @@ impl Chain {
         // it will always violate the invariant. We restore the invariant by storing the highest
         // (rightmost) removed tree just above `height` if there is no tree at that height.
         if !self.is_empty() && height < self.non_finalized_tip_height() {
-            let next_height = height.next().expect("Height should not overflow here.");
+            let next_height = height
+                .next()
+                .expect("Zebra should never reach the max height in normal operation.");
 
             if self.sapling_trees_by_height.get(&next_height).is_none() {
                 // TODO: Use `try_insert` once it stabilises.
@@ -1049,7 +1053,9 @@ impl Chain {
         // it will always violate the invariant. We restore the invariant by storing the highest
         // (rightmost) removed tree just above `height` if there is no tree at that height.
         if !self.is_empty() && height < self.non_finalized_tip_height() {
-            let next_height = height.next().expect("Height should not overflow here.");
+            let next_height = height
+                .next()
+                .expect("Zebra should never reach the max height in normal operation.");
 
             if self.orchard_trees_by_height.get(&next_height).is_none() {
                 // TODO: Use `try_insert` once it stabilises.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -556,7 +556,7 @@ impl Chain {
         // Don't add a new tree unless it differs from the previous one or there's no previous tree.
         if height.is_min()
             || self
-                .sprout_tree(height.previous().into())
+                .sprout_tree(height.previous().unwrap().into())
                 .map_or(true, |prev_tree| prev_tree != tree)
         {
             assert_eq!(
@@ -640,7 +640,7 @@ impl Chain {
         // it will always violate the invariant. We restore the invariant by storing the highest
         // (rightmost) removed tree just above `height` if there is no tree at that height.
         if !self.is_empty() && height < self.non_finalized_tip_height() {
-            let next_height = height.next();
+            let next_height = height.next().expect("Height should not overflow here.");
 
             if self.sprout_trees_by_height.get(&next_height).is_none() {
                 // TODO: Use `try_insert` once it stabilises.
@@ -754,7 +754,7 @@ impl Chain {
         // Don't add a new tree unless it differs from the previous one or there's no previous tree.
         if height.is_min()
             || self
-                .sapling_tree(height.previous().into())
+                .sapling_tree(height.previous().unwrap().into())
                 .map_or(true, |prev_tree| prev_tree != tree)
         {
             assert_eq!(
@@ -834,7 +834,7 @@ impl Chain {
         // it will always violate the invariant. We restore the invariant by storing the highest
         // (rightmost) removed tree just above `height` if there is no tree at that height.
         if !self.is_empty() && height < self.non_finalized_tip_height() {
-            let next_height = height.next();
+            let next_height = height.next().expect("Height should not overflow here.");
 
             if self.sapling_trees_by_height.get(&next_height).is_none() {
                 // TODO: Use `try_insert` once it stabilises.
@@ -954,7 +954,7 @@ impl Chain {
         // Don't add a new tree unless it differs from the previous one or there's no previous tree.
         if height.is_min()
             || self
-                .orchard_tree(height.previous().into())
+                .orchard_tree(height.previous().unwrap().into())
                 .map_or(true, |prev_tree| prev_tree != tree)
         {
             assert_eq!(
@@ -1034,7 +1034,7 @@ impl Chain {
         // it will always violate the invariant. We restore the invariant by storing the highest
         // (rightmost) removed tree just above `height` if there is no tree at that height.
         if !self.is_empty() && height < self.non_finalized_tip_height() {
-            let next_height = height.next();
+            let next_height = height.next().expect("Height should not overflow here.");
 
             if self.orchard_trees_by_height.get(&next_height).is_none() {
                 // TODO: Use `try_insert` once it stabilises.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -556,7 +556,12 @@ impl Chain {
         // Don't add a new tree unless it differs from the previous one or there's no previous tree.
         if height.is_min()
             || self
-                .sprout_tree(height.previous().unwrap().into())
+                .sprout_tree(
+                    height
+                        .previous()
+                        .expect("Already checked for underflow.")
+                        .into(),
+                )
                 .map_or(true, |prev_tree| prev_tree != tree)
         {
             assert_eq!(
@@ -754,7 +759,12 @@ impl Chain {
         // Don't add a new tree unless it differs from the previous one or there's no previous tree.
         if height.is_min()
             || self
-                .sapling_tree(height.previous().unwrap().into())
+                .sapling_tree(
+                    height
+                        .previous()
+                        .expect("Already checked for underflow.")
+                        .into(),
+                )
                 .map_or(true, |prev_tree| prev_tree != tree)
         {
             assert_eq!(
@@ -954,7 +964,12 @@ impl Chain {
         // Don't add a new tree unless it differs from the previous one or there's no previous tree.
         if height.is_min()
             || self
-                .orchard_tree(height.previous().unwrap().into())
+                .orchard_tree(
+                    height
+                        .previous()
+                        .expect("Already checked for underflow.")
+                        .into(),
+                )
                 .map_or(true, |prev_tree| prev_tree != tree)
         {
             assert_eq!(


### PR DESCRIPTION
## Motivation

Close #7263.

## Solution

- Don't panic in:
	- `Height::next()`, and
	- `Height::previous()`.

And instead:

- Create a new error type `HeightError`.
- Return the new error type wrapped in `Result`.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?