### PR TITLE
fix(deps): Remove unused dependency exceptions

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -63,15 +63,6 @@ skip-tree = [
     # wait for rocksdb to upgrade
     { name = "bindgen", version = "=0.65.1" },
 
-    # wait for console-subscriber to upgrade
-    { name = "prost-derive", version = "=0.11.9" },
-
-    # wait for console-subscriber to upgrade
-    { name = "prost-types", version = "=0.11.9" },
-
-    # wait for console-subscriber to upgrade
-    { name = "tonic", version = "=0.9.2" },
-
     # wait for tracing and many other crates to upgrade
     # this duplicate dependency currently only exists in testing builds
     { name = "regex-syntax", version = "=0.6.29" },


### PR DESCRIPTION
## Motivation

These dependency exceptions aren't needed after the latest `console-subscriber` upgrade.