### PR TITLE
fix(state): Avoid panicking in zebra-state initialization when checkpoints are missing

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -389,8 +389,7 @@ impl StateService {
         let full_verifier_utxo_lookahead = max_checkpoint_height
             - HeightDiff::try_from(checkpoint_verify_concurrency_limit)
                 .expect("fits in HeightDiff");
-        let full_verifier_utxo_lookahead =
-            full_verifier_utxo_lookahead.expect("unexpected negative height");
+        let full_verifier_utxo_lookahead = full_verifier_utxo_lookahead.unwrap_or(block::Height(0));
 
         let non_finalized_state_queued_blocks = QueuedBlocks::default();
         let pending_utxos = PendingUtxos::default();


### PR DESCRIPTION
## Motivation

Zebra should not panic without checkpoints.

Qedit asked about how to set up a local testnet with a different genesis block and a different network ID for local testing, one approach would be to modify the `genesis_hash()` return value for `Testnet` and clear initial/cached testnet peers.

## Solution

- Always store queued UTXOs when there are no checkpoints 
  (or when the `max_checkpoint_height `is lower than `checkpoint_verify_concurrency_limit`)

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
