### PR TITLE
fix(net): Add outer timeouts for critical network operations to avoid hangs

### DIFF
--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -168,6 +168,7 @@ toml = "0.8.3"
 futures = "0.3.29"
 rayon = "1.7.0"
 tokio = { version = "1.33.0", features = ["time", "rt-multi-thread", "macros", "tracing", "signal"] }
+tokio-stream = { version = "0.1.14", features = ["time"] }
 tower = { version = "0.4.13", features = ["hedge", "limit"] }
 pin-project = "1.1.3"
 

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -9,7 +9,7 @@ use std::{
     collections::HashSet,
     future::Future,
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, TryLockError},
     task::{Context, Poll},
     time::Duration,
 };
@@ -278,7 +278,11 @@ impl Service<zn::Request> for Inbound {
                     }
                 }
                 Err(TryRecvError::Empty) => {
-                    // There's no setup data yet, so keep waiting for it
+                    // There's no setup data yet, so keep waiting for it.
+                    //
+                    // We could use Future::poll() to get a waker and return Poll::Pending here.
+                    // But we want to drop excess requests during startup instead. Otherwise,
+                    // the inbound service gets overloaded, and starts disconnecting peers.
                     result = Ok(());
                     Setup::Pending {
                         full_verify_concurrency_limit,
@@ -307,6 +311,11 @@ impl Service<zn::Request> for Inbound {
                 mempool,
                 state,
             } => {
+                // # Correctness
+                //
+                // Clear the stream but ignore the final Pending return value.
+                // If we returned Pending here, and there were no waiting block downloads,
+                // then inbound requests would wait for the next block download, and hang forever.
                 while let Poll::Ready(Some(_)) = block_downloads.as_mut().poll_next(cx) {}
 
                 result = Ok(());
@@ -366,20 +375,35 @@ impl Service<zn::Request> for Inbound {
                 //
                 // # Correctness
                 //
-                // Briefly hold the address book threaded mutex while
-                // cloning the address book. Then sanitize in the future,
-                // after releasing the lock.
-                let peers = address_book.lock().unwrap().clone();
+                // If the address book is busy, try again inside the future. If it can't be locked
+                // twice, ignore the request.
+                let address_book = address_book.clone();
+
+                let get_peers = move || match address_book.try_lock() {
+                    Ok(address_book) => Some(address_book.clone()),
+                    Err(TryLockError::WouldBlock) => None,
+                    Err(TryLockError::Poisoned(_)) => panic!("previous thread panicked while holding the address book lock"),
+                };
+
+                let peers = get_peers();
 
                 async move {
-                    // Correctness: get the current time after acquiring the address book lock.
+                                        // Correctness: get the current time inside the future.
                     //
-                    // This time is used to filter outdated peers, so it doesn't really matter
+                    // This time is used to filter outdated peers, so it doesn't matter much
                     // if we get it when the future is created, or when it starts running.
                     let now = Utc::now();
 
+                    // If we didn't get the peers when the future was created, wait for other tasks
+                    // to run, then try again when the future first runs.
+                    if peers.is_none() {
+                        tokio::task::yield_now().await;
+                    }
+                    let peers = peers.or_else(get_peers);
+                    let is_busy = peers.is_none();
+
                     // Send a sanitized response
-                    let mut peers = peers.sanitized(now);
+                    let mut peers = peers.map_or_else(Vec::new, |peers| peers.sanitized(now));
 
                     // Truncate the list
                     let address_limit = div_ceil(peers.len(), ADDR_RESPONSE_LIMIT_DENOMINATOR);
@@ -387,8 +411,20 @@ impl Service<zn::Request> for Inbound {
                     peers.truncate(address_limit);
 
                     if peers.is_empty() {
-                        // We don't know if the peer response will be empty until we've sanitized them.
-                        debug!("ignoring `Peers` request from remote peer because our address book is empty");
+                        // Sometimes we don't know if the peer response will be empty until we've
+                        // sanitized them.
+                        if is_busy {
+                            debug!(
+                                "ignoring `Peers` request from remote peer because our address \
+                                 book has no available peers"
+                            );
+                        } else {
+                            info!(
+                                "ignoring `Peers` request from remote peer because our address \
+                                 book is busy"
+                            );
+                        }
+
                         Ok(zn::Response::Nil)
                     } else {
                         Ok(zn::Response::Peers(peers))

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -388,7 +388,7 @@ impl Service<zn::Request> for Inbound {
                 let peers = get_peers();
 
                 async move {
-                                        // Correctness: get the current time inside the future.
+                    // Correctness: get the current time inside the future.
                     //
                     // This time is used to filter outdated peers, so it doesn't matter much
                     // if we get it when the future is created, or when it starts running.

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -414,14 +414,14 @@ impl Service<zn::Request> for Inbound {
                         // Sometimes we don't know if the peer response will be empty until we've
                         // sanitized them.
                         if is_busy {
-                            debug!(
-                                "ignoring `Peers` request from remote peer because our address \
-                                 book has no available peers"
-                            );
-                        } else {
                             info!(
                                 "ignoring `Peers` request from remote peer because our address \
                                  book is busy"
+                            );
+                        } else {
+                            debug!(
+                                "ignoring `Peers` request from remote peer because our address \
+                                 book has no available peers"
                             );
                         }
 

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -50,7 +50,11 @@
 use std::{collections::HashSet, time::Duration};
 
 use futures::{future, pin_mut, stream::FuturesUnordered, StreamExt};
-use tokio::{sync::watch, task::JoinHandle, time::sleep};
+use tokio::{
+    sync::watch,
+    task::JoinHandle,
+    time::{sleep, timeout},
+};
 use tower::{timeout::Timeout, BoxError, Service, ServiceExt};
 use tracing_futures::Instrument;
 
@@ -191,7 +195,14 @@ where
 
         loop {
             self.wait_until_enabled().await?;
-            self.crawl_transactions().await?;
+            // Avoid hangs when the peer service is not ready, or due to bugs in async code.
+            timeout(RATE_LIMIT_DELAY, self.crawl_transactions())
+                .await
+                .unwrap_or_else(|timeout| {
+                    // Temporary errors just get logged and ignored.
+                    info!("mempool crawl timed out: {timeout:?}");
+                    Ok(())
+                })?;
             sleep(RATE_LIMIT_DELAY).await;
         }
     }

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -81,7 +81,7 @@ const FANOUT: usize = 3;
 ///
 /// Using a prime number makes sure that mempool crawler fanouts
 /// don't synchronise with other crawls.
-const RATE_LIMIT_DELAY: Duration = Duration::from_secs(73);
+pub const RATE_LIMIT_DELAY: Duration = Duration::from_secs(73);
 
 /// The time to wait for a peer response.
 ///

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -214,7 +214,10 @@ const SYNC_RESTART_DELAY: Duration = Duration::from_secs(67);
 /// If this timeout is removed (or set too low), Zebra will immediately retry
 /// to download and verify the genesis block from its peers. This can cause
 /// a denial of service on those peers.
-const GENESIS_TIMEOUT_RETRY: Duration = Duration::from_secs(5);
+///
+/// If this timeout is too short, old or buggy nodes will keep making useless
+/// network requests. If there are a lot of them, it could overwhelm the network.
+const GENESIS_TIMEOUT_RETRY: Duration = Duration::from_secs(10);
 
 /// Sync configuration section.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -548,7 +548,7 @@ where
     /// following a fork. Either way, Zebra should attempt to obtain some more tips.
     ///
     /// Returns `Err` if there was an unrecoverable error and restarting the synchronization is
-    /// necessary. This includes outer timeouts, where an entire syncing step takes an extrememly
+    /// necessary. This includes outer timeouts, where an entire syncing step takes an extremely
     /// long time. (These usually indicate hangs.)
     #[instrument(skip(self))]
     async fn try_to_sync(&mut self) -> Result<(), Report> {

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -154,6 +154,17 @@ pub enum BlockDownloadVerifyError {
         height: block::Height,
         hash: block::Hash,
     },
+
+    #[error(
+        "timeout during service readiness, download, verification, or internal downloader operation"
+    )]
+    Timeout,
+}
+
+impl From<tokio::time::error::Elapsed> for BlockDownloadVerifyError {
+    fn from(_value: tokio::time::error::Elapsed) -> Self {
+        BlockDownloadVerifyError::Timeout
+    }
 }
 
 /// Represents a [`Stream`] of download and verification tasks during chain sync.

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -487,6 +487,7 @@ where
 
                     // But if Zebra is shutting down, ignore the send error.
                     let _ = past_lookahead_limit_sender.lock().expect("thread panicked while holding the past_lookahead_limit_sender mutex guard").send(false);
+                    metrics::counter!("sync.max.height.limit.reset.count", 1);
 
                     metrics::counter!("sync.max.height.limit.reset.attempt.count", 1);
                 }


### PR DESCRIPTION
## Motivation

This is a quick fix for Zebra hanging rather than disconnecting when the peer set is empty. It prevents the requesting service side of the hang.

Close #7772

### Specifications

Sometimes a hang can happen if the called service doesn't correctly set up its waker (a bug), the request is really expensive, or the service is full of requests.

### Complex Code or Requirements

It seems unnecessary to have timeouts within service implementations, and in their callers. But it's very easy to add code that doesn't have a timeout, or has a subtle hang or slowness bug under some conditions. So we should move timeouts as far out of the service stack as possible, to include more code.

For now this PR just adds timeouts to the outermost layer of critical network services, or explains how they are already implemented.

## Solution

Timeouts:
- Add a timeout to syncer obtain, extend, and genesis block downloads and verifies
- Add a timeout to mempool crawls
- Add a timeout to mempool download and verify

Hang fixes:
- Remove a potential hang from address book requests
- Remove a potential hang when the lookahead limit is reached, then the pending blocks drop below the limit
- Remove a potential hang when the lookahead limit is reached, then the syncer is completely reset

Documentation:
- Explain why the inbound service never hangs

### Testing

- [x] TODO: Manually disconnect Zebra from the network for more than 10 minutes, then restore the network, and make sure that it reconnects within 10 minutes

## Review

This PR would be good to get in the release. It is low risk, because it just adds timeouts to existing code. (Or ignores inbound peers requests under load.)

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [ ] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

PR #7859 is a more complicated fix to an underlying peer set bug. But it should go in the next release to get more testing.