### PR TITLE
change(release): Add "wait for a full sync" to the release checklist and ticket template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -12,6 +12,18 @@ assignees: ''
 These release steps can be done a week before the release, in separate PRs.
 They can be skipped for urgent releases.
 
+## State Full Sync Test
+
+To check consensus correctness, we want to test that the state format is valid after a full sync. (Format upgrades are tested in CI on each PR.)
+
+- [ ] Make sure there has been [at least one full sync test](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-integration-docker.yml?query=event%3Aschedule) since the last state change, or
+- [ ] Start a manual workflow run with a Zebra and `lightwalletd` full sync.
+
+State format changes can be made in `zebra-state` or `zebra-chain`. The state format can be changed by data that is sent to the state, data created within the state using `zebra-chain`, or serialization formats in `zebra-state` or `zebra-chain`. 
+
+After the test has been started, or if it has finished already:
+- [ ] Ask for a state code freeze in Slack. The freeze lasts until the release has been published.
+
 ## Checkpoints
 
 For performance and security, we want to update the Zebra checkpoints in every release.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -16,7 +16,7 @@ They can be skipped for urgent releases.
 
 To check consensus correctness, we want to test that the state format is valid after a full sync. (Format upgrades are tested in CI on each PR.)
 
-- [ ] Make sure there has been [at least one full sync test](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-integration-docker.yml?query=event%3Aschedule) since the last state change, or
+- [ ] Make sure there has been [at least one successful full sync test](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-integration-docker.yml?query=event%3Aschedule) since the last state change, or
 - [ ] Start a manual workflow run with a Zebra and `lightwalletd` full sync.
 
 State format changes can be made in `zebra-state` or `zebra-chain`. The state format can be changed by data that is sent to the state, data created within the state using `zebra-chain`, or serialization formats in `zebra-state` or `zebra-chain`. 

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -9,6 +9,7 @@ assignees: ''
 
 # Prepare for the Release
 
+- [ ] Make sure there has been [at least one full sync test](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-integration-docker.yml?query=event%3Aschedule) since the last state change, or start a manual full sync.
 - [ ] Make sure the PRs with the new checkpoint hashes and missed dependencies are already merged.
       (See the release ticket checklist for details)
 

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -9,7 +9,7 @@ assignees: ''
 
 # Prepare for the Release
 
-- [ ] Make sure there has been [at least one full sync test](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-integration-docker.yml?query=event%3Aschedule) since the last state change, or start a manual full sync.
+- [ ] Make sure there has been [at least one successful full sync test](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-integration-docker.yml?query=event%3Aschedule) since the last state change, or start a manual full sync.
 - [ ] Make sure the PRs with the new checkpoint hashes and missed dependencies are already merged.
       (See the release ticket checklist for details)
 


### PR DESCRIPTION
## Motivation

We're testing the state format in CI, but some code paths don't get tested until we do a full sync.

So we need to wait for a full sync between the last state change and the release. (Or run a manual full sync.)

### Complex Code or Requirements

It's not clear which code changes can change the state format, so it might be easier just to say "anything in zebra-state or zebra-chain".

## Solution

Update the release checklist with this step
Update the release ticket template with this step

## Review

Ideally this should be merged before we open the ticket for the next release.

This is for discussion at the Zebra sync.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
  - [ ] How do you know it works? Does it have tests?

