### PR TITLE
cleanup(ci): Delete unused cached state patch job

### DIFF
--- a/.github/workflows/ci-unit-tests-docker.patch.yml
+++ b/.github/workflows/ci-unit-tests-docker.patch.yml
@@ -26,13 +26,6 @@ on:
       - '.github/workflows/sub-build-docker-image.yml'
 
 jobs:
-  # We don't patch the testnet job, because testnet isn't required to merge (it's too unstable)
-  get-available-disks:
-    name: Check if cached state disks exist for Mainnet / Check if cached state disks exist
-    runs-on: ubuntu-latest
-    steps:
-      - run: 'echo "No build required"'
-
   build:
     name: Build CI Docker / Build images
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

The cached state isn't used for Docker unit tests, so its patch job isn't needed.

There is no corresponding job in the Docker unit tests:
https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/ci-unit-tests-docker.yml#L78

The job and patch are correctly configured in the Docker GCP integration tests:
https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/ci-integration-tests-gcp.yml#L105
https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/ci-integration-tests-gcp.patch.yml#L30

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

Not a significant change.

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

Delete the unused duplicate patch job.

### Testing

If CI passes we're fine here.

## Review

This is a low priority cleanup. It can merge at any time during the release process, because it doesn't need to go in the changelog.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

