### PR TITLE
fix(ci): Retry launching failed docker test instances

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -167,23 +167,25 @@ jobs:
       - name: Launch ${{ inputs.test_id }} GCP test instance
         id: launch-instance
         uses: nick-fields/retry@v2.9.0
-        # This step usually finishes in around 5 minutes.
-        timeout_minutes: 10
-        # We use a large number of attempts because the failure rate can be up to 50%.
-        max_attempts: 10
-        # We want to fail on timeouts but retry on errors.
-        retry_on: error
-        # It can take a few minutes to delete a container, but the command should wait.
-        retry_wait_seconds: 60
-        # These commands are slow, so we don't need to check their results every second.
-        polling_interval_seconds: 10
-        # TODO: shell: bash (arguments)
-        # TODO: make a cleanup script and call it from both launch steps and delete instance.
-        on_retry_command: |
+        with:
+         # TODO: fix intendation
+         # This step usually finishes in around 5 minutes.
+         timeout_minutes: 10
+         # We use a large number of attempts because the failure rate can be up to 50%.
+         max_attempts: 10
+         # We want to fail on timeouts but retry on errors.
+         retry_on: error
+         # It can take a few minutes to delete a container, but the command should wait.
+         retry_wait_seconds: 60
+         # These commands are slow, so we don't need to check their results every second.
+         polling_interval_seconds: 10
+         # TODO: shell: bash (arguments)
+         # TODO: make a cleanup script and call it from both launch steps and delete instance.
+         on_retry_command: |
           gcloud compute instances delete "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --zone "${{ vars.GCP_ZONE }}" \
           --delete-disks all
-        command: |
+         command: |
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 50GB \
           --boot-disk-type pd-ssd \
@@ -396,19 +398,18 @@ jobs:
       - name: Launch ${{ inputs.test_id }} GCP test instance
         id: launch-instance
         uses: nick-fields/retry@v2.9.0
-        # See the other launch-instance step for details of these settings.
-        timeout_minutes: 10
-        max_attempts: 10
-        retry_on: error
-        retry_wait_seconds: 60
-        polling_interval_seconds: 10
-        # TODO: shell: bash (arguments)
-        # TODO: make a cleanup script and call it from both launch steps and delete instance.
-        on_retry_command: |
+        with:
+         # See the other launch-instance step for details of these settings.
+         timeout_minutes: 10
+         max_attempts: 10
+         retry_on: error
+         retry_wait_seconds: 60
+         polling_interval_seconds: 10
+         on_retry_command: |
           gcloud compute instances delete "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --zone "${{ vars.GCP_ZONE }}" \
           --delete-disks all
-        command: |
+         command: |
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 50GB \
           --boot-disk-type pd-ssd \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -184,7 +184,8 @@ jobs:
          on_retry_command: |
           gcloud compute instances delete "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --zone "${{ vars.GCP_ZONE }}" \
-          --delete-disks all
+          --delete-disks all \
+          --quiet
          command: |
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 50GB \
@@ -408,7 +409,8 @@ jobs:
          on_retry_command: |
           gcloud compute instances delete "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --zone "${{ vars.GCP_ZONE }}" \
-          --delete-disks all
+          --delete-disks all \
+          --quiet
          command: |
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 50GB \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -161,9 +161,11 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1.1.1
 
-      # Create a Compute Engine virtual machine
-      - name: Create ${{ inputs.test_id }} GCP compute instance
-        id: create-instance
+      # Create a Compute Engine virtual machine,
+      # Format the mounted disk if the test doesn't use a cached state,
+      # then launch the test without any cached state.
+      - name: Launch ${{ inputs.test_id }} GCP test instance
+        id: launch-instance
         run: |
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 50GB \
@@ -180,27 +182,8 @@ jobs:
           --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ vars.GCP_ZONE }}
-
-      # Format the mounted disk if the test doesn't use a cached state.
-      - name: Format ${{ inputs.test_id }} volume
-        run: |
-          gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
-          --zone ${{ vars.GCP_ZONE }} \
-          --ssh-flag="-o ServerAliveInterval=5" \
-          --ssh-flag="-o ConnectionAttempts=20" \
-          --ssh-flag="-o ConnectTimeout=5" \
-          --command \
-          "\
-          while sudo lsof /dev/sdb; do \
-            echo 'Waiting for /dev/sdb to be free...'; \
-            sleep 10; \
-          done; \
-          sudo mkfs.ext4 -v /dev/sdb \
-          "
-
-      # Launch the test without any cached state
-      - name: Launch ${{ inputs.test_id }} test
-        run: |
+          # Format the mounted disk if the test doesn't use a cached state.
+          # Then launch the test without any cached state.
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
           --ssh-flag="-o ServerAliveInterval=5" \
@@ -363,8 +346,38 @@ jobs:
 
       # Create a Compute Engine virtual machine and attach a cached state disk using the
       # $CACHED_DISK_NAME variable as the source image to populate the disk cached state
-      - name: Create ${{ inputs.test_id }} GCP compute instance
-        id: create-instance
+      #
+      # Then launch the test with the previously created Zebra cached state,
+      # and the previously created Lightwalletd cached state if it was written to the image.
+      # (If we're just running Zebra, the lightwalletd cached state mount is ignored.)
+      #
+      # SSH into the just created VM, and create a Docker container to run the incoming test
+      # from ${{ inputs.test_id }}, then mount the Docker volume created in the previous job.
+      #
+      # In this step we're using the same disk for simplicity, as mounting multiple disks to the
+      # VM and to the container might require more steps in this workflow, and additional
+      # considerations.
+      #
+      # The disk mounted in the VM is located at /dev/sdb, we want the root `/` of this disk to be
+      # available in the docker container at two different paths:
+      # - /var/cache/zebrad-cache -> ${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} -> $ZEBRA_CACHED_STATE_DIR
+      # - /var/cache/lwd-cache -> ${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} -> $LIGHTWALLETD_DATA_DIR
+      #
+      # Currently we do this by mounting the same disk at both paths, even if we only have a Zebra
+      # cached state.
+      #
+      # This doesn't cause any path conflicts, because Zebra and lightwalletd create different
+      # subdirectories for their data. (But Zebra, lightwalletd, and the test harness must not
+      # delete the whole cache directory.)
+      #
+      # This paths must match the variables used by the tests in Rust, which are also set in
+      # `continous-integration-docker.yml` to be able to run this tests.
+      #
+      # Although we're mounting the disk root to both directories, Zebra and Lightwalletd
+      # will only respect the values from $ZEBRA_CACHED_STATE_DIR and $LIGHTWALLETD_DATA_DIR,
+      # the inputs like ${{ inputs.lwd_state_dir }} are only used to match those variables paths.
+      - name: Launch ${{ inputs.test_id }} GCP test instance
+        id: launch-instance
         run: |
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 50GB \
@@ -381,81 +394,8 @@ jobs:
           --labels=app=${{ inputs.app_name }},environment=test,network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
           --tags ${{ inputs.app_name }} \
           --zone ${{ vars.GCP_ZONE }}
-          sleep 60
-
-      # Launch the test with the previously created Zebra-only cached state.
-      # Each test runs one of the "Launch test" steps, and skips the other.
-      #
-      # SSH into the just created VM, and create a Docker container to run the incoming test
-      # from ${{ inputs.test_id }}, then mount the sudo docker volume created in the previous job.
-      #
-      # The disk mounted in the VM is located at /dev/sdb, we mount the root `/` of this disk to the docker
-      # container in one path:
-      # - /var/cache/zebrad-cache -> ${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} -> $ZEBRA_CACHED_STATE_DIR
-      #
-      # This path must match the variable used by the tests in Rust, which are also set in
-      # `continous-integration-docker.yml` to be able to run this tests.
-      #
-      # Although we're mounting the disk root, Zebra will only respect the values from
-      # $ZEBRA_CACHED_STATE_DIR. The inputs like ${{ inputs.zebra_state_dir }} are only used
-      # to match that variable paths.
-      - name: Launch ${{ inputs.test_id }} test
-        # This step only runs for tests that just read or write a Zebra state.
-        #
-        # lightwalletd-full-sync reads Zebra and writes lwd, so it is handled specially.
-        # TODO: we should find a better logic for this use cases
-        if: ${{ (inputs.needs_zebra_state && !inputs.needs_lwd_state) && inputs.test_id != 'lwd-full-sync' }}
-        run: |
-          gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
-          --zone ${{ vars.GCP_ZONE }} \
-          --ssh-flag="-o ServerAliveInterval=5" \
-          --ssh-flag="-o ConnectionAttempts=20" \
-          --ssh-flag="-o ConnectTimeout=5" \
-          --command \
-          "\
-          sudo docker run \
-          --name ${{ inputs.test_id }} \
-          --tty \
-          --detach \
-          ${{ inputs.test_variables }} \
-          --mount type=volume,volume-driver=local,volume-opt=device=/dev/sdb,volume-opt=type=ext4,dst=${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} \
-          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
-          "
-
-      # Launch the test with the previously created Lightwalletd and Zebra cached state.
-      # Each test runs one of the "Launch test" steps, and skips the other.
-      #
-      # SSH into the just created VM, and create a Docker container to run the incoming test
-      # from ${{ inputs.test_id }}, then mount the sudo docker volume created in the previous job.
-      #
-      # In this step we're using the same disk for simplicity, as mounting multiple disks to the
-      # VM and to the container might require more steps in this workflow, and additional
-      # considerations.
-      #
-      # The disk mounted in the VM is located at /dev/sdb, we want the root `/` of this disk to be
-      # available in the docker container at two different paths:
-      # - /var/cache/zebrad-cache -> ${{ inputs.root_state_path }}/${{ inputs.zebra_state_dir }} -> $ZEBRA_CACHED_STATE_DIR
-      # - /var/cache/lwd-cache -> ${{ inputs.root_state_path }}/${{ inputs.lwd_state_dir }} -> $LIGHTWALLETD_DATA_DIR
-      #
-      # Currently we do this by mounting the same disk at both paths.
-      #
-      # This doesn't cause any path conflicts, because Zebra and lightwalletd create different
-      # subdirectories for their data. (But Zebra, lightwalletd, and the test harness must not
-      # delete the whole cache directory.)
-      #
-      # This paths must match the variables used by the tests in Rust, which are also set in
-      # `continous-integration-docker.yml` to be able to run this tests.
-      #
-      # Although we're mounting the disk root to both directories, Zebra and Lightwalletd
-      # will only respect the values from $ZEBRA_CACHED_STATE_DIR and $LIGHTWALLETD_DATA_DIR,
-      # the inputs like ${{ inputs.lwd_state_dir }} are only used to match those variables paths.
-      - name: Launch ${{ inputs.test_id }} test
-        # This step only runs for tests that read or write Lightwalletd and Zebra states.
-        #
-        # lightwalletd-full-sync reads Zebra and writes lwd, so it is handled specially.
-        # TODO: we should find a better logic for this use cases
-        if: ${{ (inputs.needs_zebra_state && inputs.needs_lwd_state) || inputs.test_id == 'lwd-full-sync' }}
-        run: |
+          # Then launch the test with the previously created Zebra cached state,
+          # and the previously created Lightwalletd cached state if it was written to the image.
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
           --ssh-flag="-o ServerAliveInterval=5" \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -166,7 +166,24 @@ jobs:
       # then launch the test without any cached state.
       - name: Launch ${{ inputs.test_id }} GCP test instance
         id: launch-instance
-        run: |
+        uses: nick-fields/retry@v2.9.0
+        # This step usually finishes in around 5 minutes.
+        timeout_minutes: 10
+        # We use a large number of attempts because the failure rate can be up to 50%.
+        max_attempts: 10
+        # We want to fail on timeouts but retry on errors.
+        retry_on: error
+        # It can take a few minutes to delete a container, but the command should wait.
+        retry_wait_seconds: 60
+        # These commands are slow, so we don't need to check their results every second.
+        polling_interval_seconds: 10
+        # TODO: shell: bash (arguments)
+        # TODO: make a cleanup script and call it from both launch steps and delete instance.
+        on_retry_command: |
+          gcloud compute instances delete "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
+          --zone "${{ vars.GCP_ZONE }}" \
+          --delete-disks all
+        command: |
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 50GB \
           --boot-disk-type pd-ssd \
@@ -378,7 +395,20 @@ jobs:
       # the inputs like ${{ inputs.lwd_state_dir }} are only used to match those variables paths.
       - name: Launch ${{ inputs.test_id }} GCP test instance
         id: launch-instance
-        run: |
+        uses: nick-fields/retry@v2.9.0
+        # See the other launch-instance step for details of these settings.
+        timeout_minutes: 10
+        max_attempts: 10
+        retry_on: error
+        retry_wait_seconds: 60
+        polling_interval_seconds: 10
+        # TODO: shell: bash (arguments)
+        # TODO: make a cleanup script and call it from both launch steps and delete instance.
+        on_retry_command: |
+          gcloud compute instances delete "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
+          --zone "${{ vars.GCP_ZONE }}" \
+          --delete-disks all
+        command: |
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 50GB \
           --boot-disk-type pd-ssd \
@@ -881,6 +911,7 @@ jobs:
       - name: Delete test instance
         continue-on-error: true
         run: |
+          # TODO: make a cleanup script and call it from both launch steps and delete instance.
           INSTANCE=$(gcloud compute instances list --filter=${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} --format='value(NAME)')
           if [ -z "${INSTANCE}" ]; then
             echo "No instance to delete"

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -180,15 +180,16 @@ jobs:
          retry_wait_seconds: 60
          # These commands are slow, so we don't need to check their results every second.
          polling_interval_seconds: 10
-         # We want to see which commands are being executed
-         shell: bash -x
          # TODO: make a cleanup script and call it from both launch steps and delete instance.
          on_retry_command: |
+          # We want to see which commands are being executed
+          set -x
           gcloud compute instances delete "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --zone "${{ vars.GCP_ZONE }}" \
           --delete-disks all \
           --quiet
          command: |
+          set -x
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 50GB \
           --boot-disk-type pd-ssd \
@@ -213,6 +214,7 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
+          set -x; \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \
@@ -408,13 +410,14 @@ jobs:
          retry_on: error
          retry_wait_seconds: 60
          polling_interval_seconds: 10
-         shell: bash -x
          on_retry_command: |
+          set -x
           gcloud compute instances delete "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --zone "${{ vars.GCP_ZONE }}" \
           --delete-disks all \
           --quiet
          command: |
+          set -x
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --boot-disk-size 50GB \
           --boot-disk-type pd-ssd \
@@ -439,6 +442,7 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command \
           "\
+          set -x; \
           sudo docker run \
           --name ${{ inputs.test_id }} \
           --tty \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -180,7 +180,8 @@ jobs:
          retry_wait_seconds: 60
          # These commands are slow, so we don't need to check their results every second.
          polling_interval_seconds: 10
-         # TODO: shell: bash (arguments)
+         # We want to see which commands are being executed
+         shell: bash -x
          # TODO: make a cleanup script and call it from both launch steps and delete instance.
          on_retry_command: |
           gcloud compute instances delete "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
@@ -407,6 +408,7 @@ jobs:
          retry_on: error
          retry_wait_seconds: 60
          polling_interval_seconds: 10
+         shell: bash -x
          on_retry_command: |
           gcloud compute instances delete "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
           --zone "${{ vars.GCP_ZONE }}" \

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -45,13 +45,13 @@ on:
       zebra_state_dir:
         required: false
         type: string
-        default: ''
+        default: 'zebrad-cache'
         description: 'Zebra cached state directory and input image prefix to search in GCP'
       # TODO: find a better name
       lwd_state_dir:
         required: false
         type: string
-        default: ''
+        default: 'lwd-cache'
         description: 'Lightwalletd cached state directory and input image prefix to search in GCP'
       disk_prefix:
         required: false

--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -39,7 +39,8 @@ on:
       root_state_path:
         required: false
         type: string
-        default: '/zebrad-cache'
+        # When the root path is empty it becomes `/`, because we always put a `/` after it
+        default: ''
         description: 'Cached state base directory path'
       # TODO: find a better name
       zebra_state_dir:


### PR DESCRIPTION
## Motivation

We can't merge PRs because sometimes launching the Docker test image fails.

This PR stops #7659 being a critical issue by allowing PRs to merge anyway. So we can keep that ticket open, but fix it over the next week or two while still merging other PRs.

### Action Reference

The `retry-step` arguments are listed here:
https://github.com/marketplace/actions/retry-step

### Complex Code or Requirements

I deleted some parts of the script that seemed to be redundant, and I deleted the redundant "no `lightwalletd path`" step. Instead, we always mount both paths, some tests don't use the `lightwalletd` path.

(It's also possible for tests to use the `lightwalletd` paths as temporary storage, but we never see them do it because their states aren't written as a cache image.)

## Solution

- Make create instance and launch Docker test into a single step
- Retry that step up to 10 times if it fails

## Review

This is blocking all the other PRs merging reliably. It's not a long-term solution, but it would let us merge other PRs while we're fixing the actual bug.

To reduce the diff, I used one-space indentation rather than two-space indentation. I'll fix that in another PR.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

Fix the underlying bug, and once we're sure it's fixed, remove the retries.