### PR TITLE
change(release): Only allow releases from the `main` branch, and update workflow names

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -131,8 +131,10 @@ The end of support height is calculated from the current blockchain height:
 
 ## Test the Pre-Release
 
-- [ ] Wait until the [Docker binaries have been built on `main`](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-integration-docker.yml), and the quick tests have passed.
-- [ ] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/continous-delivery.yml)
+- [ ] Wait until the Docker binaries have been built on `main`, and the quick tests have passed:
+    - [ ] [ci-unit-tests-docker.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-unit-tests-docker.yml?query=branch%3Amain)
+    - [ ] [ci-integration-tests-gcp.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-integration-tests-gcp.yml?query=branch%3Amain)
+- [ ] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/cd-deploy-nodes-gcp.yml?query=event%3Arelease)
 
 ## Publish Release
 

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -150,7 +150,7 @@ The end of support height is calculated from the current blockchain height:
       and put the output in a comment on the PR.
 
 ## Publish Docker Images
-- [ ] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml).
+- [ ] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
 - [ ] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
 - [ ] Remove `do-not-merge` from the PRs you added it to
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,13 @@ members = [
 # Use the edition 2021 dependency resolver in the workspace, to match the crates
 resolver = "2"
 
+# `cargo release` settings
+
+[workspace.metadata.release]
+
+# We always do releases from the main branch
+allow-branch = ["main"]
+
 # Compilation settings
 
 [profile.dev]


### PR DESCRIPTION
## Motivation

1. We could accidentally release from any branch, but we only want to release from `main`
2. Some of the workflow names have changed, so they need to be updated in the release template

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - ~Will the PR name make sense to users?~ Internal PR
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

Not a significant change.

_If a checkbox isn't relevant to the PR, mark it as done._

### Specifications

https://github.com/crate-ci/cargo-release/blob/master/docs/reference.md#config-fields

## Solution

1. Configure `cargo release` to only release from `main` (it exits with an error for any other branch)
2. Update workflow links

### Testing

I manually tested releasing from another branch fails, and I tested the links.

## Review

This is a low priority cleanup.

### Reviewer Checklist

Check before approving the PR:
  - [x] Does the PR scope match the ticket?
  - [x] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [x] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

