### PR TITLE
fix(ci): handle disk mounting and logs reading edge-cases

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -132,7 +132,7 @@ jobs:
 
       # Make sure Zebra can sync at least one full checkpoint on mainnet
       - name: Run tests using the default config
-        shell: /usr/bin/bash -ex {0}
+        shell: /usr/bin/bash -exo pipefail {0}
         run: |
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --detach --name default-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
@@ -143,7 +143,7 @@ jobs:
           --tail all \
           --follow \
           default-conf-tests | \
-          tee --output-error=warn /dev/stderr | \
+          tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           -e "net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter";
           LOGS_EXIT_STATUS=$?;
@@ -179,7 +179,7 @@ jobs:
 
       # Make sure Zebra can sync the genesis block on testnet
       - name: Run tests using a testnet config
-        shell: /usr/bin/bash -ex {0}
+        shell: /usr/bin/bash -exo pipefail {0}
         run: |
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --env "NETWORK=Testnet" --detach --name testnet-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
@@ -190,7 +190,7 @@ jobs:
           --tail all \
           --follow \
           testnet-conf-tests | \
-          tee --output-error=warn /dev/stderr | \
+          tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           -e "net.*=.*Test.*estimated progress to chain tip.*Genesis" \
           -e "net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter";

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -132,29 +132,36 @@ jobs:
 
       # Make sure Zebra can sync at least one full checkpoint on mainnet
       - name: Run tests using the default config
-        shell: /usr/bin/bash -x {0}
         run: |
+          set -ex
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --detach --name default-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
-          # show the logs, even if the job times out
-          docker logs --tail all --follow default-conf-tests | \
-          (tee /dev/stderr || true) | \
+
+          # Temporarily disable "set -e" to handle the broken pipe error gracefully
+          set +e;
+          sudo docker logs \
+          --tail all \
+          --follow \
+          default-conf-tests | \
+          tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          'net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter'
+          -e "net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter";
+          LOGS_EXIT_STATUS=$?;
+          set -e;
+
           docker stop default-conf-tests
-          # get the exit status from docker
-          EXIT_STATUS=$( \
-          docker wait default-conf-tests || \
-          docker inspect --format "{{.State.ExitCode}}" default-conf-tests || \
-          echo "missing container, or missing exit status for container" \
-          )
-          docker logs default-conf-tests
-          echo "docker exit status: $EXIT_STATUS"
-          if [[ "$EXIT_STATUS" = "137" ]]; then
-          echo "ignoring expected signal status"
-          exit 0
+
+          EXIT_STATUS=$(sudo docker wait default-conf-tests || echo "Error retrieving exit status");
+          echo "sudo docker exit status: $EXIT_STATUS";
+
+          # If grep found the pattern, exit with the Docker container"s exit status
+          if [ $LOGS_EXIT_STATUS -eq 0 ]; then
+              exit $EXIT_STATUS;
           fi
-          exit "$EXIT_STATUS"
+
+          # Handle other potential errors here
+          echo "An error occurred while processing the logs.";
+          exit 1;
 
   # Test reconfiguring the docker image for testnet.
   test-configuration-file-testnet:
@@ -174,28 +181,37 @@ jobs:
       - name: Run tests using a testnet config
         shell: /usr/bin/bash -x {0}
         run: |
+          set -ex
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --env "NETWORK=Testnet" --detach --name testnet-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
-          # show the logs, even if the job times out
-          docker logs --tail all --follow testnet-conf-tests | \
-          (tee /dev/stderr || true) | \
+
+          # Temporarily disable "set -e" to handle the broken pipe error gracefully
+          set +e;
+          sudo docker logs \
+          --tail all \
+          --follow \
+          testnet-conf-tests | \
+          tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          -e 'net.*=.*Test.*estimated progress to chain tip.*Genesis' \
-          -e 'net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter'
+          -e "net.*=.*Test.*estimated progress to chain tip.*Genesis' \
+          -e "net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter';
+          LOGS_EXIT_STATUS=$?;
+          set -e;
+
           docker stop testnet-conf-tests
-          # get the exit status from docker
-          EXIT_STATUS=$( \
-          docker wait testnet-conf-tests || \
-          docker inspect --format "{{.State.ExitCode}}" testnet-conf-tests || \
-          echo "missing container, or missing exit status for container" \
-          )
-          docker logs testnet-conf-tests
-          echo "docker exit status: $EXIT_STATUS"
-          if [[ "$EXIT_STATUS" = "137" ]]; then
-          echo "ignoring expected signal status"
-          exit 0
+
+          EXIT_STATUS=$(sudo docker wait testnet-conf-tests || echo "Error retrieving exit status");
+          echo "sudo docker exit status: $EXIT_STATUS";
+
+          # If grep found the pattern, exit with the Docker container"s exit status
+          if [ $LOGS_EXIT_STATUS -eq 0 ]; then
+              exit $EXIT_STATUS;
           fi
-          exit "$EXIT_STATUS"
+
+          # Handle other potential errors here
+          echo "An error occurred while processing the logs.";
+          exit 1;
+
 
   # Deploy Managed Instance Groups (MiGs) for Mainnet and Testnet,
   # with one node in the configured GCP region.

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -134,11 +134,12 @@ jobs:
       - name: Run tests using the default config
         run: |
           set -ex
+          trap "" PIPE;
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --detach --name default-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           # show the logs, even if the job times out
           docker logs --tail all --follow default-conf-tests | \
-          tee --output-error=exit /dev/stderr | \
+          tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           'net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter'
           docker stop default-conf-tests
@@ -175,11 +176,12 @@ jobs:
         shell: /usr/bin/bash -exo pipefail {0}
         run: |
           set -ex
+          trap "" PIPE;
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --env "NETWORK=Testnet" --detach --name testnet-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           # show the logs, even if the job times out
           docker logs --tail all --follow testnet-conf-tests | \
-          tee --output-error=exit /dev/stderr | \
+          tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           -e 'net.*=.*Test.*estimated progress to chain tip.*Genesis' \
           -e 'net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter'

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -29,7 +29,7 @@ on:
         type: boolean
         default: false
 
-  # Temporarily disabled to reduce network load, see #6894.
+  # TODO: Temporarily disabled to reduce network load, see #6894.
   #push:
   #  branches:
   #    - main
@@ -132,29 +132,37 @@ jobs:
 
       # Make sure Zebra can sync at least one full checkpoint on mainnet
       - name: Run tests using the default config
+        shell: /usr/bin/bash -exo pipefail {0}
         run: |
-          set -ex
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --detach --name default-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
+
           # show the logs, even if the job times out
-          docker logs --tail all --follow default-conf-tests | \
+          # Temporarily disable "set -e" to handle the broken pipe error gracefully
+          set +e;
+          docker logs \
+          --tail all \
+          --follow \
+          default-conf-tests | \
           tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          'net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter'
-          docker stop default-conf-tests
+          "net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter";
+          LOGS_EXIT_STATUS=$?;
+          set -e;
+
           # get the exit status from docker
-          EXIT_STATUS=$( \
-          docker wait default-conf-tests || \
-          docker inspect --format "{{.State.ExitCode}}" default-conf-tests || \
-          echo "missing container, or missing exit status for container" \
-          )
-          docker logs default-conf-tests
-          echo "docker exit status: $EXIT_STATUS"
-          if [[ "$EXIT_STATUS" = "137" ]]; then
-          echo "ignoring expected signal status"
-          exit 0
+          docker stop default-conf-tests
+          EXIT_STATUS=$(docker wait default-conf-tests || echo "Error retrieving exit status");
+          echo "docker exit status: $EXIT_STATUS";
+
+          # If grep found the pattern, exit with the Docker container"s exit status
+          if [ $LOGS_EXIT_STATUS -eq 0 ]; then
+              exit $EXIT_STATUS;
           fi
-          exit "$EXIT_STATUS"
+
+          # Handle other potential errors here
+          echo "An error occurred while processing the logs.";
+          exit 1
 
   # Test reconfiguring the docker image for testnet.
   test-configuration-file-testnet:
@@ -172,30 +180,37 @@ jobs:
 
       # Make sure Zebra can sync the genesis block on testnet
       - name: Run tests using a testnet config
+        shell: /usr/bin/bash -exo pipefail {0}
         run: |
-          set -ex
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --env "NETWORK=Testnet" --detach --name testnet-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
+
           # show the logs, even if the job times out
-          docker logs --tail all --follow testnet-conf-tests | \
+          # Temporarily disable "set -e" to handle the broken pipe error gracefully
+          set +e;
+          docker logs \
+          --tail all \
+          --follow \
+          testnet-conf-tests | \
           tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          -e 'net.*=.*Test.*estimated progress to chain tip.*Genesis' \
-          -e 'net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter'
-          docker stop testnet-conf-tests
+          "net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter";
+          LOGS_EXIT_STATUS=$?;
+          set -e;
+
           # get the exit status from docker
-          EXIT_STATUS=$( \
-          docker wait testnet-conf-tests || \
-          docker inspect --format "{{.State.ExitCode}}" testnet-conf-tests || \
-          echo "missing container, or missing exit status for container" \
-          )
-          docker logs testnet-conf-tests
-          echo "docker exit status: $EXIT_STATUS"
-          if [[ "$EXIT_STATUS" = "137" ]]; then
-          echo "ignoring expected signal status"
-          exit 0
+          docker stop testnet-conf-tests
+          EXIT_STATUS=$(docker wait testnet-conf-tests || echo "Error retrieving exit status");
+          echo "docker exit status: $EXIT_STATUS";
+
+          # If grep found the pattern, exit with the Docker container"s exit status
+          if [ $LOGS_EXIT_STATUS -eq 0 ]; then
+              exit $EXIT_STATUS;
           fi
-          exit "$EXIT_STATUS"
+
+          # Handle other potential errors here
+          echo "An error occurred while processing the logs.";
+          exit 1
 
   # Deploy Managed Instance Groups (MiGs) for Mainnet and Testnet,
   # with one node in the configured GCP region.

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -138,7 +138,7 @@ jobs:
           docker run --detach --name default-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           # show the logs, even if the job times out
           docker logs --tail all --follow default-conf-tests | \
-          tee /dev/stderr | \
+          (tee /dev/stderr || true) | \
           grep --max-count=1 --extended-regexp --color=always \
           'net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter'
           docker stop default-conf-tests
@@ -178,7 +178,7 @@ jobs:
           docker run --env "NETWORK=Testnet" --detach --name testnet-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           # show the logs, even if the job times out
           docker logs --tail all --follow testnet-conf-tests | \
-          tee /dev/stderr | \
+          (tee /dev/stderr || true) | \
           grep --max-count=1 --extended-regexp --color=always \
           -e 'net.*=.*Test.*estimated progress to chain tip.*Genesis' \
           -e 'net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter'

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -132,14 +132,14 @@ jobs:
 
       # Make sure Zebra can sync at least one full checkpoint on mainnet
       - name: Run tests using the default config
+        shell: /usr/bin/bash -exo pipefail {0}
         run: |
-          set -ex
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --detach --name default-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
 
           # Temporarily disable "set -e" to handle the broken pipe error gracefully
           set +e;
-          sudo docker logs \
+          docker logs \
           --tail all \
           --follow \
           default-conf-tests | \
@@ -151,8 +151,8 @@ jobs:
 
           docker stop default-conf-tests
 
-          EXIT_STATUS=$(sudo docker wait default-conf-tests || echo "Error retrieving exit status");
-          echo "sudo docker exit status: $EXIT_STATUS";
+          EXIT_STATUS=$(docker wait default-conf-tests || echo "Error retrieving exit status");
+          echo "docker exit status: $EXIT_STATUS";
 
           # If grep found the pattern, exit with the Docker container"s exit status
           if [ $LOGS_EXIT_STATUS -eq 0 ]; then
@@ -179,7 +179,7 @@ jobs:
 
       # Make sure Zebra can sync the genesis block on testnet
       - name: Run tests using a testnet config
-        shell: /usr/bin/bash -x {0}
+        shell: /usr/bin/bash -exo pipefail {0}
         run: |
           set -ex
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
@@ -187,21 +187,21 @@ jobs:
 
           # Temporarily disable "set -e" to handle the broken pipe error gracefully
           set +e;
-          sudo docker logs \
+          docker logs \
           --tail all \
           --follow \
           testnet-conf-tests | \
           tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          -e "net.*=.*Test.*estimated progress to chain tip.*Genesis' \
-          -e "net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter';
+          -e "net.*=.*Test.*estimated progress to chain tip.*Genesis" \
+          -e "net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter";
           LOGS_EXIT_STATUS=$?;
           set -e;
 
           docker stop testnet-conf-tests
 
-          EXIT_STATUS=$(sudo docker wait testnet-conf-tests || echo "Error retrieving exit status");
-          echo "sudo docker exit status: $EXIT_STATUS";
+          EXIT_STATUS=$(docker wait testnet-conf-tests || echo "Error retrieving exit status");
+          echo "docker exit status: $EXIT_STATUS";
 
           # If grep found the pattern, exit with the Docker container"s exit status
           if [ $LOGS_EXIT_STATUS -eq 0 ]; then
@@ -211,7 +211,6 @@ jobs:
           # Handle other potential errors here
           echo "An error occurred while processing the logs.";
           exit 1;
-
 
   # Deploy Managed Instance Groups (MiGs) for Mainnet and Testnet,
   # with one node in the configured GCP region.

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -143,7 +143,7 @@ jobs:
           --tail all \
           --follow \
           default-conf-tests | \
-          tee --output-error=exit /dev/stderr | \
+          tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           -e "net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter";
           LOGS_EXIT_STATUS=$?;
@@ -181,7 +181,6 @@ jobs:
       - name: Run tests using a testnet config
         shell: /usr/bin/bash -exo pipefail {0}
         run: |
-          set -ex
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --env "NETWORK=Testnet" --detach --name testnet-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
 
@@ -191,7 +190,7 @@ jobs:
           --tail all \
           --follow \
           testnet-conf-tests | \
-          tee --output-error=exit /dev/stderr | \
+          tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           -e "net.*=.*Test.*estimated progress to chain tip.*Genesis" \
           -e "net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter";

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -132,37 +132,29 @@ jobs:
 
       # Make sure Zebra can sync at least one full checkpoint on mainnet
       - name: Run tests using the default config
-        shell: /usr/bin/bash -exo pipefail {0}
         run: |
+          set -ex
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --detach --name default-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
-
           # show the logs, even if the job times out
-          # Temporarily disable "set -e" to handle the broken pipe error gracefully
-          set +e;
-          docker logs \
-          --tail all \
-          --follow \
-          default-conf-tests | \
-          tee --output-error=exit-nopipe /dev/stderr | \
+          docker logs --tail all --follow default-conf-tests | \
+          tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          "net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter";
-          LOGS_EXIT_STATUS=$?;
-          set -e;
-
-          # get the exit status from docker
+          'net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter'
           docker stop default-conf-tests
-          EXIT_STATUS=$(docker wait default-conf-tests || echo "Error retrieving exit status");
-          echo "docker exit status: $EXIT_STATUS";
-
-          # If grep found the pattern, exit with the Docker container"s exit status
-          if [ $LOGS_EXIT_STATUS -eq 0 ]; then
-              exit $EXIT_STATUS;
+          # get the exit status from docker
+          EXIT_STATUS=$( \
+          docker wait default-conf-tests || \
+          docker inspect --format "{{.State.ExitCode}}" default-conf-tests || \
+          echo "missing container, or missing exit status for container" \
+          )
+          docker logs default-conf-tests
+          echo "docker exit status: $EXIT_STATUS"
+          if [[ "$EXIT_STATUS" = "137" ]]; then
+          echo "ignoring expected signal status"
+          exit 0
           fi
-
-          # Handle other potential errors here
-          echo "An error occurred while processing the logs.";
-          exit 1
+          exit "$EXIT_STATUS"
 
   # Test reconfiguring the docker image for testnet.
   test-configuration-file-testnet:
@@ -182,35 +174,29 @@ jobs:
       - name: Run tests using a testnet config
         shell: /usr/bin/bash -exo pipefail {0}
         run: |
+          set -ex
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --env "NETWORK=Testnet" --detach --name testnet-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
-
           # show the logs, even if the job times out
-          # Temporarily disable "set -e" to handle the broken pipe error gracefully
-          set +e;
-          docker logs \
-          --tail all \
-          --follow \
-          testnet-conf-tests | \
-          tee --output-error=exit-nopipe /dev/stderr | \
+          docker logs --tail all --follow testnet-conf-tests | \
+          tee --output-error=exit /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          "net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter";
-          LOGS_EXIT_STATUS=$?;
-          set -e;
-
-          # get the exit status from docker
+          -e 'net.*=.*Test.*estimated progress to chain tip.*Genesis' \
+          -e 'net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter'
           docker stop testnet-conf-tests
-          EXIT_STATUS=$(docker wait testnet-conf-tests || echo "Error retrieving exit status");
-          echo "docker exit status: $EXIT_STATUS";
-
-          # If grep found the pattern, exit with the Docker container"s exit status
-          if [ $LOGS_EXIT_STATUS -eq 0 ]; then
-              exit $EXIT_STATUS;
+          # get the exit status from docker
+          EXIT_STATUS=$( \
+          docker wait testnet-conf-tests || \
+          docker inspect --format "{{.State.ExitCode}}" testnet-conf-tests || \
+          echo "missing container, or missing exit status for container" \
+          )
+          docker logs testnet-conf-tests
+          echo "docker exit status: $EXIT_STATUS"
+          if [[ "$EXIT_STATUS" = "137" ]]; then
+          echo "ignoring expected signal status"
+          exit 0
           fi
-
-          # Handle other potential errors here
-          echo "An error occurred while processing the logs.";
-          exit 1
+          exit "$EXIT_STATUS"
 
   # Deploy Managed Instance Groups (MiGs) for Mainnet and Testnet,
   # with one node in the configured GCP region.

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -132,14 +132,13 @@ jobs:
 
       # Make sure Zebra can sync at least one full checkpoint on mainnet
       - name: Run tests using the default config
+        shell: /usr/bin/bash -x {0}
         run: |
-          set -ex
-          trap "" PIPE;
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --detach --name default-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           # show the logs, even if the job times out
           docker logs --tail all --follow default-conf-tests | \
-          tee --output-error=exit-nopipe /dev/stderr | \
+          tee /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           'net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter'
           docker stop default-conf-tests
@@ -173,15 +172,13 @@ jobs:
 
       # Make sure Zebra can sync the genesis block on testnet
       - name: Run tests using a testnet config
-        shell: /usr/bin/bash -exo pipefail {0}
+        shell: /usr/bin/bash -x {0}
         run: |
-          set -ex
-          trap "" PIPE;
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --env "NETWORK=Testnet" --detach --name testnet-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           # show the logs, even if the job times out
           docker logs --tail all --follow testnet-conf-tests | \
-          tee --output-error=exit-nopipe /dev/stderr | \
+          tee /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           -e 'net.*=.*Test.*estimated progress to chain tip.*Genesis' \
           -e 'net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter'

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -132,18 +132,18 @@ jobs:
 
       # Make sure Zebra can sync at least one full checkpoint on mainnet
       - name: Run tests using the default config
-        shell: /usr/bin/bash -exo pipefail {0}
+        shell: /usr/bin/bash -ex {0}
         run: |
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --detach --name default-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
-
+          trap "" PIPE;
           # Temporarily disable "set -e" to handle the broken pipe error gracefully
           set +e;
           docker logs \
           --tail all \
           --follow \
           default-conf-tests | \
-          tee --output-error=exit-nopipe /dev/stderr | \
+          tee --output-error=warn /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           -e "net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter";
           LOGS_EXIT_STATUS=$?;
@@ -179,18 +179,18 @@ jobs:
 
       # Make sure Zebra can sync the genesis block on testnet
       - name: Run tests using a testnet config
-        shell: /usr/bin/bash -exo pipefail {0}
+        shell: /usr/bin/bash -ex {0}
         run: |
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --env "NETWORK=Testnet" --detach --name testnet-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
-
+          trap "" PIPE;
           # Temporarily disable "set -e" to handle the broken pipe error gracefully
           set +e;
           docker logs \
           --tail all \
           --follow \
           testnet-conf-tests | \
-          tee --output-error=exit-nopipe /dev/stderr | \
+          tee --output-error=warn /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           -e "net.*=.*Test.*estimated progress to chain tip.*Genesis" \
           -e "net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter";

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -136,25 +136,26 @@ jobs:
         run: |
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --detach --name default-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
-          trap "" PIPE;
-          # Temporarily disable "set -e" to handle the broken pipe error gracefully
-          set +e;
-          docker logs \
-          --tail all \
-          --follow \
-          default-conf-tests | \
-          tee --output-error=exit /dev/stderr | \
-          grep --max-count=1 --extended-regexp --color=always \
-          -e "net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter";
-          LOGS_EXIT_STATUS=$?;
-          set -e;
+
+          # Use a subshell to handle the broken pipe error gracefully
+          (
+            trap "" PIPE;
+            docker logs \
+            --tail all \
+            --follow \
+            default-conf-tests | \
+            tee --output-error=exit /dev/stderr | \
+            grep --max-count=1 --extended-regexp --color=always \
+            -e "net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter"
+          ) || true
+          LOGS_EXIT_STATUS=$?
 
           docker stop default-conf-tests
 
           EXIT_STATUS=$(docker wait default-conf-tests || echo "Error retrieving exit status");
           echo "docker exit status: $EXIT_STATUS";
 
-          # If grep found the pattern, exit with the Docker container"s exit status
+          # If grep found the pattern, exit with the Docker container exit status
           if [ $LOGS_EXIT_STATUS -eq 0 ]; then
               exit $EXIT_STATUS;
           fi
@@ -183,26 +184,26 @@ jobs:
         run: |
           docker pull ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           docker run --env "NETWORK=Testnet" --detach --name testnet-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
-          trap "" PIPE;
-          # Temporarily disable "set -e" to handle the broken pipe error gracefully
-          set +e;
-          docker logs \
-          --tail all \
-          --follow \
-          testnet-conf-tests | \
-          tee --output-error=exit /dev/stderr | \
-          grep --max-count=1 --extended-regexp --color=always \
-          -e "net.*=.*Test.*estimated progress to chain tip.*Genesis" \
-          -e "net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter";
-          LOGS_EXIT_STATUS=$?;
-          set -e;
+          # Use a subshell to handle the broken pipe error gracefully
+          (
+            trap "" PIPE;
+            docker logs \
+            --tail all \
+            --follow \
+            testnet-conf-tests | \
+            tee --output-error=exit /dev/stderr | \
+            grep --max-count=1 --extended-regexp --color=always \
+            -e "net.*=.*Test.*estimated progress to chain tip.*Genesis" \
+            -e "net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter";
+          ) || true
+          LOGS_EXIT_STATUS=$?
 
           docker stop testnet-conf-tests
 
           EXIT_STATUS=$(docker wait testnet-conf-tests || echo "Error retrieving exit status");
           echo "docker exit status: $EXIT_STATUS";
 
-          # If grep found the pattern, exit with the Docker container"s exit status
+          # If grep found the pattern, exit with the Docker container exit status
           if [ $LOGS_EXIT_STATUS -eq 0 ]; then
               exit $EXIT_STATUS;
           fi

--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -138,7 +138,7 @@ jobs:
           docker run --detach --name default-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           # show the logs, even if the job times out
           docker logs --tail all --follow default-conf-tests | \
-          tee --output-error=exit /dev/stderr | \
+          tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           'net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter'
           docker stop default-conf-tests
@@ -178,7 +178,7 @@ jobs:
           docker run --env "NETWORK=Testnet" --detach --name testnet-conf-tests -t ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
           # show the logs, even if the job times out
           docker logs --tail all --follow testnet-conf-tests | \
-          tee --output-error=exit /dev/stderr | \
+          tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           -e 'net.*=.*Test.*estimated progress to chain tip.*Genesis' \
           -e 'net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter'

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -180,7 +180,6 @@ jobs:
           --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ vars.GCP_ZONE }}
-          sleep 90
 
       # Format the mounted disk if the test doesn't use a cached state.
       - name: Format ${{ inputs.test_id }} volume

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -194,7 +194,7 @@ jobs:
           --command=' \
           set -ex;
           # Extract the correct disk name based on the device-name
-          export DISK_NAME=$(ls -l /dev/disk/by-id | grep --extended-regexp "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}\$" | cut -d" " -f11 | cut -d"/" -f3); \
+          export DISK_NAME=$(ls -l /dev/disk/by-id | grep -oE "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} -> ../../[^ ]+" | grep -oE "/[^/]+$" | cut -c 2-); \
           sudo mkfs.ext4 -v /dev/$DISK_NAME \
           '
 
@@ -432,7 +432,7 @@ jobs:
           --command=' \
           set -ex;
           # Extract the correct disk name based on the device-name
-          export DISK_NAME=$(ls -l /dev/disk/by-id | grep --extended-regexp "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}\$" | cut -d" " -f11 | cut -d"/" -f3); \
+          export DISK_NAME=$(ls -l /dev/disk/by-id | grep -oE "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} -> ../../[^ ]+" | grep -oE "/[^/]+$" | cut -c 2-); \
 
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -503,7 +503,7 @@ jobs:
           --command=' \
           set -ex;
           # Extract the correct disk name based on the device-name
-          export DISK_NAME=$(ls -l /dev/disk/by-id | grep --extended-regexp "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}\$" | cut -d" " -f11 | cut -d"/" -f3); \
+          export DISK_NAME=$(ls -l /dev/disk/by-id | grep -oE "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} -> ../../[^ ]+" | grep -oE "/[^/]+$" | cut -c 2-); \
 
           sudo docker run \
           --name ${{ inputs.test_id }} \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -399,6 +399,23 @@ jobs:
           --zone ${{ vars.GCP_ZONE }}
           sleep 90
 
+      # Wait for the /dev/sdb to be ready and not in use by another process
+      - name: Wait for ${{ inputs.test_id }} volume
+        shell: /usr/bin/bash -exo pipefail {0}
+        run: |
+          gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          --zone ${{ vars.GCP_ZONE }} \
+          --ssh-flag="-o ServerAliveInterval=5" \
+          --ssh-flag="-o ConnectionAttempts=20" \
+          --ssh-flag="-o ConnectTimeout=5" \
+          --command=' \
+          set -ex
+          while sudo lsof /dev/sdb; do \
+            echo "Waiting for /dev/sdb to be free..."; \
+            sleep 10; \
+          done; \
+          '
+
       # Launch the test with the previously created Zebra-only cached state.
       # Each test runs one of the "Launch test" steps, and skips the other.
       #
@@ -439,8 +456,8 @@ jobs:
           '
 
       # Show dmesg logs if previous job failed
-      - name: Show dmesg logs if previous job failed
-        if: ${{ failure() }}
+      - name: Show debug logs if previous job failed
+        if: ${{ failure() && (inputs.needs_zebra_state && !inputs.needs_lwd_state) && inputs.test_id != 'lwd-full-sync' }}
         shell: /usr/bin/bash -exo pipefail {0}
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
@@ -449,7 +466,9 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command=' \
-          sudo dmesg \
+          sudo lsof /dev/sdb;
+          sudo dmesg;
+          sudo journalctl -b \
           '
 
       # Launch the test with the previously created Lightwalletd and Zebra cached state.
@@ -505,7 +524,7 @@ jobs:
 
       # Show dmesg logs if previous job failed
       - name: Show dmesg logs if previous job failed
-        if: ${{ failure() }}
+        if: ${{ failure() && (inputs.needs_zebra_state && inputs.needs_lwd_state) || inputs.test_id == 'lwd-full-sync' }}
         shell: /usr/bin/bash -exo pipefail {0}
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
@@ -514,7 +533,9 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command=' \
-          sudo dmesg \
+          sudo lsof /dev/sdb;
+          sudo dmesg;
+          sudo journalctl -b \
           '
 
   # Show all the test logs, then follow the logs of the test we just launched, until it finishes.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -200,6 +200,7 @@ jobs:
 
       # Launch the test without any cached state
       - name: Launch ${{ inputs.test_id }} test
+        id: launch-test
         shell: /usr/bin/bash -exo pipefail {0}
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
@@ -215,6 +216,20 @@ jobs:
           ${{ inputs.test_variables }} \
           --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
+          '
+
+      # Show dmesg logs if previous job failed
+      - name: Show dmesg logs if previous job failed
+        if: ${{ failure() }}
+        shell: /usr/bin/bash -exo pipefail {0}
+        run: |
+          gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          --zone ${{ vars.GCP_ZONE }} \
+          --ssh-flag="-o ServerAliveInterval=5" \
+          --ssh-flag="-o ConnectionAttempts=20" \
+          --ssh-flag="-o ConnectTimeout=5" \
+          --command=' \
+          sudo dmesg \
           '
 
   # set up and launch the test, if it uses cached state
@@ -422,6 +437,20 @@ jobs:
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
           '
 
+      # Show dmesg logs if previous job failed
+      - name: Show dmesg logs if previous job failed
+        if: ${{ failure() }}
+        shell: /usr/bin/bash -exo pipefail {0}
+        run: |
+          gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          --zone ${{ vars.GCP_ZONE }} \
+          --ssh-flag="-o ServerAliveInterval=5" \
+          --ssh-flag="-o ConnectionAttempts=20" \
+          --ssh-flag="-o ConnectTimeout=5" \
+          --command=' \
+          sudo dmesg \
+          '
+
       # Launch the test with the previously created Lightwalletd and Zebra cached state.
       # Each test runs one of the "Launch test" steps, and skips the other.
       #
@@ -471,6 +500,20 @@ jobs:
           --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
+          '
+
+      # Show dmesg logs if previous job failed
+      - name: Show dmesg logs if previous job failed
+        if: ${{ failure() }}
+        shell: /usr/bin/bash -exo pipefail {0}
+        run: |
+          gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          --zone ${{ vars.GCP_ZONE }} \
+          --ssh-flag="-o ServerAliveInterval=5" \
+          --ssh-flag="-o ConnectionAttempts=20" \
+          --ssh-flag="-o ConnectTimeout=5" \
+          --command=' \
+          sudo dmesg \
           '
 
   # Show all the test logs, then follow the logs of the test we just launched, until it finishes.

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -166,7 +166,7 @@ jobs:
         id: create-instance
         run: |
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
-          --boot-disk-size 10GB \
+          --boot-disk-size 50GB \
           --boot-disk-type pd-ssd \
           --image-project=cos-cloud \
           --image-family=cos-stable \
@@ -383,7 +383,7 @@ jobs:
         id: create-instance
         run: |
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
-          --boot-disk-size 10GB \
+          --boot-disk-size 50GB \
           --boot-disk-type pd-ssd \
           --image-project=cos-cloud \
           --image-family=cos-stable \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -190,13 +190,13 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command=" \
+          --command=' \
           while sudo lsof /dev/sdb; do \
-            echo 'Waiting for /dev/sdb to be free...'; \
+            echo "Waiting for /dev/sdb to be free..."; \
             sleep 10; \
           done; \
           sudo mkfs.ext4 -v /dev/sdb \
-          "
+          '
 
       # Launch the test without any cached state
       - name: Launch ${{ inputs.test_id }} test
@@ -207,7 +207,7 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command=" \
+          --command=' \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
@@ -215,7 +215,7 @@ jobs:
           ${{ inputs.test_variables }} \
           --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
-          "
+          '
 
   # set up and launch the test, if it uses cached state
   # each test runs one of the *-with/without-cached-state job series, and skips the other
@@ -412,7 +412,7 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command=" \
+          --command=' \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
@@ -420,7 +420,7 @@ jobs:
           ${{ inputs.test_variables }} \
           --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
-          "
+          '
 
       # Launch the test with the previously created Lightwalletd and Zebra cached state.
       # Each test runs one of the "Launch test" steps, and skips the other.
@@ -462,7 +462,7 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command=" \
+          --command=' \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
@@ -471,7 +471,7 @@ jobs:
           --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
-          "
+          '
 
   # Show all the test logs, then follow the logs of the test we just launched, until it finishes.
   # Then check the result of the test.
@@ -545,7 +545,7 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command=" \
+          --command=' \
           sudo docker logs \
           --tail all \
           --follow \
@@ -553,8 +553,8 @@ jobs:
           head -700 | \
           tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          -e 'Zcash network: ${{ inputs.network }}' \
-          "
+          -e "Zcash network: ${{ inputs.network }}" \
+          '
 
       # Check that the container executed at least 1 Rust test harness test, and that all tests passed.
       # Then wait for the container to finish, and exit with the test's exit status.
@@ -574,10 +574,10 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command=" \
-          trap '' PIPE;
+          --command=' \
+          trap "" PIPE;
 
-          # Temporarily disable 'set -e' to handle the broken pipe error gracefully
+          # Temporarily disable "set -e" to handle the broken pipe error gracefully
           set +e;
           sudo docker logs \
           --tail all \
@@ -585,22 +585,22 @@ jobs:
           ${{ inputs.test_id }} | \
           tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          'test result: .*ok.* [1-9][0-9]* passed.*finished in';
+          "test result: .*ok.* [1-9][0-9]* passed.*finished in";
           LOGS_EXIT_STATUS=$?;
           set -e;
 
-          EXIT_STATUS=$(sudo docker wait ${{ inputs.test_id }} || echo 'Error retrieving exit status');
-          echo 'sudo docker exit status: '$EXIT_STATUS;
+          EXIT_STATUS=$(sudo docker wait ${{ inputs.test_id }} || echo "Error retrieving exit status");
+          echo "sudo docker exit status: $EXIT_STATUS";
 
-          # If grep found the pattern, exit with the Docker container's exit status
+          # If grep found the pattern, exit with the Docker container"s exit status
           if [ $LOGS_EXIT_STATUS -eq 0 ]; then
               exit $EXIT_STATUS;
           fi
 
           # Handle other potential errors here
-          echo 'An error occurred while processing the logs.';
+          echo "An error occurred while processing the logs.";
           exit 1; \
-          "
+          '
 
   # create a state image from the instance's state disk, if requested by the caller
   create-state-image:
@@ -725,9 +725,9 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command=" \
+          --command=' \
           sudo docker logs ${{ inputs.test_id }} | head -1000 \
-          ")
+          ')
 
           # either a semantic version or "creating new database"
           INITIAL_DISK_DB_VERSION=$( \
@@ -813,9 +813,9 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command=" \
+          --command=' \
           sudo docker logs ${{ inputs.test_id }} --tail 200 \
-          ")
+          ')
 
           SYNC_HEIGHT=$( \
           echo "$DOCKER_LOGS" | \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -192,11 +192,11 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command=' \
-          while sudo lsof /dev/sdb; do \
-            echo "Waiting for /dev/sdb to be free..."; \
-            sleep 10; \
-          done; \
-          sudo mkfs.ext4 -v /dev/sdb \
+          set -ex;
+          # Extract the correct disk name based on the device-name
+          DISK_IDENTIFIER="google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}";
+          export DISK_NAME=$(ls -l /dev/disk/by-id | awk -v id="$DISK_IDENTIFIER" "$9 == id {gsub(\"../../\", \"\"); print $11}");
+          sudo mkfs.ext4 -v /dev/$DISK_NAME \
           '
 
       # Launch the test without any cached state
@@ -215,12 +215,12 @@ jobs:
           --tty \
           --detach \
           ${{ inputs.test_variables }} \
-          --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
+          --mount type=volume,volume-driver=local,volume-opt=device=/dev/$DISK_NAME,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
           '
 
-      # Show dmesg logs if previous job failed
-      - name: Show dmesg logs if previous job failed
+      # Show debug logs if previous job failed
+      - name: Show debug logs if previous job failed
         if: ${{ failure() }}
         shell: /usr/bin/bash -exo pipefail {0}
         run: |
@@ -230,7 +230,10 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command=' \
-          sudo dmesg \
+          lsblk;
+          sudo lsof /dev/sdb;
+          sudo dmesg;
+          sudo journalctl -b \
           '
 
   # set up and launch the test, if it uses cached state
@@ -397,24 +400,6 @@ jobs:
           --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ vars.GCP_ZONE }}
-          sleep 90
-
-      # Wait for the /dev/sdb to be ready and not in use by another process
-      - name: Wait for ${{ inputs.test_id }} volume
-        shell: /usr/bin/bash -exo pipefail {0}
-        run: |
-          gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
-          --zone ${{ vars.GCP_ZONE }} \
-          --ssh-flag="-o ServerAliveInterval=5" \
-          --ssh-flag="-o ConnectionAttempts=20" \
-          --ssh-flag="-o ConnectTimeout=5" \
-          --command=' \
-          set -ex
-          while sudo lsof /dev/sdb; do \
-            echo "Waiting for /dev/sdb to be free..."; \
-            sleep 10; \
-          done; \
-          '
 
       # Launch the test with the previously created Zebra-only cached state.
       # Each test runs one of the "Launch test" steps, and skips the other.
@@ -446,16 +431,21 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command=' \
+          set -ex;
+          # Extract the correct disk name based on the device-name
+          DISK_IDENTIFIER="google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}";
+          export DISK_NAME=$(ls -l /dev/disk/by-id | awk -v id="$DISK_IDENTIFIER" "$9 == id {gsub(\"../../\", \"\"); print $11}");
+
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
           --detach \
           ${{ inputs.test_variables }} \
-          --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
+          --mount type=volume,volume-driver=local,volume-opt=device=/dev/$DISK_NAME,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
           '
 
-      # Show dmesg logs if previous job failed
+      # Show debug logs if previous job failed
       - name: Show debug logs if previous job failed
         if: ${{ failure() && (inputs.needs_zebra_state && !inputs.needs_lwd_state) && inputs.test_id != 'lwd-full-sync' }}
         shell: /usr/bin/bash -exo pipefail {0}
@@ -466,7 +456,8 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command=' \
-          sudo lsof /dev/sdb;
+          lsblk;
+          sudo lsof /dev/$DISK_NAME;
           sudo dmesg;
           sudo journalctl -b \
           '
@@ -512,18 +503,23 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command=' \
+          set -ex;
+          # Extract the correct disk name based on the device-name
+          DISK_IDENTIFIER="google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}";
+          export DISK_NAME=$(ls -l /dev/disk/by-id | awk -v id="$DISK_IDENTIFIER" "$9 == id {gsub(\"../../\", \"\"); print $11}");
+
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
           --detach \
           ${{ inputs.test_variables }} \
-          --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
-          --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} \
+          --mount type=volume,volume-driver=local,volume-opt=device=/dev/$DISK_NAME,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
+          --mount type=volume,volume-driver=local,volume-opt=device=/dev/$DISK_NAME,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
           '
 
-      # Show dmesg logs if previous job failed
-      - name: Show dmesg logs if previous job failed
+      # Show debug logs if previous job failed
+      - name: Show debug logs if previous job failed
         if: ${{ failure() && (inputs.needs_zebra_state && inputs.needs_lwd_state) || inputs.test_id == 'lwd-full-sync' }}
         shell: /usr/bin/bash -exo pipefail {0}
         run: |
@@ -533,7 +529,8 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command=' \
-          sudo lsof /dev/sdb;
+          lsblk;
+          sudo lsof /dev/$DISK_NAME;
           sudo dmesg;
           sudo journalctl -b \
           '

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -194,7 +194,7 @@ jobs:
           --command=' \
           set -ex;
           # Extract the correct disk name based on the device-name
-          export DISK_NAME=$(ls -l /dev/disk/by-id | grep --extended-regexp "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}\$" | cut -d" " -f11 | cut -d"/" -f3); \;
+          export DISK_NAME=$(ls -l /dev/disk/by-id | grep --extended-regexp "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}\$" | cut -d" " -f11 | cut -d"/" -f3); \
           sudo mkfs.ext4 -v /dev/$DISK_NAME \
           '
 
@@ -432,7 +432,7 @@ jobs:
           --command=' \
           set -ex;
           # Extract the correct disk name based on the device-name
-          export DISK_NAME=$(ls -l /dev/disk/by-id | grep --extended-regexp "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}\$" | cut -d" " -f11 | cut -d"/" -f3); \;
+          export DISK_NAME=$(ls -l /dev/disk/by-id | grep --extended-regexp "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}\$" | cut -d" " -f11 | cut -d"/" -f3); \
 
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -503,7 +503,7 @@ jobs:
           --command=' \
           set -ex;
           # Extract the correct disk name based on the device-name
-          export DISK_NAME=$(ls -l /dev/disk/by-id | grep --extended-regexp "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}\$" | cut -d" " -f11 | cut -d"/" -f3); \;
+          export DISK_NAME=$(ls -l /dev/disk/by-id | grep --extended-regexp "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}\$" | cut -d" " -f11 | cut -d"/" -f3); \
 
           sudo docker run \
           --name ${{ inputs.test_id }} \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -194,8 +194,7 @@ jobs:
           --command=' \
           set -ex;
           # Extract the correct disk name based on the device-name
-          DISK_IDENTIFIER="google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}";
-          export DISK_NAME=$(ls -l /dev/disk/by-id | awk -v id="$DISK_IDENTIFIER" "$9 == id {gsub(\"../../\", \"\"); print $11}");
+          export DISK_NAME=$(ls -l /dev/disk/by-id | grep --extended-regexp "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}\$" | cut -d" " -f11 | cut -d"/" -f3); \;
           sudo mkfs.ext4 -v /dev/$DISK_NAME \
           '
 
@@ -433,8 +432,7 @@ jobs:
           --command=' \
           set -ex;
           # Extract the correct disk name based on the device-name
-          DISK_IDENTIFIER="google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}";
-          export DISK_NAME=$(ls -l /dev/disk/by-id | awk -v id="$DISK_IDENTIFIER" "$9 == id {gsub(\"../../\", \"\"); print $11}");
+          export DISK_NAME=$(ls -l /dev/disk/by-id | grep --extended-regexp "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}\$" | cut -d" " -f11 | cut -d"/" -f3); \;
 
           sudo docker run \
           --name ${{ inputs.test_id }} \
@@ -505,8 +503,7 @@ jobs:
           --command=' \
           set -ex;
           # Extract the correct disk name based on the device-name
-          DISK_IDENTIFIER="google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}";
-          export DISK_NAME=$(ls -l /dev/disk/by-id | awk -v id="$DISK_IDENTIFIER" "$9 == id {gsub(\"../../\", \"\"); print $11}");
+          export DISK_NAME=$(ls -l /dev/disk/by-id | grep --extended-regexp "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}\$" | cut -d" " -f11 | cut -d"/" -f3); \;
 
           sudo docker run \
           --name ${{ inputs.test_id }} \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -183,14 +183,14 @@ jobs:
 
       # Format the mounted disk if the test doesn't use a cached state.
       - name: Format ${{ inputs.test_id }} volume
+        shell: /usr/bin/bash -exo pipefail {0}
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command \
-          "\
+          --command=" \
           while sudo lsof /dev/sdb; do \
             echo 'Waiting for /dev/sdb to be free...'; \
             sleep 10; \
@@ -200,14 +200,14 @@ jobs:
 
       # Launch the test without any cached state
       - name: Launch ${{ inputs.test_id }} test
+        shell: /usr/bin/bash -exo pipefail {0}
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command \
-          "\
+          --command=" \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
@@ -405,14 +405,14 @@ jobs:
         # lightwalletd-full-sync reads Zebra and writes lwd, so it is handled specially.
         # TODO: we should find a better logic for this use cases
         if: ${{ (inputs.needs_zebra_state && !inputs.needs_lwd_state) && inputs.test_id != 'lwd-full-sync' }}
+        shell: /usr/bin/bash -exo pipefail {0}
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command \
-          "\
+          --command=" \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
@@ -455,14 +455,14 @@ jobs:
         # lightwalletd-full-sync reads Zebra and writes lwd, so it is handled specially.
         # TODO: we should find a better logic for this use cases
         if: ${{ (inputs.needs_zebra_state && inputs.needs_lwd_state) || inputs.test_id == 'lwd-full-sync' }}
+        shell: /usr/bin/bash -exo pipefail {0}
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command \
-          "\
+          --command=" \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
@@ -538,20 +538,20 @@ jobs:
       #
       # Errors in the tests are caught by the final test status job.
       - name: Check startup logs for ${{ inputs.test_id }}
+        shell: /usr/bin/bash -exo pipefail {0}
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command \
-          "\
+          --command=" \
           sudo docker logs \
           --tail all \
           --follow \
           ${{ inputs.test_id }} | \
           head -700 | \
-          tee --output-error=exit /dev/stderr | \
+          tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
           -e 'Zcash network: ${{ inputs.network }}' \
           "
@@ -567,34 +567,40 @@ jobs:
       # with that status.
       # (`docker wait` can also wait for multiple containers, but we only ever wait for a single container.)
       - name: Result of ${{ inputs.test_id }} test
+        shell: /usr/bin/bash -exo pipefail {0}
         run: |
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command=' \
-          set -e;
-          set -o pipefail;
+          --command=" \
           trap '' PIPE;
 
+          # Temporarily disable 'set -e' to handle the broken pipe error gracefully
+          set +e;
           sudo docker logs \
           --tail all \
           --follow \
           ${{ inputs.test_id }} | \
-          tee --output-error=exit /dev/stderr | \
+          tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          "test result: .*ok.* [1-9][0-9]* passed.*finished in"; \
+          'test result: .*ok.* [1-9][0-9]* passed.*finished in';
+          LOGS_EXIT_STATUS=$?;
+          set -e;
 
-          EXIT_STATUS=$( \
-          sudo docker wait ${{ inputs.test_id }} || \
-          sudo docker inspect --format "{{.State.ExitCode}}" ${{ inputs.test_id }} || \
-          echo "missing container, or missing exit status for container" \
-          ); \
+          EXIT_STATUS=$(sudo docker wait ${{ inputs.test_id }} || echo 'Error retrieving exit status');
+          echo 'sudo docker exit status: '$EXIT_STATUS;
 
-          echo "sudo docker exit status: $EXIT_STATUS"; \
-          exit "$EXIT_STATUS" \
-          '
+          # If grep found the pattern, exit with the Docker container's exit status
+          if [ $LOGS_EXIT_STATUS -eq 0 ]; then
+              exit $EXIT_STATUS;
+          fi
+
+          # Handle other potential errors here
+          echo 'An error occurred while processing the logs.';
+          exit 1; \
+          "
 
   # create a state image from the instance's state disk, if requested by the caller
   create-state-image:
@@ -707,6 +713,7 @@ jobs:
       # Passes the versions to subsequent steps using the $INITIAL_DISK_DB_VERSION,
       # $RUNNING_DB_VERSION, and $DB_VERSION_SUMMARY env variables.
       - name: Get database versions from logs
+        shell: /usr/bin/bash -exo pipefail {0}
         run: |
           INITIAL_DISK_DB_VERSION=""
           RUNNING_DB_VERSION=""
@@ -796,6 +803,7 @@ jobs:
       #
       # Passes the sync height to subsequent steps using the $SYNC_HEIGHT env variable.
       - name: Get sync height from logs
+        shell: /usr/bin/bash -exo pipefail {0}
         run: |
           SYNC_HEIGHT=""
 

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -166,7 +166,7 @@ jobs:
         id: create-instance
         run: |
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
-          --boot-disk-size 300GB \
+          --boot-disk-size 10GB \
           --boot-disk-type pd-ssd \
           --image-project=cos-cloud \
           --image-family=cos-stable \
@@ -180,6 +180,7 @@ jobs:
           --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ vars.GCP_ZONE }}
+          sleep 90
 
       # Format the mounted disk if the test doesn't use a cached state.
       - name: Format ${{ inputs.test_id }} volume
@@ -382,7 +383,7 @@ jobs:
         id: create-instance
         run: |
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
-          --boot-disk-size 300GB \
+          --boot-disk-size 10GB \
           --boot-disk-type pd-ssd \
           --image-project=cos-cloud \
           --image-family=cos-stable \
@@ -396,7 +397,7 @@ jobs:
           --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ vars.GCP_ZONE }}
-          sleep 60
+          sleep 90
 
       # Launch the test with the previously created Zebra-only cached state.
       # Each test runs one of the "Launch test" steps, and skips the other.

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Create instance template
         run: |
           gcloud compute instance-templates create-with-container zcashd-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
-          --boot-disk-size 50GB \
+          --boot-disk-size 10GB \
           --boot-disk-type=pd-ssd \
           --image-project=cos-cloud \
           --image-family=cos-stable \

--- a/.github/workflows/zcashd-manual-deploy.yml
+++ b/.github/workflows/zcashd-manual-deploy.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Create instance template
         run: |
           gcloud compute instance-templates create-with-container zcashd-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
-          --boot-disk-size 10GB \
+          --boot-disk-size 50GB \
           --boot-disk-type=pd-ssd \
           --image-project=cos-cloud \
           --image-family=cos-stable \


### PR DESCRIPTION
## Motivation

Some tests are still failing with `tee: 'standard output': Broken pipe`, recently it has been more frequently with the `sync-to-checkpoint` test, but it could happen on other tests too.

Also, mounting errors are still happening, and we'd like to capture the `dmesg` when this happens at `launch`, for better debugging. Other options like `set -x` will also help debugging and replicating some commands locally.

**Edit:**
In the end we had this different outputs for disks from the same VM:
```shell
NAME      MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda         8:0    0  300G  0 disk 
sdb         8:16   0   50G  0 disk 
|-sdb1      8:17   0 45.8G  0 part /var/lib/toolbox
|                                  /var/lib/google
|                                  /var/lib/docker
|                                  /var/lib/containerd
|                                  /var
|                                  /home
|                                  /mnt/stateful_partition
|-sdb2      8:18   0   16M  0 part 
|-sdb3      8:19   0    2G  0 part 
| `-vroot 253:0    0  1.9G  1 dm   /
|-sdb4      8:20   0   16M  0 part 
|-sdb5      8:21   0    2G  0 part 
|-sdb6      8:22   0  512B  0 part 
|-sdb7      8:23   0  512B  0 part 
|-sdb8      8:24   0   16M  0 part /usr/share/oem
|-sdb9      8:25   0  512B  0 part 
|-sdb10     8:26   0  512B  0 part 
|-sdb11     8:27   0    8M  0 part 
`-sdb12     8:28   0   32M  0 part 
```

```shell
NAME      MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda         8:0    0   50G  0 disk 
|-sda1      8:1    0 45.8G  0 part /var/lib/toolbox
|                                  /var/lib/google
|                                  /var/lib/docker
|                                  /var/lib/containerd
|                                  /var
|                                  /home
|                                  /mnt/stateful_partition
|-sda2      8:2    0   16M  0 part 
|-sda3      8:3    0    2G  0 part 
| `-vroot 253:0    0  1.9G  1 dm   /
|-sda4      8:4    0   16M  0 part 
|-sda5      8:5    0    2G  0 part 
|-sda6      8:6    0  512B  0 part 
|-sda7      8:7    0  512B  0 part 
|-sda8      8:8    0   16M  0 part /usr/share/oem
|-sda9      8:9    0  512B  0 part 
|-sda10     8:10   0  512B  0 part 
|-sda11     8:11   0    8M  0 part 
`-sda12     8:12   0   32M  0 part 
sdb         8:16   0  300G  0 disk 
```

Based on the preceding output, we can see that GCP is mounting the disks in **different order** on each VM. This is why the `/dev/sda` and `/dev/sdb` devices are not consistent across the VMs, nor across reboots on the same VM.

Fixes #7564
Fixes #7659
Fixes #7614

## Solution

For `tee: 'standard output': Broken pipe`:
- Use `shell: /usr/bin/bash -exo pipefail {0}` in GitHub jobs, for tests deployed to GCP
- Temporarily disable "set -e" to handle the broken pipe error gracefully
- Handle the exit code a bit better when reading from `grep` and `docker wait`
- Use `trap` quotes correctly
- Standardized `--command` quoting for GCP tests

For `failed to mount local volume: mount /dev/sdb device or resource busy`:

To work around this we're extracting the disk to be use, based on the device name we set in previous GitHub Action steps.
```shell
# Extract the correct disk name based on the device-name
DISK_NAME=$(ls -l /dev/disk/by-id | grep -oE "google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} -> ../../[^ ]+" | grep -oE "/[^/]+$" | cut -c 2-); \
echo "Disk name: $DISK_NAME";
```

## Review
- Confirm this is working with `sync-to-checkpoint` test.
- Make the tests fail and confirm we're getting the required EXIT_STATUS code.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
