### PR TITLE
change(state): Stop using iterators on column families with many deletions

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_format/chain.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/chain.rs
@@ -83,7 +83,7 @@ impl FromDisk for NonEmptyHistoryTree {
     }
 }
 
-// We don't write empty history trees to disk, so we known this one is non-empty.
+// We don't write empty history trees to disk, so we know this one is non-empty.
 impl FromDisk for HistoryTree {
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
         NonEmptyHistoryTree::from_bytes(bytes).into()

--- a/zebra-state/src/service/finalized_state/disk_format/chain.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/chain.rs
@@ -10,8 +10,12 @@ use std::collections::BTreeMap;
 use bincode::Options;
 
 use zebra_chain::{
-    amount::NonNegative, block::Height, history_tree::NonEmptyHistoryTree, parameters::Network,
-    primitives::zcash_history, value_balance::ValueBalance,
+    amount::NonNegative,
+    block::Height,
+    history_tree::{HistoryTree, NonEmptyHistoryTree},
+    parameters::Network,
+    primitives::zcash_history,
+    value_balance::ValueBalance,
 };
 
 use crate::service::finalized_state::disk_format::{FromDisk, IntoDisk};
@@ -76,5 +80,12 @@ impl FromDisk for NonEmptyHistoryTree {
             parts.current_height,
         )
         .expect("deserialization format should match the serialization format used by IntoDisk")
+    }
+}
+
+// We don't write empty history trees to disk, so we known this one is non-empty.
+impl FromDisk for HistoryTree {
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
+        NonEmptyHistoryTree::from_bytes(bytes).into()
     }
 }

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -30,7 +30,6 @@ use crate::{
     request::SemanticallyVerifiedBlockWithTrees,
     service::finalized_state::{
         disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
-        disk_format::RawBytes,
         zebra_db::ZebraDb,
     },
     BoxError, SemanticallyVerifiedBlock,
@@ -85,34 +84,49 @@ impl ZebraDb {
     /// Returns the Sprout note commitment tree of the finalized tip
     /// or the empty tree if the state is empty.
     pub fn sprout_tree(&self) -> Arc<sprout::tree::NoteCommitmentTree> {
-        if self.finalized_tip_height().is_none() {
-            return Default::default();
+        if self.is_empty() {
+            return Arc::<sprout::tree::NoteCommitmentTree>::default();
         }
 
-        let sprout_nct_handle = self.db.cf_handle("sprout_note_commitment_tree").unwrap();
+        // # Performance
+        //
+        // Using `zs_last_key_value()` on this column family significantly reduces sync performance
+        // (#7618). This is probably because `zs_delete()` is also used on the same column family.
+        // See the comment in `ZebraDb::history_tree()` for details.
+        //
+        // This bug will be fixed by PR #7392, because it changes this column family to update the
+        // existing key, rather than deleting old keys.
+        let sprout_tree_cf = self.db.cf_handle("sprout_note_commitment_tree").unwrap();
 
-        // # Concurrency
-        //
-        // There is only one tree in this column family, which is atomically updated by a block
-        // write batch (database transaction). If this update runs between the height read and the
-        // tree read, the height will be wrong, and the tree will be missing.
-        //
-        // Instead, always read the last tree in the column family, regardless of height.
-        //
-        // See ticket #7581 for more details.
-        //
-        // TODO: this concurrency bug will be permanently fixed in PR #7392,
-        //       by changing the block update to overwrite the tree, rather than deleting it.
-        //
         // # Forwards Compatibility
         //
         // This code can read the column family format in 1.2.0 and earlier (tip height key),
-        // and after PR #7392 is merged (empty key).
-        self.db
-            .zs_last_key_value(&sprout_nct_handle)
-            // RawBytes will deserialize both Height and `()` (empty) keys.
-            .map(|(_key, value): (RawBytes, _)| Arc::new(value))
-            .expect("Sprout note commitment tree must exist if there is a finalized tip")
+        // and after PR #7392 is merged (empty key). The height-based code can be removed when
+        // versions 1.2.0 and earlier are no longer supported.
+        //
+        // # Concurrency
+        //
+        // There is only one tree in this column family, which is atomically updated by a block
+        // write batch (database transaction). If this update runs between the height read and
+        // the tree read, the height will be wrong, and the tree will be missing.
+        // That could cause consensus bugs.
+        //
+        // See the comment in `ZebraDb::history_tree()` for details.
+        //
+        // TODO: this concurrency bug will be permanently fixed in PR #7392,
+        //       by changing the block update to overwrite the tree, rather than deleting it.
+        let mut sprout_tree: Option<Arc<sprout::tree::NoteCommitmentTree>> =
+            self.db.zs_get(&sprout_tree_cf, &());
+
+        if sprout_tree.is_none() {
+            let tip_height = self
+                .finalized_tip_height()
+                .expect("just checked for an empty database");
+
+            sprout_tree = self.db.zs_get(&sprout_tree_cf, &tip_height);
+        }
+
+        sprout_tree.expect("Sprout note commitment tree must exist if there is a finalized tip")
     }
 
     /// Returns the Sprout note commitment tree matching the given anchor.


### PR DESCRIPTION
## Motivation

When we use a RocksDB iterator on a column family with lots of deleted keys, database performance decreases by up to 300x.

Closes #7618

### Specifications

This is a known issue with RocksDB, here are similar issues in other projects:
https://tracker.ceph.com/issues/55324
https://jira.mariadb.org/browse/MDEV-19670

## Solution

As a quick fix we can replace the iterator with `get(&key)`.
The permanent fix in PR #7392 stops deleting these keys entirely.

### Manual Testing

I did a local test of this fix, and Zebra is up to 1.2 million blocks in under 5 hours. This is faster than Marek's `main` branch checks on his machine, and about as fast as `v1.2.0` in CI:
https://github.com/ZcashFoundation/zebra/actions/runs/6049184682/job/16453440408

I think `v1.2.0` was about as fast on my machine, but I haven't done any detailed tests. (A manual check is ok, we can do detailed checks in #7649.)

## Review

This is an urgent fix which is blocking CI from working.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Permanent fixes for all column families that delete keys:
- merge the permanent fix to these column families in PR #7392 
- #7664

Performance testing for this fix:
- #7649