### PR TITLE
change(state): Make the types for finalized blocks consistent

### DIFF
--- a/zebra-chain/src/orchard/tree.rs
+++ b/zebra-chain/src/orchard/tree.rs
@@ -325,6 +325,10 @@ pub enum NoteCommitmentTreeError {
 }
 
 /// Orchard Incremental Note Commitment Tree
+///
+/// Note that the default value of the [`Root`] type is `[0, 0, 0, 0]`. However, this value differs
+/// from the default value of the root of the default tree which is the hash of the root's child
+/// nodes. The default tree is the empty tree which has all leaves empty.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(into = "LegacyNoteCommitmentTree")]
 #[serde(from = "LegacyNoteCommitmentTree")]

--- a/zebra-chain/src/parallel/tree.rs
+++ b/zebra-chain/src/parallel/tree.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// An argument wrapper struct for note commitment trees.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct NoteCommitmentTrees {
     /// The sprout note commitment tree.
     pub sprout: Arc<sprout::tree::NoteCommitmentTree>,

--- a/zebra-chain/src/parallel/tree.rs
+++ b/zebra-chain/src/parallel/tree.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// An argument wrapper struct for note commitment trees.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct NoteCommitmentTrees {
     /// The sprout note commitment tree.
     pub sprout: Arc<sprout::tree::NoteCommitmentTree>,

--- a/zebra-chain/src/parallel/tree.rs
+++ b/zebra-chain/src/parallel/tree.rs
@@ -11,6 +11,8 @@ use crate::{
 };
 
 /// An argument wrapper struct for note commitment trees.
+///
+/// The default instance represents the trees and subtrees that correspond to the genesis block.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct NoteCommitmentTrees {
     /// The sprout note commitment tree.

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -305,6 +305,10 @@ pub enum NoteCommitmentTreeError {
 }
 
 /// Sapling Incremental Note Commitment Tree.
+///
+/// Note that the default value of the [`Root`] type is `[0, 0, 0, 0]`. However, this value differs
+/// from the default value of the root of the default tree which is the hash of the root's child
+/// nodes. The default tree is the empty tree which has all leaves empty.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(into = "LegacyNoteCommitmentTree")]
 #[serde(from = "LegacyNoteCommitmentTree")]

--- a/zebra-chain/src/sprout/tree.rs
+++ b/zebra-chain/src/sprout/tree.rs
@@ -206,6 +206,10 @@ pub enum NoteCommitmentTreeError {
 /// Internally this wraps [`bridgetree::Frontier`], so that we can maintain and increment
 /// the full tree with only the minimal amount of non-empty nodes/leaves required.
 ///
+/// Note that the default value of the [`Root`] type is `[0, 0, 0, 0]`. However, this value differs
+/// from the default value of the root of the default tree (which is the empty tree) since it is the
+/// pair-wise root-hash of the tree's empty leaves at the tree's root level.
+///
 /// [Sprout Note Commitment Tree]: https://zips.z.cash/protocol/protocol.pdf#merkletree
 /// [nullifier set]: https://zips.z.cash/protocol/protocol.pdf#nullifierset
 #[derive(Debug, Serialize, Deserialize)]

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -224,7 +224,7 @@ pub struct ContextuallyVerifiedBlock {
 }
 
 /// Wraps note commitment trees and the history tree together.
-#[derive(Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Treestate {
     /// Note commitment trees.
     pub note_commitment_trees: NoteCommitmentTrees,

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -224,6 +224,8 @@ pub struct ContextuallyVerifiedBlock {
 }
 
 /// Wraps note commitment trees and the history tree together.
+///
+/// The default instance represents the treestate that corresponds to the genesis block.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Treestate {
     /// Note commitment trees.

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -26,6 +26,7 @@ use zebra_chain::{
 use zebra_test::vectors::{MAINNET_BLOCKS, TESTNET_BLOCKS};
 
 use crate::{
+    request::{FinalizedBlock, Treestate},
     service::finalized_state::{disk_db::DiskWriteBatch, ZebraDb},
     CheckpointVerifiedBlock, Config,
 };
@@ -108,7 +109,7 @@ fn test_block_db_round_trip_with(
 
         // Now, use the database
         let original_block = Arc::new(original_block);
-        let finalized = if original_block.coinbase_height().is_some() {
+        let checkpoint_verified = if original_block.coinbase_height().is_some() {
             original_block.clone().into()
         } else {
             // Fake a zero height
@@ -118,6 +119,10 @@ fn test_block_db_round_trip_with(
                 Height(0),
             )
         };
+
+        let dummy_treestate = Treestate::default();
+        let finalized =
+            FinalizedBlock::from_checkpoint_verified(checkpoint_verified, dummy_treestate);
 
         // Skip validation by writing the block directly to the database
         let mut batch = DiskWriteBatch::new();

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -19,12 +19,13 @@ use zebra_chain::{
 };
 
 use crate::{
+    request::FinalizedBlock,
     service::finalized_state::{
         disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
         disk_format::RawBytes,
         zebra_db::ZebraDb,
     },
-    BoxError, SemanticallyVerifiedBlock,
+    BoxError,
 };
 
 impl ZebraDb {
@@ -128,13 +129,13 @@ impl DiskWriteBatch {
     pub fn prepare_chain_value_pools_batch(
         &mut self,
         db: &DiskDb,
-        finalized: &SemanticallyVerifiedBlock,
+        finalized: &FinalizedBlock,
         utxos_spent_by_block: HashMap<transparent::OutPoint, transparent::Utxo>,
         value_pool: ValueBalance<NonNegative>,
     ) -> Result<(), BoxError> {
         let tip_chain_value_pool = db.cf_handle("tip_chain_value_pool").unwrap();
 
-        let SemanticallyVerifiedBlock { block, .. } = finalized;
+        let FinalizedBlock { block, .. } = finalized;
 
         let new_pool = value_pool.add_block(block.borrow(), &utxos_spent_by_block)?;
         self.zs_insert(&tip_chain_value_pool, (), new_pool);

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -25,6 +25,7 @@ use zebra_chain::{
 };
 
 use crate::{
+    request::FinalizedBlock,
     service::finalized_state::{
         disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
         disk_format::{
@@ -36,7 +37,7 @@ use crate::{
         },
         zebra_db::ZebraDb,
     },
-    BoxError, SemanticallyVerifiedBlock,
+    BoxError,
 };
 
 impl ZebraDb {
@@ -347,13 +348,13 @@ impl DiskWriteBatch {
         &mut self,
         db: &DiskDb,
         network: Network,
-        finalized: &SemanticallyVerifiedBlock,
+        finalized: &FinalizedBlock,
         new_outputs_by_out_loc: &BTreeMap<OutputLocation, transparent::Utxo>,
         spent_utxos_by_outpoint: &HashMap<transparent::OutPoint, transparent::Utxo>,
         spent_utxos_by_out_loc: &BTreeMap<OutputLocation, transparent::Utxo>,
         mut address_balances: HashMap<transparent::Address, AddressBalanceLocation>,
     ) -> Result<(), BoxError> {
-        let SemanticallyVerifiedBlock { block, height, .. } = finalized;
+        let FinalizedBlock { block, height, .. } = finalized;
 
         // Update created and spent transparent outputs
         self.prepare_new_transparent_outputs_batch(


### PR DESCRIPTION
## Motivation

Close #7273. I initially wanted to summarize the discussion that the issue points to in the issue description, but I ended up fixing the code itself because I thought it was easier.

The issue was that we were using `SemanticallyVerifiedBlock` and `SemanticallyVerifiedBlockWithTrees` for blocks that the finalized state commits to its database. Doing so is not what we want because, as Teor said:

> Also, I don't think we should be downgrading verification status from contextual or checkpoint to semantic, unless it's a quick downgrade using into(), and then calling a common verification function. Most of the time we've already done that verification on those types though!

### PR Author Checklist

  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

## Solution

- Use a new structure called `FinalizedBlock` instead of `SemanticallyVerifiedBlockWithTrees`, and also use it when writing a finalized block into the database.
- This PR doesn't really change any logic in the state. It is only a structural refactor.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._