### PR TITLE
fix(net): Fix potential network hangs, and reduce code complexity

### DIFF
--- a/zebra-chain/src/diagnostic/task.rs
+++ b/zebra-chain/src/diagnostic/task.rs
@@ -9,7 +9,7 @@ pub mod future;
 pub mod thread;
 
 /// A trait that checks a task's return value for panics.
-pub trait CheckForPanics {
+pub trait CheckForPanics: Sized {
     /// The output type, after removing panics from `Self`.
     type Output;
 
@@ -20,11 +20,34 @@ pub trait CheckForPanics {
     ///
     /// If `self` contains a panic payload or an unexpected termination.
     #[track_caller]
-    fn check_for_panics(self) -> Self::Output;
+    fn panic_if_task_has_finished(self) -> Self::Output {
+        self.check_for_panics_with(true)
+    }
+
+    /// Check if `self` contains a panic payload, then panic.
+    /// Otherwise, return the non-panic part of `self`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` contains a panic payload.
+    #[track_caller]
+    fn panic_if_task_has_panicked(self) -> Self::Output {
+        self.check_for_panics_with(true)
+    }
+
+    /// Check if `self` contains a panic payload, then panic. Also panics if
+    /// `panic_on_unexpected_termination` is true, and `self` is an unexpected termination.
+    /// Otherwise, return the non-panic part of `self`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` contains a panic payload, or if we're panicking on unexpected terminations.
+    #[track_caller]
+    fn check_for_panics_with(self, panic_on_unexpected_termination: bool) -> Self::Output;
 }
 
 /// A trait that waits for a task to finish, then handles panics and cancellations.
-pub trait WaitForPanics {
+pub trait WaitForPanics: Sized {
     /// The underlying task output, after removing panics and unwrapping termination results.
     type Output;
 
@@ -43,5 +66,44 @@ pub trait WaitForPanics {
     ///
     /// If `self` contains an expected termination, and we're shutting down anyway.
     #[track_caller]
-    fn wait_for_panics(self) -> Self::Output;
+    fn wait_and_panic_on_unexpected_termination(self) -> Self::Output {
+        self.wait_for_panics_with(true)
+    }
+
+    /// Waits for `self` to finish, then check if its output is:
+    /// - a panic payload: resume that panic,
+    /// - a task termination: hang waiting for shutdown.
+    ///
+    /// Otherwise, returns the task return value of `self`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` contains a panic payload.
+    ///
+    /// # Hangs
+    ///
+    /// If `self` contains a task termination.
+    #[track_caller]
+    fn wait_for_panics(self) -> Self::Output {
+        self.wait_for_panics_with(false)
+    }
+
+    /// Waits for `self` to finish, then check if its output is:
+    /// - a panic payload: resume that panic,
+    /// - an unexpected termination:
+    ///   - if `panic_on_unexpected_termination` is true, panic with that error,
+    ///   - otherwise, hang waiting for shutdown,
+    /// - an expected termination: hang waiting for shutdown.
+    ///
+    /// Otherwise, returns the task return value of `self`.
+    ///
+    /// # Panics
+    ///
+    /// If `self` contains a panic payload, or if we're panicking on unexpected terminations.
+    ///
+    /// # Hangs
+    ///
+    /// If `self` contains an expected or ignored termination, and we're shutting down anyway.
+    #[track_caller]
+    fn wait_for_panics_with(self, panic_on_unexpected_termination: bool) -> Self::Output;
 }

--- a/zebra-chain/src/diagnostic/task.rs
+++ b/zebra-chain/src/diagnostic/task.rs
@@ -32,7 +32,7 @@ pub trait CheckForPanics: Sized {
     /// If `self` contains a panic payload.
     #[track_caller]
     fn panic_if_task_has_panicked(self) -> Self::Output {
-        self.check_for_panics_with(true)
+        self.check_for_panics_with(false)
     }
 
     /// Check if `self` contains a panic payload, then panic. Also panics if

--- a/zebra-chain/src/diagnostic/task/thread.rs
+++ b/zebra-chain/src/diagnostic/task/thread.rs
@@ -18,9 +18,11 @@ where
 {
     type Output = T;
 
-    /// Panics if the thread panicked.
-    /// If `panic_on_unexpected_termination` is true, and Zebra is not shutting down, also panics
-    /// if the thread exits.
+    /// # Panics
+    ///
+    /// - if the thread panicked.
+    /// - if the thread is cancelled, `panic_on_unexpected_termination` is true, and
+    ///   Zebra is not shutting down.
     ///
     /// Threads can't be cancelled except by using a panic, so there are no thread errors here.
     /// `panic_on_unexpected_termination` is

--- a/zebra-chain/src/diagnostic/task/thread.rs
+++ b/zebra-chain/src/diagnostic/task/thread.rs
@@ -8,19 +8,42 @@ use std::{
     thread::{self, JoinHandle},
 };
 
+use crate::shutdown::is_shutting_down;
+
 use super::{CheckForPanics, WaitForPanics};
 
-impl<T> CheckForPanics for thread::Result<T> {
+impl<T> CheckForPanics for thread::Result<T>
+where
+    T: std::fmt::Debug,
+{
     type Output = T;
 
     /// Panics if the thread panicked.
+    /// If `panic_on_unexpected_termination` is true, and Zebra is not shutting down, also panics
+    /// if the thread exits.
     ///
     /// Threads can't be cancelled except by using a panic, so there are no thread errors here.
+    /// `panic_on_unexpected_termination` is
     #[track_caller]
-    fn check_for_panics(self) -> Self::Output {
+    fn check_for_panics_with(self, panic_on_unexpected_termination: bool) -> Self::Output {
         match self {
             // The value returned by the thread when it finished.
-            Ok(thread_output) => thread_output,
+            Ok(thread_output) => {
+                if !panic_on_unexpected_termination {
+                    debug!(?thread_output, "ignoring expected thread exit");
+
+                    thread_output
+                } else if is_shutting_down() {
+                    debug!(
+                        ?thread_output,
+                        "ignoring thread exit because Zebra is shutting down"
+                    );
+
+                    thread_output
+                } else {
+                    panic!("thread unexpectedly exited with: {:?}", thread_output)
+                }
+            }
 
             // A thread error is always a panic.
             Err(panic_payload) => panic::resume_unwind(panic_payload),
@@ -28,17 +51,24 @@ impl<T> CheckForPanics for thread::Result<T> {
     }
 }
 
-impl<T> WaitForPanics for JoinHandle<T> {
+impl<T> WaitForPanics for JoinHandle<T>
+where
+    T: std::fmt::Debug,
+{
     type Output = T;
 
     /// Waits for the thread to finish, then panics if the thread panicked.
     #[track_caller]
-    fn wait_for_panics(self) -> Self::Output {
-        self.join().check_for_panics()
+    fn wait_for_panics_with(self, panic_on_unexpected_termination: bool) -> Self::Output {
+        self.join()
+            .check_for_panics_with(panic_on_unexpected_termination)
     }
 }
 
-impl<T> WaitForPanics for Arc<JoinHandle<T>> {
+impl<T> WaitForPanics for Arc<JoinHandle<T>>
+where
+    T: std::fmt::Debug,
+{
     type Output = Option<T>;
 
     /// If this is the final `Arc`, waits for the thread to finish, then panics if the thread
@@ -46,7 +76,7 @@ impl<T> WaitForPanics for Arc<JoinHandle<T>> {
     ///
     /// If this is not the final `Arc`, drops the handle and immediately returns `None`.
     #[track_caller]
-    fn wait_for_panics(self) -> Self::Output {
+    fn wait_for_panics_with(self, panic_on_unexpected_termination: bool) -> Self::Output {
         // If we are the last Arc with a reference to this handle,
         // we can wait for it and propagate any panics.
         //
@@ -56,14 +86,17 @@ impl<T> WaitForPanics for Arc<JoinHandle<T>> {
         // This is more readable as an expanded statement.
         #[allow(clippy::manual_map)]
         if let Some(handle) = Arc::into_inner(self) {
-            Some(handle.wait_for_panics())
+            Some(handle.wait_for_panics_with(panic_on_unexpected_termination))
         } else {
             None
         }
     }
 }
 
-impl<T> CheckForPanics for &mut Option<Arc<JoinHandle<T>>> {
+impl<T> CheckForPanics for &mut Option<Arc<JoinHandle<T>>>
+where
+    T: std::fmt::Debug,
+{
     type Output = Option<T>;
 
     /// If this is the final `Arc`, checks if the thread has finished, then panics if the thread
@@ -71,14 +104,14 @@ impl<T> CheckForPanics for &mut Option<Arc<JoinHandle<T>>> {
     ///
     /// If the thread has not finished, or this is not the final `Arc`, returns `None`.
     #[track_caller]
-    fn check_for_panics(self) -> Self::Output {
+    fn check_for_panics_with(self, panic_on_unexpected_termination: bool) -> Self::Output {
         let handle = self.take()?;
 
         if handle.is_finished() {
             // This is the same as calling `self.wait_for_panics()`, but we can't do that,
             // because we've taken `self`.
             #[allow(clippy::manual_map)]
-            return handle.wait_for_panics();
+            return handle.wait_for_panics_with(panic_on_unexpected_termination);
         }
 
         *self = Some(handle);
@@ -87,7 +120,10 @@ impl<T> CheckForPanics for &mut Option<Arc<JoinHandle<T>>> {
     }
 }
 
-impl<T> WaitForPanics for &mut Option<Arc<JoinHandle<T>>> {
+impl<T> WaitForPanics for &mut Option<Arc<JoinHandle<T>>>
+where
+    T: std::fmt::Debug,
+{
     type Output = Option<T>;
 
     /// If this is the final `Arc`, waits for the thread to finish, then panics if the thread
@@ -95,10 +131,13 @@ impl<T> WaitForPanics for &mut Option<Arc<JoinHandle<T>>> {
     ///
     /// If this is not the final `Arc`, drops the handle and returns `None`.
     #[track_caller]
-    fn wait_for_panics(self) -> Self::Output {
+    fn wait_for_panics_with(self, panic_on_unexpected_termination: bool) -> Self::Output {
         // This is more readable as an expanded statement.
         #[allow(clippy::manual_map)]
-        if let Some(output) = self.take()?.wait_for_panics() {
+        if let Some(output) = self
+            .take()?
+            .wait_for_panics_with(panic_on_unexpected_termination)
+        {
             Some(output)
         } else {
             // Some other task has a reference, so we should give up ours to let them use it.

--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -441,6 +441,8 @@ impl Client {
 
         let result = match self.heartbeat_task.poll_unpin(cx) {
             Poll::Pending => {
+                // The heartbeat task returns `Pending` while it continues to run.
+                // But if it has dropped its receiver, it is shutting down, and we should also shut down.
                 if is_canceled {
                     self.set_task_exited_error(
                         "heartbeat",

--- a/zebra-network/src/peer/error.rs
+++ b/zebra-network/src/peer/error.rs
@@ -82,6 +82,10 @@ pub enum PeerError {
     #[error("Internal services over capacity")]
     Overloaded,
 
+    /// There are no ready remote peers.
+    #[error("No ready peers available")]
+    NoReadyPeers,
+
     /// This peer request's caused an internal service timeout, so the connection was dropped
     /// to shed load or prevent attacks.
     #[error("Internal services timed out")]
@@ -147,6 +151,7 @@ impl PeerError {
             PeerError::Serialization(inner) => format!("Serialization({inner})").into(),
             PeerError::DuplicateHandshake => "DuplicateHandshake".into(),
             PeerError::Overloaded => "Overloaded".into(),
+            PeerError::NoReadyPeers => "NoReadyPeers".into(),
             PeerError::InboundTimeout => "InboundTimeout".into(),
             PeerError::ServiceShutdown => "ServiceShutdown".into(),
             PeerError::NotFoundResponse(_) => "NotFoundResponse".into(),

--- a/zebra-network/src/peer/load_tracked_client.rs
+++ b/zebra-network/src/peer/load_tracked_client.rs
@@ -20,6 +20,7 @@ use crate::{
 /// A client service wrapper that keeps track of its load.
 ///
 /// It also keeps track of the peer's reported protocol version.
+#[derive(Debug)]
 pub struct LoadTrackedClient {
     /// A service representing a connected peer, wrapped in a load tracker.
     service: PeakEwma<Client>,

--- a/zebra-network/src/peer_set/inventory_registry.rs
+++ b/zebra-network/src/peer_set/inventory_registry.rs
@@ -281,7 +281,7 @@ impl InventoryRegistry {
         Update::new(self)
     }
 
-    /// Drive periodic inventory tasks
+    /// Drive periodic inventory tasks.
     ///
     /// Rotates the inventory HashMaps on every timer tick.
     /// Drains the inv_stream channel and registers all advertised inventory.
@@ -330,6 +330,8 @@ impl InventoryRegistry {
             match channel_result {
                 Ok(change) => self.register(change),
                 Err(BroadcastStreamRecvError::Lagged(count)) => {
+                    // This isn't a fatal inventory error, it's expected behaviour when Zebra is
+                    // under load from peers.
                     metrics::counter!("pool.inventory.dropped", 1);
                     metrics::counter!("pool.inventory.dropped.messages", count);
 

--- a/zebra-network/src/peer_set/inventory_registry.rs
+++ b/zebra-network/src/peer_set/inventory_registry.rs
@@ -287,14 +287,14 @@ impl InventoryRegistry {
     /// Drains the inv_stream channel and registers all advertised inventory.
     ///
     /// Returns an error if the inventory channel is closed. Otherwise returns `Poll::Pending`, and
-    /// registers a wakeup the next time there is new inventory.
-    ///
-    /// TODO: also register a wakeup for the next timer tick.
-    /// (Currently the timer never wakes the task.)
+    /// registers a wakeup the next time there is new inventory, and the next time the inventory
+    /// should rotate.
     pub fn poll_inventory(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), BoxError>> {
         // # Correctness
         //
         // Registers the current task for wakeup when the timer next becomes ready.
+        // (But doesn't return, because we also want to register the task for wakeup when more
+        // inventory arrives.)
         //
         // # Security
         //

--- a/zebra-network/src/peer_set/inventory_registry/update.rs
+++ b/zebra-network/src/peer_set/inventory_registry/update.rs
@@ -19,8 +19,11 @@ pub struct Update<'a> {
 impl Unpin for Update<'_> {}
 
 impl<'a> Update<'a> {
-    #[allow(dead_code)]
-    pub(super) fn new(registry: &'a mut InventoryRegistry) -> Self {
+    /// Returns a new future that returns when the next inventory update or rotation has been
+    /// completed by `registry`.
+    ///
+    /// See [`InventoryRegistry::poll_inventory()`] for details.
+    pub fn new(registry: &'a mut InventoryRegistry) -> Self {
         Self { registry }
     }
 }
@@ -28,7 +31,7 @@ impl<'a> Update<'a> {
 impl Future for Update<'_> {
     type Output = Result<(), BoxError>;
 
-    /// A future that returns when the next inventory update has been completed.
+    /// A future that returns when the next inventory update or rotation has been completed.
     ///
     /// See [`InventoryRegistry::poll_inventory()`] for details.
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/zebra-network/src/peer_set/inventory_registry/update.rs
+++ b/zebra-network/src/peer_set/inventory_registry/update.rs
@@ -28,9 +28,10 @@ impl<'a> Update<'a> {
 impl Future for Update<'_> {
     type Output = Result<(), BoxError>;
 
+    /// A future that returns when the next inventory update has been completed.
+    ///
+    /// See [`InventoryRegistry::poll_inventory()`] for details.
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // TODO: should the future wait until new changes arrive?
-        //       or for the rotation timer?
-        Poll::Ready(self.registry.poll_inventory(cx))
+        self.registry.poll_inventory(cx)
     }
 }

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -522,11 +522,11 @@ where
     /// task.)
     ///
     /// Returns `Poll::Ready` if there are some ready peers, and `Poll::Pending` if there are no
-    /// ready peers. Never registers any task wakeups.
+    /// ready peers. Registers a wakeup if any peer has failed due to a disconnection, hang, or protocol error.
     ///
     /// # Panics
     ///
-    /// If any peers somehow became unready. This indicates a bug in the peer set, where requests
+    /// If any peers somehow became unready without being sent a request. This indicates a bug in the peer set, where requests
     /// are sent to peers without putting them in `unready_peers`.
     fn poll_ready_peer_errors(&mut self, cx: &mut Context<'_>) -> Poll<()> {
         let mut previous = HashMap::new();

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -327,6 +327,8 @@ where
 
     /// Check background task handles to make sure they're still running.
     ///
+    /// Never returns `Ok`.
+    ///
     /// If any background task exits, shuts down all other background tasks,
     /// and returns an error. Otherwise, returns `Pending`, and registers a wakeup for
     /// receiving the background tasks, or the background tasks exiting.

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -1018,23 +1018,24 @@ where
         // - an unready peer becomes ready, or
         // - a new peer arrives.
 
-        // Check for new peers, and register a task wake when the next new peers arrive. New peers
+        // Check for new peers, and register a task wakeup when the next new peers arrive. New peers
         // can be infrequent if our connection slots are full, or we're connected to all
         // available/useful peers.
-        let _ = self.poll_discover(cx)?;
+        let _poll_pending: Poll<()> = self.poll_discover(cx)?;
 
         // These tasks don't provide new peers or newly ready peers.
-        let _ = self.poll_background_errors(cx)?;
-        let _ = self.inventory_registry.poll_inventory(cx)?;
+        let _poll_pending: Poll<()> = self.poll_background_errors(cx)?;
+        let _poll_pending: Poll<()> = self.inventory_registry.poll_inventory(cx)?;
 
         // Check for newly ready peers, including newly added peers (which are added as unready).
-        // So it needs to run after `poll_discover()`.
+        // So it needs to run after `poll_discover()`. Registers a wakeup if there are any unready
+        // peers.
         //
         // Each connected peer should become ready within a few minutes, or timeout, close the
         // connection, and release its connection slot.
         //
         // TODO: drop peers that overload us with inbound messages and never become ready (#7822)
-        let _ = self.poll_unready(cx)?;
+        let _poll_pending_or_ready: Poll<()> = self.poll_unready(cx)?;
 
         // Cleanup and metrics.
 

--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -1,7 +1,8 @@
 //! Fixed test vectors for the peer set.
 
-use std::{cmp::max, iter};
+use std::{cmp::max, iter, time::Duration};
 
+use tokio::time::timeout;
 use tower::{Service, ServiceExt};
 
 use zebra_chain::{
@@ -9,7 +10,6 @@ use zebra_chain::{
     parameters::{Network, NetworkUpgrade},
 };
 
-use super::{PeerSetBuilder, PeerVersions};
 use crate::{
     constants::DEFAULT_MAX_CONNS_PER_IP,
     peer::{ClientRequest, MinimumPeerVersion},
@@ -17,6 +17,8 @@ use crate::{
     protocol::external::{types::Version, InventoryHash},
     Request, SharedPeerError,
 };
+
+use super::{PeerSetBuilder, PeerVersions};
 
 #[test]
 fn peer_set_ready_single_connection() {
@@ -171,12 +173,7 @@ fn peer_set_ready_multiple_connections() {
 
         // Peer set hangs when no more connections are present
         let peer_ready = peer_set.ready();
-        peer_ready
-            .await
-            .expect("peer set is always ready until peers are cleared");
-
-        // TODO: re-enable this check when waiting is fixed?
-        //assert!(timeout(Duration::from_secs(10), peer_ready).await.is_err());
+        assert!(timeout(Duration::from_secs(10), peer_ready).await.is_err());
     });
 }
 

--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -1,8 +1,7 @@
 //! Fixed test vectors for the peer set.
 
-use std::{cmp::max, iter, time::Duration};
+use std::{cmp::max, iter};
 
-use tokio::time::timeout;
 use tower::{Service, ServiceExt};
 
 use zebra_chain::{
@@ -172,7 +171,12 @@ fn peer_set_ready_multiple_connections() {
 
         // Peer set hangs when no more connections are present
         let peer_ready = peer_set.ready();
-        assert!(timeout(Duration::from_secs(10), peer_ready).await.is_err());
+        peer_ready
+            .await
+            .expect("peer set is always ready until peers are cleared");
+
+        // TODO: re-enable this check when waiting is fixed?
+        //assert!(timeout(Duration::from_secs(10), peer_ready).await.is_err());
     });
 }
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -883,7 +883,7 @@ impl DbFormatChangeThreadHandle {
     ///
     /// This method should be called regularly, so that panics are detected as soon as possible.
     pub fn check_for_panics(&mut self) {
-        self.update_task.check_for_panics();
+        self.update_task.panic_if_task_has_panicked();
     }
 
     /// Wait for the spawned thread to finish. If it exited with a panic, resume that panic.


### PR DESCRIPTION
## Motivation

Zebra's peer handling code is complex, and it contains some potential hangs. This PR fixes some hangs, and simplifies the code.

Follow up to #7772
Close #7858

### Specifications

Rust futures wake a task when any waker cloned from the most recently passed Context is woken:
> When a future is not ready yet, poll returns Poll::Pending and stores a clone of the [Waker](https://doc.rust-lang.org/std/task/struct.Waker.html) copied from the current [Context](https://doc.rust-lang.org/std/task/struct.Context.html). This [Waker](https://doc.rust-lang.org/std/task/struct.Waker.html) is then woken once the future can make progress.
> ...
> Note that on multiple calls to poll, only the [Waker](https://doc.rust-lang.org/std/task/struct.Waker.html) from the [Context](https://doc.rust-lang.org/std/task/struct.Context.html) passed to the most recent call should be scheduled to receive a wakeup.

https://doc.rust-lang.org/std/future/trait.Future.html#tymethod.poll

### Complex Code or Requirements

This PR contains a lot of refactors to make future changes easier.
It also eliminates some wakers entirely to simplify the code and waking logic.

## Solution

Bug fixes:
- Pass context correctly to the peer set background task oneshot. (We're not waking on it now, but we might want to in future.)
- Pass context correctly to the peer client task, and the peer client request sender, so they always wake the client task. (The client task is the task that is spawned by the peer set buffer.)
- Check all ready peers for errors before sending requests to them.

Code simplification:
- Remove preselected peers, just select the peer when we have a new request. This makes waking much less complex.
- Use `futures::ready!` (the macro) and `?` to simplify polling

Refactors:
- Refactor polling methods to return `Poll`, and `Ok` if they do something
- Make panic checking method names clearer (this can be split into its own PR)

### Testing

The existing tests cover this behaviour fairly well. It is hard to check for hangs in tests.

Some tests have been updated for the new polling behaviour.

## Review

This might still need some test fixes.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- #7858 
- #7822