### PR TITLE
fix(ci): Replace busybox with ubuntu to avoid "device or resource busy" failures

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -171,7 +171,7 @@ jobs:
           --image-project=cos-cloud \
           --image-family=cos-stable \
           --create-disk=name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=300GB,type=pd-ssd \
-          --container-image=gcr.io/google-containers/busybox \
+          --container-image=gcr.io/google-containers/ubuntu \
           --machine-type ${{ vars.GCP_LARGE_MACHINE }} \
           --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \
           --scopes cloud-platform \
@@ -373,7 +373,7 @@ jobs:
           --image-project=cos-cloud \
           --image-family=cos-stable \
           --create-disk=image=${{ env.CACHED_DISK_NAME }},name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=300GB,type=pd-ssd \
-          --container-image=gcr.io/google-containers/busybox \
+          --container-image=gcr.io/google-containers/ubuntu \
           --machine-type ${{ vars.GCP_LARGE_MACHINE }} \
           --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \
           --scopes cloud-platform \


### PR DESCRIPTION
## Motivation

Some CI jobs are regularly failing with "device or resource busy" errors.

Close #7659

## Solution

The busybox image is really old, so I replaced it with a newer `ubuntu` image.

This could have been a kernel/OS incompatibility. Or this PR might fix the issue because it slows down automatic checks on the disks, allowing the mount command to win the race.

## Review

This is urgent so I'm going to admin-merge it if it works. It needs to admin-merge so the checkpoint rebuild job can run.

We need to run it at least 3 times to test that it works.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Work out if we can use `ubuntu-slim` instead to save image download & launch time.