### PR TITLE
fix(ci): Handle new cargo machete output format for unused dependencies

### DIFF
--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -312,8 +312,8 @@ jobs:
           echo "-- full cargo machete output, including ignored dependencies --"
           cargo machete --skip-target-dir || true
           echo "-- unused dependencies are below this line, full output is above --"
-          if (cargo machete --skip-target-dir 2>/dev/null || true) | \
-          (grep -e '^\t' || true) | \
+          if cargo machete --skip-target-dir 2>/dev/null | \
+          grep --extended-regexp -e '^\t' | \
           grep -v -e gumdrop -e humantime-serde -e tinyvec -e zebra-utils; then
               echo "New unused dependencies were found, please remove them!"
               exit 1

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -313,7 +313,7 @@ jobs:
           cargo machete --skip-target-dir || true
           echo "-- unused dependencies are below this line, full output is above --"
           if (cargo machete --skip-target-dir 2>/dev/null || true) | \
-          grep -e '\t' | \
+          grep -e '^\t' -e '^ ' | \
           grep -v -e gumdrop -e humantime-serde -e tinyvec -e zebra-utils; then
               echo "New unused dependencies were found, please remove them!"
               exit 1

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -313,7 +313,7 @@ jobs:
           cargo machete --skip-target-dir || true
           echo "-- unused dependencies are below this line, full output is above --"
           if (cargo machete --skip-target-dir 2>/dev/null || true) | \
-          grep -e '^\t' -e '^ ' | \
+          (grep -e '^\t' || true) | \
           grep -v -e gumdrop -e humantime-serde -e tinyvec -e zebra-utils; then
               echo "New unused dependencies were found, please remove them!"
               exit 1

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -313,7 +313,7 @@ jobs:
           cargo machete --skip-target-dir || true
           echo "-- unused dependencies are below this line, full output is above --"
           if cargo machete --skip-target-dir 2>/dev/null | \
-          grep --extended-regexp -e '^\t' | \
+          grep --extended-regexp -e '^\\t' | \
           grep -v -e gumdrop -e humantime-serde -e tinyvec -e zebra-utils; then
               echo "New unused dependencies were found, please remove them!"
               exit 1

--- a/.github/workflows/continous-integration-os.yml
+++ b/.github/workflows/continous-integration-os.yml
@@ -313,7 +313,8 @@ jobs:
           cargo machete --skip-target-dir || true
           echo "-- unused dependencies are below this line, full output is above --"
           if (cargo machete --skip-target-dir 2>/dev/null || true) | \
-          grep -v -e gumdrop -e humantime-serde -e tinyvec -e zebra-utils -e "found the following" -e Cargo.toml -e Done; then
+          grep -e '\t' | \
+          grep -v -e gumdrop -e humantime-serde -e tinyvec -e zebra-utils; then
               echo "New unused dependencies were found, please remove them!"
               exit 1
           else


### PR DESCRIPTION
## Motivation

`cargo machete` changed its output format, so we need to change our CI to process it.

Until we do that, every PR will fail to merge with an unused dependencies error.

## Solution

Just include the dependency lines, rather than trying to exclude the other output lines.

## Review

This is critical because it blocks everything merging.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

