### PR TITLE
imp(workflows): use larger runners on time consuming jobs

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -53,7 +53,7 @@ jobs:
   build:
     name: Build images
     timeout-minutes: 210
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xl
     outputs:
       image_digest: ${{ steps.docker_build.outputs.digest }}
       image_name: ${{ fromJSON(steps.docker_build.outputs.metadata)['image.name'] }}

--- a/.github/workflows/continous-integration-docker.yml
+++ b/.github/workflows/continous-integration-docker.yml
@@ -149,7 +149,7 @@ jobs:
   # TODO: turn this test and the getblocktemplate test into a matrix, so the jobs use exactly the same diagnostics settings
   test-all:
     name: Test all
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xl
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:
@@ -175,7 +175,7 @@ jobs:
   # Same as above but we run all the tests behind the `getblocktemplate-rpcs` feature.
   test-all-getblocktemplate-rpcs:
     name: Test all with getblocktemplate-rpcs feature
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xl
     needs: build
     if: ${{ github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -54,7 +54,7 @@ jobs:
     # - stable builds (typically 30-50 minutes), and
     # - parameter downloads (an extra 90 minutes, but only when the cache expires)
     timeout-minutes: 140
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xl
 
     steps:
       - uses: actions/checkout@v4.0.0


### PR DESCRIPTION
## Motivation

Some jobs take too much time to run, having to wait too much time between commits to confirm everything is working as expected, and making merge queues slower

Fixes: #7180
Closes: #6457
Fixes: #7625

### Specifications

https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners

## Solution

- Add different larger runners to handle these time consuming jobs

## Review

- Confirm the time has been reduced to acceptable limits

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

None