### PR TITLE
change(state): Check database format is valid every 5 minutes, to catch format errors in new block code

### DIFF
--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -1,5 +1,7 @@
 //! Constants that impact state behaviour.
 
+use std::time::Duration;
+
 use lazy_static::lazy_static;
 use regex::Regex;
 use semver::Version;
@@ -66,6 +68,12 @@ pub fn latest_version_for_adding_subtrees() -> Version {
 ///
 /// Use [`Config::version_file_path()`] to get the path to this file.
 pub(crate) const DATABASE_FORMAT_VERSION_FILE_NAME: &str = "version";
+
+/// The interval between database format checks for newly added blocks.
+///
+/// This should be short enough that format bugs cause CI test failures,
+/// but long enough that it doesn't impact performance.
+pub(crate) const DATABASE_FORMAT_CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);
 
 /// The maximum number of blocks to check for NU5 transactions,
 /// before we assume we are on a pre-NU5 legacy chain.

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -558,7 +558,8 @@ impl DbFormatChange {
         let mut results = Vec::new();
 
         // Check the entire format before returning any errors.
-        //
+        results.push(db.check_max_on_disk_tip_height());
+
         // This check can be run before the upgrade, but the upgrade code is finished, so we don't
         // run it early any more. (If future code changes accidentally make it depend on the
         // upgrade, they would accidentally break compatibility with older Zebra cached states.)

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -302,13 +302,16 @@ fn quick_check_orchard_subtrees(db: &ZebraDb) -> Result<(), &'static str> {
 }
 
 /// Check that note commitment subtrees were correctly added.
-pub fn subtree_format_validity_checks_detailed(db: &ZebraDb) -> Result<(), String> {
+pub fn subtree_format_validity_checks_detailed(
+    db: &ZebraDb,
+    cancel_receiver: &mpsc::Receiver<CancelFormatChange>,
+) -> Result<Result<(), String>, CancelFormatChange> {
     // This is redundant in some code paths, but not in others. But it's quick anyway.
     let quick_result = subtree_format_calculation_pre_checks(db);
 
     // Check the entire format before returning any errors.
-    let sapling_result = check_sapling_subtrees(db);
-    let orchard_result = check_orchard_subtrees(db);
+    let sapling_result = check_sapling_subtrees(db, cancel_receiver)?;
+    let orchard_result = check_orchard_subtrees(db, cancel_receiver)?;
 
     if quick_result.is_err() || sapling_result.is_err() || orchard_result.is_err() {
         let err = Err(format!(
@@ -316,20 +319,23 @@ pub fn subtree_format_validity_checks_detailed(db: &ZebraDb) -> Result<(), Strin
              quick: {quick_result:?}, sapling: {sapling_result:?}, orchard: {orchard_result:?}"
         ));
         warn!(?err);
-        return err;
+        return Ok(err);
     }
 
-    Ok(())
+    Ok(Ok(()))
 }
 
 /// Check that Sapling note commitment subtrees were correctly added.
 ///
 /// Returns an error if a note commitment subtree is missing or incorrect.
-fn check_sapling_subtrees(db: &ZebraDb) -> Result<(), &'static str> {
+fn check_sapling_subtrees(
+    db: &ZebraDb,
+    cancel_receiver: &mpsc::Receiver<CancelFormatChange>,
+) -> Result<Result<(), &'static str>, CancelFormatChange> {
     let Some(NoteCommitmentSubtreeIndex(mut first_incomplete_subtree_index)) =
         db.sapling_tree().subtree_index()
     else {
-        return Ok(());
+        return Ok(Ok(()));
     };
 
     // If there are no incomplete subtrees in the tree, also expect a subtree for the final index.
@@ -339,6 +345,11 @@ fn check_sapling_subtrees(db: &ZebraDb) -> Result<(), &'static str> {
 
     let mut result = Ok(());
     for index in 0..first_incomplete_subtree_index {
+        // Return early if the format check is cancelled.
+        if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
+            return Err(CancelFormatChange);
+        }
+
         // Check that there's a continuous range of subtrees from index [0, first_incomplete_subtree_index)
         let Some(subtree) = db.sapling_subtree_by_index(index) else {
             result = Err("missing subtree");
@@ -404,6 +415,11 @@ fn check_sapling_subtrees(db: &ZebraDb) -> Result<(), &'static str> {
             }
         })
     {
+        // Return early if the format check is cancelled.
+        if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
+            return Err(CancelFormatChange);
+        }
+
         // Check that there's an entry for every completed sapling subtree root in all sapling trees
         let Some(subtree) = db.sapling_subtree_by_index(index) else {
             result = Err("missing subtree");
@@ -436,17 +452,20 @@ fn check_sapling_subtrees(db: &ZebraDb) -> Result<(), &'static str> {
         );
     }
 
-    result
+    Ok(result)
 }
 
 /// Check that Orchard note commitment subtrees were correctly added.
 ///
 /// Returns an error if a note commitment subtree is missing or incorrect.
-fn check_orchard_subtrees(db: &ZebraDb) -> Result<(), &'static str> {
+fn check_orchard_subtrees(
+    db: &ZebraDb,
+    cancel_receiver: &mpsc::Receiver<CancelFormatChange>,
+) -> Result<Result<(), &'static str>, CancelFormatChange> {
     let Some(NoteCommitmentSubtreeIndex(mut first_incomplete_subtree_index)) =
         db.orchard_tree().subtree_index()
     else {
-        return Ok(());
+        return Ok(Ok(()));
     };
 
     // If there are no incomplete subtrees in the tree, also expect a subtree for the final index.
@@ -456,6 +475,11 @@ fn check_orchard_subtrees(db: &ZebraDb) -> Result<(), &'static str> {
 
     let mut result = Ok(());
     for index in 0..first_incomplete_subtree_index {
+        // Return early if the format check is cancelled.
+        if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
+            return Err(CancelFormatChange);
+        }
+
         // Check that there's a continuous range of subtrees from index [0, first_incomplete_subtree_index)
         let Some(subtree) = db.orchard_subtree_by_index(index) else {
             result = Err("missing subtree");
@@ -521,6 +545,11 @@ fn check_orchard_subtrees(db: &ZebraDb) -> Result<(), &'static str> {
             }
         })
     {
+        // Return early if the format check is cancelled.
+        if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
+            return Err(CancelFormatChange);
+        }
+
         // Check that there's an entry for every completed orchard subtree root in all orchard trees
         let Some(subtree) = db.orchard_subtree_by_index(index) else {
             result = Err("missing subtree");
@@ -553,7 +582,7 @@ fn check_orchard_subtrees(db: &ZebraDb) -> Result<(), &'static str> {
         );
     }
 
-    result
+    Ok(result)
 }
 
 /// Calculates a note commitment subtree for Sapling, reading blocks from `read_db` if needed.

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -19,7 +19,7 @@ use crate::{
         disk_db::DiskDb,
         disk_format::{
             block::MAX_ON_DISK_HEIGHT,
-            upgrade::{self, DbFormatChange, DbFormatChangeThreadHandle},
+            upgrade::{DbFormatChange, DbFormatChangeThreadHandle},
         },
     },
     Config,
@@ -118,12 +118,8 @@ impl ZebraDb {
             // If we're re-opening a previously upgraded or newly created database,
             // the database format should be valid.
             // (There's no format change here, so the format change checks won't run.)
-            //
-            // Do the quick checks first, then the slower checks.
-            upgrade::add_subtrees::quick_check(&db);
-
-            DbFormatChange::check_for_duplicate_trees(db.clone());
-            upgrade::add_subtrees::check(&db);
+            DbFormatChange::format_validity_checks_detailed(&db)
+                .expect("current database format is valid");
         }
 
         db

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -75,7 +75,7 @@ impl ZebraDb {
             .expect("unable to read database format version file");
 
         // Log any format changes before opening the database, in case opening fails.
-        let format_change = DbFormatChange::open(running_version, disk_version);
+        let format_change = DbFormatChange::open_database(running_version, disk_version);
 
         // Open the database and do initial checks.
         let mut db = ZebraDb {


### PR DESCRIPTION
## Motivation

We want to catch format errors in new block code. But currently that code is only tested when Zebra adds new blocks, then shuts down, then opens the same state. So PRs can merge with bugs in that code.

Instead, we check the format is valid every 5 minutes while Zebra is running.

This is the periodic part of #7570.

### Complex Code or Requirements

We can't run this code too often, or it will impact performance. But we want to make sure it gets run during most tests, so we catch bugs early.

## Solution

Continue running the format change thread after the initial change finishes, then periodically run a format check:
- Turn the format change task into a continuous loop
- Move the max height check into the format checks
- Make slower format checks cancellable on shutdown

Related changes:
- Refactor the format change/check code so that "no change" has an enum variant
- Add a variant for checking the format of new blocks
- Refactor the format checks so they can be called using a single method
- Make all the format checks run completely, and log their errors, then panic
- Time format upgrades and format checks
- Store the format change flag in the database struct for debugging

### Example Logs

On startup, it takes 2 seconds to open the database, and 7 seconds to check the format is valid:
```
2023-09-21T02:45:10.692975Z  INFO zebra_state::service::finalized_state::disk_format::upgrade: trying to open newer database format: data should be compatible running_version=25.2.1 disk_version=25.2.2
2023-09-21T02:45:12.388329Z  INFO zebra_state::service::finalized_state::disk_format::upgrade: marked database format as downgraded running_version=25.2.1 disk_version=25.2.2 
2023-09-21T02:45:19.485921Z  INFO zebra_state::service::finalized_state::disk_format::upgrade: database format is valid running_version=25.2.1 inital_disk_version=25.2.2
```

So the format check is running approximately 2% of the time. Since it runs in parallel with the rest of the code, and it will be faster when the data is in the database memory cache, this is acceptable performace.

## Review

This is on the critical path for finishing off the subtree work. It's not strictly required for the 1.3.0 release, but it would help to find any other data bugs.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
