### PR TITLE
Release Zebra 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ macOS on a best-effort basis.
 We have changed our documentation website URL, and we are considering deprecating some Docker image
 tags in release 1.5.0 and later.
 
-TODO: rest of intro
-
 ### Deprecation Warnings
 
 This release has the following deprecation warnings:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,19 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Zebra 1.4.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.4.0) - TODO: DATE
+## [Zebra 1.4.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.4.0) - 2023-11-07
 
-Zebra's mining RPCs are now available in release builds. Our Docker images are significantly smaller,
-because the smaller Zcash verification parameters are now built into the `zebrad` binary.
+Zebra's mining RPCs are now available in release builds. Our Docker images are significantly
+smaller, because the smaller Zcash verification parameters are now built into the `zebrad` binary.
+Zebra has updated to the shared Rust dependencies from the `zcashd` 5.7.0 release.
+
+Zebra recovers better from brief network interruptions, and avoids some network and verification
+denial of service and performance issues. We have restored our macOS tests in CI, and now support
+macOS on a best-effort basis.
+
+We have changed our documentation website URL, and we are considering deprecating some Docker image
+tags in release 1.5.0 and later.
+
 TODO: rest of intro
 
 ### Deprecation Warnings
@@ -87,9 +96,44 @@ so it can't be used to retry failed downloads in `zebrad` 1.3.0 and earlier.
 
 We recommend upgrading to the latest Zebra release to avoid download issues in new installs.
 
+#### macOS Support
+
+macOS x86_64 is now supported on a best-effort basis. macOS builds and some tests run in Zebra's CI.
+
 ### Security
 
-TODO: rest of changelog
+- Reconnect with peers after brief network interruption ([#7853](https://github.com/ZcashFoundation/zebra/pull/7853))
+- Add outer timeouts for critical network operations to avoid hangs ([#7869](https://github.com/ZcashFoundation/zebra/pull/7869))
+- Set iterator read bounds where possible in DiskDb, to avoid a known RocksDB denial of service issue ([#7731](https://github.com/ZcashFoundation/zebra/pull/7731), [#7732](https://github.com/ZcashFoundation/zebra/pull/7732))
+- Fix concurrency issues in tree key formats, and CPU usage in genesis tree roots ([#7392](https://github.com/ZcashFoundation/zebra/pull/7392))
+
+### Removed
+
+- Remove the `zebrad download` command, because it no longer does anything ([#7819](https://github.com/ZcashFoundation/zebra/pull/7819))
+
+### Added
+
+- Enable mining RPCs by default in production builds ([#7740](https://github.com/ZcashFoundation/zebra/pull/7740))
+- Re-enable macOS builds and tests in CI ([#7834](https://github.com/ZcashFoundation/zebra/pull/7834))
+- Make macOS x86_64 a tier 2 supported platform in the docs ([#7843](https://github.com/ZcashFoundation/zebra/pull/7843))
+- Add macOS M1 as a tier 3 supported platform ([#7851](https://github.com/ZcashFoundation/zebra/pull/7851))
+
+### Changed
+
+- Build Sprout and Sapling parameters into the zebrad binary, so a download server isn't needed ([#7800](https://github.com/ZcashFoundation/zebra/pull/7800), [#7844](https://github.com/ZcashFoundation/zebra/pull/7844))
+- Bump ECC dependencies for `zcashd` 5.7.0 ([#7784](https://github.com/ZcashFoundation/zebra/pull/7784))
+- Refactor the installation instructions for the `s-nomp` mining pool software ([#7835](https://github.com/ZcashFoundation/zebra/pull/7835))
+
+### Fixed
+
+- Make the `latest` Docker tag point to the production build, rather than the build with experimental features ([#7817](https://github.com/ZcashFoundation/zebra/pull/7817))
+- Fix an incorrect consensus-critical ZIP 212 comment ([#7774](https://github.com/ZcashFoundation/zebra/pull/7774))
+- Fix broken links to `zebra_network` and `zebra_state` `Config` structs on doc-internal.zebra.zfnd.org ([#7838](https://github.com/ZcashFoundation/zebra/pull/7838))
+
+### Contributors
+
+Thank you to everyone who contributed to this release, we couldn't make Zebra without you:
+@arya2, @gustavovalverde, @mpguerra, @oxarbitrage, @rex4539, @teor2345, @upbqdn, and @vuittont60.
 
 ## [Zebra 1.3.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.3.0) - 2023-10-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "tower-batch-control"
-version = "0.2.41-beta.6"
+version = "0.2.41-beta.7"
 dependencies = [
  "color-eyre",
  "ed25519-zebra",
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "tower-fallback"
-version = "0.2.41-beta.6"
+version = "0.2.41-beta.7"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5543,7 +5543,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 dependencies = [
  "bitflags 2.4.1",
  "bitflags-serde-legacy",
@@ -5604,7 +5604,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5650,7 +5650,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 dependencies = [
  "bitflags 2.4.1",
  "byteorder",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 dependencies = [
  "color-eyre",
  "jsonrpc-core",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 dependencies = [
  "chrono",
  "futures",
@@ -5735,7 +5735,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 dependencies = [
  "displaydoc",
  "hex",
@@ -5748,7 +5748,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 dependencies = [
  "bincode",
  "chrono",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-test"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 dependencies = [
  "color-eyre",
  "futures",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 dependencies = [
  "color-eyre",
  "hex",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ performance.
 
 There are a few bugs in Zebra that we're still working on fixing:
 
+- [The `getpeerinfo` RPC shows current and recent outbound connections](https://github.com/ZcashFoundation/zebra/issues/7893), rather than current inbound and outbound connections.
+
 - [Progress bar estimates can become extremely large](https://github.com/console-rs/indicatif/issues/556). We're waiting on a fix in the progress bar library.
 
 - Zebra currently gossips and connects to [private IP addresses](https://en.wikipedia.org/wiki/IP_address#Private_addresses), we want to [disable private IPs but provide a config (#3117)](https://github.com/ZcashFoundation/zebra/issues/3117) in an upcoming release

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -17,7 +17,7 @@ docker run --detach zfnd/zebra:latest
 ### Build it locally
 
 ```shell
-git clone --depth 1 --branch v1.3.0 https://github.com/ZcashFoundation/zebra.git
+git clone --depth 1 --branch v1.4.0 https://github.com/ZcashFoundation/zebra.git
 docker build --file docker/Dockerfile --target runtime --tag zebra:local .
 docker run --detach zebra:local
 ```

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -20,7 +20,7 @@ To compile Zebra directly from GitHub, or from a GitHub release source archive:
 ```sh
 git clone https://github.com/ZcashFoundation/zebra.git
 cd zebra
-git checkout v1.3.0
+git checkout v1.4.0
 ```
 
 3. Build and Run `zebrad`
@@ -33,7 +33,7 @@ target/release/zebrad start
 ### Compiling from git using cargo install
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.3.0 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.4.0 zebrad
 ```
 
 ### Compiling on ARM

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-batch-control"
-version = "0.2.41-beta.6"
+version = "0.2.41-beta.7"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Tower middleware for batch request processing"
 # # Legal

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-fallback"
-version = "0.2.41-beta.6"
+version = "0.2.41-beta.7"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Tower service combinator that sends requests to a first service, then retries processing on a second fallback service if the first service errors."
 license = "MIT OR Apache-2.0"

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Core Zcash data structures"
 license = "MIT OR Apache-2.0"
@@ -126,7 +126,7 @@ proptest-derive = { version = "0.4.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand_chacha = { version = "0.3.1", optional = true }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.30", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.31", optional = true }
 
 [dev-dependencies]
 # Benchmarks

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Implementation of Zcash consensus checks"
 license = "MIT OR Apache-2.0"
@@ -63,13 +63,13 @@ orchard = "0.6.0"
 zcash_proofs = { version = "0.13.0-rc.1", features = ["multicore" ] }
 wagyu-zcash-parameters = "0.2.0"
 
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.6" }
-tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.6" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.7" }
+tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.7" }
 
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.30" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.30" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.30" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.30" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.31" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.31" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.31" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.31" }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal
@@ -83,7 +83,7 @@ howudoin = { version = "0.1.2", optional = true }
 proptest = { version = "1.3.1", optional = true }
 proptest-derive = { version = "0.4.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.30", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.31", features = ["async-error"] }
 
 [dev-dependencies]
 proptest = "1.3.1"

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-node-services"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The interfaces of some Zebra node services"
 license = "MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.30" }
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.31" }
 
 # Optional dependencies
 

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license = "MIT OR Apache-2.0"
@@ -70,12 +70,12 @@ zcash_address = { version = "0.3.0", optional = true }
 # Test-only feature proptest-impl
 proptest = { version = "1.3.1", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.30", features = ["json-conversion"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.30" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.30" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.30" }
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.30" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.30" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.31", features = ["json-conversion"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.31" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.31" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.31" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.31" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.31" }
 
 [dev-dependencies]
 insta = { version = "1.33.0", features = ["redactions", "json", "ron"] }

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license = "MIT OR Apache-2.0"
@@ -17,7 +17,7 @@ categories = ["api-bindings", "cryptography::cryptocurrencies"]
 [dependencies]
 zcash_script = "0.1.14"
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.30" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.31" }
 
 thiserror = "1.0.48"
 displaydoc = "0.2.4"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "State contextual verification and storage code for Zebra"
 license = "MIT OR Apache-2.0"
@@ -73,13 +73,13 @@ tracing = "0.1.39"
 elasticsearch = { version = "8.5.0-alpha.1", default-features = false, features = ["rustls-tls"], optional = true }
 serde_json = { version = "1.0.108", package = "serde_json", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.30", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.31", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
 
 # test feature proptest-impl
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.30", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.31", optional = true }
 proptest = { version = "1.3.1", optional = true }
 proptest-derive = { version = "0.4.0", optional = true }
 

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-test"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Test harnesses and test vectors for Zebra"
 license = "MIT OR Apache-2.0"

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Developer tools for Zebra maintenance and testing"
 license = "MIT OR Apache-2.0"
@@ -74,11 +74,11 @@ tracing-error = "0.2.0"
 tracing-subscriber = "0.3.17"
 thiserror = "1.0.48"
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.30" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.30" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.31" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.31" }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.30", optional = true }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.31", optional = true }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { version = "0.11.0", optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license = "MIT OR Apache-2.0"
@@ -145,15 +145,15 @@ test_sync_past_mandatory_checkpoint_mainnet = []
 test_sync_past_mandatory_checkpoint_testnet = []
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.30" }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.30" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.30" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.30" }
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.30" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.30" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.31" }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.31" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.31" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.31" }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.31" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.31" }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.30", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.31", optional = true }
 
 abscissa_core = "0.7.0"
 clap = { version = "4.4.7", features = ["cargo"] }

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_264_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_290_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
Close #7764

# Prepare for the Release

- [x] Make sure there has been [at least one successful full sync test](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-integration-docker.yml?query=event%3Aschedule) since the last state change, or start a manual full sync.
- [x] Make sure the PRs with the new checkpoint hashes and missed dependencies are already merged.
      (See the release ticket checklist for details)


# Summarise Release Changes

These steps can be done a few days before the release, in the same PR:

## Change Log

**Important**: Any merge into `main` deletes any edits to the draft changelog.
Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.

We use [the Release Drafter workflow](https://github.com/marketplace/actions/release-drafter) to automatically create a [draft changelog](https://github.com/ZcashFoundation/zebra/releases). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.

To create the final change log:
- [x] Copy the **latest** draft changelog into `CHANGELOG.md` (there can be multiple draft releases)
- [x] Delete any trivial changes
    - [x] Put the list of deleted changelog entries in a PR comment to make reviewing easier
- [x] Combine duplicate changes
- [x] Edit change descriptions so they will make sense to Zebra users
- [x] Check the category for each change
  - Prefer the "Fix" category if you're not sure

## README

README updates can be skipped for urgent releases.

Update the README to:
- [x] Remove any "Known Issues" that have been fixed since the last release.
- [x] Update the "Build and Run Instructions" with any new dependencies.
      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
- [x] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s

You can use a command like:
```sh
fastmod --fixed-strings '1.58' '1.65'
```

## Create the Release PR

- [x] Push the updated changelog and README into a new branch
      for example: `bump-v1.0.0` - this needs to be different to the tag name
- [x] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
- [x] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
- [x] Mark all non-release PRs with `do-not-merge`, because Mergify checks approved PRs against every commit, even when a queue is frozen.


# Update Versions and End of Support

## Update Zebra Version

### Choose a Release Level

Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]

Choose a release level for `zebrad`. Release levels are based on user-visible changes from the changelog:
- Mainnet Network Upgrades are `major` releases
- significant new features or behaviour changes; changes to RPCs, command-line, or configs; and deprecations or removals are `minor` releases
- otherwise, it is a `patch` release

Zebra's Rust API doesn't have any support or stability guarantees, so we keep all the `zebra-*` and `tower-*` crates on a beta `pre-release` version.

### Update Crate Versions

If you're publishing crates for the first time, [log in to crates.io](https://github.com/ZcashFoundation/zebra/blob/doc-crate-own/book/src/dev/crate-owners.md#logging-in-to-cratesio),
and make sure you're a member of owners group.

Check that the release will work:
- [x] Update crate versions, commit the changes to the release branch, and do a release dry-run:

```sh
cargo release version --verbose --execute --allow-branch '*' --workspace --exclude zebrad beta
cargo release version --verbose --execute --allow-branch '*' --package zebrad patch # [ major | minor | patch ]
cargo release replace --verbose --execute --allow-branch '*' --package zebrad
cargo release commit --verbose --execute --allow-branch '*'
```

Crate publishing is [automatically checked in CI](https://github.com/ZcashFoundation/zebra/actions/workflows/release-crates-io.yml) using "dry run" mode.

## Update End of Support

The end of support height is calculated from the current blockchain height:
- [x] Find where the Zcash blockchain tip is now by using a [Zcash explorer](https://zcashblockexplorer.com/blocks) or other tool.
- [x] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.

<details>

<summary>Optional: calculate the release tagging height</summary>

- Add `1152` blocks for each day until the release
- For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height

</details>

## Update the Release PR

- [x] Push the version increments and the release constants to the release branch.


# Publish the Zebra Release

## Create the GitHub Pre-Release

- [x] Wait for all the release PRs to be merged
- [x] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
- [x] Set the tag name to the version tag,
      for example: `v1.0.0`
- [x] Set the release to target the `main` branch
- [x] Set the release title to `Zebra ` followed by the version tag,
      for example: `Zebra 1.0.0`
- [x] Replace the prepopulated draft changelog in the release description with the final changelog you created;
      starting just _after_ the title `## [Zebra ...` of the current version being released,
      and ending just _before_ the title of the previous release.
- [x] Mark the release as 'pre-release', until it has been built and tested
- [x] Publish the pre-release to GitHub using "Publish Release"
- [x] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)

## Test the Pre-Release

- [x] Wait until the Docker binaries have been built on `main`, and the quick tests have passed:
    - [x] [ci-unit-tests-docker.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-unit-tests-docker.yml?query=branch%3Amain)
    - [x] [ci-integration-tests-gcp.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-integration-tests-gcp.yml?query=branch%3Amain)
- [x] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/cd-deploy-nodes-gcp.yml?query=event%3Arelease)

## Publish Release

- [x] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"

## Publish Crates

- [x] [Run `cargo login`](https://github.com/ZcashFoundation/zebra/blob/doc-crate-own/book/src/dev/crate-owners.md#logging-in-to-cratesio)
- [x] Run `cargo clean` in the zebra repo (optional)
- [x] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute`
- [x] Check that Zebra can be installed from `crates.io`:
      `cargo install --locked --force --version 1.minor.patch zebrad && ~/.cargo/bin/zebrad`
      and put the output in a comment on the PR.

## Publish Docker Images
- [x] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml).
- [x] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Remove `do-not-merge` from the PRs you added it to

## Release Failures

If building or running fails after tagging:

<details>

<summary>Tag a new release, following these instructions...</summary>

1. Fix the bug that caused the failure
2. Start a new `patch` release
3. Skip the **Release Preparation**, and start at the **Release Changes** step
4. Update `CHANGELOG.md` with details about the fix
5. Follow the release checklist for the new Zebra version

</details>
