### PR TITLE
fix(ci): Increase Docker unit test timeout

### DIFF
--- a/.github/workflows/sub-test-zebra-config.yml
+++ b/.github/workflows/sub-test-zebra-config.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   test-docker-config:
     name: Test ${{ inputs.test_id }} in Docker
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1


### PR DESCRIPTION
## Motivation

Every week or two, the DockerHub servers are slow, and the Docker tests time out. They can also fail if testnet is slow, or the machine is slow.

Close #7614

## Solution

Double the timeout to 30 minutes.

## Review

This is a routine fix.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

