### PR TITLE
fix(ci): Add missing timeouts to CI and CD tests

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -118,6 +118,7 @@ jobs:
   # Test that Zebra works using the default config with the latest Zebra version.
   test-configuration-file:
     name: Test CD default Docker config file
+    timeout-minutes: 60
     needs: build
     uses: ./.github/workflows/sub-test-zebra-config.yml
     with:
@@ -130,6 +131,7 @@ jobs:
   # Test reconfiguring the docker image for testnet.
   test-configuration-file-testnet:
     name: Test CD testnet Docker config file
+    timeout-minutes: 60
     needs: build
     # Make sure Zebra can sync the genesis block on testnet
     uses: ./.github/workflows/sub-test-zebra-config.yml
@@ -143,6 +145,7 @@ jobs:
   # Test that Zebra works using $ZEBRA_CONF_PATH config
   test-zebra-conf-path:
     name: Test CD custom Docker config file
+    timeout-minutes: 60
     needs: build
     uses: ./.github/workflows/sub-test-zebra-config.yml
     with:

--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -118,7 +118,6 @@ jobs:
   # Test that Zebra works using the default config with the latest Zebra version.
   test-configuration-file:
     name: Test CD default Docker config file
-    timeout-minutes: 60
     needs: build
     uses: ./.github/workflows/sub-test-zebra-config.yml
     with:
@@ -131,7 +130,6 @@ jobs:
   # Test reconfiguring the docker image for testnet.
   test-configuration-file-testnet:
     name: Test CD testnet Docker config file
-    timeout-minutes: 60
     needs: build
     # Make sure Zebra can sync the genesis block on testnet
     uses: ./.github/workflows/sub-test-zebra-config.yml
@@ -145,7 +143,6 @@ jobs:
   # Test that Zebra works using $ZEBRA_CONF_PATH config
   test-zebra-conf-path:
     name: Test CD custom Docker config file
-    timeout-minutes: 60
     needs: build
     uses: ./.github/workflows/sub-test-zebra-config.yml
     with:

--- a/.github/workflows/ci-build-crates.yml
+++ b/.github/workflows/ci-build-crates.yml
@@ -99,6 +99,7 @@ jobs:
 
   build:
     name: Build ${{ matrix.crate }} crate
+    timeout-minutes: 90
     needs: [ matrix, check-matrix ]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci-unit-tests-docker.yml
+++ b/.github/workflows/ci-unit-tests-docker.yml
@@ -91,6 +91,7 @@ jobs:
   # TODO: turn this test and the getblocktemplate test into a matrix, so the jobs use exactly the same diagnostics settings
   test-all:
     name: Test all
+    timeout-minutes: 180
     runs-on: ubuntu-latest-xl
     needs: build
     steps:
@@ -144,6 +145,7 @@ jobs:
   # (The gRPC feature is a zebrad feature, so it isn't needed here.)
   test-fake-activation-heights:
     name: Test with fake activation heights
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -167,6 +169,7 @@ jobs:
   # (We activate the gRPC feature to avoid recompiling `zebrad`, but we don't actually run any gRPC tests.)
   test-empty-sync:
     name: Test checkpoint sync from empty state
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -189,6 +192,7 @@ jobs:
   # (We activate the gRPC feature to avoid recompiling `zebrad`, but we don't actually run any gRPC tests.)
   test-lightwalletd-integration:
     name: Test integration with lightwalletd
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -210,6 +214,7 @@ jobs:
   # Test that Zebra works using the default config with the latest Zebra version.
   test-configuration-file:
     name: Test CI default Docker config file
+    timeout-minutes: 60
     needs: build
     uses: ./.github/workflows/sub-test-zebra-config.yml
     with:
@@ -222,6 +227,7 @@ jobs:
   # Test reconfiguring the the docker image for tesnet.
   test-configuration-file-testnet:
     name: Test CI testnet Docker config file
+    timeout-minutes: 60
     needs: build
     # Make sure Zebra can sync the genesis block on testnet
     uses: ./.github/workflows/sub-test-zebra-config.yml
@@ -236,6 +242,7 @@ jobs:
   # Test that Zebra works using $ZEBRA_CONF_PATH config
   test-zebra-conf-path:
     name: Test CI custom Docker config file
+    timeout-minutes: 60
     needs: build
     uses: ./.github/workflows/sub-test-zebra-config.yml
     with:

--- a/.github/workflows/ci-unit-tests-docker.yml
+++ b/.github/workflows/ci-unit-tests-docker.yml
@@ -214,7 +214,6 @@ jobs:
   # Test that Zebra works using the default config with the latest Zebra version.
   test-configuration-file:
     name: Test CI default Docker config file
-    timeout-minutes: 60
     needs: build
     uses: ./.github/workflows/sub-test-zebra-config.yml
     with:
@@ -227,7 +226,6 @@ jobs:
   # Test reconfiguring the the docker image for tesnet.
   test-configuration-file-testnet:
     name: Test CI testnet Docker config file
-    timeout-minutes: 60
     needs: build
     # Make sure Zebra can sync the genesis block on testnet
     uses: ./.github/workflows/sub-test-zebra-config.yml
@@ -242,7 +240,6 @@ jobs:
   # Test that Zebra works using $ZEBRA_CONF_PATH config
   test-zebra-conf-path:
     name: Test CI custom Docker config file
-    timeout-minutes: 60
     needs: build
     uses: ./.github/workflows/sub-test-zebra-config.yml
     with:


### PR DESCRIPTION
## Motivation

If some CI Docker tests hang, they won't time out for 6 hours. But they never usually take more than 90 minutes.

This means it can be a long time before we see the timeout, which slows down PR fixes (and also other PRs can't use those runners). 

Since some runners are custom runners, this also increases our costs.

Depends-On: #7616

## Solution

Add 90 minute timeouts to these jobs.

## Review

This is a low priority.

@gustavovalverde did you want it to wait until the other refactors merge?

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

