### PR TITLE
fix(ci): Limit parallel jobs launched by the crates workflow

### DIFF
--- a/.github/workflows/ci-build-crates.yml
+++ b/.github/workflows/ci-build-crates.yml
@@ -102,6 +102,8 @@ jobs:
     needs: [ matrix, check-matrix ]
     runs-on: ubuntu-latest
     strategy:
+      # avoid rate-limit errors by only launching a few of these jobs at a time
+      max-parallel: 2
       fail-fast: true
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
 


### PR DESCRIPTION
## Motivation

Some workflows launch a lot of jobs, but those jobs are fast. So they can wait until later to run.

This also avoids hitting some rate limits.

Close #6702 

Depends-On: #7616

## Solution

Limit the number of parallel crate build jobs to avoid reaching rate-limits.

Limiting the number of parallel jobs also makes CI faster overall, because other long jobs can start earlier.

## Review

This is a routine fix.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

We could stop installing protoc that way if the bug happens again.