### PR TITLE
change(state): Refactor the naming of note commitment subtrees

### DIFF
--- a/zebra-chain/src/subtree.rs
+++ b/zebra-chain/src/subtree.rs
@@ -55,21 +55,21 @@ impl From<NoteCommitmentSubtreeIndex> for u64 {
 /// with its associated block height and subtree index.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
-pub struct NoteCommitmentSubtree<Root> {
+pub struct NoteCommitmentSubtree<SubtreeRoot> {
     /// Index of this subtree
     pub index: NoteCommitmentSubtreeIndex,
     /// Root of this subtree.
-    pub root: Root,
+    pub root: SubtreeRoot,
     /// End boundary of this subtree, the block height of its last leaf.
     pub end_height: Height,
 }
 
-impl<Root> NoteCommitmentSubtree<Root> {
+impl<SubtreeRoot> NoteCommitmentSubtree<SubtreeRoot> {
     /// Creates new [`NoteCommitmentSubtree`]
     pub fn new(
         index: impl Into<NoteCommitmentSubtreeIndex>,
         end_height: Height,
-        root: Root,
+        root: SubtreeRoot,
     ) -> Self {
         let index = index.into();
         Self {
@@ -80,7 +80,7 @@ impl<Root> NoteCommitmentSubtree<Root> {
     }
 
     /// Converts struct to [`NoteCommitmentSubtreeData`].
-    pub fn into_data(self) -> NoteCommitmentSubtreeData<Root> {
+    pub fn into_data(self) -> NoteCommitmentSubtreeData<SubtreeRoot> {
         NoteCommitmentSubtreeData::new(self.end_height, self.root)
     }
 }
@@ -89,17 +89,17 @@ impl<Root> NoteCommitmentSubtree<Root> {
 /// Used for database key-value serialization, where the subtree index is the key, and this struct is the value.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
-pub struct NoteCommitmentSubtreeData<Root> {
+pub struct NoteCommitmentSubtreeData<SubtreeRoot> {
     /// Merkle root of the 2^16-leaf subtree.
-    pub root: Root,
+    pub root: SubtreeRoot,
 
     /// Height of the block containing the note that completed this subtree.
     pub end_height: Height,
 }
 
-impl<Root> NoteCommitmentSubtreeData<Root> {
+impl<SubtreeRoot> NoteCommitmentSubtreeData<SubtreeRoot> {
     /// Creates new [`NoteCommitmentSubtreeData`]
-    pub fn new(end_height: Height, root: Root) -> Self {
+    pub fn new(end_height: Height, root: SubtreeRoot) -> Self {
         Self { end_height, root }
     }
 
@@ -107,7 +107,7 @@ impl<Root> NoteCommitmentSubtreeData<Root> {
     pub fn with_index(
         self,
         index: impl Into<NoteCommitmentSubtreeIndex>,
-    ) -> NoteCommitmentSubtree<Root> {
+    ) -> NoteCommitmentSubtree<SubtreeRoot> {
         NoteCommitmentSubtree::new(index, self.end_height, self.root)
     }
 }

--- a/zebra-chain/src/subtree.rs
+++ b/zebra-chain/src/subtree.rs
@@ -61,19 +61,27 @@ pub struct NoteCommitmentSubtree<Root> {
     /// Root of this subtree.
     pub root: Root,
     /// End boundary of this subtree, the block height of its last leaf.
-    pub end: Height,
+    pub end_height: Height,
 }
 
 impl<Root> NoteCommitmentSubtree<Root> {
     /// Creates new [`NoteCommitmentSubtree`]
-    pub fn new(index: impl Into<NoteCommitmentSubtreeIndex>, end: Height, root: Root) -> Self {
+    pub fn new(
+        index: impl Into<NoteCommitmentSubtreeIndex>,
+        end_height: Height,
+        root: Root,
+    ) -> Self {
         let index = index.into();
-        Self { index, end, root }
+        Self {
+            index,
+            end_height,
+            root,
+        }
     }
 
     /// Converts struct to [`NoteCommitmentSubtreeData`].
     pub fn into_data(self) -> NoteCommitmentSubtreeData<Root> {
-        NoteCommitmentSubtreeData::new(self.end, self.root)
+        NoteCommitmentSubtreeData::new(self.end_height, self.root)
     }
 }
 
@@ -86,14 +94,13 @@ pub struct NoteCommitmentSubtreeData<Root> {
     pub root: Root,
 
     /// Height of the block containing the note that completed this subtree.
-    #[serde(rename = "end_height")]
-    pub end: Height,
+    pub end_height: Height,
 }
 
 impl<Root> NoteCommitmentSubtreeData<Root> {
     /// Creates new [`NoteCommitmentSubtreeData`]
-    pub fn new(end: Height, root: Root) -> Self {
-        Self { end, root }
+    pub fn new(end_height: Height, root: Root) -> Self {
+        Self { end_height, root }
     }
 
     /// Creates new [`NoteCommitmentSubtree`] from a [`NoteCommitmentSubtreeData`] and index
@@ -101,6 +108,6 @@ impl<Root> NoteCommitmentSubtreeData<Root> {
         self,
         index: impl Into<NoteCommitmentSubtreeIndex>,
     ) -> NoteCommitmentSubtree<Root> {
-        NoteCommitmentSubtree::new(index, self.end, self.root)
+        NoteCommitmentSubtree::new(index, self.end_height, self.root)
     }
 }

--- a/zebra-chain/src/subtree.rs
+++ b/zebra-chain/src/subtree.rs
@@ -50,31 +50,30 @@ impl From<NoteCommitmentSubtreeIndex> for u64 {
 // TODO:
 // - consider defining sapling::SubtreeRoot and orchard::SubtreeRoot types or type wrappers,
 //   to avoid type confusion between the leaf Node and subtree root types.
-// - rename the `Node` generic to `SubtreeRoot`
 
 /// Subtree root of Sapling or Orchard note commitment tree,
 /// with its associated block height and subtree index.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
-pub struct NoteCommitmentSubtree<Node> {
+pub struct NoteCommitmentSubtree<Root> {
     /// Index of this subtree
     pub index: NoteCommitmentSubtreeIndex,
     /// Root of this subtree.
-    pub node: Node,
+    pub root: Root,
     /// End boundary of this subtree, the block height of its last leaf.
     pub end: Height,
 }
 
-impl<Node> NoteCommitmentSubtree<Node> {
+impl<Root> NoteCommitmentSubtree<Root> {
     /// Creates new [`NoteCommitmentSubtree`]
-    pub fn new(index: impl Into<NoteCommitmentSubtreeIndex>, end: Height, node: Node) -> Self {
+    pub fn new(index: impl Into<NoteCommitmentSubtreeIndex>, end: Height, root: Root) -> Self {
         let index = index.into();
-        Self { index, end, node }
+        Self { index, end, root }
     }
 
     /// Converts struct to [`NoteCommitmentSubtreeData`].
-    pub fn into_data(self) -> NoteCommitmentSubtreeData<Node> {
-        NoteCommitmentSubtreeData::new(self.end, self.node)
+    pub fn into_data(self) -> NoteCommitmentSubtreeData<Root> {
+        NoteCommitmentSubtreeData::new(self.end, self.root)
     }
 }
 
@@ -82,29 +81,26 @@ impl<Node> NoteCommitmentSubtree<Node> {
 /// Used for database key-value serialization, where the subtree index is the key, and this struct is the value.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
-pub struct NoteCommitmentSubtreeData<Node> {
+pub struct NoteCommitmentSubtreeData<Root> {
     /// Merkle root of the 2^16-leaf subtree.
-    //
-    // TODO: rename both Rust fields to match the RPC field names
-    #[serde(rename = "root")]
-    pub node: Node,
+    pub root: Root,
 
     /// Height of the block containing the note that completed this subtree.
     #[serde(rename = "end_height")]
     pub end: Height,
 }
 
-impl<Node> NoteCommitmentSubtreeData<Node> {
+impl<Root> NoteCommitmentSubtreeData<Root> {
     /// Creates new [`NoteCommitmentSubtreeData`]
-    pub fn new(end: Height, node: Node) -> Self {
-        Self { end, node }
+    pub fn new(end: Height, root: Root) -> Self {
+        Self { end, root }
     }
 
     /// Creates new [`NoteCommitmentSubtree`] from a [`NoteCommitmentSubtreeData`] and index
     pub fn with_index(
         self,
         index: impl Into<NoteCommitmentSubtreeIndex>,
-    ) -> NoteCommitmentSubtree<Node> {
-        NoteCommitmentSubtree::new(index, self.end, self.node)
+    ) -> NoteCommitmentSubtree<Root> {
+        NoteCommitmentSubtree::new(index, self.end, self.root)
     }
 }

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1173,7 +1173,7 @@ where
                     .values()
                     .map(|subtree| SubtreeRpcData {
                         root: subtree.root.encode_hex(),
-                        end: subtree.end,
+                        end_height: subtree.end_height,
                     })
                     .collect();
 
@@ -1203,7 +1203,7 @@ where
                     .values()
                     .map(|subtree| SubtreeRpcData {
                         root: subtree.root.encode_hex(),
-                        end: subtree.end,
+                        end_height: subtree.end_height,
                     })
                     .collect();
 

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1172,7 +1172,7 @@ where
                 let subtrees = subtrees
                     .values()
                     .map(|subtree| SubtreeRpcData {
-                        node: subtree.node.encode_hex(),
+                        root: subtree.root.encode_hex(),
                         end: subtree.end,
                     })
                     .collect();
@@ -1202,7 +1202,7 @@ where
                 let subtrees = subtrees
                     .values()
                     .map(|subtree| SubtreeRpcData {
-                        node: subtree.node.encode_hex(),
+                        root: subtree.root.encode_hex(),
                         end: subtree.end,
                     })
                     .collect();

--- a/zebra-state/src/service/finalized_state/disk_format/shielded.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/shielded.rs
@@ -178,11 +178,11 @@ impl IntoDisk for orchard::tree::Node {
     }
 }
 
-impl<Node: IntoDisk<Bytes = Vec<u8>>> IntoDisk for NoteCommitmentSubtreeData<Node> {
+impl<Root: IntoDisk<Bytes = Vec<u8>>> IntoDisk for NoteCommitmentSubtreeData<Root> {
     type Bytes = Vec<u8>;
 
     fn as_bytes(&self) -> Self::Bytes {
-        [self.end.as_bytes().to_vec(), self.node.as_bytes()].concat()
+        [self.end.as_bytes().to_vec(), self.root.as_bytes()].concat()
     }
 }
 

--- a/zebra-state/src/service/finalized_state/disk_format/shielded.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/shielded.rs
@@ -182,7 +182,7 @@ impl<Root: IntoDisk<Bytes = Vec<u8>>> IntoDisk for NoteCommitmentSubtreeData<Roo
     type Bytes = Vec<u8>;
 
     fn as_bytes(&self) -> Self::Bytes {
-        [self.end.as_bytes().to_vec(), self.root.as_bytes()].concat()
+        [self.end_height.as_bytes().to_vec(), self.root.as_bytes()].concat()
     }
 }
 

--- a/zebra-state/src/service/finalized_state/disk_format/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/prop.rs
@@ -376,7 +376,7 @@ fn roundtrip_sapling_subtree_data() {
     let _init_guard = zebra_test::init();
 
     proptest!(|(mut val in any::<NoteCommitmentSubtreeData<sapling::tree::Node>>())| {
-        val.end.0 %= MAX_ON_DISK_HEIGHT.0 + 1;
+        val.end_height.0 %= MAX_ON_DISK_HEIGHT.0 + 1;
         assert_value_properties(val)
     });
 }
@@ -461,8 +461,8 @@ fn roundtrip_orchard_subtree_data() {
     let _init_guard = zebra_test::init();
 
     proptest!(|(mut val in any::<NoteCommitmentSubtreeData<orchard::tree::Node>>())| {
-        val.end = val.end.clamp(Height(0), MAX_ON_DISK_HEIGHT);
-        val.end.0 %= MAX_ON_DISK_HEIGHT.0 + 1;
+        val.end_height = val.end_height.clamp(Height(0), MAX_ON_DISK_HEIGHT);
+        val.end_height.0 %= MAX_ON_DISK_HEIGHT.0 + 1;
         assert_value_properties(val)
     });
 }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -171,7 +171,7 @@ fn first_sapling_mainnet_subtree() -> NoteCommitmentSubtree<sapling::tree::Node>
     // ```
     NoteCommitmentSubtree {
         index: 0.into(),
-        node: hex!("754bb593ea42d231a7ddf367640f09bbf59dc00f2c1d2003cc340e0c016b5b13")
+        root: hex!("754bb593ea42d231a7ddf367640f09bbf59dc00f2c1d2003cc340e0c016b5b13")
             .as_slice()
             .try_into()
             .expect("test vector is valid"),
@@ -187,7 +187,7 @@ fn first_orchard_mainnet_subtree() -> NoteCommitmentSubtree<orchard::tree::Node>
     // ```
     NoteCommitmentSubtree {
         index: 0.into(),
-        node: hex!("d4e323b3ae0cabfb6be4087fec8c66d9a9bbfc354bf1d9588b6620448182063b")
+        root: hex!("d4e323b3ae0cabfb6be4087fec8c66d9a9bbfc354bf1d9588b6620448182063b")
             .as_slice()
             .try_into()
             .expect("test vector is valid"),
@@ -373,7 +373,7 @@ fn check_sapling_subtrees(
                 error!(?result);
             }
 
-            if subtree.node != node {
+            if subtree.root != node {
                 result = Err("completed subtree roots should match");
                 error!(?result);
             }
@@ -438,7 +438,7 @@ fn check_sapling_subtrees(
 
         // Check the root if the sapling note commitment tree at this height is a complete subtree.
         if let Some((_index, node)) = tree.completed_subtree_index_and_root() {
-            if subtree.node != node {
+            if subtree.root != node {
                 result = Err("completed subtree roots should match");
                 error!(?result);
             }
@@ -503,7 +503,7 @@ fn check_orchard_subtrees(
                 error!(?result);
             }
 
-            if subtree.node != node {
+            if subtree.root != node {
                 result = Err("completed subtree roots should match");
                 error!(?result);
             }
@@ -568,7 +568,7 @@ fn check_orchard_subtrees(
 
         // Check the root if the orchard note commitment tree at this height is a complete subtree.
         if let Some((_index, node)) = tree.completed_subtree_index_and_root() {
-            if subtree.node != node {
+            if subtree.root != node {
                 result = Err("completed subtree roots should match");
                 error!(?result);
             }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -175,7 +175,7 @@ fn first_sapling_mainnet_subtree() -> NoteCommitmentSubtree<sapling::tree::Node>
             .as_slice()
             .try_into()
             .expect("test vector is valid"),
-        end: Height(558822),
+        end_height: Height(558822),
     }
 }
 
@@ -191,7 +191,7 @@ fn first_orchard_mainnet_subtree() -> NoteCommitmentSubtree<orchard::tree::Node>
             .as_slice()
             .try_into()
             .expect("test vector is valid"),
-        end: Height(1707429),
+        end_height: Height(1707429),
     }
 }
 
@@ -360,9 +360,9 @@ fn check_sapling_subtrees(
         };
 
         // Check that there was a sapling note at the subtree's end height.
-        let Some(tree) = db.sapling_tree_by_height(&subtree.end) else {
+        let Some(tree) = db.sapling_tree_by_height(&subtree.end_height) else {
             result = Err("missing note commitment tree at subtree completion height");
-            error!(?result, ?subtree.end);
+            error!(?result, ?subtree.end_height);
             continue;
         };
 
@@ -381,13 +381,13 @@ fn check_sapling_subtrees(
         // Check that the final note has a greater subtree index if it didn't complete a subtree.
         else {
             let prev_height = subtree
-                .end
+                .end_height
                 .previous()
                 .expect("Note commitment subtrees should not end at the minimal height.");
 
             let Some(prev_tree) = db.sapling_tree_by_height(&prev_height) else {
                 result = Err("missing note commitment tree below subtree completion height");
-                error!(?result, ?subtree.end);
+                error!(?result, ?subtree.end_height);
                 continue;
             };
 
@@ -430,10 +430,10 @@ fn check_sapling_subtrees(
         };
 
         // Check that the subtree end height matches that in the sapling trees.
-        if subtree.end != height {
+        if subtree.end_height != height {
             let is_complete = tree.is_complete_subtree();
             result = Err("bad sapling subtree end height");
-            error!(?result, ?subtree.end, ?height, ?index, ?is_complete, );
+            error!(?result, ?subtree.end_height, ?height, ?index, ?is_complete, );
         }
 
         // Check the root if the sapling note commitment tree at this height is a complete subtree.
@@ -490,9 +490,9 @@ fn check_orchard_subtrees(
         };
 
         // Check that there was a orchard note at the subtree's end height.
-        let Some(tree) = db.orchard_tree_by_height(&subtree.end) else {
+        let Some(tree) = db.orchard_tree_by_height(&subtree.end_height) else {
             result = Err("missing note commitment tree at subtree completion height");
-            error!(?result, ?subtree.end);
+            error!(?result, ?subtree.end_height);
             continue;
         };
 
@@ -511,13 +511,13 @@ fn check_orchard_subtrees(
         // Check that the final note has a greater subtree index if it didn't complete a subtree.
         else {
             let prev_height = subtree
-                .end
+                .end_height
                 .previous()
                 .expect("Note commitment subtrees should not end at the minimal height.");
 
             let Some(prev_tree) = db.orchard_tree_by_height(&prev_height) else {
                 result = Err("missing note commitment tree below subtree completion height");
-                error!(?result, ?subtree.end);
+                error!(?result, ?subtree.end_height);
                 continue;
             };
 
@@ -560,10 +560,10 @@ fn check_orchard_subtrees(
         };
 
         // Check that the subtree end height matches that in the orchard trees.
-        if subtree.end != height {
+        if subtree.end_height != height {
             let is_complete = tree.is_complete_subtree();
             result = Err("bad orchard subtree end height");
-            error!(?result, ?subtree.end, ?height, ?index, ?is_complete, );
+            error!(?result, ?subtree.end_height, ?height, ?index, ?is_complete, );
         }
 
         // Check the root if the orchard note commitment tree at this height is a complete subtree.
@@ -851,10 +851,10 @@ fn write_sapling_subtree(
         .expect("writing sapling note commitment subtrees should always succeed.");
 
     if subtree.index.0 % 100 == 0 {
-        info!(end_height = ?subtree.end, index = ?subtree.index.0, "calculated and added sapling subtree");
+        info!(end_height = ?subtree.end_height, index = ?subtree.index.0, "calculated and added sapling subtree");
     }
     // This log happens about once per second on recent machines with SSD disks.
-    debug!(end_height = ?subtree.end, index = ?subtree.index.0, "calculated and added sapling subtree");
+    debug!(end_height = ?subtree.end_height, index = ?subtree.index.0, "calculated and added sapling subtree");
 }
 
 /// Writes an Orchard note commitment subtree to `upgrade_db`.
@@ -871,8 +871,8 @@ fn write_orchard_subtree(
         .expect("writing orchard note commitment subtrees should always succeed.");
 
     if subtree.index.0 % 100 == 0 {
-        info!(end_height = ?subtree.end, index = ?subtree.index.0, "calculated and added orchard subtree");
+        info!(end_height = ?subtree.end_height, index = ?subtree.index.0, "calculated and added orchard subtree");
     }
     // This log happens about once per second on recent machines with SSD disks.
-    debug!(end_height = ?subtree.end, index = ?subtree.index.0, "calculated and added orchard subtree");
+    debug!(end_height = ?subtree.end_height, index = ?subtree.index.0, "calculated and added orchard subtree");
 }

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -275,7 +275,7 @@ impl ZebraDb {
         ) = self.db.zs_last_key_value(&sapling_subtrees)?;
 
         let tip_height = self.finalized_tip_height()?;
-        if subtree_data.end != tip_height {
+        if subtree_data.end_height != tip_height {
             return None;
         }
 
@@ -401,7 +401,7 @@ impl ZebraDb {
         ) = self.db.zs_last_key_value(&orchard_subtrees)?;
 
         let tip_height = self.finalized_tip_height()?;
-        if subtree_data.end != tip_height {
+        if subtree_data.end_height != tip_height {
             return None;
         }
 

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -694,7 +694,7 @@ impl Chain {
 
         self.sapling_subtrees
             .iter()
-            .find(|(_index, subtree)| subtree.end == height)
+            .find(|(_index, subtree)| subtree.end_height == height)
             .map(|(index, subtree)| subtree.with_index(*index))
     }
 
@@ -898,7 +898,7 @@ impl Chain {
 
         self.orchard_subtrees
             .iter()
-            .find(|(_index, subtree)| subtree.end == height)
+            .find(|(_index, subtree)| subtree.end_height == height)
             .map(|(index, subtree)| subtree.with_index(*index))
     }
 

--- a/zebra-state/src/service/read/tests/vectors.rs
+++ b/zebra-state/src/service/read/tests/vectors.rs
@@ -179,7 +179,10 @@ async fn test_read_subtrees() -> Result<()> {
         .pop_first()
         .expect("chain_subtrees should not be empty");
     assert_eq!(first_chain_index, index, "subtree indexes should match");
-    assert_eq!(end_height, subtree.end, "subtree end heights should match");
+    assert_eq!(
+        end_height, subtree.end_height,
+        "subtree end heights should match"
+    );
 
     // Check that Zebra retrieves subtrees correctly when using a range with an Excluded start bound
 


### PR DESCRIPTION
## Motivation

Close #7463.

## Solution

#7463 mentions that "_We are storing subtree roots and end heights in the subtree indexes, not the subtree trees themselves._" I thought of renaming `NoteCommitmentSubtree` to `SubtreeRoot`, but there were at least two problems with that:

1. There is also the struct `NoteCommitmentSubtreeData`, which I wasn't sure how to rename.
2. `NoteCommitmentSubtree` has a field `node`, which I had renamed to `root`, so we would end up with something like `subtree_root.root`.

Given the issues above, I decided to do a simpler refactor:

1. Rename the generic type `Node` in `NoteCommitmentSubtree` to `Root`.
2. Rename the field `node` in `NoteCommitmentSubtree` to `root`.
3. Rename the field `end` in `NoteCommitmentSubtree` to `end_height` to match the name in the RPC so that the field doesn't need to be renamed for the RPC.

After this refactor, I didn't find any docs that would require changes. 

Also, if we ever need to store whole subtrees instead of only roots, we can use the already existing struct `NoteCommitmentSubtree`, but keep the RPC that currently uses this struct intact because it actually uses `NoteCommitmentSubtreeData`. 

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?