### PR TITLE
fix(net): Fix a potential hang caused by accessing the address book directly

### DIFF
--- a/zebra-network/src/address_book/tests/vectors.rs
+++ b/zebra-network/src/address_book/tests/vectors.rs
@@ -128,9 +128,7 @@ fn address_book_peer_order() {
 fn reconnection_peers_skips_recently_updated_ip() {
     // tests that reconnection_peers() skips addresses where there's a connection at that IP with a recent:
     // - `last_response`
-    test_reconnection_peers_skips_recently_updated_ip(true, |addr| {
-        MetaAddr::new_responded(addr, &PeerServices::NODE_NETWORK)
-    });
+    test_reconnection_peers_skips_recently_updated_ip(true, MetaAddr::new_responded);
 
     // tests that reconnection_peers() *does not* skip addresses where there's a connection at that IP with a recent:
     // - `last_attempt`

--- a/zebra-network/src/address_book_updater.rs
+++ b/zebra-network/src/address_book_updater.rs
@@ -1,6 +1,6 @@
 //! The timestamp collector collects liveness information from peers.
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{cmp::max, net::SocketAddr, sync::Arc};
 
 use thiserror::Error;
 use tokio::{
@@ -12,6 +12,9 @@ use tracing::{Level, Span};
 use crate::{
     address_book::AddressMetrics, meta_addr::MetaAddrChange, AddressBook, BoxError, Config,
 };
+
+/// The minimum size of the address book updater channel.
+pub const MIN_CHANNEL_SIZE: usize = 10;
 
 /// The `AddressBookUpdater` hooks into incoming message streams for each peer
 /// and lets the owner of the sender handle update the address book. For
@@ -46,7 +49,10 @@ impl AddressBookUpdater {
     ) {
         // Create an mpsc channel for peerset address book updates,
         // based on the maximum number of inbound and outbound peers.
-        let (worker_tx, mut worker_rx) = mpsc::channel(config.peerset_total_connection_limit());
+        let (worker_tx, mut worker_rx) = mpsc::channel(max(
+            config.peerset_total_connection_limit(),
+            MIN_CHANNEL_SIZE,
+        ));
 
         let address_book = AddressBook::new(
             local_listener,

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -391,8 +391,7 @@ impl MetaAddr {
         }
     }
 
-    /// Returns a [`MetaAddrChange::UpdateFailed`] for a peer that has just had
-    /// an error.
+    /// Returns a [`MetaAddrChange::UpdateFailed`] for a peer that has just had an error.
     pub fn new_errored(
         addr: PeerSocketAddr,
         services: impl Into<Option<PeerServices>>,
@@ -404,13 +403,10 @@ impl MetaAddr {
     }
 
     /// Create a new `MetaAddr` for a peer that has just shut down.
-    pub fn new_shutdown(
-        addr: PeerSocketAddr,
-        services: impl Into<Option<PeerServices>>,
-    ) -> MetaAddrChange {
+    pub fn new_shutdown(addr: PeerSocketAddr) -> MetaAddrChange {
         // TODO: if the peer shut down in the Responded state, preserve that
         // state. All other states should be treated as (timeout) errors.
-        MetaAddr::new_errored(addr, services.into())
+        MetaAddr::new_errored(addr, None)
     }
 
     /// Return the address for this `MetaAddr`.

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -170,7 +170,7 @@ fn recently_responded_peer_is_gossipable() {
         .into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
-    let peer = MetaAddr::new_responded(address, &PeerServices::NODE_NETWORK)
+    let peer = MetaAddr::new_responded(address)
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 
@@ -191,7 +191,7 @@ fn not_so_recently_responded_peer_is_still_gossipable() {
         .into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
-    let mut peer = MetaAddr::new_responded(address, &PeerServices::NODE_NETWORK)
+    let mut peer = MetaAddr::new_responded(address)
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 
@@ -222,7 +222,7 @@ fn responded_long_ago_peer_is_not_gossipable() {
         .into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
-    let mut peer = MetaAddr::new_responded(address, &PeerServices::NODE_NETWORK)
+    let mut peer = MetaAddr::new_responded(address)
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 
@@ -253,7 +253,7 @@ fn long_delayed_change_is_not_applied() {
         .into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
-    let peer = MetaAddr::new_responded(address, &PeerServices::NODE_NETWORK)
+    let peer = MetaAddr::new_responded(address)
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 
@@ -297,7 +297,7 @@ fn later_revert_change_is_applied() {
         .into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
-    let peer = MetaAddr::new_responded(address, &PeerServices::NODE_NETWORK)
+    let peer = MetaAddr::new_responded(address)
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 
@@ -340,7 +340,7 @@ fn concurrent_state_revert_change_is_not_applied() {
         .into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
-    let peer = MetaAddr::new_responded(address, &PeerServices::NODE_NETWORK)
+    let peer = MetaAddr::new_responded(address)
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 
@@ -400,7 +400,7 @@ fn concurrent_state_progress_change_is_applied() {
         .into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
-    let peer = MetaAddr::new_responded(address, &PeerServices::NODE_NETWORK)
+    let peer = MetaAddr::new_responded(address)
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -929,12 +929,13 @@ where
                 let _ = address_book_updater.send(alt_addr).await;
             }
 
-            // The handshake succeeded: update the peer status from AttemptPending to Responded
+            // The handshake succeeded: update the peer status from AttemptPending to Responded,
+            // and send initial connection info.
             if let Some(book_addr) = connected_addr.get_address_book_addr() {
                 // the collector doesn't depend on network activity,
                 // so this await should not hang
                 let _ = address_book_updater
-                    .send(MetaAddr::new_responded(book_addr, &remote_services))
+                    .send(MetaAddr::new_connected(book_addr, &remote_services))
                     .await;
             }
 

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -414,6 +414,8 @@ where
     }
 
     /// Returns the address book for this `CandidateSet`.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    #[allow(dead_code)]
     pub async fn address_book(&self) -> Arc<std::sync::Mutex<AddressBook>> {
         self.address_book.clone()
     }

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -1097,7 +1097,8 @@ async fn report_failed(
     address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
     addr: MetaAddr,
 ) {
-    let addr = MetaAddr::new_errored(addr.addr, addr.services);
+    // The connection info is the same as what's already in the address book.
+    let addr = MetaAddr::new_errored(addr.addr, None);
 
     // Ignore send errors on Zebra shutdown.
     let _ = address_book_updater.send(addr).await;

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -29,7 +29,6 @@ use tokio_stream::wrappers::IntervalStream;
 use tower::{
     buffer::Buffer, discover::Change, layer::Layer, util::BoxService, Service, ServiceExt,
 };
-use tracing::Span;
 use tracing_futures::Instrument;
 
 use zebra_chain::{chain_tip::ChainTip, diagnostic::task::WaitForPanics};
@@ -197,7 +196,7 @@ where
         config.clone(),
         outbound_connector.clone(),
         peerset_tx.clone(),
-        address_book_updater,
+        address_book_updater.clone(),
     );
     let initial_peers_join = tokio::spawn(initial_peers_fut.in_current_span());
 
@@ -242,6 +241,7 @@ where
         outbound_connector,
         peerset_tx,
         active_outbound_connections,
+        address_book_updater,
     );
     let crawl_guard = tokio::spawn(crawl_fut.in_current_span());
 
@@ -740,6 +740,7 @@ enum CrawlerAction {
 ///
 /// Uses `active_outbound_connections` to limit the number of active outbound connections
 /// across both the initial peers and crawler. The limit is based on `config`.
+#[allow(clippy::too_many_arguments)]
 #[instrument(
     skip(
         config,
@@ -749,6 +750,7 @@ enum CrawlerAction {
         outbound_connector,
         peerset_tx,
         active_outbound_connections,
+        address_book_updater,
     ),
     fields(
         new_peer_interval = ?config.crawl_new_peer_interval,
@@ -762,6 +764,7 @@ async fn crawl_and_dial<C, S>(
     outbound_connector: C,
     peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
     mut active_outbound_connections: ActiveConnectionCounter,
+    address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
 ) -> Result<(), BoxError>
 where
     C: Service<
@@ -782,8 +785,6 @@ where
         outbound_connections = ?active_outbound_connections.update_count(),
         "starting the peer address crawler",
     );
-
-    let address_book = candidates.address_book().await;
 
     // # Concurrency
     //
@@ -857,7 +858,7 @@ where
                 let candidates = candidates.clone();
                 let outbound_connector = outbound_connector.clone();
                 let peerset_tx = peerset_tx.clone();
-                let address_book = address_book.clone();
+                let address_book_updater = address_book_updater.clone();
                 let demand_tx = demand_tx.clone();
 
                 // Increment the connection count before we spawn the connection.
@@ -886,7 +887,7 @@ where
                                 outbound_connector,
                                 outbound_connection_tracker,
                                 peerset_tx,
-                                address_book,
+                                address_book_updater,
                                 demand_tx,
                             )
                             .await?;
@@ -1020,7 +1021,7 @@ where
     outbound_connector,
     outbound_connection_tracker,
     peerset_tx,
-    address_book,
+    address_book_updater,
     demand_tx
 ))]
 async fn dial<C>(
@@ -1028,7 +1029,7 @@ async fn dial<C>(
     mut outbound_connector: C,
     outbound_connection_tracker: ConnectionTracker,
     mut peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
-    address_book: Arc<std::sync::Mutex<AddressBook>>,
+    address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
 ) -> Result<(), BoxError>
 where
@@ -1069,8 +1070,8 @@ where
         }
         // The connection was never opened, or it failed the handshake and was dropped.
         Err(error) => {
-            debug!(?error, ?candidate.addr, "failed to make outbound connection to peer");
-            report_failed(address_book.clone(), candidate).await;
+            info!(?error, ?candidate.addr, "failed to make outbound connection to peer");
+            report_failed(address_book_updater.clone(), candidate).await;
 
             // The demand signal that was taken out of the queue to attempt to connect to the
             // failed candidate never turned into a connection, so add it back.
@@ -1090,25 +1091,14 @@ where
     Ok(())
 }
 
-/// Mark `addr` as a failed peer in `address_book`.
-#[instrument(skip(address_book))]
-async fn report_failed(address_book: Arc<std::sync::Mutex<AddressBook>>, addr: MetaAddr) {
+/// Mark `addr` as a failed peer to `address_book_updater`.
+#[instrument(skip(address_book_updater))]
+async fn report_failed(
+    address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
+    addr: MetaAddr,
+) {
     let addr = MetaAddr::new_errored(addr.addr, addr.services);
 
-    // # Correctness
-    //
-    // Spawn address book accesses on a blocking thread, to avoid deadlocks (see #1976).
-    let span = Span::current();
-    let updated_addr = tokio::task::spawn_blocking(move || {
-        span.in_scope(|| address_book.lock().unwrap().update(addr))
-    })
-    .wait_for_panics()
-    .await;
-
-    assert_eq!(
-        updated_addr.map(|addr| addr.addr()),
-        Some(addr.addr()),
-        "incorrect address updated by address book: \
-         original: {addr:?}, updated: {updated_addr:?}"
-    );
+    // Ignore send errors on Zebra shutdown.
+    let _ = address_book_updater.send(addr).await;
 }


### PR DESCRIPTION
## Motivation

The outbound connector accesses the address book directly, potentially blocking other connections or async tasks. Instead, we can send the failure to the channel.

Also there are some unnecessary services arguments in address book updates.

These fixes happened as part of #7787.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - ~~Have you added or updated tests?~~ Hangs are extremely difficult to test for.
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

### Complex Code or Requirements

Sending to channels is much faster and cheaper than locking a mutex, which can be delayed for a long time under heavy load.

## Solution

- Send failures to the address book update channel
- Fix a (possibly unreachable) panic with a zero channel size
- Remove unnecessary `services` arguments from some address book updates
- Update tests

### Testing

Existing tests cover this code, but hangs are hard to test for.

## Review

This is a low priority bug fix.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._


