### PR TITLE
fix(ci): wait for disk to be mounted in VM

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -432,6 +432,8 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
+          # Wait for the disk to be attached
+          while [[ ! -e /dev/sdb ]]; do sleep 1; done && \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
@@ -480,6 +482,8 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
+          # Wait for the disk to be attached
+          while [[ ! -e /dev/sdb ]]; do sleep 1; done && \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \


### PR DESCRIPTION
## Motivation

Lately, mounting the disk by Docker has been unreliable, the root cause might be different things, but in the end we should confirm the disk is mounted before running the container with disk being mounted or _busy_

Fixes: #7659

## Solution

Add a wait command: `while [[ ! -e /dev/sdb ]]; do sleep 1; done`

## Review

We might want to run this PR multiple times if it works at first, just to confirm multiple runs (4+) will output the same result.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
