### PR TITLE
change(docs): Replace doc.zebra.zfnd.org API documentation with docs.rs

### DIFF
--- a/.github/workflows/docs-deploy-firebase.patch.yml
+++ b/.github/workflows/docs-deploy-firebase.patch.yml
@@ -27,13 +27,6 @@ jobs:
     steps:
       - run: 'echo "No build required"'
 
-  build-docs-external:
-    name: Build and Deploy Zebra External Docs
-    timeout-minutes: 45
-    runs-on: ubuntu-latest
-    steps:
-      - run: 'echo "No build required"'
-
   build-docs-internal:
     name: Build and Deploy Zebra Internal Docs
     timeout-minutes: 45

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -114,62 +114,6 @@ jobs:
           projectId: ${{ vars.GCP_FIREBASE_PROJECT }}
           target: docs-book
 
-  build-docs-external:
-    name: Build and Deploy Zebra External Docs
-    timeout-minutes: 45
-    runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      contents: 'read'
-      id-token: 'write'
-      pull-requests: write
-    steps:
-      - name: Checkout the source code
-        uses: actions/checkout@v4.1.1
-        with:
-          persist-credentials: false
-
-      - name: Install last version of Protoc
-        uses: arduino/setup-protoc@v2.1.0
-        with:
-          version: '23.x'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Setup Rust with beta toolchain and default profile (to include rust-docs)
-      - name: Setup Rust
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=beta --profile=default
-
-      - uses: Swatinem/rust-cache@v2.7.1
-
-      - name: Build external docs
-        run: |
-          # Exclude zebra-utils and zebra-test, they are not for library or app users
-          cargo doc --no-deps --workspace --all-features --exclude zebra-utils --exclude zebra-test --target-dir "$(pwd)"/target/external
-
-      # Setup gcloud CLI
-      - name: Authenticate to Google Cloud
-        id: auth
-        uses: google-github-actions/auth@v1.1.1
-        with:
-          retries: '3'
-          workload_identity_provider: '${{ vars.GCP_WIF }}'
-          service_account: '${{ vars.GCP_FIREBASE_SA }}'
-
-      # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed
-      - name: Add $GCP_FIREBASE_SA_PATH to env
-        run: |
-          # shellcheck disable=SC2002
-          echo "GCP_FIREBASE_SA_PATH=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
-
-      - name: Deploy external docs to firebase
-        uses: FirebaseExtended/action-hosting-deploy@v0.7.1
-        with:
-          firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA_PATH }}
-          channelId: ${{ env.FIREBASE_CHANNEL }}
-          target: docs-external
-          projectId: ${{ vars.GCP_FIREBASE_PROJECT }}
-
   build-docs-internal:
     name: Build and Deploy Zebra Internal Docs
     timeout-minutes: 45

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -996,12 +996,12 @@ When there are a lot of large user-generated transactions on the network, Zebra 
 
 ### Configuration Changes
 
-- Split the checkpoint and full verification [`sync` concurrency options](https://doc.zebra.zfnd.org/zebrad/config/struct.SyncSection.html) (#4726, #4758):
+- Split the checkpoint and full verification [`sync` concurrency options](https://docs.rs/zebrad/latest/zebrad/config/struct.SyncSection.html) (#4726, #4758):
   - Add a new `full_verify_concurrency_limit`
   - Rename `max_concurrent_block_requests` to `download_concurrency_limit`
   - Rename `lookahead_limit` to `checkpoint_verify_concurrency_limit`
   For backwards compatibility, the old names are still accepted as aliases.
-- Add a new `parallel_cpu_threads` [`sync` concurrency option](https://doc.zebra.zfnd.org/zebrad/config/struct.SyncSection.html) (#4776).
+- Add a new `parallel_cpu_threads` [`sync` concurrency option](https://docs.rs/zebrad/latest/zebrad/config/struct.SyncSection.html) (#4776).
   This option sets the number of threads to use for CPU-bound tasks, such as proof and signature verification.
   By default, Zebra uses all available CPU cores.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1007,12 +1007,12 @@ When there are a lot of large user-generated transactions on the network, Zebra 
 
 ### Configuration Changes
 
-- Split the checkpoint and full verification [`sync` concurrency options](https://docs.rs/zebrad/latest/zebrad/config/struct.SyncSection.html) (#4726, #4758):
+- Split the checkpoint and full verification [`sync` concurrency options](https://docs.rs/zebrad/latest/zebrad/components/sync/struct.Config.html) (#4726, #4758):
   - Add a new `full_verify_concurrency_limit`
   - Rename `max_concurrent_block_requests` to `download_concurrency_limit`
   - Rename `lookahead_limit` to `checkpoint_verify_concurrency_limit`
   For backwards compatibility, the old names are still accepted as aliases.
-- Add a new `parallel_cpu_threads` [`sync` concurrency option](https://docs.rs/zebrad/latest/zebrad/config/struct.SyncSection.html) (#4776).
+- Add a new `parallel_cpu_threads` [`sync` concurrency option](https://docs.rs/zebrad/latest/zebrad/components/sync/struct.Config.html) (#4776).
   This option sets the number of threads to use for CPU-bound tasks, such as proof and signature verification.
   By default, Zebra uses all available CPU cores.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,17 @@ so it can't be used to retry failed downloads in `zebrad` 1.3.0 and earlier.
 
 We recommend upgrading to the latest Zebra release to avoid download issues in new installs.
 
+### Documentation Website Change
+
+We have replaced the API documentation on the [doc.zebra.zfnd.org](https://doc.zebra.zfnd.org)
+website with [docs.rs](https://docs.rs/releases/search?query=zebra). All links have been updated.
+
+Zebra's API documentation can be found on:
+- [`docs.rs`](https://docs.rs/releases/search?query=zebra), which renders documentation for the
+  public API of the latest crate releases;
+- [`doc-internal.zebra.zfnd.org`](https://doc-internal.zebra.zfnd.org/), which renders
+  documentation for the internal API on the `main` branch.
+
 ### Security
 
 TODO: rest of changelog

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ consensus-compatible implementation of a Zcash node.
 Zebra's network stack is interoperable with `zcashd`, and Zebra implements all
 the features required to reach Zcash network consensus, including the validation
 of all the consensus rules for the NU5 network upgrade.
-[Here](https://doc.zebra.zfnd.org/zebrad/index.html#zebra-advantages) are some
+[Here](https://docs.rs/zebrad/latest/zebrad/index.html#zebra-advantages) are some
 benefits of Zebra.
 
 Zebra validates blocks and transactions, but needs extra software to generate
@@ -148,8 +148,7 @@ You can combine multiple features by listing them as parameters of the `--featur
 cargo install --features="<feature1> <feature2> ..." ...
 ```
 
-Our full list of experimental and developer features is in [the API
-documentation](https://doc.zebra.zfnd.org/zebrad/index.html#zebra-feature-flags).
+Our full list of experimental and developer features is in [the API documentation](https://docs.rs/zebrad/latest/zebrad/index.html#zebra-feature-flags).
 
 Some debugging and monitoring features are disabled in release builds to increase
 performance.

--- a/README.md
+++ b/README.md
@@ -176,10 +176,12 @@ We will continue to add new features as part of future network upgrades, and in 
 
 The [Zebra website](https://zebra.zfnd.org/) contains user documentation, such
 as how to run or configure Zebra, set up metrics integrations, etc., as well as
-developer documentation, such as design documents. We also render [API
-documentation](https://doc.zebra.zfnd.org) for the external API of our crates,
-as well as [internal documentation](https://doc-internal.zebra.zfnd.org) for
-private APIs.
+developer documentation, such as design documents. It also renders
+[internal documentation](https://doc-internal.zebra.zfnd.org) for private APIs
+on the `main` branch.
+
+`docs.rs` renders [API documentation](https://docs.rs/releases/search?query=zebra)
+for the external API of the latest releases of our crates.
 
 ## User support
 

--- a/book/src/api.md
+++ b/book/src/api.md
@@ -2,5 +2,5 @@
 
 Zebra's API documentation is generated using Rustdoc:
 
-- [`doc.zebra.zfnd.org`](https://doc.zebra.zfnd.org/) renders documentation for the public API;
+- [`docs.rs`](https://docs.rs/) renders documentation for the public API;
 - [`doc-internal.zebra.zfnd.org`](https://doc-internal.zebra.zfnd.org/) renders documentation for the internal API.

--- a/book/src/api.md
+++ b/book/src/api.md
@@ -2,5 +2,7 @@
 
 Zebra's API documentation is generated using Rustdoc:
 
-- [`docs.rs`](https://docs.rs/) renders documentation for the public API;
-- [`doc-internal.zebra.zfnd.org`](https://doc-internal.zebra.zfnd.org/) renders documentation for the internal API.
+- [`docs.rs`](https://docs.rs/releases/search?query=zebra) renders documentation for the public API
+  of the latest crate releases;
+- [`doc-internal.zebra.zfnd.org`](https://doc-internal.zebra.zfnd.org/) renders documentation for
+  the internal API on the `main` branch.

--- a/book/src/dev.md
+++ b/book/src/dev.md
@@ -3,5 +3,5 @@
 This section contains the contribution guide and design documentation. It
 does not contain API documentation, which is generated using Rustdoc:
 
-- [`doc.zebra.zfnd.org`](https://doc.zebra.zfnd.org/) renders documentation for the public API;
+- [`docs.rs`](https://docs.rs/) renders documentation for the public API;
 - [`doc-internal.zebra.zfnd.org`](https://doc-internal.zebra.zfnd.org/) renders documentation for the internal API.

--- a/book/src/dev.md
+++ b/book/src/dev.md
@@ -3,5 +3,7 @@
 This section contains the contribution guide and design documentation. It
 does not contain API documentation, which is generated using Rustdoc:
 
-- [`docs.rs`](https://docs.rs/) renders documentation for the public API;
-- [`doc-internal.zebra.zfnd.org`](https://doc-internal.zebra.zfnd.org/) renders documentation for the internal API.
+- [`docs.rs`](https://docs.rs/releases/search?query=zebra) renders documentation for the public API
+  of the latest crate releases;
+- [`doc-internal.zebra.zfnd.org`](https://doc-internal.zebra.zfnd.org/) renders documentation for
+  the internal API on the `main` branch.

--- a/book/src/dev/overview.md
+++ b/book/src/dev/overview.md
@@ -86,7 +86,7 @@ other functionality, without requiring a full node.
 At a high level, the fullnode functionality required by `zebrad` is factored
 into several components:
 
-- [`zebra-chain`](https://doc.zebra.zfnd.org/zebra_chain/index.html), providing
+- [`zebra-chain`](https://docs.rs/zebra_chain), providing
   definitions of core data structures for Zcash, such as blocks, transactions,
   addresses, etc., and related functionality.  It also contains the
   implementation of the consensus-critical serialization formats used in Zcash.
@@ -100,7 +100,7 @@ into several components:
   towards verifying transactions, but will be extended to support creating them
   in the future.
 
-- [`zebra-network`](https://doc.zebra.zfnd.org/zebra_network/index.html),
+- [`zebra-network`](https://docs.rs/zebra_network),
   providing an asynchronous, multithreaded implementation of the Zcash network
   protocol inherited from Bitcoin. In contrast to `zcashd`, each peer
   connection has a separate state machine, and the crate translates the
@@ -113,21 +113,21 @@ into several components:
     isolated from all other node state.  This can be used, for instance, to
     safely relay data over Tor, without revealing distinguishing information.
 
-- [`zebra-script`](https://doc.zebra.zfnd.org/zebra_script/index.html) provides
+- [`zebra-script`](https://docs.rs/zebra_script) provides
   script validation. Currently, this is implemented by linking to the C++
   script verification code from `zcashd`, but in the future we may implement a
   pure-Rust script implementation.
 
-- [`zebra-consensus`](https://doc.zebra.zfnd.org/zebra_consensus/index.html)
+- [`zebra-consensus`](https://docs.rs/zebra_consensus)
   performs [*semantic validation*](https://zebra.zfnd.org/dev/rfcs/0002-parallel-verification.html#verification-stages)
   of blocks and transactions: all consensus
   rules that can be checked independently of the chain state, such as
   verification of signatures, proofs, and scripts. Internally, the library
-  uses [`tower-batch-control`](https://doc.zebra.zfnd.org/tower_batch_control/index.html) to
+  uses [`tower-batch-control`](https://docs.rs/tower_batch_control) to
   perform automatic, transparent batch processing of contemporaneous
   verification requests.
 
-- [`zebra-state`](https://doc.zebra.zfnd.org/zebra_state/index.html) is
+- [`zebra-state`](https://docs.rs/zebra_state) is
   responsible for storing, updating, and querying the chain state. The state
   service is responsible for [*contextual verification*](https://zebra.zfnd.org/dev/rfcs/0002-parallel-verification.html#verification-stages):
   all consensus rules
@@ -135,7 +135,7 @@ into several components:
   such as updating the nullifier set or checking that transaction inputs remain
   unspent.
 
-- [`zebrad`](https://doc.zebra.zfnd.org/zebrad/index.html) contains the full
+- [`zebrad`](https://docs.rs/zebrad) contains the full
   node, which connects these components together and implements logic to handle
   inbound requests from peers and the chain sync process.
 

--- a/book/src/dev/rfcs/0004-asynchronous-script-verification.md
+++ b/book/src/dev/rfcs/0004-asynchronous-script-verification.md
@@ -31,11 +31,11 @@ and in parallel on a thread pool.
 - unlock script: a script satisfying the conditions of the lock script, allowing a UTXO to be spent.
   Stored in the [`transparent::Input::PrevOut::lock_script`][lock_script] field.
 
-[transout]: https://doc.zebra.zfnd.org/zebra_chain/transparent/struct.Output.html
-[outpoint]: https://doc.zebra.zfnd.org/zebra_chain/transparent/struct.OutPoint.html
-[lock_script]: https://doc.zebra.zfnd.org/zebra_chain/transparent/struct.Output.html#structfield.lock_script
-[transin]: https://doc.zebra.zfnd.org/zebra_chain/transparent/enum.Input.html
-[unlock_script]: https://doc.zebra.zfnd.org/zebra_chain/transparent/enum.Input.html#variant.PrevOut.field.unlock_script
+[transout]: https://doc-internal.zebra.zfnd.org/zebra_chain/transparent/struct.Output.html
+[outpoint]: https://doc-internal.zebra.zfnd.org/zebra_chain/transparent/struct.OutPoint.html
+[lock_script]: https://doc-internal.zebra.zfnd.org/zebra_chain/transparent/struct.Output.html#structfield.lock_script
+[transin]: https://doc-internal.zebra.zfnd.org/zebra_chain/transparent/enum.Input.html
+[unlock_script]: https://doc-internal.zebra.zfnd.org/zebra_chain/transparent/enum.Input.html#variant.PrevOut.field.unlock_script
 
 
 # Guide-level explanation

--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -713,9 +713,9 @@ validation and the anchor calculations.)
 Hypothetically, if Sapling were activated from genesis, the specification requires
 a Sapling anchor, but `zcashd` would ignore that anchor.
 
-[`JoinSplit`]: https://doc.zebra.zfnd.org/zebra_chain/sprout/struct.JoinSplit.html
-[`Spend`]: https://doc.zebra.zfnd.org/zebra_chain/sapling/spend/struct.Spend.html
-[`Action`]: https://doc.zebra.zfnd.org/zebra_chain/orchard/struct.Action.html
+[`JoinSplit`]: https://doc-internal.zebra.zfnd.org/zebra_chain/sprout/struct.JoinSplit.html
+[`Spend`]: https://doc-internal.zebra.zfnd.org/zebra_chain/sapling/spend/struct.Spend.html
+[`Action`]: https://doc-internal.zebra.zfnd.org/zebra_chain/orchard/struct.Action.html
 
 These updates can be performed in a batch or without necessarily iterating
 over all transactions, if the data is available by other means; they're

--- a/book/src/user/lightwalletd.md
+++ b/book/src/user/lightwalletd.md
@@ -55,7 +55,7 @@ parallel_cpu_threads = 0
 ```
 
 **WARNING:** This config allows multiple Zebra instances to share the same RPC port.
-See the [RPC config documentation](https://doc.zebra.zfnd.org/zebra_rpc/config/struct.Config.html) for details.
+See the [RPC config documentation](https://docs.rs/zebra_rpc/latest/zebra_rpc/config/struct.Config.html) for details.
 
 ## Sync Zebra
 
@@ -71,7 +71,7 @@ Zebra will display information about sync process:
 
 ```console
 ...
-zebrad::commands::start: estimated progress to chain tip sync_percent=10.783 % 
+zebrad::commands::start: estimated progress to chain tip sync_percent=10.783 %
 ...
 ```
 
@@ -79,13 +79,13 @@ Until eventually it will get there:
 
 ```console
 ...
-zebrad::commands::start: finished initial sync to chain tip, using gossiped blocks sync_percent=100.000 % 
+zebrad::commands::start: finished initial sync to chain tip, using gossiped blocks sync_percent=100.000 %
 ...
 ```
 
 You can interrupt the process at any time with `ctrl-c` and Zebra will resume the next time at around the block you were downloading when stopping the process.
 
-When deploying for production infrastructure, the above command can/should be implemented as a server service or similar configuration. 
+When deploying for production infrastructure, the above command can be run as a service or daemon.
 
 For implementing zebra as a service please see [here](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/systemd/zebrad.service).
 
@@ -144,7 +144,7 @@ Wait until lightwalletd is in sync before connecting any wallet into it. You wil
 ## Run tests
 [#run-tests]: (#run-tests)
 
-The Zebra team created tests for the interaction of `zebrad` and `lightwalletd`. 
+The Zebra team created tests for the interaction of `zebrad` and `lightwalletd`.
 
 To run all the Zebra `lightwalletd` tests:
 1. install `lightwalletd`
@@ -156,7 +156,7 @@ Please refer to [acceptance](https://github.com/ZcashFoundation/zebra/blob/main/
 ## Connect a wallet to lightwalletd
 [#connect-wallet-to-lightwalletd]: (#connect-wallet-to-lightwalletd)
 
-The final goal is to connect wallets to the lightwalletd service backed by Zebra. 
+The final goal is to connect wallets to the lightwalletd service backed by Zebra.
 
 For demo purposes we used [zecwallet-cli](https://github.com/adityapk00/zecwallet-light-cli) with the [adityapk00/lightwalletd](https://github.com/adityapk00/lightwalletd) fork.
 We didn't test [zecwallet-cli](https://github.com/adityapk00/zecwallet-light-cli) with [zcash/lightwalletd](https://github.com/zcash/lightwalletd) yet.
@@ -184,5 +184,5 @@ Lightclient connecting to http://127.0.0.1:9067/
   "total_blocks_synced": 49476
 }
 Ready!
-(main) Block:1683911 (type 'help') >> 
+(main) Block:1683911 (type 'help') >>
 ```

--- a/book/src/user/metrics.md
+++ b/book/src/user/metrics.md
@@ -56,4 +56,4 @@ front end that you can visualize:
 
 ![image info](grafana.png)
 
-[metrics_section]: https://docs.rs/zebrad/latest/zebrad/config/struct.MetricsSection.html
+[metrics_section]: https://docs.rs/zebrad/latest/zebrad/components/metrics/struct.Config.html

--- a/book/src/user/metrics.md
+++ b/book/src/user/metrics.md
@@ -56,4 +56,4 @@ front end that you can visualize:
 
 ![image info](grafana.png)
 
-[metrics_section]: https://doc.zebra.zfnd.org/zebrad/config/struct.MetricsSection.html
+[metrics_section]: https://docs.rs/zebrad/latest/zebrad/config/struct.MetricsSection.html

--- a/book/src/user/requirements.md
+++ b/book/src/user/requirements.md
@@ -31,7 +31,7 @@ Zebra uses the following inbound and outbound TCP ports:
 - 18233 on Testnet
 
 If you configure Zebra with a specific
-[`listen_addr`](https://doc.zebra.zfnd.org/zebra_network/struct.Config.html#structfield.listen_addr),
+[`listen_addr`](https://docs.rs/zebra_network/latest/zebra_network/struct.Config.html#structfield.listen_addr),
 it will advertise this address to other nodes for inbound connections. Outbound
 connections are required to sync, inbound connections are optional. Zebra also
 needs access to the Zcash DNS seeders, via the OS DNS resolver (usually port

--- a/book/src/user/run.md
+++ b/book/src/user/run.md
@@ -7,7 +7,7 @@ changing the config.
 
 The configuration format is the TOML encoding of the internal config
 structure, and documentation for all of the config options can be found
-[here](https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html).
+[here](https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html).
 
 - `zebrad start` starts a full node.
 

--- a/book/src/user/startup.md
+++ b/book/src/user/startup.md
@@ -27,7 +27,7 @@ Some important parts of the config are:
 - `state.cache_dir`: where the cached state is stored on disk
 - `rpc.listen_addr`: optional JSON-RPC listener port
 
-See [the full list of configuration options](https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html).
+See [the full list of configuration options](https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html).
 
 ```
 zebrad::commands::start: Starting zebrad

--- a/book/src/user/tracing.md
+++ b/book/src/user/tracing.md
@@ -36,10 +36,10 @@ and the [`flamegraph`][flamegraph] runtime config option.
 
 Compile Zebra with `--features sentry` to monitor it using [Sentry][sentry] in production.
 
-[tracing_section]: https://doc.zebra.zfnd.org/zebrad/components/tracing/struct.Config.html
-[filter]: https://doc.zebra.zfnd.org/zebrad/components/tracing/struct.Config.html#structfield.filter
-[flamegraph]: https://doc.zebra.zfnd.org/zebrad/components/tracing/struct.Config.html#structfield.flamegraph
+[tracing_section]: https://docs.rs/zebrad/latest/zebrad/components/tracing/struct.Config.html
+[filter]: https://docs.rs/zebrad/latest/zebrad/components/tracing/struct.Config.html#structfield.filter
+[flamegraph]: https://docs.rs/zebrad/latest/zebrad/components/tracing/struct.Config.html#structfield.flamegraph
 [flamegraphs]: http://www.brendangregg.com/flamegraphs.html
 [systemd_journald]: https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
-[use_journald]: https://doc.zebra.zfnd.org/zebrad/components/tracing/struct.Config.html#structfield.use_journald
+[use_journald]: https://docs.rs/zebrad/latest/zebrad/components/tracing/struct.Config.html#structfield.use_journald
 [sentry]: https://sentry.io/welcome/

--- a/book/src/user/troubleshooting.md
+++ b/book/src/user/troubleshooting.md
@@ -48,7 +48,7 @@ Make sure you're using a release build on your native architecture.
 ### Syncer Lookahead Limit
 
 If your connection is slow, try
-[downloading fewer blocks at a time](https://docs.rs/zebrad/latest/zebrad/config/struct.SyncSection.html#structfield.lookahead_limit):
+[downloading fewer blocks at a time](https://docs.rs/zebrad/latest/zebrad/components/sync/struct.Config.html#structfield.lookahead_limit):
 
 ```toml
 [sync]

--- a/book/src/user/troubleshooting.md
+++ b/book/src/user/troubleshooting.md
@@ -58,7 +58,7 @@ max_concurrent_block_requests = 25
 
 ### Peer Set Size
 
-If your connection is slow, try [connecting to fewer peers](https://doc.zebra.zfnd.org/zebra_network/struct.Config.html#structfield.peerset_initial_target_size):
+If your connection is slow, try [connecting to fewer peers](https://docs.rs/zebra-network/latest/zebra_network/struct.Config.html#structfield.peerset_initial_target_size):
 
 ```toml
 [network]

--- a/book/src/user/troubleshooting.md
+++ b/book/src/user/troubleshooting.md
@@ -48,7 +48,7 @@ Make sure you're using a release build on your native architecture.
 ### Syncer Lookahead Limit
 
 If your connection is slow, try
-[downloading fewer blocks at a time](https://doc.zebra.zfnd.org/zebrad/config/struct.SyncSection.html#structfield.lookahead_limit):
+[downloading fewer blocks at a time](https://docs.rs/zebrad/latest/zebrad/config/struct.SyncSection.html#structfield.lookahead_limit):
 
 ```toml
 [sync]

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -5,7 +5,7 @@
 
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
-#![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_chain")]
+#![doc(html_root_url = "https://docs.rs/zebra_chain")]
 // Required by bitvec! macro
 #![recursion_limit = "256"]
 //

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -32,7 +32,7 @@
 
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
-#![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_consensus")]
+#![doc(html_root_url = "https://docs.rs/zebra_consensus")]
 //
 // Rust 1.72 has a false positive when nested generics are used inside Arc.
 // This makes the `arc_with_non_send_sync` lint trigger on a lot of proptest code.

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -131,7 +131,7 @@
 
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
-#![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_network")]
+#![doc(html_root_url = "https://docs.rs/zebra_network")]
 //
 // Rust 1.72 has a false positive when nested generics are used inside Arc.
 // This makes the `arc_with_non_send_sync` lint trigger on a lot of proptest code.

--- a/zebra-rpc/src/config.rs
+++ b/zebra-rpc/src/config.rs
@@ -34,7 +34,7 @@ pub struct Config {
     ///
     /// Zebra's RPC server has a separate thread pool and a `tokio` executor for each thread.
     /// State queries are run concurrently using the shared thread pool controlled by
-    /// the [`SyncSection.parallel_cpu_threads`](https://doc.zebra.zfnd.org/zebrad/config/struct.SyncSection.html#structfield.parallel_cpu_threads) config.
+    /// the [`SyncSection.parallel_cpu_threads`](https://docs.rs/zebrad/latest/zebrad/config/struct.SyncSection.html#structfield.parallel_cpu_threads) config.
     ///
     /// We recommend setting both configs to `0` (automatic scaling) for the best performance.
     /// This uses one thread per available CPU core.

--- a/zebra-rpc/src/config.rs
+++ b/zebra-rpc/src/config.rs
@@ -34,7 +34,7 @@ pub struct Config {
     ///
     /// Zebra's RPC server has a separate thread pool and a `tokio` executor for each thread.
     /// State queries are run concurrently using the shared thread pool controlled by
-    /// the [`SyncSection.parallel_cpu_threads`](https://docs.rs/zebrad/latest/zebrad/config/struct.SyncSection.html#structfield.parallel_cpu_threads) config.
+    /// the [`SyncSection.parallel_cpu_threads`](https://docs.rs/zebrad/latest/zebrad/components/sync/struct.Config.html#structfield.parallel_cpu_threads) config.
     ///
     /// We recommend setting both configs to `0` (automatic scaling) for the best performance.
     /// This uses one thread per available CPU core.

--- a/zebra-rpc/src/lib.rs
+++ b/zebra-rpc/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
-#![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_rpc")]
+#![doc(html_root_url = "https://docs.rs/zebra_rpc")]
 
 pub mod config;
 pub mod constants;

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -1,7 +1,7 @@
 //! Zebra script verification wrapping zcashd's zcash_script library
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
-#![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_script")]
+#![doc(html_root_url = "https://docs.rs/zebra_script")]
 // We allow unsafe code, so we can call zcash_script
 #![allow(unsafe_code)]
 

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
-#![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_state")]
+#![doc(html_root_url = "https://docs.rs/zebra_state")]
 //
 // Rust 1.72 has a false positive when nested generics are used inside Arc.
 // This makes the `arc_with_non_send_sync` lint trigger on a lot of proptest code.

--- a/zebra-test/src/lib.rs
+++ b/zebra-test/src/lib.rs
@@ -1,7 +1,7 @@
 //! Miscellaneous test code for Zebra.
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
-#![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_test")]
+#![doc(html_root_url = "https://docs.rs/zebra_test")]
 // Each lazy_static variable uses additional recursion
 #![recursion_limit = "512"]
 

--- a/zebra-utils/README.md
+++ b/zebra-utils/README.md
@@ -39,7 +39,7 @@ To create checkpoints, you need a synchronized instance of `zebrad` or `zcashd`.
 
 #### Checkpoint Generation Setup
 
-Make sure your `zebrad` or `zcashd` is [listening for RPC requests](https://doc.zebra.zfnd.org/zebra_rpc/config/struct.Config.html#structfield.listen_addr),
+Make sure your `zebrad` or `zcashd` is [listening for RPC requests](https://doc-internal.zebra.zfnd.org/zebra_rpc/config/struct.Config.html#structfield.listen_addr),
 and synced to the network tip.
 
 If you are on a Debian system, `zcash-cli` [can be installed as a package](https://zcash.readthedocs.io/en/latest/rtd_pages/install_debian_bin_packages.html).
@@ -81,7 +81,7 @@ For more details about checkpoint lists, see the [`zebra-checkpoints` README.](h
 To update the testnet checkpoints, `zebra-checkpoints` needs to connect to a testnet node.
 
 To launch a testnet node, you can either:
-- start `zebrad` [with a `zebrad.toml` with `network.network` set to `Testnet`](https://doc.zebra.zfnd.org/zebra_network/struct.Config.html#structfield.network), or
+- start `zebrad` [with a `zebrad.toml` with `network.network` set to `Testnet`](https://doc-internal.zebra.zfnd.org/zebra_network/struct.Config.html#structfield.network), or
 - run `zcashd -testnet`.
 
 Then use the commands above to regenerate the checkpoints.

--- a/zebra-utils/README.md
+++ b/zebra-utils/README.md
@@ -42,7 +42,7 @@ To create checkpoints, you need a synchronized instance of `zebrad` or `zcashd`.
 Make sure your `zebrad` or `zcashd` is [listening for RPC requests](https://doc-internal.zebra.zfnd.org/zebra_rpc/config/struct.Config.html#structfield.listen_addr),
 and synced to the network tip.
 
-If you are on a Debian system, `zcash-cli` [can be installed as a package](https://zcash.readthedocs.io/en/latest/rtd_pages/install_debian_bin_packages.html).
+If you are on a Debian system, `zcash-cli` [can be installed as a package](https://zcash.readthedocs.io/en/master/rtd_pages/install_debian_bin_packages.html).
 
 `zebra-checkpoints` is a standalone rust binary, you can compile it using:
 
@@ -81,7 +81,7 @@ For more details about checkpoint lists, see the [`zebra-checkpoints` README.](h
 To update the testnet checkpoints, `zebra-checkpoints` needs to connect to a testnet node.
 
 To launch a testnet node, you can either:
-- start `zebrad` [with a `zebrad.toml` with `network.network` set to `Testnet`](https://doc-internal.zebra.zfnd.org/zebra_network/struct.Config.html#structfield.network), or
+- start `zebrad` [with a `zebrad.toml` with `network.network` set to `Testnet`](https://docs.rs/zebra-network/latest/zebra_network/struct.Config.html#structfield.network), or
 - run `zcashd -testnet`.
 
 Then use the commands above to regenerate the checkpoints.

--- a/zebra-utils/src/lib.rs
+++ b/zebra-utils/src/lib.rs
@@ -1,7 +1,7 @@
 //! Utilities for Zebra development, not for library or application users.
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
-#![doc(html_root_url = "https://doc.zebra.zfnd.org/zebra_utils")]
+#![doc(html_root_url = "https://docs.rs/zebra_utils")]
 
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 

--- a/zebrad/src/commands/generate.rs
+++ b/zebrad/src/commands/generate.rs
@@ -37,7 +37,7 @@ impl Runnable for GenerateCmd {
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -6,7 +6,10 @@
 //! which implement the different components of a Zcash node
 //! (networking, chain structures, validation, rpc, etc).
 //!
-//! [Rendered docs from the `main` branch](https://doc.zebra.zfnd.org).
+//! [Rendered docs for the latest crate releases](https://docs.rs/releases/search?query=zebra).
+//!
+//! [Rendered docs from the `main` branch](https://doc-internal.zebra.zfnd.org).
+//!
 //! [Join us on the Zcash Foundation Engineering Discord](https://discord.gg/na6QZNd).
 //!
 //! ## About Zcash

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -102,7 +102,7 @@
 
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
-#![doc(html_root_url = "https://doc.zebra.zfnd.org/zebrad")]
+#![doc(html_root_url = "https://docs.rs/zebrad")]
 // Tracing causes false positives on this lint:
 // https://github.com/tokio-rs/tracing/issues/553
 #![allow(clippy::cognitive_complexity)]

--- a/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.1.toml
+++ b/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.1.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.2.toml
+++ b/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.2.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.3.toml
+++ b/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.3.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.4.toml
+++ b/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.4.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.5.toml
+++ b/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.5.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.9.toml
+++ b/zebrad/tests/common/configs/getblocktemplate-v1.0.0-rc.9.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/getblocktemplate-v1.0.1.toml
+++ b/zebrad/tests/common/configs/getblocktemplate-v1.0.1.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/v1.0.0-beta.12.toml
+++ b/zebrad/tests/common/configs/v1.0.0-beta.12.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/v1.0.0-beta.13.toml
+++ b/zebrad/tests/common/configs/v1.0.0-beta.13.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/v1.0.0-beta.15.toml
+++ b/zebrad/tests/common/configs/v1.0.0-beta.15.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/v1.0.0-rc.0.toml
+++ b/zebrad/tests/common/configs/v1.0.0-rc.0.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/v1.0.0-rc.2.toml
+++ b/zebrad/tests/common/configs/v1.0.0-rc.2.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/v1.0.0-rc.4.toml
+++ b/zebrad/tests/common/configs/v1.0.0-rc.4.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/v1.0.0-rc.9.toml
+++ b/zebrad/tests/common/configs/v1.0.0-rc.9.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/v1.0.1.toml
+++ b/zebrad/tests/common/configs/v1.0.1.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/v1.3.0-progress-bars.toml
+++ b/zebrad/tests/common/configs/v1.3.0-progress-bars.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #

--- a/zebrad/tests/common/configs/v1.4.0.toml
+++ b/zebrad/tests/common/configs/v1.4.0.toml
@@ -12,7 +12,7 @@
 #
 # The config format (including a complete list of sections and fields) is
 # documented here:
-# https://doc.zebra.zfnd.org/zebrad/config/struct.ZebradConfig.html
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
 #
 # zebrad attempts to load configs in the following order:
 #


### PR DESCRIPTION
## Motivation

docs.rs already renders our external API, so we don't need to do it ourselves on doc.zebra.zfnd.org.

Close #7837

## Solution

- Update all the links to docs.rs or doc-internal.zebra.zfnd.org
- Remove publishing to doc.zebra.zfnd.org
- Admin: remove the branch protection rule for the publishing job

## Review

This is a routine cleanup.

### Reviewer Checklist

  - [ ] Will the PR name make sense to users?
    - [x] Does it need extra CHANGELOG info? (new features, breaking changes, large changes)
  - [ ] Are the PR labels correct?
  - [ ] Does the code do what the ticket and PR says?
    - [ ] Does it change concurrent code, unsafe code, or consensus rules?
  - [ ] How do you know it works? Does it have tests?

## Follow Up Work

- DevOps: Delete the doc.zebra.zfnd.org website and DNS name