### PR TITLE
change(devops): Use correct name for cd-build-zcash-params.yml

### DIFF
--- a/.github/workflows/cd-build-zcash-params.yml
+++ b/.github/workflows/cd-build-zcash-params.yml
@@ -28,7 +28,7 @@ on:
       # workflow definitions
       - 'docker/zcash-params/Dockerfile'
       - '.dockerignore'
-      - '.github/workflows/sub-build-zcash-params.yml'
+      - '.github/workflows/cd-build-zcash-params.yml'
       - '.github/workflows/sub-build-docker-image.yml'
 
 jobs:

--- a/docker/zcash-params/Dockerfile
+++ b/docker/zcash-params/Dockerfile
@@ -1,7 +1,7 @@
 # This image is for caching Zcash Sprout and Sapling parameters.
 # We don't test it automatically in CI due to download server rate-limiting.
 # To manually run it on the PR branch before merging, go to:
-# https://github.com/ZcashFoundation/zebra/actions/workflows/zcash-params.yml
+# https://github.com/ZcashFoundation/zebra/actions/workflows/cd-build-zcash-params.yml
 
 FROM debian:bullseye-slim AS release
 


### PR DESCRIPTION
## Motivation

This isn't a reusable workflow, so it should either start with `ci` or `cd`. Since it is only run on the `main` branch, `cd` seems better.

## Review

This is a low priority cleanup.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

