### PR TITLE
fix(network): Reconnect with peers after brief network interruption

### DIFF
--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -910,6 +910,7 @@ where
             Ok(TimerCrawl { tick }) => {
                 let candidates = candidates.clone();
                 let demand_tx = demand_tx.clone();
+                let should_always_dial = active_outbound_connections.update_count() == 0;
 
                 let crawl_handle = tokio::spawn(
                     async move {
@@ -918,7 +919,7 @@ where
                             "crawling for more peers in response to the crawl timer"
                         );
 
-                        crawl(candidates, demand_tx, true).await?;
+                        crawl(candidates, demand_tx, should_always_dial).await?;
 
                         Ok(TimerCrawlFinished)
                     }


### PR DESCRIPTION
## Motivation

Zebra currently will not reconnect after an internet connection failure.

Part of #7772.

## Solution

- Always attempt to make an outbound connection in `TimerCrawl`

## Review

Anyone can review.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- Investigate why it isn't sending a `MorePeers` message in [`PeerSet::poll_ready()`](https://github.com/ZcashFoundation/zebra/blob/main/zebra-network/src/peer_set/set.rs#L1047)
- Fix that and revert this PR