### PR TITLE
Re-enable macOS builds and tests in CI

### DIFF
--- a/.github/workflows/ci-unit-tests-os.patch.yml
+++ b/.github/workflows/ci-unit-tests-os.patch.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         rust: [stable, beta]
         features: [""]
         exclude:

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -74,7 +74,6 @@ jobs:
       fail-fast: false
       matrix:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
-        # TODO: macOS tests were removed for now, see https://github.com/ZcashFoundation/zebra/issues/6824
         os: [ubuntu-latest, macos-latest]
         rust: [stable, beta]
         # TODO: When vars.EXPERIMENTAL_FEATURES has features in it, add it here.

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -75,7 +75,7 @@ jobs:
       matrix:
         # TODO: Windows was removed for now, see https://github.com/ZcashFoundation/zebra/issues/3801
         # TODO: macOS tests were removed for now, see https://github.com/ZcashFoundation/zebra/issues/6824
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         rust: [stable, beta]
         # TODO: When vars.EXPERIMENTAL_FEATURES has features in it, add it here.
         #       Or work out a way to trim the space from the variable: GitHub doesn't allow empty variables.


### PR DESCRIPTION
## Motivation

This is a test to see if macos tests pass the CI as they are passing with a mac locally. See https://github.com/ZcashFoundation/zebra/issues/6812#issuecomment-1780186591

Close https://github.com/ZcashFoundation/zebra/issues/6812

## Solution

Revert #6825 

## Review

Should be merged if CI passes.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work
