### PR TITLE
change(ci): Run slow builds and tests on zfnd-runners to speed up CI

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -53,7 +53,7 @@ jobs:
   build:
     name: Build images
     timeout-minutes: 210
-    runs-on: ubuntu-latest
+    runs-on: zfnd-runners
     outputs:
       image_digest: ${{ steps.docker_build.outputs.digest }}
       image_name: ${{ fromJSON(steps.docker_build.outputs.metadata)['image.name'] }}

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -149,7 +149,7 @@ jobs:
   # TODO: turn this test and the getblocktemplate test into a matrix, so the jobs use exactly the same diagnostics settings
   test-all:
     name: Test all
-    runs-on: ubuntu-latest
+    runs-on: zfnd-runners
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
@@ -175,7 +175,7 @@ jobs:
   # Same as above but we run all the tests behind the `getblocktemplate-rpcs` feature.
   test-all-getblocktemplate-rpcs:
     name: Test all with getblocktemplate-rpcs feature
-    runs-on: ubuntu-latest
+    runs-on: zfnd-runners
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -70,7 +70,7 @@ jobs:
       matrix:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
         # TODO: macOS tests were removed for now, see https://github.com/ZcashFoundation/zebra/issues/6824
-        os: [ubuntu-latest]
+        os: [zfnd-runners]
         rust: [stable, beta]
         features: ["", " --features getblocktemplate-rpcs"]
         exclude:
@@ -84,7 +84,7 @@ jobs:
             features: " --features getblocktemplate-rpcs"
         # getblocktemplate-rpcs is an experimental feature, so we just need to test it on stable Rust
         # beta is unlikely to fail just for this feature, and if it does, we can fix it when it reaches stable.
-          - os: ubuntu-latest
+          - os: zfnd-runners
             rust: beta
             features: " --features getblocktemplate-rpcs"
 


### PR DESCRIPTION
## Motivation

CI currently takes over 2 hours to run, and then another 2 hours to merge after a review. This is due to one slow build and a few slow tests.

I wanted to check if they are faster if they run on our own custom runners.

### Complex Code or Requirements

This might cause cost or CPU load issues, so I need to check with Gustavo before merging this.

- [ ] Admin: change 3 branch protection rules from ubuntu-latest to zfnd-runners (or change the workflow to use "linux" in the job name, and change the branch protection rules to that)

## Solution

Run Docker image builds on custom runners (63 minutes on GitHub actions)
Run Docker image Test all on custom runners (60-64 minutes on GitHub actions, in addition to the image build)

Run OS Test all on custom runners (60 minutes on GitHub actions, in parallel with the Docker image tests)

## Review

I need Gustavo to review this to make sure it doesn't cause unexpected issues.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

