### PR TITLE
change(docs): Add changelog entry for stable mining feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Zebra 1.4.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.4.0) - TODO: DATE
+
+Zebra's mining RPCs are now available in release builds. TODO: rest of intro
+
+This release contains the following changes:
+ 
+### Mining RPCs in Production Builds
+
+Zebra's mining RPCs are now available in release builds (#7740). Any Zebra instance can be used
+by a miner or mining pool. This stabilises 12 RPCs, including  `getblocktemplate`, `submitblock`,
+`getmininginfo`, `getnetworksolps`, `[z_]validateaddress` and `getblocksubsidy`. For more infomation,
+read our [mining blog post](https://zfnd.org/experimental-mining-support-in-zebra/).
+
+Please [let us know](https://github.com/ZcashFoundation/zebra/issues/new?assignees=&labels=C-enhancement%2CS-needs-triage&projects=&template=feature_request.yml&title=feature%3A+)
+if your mining pool needs extra RPC methods or fields.
+
+### Security
+
+TODO: rest of changelog
+
 ## [Zebra 1.3.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.3.0) - 2023-10-16
 
 This release adds RPC methods for the "Spend before Sync" light wallet feature,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ This release contains the following changes:
 ### Mining RPCs in Production Builds
 
 Zebra's mining RPCs are now available in release builds (#7740). Any Zebra instance can be used
-by a miner or mining pool. This stabilises 12 RPCs, including  `getblocktemplate`, `submitblock`,
-`getmininginfo`, `getnetworksolps`, `[z_]validateaddress` and `getblocksubsidy`. For more infomation,
+by a solo miner or mining pool. This stabilises 12 RPCs, including  `getblocktemplate`, `submitblock`,
+`getmininginfo`, `getnetworksolps`, `[z_]validateaddress` and `getblocksubsidy`. For more information,
 read our [mining blog post](https://zfnd.org/experimental-mining-support-in-zebra/).
 
 Please [let us know](https://github.com/ZcashFoundation/zebra/issues/new?assignees=&labels=C-enhancement%2CS-needs-triage&projects=&template=feature_request.yml&title=feature%3A+)

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ them:
 
 - To generate transactions, [run Zebra with
   `lightwalletd`](https://zebra.zfnd.org/user/lightwalletd.html).
-- To generate blocks, [enable mining
-  support](https://zebra.zfnd.org/user/mining.html), and use a mining pool or
-  miner with Zebra's mining JSON-RPCs. Mining support is currently incomplete,
-  experimental, and off by default.
+- To generate blocks, use a mining pool or miner with Zebra's mining JSON-RPCs.
+  Currently Zebra can only send mining rewards to a single fixed address.
+  To distribute rewards, use mining software that creates its own distribution transactions,
+  or a light wallet or `zcashd` wallet.
 
 Please [join us on Discord](https://discord.gg/na6QZNd) if you'd like to find
 out more or get involved!

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ them:
 - To generate blocks, use a mining pool or miner with Zebra's mining JSON-RPCs.
   Currently Zebra can only send mining rewards to a single fixed address.
   To distribute rewards, use mining software that creates its own distribution transactions,
-  or a light wallet or `zcashd` wallet.
+  a light wallet or the `zcashd` wallet.
 
 Please [join us on Discord](https://discord.gg/na6QZNd) if you'd like to find
 out more or get involved!


### PR DESCRIPTION
## Motivation

We want to talk about stabilising mining RPCs in the changelog for the next release.

The mining part of the README also needs an update.

This is a follow-up to ticket #7361.

## Review

This is a low priority documentation change. Technically it blocks the next release, but it should be merged long before then.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

