### PR TITLE
fix(test): `roundtrip_sapling_tree_root` and `roundtrip_orchard_tree_root`

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_format/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/prop.rs
@@ -376,7 +376,7 @@ fn roundtrip_sapling_subtree_data() {
     let _init_guard = zebra_test::init();
 
     proptest!(|(mut val in any::<NoteCommitmentSubtreeData<sapling::tree::Node>>())| {
-        val.end = val.end.clamp(Height(0), MAX_ON_DISK_HEIGHT);
+        val.end.0 %= MAX_ON_DISK_HEIGHT.0 + 1;
         assert_value_properties(val)
     });
 }
@@ -462,6 +462,7 @@ fn roundtrip_orchard_subtree_data() {
 
     proptest!(|(mut val in any::<NoteCommitmentSubtreeData<orchard::tree::Node>>())| {
         val.end = val.end.clamp(Height(0), MAX_ON_DISK_HEIGHT);
+        val.end.0 %= MAX_ON_DISK_HEIGHT.0 + 1;
         assert_value_properties(val)
     });
 }


### PR DESCRIPTION
## Motivation

The round trip tree root proptests almost always test the same end height:

```
running 1 test
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:467] &val.end.0 = 16777215
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:467] &val.end.0 = 16777215
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:467] &val.end.0 = 16777215
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:467] &val.end.0 = 16777215
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:467] &val.end.0 = 16777215
...
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:467] &val.end.0 = 3342791
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:467] &val.end.0 = 16777215
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:467] &val.end.0 = 16777215
```
 
Close https://github.com/ZcashFoundation/zebra/issues/7443

## Solution

Add suggested fix, when applied the tests will cover much more values:

```
running 1 test
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:466] &val.end.0 = 13521308
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:466] &val.end.0 = 13932221
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:466] &val.end.0 = 15280320
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:466] &val.end.0 = 5739578
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:466] &val.end.0 = 4218397
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:466] &val.end.0 = 10812062
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:466] &val.end.0 = 5608137
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:466] &val.end.0 = 12093244
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:466] &val.end.0 = 1981967
[zebra-state/src/service/finalized_state/disk_format/tests/prop.rs:466] &val.end.0 = 3483660
...
```

## Review

Anyone can review. This is medium priority as it is part of the [spend before sync](https://github.com/ZcashFoundation/zebra/issues/6642)

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

