### PR TITLE
fix(doc): Fix broken links to `zebra_network` and `zebra_state` `Config` structs on doc.zebra.zfnd.org

### DIFF
--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -144,8 +144,8 @@ jobs:
 
       - name: Build external docs
         run: |
-          # Exclude zebra-utils, it is not for library or app users
-          cargo doc --no-deps --workspace --all-features --exclude zebra-utils --target-dir "$(pwd)"/target/external
+          # Exclude zebra-utils and zebra-test, they are not for library or app users
+          cargo doc --no-deps --workspace --all-features --exclude zebra-utils --exclude zebra-test --target-dir "$(pwd)"/target/external
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -46,11 +46,11 @@
 
 mod block;
 mod checkpoint;
-mod config;
 mod parameters;
 mod primitives;
 mod script;
 
+pub mod config;
 pub mod error;
 pub mod router;
 pub mod transaction;

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -159,11 +159,12 @@ extern crate bitflags;
 /// parameterized by 'a), *not* that the object itself has 'static lifetime.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-mod address_book;
 pub mod address_book_peers;
-mod address_book_updater;
-mod config;
+pub mod config;
 pub mod constants;
+
+mod address_book;
+mod address_book_updater;
 mod isolated;
 mod meta_addr;
 mod peer;

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -385,44 +385,52 @@ pub(crate) fn database_format_version_at_path(
     }
 }
 
-/// Writes `changed_version` to the on-disk database after the format is changed.
-/// (Or a new database is created.)
-///
-/// # Correctness
-///
-/// This should only be called:
-/// - after each format upgrade is complete,
-/// - when creating a new database, or
-/// - when an older Zebra version opens a newer database.
-///
-/// # Concurrency
-///
-/// This must only be called while RocksDB has an open database for `config`.
-/// Otherwise, multiple Zebra processes could write the version at the same time,
-/// corrupting the file.
-///
-/// # Panics
-///
-/// If the major versions do not match. (The format is incompatible.)
-pub fn write_database_format_version_to_disk(
-    changed_version: &Version,
-    config: &Config,
-    network: Network,
-) -> Result<(), BoxError> {
-    let version_path = config.version_file_path(network);
+// Hide this destructive method from the public API, except in tests.
+pub(crate) use hidden::write_database_format_version_to_disk;
 
-    // The major version is already in the directory path.
-    assert_eq!(
-        changed_version.major, DATABASE_FORMAT_VERSION,
-        "tried to do in-place database format change to an incompatible version"
-    );
+pub(crate) mod hidden {
 
-    let version = format!("{}.{}", changed_version.minor, changed_version.patch);
+    use super::*;
 
-    // # Concurrency
-    //
-    // The caller handles locking for this file write.
-    fs::write(version_path, version.as_bytes())?;
+    /// Writes `changed_version` to the on-disk database after the format is changed.
+    /// (Or a new database is created.)
+    ///
+    /// # Correctness
+    ///
+    /// This should only be called:
+    /// - after each format upgrade is complete,
+    /// - when creating a new database, or
+    /// - when an older Zebra version opens a newer database.
+    ///
+    /// # Concurrency
+    ///
+    /// This must only be called while RocksDB has an open database for `config`.
+    /// Otherwise, multiple Zebra processes could write the version at the same time,
+    /// corrupting the file.
+    ///
+    /// # Panics
+    ///
+    /// If the major versions do not match. (The format is incompatible.)
+    pub fn write_database_format_version_to_disk(
+        changed_version: &Version,
+        config: &Config,
+        network: Network,
+    ) -> Result<(), BoxError> {
+        let version_path = config.version_file_path(network);
 
-    Ok(())
+        // The major version is already in the directory path.
+        assert_eq!(
+            changed_version.major, DATABASE_FORMAT_VERSION,
+            "tried to do in-place database format change to an incompatible version"
+        );
+
+        let version = format!("{}.{}", changed_version.minor, changed_version.patch);
+
+        // # Concurrency
+        //
+        // The caller handles locking for this file write.
+        fs::write(version_path, version.as_bytes())?;
+
+        Ok(())
+    }
 }

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -25,12 +25,12 @@
 #[macro_use]
 extern crate tracing;
 
+pub mod config;
 pub mod constants;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod arbitrary;
 
-mod config;
 mod error;
 mod request;
 mod response;
@@ -71,7 +71,7 @@ pub use service::{
 };
 
 #[cfg(any(test, feature = "proptest-impl"))]
-pub use config::write_database_format_version_to_disk;
+pub use config::hidden::write_database_format_version_to_disk;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use constants::latest_version_for_adding_subtrees;

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -15,16 +15,18 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields, default)]
 pub struct ZebradConfig {
     /// Consensus configuration
-    pub consensus: zebra_consensus::Config,
+    //
+    // These configs use full paths to avoid a rustdoc link bug (#7048).
+    pub consensus: zebra_consensus::config::Config,
 
     /// Metrics configuration
     pub metrics: crate::components::metrics::Config,
 
     /// Networking configuration
-    pub network: zebra_network::Config,
+    pub network: zebra_network::config::Config,
 
     /// State configuration
-    pub state: zebra_state::Config,
+    pub state: zebra_state::config::Config,
 
     /// Tracing configuration
     pub tracing: crate::components::tracing::Config,


### PR DESCRIPTION
## Motivation

_What are the most important goals of the ticket or PR?_

This PR fixes broken links to the `zebra_network` and `zebra_state` `Config` structs in https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html

Close #7048

### PR Author Checklist

Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
    - ~~Does it need extra CHANGELOG info?~~
    - [x] Does the PR have a priority label?
  - ~~Have you added or updated tests?~~
  - ~~Is the documentation up to date?~~

This PR doesn't change Rust code behaviour, just the generated doc links.

## Solution

- Use full paths to config imports to avoid a doc link bug

Related:
- Exclude `zebra-test` from the external docs build

### Testing

I manually tested this locally with the doc build command we use in CI, and checked the files for `zebra_network/zebra_network` and `zebra_state/zebra_state`.

## Review

This is a routine fix.

The generated docs from this PR should be checked for broken links in https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html

The "Deploy external docs to firebase" step logs a preview URL with the docs from each PR.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] How do you know it works? Do the tests cover the PR motivation?
  - [ ] Are there any blockers to merging this PR?
    - [ ] Can some changes go in new tickets or PRs?
  - [ ] Manually test the PR

_And check the PR Author checklist is complete._

## Follow Up Work

If this happens again we should just link to docs.rs, it doesn't have this bug:
- #7837