### PR TITLE
fix(ci): `grep` the Zcash network correctly

### DIFF
--- a/.github/workflows/deploy-gcp-tests.yml
+++ b/.github/workflows/deploy-gcp-tests.yml
@@ -604,6 +604,10 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command=' \
+          trap "" PIPE;
+
+          # Temporarily disable "set -e" to handle the broken pipe error gracefully
+          set +e;
           sudo docker logs \
           --tail all \
           --follow \
@@ -611,7 +615,7 @@ jobs:
           head -700 | \
           tee --output-error=exit-nopipe /dev/stderr | \
           grep --max-count=1 --extended-regexp --color=always \
-          -e "Zcash network: ${{ inputs.network }}" \
+          "Zcash network: ${{ inputs.network }}"; \
           '
 
       # Check that the container executed at least 1 Rust test harness test, and that all tests passed.


### PR DESCRIPTION
## Motivation

Some tests fail to grep `Zcash network: ${{ inputs.network }}`, and fail, timeout or take longer than needed.

## Solution

- Use the same approach as in the `Result of ${{ inputs.test_id }} test` step, which is handling odd use cases nicely.

## Review

- Validate the startup logs take less than 1-2 minutes

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

