### PR TITLE
change(state): Set upper bound when reading from deleting column family tx_loc_by_transparent_addr_loc

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_format/block.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/block.rs
@@ -132,7 +132,6 @@ pub struct TransactionLocation {
 
 impl TransactionLocation {
     /// Creates a transaction location from a block height and transaction index.
-    #[allow(dead_code)]
     pub fn from_index(height: Height, transaction_index: u16) -> TransactionLocation {
         TransactionLocation {
             height,

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -433,13 +433,13 @@ impl AddressTransaction {
         address_location: AddressLocation,
         query_start: Height,
     ) -> std::ops::RangeInclusive<AddressTransaction> {
+        // Iterating from the start height filters out transactions that aren't needed.
+        let start_height = max(query_start, address_location.height());
+
         // Iterating from the lowest possible transaction location gets us the first transaction.
         //
         // The address location is the output location of the first UTXO sent to the address,
         // and addresses can not spend funds until they receive their first UTXO.
-        //
-        // Iterating from the start height filters out transactions that aren't needed.
-        let start_height = max(query_start, address_location.height());
         let first_utxo_idx = address_location.transaction_index().0;
 
         let tx_loc = |tx_idx| TransactionLocation::from_index(start_height, tx_idx);
@@ -457,6 +457,7 @@ impl AddressTransaction {
     /// existing (valid) value.
     ///
     /// [1]: super::super::disk_db::ReadDisk::zs_next_key_value_from
+    #[allow(dead_code)]
     pub fn address_iterator_next(&mut self) {
         // Iterating from the next possible output location gets us the next output,
         // even if it is in a later block or transaction.

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -416,36 +416,36 @@ impl AddressTransaction {
         }
     }
 
-    /// Create an [`AddressTransaction`] which starts iteration for the supplied
+    /// Create a range of [`AddressTransaction`]s which starts iteration for the supplied
     /// address. Starts at the first UTXO, or at the `query_start` height,
-    /// whichever is greater.
+    /// whichever is greater. Ends at the last transaction index for an [`AddressLocation`].
     ///
-    /// Used to look up the first transaction with
-    /// [`ReadDisk::zs_next_key_value_from`][1].
+    /// Used to look up transactions with
+    /// [`DiskDb::zs_range_iter`][1].
     ///
     /// The transaction location might be invalid, if it is based on the
     /// `query_start` height. But this is not an issue, since
-    /// [`ReadDisk::zs_next_key_value_from`][1] will fetch the next existing
-    /// (valid) value.
+    /// [`DiskDb::zs_range_iter`][1] will fetch all existing
+    /// (valid) values in the range.
     ///
-    /// [1]: super::super::disk_db::ReadDisk::zs_next_key_value_from
-    pub fn address_iterator_start(
+    /// [1]: super::super::disk_db::DiskDb
+    pub fn address_iterator_range(
         address_location: AddressLocation,
         query_start: Height,
-    ) -> AddressTransaction {
+    ) -> std::ops::RangeInclusive<AddressTransaction> {
         // Iterating from the lowest possible transaction location gets us the first transaction.
         //
         // The address location is the output location of the first UTXO sent to the address,
         // and addresses can not spend funds until they receive their first UTXO.
-        let first_utxo_location = address_location.transaction_location();
-
+        //
         // Iterating from the start height filters out transactions that aren't needed.
-        let query_start_location = TransactionLocation::from_usize(query_start, 0);
+        let start_height = max(query_start, address_location.height());
+        let first_utxo_idx = address_location.transaction_index().0;
 
-        AddressTransaction {
-            address_location,
-            transaction_location: max(first_utxo_location, query_start_location),
-        }
+        let tx_loc = |tx_idx| TransactionLocation::from_index(start_height, tx_idx);
+        let addr_tx = |tx_idx| AddressTransaction::new(address_location, tx_loc(tx_idx));
+
+        addr_tx(first_utxo_idx)..=addr_tx(u16::MAX)
     }
 
     /// Update the transaction location to the next possible transaction for the

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -417,15 +417,16 @@ impl AddressTransaction {
     }
 
     /// Create a range of [`AddressTransaction`]s which starts iteration for the supplied
-    /// address. Starts at the first UTXO, or at the `query_start` height,
-    /// whichever is greater. Ends at the last transaction index for an [`AddressLocation`].
+    /// address. Starts at the first UTXO, or at the `query` start height, whichever is greater.
+    /// Ends at the maximum possible transaction index for the end height.
     ///
-    /// Used to look up transactions with
-    /// [`DiskDb::zs_range_iter`][1].
+    /// Used to look up transactions with [`DiskDb::zs_range_iter`][1].
     ///
-    /// The transaction location might be invalid, if it is based on the
-    /// `query_start` height. But this is not an issue, since
-    /// [`DiskDb::zs_range_iter`][1] will fetch all existing
+    /// The transaction locations in the:
+    /// - start bound might be invalid, if it is based on the `query` start height.
+    /// - end bound will always be invalid.
+    ///
+    /// But this is not an issue, since [`DiskDb::zs_range_iter`][1] will fetch all existing
     /// (valid) values in the range.
     ///
     /// [1]: super::super::disk_db::DiskDb
@@ -439,7 +440,7 @@ impl AddressTransaction {
         // and addresses can not spend funds until they receive their first UTXO.
         let first_utxo_location = address_location.transaction_location();
 
-        // Iterating from the start height filters out transactions that aren't needed.
+        // Iterating from the start height to the end height filters out transactions that aren't needed.
         let query_start_location = TransactionLocation::from_index(*query.start(), 0);
         let query_end_location = TransactionLocation::from_index(*query.end(), u16::MAX);
 

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -237,21 +237,13 @@ impl ZebraDb {
 
         // A potentially invalid key representing the first UTXO send to the address,
         // or the query start height.
-        let transaction_location = AddressTransaction::address_iterator_start(
+        let transaction_location_range = AddressTransaction::address_iterator_range(
             address_location,
             *query_height_range.start(),
         );
 
-        let last_transaction_location = AddressTransaction::new(
-            address_location,
-            TransactionLocation::from_usize(*query_height_range.end(), u16::MAX.into()),
-        );
-
         self.db
-            .zs_range_iter(
-                &tx_loc_by_transparent_addr_loc,
-                &transaction_location..=&last_transaction_location,
-            )
+            .zs_range_iter(&tx_loc_by_transparent_addr_loc, transaction_location_range)
             .map(|(tx_loc, ())| tx_loc)
             .collect()
     }

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -235,44 +235,24 @@ impl ZebraDb {
         let tx_loc_by_transparent_addr_loc =
             self.db.cf_handle("tx_loc_by_transparent_addr_loc").unwrap();
 
-        // Manually fetch the entire addresses' transaction locations
-        let mut addr_transactions = BTreeSet::new();
-
         // A potentially invalid key representing the first UTXO send to the address,
         // or the query start height.
-        let mut transaction_location = AddressTransaction::address_iterator_start(
+        let transaction_location = AddressTransaction::address_iterator_start(
             address_location,
             *query_height_range.start(),
         );
 
-        loop {
-            // Seek to a valid entry for this address, or the first entry for the next address
-            transaction_location = match self
-                .db
-                .zs_next_key_value_from(&tx_loc_by_transparent_addr_loc, &transaction_location)
-            {
-                Some((transaction_location, ())) => transaction_location,
-                // We're finished with the final address in the column family
-                None => break,
-            };
+        let last_transaction_location = AddressTransaction::new(
+            address_location,
+            TransactionLocation::from_usize(*query_height_range.end(), usize::MAX),
+        );
 
-            // We found the next address, so we're finished with this address
-            if transaction_location.address_location() != address_location {
-                break;
-            }
-
-            // We're past the end height, so we're finished with this query
-            if transaction_location.transaction_location().height > *query_height_range.end() {
-                break;
-            }
-
-            addr_transactions.insert(transaction_location);
-
-            // A potentially invalid key representing the next possible output
-            transaction_location.address_iterator_next();
-        }
-
-        addr_transactions
+        self.zs_range_iter(
+            &tx_loc_by_transparent_addr_loc,
+            &transaction_location..=&last_transaction_location,
+        )
+        .map(|(tx_loc, ())| tx_loc)
+        .collect()
     }
 
     // Address index queries

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -237,10 +237,8 @@ impl ZebraDb {
 
         // A potentially invalid key representing the first UTXO send to the address,
         // or the query start height.
-        let transaction_location_range = AddressTransaction::address_iterator_range(
-            address_location,
-            *query_height_range.start(),
-        );
+        let transaction_location_range =
+            AddressTransaction::address_iterator_range(address_location, query_height_range);
 
         self.db
             .zs_range_iter(&tx_loc_by_transparent_addr_loc, transaction_location_range)

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -244,15 +244,16 @@ impl ZebraDb {
 
         let last_transaction_location = AddressTransaction::new(
             address_location,
-            TransactionLocation::from_usize(*query_height_range.end(), usize::MAX),
+            TransactionLocation::from_usize(*query_height_range.end(), u16::MAX.into()),
         );
 
-        self.zs_range_iter(
-            &tx_loc_by_transparent_addr_loc,
-            &transaction_location..=&last_transaction_location,
-        )
-        .map(|(tx_loc, ())| tx_loc)
-        .collect()
+        self.db
+            .zs_range_iter(
+                &tx_loc_by_transparent_addr_loc,
+                &transaction_location..=&last_transaction_location,
+            )
+            .map(|(tx_loc, ())| tx_loc)
+            .collect()
     }
 
     // Address index queries


### PR DESCRIPTION
## Motivation

This PR updates `address_transaction_locations()` to avoid using multiple iterators to read data from disk and to set an upper iterate bound.

This function is currently used by `zebra-rpc` for the `get_address_tx_ids` method.

Part of #7664.

## Solution

- Refactor `address_transaction_locations()` to use `zs_range_iter` instead of `zs_next_key_value_from`

Related cleanups:
- Speed up `rpc_getaddresstxids_response`

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
