### PR TITLE
fix(ci): In config tests, look for the config being successfully loaded by Zebra

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -148,7 +148,7 @@ jobs:
     with:
       test_id: 'custom-conf'
       docker_image: ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
-      grep_patterns: '-e "v1.0.0-rc.2.toml"'
+      grep_patterns: '-e "loaded zebrad config.*config_path.*=.*v1.0.0-rc.2.toml"'
       test_variables: '-e NETWORK -e ZEBRA_CONF_PATH="zebrad/tests/common/configs/v1.0.0-rc.2.toml"'
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
 

--- a/.github/workflows/ci-unit-tests-docker.yml
+++ b/.github/workflows/ci-unit-tests-docker.yml
@@ -237,7 +237,7 @@ jobs:
     with:
       test_id: 'custom-conf'
       docker_image: ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
-      grep_patterns: '-e "v1.0.0-rc.2.toml"'
+      grep_patterns: '-e "loaded zebrad config.*config_path.*=.*v1.0.0-rc.2.toml"'
       test_variables: '-e NETWORK -e ZEBRA_CONF_PATH="zebrad/tests/common/configs/v1.0.0-rc.2.toml"'
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
 


### PR DESCRIPTION
## Motivation

Zebra's configuration loading tests are checking for the file name of the config in any log. But since the entrypoint script also logs the file name, the test can pass before Zebra starts to run:
https://github.com/ZcashFoundation/zebra/actions/runs/6734364310/job/18305634496#step:5:226

(The red highlight shows `grep` finding the success pattern, and then Docker gets stopped.)

Instead, we should check for the log line that loads the config.

This bug doesn't have a ticket, but it blocks this release checklist item in ticket #7764:
>  Wait until the [Docker binaries have been built on main](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-integration-docker.yml), and the quick tests have passed.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - ~~Will the PR name make sense to users?~~ This is an internal CI test coverage bug.
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - ~~Is the documentation up to date?~~ No doc updates required.

Not a significant change.

### Complex Code or Requirements

We need to add some wildcards to the log line, to ignore terminal formatting characters.

## Solution

- Make the test pass when Zebra successfully loads the config file, rather than when any process logs the name of the file

### Testing

Manually inspect the CI logs for Zebra running and logging the config line.

## Review

This is possibly a release blocker (but only if config loading is actually broken).

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
      - Note: There is no ticket, this bug blocks the Docker release tests
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

