### PR TITLE
temporary diagnostics for peer investigation

### DIFF
--- a/zebra-chain/src/block/height.rs
+++ b/zebra-chain/src/block/height.rs
@@ -23,6 +23,7 @@ pub mod json_conversion;
 /// There are multiple formats for serializing a height, so we don't implement
 /// `ZcashSerialize` or `ZcashDeserialize` for `Height`.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Default))]
 pub struct Height(pub u32);
 
 #[derive(Error, Debug)]

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -770,6 +770,12 @@ impl AddressBookPeers for AddressBook {
             .cloned()
             .collect()
     }
+
+    fn all_peers(&self) -> Vec<MetaAddr> {
+        let _guard = self.span.enter();
+
+        self.peers().collect()
+    }
 }
 
 impl AddressBookPeers for Arc<Mutex<AddressBook>> {
@@ -777,6 +783,12 @@ impl AddressBookPeers for Arc<Mutex<AddressBook>> {
         self.lock()
             .expect("panic in a previous thread that was holding the mutex")
             .recently_live_peers(now)
+    }
+
+    fn all_peers(&self) -> Vec<MetaAddr> {
+        self.lock()
+            .expect("panic in a previous thread that was holding the mutex")
+            .all_peers()
     }
 }
 

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -258,7 +258,7 @@ impl AddressBook {
         let now: DateTime32 = now.try_into().expect("will succeed until 2038");
 
         MetaAddr::new_local_listener_change(self.local_listener)
-            .local_listener_into_new_meta_addr(now)
+            .local_listener_to_new_meta_addr(now)
     }
 
     /// Get the local listener [`SocketAddr`].

--- a/zebra-network/src/address_book/tests/prop.rs
+++ b/zebra-network/src/address_book/tests/prop.rs
@@ -107,7 +107,7 @@ proptest! {
 
         for (_addr, changes) in addr_changes_lists.iter() {
             for change in changes {
-                address_book.update(*change);
+                address_book.update(change.clone());
 
                 prop_assert!(
                     address_book.len() <= addr_limit,
@@ -131,7 +131,7 @@ proptest! {
         for index in 0..MAX_ADDR_CHANGE {
             for (_addr, changes) in addr_changes_lists.iter() {
                 if let Some(change) = changes.get(index) {
-                    address_book.update(*change);
+                    address_book.update(change.clone());
 
                     prop_assert!(
                         address_book.len() <= addr_limit,

--- a/zebra-network/src/address_book/tests/vectors.rs
+++ b/zebra-network/src/address_book/tests/vectors.rs
@@ -51,7 +51,7 @@ fn address_book_peer_order() {
     );
 
     // Regardless of the order of insertion, the most recent address should be chosen first
-    let addrs = vec![meta_addr1, meta_addr2];
+    let addrs = vec![meta_addr1.clone(), meta_addr2.clone()];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         Mainnet,
@@ -64,11 +64,11 @@ fn address_book_peer_order() {
         address_book
             .reconnection_peers(Instant::now(), Utc::now())
             .next(),
-        Some(meta_addr2),
+        Some(meta_addr2.clone()),
     );
 
     // Reverse the order, check that we get the same result
-    let addrs = vec![meta_addr2, meta_addr1];
+    let addrs = vec![meta_addr2.clone(), meta_addr1.clone()];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         Mainnet,
@@ -81,14 +81,14 @@ fn address_book_peer_order() {
         address_book
             .reconnection_peers(Instant::now(), Utc::now())
             .next(),
-        Some(meta_addr2),
+        Some(meta_addr2.clone()),
     );
 
     // Now check that the order depends on the time, not the address
     meta_addr1.addr = addr2;
     meta_addr2.addr = addr1;
 
-    let addrs = vec![meta_addr1, meta_addr2];
+    let addrs = vec![meta_addr1.clone(), meta_addr2.clone()];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         Mainnet,
@@ -101,11 +101,11 @@ fn address_book_peer_order() {
         address_book
             .reconnection_peers(Instant::now(), Utc::now())
             .next(),
-        Some(meta_addr2),
+        Some(meta_addr2.clone()),
     );
 
     // Reverse the order, check that we get the same result
-    let addrs = vec![meta_addr2, meta_addr1];
+    let addrs = vec![meta_addr2.clone(), meta_addr1.clone()];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         Mainnet,

--- a/zebra-network/src/address_book/tests/vectors.rs
+++ b/zebra-network/src/address_book/tests/vectors.rs
@@ -128,9 +128,7 @@ fn address_book_peer_order() {
 fn reconnection_peers_skips_recently_updated_ip() {
     // tests that reconnection_peers() skips addresses where there's a connection at that IP with a recent:
     // - `last_response`
-    test_reconnection_peers_skips_recently_updated_ip(true, |addr| {
-        MetaAddr::new_responded(addr, &PeerServices::NODE_NETWORK)
-    });
+    test_reconnection_peers_skips_recently_updated_ip(true, MetaAddr::new_responded);
 
     // tests that reconnection_peers() *does not* skip addresses where there's a connection at that IP with a recent:
     // - `last_attempt`
@@ -150,7 +148,7 @@ fn test_reconnection_peers_skips_recently_updated_ip<
     let addr1 = "127.0.0.1:1".parse().unwrap();
     let addr2 = "127.0.0.1:2".parse().unwrap();
 
-    let meta_addr1 = make_meta_addr_change(addr1).into_new_meta_addr(
+    let meta_addr1 = make_meta_addr_change(addr1).to_new_meta_addr(
         Instant::now(),
         Utc::now().try_into().expect("will succeed until 2038"),
     );

--- a/zebra-network/src/address_book/tests/vectors.rs
+++ b/zebra-network/src/address_book/tests/vectors.rs
@@ -135,7 +135,7 @@ fn reconnection_peers_skips_recently_updated_ip() {
     test_reconnection_peers_skips_recently_updated_ip(false, MetaAddr::new_reconnect);
     // - `last_failure`
     test_reconnection_peers_skips_recently_updated_ip(false, |addr| {
-        MetaAddr::new_errored(addr, PeerServices::NODE_NETWORK)
+        MetaAddr::new_errored(addr, None)
     });
 }
 

--- a/zebra-network/src/address_book_peers.rs
+++ b/zebra-network/src/address_book_peers.rs
@@ -14,4 +14,7 @@ pub use mock::MockAddressBookPeers;
 pub trait AddressBookPeers {
     /// Return an Vec of peers we've seen recently, in reconnection attempt order.
     fn recently_live_peers(&self, now: chrono::DateTime<Utc>) -> Vec<MetaAddr>;
+
+    /// Return an Vec of all peers, in reconnection attempt order.
+    fn all_peers(&self) -> Vec<MetaAddr>;
 }

--- a/zebra-network/src/address_book_peers/mock.rs
+++ b/zebra-network/src/address_book_peers/mock.rs
@@ -22,4 +22,9 @@ impl AddressBookPeers for MockAddressBookPeers {
     fn recently_live_peers(&self, _now: chrono::DateTime<chrono::Utc>) -> Vec<MetaAddr> {
         self.recently_live_peers.clone()
     }
+
+    fn all_peers(&self) -> Vec<MetaAddr> {
+        // This is wrong but we aren't going to merge this PR.
+        self.recently_live_peers.clone()
+    }
 }

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -445,7 +445,7 @@ impl MetaAddr {
     /// See the [`MetaAddr::last_seen`] method for details.
     //
     // TODO: pub(in crate::address_book) - move meta_addr into address_book
-    pub(crate) fn untrusted_last_seen(&self) -> Option<DateTime32> {
+    pub fn untrusted_last_seen(&self) -> Option<DateTime32> {
         self.untrusted_last_seen
     }
 
@@ -455,7 +455,7 @@ impl MetaAddr {
     //
     // TODO: pub(in crate::address_book) - move meta_addr into address_book
     #[allow(dead_code)]
-    pub(crate) fn last_response(&self) -> Option<DateTime32> {
+    pub fn last_response(&self) -> Option<DateTime32> {
         self.last_response
     }
 
@@ -674,6 +674,11 @@ impl MetaAddr {
             last_failure: None,
             last_connection_state: NeverAttemptedGossiped,
         })
+    }
+
+    /// Returns the internal state.
+    pub fn last_connection_state(&self) -> PeerAddrState {
+        self.last_connection_state
     }
 }
 

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -715,6 +715,11 @@ impl MetaAddr {
     pub fn last_connection_state(&self) -> PeerAddrState {
         self.last_connection_state
     }
+
+    /// Returns the last version message sent by the peer, and the negotiated connection version.
+    pub fn last_connection_info(&self) -> &Option<Arc<ConnectionInfo>> {
+        &self.connection_info
+    }
 }
 
 #[cfg(test)]

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -308,7 +308,7 @@ pub enum MetaAddrChange {
             proptest(strategy = "canonical_peer_addr_strategy()")
         )]
         addr: PeerSocketAddr,
-        services: Option<PeerServices>,
+        connection_info: Option<Arc<ConnectionInfo>>,
     },
 }
 
@@ -425,11 +425,11 @@ impl MetaAddr {
     /// Returns a [`MetaAddrChange::UpdateFailed`] for a peer that has just had an error.
     pub fn new_errored(
         addr: PeerSocketAddr,
-        services: impl Into<Option<PeerServices>>,
+        connection_info: impl Into<Option<Arc<ConnectionInfo>>>,
     ) -> MetaAddrChange {
         UpdateFailed {
             addr: canonical_peer_addr(*addr),
-            services: services.into(),
+            connection_info: connection_info.into(),
         }
     }
 
@@ -770,7 +770,9 @@ impl MetaAddrChange {
                 connection_info, ..
             } => Some(connection_info.remote.services),
             UpdateResponded { .. } => None,
-            UpdateFailed { services, .. } => *services,
+            UpdateFailed {
+                connection_info, ..
+            } => connection_info.as_ref().map(|info| info.remote.services),
         }
     }
 

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -422,8 +422,7 @@ impl MetaAddr {
         }
     }
 
-    /// Returns a [`MetaAddrChange::UpdateFailed`] for a peer that has just had
-    /// an error.
+    /// Returns a [`MetaAddrChange::UpdateFailed`] for a peer that has just had an error.
     pub fn new_errored(
         addr: PeerSocketAddr,
         services: impl Into<Option<PeerServices>>,
@@ -435,13 +434,10 @@ impl MetaAddr {
     }
 
     /// Create a new `MetaAddr` for a peer that has just shut down.
-    pub fn new_shutdown(
-        addr: PeerSocketAddr,
-        services: impl Into<Option<PeerServices>>,
-    ) -> MetaAddrChange {
+    pub fn new_shutdown(addr: PeerSocketAddr) -> MetaAddrChange {
         // TODO: if the peer shut down in the Responded state, preserve that
         // state. All other states should be treated as (timeout) errors.
-        MetaAddr::new_errored(addr, services.into())
+        MetaAddr::new_errored(addr, None)
     }
 
     /// Return the address for this `MetaAddr`.

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -260,7 +260,7 @@ pub enum MetaAddrChange {
             proptest(strategy = "canonical_peer_addr_strategy()")
         )]
         addr: PeerSocketAddr,
-        untrusted_services: PeerServices,
+        untrusted_connection_info: Arc<ConnectionInfo>,
     },
 
     /// Creates new local listener `MetaAddr`.
@@ -407,11 +407,11 @@ impl MetaAddr {
     /// received via a `Version` message.
     pub fn new_alternate(
         addr: PeerSocketAddr,
-        untrusted_services: &PeerServices,
+        untrusted_connection_info: Arc<ConnectionInfo>,
     ) -> MetaAddrChange {
         NewAlternate {
             addr: canonical_peer_addr(*addr),
-            untrusted_services: *untrusted_services,
+            untrusted_connection_info,
         }
     }
 
@@ -762,10 +762,11 @@ impl MetaAddrChange {
             // TODO: split untrusted and direct services (#2324)
             NewGossiped {
                 untrusted_services, ..
-            }
-            | NewAlternate {
-                untrusted_services, ..
             } => Some(*untrusted_services),
+            NewAlternate {
+                untrusted_connection_info,
+                ..
+            } => Some(untrusted_connection_info.remote.services),
             // TODO: create a "services implemented by Zebra" constant (#2324)
             NewLocal { .. } => Some(PeerServices::NODE_NETWORK),
             UpdateAttempt { .. } => None,

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -280,6 +280,16 @@ pub enum MetaAddrChange {
         addr: PeerSocketAddr,
     },
 
+    /// Updates an existing `MetaAddr` when we've made a successful connection with a peer.
+    UpdateConnected {
+        #[cfg_attr(
+            any(test, feature = "proptest-impl"),
+            proptest(strategy = "canonical_peer_addr_strategy()")
+        )]
+        addr: PeerSocketAddr,
+        services: PeerServices,
+    },
+
     /// Updates an existing `MetaAddr` when a peer responds with a message.
     UpdateResponded {
         #[cfg_attr(
@@ -287,7 +297,6 @@ pub enum MetaAddrChange {
             proptest(strategy = "canonical_peer_addr_strategy()")
         )]
         addr: PeerSocketAddr,
-        services: PeerServices,
     },
 
     /// Updates an existing `MetaAddr` when a peer fails.
@@ -345,8 +354,8 @@ impl MetaAddr {
         })
     }
 
-    /// Returns a [`MetaAddrChange::UpdateResponded`] for a peer that has just
-    /// sent us a message.
+    /// Returns a [`MetaAddrChange::UpdateConnected`] for a peer that has just successfully
+    /// connected.
     ///
     /// # Security
     ///
@@ -354,13 +363,30 @@ impl MetaAddr {
     /// and the services must be the services from that peer's handshake.
     ///
     /// Otherwise:
-    /// - malicious peers could interfere with other peers' [`AddressBook`](crate::AddressBook) state,
-    ///   or
+    /// - malicious peers could interfere with other peers' [`AddressBook`](crate::AddressBook)
+    ///   state, or
     /// - Zebra could advertise unreachable addresses to its own peers.
-    pub fn new_responded(addr: PeerSocketAddr, services: &PeerServices) -> MetaAddrChange {
-        UpdateResponded {
+    pub fn new_connected(addr: PeerSocketAddr, services: &PeerServices) -> MetaAddrChange {
+        UpdateConnected {
             addr: canonical_peer_addr(*addr),
             services: *services,
+        }
+    }
+
+    /// Returns a [`MetaAddrChange::UpdateResponded`] for a peer that has just
+    /// sent us a message.
+    ///
+    /// # Security
+    ///
+    /// This address must be the remote address from an outbound connection.
+    ///
+    /// Otherwise:
+    /// - malicious peers could interfere with other peers' [`AddressBook`](crate::AddressBook)
+    ///   state, or
+    /// - Zebra could advertise unreachable addresses to its own peers.
+    pub fn new_responded(addr: PeerSocketAddr) -> MetaAddrChange {
+        UpdateResponded {
+            addr: canonical_peer_addr(*addr),
         }
     }
 
@@ -701,6 +727,7 @@ impl MetaAddrChange {
             | NewAlternate { addr, .. }
             | NewLocal { addr, .. }
             | UpdateAttempt { addr }
+            | UpdateConnected { addr, .. }
             | UpdateResponded { addr, .. }
             | UpdateFailed { addr, .. } => *addr,
         }
@@ -717,6 +744,7 @@ impl MetaAddrChange {
             | NewAlternate { addr, .. }
             | NewLocal { addr, .. }
             | UpdateAttempt { addr }
+            | UpdateConnected { addr, .. }
             | UpdateResponded { addr, .. }
             | UpdateFailed { addr, .. } => *addr = new_addr,
         }
@@ -726,17 +754,18 @@ impl MetaAddrChange {
     pub fn untrusted_services(&self) -> Option<PeerServices> {
         match self {
             NewInitial { .. } => None,
+            // TODO: split untrusted and direct services (#2324)
             NewGossiped {
                 untrusted_services, ..
-            } => Some(*untrusted_services),
-            NewAlternate {
+            }
+            | NewAlternate {
                 untrusted_services, ..
             } => Some(*untrusted_services),
             // TODO: create a "services implemented by Zebra" constant (#2324)
             NewLocal { .. } => Some(PeerServices::NODE_NETWORK),
             UpdateAttempt { .. } => None,
-            // TODO: split untrusted and direct services (#2324)
-            UpdateResponded { services, .. } => Some(*services),
+            UpdateConnected { services, .. } => Some(*services),
+            UpdateResponded { .. } => None,
             UpdateFailed { services, .. } => *services,
         }
     }
@@ -752,9 +781,10 @@ impl MetaAddrChange {
             NewAlternate { .. } => None,
             // We know that our local listener is available
             NewLocal { .. } => Some(now),
-            UpdateAttempt { .. } => None,
-            UpdateResponded { .. } => None,
-            UpdateFailed { .. } => None,
+            UpdateAttempt { .. }
+            | UpdateConnected { .. }
+            | UpdateResponded { .. }
+            | UpdateFailed { .. } => None,
         }
     }
 
@@ -780,33 +810,29 @@ impl MetaAddrChange {
     /// Return the last attempt for this change, if available.
     pub fn last_attempt(&self, now: Instant) -> Option<Instant> {
         match self {
-            NewInitial { .. } => None,
-            NewGossiped { .. } => None,
-            NewAlternate { .. } => None,
-            NewLocal { .. } => None,
+            NewInitial { .. } | NewGossiped { .. } | NewAlternate { .. } | NewLocal { .. } => None,
             // Attempt changes are applied before we start the handshake to the
             // peer address. So the attempt time is a lower bound for the actual
             // handshake time.
             UpdateAttempt { .. } => Some(now),
-            UpdateResponded { .. } => None,
-            UpdateFailed { .. } => None,
+            UpdateConnected { .. } | UpdateResponded { .. } | UpdateFailed { .. } => None,
         }
     }
 
     /// Return the last response for this change, if available.
     pub fn last_response(&self, now: DateTime32) -> Option<DateTime32> {
         match self {
-            NewInitial { .. } => None,
-            NewGossiped { .. } => None,
-            NewAlternate { .. } => None,
-            NewLocal { .. } => None,
-            UpdateAttempt { .. } => None,
+            NewInitial { .. }
+            | NewGossiped { .. }
+            | NewAlternate { .. }
+            | NewLocal { .. }
+            | UpdateAttempt { .. } => None,
             // If there is a large delay applying this change, then:
             // - the peer might stay in the `AttemptPending` state for longer,
             // - we might send outdated last seen times to our peers, and
             // - the peer will appear to be live for longer, delaying future
             //   reconnection attempts.
-            UpdateResponded { .. } => Some(now),
+            UpdateConnected { .. } | UpdateResponded { .. } => Some(now),
             UpdateFailed { .. } => None,
         }
     }
@@ -814,12 +840,13 @@ impl MetaAddrChange {
     /// Return the last failure for this change, if available.
     pub fn last_failure(&self, now: Instant) -> Option<Instant> {
         match self {
-            NewInitial { .. } => None,
-            NewGossiped { .. } => None,
-            NewAlternate { .. } => None,
-            NewLocal { .. } => None,
-            UpdateAttempt { .. } => None,
-            UpdateResponded { .. } => None,
+            NewInitial { .. }
+            | NewGossiped { .. }
+            | NewAlternate { .. }
+            | NewLocal { .. }
+            | UpdateAttempt { .. }
+            | UpdateConnected { .. }
+            | UpdateResponded { .. } => None,
             // If there is a large delay applying this change, then:
             // - the peer might stay in the `AttemptPending` or `Responded`
             //   states for longer, and
@@ -838,7 +865,7 @@ impl MetaAddrChange {
             // local listeners get sanitized, so the state doesn't matter here
             NewLocal { .. } => NeverAttemptedGossiped,
             UpdateAttempt { .. } => AttemptPending,
-            UpdateResponded { .. } => Responded,
+            UpdateConnected { .. } | UpdateResponded { .. } => Responded,
             UpdateFailed { .. } => Failed,
         }
     }

--- a/zebra-network/src/meta_addr/arbitrary.rs
+++ b/zebra-network/src/meta_addr/arbitrary.rs
@@ -62,7 +62,7 @@ impl MetaAddr {
                     // instant_now is not actually used for this variant,
                     // so we could just provide a default value
                     MetaAddr::new_alternate(socket_addr, &untrusted_services)
-                        .into_new_meta_addr(instant_now, local_now)
+                        .to_new_meta_addr(instant_now, local_now)
                 },
             )
             .boxed()
@@ -132,7 +132,7 @@ impl MetaAddrChange {
 
                     let change = MetaAddr::new_alternate(addr, &PeerServices::NODE_NETWORK);
                     if change
-                        .into_new_meta_addr(instant_now, local_now)
+                        .to_new_meta_addr(instant_now, local_now)
                         .last_known_info_is_valid_for_outbound(Mainnet)
                     {
                         Some(addr.port())

--- a/zebra-network/src/meta_addr/arbitrary.rs
+++ b/zebra-network/src/meta_addr/arbitrary.rs
@@ -91,9 +91,10 @@ impl MetaAddrChange {
     ) -> BoxedStrategy<(MetaAddr, Vec<MetaAddrChange>)> {
         any::<MetaAddr>()
             .prop_flat_map(move |addr| {
+                let ip_addr = addr.addr;
                 (
                     Just(addr),
-                    vec(MetaAddrChange::addr_strategy(addr.addr), 1..max_addr_change),
+                    vec(MetaAddrChange::addr_strategy(ip_addr), 1..max_addr_change),
                 )
             })
             .boxed()

--- a/zebra-network/src/meta_addr/arbitrary.rs
+++ b/zebra-network/src/meta_addr/arbitrary.rs
@@ -146,3 +146,13 @@ impl MetaAddrChange {
             .boxed()
     }
 }
+
+impl Default for PeerSocketAddr {
+    fn default() -> Self {
+        // This is a documentation and examples IP address:
+        // <https://en.wikipedia.org/wiki/Reserved_IP_addresses>
+        "203.0.113.0:8233"
+            .parse()
+            .expect("hard-coded address is valid")
+    }
+}

--- a/zebra-network/src/meta_addr/peer_addr.rs
+++ b/zebra-network/src/meta_addr/peer_addr.rs
@@ -27,10 +27,11 @@ impl fmt::Debug for PeerSocketAddr {
 
 impl fmt::Display for PeerSocketAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let ip_version = if self.is_ipv4() { "v4" } else { "v6" };
+        //let ip_version = if self.is_ipv4() { "v4" } else { "v6" };
 
         // The port is usually not sensitive, and it's useful for debugging.
-        f.pad(&format!("{}redacted:{}", ip_version, self.port()))
+        //f.pad(&format!("{}redacted:{}", ip_version, self.port()))
+        f.pad(&format!("{}", self.remove_socket_addr_privacy()))
     }
 }
 

--- a/zebra-network/src/meta_addr/tests/prop.rs
+++ b/zebra-network/src/meta_addr/tests/prop.rs
@@ -225,7 +225,7 @@ proptest! {
             );
 
             let expected_result = new_addr;
-            let book_result = address_book.update(change);
+            let book_result = address_book.update(change.clone());
             let book_contents: Vec<MetaAddr> = address_book.peers().collect();
 
             // Ignore the same addresses that the address book ignores

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -269,7 +269,7 @@ fn long_delayed_change_is_not_applied() {
         - chrono::Duration::from_std(CONCURRENT_ADDRESS_CHANGE_PERIOD * 3)
             .expect("constant is valid");
 
-    let change = MetaAddr::new_errored(address, PeerServices::NODE_NETWORK);
+    let change = MetaAddr::new_errored(address, None);
     let outcome = change.apply_to_meta_addr(peer, instant_early, chrono_early);
 
     assert_eq!(

--- a/zebra-network/src/peer/client/tests.rs
+++ b/zebra-network/src/peer/client/tests.rs
@@ -325,7 +325,7 @@ where
         let connection_info = Arc::new(ConnectionInfo {
             connected_addr: crate::peer::ConnectedAddr::Isolated,
             remote,
-            negotiated_version,
+            negotiated_version: Some(negotiated_version),
         });
 
         let client = Client {

--- a/zebra-network/src/peer/connection/tests.rs
+++ b/zebra-network/src/peer/connection/tests.rs
@@ -73,7 +73,7 @@ fn new_test_connection<A>() -> (
     let connection_info = ConnectionInfo {
         connected_addr: ConnectedAddr::Isolated,
         remote,
-        negotiated_version: fake_version,
+        negotiated_version: Some(fake_version),
     };
 
     let connection = Connection::new(

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -51,7 +51,7 @@ use crate::{
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "proptest-impl"))]
 mod tests;
 
 /// A [`Service`] that handshakes with a remote peer and constructs a
@@ -125,7 +125,7 @@ where
 
 /// The metadata for a peer connection.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary, Default))]
 pub struct ConnectionInfo {
     /// The connected peer address, if known.
     /// This address might not be valid for outbound connections.

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -943,7 +943,7 @@ where
             // - we only send these messages once per handshake
             let alternate_addrs = connected_addr.get_alternate_addrs(remote_canonical_addr);
             for alt_addr in alternate_addrs {
-                let alt_addr = MetaAddr::new_alternate(alt_addr, &remote_services);
+                let alt_addr = MetaAddr::new_alternate(alt_addr, connection_info.clone());
                 // awaiting a local task won't hang
                 let _ = address_book_updater.send(alt_addr).await;
             }

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -730,11 +730,12 @@ where
     // network upgrades and could lead to chain forks or slower block propagation.
     let min_version = minimum_peer_version.current();
     if remote.version < min_version {
-        debug!(
+        info!(
             remote_ip = ?their_addr,
             ?remote.version,
             ?min_version,
             ?remote.user_agent,
+            ?remote.start_height,
             "disconnecting from peer with obsolete network protocol version",
         );
 

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -1431,10 +1431,8 @@ async fn handle_heartbeat_shutdown(
     tracing::debug!(?peer_error, "client shutdown, shutting down heartbeat");
 
     if let Some(book_addr) = connected_addr.get_address_book_addr() {
-        // The connection info was sent to the address book when we successfully opened the
-        // connection, so it isn't needed here.
         let _ = address_book_updater
-            .send(MetaAddr::new_shutdown(book_addr, None))
+            .send(MetaAddr::new_shutdown(book_addr))
             .await;
     }
 

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -932,12 +932,13 @@ where
                 let _ = address_book_updater.send(alt_addr).await;
             }
 
-            // The handshake succeeded: update the peer status from AttemptPending to Responded
+            // The handshake succeeded: update the peer status from AttemptPending to Responded,
+            // and send initial connection info.
             if let Some(book_addr) = connected_addr.get_address_book_addr() {
                 // the collector doesn't depend on network activity,
                 // so this await should not hang
                 let _ = address_book_updater
-                    .send(MetaAddr::new_responded(book_addr, &remote_services))
+                    .send(MetaAddr::new_connected(book_addr, &remote_services))
                     .await;
             }
 
@@ -1311,7 +1312,7 @@ async fn send_periodic_heartbeats_run_loop(
             // the collector doesn't depend on network activity,
             // so this await should not hang
             let _ = heartbeat_ts_collector
-                .send(MetaAddr::new_responded(book_addr, &remote_services))
+                .send(MetaAddr::new_responded(book_addr))
                 .await;
         }
     }

--- a/zebra-network/src/peer/handshake/tests.rs
+++ b/zebra-network/src/peer/handshake/tests.rs
@@ -9,6 +9,7 @@ where
     C: ChainTip + Clone + Send + 'static,
 {
     /// Returns a count of how many connection nonces are stored in this [`Handshake`]
+    #[allow(dead_code)]
     pub async fn nonce_count(&self) -> usize {
         self.nonces.lock().await.len()
     }

--- a/zebra-network/src/peer/handshake/tests.rs
+++ b/zebra-network/src/peer/handshake/tests.rs
@@ -13,3 +13,15 @@ where
         self.nonces.lock().await.len()
     }
 }
+
+impl Default for ConnectedAddr {
+    fn default() -> Self {
+        // This is a documentation and examples IP address:
+        // <https://en.wikipedia.org/wiki/Reserved_IP_addresses>
+        Self::OutboundDirect {
+            addr: "198.51.100.0:8233"
+                .parse()
+                .expect("hard-coded address is valid"),
+        }
+    }
+}

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -414,6 +414,8 @@ where
     }
 
     /// Returns the address book for this `CandidateSet`.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    #[allow(dead_code)]
     pub async fn address_book(&self) -> Arc<std::sync::Mutex<AddressBook>> {
         self.address_book.clone()
     }

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -326,7 +326,7 @@ where
         // - the number of addresses per peer is limited
         let addrs: Vec<MetaAddrChange> = addrs
             .into_iter()
-            .map(MetaAddr::new_gossiped_change)
+            .map(|addr| addr.new_gossiped_change())
             .map(|maybe_addr| maybe_addr.expect("Received gossiped peers always have services set"))
             .collect();
 

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -1099,8 +1099,9 @@ async fn report_failed(address_book: Arc<std::sync::Mutex<AddressBook>>, addr: M
     //
     // Spawn address book accesses on a blocking thread, to avoid deadlocks (see #1976).
     let span = Span::current();
+    let addr2 = addr.clone();
     let updated_addr = tokio::task::spawn_blocking(move || {
-        span.in_scope(|| address_book.lock().unwrap().update(addr))
+        span.in_scope(|| address_book.lock().unwrap().update(addr2))
     })
     .wait_for_panics()
     .await;

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -1097,7 +1097,8 @@ async fn report_failed(
     address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
     addr: MetaAddr,
 ) {
-    let addr = MetaAddr::new_errored(addr.addr, addr.services);
+    // The connection info is the same as what's already in the address book.
+    let addr = MetaAddr::new_errored(addr.addr, None);
 
     // Ignore send errors on Zebra shutdown.
     let _ = address_book_updater.send(addr).await;

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -375,7 +375,7 @@ where
                 }
 
                 if expected_error {
-                    debug!(
+                    info!(
                         successes = ?handshake_success_total,
                         errors = ?handshake_error_total,
                         ?addr,
@@ -696,7 +696,7 @@ where
                 // The connection limit makes sure this send doesn't block
                 let _ = peerset_tx.send((addr, client)).await;
             } else {
-                debug!(?handshake_result, "error handshaking with inbound peer");
+                info!(?handshake_result, "error handshaking with inbound peer");
             }
         }
         .in_current_span(),
@@ -1069,7 +1069,7 @@ where
         }
         // The connection was never opened, or it failed the handshake and was dropped.
         Err(error) => {
-            debug!(?error, ?candidate.addr, "failed to make outbound connection to peer");
+            info!(?error, ?candidate.addr, "failed to make outbound connection to peer");
             report_failed(address_book.clone(), candidate).await;
 
             // The demand signal that was taken out of the queue to attempt to connect to the

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -1202,17 +1202,17 @@ async fn self_connections_should_fail() {
         "inserting our own address into the address book failed: {real_self_listener:?}"
     );
     assert_eq!(
-        updated_addr.unwrap().addr(),
+        updated_addr.as_ref().unwrap().addr(),
         real_self_listener.addr(),
         "wrong address inserted into address book"
     );
     assert_ne!(
-        updated_addr.unwrap().addr().ip(),
+        updated_addr.as_ref().unwrap().addr().ip(),
         Ipv4Addr::UNSPECIFIED,
         "invalid address inserted into address book: ip must be valid for inbound connections"
     );
     assert_ne!(
-        updated_addr.unwrap().addr().port(),
+        updated_addr.as_ref().unwrap().addr().port(),
         0,
         "invalid address inserted into address book: port must be valid for inbound connections"
     );
@@ -1521,7 +1521,6 @@ where
 
     // Add enough fake peers to go over the limit, even if the limit is zero.
     let over_limit_peers = config.peerset_outbound_connection_limit() * 2 + 1;
-    let mut fake_peer = None;
     for address_number in 0..over_limit_peers {
         let addr = SocketAddr::new(Ipv4Addr::new(127, 1, 1, address_number as _).into(), 1);
         let addr = MetaAddr::new_gossiped_meta_addr(
@@ -1529,7 +1528,6 @@ where
             PeerServices::NODE_NETWORK,
             DateTime32::now(),
         );
-        fake_peer = Some(addr);
         let addr = addr
             .new_gossiped_change()
             .expect("created MetaAddr contains enough information to represent a gossiped address");
@@ -1545,7 +1543,7 @@ where
         let rsp = match req {
             // Return the correct response variant for Peers requests,
             // re-using one of the peers we already provided.
-            Request::Peers => Response::Peers(vec![fake_peer.unwrap()]),
+            Request::Peers => Response::Peers(vec![]),
             _ => unreachable!("unexpected request: {:?}", req),
         };
 

--- a/zebra-network/src/protocol/external/addr/in_version.rs
+++ b/zebra-network/src/protocol/external/addr/in_version.rs
@@ -29,7 +29,7 @@ use super::{canonical_peer_addr, v1::ipv6_mapped_ip_addr};
 ///
 /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#Network_address)
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary, Default))]
 pub struct AddrInVersion {
     /// The unverified services for the peer at `addr`.
     ///

--- a/zebra-network/src/protocol/external/addr/v1.rs
+++ b/zebra-network/src/protocol/external/addr/v1.rs
@@ -69,6 +69,12 @@ pub(in super::super) struct AddrV1 {
 
 impl From<MetaAddr> for AddrV1 {
     fn from(meta_addr: MetaAddr) -> Self {
+        AddrV1::from(&meta_addr)
+    }
+}
+
+impl From<&MetaAddr> for AddrV1 {
+    fn from(meta_addr: &MetaAddr) -> Self {
         let addr = canonical_peer_addr(meta_addr.addr);
 
         let untrusted_services = meta_addr.services.expect(

--- a/zebra-network/src/protocol/external/addr/v2.rs
+++ b/zebra-network/src/protocol/external/addr/v2.rs
@@ -126,9 +126,16 @@ pub(in super::super) enum AddrV2 {
 // https://zips.z.cash/zip-0155#deployment
 //
 // And Zebra doesn't use different codecs for different peer versions.
-#[cfg(test)]
+#[cfg(any(test, feature = "proptest-impl"))]
 impl From<MetaAddr> for AddrV2 {
     fn from(meta_addr: MetaAddr) -> Self {
+        AddrV2::from(&meta_addr)
+    }
+}
+
+#[cfg(any(test, feature = "proptest-impl"))]
+impl From<&MetaAddr> for AddrV2 {
+    fn from(meta_addr: &MetaAddr) -> Self {
         let untrusted_services = meta_addr.services.expect(
             "unexpected MetaAddr with missing peer services: \
              MetaAddrs should be sanitized before serialization",

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -278,7 +278,7 @@ impl Codec {
 
                 // Regardless of the way we received the address,
                 // Zebra always sends `addr` messages
-                let v1_addrs: Vec<AddrV1> = addrs.iter().map(|addr| AddrV1::from(*addr)).collect();
+                let v1_addrs: Vec<AddrV1> = addrs.iter().map(AddrV1::from).collect();
                 v1_addrs.zcash_serialize(&mut writer)?
             }
             Message::GetAddr => { /* Empty payload -- no-op */ }

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -314,7 +314,7 @@ pub const MAX_USER_AGENT_LENGTH: usize = 256;
 ///
 /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#version)
 #[derive(Clone, Eq, PartialEq, Debug)]
-#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary, Default))]
 pub struct VersionMessage {
     /// The network version number supported by the sender.
     pub version: Version,

--- a/zebra-network/src/protocol/external/tests/prop.rs
+++ b/zebra-network/src/protocol/external/tests/prop.rs
@@ -122,7 +122,7 @@ proptest! {
         //
         // If this is a gossiped or DNS seeder address,
         // we're also checking that malicious peers can't make Zebra's serialization fail.
-        let addr_bytes = AddrV1::from(sanitized_addr).zcash_serialize_to_vec();
+        let addr_bytes = AddrV1::from(&sanitized_addr).zcash_serialize_to_vec();
         prop_assert!(
             addr_bytes.is_ok(),
             "unexpected serialization error: {:?}, addr: {:?}",
@@ -144,8 +144,8 @@ proptest! {
 
         // Check that the addrs are equal
         prop_assert_eq!(
-            sanitized_addr,
-            deserialized_addr,
+            &sanitized_addr,
+            &deserialized_addr,
             "unexpected round-trip mismatch with bytes: {:?}",
             hex::encode(addr_bytes),
         );
@@ -155,7 +155,7 @@ proptest! {
 
         // Now check that the re-serialized bytes are equal
         // (`impl PartialEq for MetaAddr` might not match serialization equality)
-        let addr_bytes2 = AddrV1::from(deserialized_addr).zcash_serialize_to_vec();
+        let addr_bytes2 = AddrV1::from(&deserialized_addr).zcash_serialize_to_vec();
         prop_assert!(
             addr_bytes2.is_ok(),
             "unexpected serialization error after round-trip: {:?}, original addr: {:?}, bytes: {:?}, deserialized addr: {:?}",
@@ -195,7 +195,7 @@ proptest! {
         //
         // If this is a gossiped or DNS seeder address,
         // we're also checking that malicious peers can't make Zebra's serialization fail.
-        let addr_bytes = AddrV2::from(sanitized_addr).zcash_serialize_to_vec();
+        let addr_bytes = AddrV2::from(&sanitized_addr).zcash_serialize_to_vec();
         prop_assert!(
             addr_bytes.is_ok(),
             "unexpected serialization error: {:?}, addr: {:?}",
@@ -218,8 +218,8 @@ proptest! {
 
         // Check that the addrs are equal
         prop_assert_eq!(
-            sanitized_addr,
-            deserialized_addr,
+            &sanitized_addr,
+            &deserialized_addr,
             "unexpected round-trip mismatch with bytes: {:?}",
             hex::encode(addr_bytes),
         );
@@ -229,7 +229,7 @@ proptest! {
 
         // Now check that the re-serialized bytes are equal
         // (`impl PartialEq for MetaAddr` might not match serialization equality)
-        let addr_bytes2 = AddrV2::from(deserialized_addr).zcash_serialize_to_vec();
+        let addr_bytes2 = AddrV2::from(&deserialized_addr).zcash_serialize_to_vec();
         prop_assert!(
             addr_bytes2.is_ok(),
             "unexpected serialization error after round-trip: {:?}, original addr: {:?}, bytes: {:?}, deserialized addr: {:?}",

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -36,6 +36,7 @@ impl From<Network> for Magic {
 
 /// A protocol version number.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Default))]
 pub struct Version(pub u32);
 
 impl fmt::Display for Version {

--- a/zebra-network/tests/acceptance.rs
+++ b/zebra-network/tests/acceptance.rs
@@ -40,6 +40,6 @@ fn connection_info_types_are_public() {
     let _connection_info = Arc::new(ConnectionInfo {
         connected_addr,
         remote,
-        negotiated_version,
+        negotiated_version: Some(negotiated_version),
     });
 }

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -892,7 +892,7 @@ where
         let address_book = self.address_book.clone();
         async move {
             Ok(address_book
-                .recently_live_peers(chrono::Utc::now())
+                .all_peers()
                 .into_iter()
                 .map(PeerInfo::from)
                 .collect())

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/peer_info.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/peer_info.rs
@@ -11,26 +11,47 @@ pub struct PeerInfo {
     /// The internal state of the peer.
     pub state: String,
 
+    /// The negotiated connection version.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub negotiated_version: Option<String>,
+
+    /// The last version message sent by the peer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_version_message: Option<String>,
+
     /// The untrusted remote last seen time of the peer.
-    pub remote_last_seen: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_last_seen: Option<String>,
 
     /// The last response time from the peer.
     ///
     /// If this was in seconds since the epoch, it would be the specified `lastrecv` field.
-    pub last_response: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_response: Option<String>,
 
     /// The last failure time from the peer.
-    pub last_failed: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_failure: Option<String>,
 }
 
 impl From<MetaAddr> for PeerInfo {
     fn from(meta_addr: MetaAddr) -> Self {
+        let info = meta_addr.last_connection_info();
+
         Self {
             addr: meta_addr.addr(),
             state: format!("{:?}", meta_addr.last_connection_state()),
-            remote_last_seen: format!("{:?}", meta_addr.untrusted_last_seen()),
-            last_response: format!("{:?}", meta_addr.last_response()),
-            last_failed: format!("{:?}", meta_addr.last_failure()),
+            negotiated_version: info
+                .as_ref()
+                .and_then(|info| Some(format!("{:?}", info.negotiated_version?))),
+            last_version_message: info.as_ref().map(|info| format!("{:?}", info.remote)),
+            remote_last_seen: meta_addr
+                .untrusted_last_seen()
+                .map(|time| format!("{:?}", time)),
+            last_response: meta_addr.last_response().map(|time| format!("{:?}", time)),
+            last_failure: meta_addr
+                .last_failure()
+                .map(|instant| format!("{:?}", instant)),
         }
     }
 }

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/peer_info.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/peer_info.rs
@@ -7,12 +7,30 @@ use zebra_network::{types::MetaAddr, PeerSocketAddr};
 pub struct PeerInfo {
     /// The IP address and port of the peer
     pub addr: PeerSocketAddr,
+
+    /// The internal state of the peer.
+    pub state: String,
+
+    /// The untrusted remote last seen time of the peer.
+    pub remote_last_seen: String,
+
+    /// The last response time from the peer.
+    ///
+    /// If this was in seconds since the epoch, it would be the specified `lastrecv` field.
+    pub last_response: String,
+
+    /// The last failure time from the peer.
+    pub last_failed: String,
 }
 
 impl From<MetaAddr> for PeerInfo {
     fn from(meta_addr: MetaAddr) -> Self {
         Self {
             addr: meta_addr.addr(),
+            state: format!("{:?}", meta_addr.last_connection_state()),
+            remote_last_seen: format!("{:?}", meta_addr.untrusted_last_seen()),
+            last_response: format!("{:?}", meta_addr.last_response()),
+            last_failed: format!("{:?}", meta_addr.last_failure()),
         }
     }
 }

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -128,7 +128,7 @@ pub async fn test_responses<State, ReadState>(
         )
         .into(),
     )
-    .into_new_meta_addr(Instant::now(), DateTime32::now())]);
+    .to_new_meta_addr(Instant::now(), DateTime32::now())]);
 
     // get an rpc instance with continuous blockchain state
     let get_block_template_rpc = GetBlockTemplateRpcImpl::new(

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -976,7 +976,7 @@ async fn rpc_getpeerinfo() {
         )
         .into(),
     )
-    .into_new_meta_addr(
+    .to_new_meta_addr(
         std::time::Instant::now(),
         zebra_chain::serialization::DateTime32::now(),
     );

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -981,7 +981,7 @@ async fn rpc_getpeerinfo() {
         zebra_chain::serialization::DateTime32::now(),
     );
 
-    let mock_address_book = MockAddressBookPeers::new(vec![mock_peer_address]);
+    let mock_address_book = MockAddressBookPeers::new(vec![mock_peer_address.clone()]);
 
     // Init RPC
     let get_block_template_rpc = get_block_template_rpcs::GetBlockTemplateRpcImpl::new(


### PR DESCRIPTION
## Motivation

This PR shows extra peer connection information in the `getpeerinfo` RPC and Zebra's logs.

It is just for investigating ticket #7787, these fields are not standard and should not be merged.