### PR TITLE
change(devops): Split dependency upgrades into 4 large categories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # Rust section
   - package-ecosystem: cargo
     directory: '/'
     # serde, clap, and other dependencies sometimes have multiple updates in a week
@@ -18,112 +19,32 @@ updates:
         ecc:
           patterns:
             # deliberately include zcash_script (even though it is maintained by ZF)
-            - "zcash_*"
-            - "orchard"
-            - "halo2*"
-            - "incrementalmerkletree"
-            - "bridgetree"
-            - "equihash"
-            # addresses
-            - "bs58"
-            - "ripemd"
+            - "zcash_*|orchard|halo2*|incrementalmerkletree|bridgetree|equihash"
         # groups are limited to 10 items
         prod:
           patterns:
-        # crypto:
-        #   patterns:
-            - "bellman"
-            # reddsa, redjubjub
-            - "red*"
-            - "jubjub"
-            - "group"
-            - "bls12_381"
-            - "blake*"
-            - "secp256k1"
-            - "sha2"
-            - "*25519*"
-            - "rand*"
-        # async:
-        #   patterns:
-            - "tokio*"
-            - "console-subscriber"
-            - "tower*"
-            - "hyper*"
-            - "h2"
-            - "reqwest"
-            - "futures*"
-            - "pin-project*"
-        # log-time:
-        #   patterns:
-            - "tracing*"
-            - "log"
-            - "*eyre*"
-            - "thiserror"
-            # displaydoc, spandoc
-            - "*doc"
-            - "owo-colors"
-            - "sentry*"
-            - "metrics*"
-            # time, humantime
-            - "*time*"
-            - "chrono*"
-        # concurrency:
-        #   patterns:
-            - "once_cell"
-            - "lazy_static"
-            - "rayon*"
-            - "crossbeam*"
-            - "num_cpus"
-        # progress-bar:
-        #   patterns:
-            - "indicatif"
-            - "howudoin"
-        # app:
-        #   patterns:
-            - "abscissa*"
-            - "structopt*"
-            - "clap*"
-            - "atty*"
-            - "semver*"
-            # dirs, directories, directories-next
-            - "dir*"
-            - "vergen"
-            - "*git*"
-            - "toml*"
-            - "rlimit"
-        # formats:
-        #   patterns:
-            - "serde*"
-            - "jsonrpc*"
-            - "hex*"
-            - "regex"
-            - "byteorder"
-            - "bytes"
-            - "bincode"    
-        # data-structures:
-        #   patterns:
-            - "bitflags*"
-            - "bitvec"
-            - "indexmap"
-            - "num-integer"
-            - "primitive-types"
-            - "uint"
-            - "tinyvec"
-            - "itertools"
-            - "ordered-map"
-            - "mset"
+          # addresses
+            - "bs58|ripemd"
+          # crypto:
+            - "bellman|red*|jubjub|group|bls12_381|blake*|secp256k1|sha2|*25519*|rand*"
+          # async:
+            - "tokio*|console-subscriber|tower*|hyper*|h2|reqwest|futures*|pin-project*"
+          # log-time:
+            - "tracing*|log|*eyre*|thiserror|*doc|owo-colors|sentry*|metrics*|*time*|chrono*"
+          # concurrency:
+            - "once_cell|lazy_static|rayon*|crossbeam*|num_cpus"
+          # app:
+            - "abscissa*|structopt*|clap*|atty*|semver*|dir*|vergen|*git*|toml*|rlimit|indicatif|howudoin"
+          # formats:
+            - "serde|jsonrpc|hex|rege|byteorde|byte|bincode"    
+          # data-structures:
+            - "bitflags*|bitvec|indexmap|num-integer|primitive-types|uint|tinyvec|itertools|ordered-map|mset"
         test:
           patterns:
-            - "proptest*"
-            - "insta"
-            - "prost*"
-            - "tonic*"
+            - "proptest*|insta|prost*|tonic*"
             # depends on tonic and prost
-            - "console-subscriber"
-            - "tempfile"
-            - "static_assertions"
-            - "criterion"
-            - "inferno"
+            - "console-subscriber|tempfile|static_assertions|criterion|inferno"
+  # Devops section
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
@@ -137,3 +58,7 @@ updates:
       - 'A-devops'
       - 'A-dependencies'
       - 'P-Low :snowflake:'
+    groups:
+      devops:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,30 +20,12 @@ updates:
           patterns:
             # deliberately include zcash_script (even though it is maintained by ZF)
             - "zcash_*|orchard|halo2*|incrementalmerkletree|bridgetree|equihash"
-        # groups are limited to 10 items
         prod:
-          patterns:
-          # addresses
-            - "bs58|ripemd"
-          # crypto:
-            - "bellman|red*|jubjub|group|bls12_381|blake*|secp256k1|sha2|*25519*|rand*"
-          # async:
-            - "tokio*|console-subscriber|tower*|hyper*|h2|reqwest|futures*|pin-project*"
-          # log-time:
-            - "tracing*|log|*eyre*|thiserror|*doc|owo-colors|sentry*|metrics*|*time*|chrono*"
-          # concurrency:
-            - "once_cell|lazy_static|rayon*|crossbeam*|num_cpus"
-          # app:
-            - "abscissa*|structopt*|clap*|atty*|semver*|dir*|vergen|*git*|toml*|rlimit|indicatif|howudoin"
-          # formats:
-            - "serde|jsonrpc|hex|rege|byteorde|byte|bincode"    
-          # data-structures:
-            - "bitflags*|bitvec|indexmap|num-integer|primitive-types|uint|tinyvec|itertools|ordered-map|mset"
-        test:
-          patterns:
-            - "proptest*|insta|prost*|tonic*"
-            # depends on tonic and prost
-            - "console-subscriber|tempfile|static_assertions|criterion|inferno"
+          dependency-type: "production"
+          exclude-patterns:
+            - "zcash_*|orchard|halo2*|incrementalmerkletree|bridgetree|equihash"
+        dev:
+          dependency-type: "development"
   # Devops section
   - package-ecosystem: github-actions
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,10 @@ updates:
             - "bs58"
             - "ripemd"
         # groups are limited to 10 items
-        crypto:
+        prod:
           patterns:
+        # crypto:
+        #   patterns:
             - "bellman"
             # reddsa, redjubjub
             - "red*"
@@ -41,8 +43,8 @@ updates:
             - "sha2"
             - "*25519*"
             - "rand*"
-        async:
-          patterns:
+        # async:
+        #   patterns:
             - "tokio*"
             - "console-subscriber"
             - "tower*"
@@ -51,8 +53,8 @@ updates:
             - "reqwest"
             - "futures*"
             - "pin-project*"
-        log-time:
-          patterns:
+        # log-time:
+        #   patterns:
             - "tracing*"
             - "log"
             - "*eyre*"
@@ -65,19 +67,19 @@ updates:
             # time, humantime
             - "*time*"
             - "chrono*"
-        concurrency:
-          patterns:
+        # concurrency:
+        #   patterns:
             - "once_cell"
             - "lazy_static"
             - "rayon*"
             - "crossbeam*"
             - "num_cpus"
-        progress-bar:
-          patterns:
+        # progress-bar:
+        #   patterns:
             - "indicatif"
             - "howudoin"
-        app:
-          patterns:
+        # app:
+        #   patterns:
             - "abscissa*"
             - "structopt*"
             - "clap*"
@@ -89,8 +91,8 @@ updates:
             - "*git*"
             - "toml*"
             - "rlimit"
-        formats:
-          patterns:
+        # formats:
+        #   patterns:
             - "serde*"
             - "jsonrpc*"
             - "hex*"
@@ -98,8 +100,8 @@ updates:
             - "byteorder"
             - "bytes"
             - "bincode"    
-        data-structures:
-          patterns:
+        # data-structures:
+        #   patterns:
             - "bitflags*"
             - "bitvec"
             - "indexmap"


### PR DESCRIPTION
## Motivation

This PR merges the dependabot groups for crypto, async, log-time, concurrency, progress-bar, app, formats, and data-structures into prod.

~~It's still missing a group for DevOps dependencies.~~

Closes #7809.

### Specifications

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

## Solution

- Merge the groups for production dependencies

## Review

Not yet ready for review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?
