### PR TITLE
change(state): Set iterator read bounds where possible in DiskDb

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -359,7 +359,7 @@ impl ReadDisk for DiskDb {
         V: FromDisk,
     {
         // Reading individual values from iterators does not seem to cause database hangs.
-        self.zs_range_iter(cf, ..=upper_bound, false).next()
+        self.zs_range_iter(cf, ..=upper_bound, true).next()
     }
 
     fn zs_items_in_range_ordered<C, K, V, R>(&self, cf: &C, range: R) -> BTreeMap<K, V>

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -534,7 +534,13 @@ impl DiskDb {
                 // Increment the last byte in the vector that is not u8::MAX, or
                 // skip adding an upper bound if every byte is u8::MAX
                 if let Some(increment_idx) = bound.iter().rposition(|&v| v != u8::MAX) {
-                    bound[increment_idx] += 1;
+                    let increment_byte = bound
+                        .get_mut(increment_idx)
+                        .expect("index should be in bounds");
+                    *increment_byte = increment_byte
+                        .checked_add(1)
+                        .expect("adding 1 should succeed");
+
                     opts.set_iterate_upper_bound(bound);
                 }
             }

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -537,12 +537,17 @@ impl DiskDb {
                 // increment the last byte in the upper bound that is less than u8::MAX,
                 // and clear any bytes after it to increment the big-endian number this
                 // Vec represents to RocksDB.
-                let is_max_key = bound.iter_mut().rev().all(|v| {
+                let is_zero = bound.iter_mut().rev().all(|v| {
                     *v = v.wrapping_add(1);
                     v == &0
                 });
 
-                (!is_max_key).then_some(bound)
+                if is_zero {
+                    bound.push(0);
+                    *bound.get_mut(0).expect("should have at least 1 element") += 1;
+                }
+
+                Some(bound)
             }
             Excluded(bound) => Some(bound),
             Unbounded => None,

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -515,6 +515,11 @@ impl DiskDb {
     }
 
     /// Returns a lower and upper iterate bounds for a range.
+    ///
+    /// Note: Since upper iterate bounds are always exclusive in RocksDB, this method
+    ///       will increment the upper bound by 1 if the end bound of the provided range
+    ///       is inclusive, or will return an upper bound of `None` if the end bound of a
+    ///       provided range is inclusive and already the max key for that column family.
     fn zs_iter_bounds<R>(range: &R) -> (Option<Vec<u8>>, Option<Vec<u8>>)
     where
         R: RangeBounds<Vec<u8>>,
@@ -531,7 +536,7 @@ impl DiskDb {
                 // Skip adding an upper bound if every byte is u8::MAX, or
                 // increment the last byte in the upper bound that is less than u8::MAX,
                 // and clear any bytes after it to increment the big-endian number this
-                // string represents to RocksDB.
+                // Vec represents to RocksDB.
                 let is_max_key = bound.iter_mut().rev().all(|v| {
                     *v = v.wrapping_add(1);
                     v == &0

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -518,8 +518,7 @@ impl DiskDb {
     ///
     /// Note: Since upper iterate bounds are always exclusive in RocksDB, this method
     ///       will increment the upper bound by 1 if the end bound of the provided range
-    ///       is inclusive, or will return an upper bound of `None` if the end bound of a
-    ///       provided range is inclusive and already the max key for that column family.
+    ///       is inclusive.
     fn zs_iter_bounds<R>(range: &R) -> (Option<Vec<u8>>, Option<Vec<u8>>)
     where
         R: RangeBounds<Vec<u8>>,
@@ -533,8 +532,7 @@ impl DiskDb {
 
         let upper_bound = match range.end_bound().cloned() {
             Included(mut bound) => {
-                // Skip adding an upper bound if every byte is u8::MAX, or
-                // increment the last byte in the upper bound that is less than u8::MAX,
+                // Increment the last byte in the upper bound that is less than u8::MAX,
                 // and clear any bytes after it to increment the big-endian number this
                 // Vec represents to RocksDB.
                 let is_zero = bound.iter_mut().rev().all(|v| {

--- a/zebra-state/src/service/finalized_state/disk_db/tests.rs
+++ b/zebra-state/src/service/finalized_state/disk_db/tests.rs
@@ -30,9 +30,6 @@ impl DiskDb {
 fn zs_iter_opts_increments_key_by_one() {
     let _init_guard = zebra_test::init();
 
-    // let (config, network) = Default::default();
-    // let db = DiskDb::new(&config, network);
-
     let keys: [u32; 13] = [
         0, 1, 200, 255, 256, 257, 65535, 65536, 65537, 16777215, 16777216, 16777217, 16777218,
     ];

--- a/zebra-state/src/service/finalized_state/disk_db/tests.rs
+++ b/zebra-state/src/service/finalized_state/disk_db/tests.rs
@@ -24,3 +24,28 @@ impl DiskDb {
         rocksdb::DB::list_cf(&opts, path)
     }
 }
+
+/// Check that the sprout tree database serialization format has not changed.
+#[test]
+fn zs_iter_opts_increments_key_by_one() {
+    let _init_guard = zebra_test::init();
+
+    // let (config, network) = Default::default();
+    // let db = DiskDb::new(&config, network);
+
+    let keys: [u32; 13] = [
+        0, 1, 200, 255, 256, 257, 65535, 65536, 65537, 16777215, 16777216, 16777217, 16777218,
+    ];
+
+    for key in keys {
+        let (_, upper_bound_bytes) = DiskDb::zs_iter_bounds(&..=key.to_be_bytes().to_vec());
+        let upper_bound_bytes = upper_bound_bytes.expect("there should be an upper bound");
+        let upper_bound = u32::from_be_bytes(upper_bound_bytes.try_into().unwrap());
+        let expected_upper_bound = key + 1;
+
+        assert_eq!(
+            expected_upper_bound, upper_bound,
+            "the upper bound should be 1 greater than the original key"
+        );
+    }
+}

--- a/zebra-state/src/service/finalized_state/disk_db/tests.rs
+++ b/zebra-state/src/service/finalized_state/disk_db/tests.rs
@@ -25,7 +25,7 @@ impl DiskDb {
     }
 }
 
-/// Check that the sprout tree database serialization format has not changed.
+/// Check that zs_iter_opts returns an upper bound one greater than provided inclusive end bounds.
 #[test]
 fn zs_iter_opts_increments_key_by_one() {
     let _init_guard = zebra_test::init();

--- a/zebra-state/src/service/finalized_state/disk_db/tests.rs
+++ b/zebra-state/src/service/finalized_state/disk_db/tests.rs
@@ -30,19 +30,41 @@ impl DiskDb {
 fn zs_iter_opts_increments_key_by_one() {
     let _init_guard = zebra_test::init();
 
-    let keys: [u32; 13] = [
-        0, 1, 200, 255, 256, 257, 65535, 65536, 65537, 16777215, 16777216, 16777217, 16777218,
+    let keys: [u32; 14] = [
+        0,
+        1,
+        200,
+        255,
+        256,
+        257,
+        65535,
+        65536,
+        65537,
+        16777215,
+        16777216,
+        16777217,
+        16777218,
+        u32::MAX,
     ];
 
     for key in keys {
-        let (_, upper_bound_bytes) = DiskDb::zs_iter_bounds(&..=key.to_be_bytes().to_vec());
-        let upper_bound_bytes = upper_bound_bytes.expect("there should be an upper bound");
+        let (_, bytes) = DiskDb::zs_iter_bounds(&..=key.to_be_bytes().to_vec());
+        let mut bytes = bytes.expect("there should be an upper bound");
+        let upper_bound_bytes = bytes.split_off(bytes.len() - 4);
         let upper_bound = u32::from_be_bytes(upper_bound_bytes.try_into().unwrap());
-        let expected_upper_bound = key + 1;
+        let expected_upper_bound = key.wrapping_add(1);
 
         assert_eq!(
             expected_upper_bound, upper_bound,
             "the upper bound should be 1 greater than the original key"
         );
+
+        if expected_upper_bound == 0 {
+            assert_eq!(
+                bytes,
+                vec![1],
+                "there should be an extra byte with a value of 1"
+            );
+        }
     }
 }

--- a/zebra-state/src/service/finalized_state/disk_db/tests.rs
+++ b/zebra-state/src/service/finalized_state/disk_db/tests.rs
@@ -51,7 +51,7 @@ fn zs_iter_opts_increments_key_by_one() {
         let (_, bytes) = DiskDb::zs_iter_bounds(&..=key.to_be_bytes().to_vec());
         let mut bytes = bytes.expect("there should be an upper bound");
         let upper_bound_bytes = bytes.split_off(bytes.len() - 4);
-        let upper_bound = u32::from_be_bytes(upper_bound_bytes.try_into().unwrap());
+        let upper_bound = u32::from_be_bytes(upper_bound_bytes.try_into().expect("no added bytes"));
         let expected_upper_bound = key.wrapping_add(1);
 
         assert_eq!(

--- a/zebra-state/src/service/finalized_state/disk_db/tests.rs
+++ b/zebra-state/src/service/finalized_state/disk_db/tests.rs
@@ -68,15 +68,14 @@ fn zs_iter_opts_increments_key_by_one() {
             );
         } else {
             assert_eq!(
-                key.len(),
+                key.to_be_bytes().len(),
                 bytes.len(),
                 "there should be no extra bytes"
             );
         }
 
         assert_ne!(
-            bytes[0],
-            0x00,
+            bytes[0], 0x00,
             "there must be at least one byte, and the first byte can't be zero"
         );
     }

--- a/zebra-state/src/service/finalized_state/disk_db/tests.rs
+++ b/zebra-state/src/service/finalized_state/disk_db/tests.rs
@@ -30,6 +30,7 @@ impl DiskDb {
 fn zs_iter_opts_increments_key_by_one() {
     let _init_guard = zebra_test::init();
 
+    // TODO: add an empty key (`()` type or `[]` when serialized) test case
     let keys: [u32; 14] = [
         0,
         1,
@@ -65,6 +66,18 @@ fn zs_iter_opts_increments_key_by_one() {
                 vec![1],
                 "there should be an extra byte with a value of 1"
             );
+        } else {
+            assert_eq!(
+                key.len(),
+                bytes.len(),
+                "there should be no extra bytes"
+            );
         }
+
+        assert_ne!(
+            bytes[0],
+            0x00,
+            "there must be at least one byte, and the first byte can't be zero"
+        );
     }
 }

--- a/zebra-state/src/service/finalized_state/disk_db/tests.rs
+++ b/zebra-state/src/service/finalized_state/disk_db/tests.rs
@@ -69,11 +69,5 @@ fn zs_iter_opts_increments_key_by_one() {
         } else {
             assert_eq!(extra_bytes.len(), 0, "there should be no extra bytes");
         }
-
-        assert_ne!(
-            extra_bytes.last().expect("there must be at least one byte"),
-            &0,
-            "the last byte can't be zero"
-        );
     }
 }

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -75,7 +75,7 @@ impl ZebraDb {
     ) -> impl Iterator<Item = (RawBytes, Arc<HistoryTree>)> + '_ {
         let history_tree_cf = self.db.cf_handle("history_tree").unwrap();
 
-        self.db.zs_range_iter(&history_tree_cf, ..)
+        self.db.zs_range_iter(&history_tree_cf, .., false)
     }
 
     // Value pool methods

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -153,7 +153,7 @@ impl ZebraDb {
         &self,
     ) -> impl Iterator<Item = (RawBytes, Arc<sprout::tree::NoteCommitmentTree>)> + '_ {
         let sprout_trees = self.db.cf_handle("sprout_note_commitment_tree").unwrap();
-        self.db.zs_range_iter(&sprout_trees, ..)
+        self.db.zs_range_iter(&sprout_trees, .., false)
     }
 
     // # Sapling trees

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -207,7 +207,7 @@ impl ZebraDb {
         R: std::ops::RangeBounds<Height>,
     {
         let sapling_trees = self.db.cf_handle("sapling_note_commitment_tree").unwrap();
-        self.db.zs_range_iter(&sapling_trees, range)
+        self.db.zs_range_iter(&sapling_trees, range, false)
     }
 
     /// Returns the Sapling note commitment trees in the reversed range, in decreasing height order.
@@ -278,7 +278,7 @@ impl ZebraDb {
         if let Some(exclusive_end_bound) = exclusive_end_bound {
             list = self
                 .db
-                .zs_range_iter(&sapling_subtrees, start_index..exclusive_end_bound)
+                .zs_range_iter(&sapling_subtrees, start_index..exclusive_end_bound, false)
                 .collect();
         } else {
             // If there is no end bound, just return all the trees.
@@ -287,7 +287,7 @@ impl ZebraDb {
             // the trees run out.)
             list = self
                 .db
-                .zs_range_iter(&sapling_subtrees, start_index..)
+                .zs_range_iter(&sapling_subtrees, start_index.., false)
                 .collect();
         }
 
@@ -377,7 +377,7 @@ impl ZebraDb {
         R: std::ops::RangeBounds<Height>,
     {
         let orchard_trees = self.db.cf_handle("orchard_note_commitment_tree").unwrap();
-        self.db.zs_range_iter(&orchard_trees, range)
+        self.db.zs_range_iter(&orchard_trees, range, false)
     }
 
     /// Returns the Orchard note commitment trees in the reversed range, in decreasing height order.
@@ -448,7 +448,7 @@ impl ZebraDb {
         if let Some(exclusive_end_bound) = exclusive_end_bound {
             list = self
                 .db
-                .zs_range_iter(&orchard_subtrees, start_index..exclusive_end_bound)
+                .zs_range_iter(&orchard_subtrees, start_index..exclusive_end_bound, false)
                 .collect();
         } else {
             // If there is no end bound, just return all the trees.
@@ -457,7 +457,7 @@ impl ZebraDb {
             // the trees run out.)
             list = self
                 .db
-                .zs_range_iter(&orchard_subtrees, start_index..)
+                .zs_range_iter(&orchard_subtrees, start_index.., false)
                 .collect();
         }
 

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -241,7 +241,11 @@ impl ZebraDb {
             AddressTransaction::address_iterator_range(address_location, query_height_range);
 
         self.db
-            .zs_range_iter(&tx_loc_by_transparent_addr_loc, transaction_location_range)
+            .zs_range_iter(
+                &tx_loc_by_transparent_addr_loc,
+                transaction_location_range,
+                false,
+            )
             .map(|(tx_loc, ())| tx_loc)
             .collect()
     }


### PR DESCRIPTION
## Motivation

Unbounded RocksDB iterators are slow in column families with many delete tombstones.

This PR updates `DiskDb` to bound iterators when reading a range of keys.

Close #7664.

## Solution

- Set lower and upper bounds on rocksdb iterators where possible in `DiskDb` methods

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- Refactor `address_utxo_locations()`
