### PR TITLE
docs: Refactor the installation instructions for `s-nomp`

### DIFF
--- a/book/src/user/mining-testnet-s-nomp.md
+++ b/book/src/user/mining-testnet-s-nomp.md
@@ -164,7 +164,7 @@ These fixes disable mining pool operator payments and miner payments: they just 
    git clone https://github.com/ZcashFoundation/s-nomp && cd s-nomp
    ```
 
-5. Use Node 8.11:
+5. Use Node 10:
 
     ```sh
     unset npm_config_prefix

--- a/book/src/user/mining-testnet-s-nomp.md
+++ b/book/src/user/mining-testnet-s-nomp.md
@@ -77,8 +77,7 @@ These fixes disable mining pool operator payments and miner payments: they just 
     ```sh
     zebrad -c zebrad.toml
     ```
-3. Wait for Zebra to sync to the testnet tip. This takes 2-3 days on Mainnet at
-   the time of writing this manual.
+3. Wait for Zebra to sync to the testnet tip. This takes 8-12 hours on testnet (or 2-3 days on mainnet) as of October 2023.
 
 ## Install `s-nomp`
 

--- a/book/src/user/mining-testnet-s-nomp.md
+++ b/book/src/user/mining-testnet-s-nomp.md
@@ -73,9 +73,9 @@ These fixes disable mining pool operator payments and miner payments: they just 
 
     </details>
 
-2. [Build](https://github.com/ZcashFoundation/zebra#build-instructions) and [Run Zebra](https://zebra.zfnd.org/user/run.html) with the `getblocktemplate-rpcs` feature:
+2. [Run Zebra](https://zebra.zfnd.org/user/run.html) with the config you created:
     ```sh
-    cargo run --release --features "getblocktemplate-rpcs" --bin zebrad -- -c zebrad.toml
+    zebrad -c zebrad.toml
     ```
 3. Wait a few hours for Zebra to sync to the testnet tip (on mainnet this takes 2-3 days)
 

--- a/book/src/user/mining-testnet-s-nomp.md
+++ b/book/src/user/mining-testnet-s-nomp.md
@@ -138,43 +138,49 @@ These fixes disable mining pool operator payments and miner payments: they just 
 
 <details><summary>Arch-specific instructions</summary>
 
-#### Install dependencies
+#### Install `s-nomp`
 
-1. Install [`redis`](https://redis.io/docs/getting-started/) and run it on the default port:
+1. Install Redis, and development libraries required by S-nomp
 
     ```sh
-    sudo pacman -S redis
+    sudo pacman -S redis boost libsodium
+    ```
+    
+2. Install `nvm`, Python 3.10 and `virtualenv`
+
+    ```sh
+    paru -S python310 nvm
+    sudo pacman -S python-virtualenv
+    ```
+
+3. Start Redis
+    ```sh
     sudo systemctl start redis
     ```
 
-2. Install and activate [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating):
+4. Clone the repository
+
+   ```sh
+   git clone https://github.com/ZcashFoundation/s-nomp && cd s-nomp
+   ```
+
+5. Use Node 8.11:
 
     ```sh
-    sudo pacman -S nvm
     unset npm_config_prefix
     source /usr/share/nvm/init-nvm.sh
+    nvm install 10
+    nvm use 10
     ```
 
-3. Install `boost` and `libsodium` development libraries:
+6. Use Python 3.10
 
     ```sh
-    sudo pacman -S boost libsodium
+    virtualenv -p 3.10 s-nomp
+    source s-nomp/bin/activate
     ```
 
-#### Install `s-nomp`
-
-1. `git clone https://github.com/ZcashFoundation/s-nomp && cd s-nomp`
-
-2. Use the Zebra configs: `git checkout zebra-mining`
-
-3. Use node 8.11.0:
-
-    ```sh
-    nvm install 8.11.0
-    nvm use 8.11.0
-    ```
-
-4. Update dependencies and install:
+7. Update dependencies and install:
 
     ```sh
     npm update

--- a/book/src/user/mining-testnet-s-nomp.md
+++ b/book/src/user/mining-testnet-s-nomp.md
@@ -77,7 +77,8 @@ These fixes disable mining pool operator payments and miner payments: they just 
     ```sh
     zebrad -c zebrad.toml
     ```
-3. Wait a few hours for Zebra to sync to the testnet tip (on mainnet this takes 2-3 days)
+3. Wait for Zebra to sync to the testnet tip. This takes 2-3 days on Mainnet at
+   the time of writing this manual.
 
 ## Install `s-nomp`
 


### PR DESCRIPTION
## Motivation

When working on #7423, I noticed our documentation for mining with `s-nomp` was outdated.

## Solution

- Don't mention the `getblocktemplate-rpcs` feature anymore.
- Refactor the installation instructions for `s-nomp`. I only did this refactor for the Arch Linux section.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?