### PR TITLE
change(docs): Add macOS M1 as a tier 3 supported platform

### DIFF
--- a/book/src/user/supported-platforms.md
+++ b/book/src/user/supported-platforms.md
@@ -47,4 +47,4 @@ For the full requirements, see [Tier 3 platform policy](platform-tier-policy.md#
 | platform | os | notes | rust | artifacts
 | -------|-------|-------|-------|-------
 | `aarch64-unknown-linux-gnu` | [Debian 11](https://www.debian.org/releases/bullseye/) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A
-| `aarch64-apple-darwin` | latest macOS | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A
+| `aarch64-apple-darwin` | latest macOS | 64-bit, Apple M1 or M2 | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A

--- a/book/src/user/supported-platforms.md
+++ b/book/src/user/supported-platforms.md
@@ -47,3 +47,4 @@ For the full requirements, see [Tier 3 platform policy](platform-tier-policy.md#
 | platform | os | notes | rust | artifacts
 | -------|-------|-------|-------|-------
 | `aarch64-unknown-linux-gnu` | [Debian 11](https://www.debian.org/releases/bullseye/) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A
+| `aarch64-apple-darwin` | latest macOS | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A


### PR DESCRIPTION
## Motivation

We manually tested this yesterday and it worked, that's more than what's required for tier 3, which documents support but no testing.

This is worth documenting because users have asked about it.

## Review

This is a low priority docs change.

### Reviewer Checklist

  - [ ] Are the PR labels correct?
  - [ ] How do you know it works? Does it have tests?

