### PR TITLE
fix(ci): disk validation for docker volume mount

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -193,15 +193,15 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           " \
-          set -x \
+          set -x; \
           while ! \
           sudo mkfs.ext4 -v /dev/sdb \
           && \
           sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
           ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           do \
-          sudo journalctl -u docker.service \
-          sleep 5 \
+          sudo journalctl -u docker.service; \
+          sleep 5; \
           done \
           "
 
@@ -215,7 +215,7 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
-          set -x \
+          set -x; \
           while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -225,8 +225,8 @@ jobs:
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
           do \
-          sudo journalctl -u docker.service \
-          sleep 5 \
+          sudo journalctl -u docker.service; \
+          sleep 5; \
           done \
           "
 
@@ -409,13 +409,13 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
-          set -x \
+          set -x; \
           while ! \
           sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
           ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           do \
-          sudo journalctl -u docker.service \
-          sleep 5 \
+          sudo journalctl -u docker.service; \
+          sleep 5; \
           done \
           "
 
@@ -449,7 +449,7 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
-          set -x \
+          set -x; \
           while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -459,8 +459,8 @@ jobs:
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
           do \
-          sudo journalctl -u docker.service \
-          sleep 5 \
+          sudo journalctl -u docker.service; \
+          sleep 5; \
           done \
           "
 
@@ -508,7 +508,7 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
-          set -x \
+          set -x; \
           while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -518,8 +518,8 @@ jobs:
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
           do \
-          sudo journalctl -u docker.service \
-          sleep 5 \
+          sudo journalctl -u docker.service; \
+          sleep 5; \
           done \
           "
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -492,7 +492,7 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
-          '\
+          "\
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
@@ -500,8 +500,7 @@ jobs:
           ${{ inputs.test_variables }} \
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
-          --entrypoint "ln -s ${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} ${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} && /entrypoint.sh" \
-          '
+          "
 
   # Show all the test logs, then follow the logs of the test we just launched, until it finishes.
   # Then check the result of the test.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -225,6 +225,7 @@ jobs:
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
           do \
+          sudo docker rm --force ${{ inputs.test_id }}; \
           sudo journalctl -u docker.service; \
           sleep 5; \
           done \
@@ -459,6 +460,7 @@ jobs:
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
           do \
+          sudo docker rm --force ${{ inputs.test_id }}; \
           sudo journalctl -u docker.service; \
           sleep 5; \
           done \
@@ -479,10 +481,7 @@ jobs:
       # - /var/cache/zebrad-cache -> ${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} -> $ZEBRA_CACHED_STATE_DIR
       # - /var/cache/lwd-cache -> ${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} -> $LIGHTWALLETD_DATA_DIR
       #
-      # Doing two mounts has caused "device or resource busy" errors in the past (#7659, #4415).
-      # So we use a symlink for the lightwalletd path instead.
-      # TODO: remove duplicate code by doing the zebrad mount in one common step
-      #       then only doing the symlink for the lightwalletd tests in entrypoint.sh
+      # Currently we do this by mounting the same disk at both paths.
       #
       # This doesn't cause any path conflicts, because Zebra and lightwalletd create different
       # subdirectories for their data. (But Zebra, lightwalletd, and the test harness must not
@@ -516,8 +515,10 @@ jobs:
           --detach \
           ${{ inputs.test_variables }} \
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
+          --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
           do \
+          sudo docker rm --force ${{ inputs.test_id }}; \
           sudo journalctl -u docker.service; \
           sleep 5; \
           done \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -381,6 +381,7 @@ jobs:
           --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ vars.GCP_ZONE }}
+          sleep 60
 
       # Launch the test with the previously created Zebra-only cached state.
       # Each test runs one of the "Launch test" steps, and skips the other.
@@ -418,7 +419,7 @@ jobs:
           --detach \
           ${{ inputs.test_variables }} \
           --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
-          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
+          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
           "
 
       # Launch the test with the previously created Lightwalletd and Zebra cached state.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -382,7 +382,6 @@ jobs:
           --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ vars.GCP_ZONE }}
-          sleep 60
 
       # Create a docker volume with the selected cached state.
       #
@@ -398,6 +397,10 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
+          # Wait for the disk exist and verify it's not in use
+          while [[ ! -e /dev/sdb ]] || lsof /dev/sdb &>/dev/null; do
+            sleep 1;
+          done && \
           sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
           ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} \
           "
@@ -432,8 +435,6 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
-          # Wait for the disk to be attached
-          while [[ ! -e /dev/sdb ]]; do sleep 1; done && \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
@@ -482,8 +483,6 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
-          # Wait for the disk to be attached
-          while [[ ! -e /dev/sdb ]]; do sleep 1; done && \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -191,7 +191,7 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
-          while [[ ! -e /dev/sdb ]] || sudo lsof /dev/sdb &>/dev/null; do \
+          while sudo lsof /dev/sdb; do \
             echo 'Waiting for /dev/sdb to be free...'; \
             sleep 10; \
           done; \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -218,9 +218,8 @@ jobs:
           --command \
           "\
           set -x; \
-          sudo lsof +f -- /dev/sdb; \
-          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
-          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}/_data; \
+          sudo lsof /dev/sdb; \
+          sudo lsof +D -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -231,9 +230,8 @@ jobs:
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
           do \
           sudo docker rm --force ${{ inputs.test_id }}; \
-          sudo lsof +f -- /dev/sdb; \
-          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
-          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}/_data; \
+          sudo lsof /dev/sdb; \
+          sudo lsof +D -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           sudo journalctl --unit docker.service --reverse --lines=10; \
           sleep 5; \
           done \
@@ -460,9 +458,8 @@ jobs:
           --command \
           "\
           set -x; \
-          sudo lsof +f -- /dev/sdb; \
-          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
-          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}/_data; \
+          sudo lsof /dev/sdb; \
+          sudo lsof +D -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -473,9 +470,8 @@ jobs:
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
           do \
           sudo docker rm --force ${{ inputs.test_id }}; \
-          sudo lsof +f -- /dev/sdb; \
-          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
-          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}/_data; \
+          sudo lsof /dev/sdb; \
+          sudo lsof +D -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           sudo journalctl --unit docker.service --reverse --lines=10; \
           sleep 5; \
           done \
@@ -523,9 +519,8 @@ jobs:
           --command \
           "\
           set -x; \
-          sudo lsof +f -- /dev/sdb; \
-          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
-          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}/_data; \
+          sudo lsof /dev/sdb; \
+          sudo lsof +D -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -537,9 +532,8 @@ jobs:
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
           do \
           sudo docker rm --force ${{ inputs.test_id }}; \
-          sudo lsof +f -- /dev/sdb; \
-          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
-          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}/_data; \
+          sudo lsof /dev/sdb; \
+          sudo lsof +D -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           sudo journalctl --unit docker.service --reverse --lines=10; \
           sleep 5; \
           done \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -214,7 +214,7 @@ jobs:
           --detach \
           ${{ inputs.test_variables }} \
           --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
-          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
+          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
           "
 
   # set up and launch the test, if it uses cached state
@@ -469,7 +469,7 @@ jobs:
           ${{ inputs.test_variables }} \
           --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} \
-          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
+          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
           "
 
   # Show all the test logs, then follow the logs of the test we just launched, until it finishes.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -197,10 +197,12 @@ jobs:
           while ! \
           sudo mkfs.ext4 -v /dev/sdb \
           && \
+          sudo journalctl --unit docker.service --reverse \
+          && \
           sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
           ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           do \
-          sudo journalctl -u docker.service; \
+          sudo journalctl --unit docker.service --reverse --lines=10; \
           sleep 5; \
           done \
           "
@@ -216,6 +218,9 @@ jobs:
           --command \
           "\
           set -x; \
+          sudo lsof +f -- /dev/sdb; \
+          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
+          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}/_data; \
           while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -226,7 +231,10 @@ jobs:
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
           do \
           sudo docker rm --force ${{ inputs.test_id }}; \
-          sudo journalctl -u docker.service; \
+          sudo lsof +f -- /dev/sdb; \
+          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
+          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}/_data; \
+          sudo journalctl --unit docker.service --reverse --lines=10; \
           sleep 5; \
           done \
           "
@@ -411,11 +419,12 @@ jobs:
           --command \
           "\
           set -x; \
+          sudo journalctl --unit docker.service --reverse;
           while ! \
           sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
           ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           do \
-          sudo journalctl -u docker.service; \
+          sudo journalctl --unit docker.service --reverse --lines=10; \
           sleep 5; \
           done \
           "
@@ -451,6 +460,9 @@ jobs:
           --command \
           "\
           set -x; \
+          sudo lsof +f -- /dev/sdb; \
+          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
+          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}/_data; \
           while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -461,7 +473,10 @@ jobs:
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
           do \
           sudo docker rm --force ${{ inputs.test_id }}; \
-          sudo journalctl -u docker.service; \
+          sudo lsof +f -- /dev/sdb; \
+          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
+          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}/_data; \
+          sudo journalctl --unit docker.service --reverse --lines=10; \
           sleep 5; \
           done \
           "
@@ -508,6 +523,9 @@ jobs:
           --command \
           "\
           set -x; \
+          sudo lsof +f -- /dev/sdb; \
+          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
+          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}/_data; \
           while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -519,7 +537,10 @@ jobs:
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
           do \
           sudo docker rm --force ${{ inputs.test_id }}; \
-          sudo journalctl -u docker.service; \
+          sudo lsof +f -- /dev/sdb; \
+          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
+          sudo lsof +f -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}/_data; \
+          sudo journalctl --unit docker.service --reverse --lines=10; \
           sleep 5; \
           done \
           "

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -180,8 +180,6 @@ jobs:
           --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ vars.GCP_ZONE }}
-          # TODO: remove this sleep if it's not needed
-          sleep 60
 
       # Create a docker volume with the new disk we just created.
       #
@@ -194,16 +192,18 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
-          "\
+          " \
+          set -x \
+          while ! \
           sudo mkfs.ext4 -v /dev/sdb \
           && \
-          sleep 30 \
-          && \
           sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
-          ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} \
+          ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
+          do \
+          sudo journalctl -u docker.service \
+          sleep 5 \
+          done \
           "
-          # TODO: remove this sleep and the one above if they're not needed
-          sleep 30
 
       # Launch the test without any cached state
       - name: Launch ${{ inputs.test_id }} test
@@ -215,13 +215,19 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
+          set -x \
+          while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
           --detach \
           ${{ inputs.test_variables }} \
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
-          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
+          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
+          do \
+          sudo journalctl -u docker.service \
+          sleep 5 \
+          done \
           "
 
   # set up and launch the test, if it uses cached state
@@ -301,6 +307,7 @@ jobs:
       - name: Find ${{ inputs.test_id }} cached state disk
         id: get-disk-name
         run: |
+          set -x
           LOCAL_STATE_VERSION=$(grep -oE "DATABASE_FORMAT_VERSION: .* [0-9]+" "$GITHUB_WORKSPACE/zebra-state/src/constants.rs" | grep -oE "[0-9]+" | tail -n1)
           echo "STATE_VERSION: $LOCAL_STATE_VERSION"
 
@@ -387,8 +394,6 @@ jobs:
           --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ vars.GCP_ZONE }}
-          # TODO: remove this sleep if it's not needed
-          sleep 60
 
       # Create a docker volume with the selected cached state.
       #
@@ -404,11 +409,15 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
+          set -x \
+          while ! \
           sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
-          ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} \
+          ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
+          do \
+          sudo journalctl -u docker.service \
+          sleep 5 \
+          done \
           "
-          # TODO: remove this sleep if it's not needed
-          sleep 30
 
       # Launch the test with the previously created Zebra-only cached state.
       # Each test runs one of the "Launch test" steps, and skips the other.
@@ -440,13 +449,19 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
+          set -x \
+          while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
           --detach \
           ${{ inputs.test_variables }} \
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
-          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
+          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
+          do \
+          sudo journalctl -u docker.service \
+          sleep 5 \
+          done \
           "
 
       # Launch the test with the previously created Lightwalletd and Zebra cached state.
@@ -493,13 +508,19 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
+          set -x \
+          while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
           --detach \
           ${{ inputs.test_variables }} \
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
-          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
+          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
+          do \
+          sudo journalctl -u docker.service \
+          sleep 5 \
+          done \
           "
 
   # Show all the test logs, then follow the logs of the test we just launched, until it finishes.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -180,6 +180,7 @@ jobs:
           --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ vars.GCP_ZONE }}
+          # TODO: remove this sleep if it's not needed
           sleep 60
 
       # Create a docker volume with the new disk we just created.
@@ -382,6 +383,8 @@ jobs:
           --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ vars.GCP_ZONE }}
+          # TODO: remove this sleep if it's not needed
+          sleep 60
 
       # Create a docker volume with the selected cached state.
       #
@@ -397,10 +400,6 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
-          # Wait for the disk exist and verify it's not in use
-          while [[ ! -e /dev/sdb ]] || lsof /dev/sdb &>/dev/null; do
-            sleep 1;
-          done && \
           sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
           ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} \
           "
@@ -454,10 +453,15 @@ jobs:
       # VM and to the container might require more steps in this workflow, and additional
       # considerations.
       #
-      # The disk mounted in the VM is located at /dev/sdb, we mount the root `/` of this disk to the docker
-      # container in two different paths:
+      # The disk mounted in the VM is located at /dev/sdb, we want the root `/` of this disk to be
+      # available in the docker container at two different paths:
       # - /var/cache/zebrad-cache -> ${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} -> $ZEBRA_CACHED_STATE_DIR
       # - /var/cache/lwd-cache -> ${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} -> $LIGHTWALLETD_DATA_DIR
+      #
+      # Doing two mounts has caused "device or resource busy" errors in the past (#7659, #4415).
+      # So we use a symlink for the lightwalletd path instead.
+      # TODO: remove duplicate code by doing the zebrad mount in one common step
+      #       then only doing the symlink for the lightwalletd tests in entrypoint.sh
       #
       # This doesn't cause any path conflicts, because Zebra and lightwalletd create different
       # subdirectories for their data. (But Zebra, lightwalletd, and the test harness must not
@@ -482,16 +486,16 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
-          "\
+          '\
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
           --detach \
           ${{ inputs.test_variables }} \
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
-          --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
-          "
+          --entrypoint "ln -s ${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} ${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} && /entrypoint.sh"
+          '
 
   # Show all the test logs, then follow the logs of the test we just launched, until it finishes.
   # Then check the result of the test.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -219,7 +219,7 @@ jobs:
           "\
           set -x; \
           sudo lsof /dev/sdb; \
-          sudo lsof +D -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
+          sudo lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -231,7 +231,7 @@ jobs:
           do \
           sudo docker rm --force ${{ inputs.test_id }}; \
           sudo lsof /dev/sdb; \
-          sudo lsof +D -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
+          sudo lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           sudo journalctl --unit docker.service --reverse --lines=10; \
           sleep 5; \
           done \
@@ -459,7 +459,7 @@ jobs:
           "\
           set -x; \
           sudo lsof /dev/sdb; \
-          sudo lsof +D -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
+          sudo lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -471,7 +471,7 @@ jobs:
           do \
           sudo docker rm --force ${{ inputs.test_id }}; \
           sudo lsof /dev/sdb; \
-          sudo lsof +D -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
+          sudo lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           sudo journalctl --unit docker.service --reverse --lines=10; \
           sleep 5; \
           done \
@@ -520,7 +520,7 @@ jobs:
           "\
           set -x; \
           sudo lsof /dev/sdb; \
-          sudo lsof +D -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
+          sudo lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -533,7 +533,7 @@ jobs:
           do \
           sudo docker rm --force ${{ inputs.test_id }}; \
           sudo lsof /dev/sdb; \
-          sudo lsof +D -- /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
+          sudo lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
           sudo journalctl --unit docker.service --reverse --lines=10; \
           sleep 5; \
           done \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -171,7 +171,7 @@ jobs:
           --image-project=cos-cloud \
           --image-family=cos-stable \
           --create-disk=name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=300GB,type=pd-ssd \
-          --container-image=gcr.io/google-containers/ubuntu \
+          --container-image=gcr.io/google-containers/busybox \
           --machine-type ${{ vars.GCP_LARGE_MACHINE }} \
           --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \
           --scopes cloud-platform \
@@ -181,10 +181,8 @@ jobs:
           --tags ${{ inputs.app_name }} \
           --zone ${{ vars.GCP_ZONE }}
 
-      # Create a docker volume with the new disk we just created.
-      #
-      # SSH into the just created VM, and create a docker volume with the newly created disk.
-      - name: Create ${{ inputs.test_id }} Docker volume
+      # Format the mounted disk if the test doesn't use a cached state.
+      - name: Format ${{ inputs.test_id }} volume
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
@@ -192,19 +190,12 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
-          " \
-          set -x; \
-          while ! \
+          "\
+          while [[ ! -e /dev/sdb ]] || sudo lsof /dev/sdb &>/dev/null; do \
+            echo 'Waiting for /dev/sdb to be free...'; \
+            sleep 10; \
+          done; \
           sudo mkfs.ext4 -v /dev/sdb \
-          && \
-          sudo journalctl --unit docker.service --reverse \
-          && \
-          sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
-          ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
-          do \
-          sudo journalctl --unit docker.service --reverse --lines=10; \
-          sleep 5; \
-          done \
           "
 
       # Launch the test without any cached state
@@ -217,24 +208,13 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
-          set -x; \
-          sudo lsof /dev/sdb; \
-          sudo lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
-          while ! \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
           --detach \
           ${{ inputs.test_variables }} \
-          --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
+          --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
-          do \
-          sudo docker rm --force ${{ inputs.test_id }}; \
-          sudo lsof /dev/sdb; \
-          sudo lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
-          sudo journalctl --unit docker.service --reverse --lines=10; \
-          sleep 5; \
-          done \
           "
 
   # set up and launch the test, if it uses cached state
@@ -392,7 +372,7 @@ jobs:
           --image-project=cos-cloud \
           --image-family=cos-stable \
           --create-disk=image=${{ env.CACHED_DISK_NAME }},name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=300GB,type=pd-ssd \
-          --container-image=gcr.io/google-containers/ubuntu \
+          --container-image=gcr.io/google-containers/busybox \
           --machine-type ${{ vars.GCP_LARGE_MACHINE }} \
           --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \
           --scopes cloud-platform \
@@ -401,31 +381,6 @@ jobs:
           --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ vars.GCP_ZONE }}
-
-      # Create a docker volume with the selected cached state.
-      #
-      # SSH into the just created VM and create a docker volume with the recently attached disk.
-      # (The cached state and disk are usually the same size,
-      # but the cached state can be smaller if we just increased the disk size.)
-      - name: Create ${{ inputs.test_id }} Docker volume
-        run: |
-          gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
-          --zone ${{ vars.GCP_ZONE }} \
-          --ssh-flag="-o ServerAliveInterval=5" \
-          --ssh-flag="-o ConnectionAttempts=20" \
-          --ssh-flag="-o ConnectTimeout=5" \
-          --command \
-          "\
-          set -x; \
-          sudo journalctl --unit docker.service --reverse;
-          while ! \
-          sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
-          ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
-          do \
-          sudo journalctl --unit docker.service --reverse --lines=10; \
-          sleep 5; \
-          done \
-          "
 
       # Launch the test with the previously created Zebra-only cached state.
       # Each test runs one of the "Launch test" steps, and skips the other.
@@ -457,19 +412,13 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
-          set -x; \
-          while [[ ! -e /dev/sdb ]] || lsof /dev/sdb &>/dev/null || lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} &>/dev/null; do \
-            echo 'Waiting for /dev/sdb to be free...'; \
-            sleep 5; \
-          done; \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
           --detach \
           ${{ inputs.test_variables }} \
-          --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
-          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
-          sudo journalctl --unit docker.service --reverse --lines=10 \
+          --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
+          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
           "
 
       # Launch the test with the previously created Lightwalletd and Zebra cached state.
@@ -513,19 +462,14 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
-          while [[ ! -e /dev/sdb ]] || lsof /dev/sdb &>/dev/null || lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} &>/dev/null; do \
-            echo 'Waiting for /dev/sdb to be free...'; \
-            sleep 5; \
-          done; \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
           --detach \
           ${{ inputs.test_variables }} \
-          --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
-          --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} \
-          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
-          sudo journalctl --unit docker.service --reverse --lines=10 \
+          --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
+          --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} \
+          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
           "
 
   # Show all the test logs, then follow the logs of the test we just launched, until it finishes.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -500,7 +500,7 @@ jobs:
           ${{ inputs.test_variables }} \
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
-          --entrypoint "ln -s ${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} ${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} && /entrypoint.sh"
+          --entrypoint "ln -s ${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} ${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} && /entrypoint.sh" \
           '
 
   # Show all the test logs, then follow the logs of the test we just launched, until it finishes.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -197,9 +197,13 @@ jobs:
           "\
           sudo mkfs.ext4 -v /dev/sdb \
           && \
+          sleep 30 \
+          && \
           sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
           ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} \
           "
+          # TODO: remove this sleep and the one above if they're not needed
+          sleep 30
 
       # Launch the test without any cached state
       - name: Launch ${{ inputs.test_id }} test
@@ -403,6 +407,8 @@ jobs:
           sudo docker volume create --driver local --opt type=ext4 --opt device=/dev/sdb \
           ${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} \
           "
+          # TODO: remove this sleep if it's not needed
+          sleep 30
 
       # Launch the test with the previously created Zebra-only cached state.
       # Each test runs one of the "Launch test" steps, and skips the other.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -458,23 +458,18 @@ jobs:
           --command \
           "\
           set -x; \
-          sudo lsof /dev/sdb; \
-          sudo lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
-          while ! \
+          while [[ ! -e /dev/sdb ]] || lsof /dev/sdb &>/dev/null || lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} &>/dev/null; do \
+            echo 'Waiting for /dev/sdb to be free...'; \
+            sleep 5; \
+          done; \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
           --detach \
           ${{ inputs.test_variables }} \
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
-          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
-          do \
-          sudo docker rm --force ${{ inputs.test_id }}; \
-          sudo lsof /dev/sdb; \
-          sudo lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
-          sudo journalctl --unit docker.service --reverse --lines=10; \
-          sleep 5; \
-          done \
+          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
+          sudo journalctl --unit docker.service --reverse --lines=10 \
           "
 
       # Launch the test with the previously created Lightwalletd and Zebra cached state.
@@ -518,10 +513,10 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
-          set -x; \
-          sudo lsof /dev/sdb; \
-          sudo lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
-          while ! \
+          while [[ ! -e /dev/sdb ]] || lsof /dev/sdb &>/dev/null || lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} &>/dev/null; do \
+            echo 'Waiting for /dev/sdb to be free...'; \
+            sleep 5; \
+          done; \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
@@ -529,14 +524,8 @@ jobs:
           ${{ inputs.test_variables }} \
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           --mount type=volume,src=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }},dst=${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} \
-          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}; \
-          do \
-          sudo docker rm --force ${{ inputs.test_id }}; \
-          sudo lsof /dev/sdb; \
-          sudo lsof +D /var/lib/docker/volumes/${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}; \
-          sudo journalctl --unit docker.service --reverse --lines=10; \
-          sleep 5; \
-          done \
+          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
+          sudo journalctl --unit docker.service --reverse --lines=10 \
           "
 
   # Show all the test logs, then follow the logs of the test we just launched, until it finishes.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -91,13 +91,11 @@ case "$1" in
         elif [[ "$TEST_LWD_FULL_SYNC" -eq "1" ]]; then
             # Starting at a cached Zebra tip, run a lightwalletd sync to tip.
             ls -lh "$ZEBRA_CACHED_STATE_DIR"/*/* || (echo "No $ZEBRA_CACHED_STATE_DIR/*/*"; ls -lhR  "$ZEBRA_CACHED_STATE_DIR" | head -50 || echo "No $ZEBRA_CACHED_STATE_DIR directory")
-            ln -s "$ZEBRA_CACHED_STATE_DIR" "$LIGHTWALLETD_DATA_DIR"
             cargo test --locked --release --features "$ENTRYPOINT_FEATURES" --package zebrad --test acceptance -- --nocapture --include-ignored lightwalletd_full_sync
             ls -lhR "$LIGHTWALLETD_DATA_DIR/db" || (echo "No $LIGHTWALLETD_DATA_DIR/db"; ls -lhR "$LIGHTWALLETD_DATA_DIR" | head -50 || echo "No $LIGHTWALLETD_DATA_DIR directory")
         elif [[ "$TEST_LWD_UPDATE_SYNC" -eq "1" ]]; then
             # Starting with a cached Zebra and lightwalletd tip, run a quick update sync.
             ls -lh "$ZEBRA_CACHED_STATE_DIR"/*/* || (echo "No $ZEBRA_CACHED_STATE_DIR/*/*"; ls -lhR  "$ZEBRA_CACHED_STATE_DIR" | head -50 || echo "No $ZEBRA_CACHED_STATE_DIR directory")
-            ln -s "$ZEBRA_CACHED_STATE_DIR" "$LIGHTWALLETD_DATA_DIR"
             ls -lhR "$LIGHTWALLETD_DATA_DIR/db" || (echo "No $LIGHTWALLETD_DATA_DIR/db"; ls -lhR "$LIGHTWALLETD_DATA_DIR" | head -50 || echo "No $LIGHTWALLETD_DATA_DIR directory")
             cargo test --locked --release --features "$ENTRYPOINT_FEATURES" --package zebrad --test acceptance -- --nocapture --include-ignored lightwalletd_update_sync
 
@@ -105,13 +103,11 @@ case "$1" in
         elif [[ "$TEST_LWD_GRPC" -eq "1" ]]; then
             # Starting with a cached Zebra and lightwalletd tip, test all gRPC calls to lightwalletd, which calls Zebra.
             ls -lh "$ZEBRA_CACHED_STATE_DIR"/*/* || (echo "No $ZEBRA_CACHED_STATE_DIR/*/*"; ls -lhR  "$ZEBRA_CACHED_STATE_DIR" | head -50 || echo "No $ZEBRA_CACHED_STATE_DIR directory")
-            ln -s "$ZEBRA_CACHED_STATE_DIR" "$LIGHTWALLETD_DATA_DIR"
             ls -lhR "$LIGHTWALLETD_DATA_DIR/db" || (echo "No $LIGHTWALLETD_DATA_DIR/db"; ls -lhR "$LIGHTWALLETD_DATA_DIR" | head -50 || echo "No $LIGHTWALLETD_DATA_DIR directory")
             cargo test --locked --release --features "$ENTRYPOINT_FEATURES" --package zebrad --test acceptance -- --nocapture --include-ignored lightwalletd_wallet_grpc_tests
         elif [[ "$TEST_LWD_TRANSACTIONS" -eq "1" ]]; then
             # Starting with a cached Zebra and lightwalletd tip, test sending transactions gRPC call to lightwalletd, which calls Zebra.
             ls -lh "$ZEBRA_CACHED_STATE_DIR"/*/* || (echo "No $ZEBRA_CACHED_STATE_DIR/*/*"; ls -lhR  "$ZEBRA_CACHED_STATE_DIR" | head -50 || echo "No $ZEBRA_CACHED_STATE_DIR directory")
-            ln -s "$ZEBRA_CACHED_STATE_DIR" "$LIGHTWALLETD_DATA_DIR"
             ls -lhR "$LIGHTWALLETD_DATA_DIR/db" || (echo "No $LIGHTWALLETD_DATA_DIR/db"; ls -lhR "$LIGHTWALLETD_DATA_DIR" | head -50 || echo "No $LIGHTWALLETD_DATA_DIR directory")
             cargo test --locked --release --features "$ENTRYPOINT_FEATURES" --package zebrad --test acceptance -- --nocapture --include-ignored sending_transactions_using_lightwalletd
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -91,11 +91,13 @@ case "$1" in
         elif [[ "$TEST_LWD_FULL_SYNC" -eq "1" ]]; then
             # Starting at a cached Zebra tip, run a lightwalletd sync to tip.
             ls -lh "$ZEBRA_CACHED_STATE_DIR"/*/* || (echo "No $ZEBRA_CACHED_STATE_DIR/*/*"; ls -lhR  "$ZEBRA_CACHED_STATE_DIR" | head -50 || echo "No $ZEBRA_CACHED_STATE_DIR directory")
+            ln -s "$ZEBRA_CACHED_STATE_DIR" "$LIGHTWALLETD_DATA_DIR"
             cargo test --locked --release --features "$ENTRYPOINT_FEATURES" --package zebrad --test acceptance -- --nocapture --include-ignored lightwalletd_full_sync
             ls -lhR "$LIGHTWALLETD_DATA_DIR/db" || (echo "No $LIGHTWALLETD_DATA_DIR/db"; ls -lhR "$LIGHTWALLETD_DATA_DIR" | head -50 || echo "No $LIGHTWALLETD_DATA_DIR directory")
         elif [[ "$TEST_LWD_UPDATE_SYNC" -eq "1" ]]; then
             # Starting with a cached Zebra and lightwalletd tip, run a quick update sync.
             ls -lh "$ZEBRA_CACHED_STATE_DIR"/*/* || (echo "No $ZEBRA_CACHED_STATE_DIR/*/*"; ls -lhR  "$ZEBRA_CACHED_STATE_DIR" | head -50 || echo "No $ZEBRA_CACHED_STATE_DIR directory")
+            ln -s "$ZEBRA_CACHED_STATE_DIR" "$LIGHTWALLETD_DATA_DIR"
             ls -lhR "$LIGHTWALLETD_DATA_DIR/db" || (echo "No $LIGHTWALLETD_DATA_DIR/db"; ls -lhR "$LIGHTWALLETD_DATA_DIR" | head -50 || echo "No $LIGHTWALLETD_DATA_DIR directory")
             cargo test --locked --release --features "$ENTRYPOINT_FEATURES" --package zebrad --test acceptance -- --nocapture --include-ignored lightwalletd_update_sync
 
@@ -103,11 +105,13 @@ case "$1" in
         elif [[ "$TEST_LWD_GRPC" -eq "1" ]]; then
             # Starting with a cached Zebra and lightwalletd tip, test all gRPC calls to lightwalletd, which calls Zebra.
             ls -lh "$ZEBRA_CACHED_STATE_DIR"/*/* || (echo "No $ZEBRA_CACHED_STATE_DIR/*/*"; ls -lhR  "$ZEBRA_CACHED_STATE_DIR" | head -50 || echo "No $ZEBRA_CACHED_STATE_DIR directory")
+            ln -s "$ZEBRA_CACHED_STATE_DIR" "$LIGHTWALLETD_DATA_DIR"
             ls -lhR "$LIGHTWALLETD_DATA_DIR/db" || (echo "No $LIGHTWALLETD_DATA_DIR/db"; ls -lhR "$LIGHTWALLETD_DATA_DIR" | head -50 || echo "No $LIGHTWALLETD_DATA_DIR directory")
             cargo test --locked --release --features "$ENTRYPOINT_FEATURES" --package zebrad --test acceptance -- --nocapture --include-ignored lightwalletd_wallet_grpc_tests
         elif [[ "$TEST_LWD_TRANSACTIONS" -eq "1" ]]; then
             # Starting with a cached Zebra and lightwalletd tip, test sending transactions gRPC call to lightwalletd, which calls Zebra.
             ls -lh "$ZEBRA_CACHED_STATE_DIR"/*/* || (echo "No $ZEBRA_CACHED_STATE_DIR/*/*"; ls -lhR  "$ZEBRA_CACHED_STATE_DIR" | head -50 || echo "No $ZEBRA_CACHED_STATE_DIR directory")
+            ln -s "$ZEBRA_CACHED_STATE_DIR" "$LIGHTWALLETD_DATA_DIR"
             ls -lhR "$LIGHTWALLETD_DATA_DIR/db" || (echo "No $LIGHTWALLETD_DATA_DIR/db"; ls -lhR "$LIGHTWALLETD_DATA_DIR" | head -50 || echo "No $LIGHTWALLETD_DATA_DIR directory")
             cargo test --locked --release --features "$ENTRYPOINT_FEATURES" --package zebrad --test acceptance -- --nocapture --include-ignored sending_transactions_using_lightwalletd
 


### PR DESCRIPTION
## Reviewer Instructions

Since this change is urgent, please put suggested cleanups in ticket #7677.

## Motivation

PR #7662 did not work as expected, as the validation was too simplistic.

@teor2345 also found that Google recently updated their `cos-stable` image and this upgraded Docker considerably (by 4 major versions), which might be the reason of this appearing recently with no changes to the code. 

Fixes: #7659

## Solution

- Revert to use `busybox` instead of `ubuntu`, as this was causing errors in the VM logs
- Before formatting, validate the disk is not being used with `lsof`
- Do not mount the Docker volume before running Docker. Instead mount it in the `docker run` command
  -  Based on new Docker versions, this approach can now be used: https://docs.docker.com/storage/volumes/#how-mounting-block-devices-works

## Review

- We did not run this multiple times in the previous PR, we should re-run the tests multiple times to confirm.
- Since this change is urgent, please put suggested cleanups in ticket #7677

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

