### PR TITLE
change(state): Check database format is valid on shutdown, to catch format errors in new block code

### DIFF
--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -323,7 +323,18 @@ pub fn database_format_version_on_disk(
     network: Network,
 ) -> Result<Option<Version>, BoxError> {
     let version_path = config.version_file_path(network);
+    let db_path = config.db_path(network);
 
+    database_format_version_at_path(&version_path, &db_path)
+}
+
+/// Returns the full semantic version of the on-disk database at `version_path`.
+///
+/// See [`database_format_version_on_disk()`] for details.
+pub(crate) fn database_format_version_at_path(
+    version_path: &Path,
+    db_path: &Path,
+) -> Result<Option<Version>, BoxError> {
     let disk_version_file = match fs::read_to_string(version_path) {
         Ok(version) => Some(version),
         Err(e) if e.kind() == ErrorKind::NotFound => {
@@ -345,8 +356,6 @@ pub fn database_format_version_on_disk(
             patch.parse()?,
         )));
     }
-
-    let db_path = config.db_path(network);
 
     // There's no version file on disk, so we need to guess the version
     // based on the database content

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -300,7 +300,7 @@ impl DbFormatChange {
 
     /// Run a format change in the database, or check the format of the database once.
     #[allow(clippy::unwrap_in_result)]
-    fn run_format_change_or_check(
+    pub(crate) fn run_format_change_or_check(
         &self,
         config: &Config,
         network: Network,

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -104,7 +104,7 @@ pub struct DbFormatChangeThreadHandle {
     cancel_handle: mpsc::SyncSender<CancelFormatChange>,
 }
 
-/// Marker type that is sent to cancel a format upgrade, and returned as a error on cancellation.
+/// Marker type that is sent to cancel a format upgrade, and returned as an error on cancellation.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct CancelFormatChange;
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -369,8 +369,12 @@ impl DbFormatChange {
         //   (unless a future upgrade breaks these format checks)
         // - re-opening the current version should be valid, regardless of whether the upgrade
         //   or new block code created the format (or any combination).
-        Self::format_validity_checks_detailed(upgrade_db, cancel_receiver)?
-            .expect("new, upgraded, or downgraded database format is valid");
+        Self::format_validity_checks_detailed(upgrade_db, cancel_receiver)?.unwrap_or_else(|_| {
+            panic!(
+                "unexpected invalid database format: delete and re-sync the database at '{:?}'",
+                upgrade_db.path()
+            )
+        });
 
         let inital_disk_version = self
             .initial_disk_version()

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -188,7 +188,7 @@ impl ZebraDb {
             // # Testinng
             //
             // In Zebra's CI, panicking here stops us writing invalid cached states,
-            // which would then get make unrelated PRs fail when Zebra starts up.
+            // which would then make unrelated PRs fail when Zebra starts up.
 
             // If the upgrade has completed, or we've done a downgrade, check the state is valid.
             let disk_version = database_format_version_on_disk(&self.config, self.network())


### PR DESCRIPTION
## Motivation

We want to catch format errors in new block code. But currently that code is only tested when Zebra adds new blocks, then shuts down, then opens the same state. So PRs can merge with bugs in that code.

Instead, we check the format is valid before Zebra shuts down. This tells users early if they need to re-sync their state, rather than surprising them the next time they launch Zebra.

It also prevents us writing invalid cached states in CI.

Close #7570.

### Complex Code or Requirements

I think a panic on shutdown should fail CI, but I haven't checked to make sure. Do you think it's worth doing that manually?

## Solution

- [Tell the user what to do when the database format is invalid](https://github.com/ZcashFoundation/zebra/commit/91c52a5bd66ea3554823badfb99aa4730f247e76)
- [Check the database format before Zebra shuts down](https://github.com/ZcashFoundation/zebra/commit/1878581e8f7a863cc0af93fe05f2343c24d6cf79)

Related Refactors:
- [Split a path-based database version method](https://github.com/ZcashFoundation/zebra/commit/48d13295b55d12034bd837d2e543a48faf7f2d30)

## Review

This is optional for the release.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We could replace a whole lot of `config` arguments with the database and version paths, but that can happen later if needed. Storing an `Arc<Config>` isn't that expensive.