### PR TITLE
fix(doc): Fix an incorrect consensus-critical ZIP 212 comment

### DIFF
--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -101,7 +101,7 @@ impl Network {
     pub fn mandatory_checkpoint_height(&self) -> Height {
         // Currently this is after the ZIP-212 grace period.
         //
-        // See the `ZIP_212_GRACE_PERIOD_DOCUMENTATION` for more information.
+        // See the `ZIP_212_GRACE_PERIOD_DURATION` documentation for more information.
 
         let canopy_activation = Canopy
             .activation_height(*self)


### PR DESCRIPTION
## Motivation

This comment is potentially confusing, because the consensus rule reference is wrong.

## Review

This is a low priority consensus docs bug.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

