### PR TITLE
change(network): Add configurable network parameters to `Network::Testnet`

### DIFF
--- a/zebra-chain/src/block/tests/vectors.rs
+++ b/zebra-chain/src/block/tests/vectors.rs
@@ -202,7 +202,7 @@ fn block_test_vectors_height_mainnet() {
 fn block_test_vectors_height_testnet() {
     let _init_guard = zebra_test::init();
 
-    block_test_vectors_height(Testnet(None.into()));
+    block_test_vectors_height(Network::new_testnet());
 }
 
 /// Test that the block test vector indexes match the heights in the block data,
@@ -254,7 +254,7 @@ fn block_commitment_mainnet() {
 fn block_commitment_testnet() {
     let _init_guard = zebra_test::init();
 
-    block_commitment(Testnet(None.into()));
+    block_commitment(Network::new_testnet());
 }
 
 /// Check that the block commitment field parses without errors.

--- a/zebra-chain/src/block/tests/vectors.rs
+++ b/zebra-chain/src/block/tests/vectors.rs
@@ -202,7 +202,7 @@ fn block_test_vectors_height_mainnet() {
 fn block_test_vectors_height_testnet() {
     let _init_guard = zebra_test::init();
 
-    block_test_vectors_height(Testnet);
+    block_test_vectors_height(Testnet(None.into()));
 }
 
 /// Test that the block test vector indexes match the heights in the block data,
@@ -213,7 +213,7 @@ fn block_test_vectors_height(network: Network) {
             zebra_test::vectors::MAINNET_BLOCKS.iter(),
             zebra_test::vectors::MAINNET_FINAL_SAPLING_ROOTS.clone(),
         ),
-        Testnet => (
+        Testnet(_) => (
             zebra_test::vectors::TESTNET_BLOCKS.iter(),
             zebra_test::vectors::TESTNET_FINAL_SAPLING_ROOTS.clone(),
         ),
@@ -254,7 +254,7 @@ fn block_commitment_mainnet() {
 fn block_commitment_testnet() {
     let _init_guard = zebra_test::init();
 
-    block_commitment(Testnet);
+    block_commitment(Testnet(None.into()));
 }
 
 /// Check that the block commitment field parses without errors.
@@ -267,7 +267,7 @@ fn block_commitment(network: Network) {
             zebra_test::vectors::MAINNET_BLOCKS.iter(),
             zebra_test::vectors::MAINNET_FINAL_SAPLING_ROOTS.clone(),
         ),
-        Testnet => (
+        Testnet(_) => (
             zebra_test::vectors::TESTNET_BLOCKS.iter(),
             zebra_test::vectors::TESTNET_FINAL_SAPLING_ROOTS.clone(),
         ),

--- a/zebra-chain/src/history_tree/tests/vectors.rs
+++ b/zebra-chain/src/history_tree/tests/vectors.rs
@@ -26,9 +26,9 @@ use zebra_test::vectors::{
 #[test]
 fn push_and_prune() -> Result<()> {
     push_and_prune_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Heartwood)?;
-    push_and_prune_for_network_upgrade(Network::Testnet(None.into()), NetworkUpgrade::Heartwood)?;
+    push_and_prune_for_network_upgrade(Network::new_testnet(), NetworkUpgrade::Heartwood)?;
     push_and_prune_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Canopy)?;
-    push_and_prune_for_network_upgrade(Network::Testnet(None.into()), NetworkUpgrade::Canopy)?;
+    push_and_prune_for_network_upgrade(Network::new_testnet(), NetworkUpgrade::Canopy)?;
     Ok(())
 }
 
@@ -115,7 +115,7 @@ fn upgrade() -> Result<()> {
     // The history tree only exists Hearwood-onward, and the only upgrade for which
     // we have vectors since then is Canopy. Therefore, only test the Heartwood->Canopy upgrade.
     upgrade_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Canopy)?;
-    upgrade_for_network_upgrade(Network::Testnet(None.into()), NetworkUpgrade::Canopy)?;
+    upgrade_for_network_upgrade(Network::new_testnet(), NetworkUpgrade::Canopy)?;
     Ok(())
 }
 

--- a/zebra-chain/src/history_tree/tests/vectors.rs
+++ b/zebra-chain/src/history_tree/tests/vectors.rs
@@ -26,9 +26,9 @@ use zebra_test::vectors::{
 #[test]
 fn push_and_prune() -> Result<()> {
     push_and_prune_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Heartwood)?;
-    push_and_prune_for_network_upgrade(Network::Testnet, NetworkUpgrade::Heartwood)?;
+    push_and_prune_for_network_upgrade(Network::Testnet(None.into()), NetworkUpgrade::Heartwood)?;
     push_and_prune_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Canopy)?;
-    push_and_prune_for_network_upgrade(Network::Testnet, NetworkUpgrade::Canopy)?;
+    push_and_prune_for_network_upgrade(Network::Testnet(None.into()), NetworkUpgrade::Canopy)?;
     Ok(())
 }
 
@@ -38,7 +38,7 @@ fn push_and_prune_for_network_upgrade(
 ) -> Result<()> {
     let (blocks, sapling_roots) = match network {
         Network::Mainnet => (&*MAINNET_BLOCKS, &*MAINNET_FINAL_SAPLING_ROOTS),
-        Network::Testnet => (&*TESTNET_BLOCKS, &*TESTNET_FINAL_SAPLING_ROOTS),
+        Network::Testnet(_) => (&*TESTNET_BLOCKS, &*TESTNET_FINAL_SAPLING_ROOTS),
     };
     let height = network_upgrade.activation_height(network).unwrap().0;
 
@@ -115,14 +115,14 @@ fn upgrade() -> Result<()> {
     // The history tree only exists Hearwood-onward, and the only upgrade for which
     // we have vectors since then is Canopy. Therefore, only test the Heartwood->Canopy upgrade.
     upgrade_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Canopy)?;
-    upgrade_for_network_upgrade(Network::Testnet, NetworkUpgrade::Canopy)?;
+    upgrade_for_network_upgrade(Network::Testnet(None.into()), NetworkUpgrade::Canopy)?;
     Ok(())
 }
 
 fn upgrade_for_network_upgrade(network: Network, network_upgrade: NetworkUpgrade) -> Result<()> {
     let (blocks, sapling_roots) = match network {
         Network::Mainnet => (&*MAINNET_BLOCKS, &*MAINNET_FINAL_SAPLING_ROOTS),
-        Network::Testnet => (&*TESTNET_BLOCKS, &*TESTNET_FINAL_SAPLING_ROOTS),
+        Network::Testnet(_) => (&*TESTNET_BLOCKS, &*TESTNET_FINAL_SAPLING_ROOTS),
     };
     let height = network_upgrade.activation_height(network).unwrap().0;
 

--- a/zebra-chain/src/parameters/arbitrary.rs
+++ b/zebra-chain/src/parameters/arbitrary.rs
@@ -2,7 +2,7 @@
 
 use proptest::prelude::*;
 
-use super::NetworkUpgrade;
+use super::{Network, NetworkUpgrade};
 
 impl NetworkUpgrade {
     /// Generates network upgrades.
@@ -31,4 +31,15 @@ impl NetworkUpgrade {
         ]
         .boxed()
     }
+}
+
+#[cfg(any(test, feature = "proptest-impl"))]
+impl Arbitrary for Network {
+    type Parameters = ();
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        prop_oneof![Just(Self::Mainnet), Just(Self::new_testnet()),].boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
 }

--- a/zebra-chain/src/parameters/genesis.rs
+++ b/zebra-chain/src/parameters/genesis.rs
@@ -14,7 +14,9 @@ pub fn genesis_hash(network: Network) -> block::Hash {
         // zcash-cli getblockhash 0
         Network::Mainnet => "00040fe8ec8471911baa1db1266ea15dd06b4a8a5c453883c000b031973dce08",
         // zcash-cli -testnet getblockhash 0
-        Network::Testnet => "05a60a92d99d85997cce3b87616c089f6124d7342af37106edc76126334a2c38",
+        Network::Testnet(params) => params
+            .genesis_hash()
+            .unwrap_or("05a60a92d99d85997cce3b87616c089f6124d7342af37106edc76126334a2c38"),
     }
     .parse()
     .expect("hard-coded hash parses")

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -49,14 +49,14 @@ mod tests;
 const ZIP_212_GRACE_PERIOD_DURATION: HeightDiff = 32_256;
 
 /// An enum describing the possible network choices.
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Serialize)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum Network {
     /// The production mainnet.
     #[default]
     Mainnet,
 
     /// The oldest public test network.
-    Testnet(TestnetParameters),
+    Testnet(#[serde(skip)] TestnetParameters),
 }
 
 /// Configures testnet chain parameters to use instead of default values.

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -218,7 +218,8 @@ impl Network {
 
     /// Return the network cache name.
     pub fn cache_name(&self) -> String {
-        self.with_testnet_parameters(NetworkParameters::cache_name)
+        self.testnet_parameters()
+            .cache_name()
             .map_or_else(|| self.lowercase_name(), ToString::to_string)
     }
 
@@ -233,14 +234,11 @@ impl Network {
     }
 
     /// Returns testnet parameters, if any.
-    pub fn with_testnet_parameters<T, F>(&self, f: F) -> Option<T>
-    where
-        F: FnOnce(NetworkParameters) -> Option<T>,
-    {
+    pub fn testnet_parameters(&self) -> TestnetParameters {
         if let Network::Testnet(testnet_parameters) = *self {
-            testnet_parameters.0.and_then(f)
+            testnet_parameters
         } else {
-            None
+            None.into()
         }
     }
 }

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -80,27 +80,27 @@ impl From<Option<NetworkParameters>> for TestnetParameters {
 impl TestnetParameters {
     /// Returns `network_id` in network parameters, if any.
     pub fn network_id(self) -> Option<[u8; 4]> {
-        self.0.and_then(NetworkParameters::network_id)
+        self.0?.network_id()
     }
 
     /// Returns `default_port` in network parameters, if any.
     pub fn default_port(self) -> Option<u16> {
-        self.0.and_then(NetworkParameters::default_port)
+        self.0?.default_port()
     }
 
     /// Returns `cache_name` in network parameters, if any.
     pub fn cache_name(self) -> Option<&'static str> {
-        self.0.and_then(NetworkParameters::cache_name)
+        self.0?.cache_name()
     }
 
     /// Returns `genesis_hash` in network parameters, if any.
     pub fn genesis_hash(self) -> Option<&'static str> {
-        self.0.and_then(NetworkParameters::genesis_hash)
+        self.0?.genesis_hash()
     }
 
     /// Returns `activation_heights` in network parameters, if any.
     pub fn activation_heights(self) -> Option<&'static [(Height, NetworkUpgrade)]> {
-        self.0.and_then(NetworkParameters::activation_heights)
+        self.0?.activation_heights()
     }
 }
 

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -239,7 +239,7 @@ impl Network {
     }
 
     /// Returns `true` if this network is a testing network.
-    pub fn is_testnet(&self) -> bool {
+    pub fn is_a_test_network(&self) -> bool {
         matches!(*self, Network::Testnet(_))
     }
 

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -78,17 +78,17 @@ impl From<Option<NetworkParameters>> for TestnetParameters {
 }
 
 impl TestnetParameters {
-    /// Returns `network_id` in chain parameters, if any.
+    /// Returns `network_id` in network parameters, if any.
     pub fn network_id(self) -> Option<NetworkId> {
         self.0.and_then(NetworkParameters::network_id)
     }
 
-    /// Returns `default_port` in chain parameters, if any.
+    /// Returns `default_port` in network parameters, if any.
     pub fn default_port(self) -> Option<u16> {
         self.0.and_then(NetworkParameters::default_port)
     }
 
-    /// Returns `cache_name` in chain parameters, if any.
+    /// Returns `cache_name` in network parameters, if any.
     pub fn cache_name(self) -> Option<&'static str> {
         self.0.and_then(NetworkParameters::cache_name)
     }
@@ -98,13 +98,13 @@ impl TestnetParameters {
         self.0.and_then(NetworkParameters::genesis_hash)
     }
 
-    /// Returns `activation_heights` in chain parameters, if any.
+    /// Returns `activation_heights` in network parameters, if any.
     pub fn activation_heights(self) -> Option<&'static [(Height, NetworkUpgrade)]> {
         self.0.and_then(NetworkParameters::activation_heights)
     }
 }
 
-/// Configures chain parameters to use instead of default values.
+/// Configures network parameters to use instead of default values.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Serialize)]
 pub struct NetworkParameters {
     network_id: Option<NetworkId>,

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -107,10 +107,20 @@ impl TestnetParameters {
 /// Configures network parameters to use instead of default values.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Serialize)]
 pub struct NetworkParameters {
+    /// Used as the network magic, Zebra will reject messages and connections from peers
+    /// with a different network magic.
     network_id: Option<[u8; 4]>,
+
+    /// Default port for the network
     default_port: Option<u16>,
+
+    /// Network portion of zebra-state cache path
     cache_name: Option<&'static str>,
+
+    /// Genesis hash for this testnet
     genesis_hash: Option<&'static str>,
+
+    /// Activation heights for this testnet
     activation_heights: Option<&'static [(Height, NetworkUpgrade)]>,
 }
 

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -79,7 +79,7 @@ impl From<Option<NetworkParameters>> for TestnetParameters {
 
 impl TestnetParameters {
     /// Returns `network_id` in network parameters, if any.
-    pub fn network_id(self) -> Option<NetworkId> {
+    pub fn network_id(self) -> Option<[u8; 4]> {
         self.0.and_then(NetworkParameters::network_id)
     }
 
@@ -107,7 +107,7 @@ impl TestnetParameters {
 /// Configures network parameters to use instead of default values.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Serialize)]
 pub struct NetworkParameters {
-    network_id: Option<NetworkId>,
+    network_id: Option<[u8; 4]>,
     default_port: Option<u16>,
     cache_name: Option<&'static str>,
     genesis_hash: Option<&'static str>,
@@ -115,7 +115,7 @@ pub struct NetworkParameters {
 }
 
 impl NetworkParameters {
-    fn network_id(self) -> Option<NetworkId> {
+    fn network_id(self) -> Option<[u8; 4]> {
         self.network_id
     }
     fn default_port(self) -> Option<u16> {

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -59,7 +59,7 @@ pub enum Network {
     Testnet(#[serde(skip)] TestnetParameters),
 }
 
-/// Configures testnet chain parameters to use instead of default values.
+/// Configures testnet network parameters to use instead of default values.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Serialize)]
 pub struct TestnetParameters(Option<NetworkParameters>);
 
@@ -93,7 +93,7 @@ impl TestnetParameters {
         self.0.and_then(NetworkParameters::cache_name)
     }
 
-    /// Returns `genesis_hash` in chain parameters, if any.
+    /// Returns `genesis_hash` in network parameters, if any.
     pub fn genesis_hash(self) -> Option<&'static str> {
         self.0.and_then(NetworkParameters::genesis_hash)
     }

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -273,7 +273,7 @@ impl NetworkUpgrade {
             Mainnet => mainnet_heights,
 
             // TODO: use params if available
-            Testnet(_) => testnet_heights,
+            Testnet(params) => params.activation_heights().unwrap_or(testnet_heights),
         }
         .iter()
         .cloned()

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -271,7 +271,9 @@ impl NetworkUpgrade {
         };
         match network {
             Mainnet => mainnet_heights,
-            Testnet => testnet_heights,
+
+            // TODO: use params if available
+            Testnet(_) => testnet_heights,
         }
         .iter()
         .cloned()
@@ -388,9 +390,11 @@ impl NetworkUpgrade {
         height: block::Height,
     ) -> Option<Duration> {
         match (network, height) {
-            (Network::Testnet, height) if height < TESTNET_MINIMUM_DIFFICULTY_START_HEIGHT => None,
+            (Network::Testnet(_), height) if height < TESTNET_MINIMUM_DIFFICULTY_START_HEIGHT => {
+                None
+            }
             (Network::Mainnet, _) => None,
-            (Network::Testnet, _) => {
+            (Network::Testnet(_), _) => {
                 let network_upgrade = NetworkUpgrade::current(network, height);
                 Some(network_upgrade.target_spacing() * TESTNET_MINIMUM_DIFFICULTY_GAP_MULTIPLIER)
             }
@@ -456,7 +460,7 @@ impl NetworkUpgrade {
     pub fn is_max_block_time_enforced(network: Network, height: block::Height) -> bool {
         match network {
             Network::Mainnet => true,
-            Network::Testnet => height >= TESTNET_MAX_TIME_START_HEIGHT,
+            Network::Testnet(_) => height >= TESTNET_MAX_TIME_START_HEIGHT,
         }
     }
     /// Returns the NetworkUpgrade given an u32 as ConsensusBranchId

--- a/zebra-chain/src/parameters/tests.rs
+++ b/zebra-chain/src/parameters/tests.rs
@@ -21,7 +21,7 @@ fn activation_bijective() {
     let mainnet_nus: HashSet<&NetworkUpgrade> = mainnet_activations.values().collect();
     assert_eq!(MAINNET_ACTIVATION_HEIGHTS.len(), mainnet_nus.len());
 
-    let testnet_activations = NetworkUpgrade::activation_list(Testnet(None.into()));
+    let testnet_activations = NetworkUpgrade::activation_list(Network::new_testnet());
     let testnet_heights: HashSet<&block::Height> = testnet_activations.keys().collect();
     assert_eq!(TESTNET_ACTIVATION_HEIGHTS.len(), testnet_heights.len());
 
@@ -38,7 +38,7 @@ fn activation_extremes_mainnet() {
 #[test]
 fn activation_extremes_testnet() {
     let _init_guard = zebra_test::init();
-    activation_extremes(Testnet(None.into()))
+    activation_extremes(Network::new_testnet())
 }
 
 /// Test the activation_list, activation_height, current, and next functions
@@ -115,7 +115,7 @@ fn activation_consistent_mainnet() {
 #[test]
 fn activation_consistent_testnet() {
     let _init_guard = zebra_test::init();
-    activation_consistent(Testnet(None.into()))
+    activation_consistent(Network::new_testnet())
 }
 
 /// Check that the `activation_height`, `is_activation_height`,
@@ -175,7 +175,7 @@ fn branch_id_extremes_mainnet() {
 #[test]
 fn branch_id_extremes_testnet() {
     let _init_guard = zebra_test::init();
-    branch_id_extremes(Testnet(None.into()))
+    branch_id_extremes(Network::new_testnet())
 }
 
 /// Test the branch_id_list, branch_id, and current functions for `network` with
@@ -213,7 +213,7 @@ fn branch_id_consistent_mainnet() {
 #[test]
 fn branch_id_consistent_testnet() {
     let _init_guard = zebra_test::init();
-    branch_id_consistent(Testnet(None.into()))
+    branch_id_consistent(Network::new_testnet())
 }
 
 /// Check that the branch_id and current functions are consistent for `network`.

--- a/zebra-chain/src/parameters/tests.rs
+++ b/zebra-chain/src/parameters/tests.rs
@@ -21,7 +21,7 @@ fn activation_bijective() {
     let mainnet_nus: HashSet<&NetworkUpgrade> = mainnet_activations.values().collect();
     assert_eq!(MAINNET_ACTIVATION_HEIGHTS.len(), mainnet_nus.len());
 
-    let testnet_activations = NetworkUpgrade::activation_list(Testnet);
+    let testnet_activations = NetworkUpgrade::activation_list(Testnet(None.into()));
     let testnet_heights: HashSet<&block::Height> = testnet_activations.keys().collect();
     assert_eq!(TESTNET_ACTIVATION_HEIGHTS.len(), testnet_heights.len());
 
@@ -38,7 +38,7 @@ fn activation_extremes_mainnet() {
 #[test]
 fn activation_extremes_testnet() {
     let _init_guard = zebra_test::init();
-    activation_extremes(Testnet)
+    activation_extremes(Testnet(None.into()))
 }
 
 /// Test the activation_list, activation_height, current, and next functions
@@ -115,7 +115,7 @@ fn activation_consistent_mainnet() {
 #[test]
 fn activation_consistent_testnet() {
     let _init_guard = zebra_test::init();
-    activation_consistent(Testnet)
+    activation_consistent(Testnet(None.into()))
 }
 
 /// Check that the `activation_height`, `is_activation_height`,
@@ -175,7 +175,7 @@ fn branch_id_extremes_mainnet() {
 #[test]
 fn branch_id_extremes_testnet() {
     let _init_guard = zebra_test::init();
-    branch_id_extremes(Testnet)
+    branch_id_extremes(Testnet(None.into()))
 }
 
 /// Test the branch_id_list, branch_id, and current functions for `network` with
@@ -213,7 +213,7 @@ fn branch_id_consistent_mainnet() {
 #[test]
 fn branch_id_consistent_testnet() {
     let _init_guard = zebra_test::init();
-    branch_id_consistent(Testnet)
+    branch_id_consistent(Testnet(None.into()))
 }
 
 /// Check that the branch_id and current functions are consistent for `network`.

--- a/zebra-chain/src/primitives/address.rs
+++ b/zebra-chain/src/primitives/address.rs
@@ -7,6 +7,8 @@ use zcash_primitives::sapling;
 
 use crate::{parameters::Network, transparent, BoxError};
 
+// TODO: fix lint.
+#[allow(clippy::large_enum_variant)]
 /// Zcash address variants
 pub enum Address {
     /// Transparent address
@@ -47,7 +49,7 @@ impl TryFrom<zcash_address::Network> for Network {
     fn try_from(network: zcash_address::Network) -> Result<Self, Self::Error> {
         match network {
             zcash_address::Network::Main => Ok(Network::Mainnet),
-            zcash_address::Network::Test => Ok(Network::Testnet),
+            zcash_address::Network::Test => Ok(Network::new_testnet()),
             zcash_address::Network::Regtest => Err("unsupported Zcash network parameters".into()),
         }
     }
@@ -57,7 +59,7 @@ impl From<Network> for zcash_address::Network {
     fn from(network: Network) -> Self {
         match network {
             Network::Mainnet => zcash_address::Network::Main,
-            Network::Testnet => zcash_address::Network::Test,
+            Network::Testnet(_) => zcash_address::Network::Test,
         }
     }
 }

--- a/zebra-chain/src/primitives/zcash_history/tests/vectors.rs
+++ b/zebra-chain/src/primitives/zcash_history/tests/vectors.rs
@@ -15,16 +15,16 @@ use zebra_test::vectors::{
 #[test]
 fn tree() -> Result<()> {
     tree_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Heartwood)?;
-    tree_for_network_upgrade(Network::Testnet, NetworkUpgrade::Heartwood)?;
+    tree_for_network_upgrade(Network::new_testnet(), NetworkUpgrade::Heartwood)?;
     tree_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Canopy)?;
-    tree_for_network_upgrade(Network::Testnet, NetworkUpgrade::Canopy)?;
+    tree_for_network_upgrade(Network::new_testnet(), NetworkUpgrade::Canopy)?;
     Ok(())
 }
 
 fn tree_for_network_upgrade(network: Network, network_upgrade: NetworkUpgrade) -> Result<()> {
     let (blocks, sapling_roots) = match network {
         Network::Mainnet => (&*MAINNET_BLOCKS, &*MAINNET_FINAL_SAPLING_ROOTS),
-        Network::Testnet => (&*TESTNET_BLOCKS, &*TESTNET_FINAL_SAPLING_ROOTS),
+        Network::Testnet(_) => (&*TESTNET_BLOCKS, &*TESTNET_FINAL_SAPLING_ROOTS),
     };
     let height = network_upgrade.activation_height(network).unwrap().0;
 

--- a/zebra-chain/src/primitives/zcash_note_encryption.rs
+++ b/zebra-chain/src/primitives/zcash_note_encryption.rs
@@ -34,7 +34,7 @@ pub fn decrypts_successfully(transaction: &Transaction, network: Network, height
                         output,
                     )
                 }
-                Network::Testnet => {
+                Network::Testnet(_) => {
                     zcash_primitives::sapling::note_encryption::try_sapling_output_recovery(
                         &zcash_primitives::consensus::TEST_NETWORK,
                         alt_height,

--- a/zebra-chain/src/sapling/tests/tree.rs
+++ b/zebra-chain/src/sapling/tests/tree.rs
@@ -55,14 +55,14 @@ fn incremental_roots() {
 #[test]
 fn incremental_roots_with_blocks() -> Result<()> {
     incremental_roots_with_blocks_for_network(Network::Mainnet)?;
-    incremental_roots_with_blocks_for_network(Network::Testnet)?;
+    incremental_roots_with_blocks_for_network(Network::new_testnet())?;
     Ok(())
 }
 
 fn incremental_roots_with_blocks_for_network(network: Network) -> Result<()> {
     let (blocks, sapling_roots) = match network {
         Network::Mainnet => (&*MAINNET_BLOCKS, &*MAINNET_FINAL_SAPLING_ROOTS),
-        Network::Testnet => (&*TESTNET_BLOCKS, &*TESTNET_FINAL_SAPLING_ROOTS),
+        Network::Testnet(_) => (&*TESTNET_BLOCKS, &*TESTNET_FINAL_SAPLING_ROOTS),
     };
     let height = NetworkUpgrade::Sapling
         .activation_height(network)

--- a/zebra-chain/src/sprout/tests/tree.rs
+++ b/zebra-chain/src/sprout/tests/tree.rs
@@ -82,7 +82,7 @@ fn incremental_roots() {
 #[test]
 fn incremental_roots_with_blocks() -> Result<()> {
     incremental_roots_with_blocks_for_network(Network::Mainnet)?;
-    incremental_roots_with_blocks_for_network(Network::Testnet)?;
+    incremental_roots_with_blocks_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -101,7 +101,7 @@ fn incremental_roots_with_blocks_for_network(network: Network) -> Result<()> {
             &*vectors::MAINNET_FINAL_SPROUT_ROOTS,
             MAINNET_FIRST_JOINSPLIT_HEIGHT,
         ),
-        Network::Testnet => (
+        Network::Testnet(_) => (
             &*vectors::TESTNET_BLOCKS,
             &*vectors::TESTNET_FINAL_SPROUT_ROOTS,
             TESTNET_FIRST_JOINSPLIT_HEIGHT,

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -997,7 +997,7 @@ pub fn test_transactions(
 ) -> impl DoubleEndedIterator<Item = (block::Height, Arc<Transaction>)> {
     let blocks = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     transactions_from_blocks(blocks)

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -345,13 +345,13 @@ fn fake_v5_round_trip() {
     let _init_guard = zebra_test::init();
 
     fake_v5_round_trip_for_network(Network::Mainnet);
-    fake_v5_round_trip_for_network(Network::Testnet);
+    fake_v5_round_trip_for_network(Network::new_testnet());
 }
 
 fn fake_v5_round_trip_for_network(network: Network) {
     let block_iter = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     let overwinter_activation_height = NetworkUpgrade::Overwinter
@@ -496,13 +496,13 @@ fn fake_v5_librustzcash_round_trip() {
     let _init_guard = zebra_test::init();
 
     fake_v5_librustzcash_round_trip_for_network(Network::Mainnet);
-    fake_v5_librustzcash_round_trip_for_network(Network::Testnet);
+    fake_v5_librustzcash_round_trip_for_network(Network::new_testnet());
 }
 
 fn fake_v5_librustzcash_round_trip_for_network(network: Network) {
     let block_iter = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     let overwinter_activation_height = NetworkUpgrade::Overwinter
@@ -939,13 +939,13 @@ fn binding_signatures() {
     let _init_guard = zebra_test::init();
 
     binding_signatures_for_network(Network::Mainnet);
-    binding_signatures_for_network(Network::Testnet);
+    binding_signatures_for_network(Network::new_testnet());
 }
 
 fn binding_signatures_for_network(network: Network) {
     let block_iter = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     for (height, bytes) in block_iter {

--- a/zebra-chain/src/transparent/address.rs
+++ b/zebra-chain/src/transparent/address.rs
@@ -158,7 +158,7 @@ impl ZcashDeserialize for Address {
                 script_hash: hash_bytes,
             }),
             magics::p2sh::TESTNET => Ok(Address::PayToScriptHash {
-                network: Network::Testnet,
+                network: Network::new_testnet(),
                 script_hash: hash_bytes,
             }),
             magics::p2pkh::MAINNET => Ok(Address::PayToPublicKeyHash {
@@ -166,7 +166,7 @@ impl ZcashDeserialize for Address {
                 pub_key_hash: hash_bytes,
             }),
             magics::p2pkh::TESTNET => Ok(Address::PayToPublicKeyHash {
-                network: Network::Testnet,
+                network: Network::new_testnet(),
                 pub_key_hash: hash_bytes,
             }),
             _ => Err(SerializationError::Parse("bad t-addr version/type")),
@@ -314,7 +314,7 @@ mod tests {
         ])
         .expect("A PublicKey from slice");
 
-        let t_addr = pub_key.to_address(Network::Testnet);
+        let t_addr = pub_key.to_address(Network::new_testnet());
 
         assert_eq!(format!("{t_addr}"), "tmTc6trRhbv96kGfA99i7vrFwb5p7BVFwc3");
     }
@@ -336,7 +336,7 @@ mod tests {
 
         let script = Script::new(&[0; 20]);
 
-        let t_addr = script.to_address(Network::Testnet);
+        let t_addr = script.to_address(Network::new_testnet());
 
         assert_eq!(format!("{t_addr}"), "t2L51LcmpA43UMvKTw2Lwtt9LMjwyqU2V1P");
     }

--- a/zebra-chain/src/transparent/tests/vectors.rs
+++ b/zebra-chain/src/transparent/tests/vectors.rs
@@ -67,14 +67,14 @@ fn get_transparent_output_address() -> Result<()> {
     let addr = transparent_output_address(&transaction.outputs()[0], Network::Mainnet)
         .expect("should return address");
     assert_eq!(addr.to_string(), "t3M5FDmPfWNRG3HRLddbicsuSCvKuk9hxzZ");
-    let addr = transparent_output_address(&transaction.outputs()[0], Network::Testnet)
+    let addr = transparent_output_address(&transaction.outputs()[0], Network::new_testnet())
         .expect("should return address");
     assert_eq!(addr.to_string(), "t294SGSVoNq2daz15ZNbmAW65KQZ5e3nN5G");
     // Public key hash e4ff5512ffafe9287992a1cd177ca6e408e03003
     let addr = transparent_output_address(&transaction.outputs()[1], Network::Mainnet)
         .expect("should return address");
     assert_eq!(addr.to_string(), "t1ekRwsd4LaSsd6NXgsx66q2HxQWTLCF44y");
-    let addr = transparent_output_address(&transaction.outputs()[1], Network::Testnet)
+    let addr = transparent_output_address(&transaction.outputs()[1], Network::new_testnet())
         .expect("should return address");
     assert_eq!(addr.to_string(), "tmWbBGi7TjExNmLZyMcFpxVh3ZPbGrpbX3H");
 
@@ -86,7 +86,7 @@ fn get_transparent_output_address_with_blocks() {
     let _init_guard = zebra_test::init();
 
     get_transparent_output_address_with_blocks_for_network(Network::Mainnet);
-    get_transparent_output_address_with_blocks_for_network(Network::Testnet);
+    get_transparent_output_address_with_blocks_for_network(Network::new_testnet());
 }
 
 /// Test that the block test vector indexes match the heights in the block data,
@@ -94,7 +94,7 @@ fn get_transparent_output_address_with_blocks() {
 fn get_transparent_output_address_with_blocks_for_network(network: Network) {
     let block_iter = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     let mut valid_addresses = 0;

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -394,7 +394,7 @@ impl ExpandedDifficulty {
             /* 2^243 - 1 */
             Network::Mainnet => (U256::one() << 243) - 1,
             /* 2^251 - 1 */
-            Network::Testnet => (U256::one() << 251) - 1,
+            Network::Testnet(_) => (U256::one() << 251) - 1,
         };
 
         // `zcashd` converts the PoWLimit into a compact representation before

--- a/zebra-chain/src/work/difficulty/tests/vectors.rs
+++ b/zebra-chain/src/work/difficulty/tests/vectors.rs
@@ -264,7 +264,7 @@ fn compact_bitcoin_test_vectors() {
 #[test]
 fn block_difficulty() -> Result<(), Report> {
     block_difficulty_for_network(Network::Mainnet)?;
-    block_difficulty_for_network(Network::Testnet)?;
+    block_difficulty_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -275,7 +275,7 @@ fn block_difficulty_for_network(network: Network) -> Result<(), Report> {
 
     let block_iter = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     let diff_zero = ExpandedDifficulty(U256::zero());
@@ -353,7 +353,7 @@ fn block_difficulty_for_network(network: Network) -> Result<(), Report> {
 #[test]
 fn genesis_block_difficulty() -> Result<(), Report> {
     genesis_block_difficulty_for_network(Network::Mainnet)?;
-    genesis_block_difficulty_for_network(Network::Testnet)?;
+    genesis_block_difficulty_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -364,7 +364,7 @@ fn genesis_block_difficulty_for_network(network: Network) -> Result<(), Report> 
 
     let block = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.get(&0),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.get(&0),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.get(&0),
     };
 
     let block = block.expect("test vectors contain the genesis block");
@@ -460,7 +460,8 @@ fn check_testnet_minimum_difficulty_block(height: block::Height) -> Result<(), R
         // threshold, as documented in ZIP-205 and ZIP-208:
         // https://zips.z.cash/zip-0205#change-to-difficulty-adjustment-on-testnet
         // https://zips.z.cash/zip-0208#minimum-difficulty-blocks-on-testnet
-        match NetworkUpgrade::minimum_difficulty_spacing_for_height(Network::Testnet, height) {
+        match NetworkUpgrade::minimum_difficulty_spacing_for_height(Network::new_testnet(), height)
+        {
             None => Err(eyre!("the minimum difficulty rule is not active"))?,
             Some(spacing) if (time_gap <= spacing) => Err(eyre!(
                 "minimum difficulty block times must be more than 6 target spacing intervals apart"
@@ -483,12 +484,12 @@ fn check_testnet_minimum_difficulty_block(height: block::Height) -> Result<(), R
 
     /// SPANDOC: Check that the testnet minimum difficulty is the PoWLimit {?height, ?threshold, ?hash}
     {
-        assert_eq!(threshold, ExpandedDifficulty::target_difficulty_limit(Network::Testnet),
+        assert_eq!(threshold, ExpandedDifficulty::target_difficulty_limit(Network::new_testnet()),
                    "testnet minimum difficulty thresholds should be equal to the PoWLimit. Hint: Blocks with large gaps are allowed to have the minimum difficulty, but it's not required.");
         // all blocks pass the minimum difficulty threshold, even if they aren't minimum
         // difficulty blocks, because it's the lowest permitted difficulty
         assert!(
-            hash <= ExpandedDifficulty::target_difficulty_limit(Network::Testnet),
+            hash <= ExpandedDifficulty::target_difficulty_limit(Network::new_testnet()),
             "testnet minimum difficulty hashes must be less than the PoWLimit"
         );
     }

--- a/zebra-consensus/src/block/subsidy/funding_streams.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams.rs
@@ -60,7 +60,7 @@ pub fn height_for_first_halving(network: Network) -> Height {
         Network::Mainnet => Canopy
             .activation_height(network)
             .expect("canopy activation height should be available"),
-        Network::Testnet => FIRST_HALVING_TESTNET,
+        Network::Testnet(_) => FIRST_HALVING_TESTNET,
     }
 }
 
@@ -95,7 +95,7 @@ fn funding_stream_address_period(height: Height, network: Network) -> u32 {
 fn funding_stream_address_index(height: Height, network: Network) -> usize {
     let num_addresses = match network {
         Network::Mainnet => FUNDING_STREAMS_NUM_ADDRESSES_MAINNET,
-        Network::Testnet => FUNDING_STREAMS_NUM_ADDRESSES_TESTNET,
+        Network::Testnet(_) => FUNDING_STREAMS_NUM_ADDRESSES_TESTNET,
     };
 
     let index = 1u32

--- a/zebra-consensus/src/block/subsidy/general.rs
+++ b/zebra-consensus/src/block/subsidy/general.rs
@@ -124,7 +124,7 @@ mod test {
         let _init_guard = zebra_test::init();
 
         halving_for_network(Network::Mainnet)?;
-        halving_for_network(Network::Testnet)?;
+        halving_for_network(Network::new_testnet())?;
 
         Ok(())
     }
@@ -134,7 +134,7 @@ mod test {
         let first_halving_height = match network {
             Network::Mainnet => Canopy.activation_height(network).unwrap(),
             // Based on "7.8 Calculation of Block Subsidy and Founders' Reward"
-            Network::Testnet => Height(1_116_000),
+            Network::Testnet(_) => Height(1_116_000),
         };
 
         assert_eq!(
@@ -254,7 +254,7 @@ mod test {
         let _init_guard = zebra_test::init();
 
         block_subsidy_for_network(Network::Mainnet)?;
-        block_subsidy_for_network(Network::Testnet)?;
+        block_subsidy_for_network(Network::new_testnet())?;
 
         Ok(())
     }
@@ -264,7 +264,7 @@ mod test {
         let first_halving_height = match network {
             Network::Mainnet => Canopy.activation_height(network).unwrap(),
             // Based on "7.8 Calculation of Block Subsidy and Founders' Reward"
-            Network::Testnet => Height(1_116_000),
+            Network::Testnet(_) => Height(1_116_000),
         };
 
         // After slow-start mining and before Blossom the block subsidy is 12.5 ZEC

--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -183,7 +183,7 @@ fn difficulty_is_valid_for_historical_blocks() -> Result<(), Report> {
     let _init_guard = zebra_test::init();
 
     difficulty_is_valid_for_network(Network::Mainnet)?;
-    difficulty_is_valid_for_network(Network::Testnet)?;
+    difficulty_is_valid_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -191,7 +191,7 @@ fn difficulty_is_valid_for_historical_blocks() -> Result<(), Report> {
 fn difficulty_is_valid_for_network(network: Network) -> Result<(), Report> {
     let block_iter = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     for (&height, block) in block_iter {
@@ -290,7 +290,7 @@ fn subsidy_is_valid_for_historical_blocks() -> Result<(), Report> {
     let _init_guard = zebra_test::init();
 
     subsidy_is_valid_for_network(Network::Mainnet)?;
-    subsidy_is_valid_for_network(Network::Testnet)?;
+    subsidy_is_valid_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -298,7 +298,7 @@ fn subsidy_is_valid_for_historical_blocks() -> Result<(), Report> {
 fn subsidy_is_valid_for_network(network: Network) -> Result<(), Report> {
     let block_iter = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     for (&height, block) in block_iter {
@@ -395,7 +395,7 @@ fn funding_stream_validation() -> Result<(), Report> {
     let _init_guard = zebra_test::init();
 
     funding_stream_validation_for_network(Network::Mainnet)?;
-    funding_stream_validation_for_network(Network::Testnet)?;
+    funding_stream_validation_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -403,7 +403,7 @@ fn funding_stream_validation() -> Result<(), Report> {
 fn funding_stream_validation_for_network(network: Network) -> Result<(), Report> {
     let block_iter = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     let canopy_activation_height = NetworkUpgrade::Canopy
@@ -473,7 +473,7 @@ fn miner_fees_validation_success() -> Result<(), Report> {
     let _init_guard = zebra_test::init();
 
     miner_fees_validation_for_network(Network::Mainnet)?;
-    miner_fees_validation_for_network(Network::Testnet)?;
+    miner_fees_validation_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -481,7 +481,7 @@ fn miner_fees_validation_success() -> Result<(), Report> {
 fn miner_fees_validation_for_network(network: Network) -> Result<(), Report> {
     let block_iter = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     for (&height, block) in block_iter {
@@ -558,11 +558,11 @@ fn merkle_root_is_valid() -> Result<(), Report> {
 
     // test all original blocks available, all blocks validate
     merkle_root_is_valid_for_network(Network::Mainnet)?;
-    merkle_root_is_valid_for_network(Network::Testnet)?;
+    merkle_root_is_valid_for_network(Network::new_testnet())?;
 
     // create and test fake blocks with v5 transactions, all blocks fail validation
     merkle_root_fake_v5_for_network(Network::Mainnet)?;
-    merkle_root_fake_v5_for_network(Network::Testnet)?;
+    merkle_root_fake_v5_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -570,7 +570,7 @@ fn merkle_root_is_valid() -> Result<(), Report> {
 fn merkle_root_is_valid_for_network(network: Network) -> Result<(), Report> {
     let block_iter = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     for (_height, block) in block_iter {
@@ -594,7 +594,7 @@ fn merkle_root_is_valid_for_network(network: Network) -> Result<(), Report> {
 fn merkle_root_fake_v5_for_network(network: Network) -> Result<(), Report> {
     let block_iter = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     for (height, block) in block_iter {
@@ -701,7 +701,7 @@ fn transaction_expiration_height_validation() -> Result<(), Report> {
     let _init_guard = zebra_test::init();
 
     transaction_expiration_height_for_network(Network::Mainnet)?;
-    transaction_expiration_height_for_network(Network::Testnet)?;
+    transaction_expiration_height_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -709,7 +709,7 @@ fn transaction_expiration_height_validation() -> Result<(), Report> {
 fn transaction_expiration_height_for_network(network: Network) -> Result<(), Report> {
     let block_iter = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     for (&height, block) in block_iter {

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -237,7 +237,8 @@ where
         state_service: S,
     ) -> Result<Self, VerifyCheckpointError> {
         Ok(Self::from_checkpoint_list(
-            CheckpointList::from_list(list).map_err(VerifyCheckpointError::CheckpointList)?,
+            CheckpointList::from_list(list, network)
+                .map_err(VerifyCheckpointError::CheckpointList)?,
             network,
             initial_tip,
             state_service,

--- a/zebra-consensus/src/checkpoint/list/tests.rs
+++ b/zebra-consensus/src/checkpoint/list/tests.rs
@@ -31,7 +31,7 @@ fn checkpoint_list_genesis() -> Result<(), BoxError> {
     // Make a checkpoint list containing the genesis block
     let checkpoint_list: BTreeMap<block::Height, block::Hash> =
         checkpoint_data.iter().cloned().collect();
-    let _ = CheckpointList::from_list(checkpoint_list)?;
+    let _ = CheckpointList::from_list(checkpoint_list, Mainnet)?;
 
     Ok(())
 }
@@ -60,7 +60,7 @@ fn checkpoint_list_multiple() -> Result<(), BoxError> {
     // Make a checkpoint list containing all the blocks
     let checkpoint_list: BTreeMap<block::Height, block::Hash> =
         checkpoint_data.iter().cloned().collect();
-    let _ = CheckpointList::from_list(checkpoint_list)?;
+    let _ = CheckpointList::from_list(checkpoint_list, Mainnet)?;
 
     Ok(())
 }
@@ -70,7 +70,8 @@ fn checkpoint_list_multiple() -> Result<(), BoxError> {
 fn checkpoint_list_empty_fail() -> Result<(), BoxError> {
     let _init_guard = zebra_test::init();
 
-    let _ = CheckpointList::from_list(Vec::new()).expect_err("empty checkpoint lists should fail");
+    let _ = CheckpointList::from_list(Vec::new(), Mainnet)
+        .expect_err("empty checkpoint lists should fail");
 
     Ok(())
 }
@@ -92,7 +93,7 @@ fn checkpoint_list_no_genesis_fail() -> Result<(), BoxError> {
     // Make a checkpoint list containing the non-genesis block
     let checkpoint_list: BTreeMap<block::Height, block::Hash> =
         checkpoint_data.iter().cloned().collect();
-    let _ = CheckpointList::from_list(checkpoint_list)
+    let _ = CheckpointList::from_list(checkpoint_list, Mainnet)
         .expect_err("a checkpoint list with no genesis block should fail");
 
     Ok(())
@@ -108,7 +109,7 @@ fn checkpoint_list_null_hash_fail() -> Result<(), BoxError> {
     // Make a checkpoint list containing the non-genesis block
     let checkpoint_list: BTreeMap<block::Height, block::Hash> =
         checkpoint_data.iter().cloned().collect();
-    let _ = CheckpointList::from_list(checkpoint_list)
+    let _ = CheckpointList::from_list(checkpoint_list, Mainnet)
         .expect_err("a checkpoint list with a null block hash should fail");
 
     Ok(())
@@ -127,7 +128,7 @@ fn checkpoint_list_bad_height_fail() -> Result<(), BoxError> {
     // Make a checkpoint list containing the non-genesis block
     let checkpoint_list: BTreeMap<block::Height, block::Hash> =
         checkpoint_data.iter().cloned().collect();
-    let _ = CheckpointList::from_list(checkpoint_list).expect_err(
+    let _ = CheckpointList::from_list(checkpoint_list, Mainnet).expect_err(
         "a checkpoint list with an invalid block height (block::Height::MAX + 1) should fail",
     );
 
@@ -136,7 +137,7 @@ fn checkpoint_list_bad_height_fail() -> Result<(), BoxError> {
     // Make a checkpoint list containing the non-genesis block
     let checkpoint_list: BTreeMap<block::Height, block::Hash> =
         checkpoint_data.iter().cloned().collect();
-    let _ = CheckpointList::from_list(checkpoint_list)
+    let _ = CheckpointList::from_list(checkpoint_list, Mainnet)
         .expect_err("a checkpoint list with an invalid block height (u32::MAX) should fail");
 
     Ok(())
@@ -163,7 +164,7 @@ fn checkpoint_list_duplicate_blocks_fail() -> Result<(), BoxError> {
     }
 
     // Make a checkpoint list containing some duplicate blocks
-    let _ = CheckpointList::from_list(checkpoint_data)
+    let _ = CheckpointList::from_list(checkpoint_data, Mainnet)
         .expect_err("checkpoint lists with duplicate blocks should fail");
 
     Ok(())
@@ -190,7 +191,7 @@ fn checkpoint_list_duplicate_heights_fail() -> Result<(), BoxError> {
     checkpoint_data.push((block::Height(1), block::Hash([0xbb; 32])));
 
     // Make a checkpoint list containing some duplicate blocks
-    let _ = CheckpointList::from_list(checkpoint_data)
+    let _ = CheckpointList::from_list(checkpoint_data, Mainnet)
         .expect_err("checkpoint lists with duplicate heights should fail");
 
     Ok(())
@@ -217,7 +218,7 @@ fn checkpoint_list_duplicate_hashes_fail() -> Result<(), BoxError> {
     checkpoint_data.push((block::Height(2), block::Hash([0xcc; 32])));
 
     // Make a checkpoint list containing some duplicate blocks
-    let _ = CheckpointList::from_list(checkpoint_data)
+    let _ = CheckpointList::from_list(checkpoint_data, Mainnet)
         .expect_err("checkpoint lists with duplicate hashes should fail");
 
     Ok(())
@@ -228,15 +229,13 @@ fn checkpoint_list_duplicate_hashes_fail() -> Result<(), BoxError> {
 fn checkpoint_list_load_hard_coded() -> Result<(), BoxError> {
     let _init_guard = zebra_test::init();
 
-    let _: CheckpointList = MAINNET_CHECKPOINTS
-        .parse()
+    let _: CheckpointList = CheckpointList::from_str(MAINNET_CHECKPOINTS, Mainnet)
         .expect("hard-coded Mainnet checkpoint list should parse");
-    let _: CheckpointList = TESTNET_CHECKPOINTS
-        .parse()
+    let _: CheckpointList = CheckpointList::from_str(TESTNET_CHECKPOINTS, Network::new_testnet())
         .expect("hard-coded Testnet checkpoint list should parse");
 
     let _ = CheckpointList::new(Mainnet);
-    let _ = CheckpointList::new(Testnet);
+    let _ = CheckpointList::new(Network::new_testnet());
 
     Ok(())
 }
@@ -248,7 +247,7 @@ fn checkpoint_list_hard_coded_mandatory_mainnet() -> Result<(), BoxError> {
 
 #[test]
 fn checkpoint_list_hard_coded_mandatory_testnet() -> Result<(), BoxError> {
-    checkpoint_list_hard_coded_mandatory(Testnet)
+    checkpoint_list_hard_coded_mandatory(Testnet(None.into()))
 }
 
 /// Check that the hard-coded lists cover the mandatory checkpoint
@@ -274,7 +273,7 @@ fn checkpoint_list_hard_coded_max_gap_mainnet() -> Result<(), BoxError> {
 
 #[test]
 fn checkpoint_list_hard_coded_max_gap_testnet() -> Result<(), BoxError> {
-    checkpoint_list_hard_coded_max_gap(Testnet)
+    checkpoint_list_hard_coded_max_gap(Testnet(None.into()))
 }
 
 /// Check that the hard-coded checkpoints are within [`MAX_CHECKPOINT_HEIGHT_GAP`],

--- a/zebra-consensus/src/checkpoint/list/tests.rs
+++ b/zebra-consensus/src/checkpoint/list/tests.rs
@@ -247,7 +247,7 @@ fn checkpoint_list_hard_coded_mandatory_mainnet() -> Result<(), BoxError> {
 
 #[test]
 fn checkpoint_list_hard_coded_mandatory_testnet() -> Result<(), BoxError> {
-    checkpoint_list_hard_coded_mandatory(Testnet(None.into()))
+    checkpoint_list_hard_coded_mandatory(Network::new_testnet())
 }
 
 /// Check that the hard-coded lists cover the mandatory checkpoint
@@ -273,7 +273,7 @@ fn checkpoint_list_hard_coded_max_gap_mainnet() -> Result<(), BoxError> {
 
 #[test]
 fn checkpoint_list_hard_coded_max_gap_testnet() -> Result<(), BoxError> {
-    checkpoint_list_hard_coded_max_gap(Testnet(None.into()))
+    checkpoint_list_hard_coded_max_gap(Network::new_testnet())
 }
 
 /// Check that the hard-coded checkpoints are within [`MAX_CHECKPOINT_HEIGHT_GAP`],

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -206,7 +206,7 @@ async fn multi_item_checkpoint_list() -> Result<(), Report> {
 #[tokio::test(flavor = "multi_thread")]
 async fn continuous_blockchain_no_restart() -> Result<(), Report> {
     continuous_blockchain(None, Mainnet).await?;
-    continuous_blockchain(None, Testnet(None.into())).await?;
+    continuous_blockchain(None, Network::new_testnet()).await?;
     Ok(())
 }
 
@@ -218,7 +218,7 @@ async fn continuous_blockchain_restart() -> Result<(), Report> {
     for height in 0..zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS.len() {
         continuous_blockchain(
             Some(block::Height(height.try_into().unwrap())),
-            Testnet(None.into()),
+            Network::new_testnet(),
         )
         .await?;
     }

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -206,7 +206,7 @@ async fn multi_item_checkpoint_list() -> Result<(), Report> {
 #[tokio::test(flavor = "multi_thread")]
 async fn continuous_blockchain_no_restart() -> Result<(), Report> {
     continuous_blockchain(None, Mainnet).await?;
-    continuous_blockchain(None, Testnet).await?;
+    continuous_blockchain(None, Testnet(None.into())).await?;
     Ok(())
 }
 
@@ -216,7 +216,11 @@ async fn continuous_blockchain_restart() -> Result<(), Report> {
         continuous_blockchain(Some(block::Height(height.try_into().unwrap())), Mainnet).await?;
     }
     for height in 0..zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS.len() {
-        continuous_blockchain(Some(block::Height(height.try_into().unwrap())), Testnet).await?;
+        continuous_blockchain(
+            Some(block::Height(height.try_into().unwrap())),
+            Testnet(None.into()),
+        )
+        .await?;
     }
     Ok(())
 }
@@ -235,7 +239,7 @@ async fn continuous_blockchain(
     // A continuous blockchain
     let blockchain = match network {
         Mainnet => zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS.iter(),
-        Testnet => zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS.iter(),
+        Testnet(_) => zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS.iter(),
     };
     let blockchain: Vec<_> = blockchain
         .map(|(height, b)| {

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -107,7 +107,7 @@ lazy_static! {
     pub static ref FUNDING_STREAM_HEIGHT_RANGES: HashMap<Network, std::ops::Range<Height>> = {
         let mut hash_map = HashMap::new();
         hash_map.insert(Network::Mainnet, Height(1_046_400)..Height(2_726_400));
-        hash_map.insert(Network::Testnet, Height(1_028_500)..Height(2_796_000));
+        hash_map.insert(Network::new_testnet(), Height(1_028_500)..Height(2_796_000));
         hash_map
     };
 
@@ -127,7 +127,7 @@ lazy_static! {
         testnet_addresses.insert(FundingStreamReceiver::Ecc, FUNDING_STREAM_ECC_ADDRESSES_TESTNET.iter().map(|a| a.to_string()).collect());
         testnet_addresses.insert(FundingStreamReceiver::ZcashFoundation, FUNDING_STREAM_ZF_ADDRESSES_TESTNET.iter().map(|a| a.to_string()).collect());
         testnet_addresses.insert(FundingStreamReceiver::MajorGrants, FUNDING_STREAM_MG_ADDRESSES_TESTNET.iter().map(|a| a.to_string()).collect());
-        addresses_by_network.insert(Network::Testnet, testnet_addresses);
+        addresses_by_network.insert(Network::new_testnet(), testnet_addresses);
 
         addresses_by_network
     };

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -44,7 +44,10 @@ fn v5_fake_transactions() -> Result<(), Report> {
 
     let networks = vec![
         (Network::Mainnet, zebra_test::vectors::MAINNET_BLOCKS.iter()),
-        (Network::Testnet, zebra_test::vectors::TESTNET_BLOCKS.iter()),
+        (
+            Network::new_testnet(),
+            zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        ),
     ];
 
     for (network, blocks) in networks {
@@ -860,7 +863,10 @@ async fn v5_transaction_is_rejected_before_nu5_activation() {
     let canopy = NetworkUpgrade::Canopy;
     let networks = vec![
         (Network::Mainnet, zebra_test::vectors::MAINNET_BLOCKS.iter()),
-        (Network::Testnet, zebra_test::vectors::TESTNET_BLOCKS.iter()),
+        (
+            Network::new_testnet(),
+            zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        ),
     ];
 
     for (network, blocks) in networks {
@@ -899,7 +905,7 @@ fn v5_transaction_is_accepted_after_nu5_activation_mainnet() {
 
 #[test]
 fn v5_transaction_is_accepted_after_nu5_activation_testnet() {
-    v5_transaction_is_accepted_after_nu5_activation_for_network(Network::Testnet)
+    v5_transaction_is_accepted_after_nu5_activation_for_network(Network::new_testnet())
 }
 
 fn v5_transaction_is_accepted_after_nu5_activation_for_network(network: Network) {
@@ -912,7 +918,7 @@ fn v5_transaction_is_accepted_after_nu5_activation_for_network(network: Network)
 
         let blocks = match network {
             Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-            Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+            Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
         };
 
         let state_service = service_fn(|_| async { unreachable!("Service should not be called") });
@@ -1548,7 +1554,7 @@ fn v4_transaction_with_conflicting_sprout_nullifier_across_joinsplits_is_rejecte
 /// Test if V5 transaction with transparent funds is accepted.
 #[tokio::test]
 async fn v5_transaction_with_transparent_transfer_is_accepted() {
-    let network = Network::Testnet;
+    let network = Network::new_testnet();
     let network_upgrade = NetworkUpgrade::Nu5;
 
     let nu5_activation_height = network_upgrade
@@ -1607,10 +1613,10 @@ async fn v5_transaction_with_transparent_transfer_is_accepted() {
 async fn v5_transaction_with_last_valid_expiry_height() {
     let state_service =
         service_fn(|_| async { unreachable!("State service should not be called") });
-    let verifier = Verifier::new(Network::Testnet, state_service);
+    let verifier = Verifier::new(Network::new_testnet(), state_service);
 
     let block_height = NetworkUpgrade::Nu5
-        .activation_height(Network::Testnet)
+        .activation_height(Network::new_testnet())
         .expect("Nu5 activation height for testnet is specified");
     let fund_height = (block_height - 1).expect("fake source fund block height is too small");
     let (input, output, known_utxos) = mock_transparent_transfer(
@@ -1652,10 +1658,10 @@ async fn v5_transaction_with_last_valid_expiry_height() {
 async fn v5_coinbase_transaction_expiry_height() {
     let state_service =
         service_fn(|_| async { unreachable!("State service should not be called") });
-    let verifier = Verifier::new(Network::Testnet, state_service);
+    let verifier = Verifier::new(Network::new_testnet(), state_service);
 
     let block_height = NetworkUpgrade::Nu5
-        .activation_height(Network::Testnet)
+        .activation_height(Network::new_testnet())
         .expect("Nu5 activation height for testnet is specified");
 
     let (input, output) = mock_coinbase_transparent_output(block_height);
@@ -1767,10 +1773,10 @@ async fn v5_coinbase_transaction_expiry_height() {
 async fn v5_transaction_with_too_low_expiry_height() {
     let state_service =
         service_fn(|_| async { unreachable!("State service should not be called") });
-    let verifier = Verifier::new(Network::Testnet, state_service);
+    let verifier = Verifier::new(Network::new_testnet(), state_service);
 
     let block_height = NetworkUpgrade::Nu5
-        .activation_height(Network::Testnet)
+        .activation_height(Network::new_testnet())
         .expect("Nu5 activation height for testnet is specified");
     let fund_height = (block_height - 1).expect("fake source fund block height is too small");
     let (input, output, known_utxos) = mock_transparent_transfer(
@@ -1868,7 +1874,7 @@ async fn v5_transaction_with_exceeding_expiry_height() {
 /// Test if V5 coinbase transaction is accepted.
 #[tokio::test]
 async fn v5_coinbase_transaction_is_accepted() {
-    let network = Network::Testnet;
+    let network = Network::new_testnet();
     let network_upgrade = NetworkUpgrade::Nu5;
 
     let nu5_activation_height = network_upgrade
@@ -1920,7 +1926,7 @@ async fn v5_coinbase_transaction_is_accepted() {
 /// script prevents spending the source UTXO.
 #[tokio::test]
 async fn v5_transaction_with_transparent_transfer_is_rejected_by_the_script() {
-    let network = Network::Testnet;
+    let network = Network::new_testnet();
     let network_upgrade = NetworkUpgrade::Nu5;
 
     let nu5_activation_height = network_upgrade
@@ -2764,7 +2770,7 @@ fn coinbase_outputs_are_decryptable_for_historical_blocks() -> Result<(), Report
     let _init_guard = zebra_test::init();
 
     coinbase_outputs_are_decryptable_for_historical_blocks_for_network(Network::Mainnet)?;
-    coinbase_outputs_are_decryptable_for_historical_blocks_for_network(Network::Testnet)?;
+    coinbase_outputs_are_decryptable_for_historical_blocks_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -2774,7 +2780,7 @@ fn coinbase_outputs_are_decryptable_for_historical_blocks_for_network(
 ) -> Result<(), Report> {
     let block_iter = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     let mut tested_coinbase_txs = 0;
@@ -2851,7 +2857,7 @@ fn fill_action_with_note_encryption_test_vector(
 /// viewing key.
 #[test]
 fn coinbase_outputs_are_decryptable_for_fake_v5_blocks() {
-    let network = Network::Testnet;
+    let network = Network::new_testnet();
 
     for v in zebra_test::vectors::ORCHARD_NOTE_ENCRYPTION_ZERO_VECTOR.iter() {
         // Find a transaction with no inputs or outputs to use as base
@@ -2893,7 +2899,7 @@ fn coinbase_outputs_are_decryptable_for_fake_v5_blocks() {
 /// viewing key.
 #[test]
 fn shielded_outputs_are_not_decryptable_for_fake_v5_blocks() {
-    let network = Network::Testnet;
+    let network = Network::new_testnet();
 
     for v in zebra_test::vectors::ORCHARD_NOTE_ENCRYPTION_VECTOR.iter() {
         // Find a transaction with no inputs or outputs to use as base

--- a/zebra-network/proptest-regressions/peer_set/set/tests/prop.txt
+++ b/zebra-network/proptest-regressions/peer_set/set/tests/prop.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 9787acf42b2d604cd553a8b2bb0b59552f213587fb162e15f36c66a1147b0986 # shrinks to total_number_of_peers = 2

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -225,7 +225,7 @@ impl Config {
     pub fn initial_peer_hostnames(&self) -> &IndexSet<String> {
         match self.network {
             Network::Mainnet => &self.initial_mainnet_peers,
-            Network::Testnet => &self.initial_testnet_peers,
+            Network::Testnet(_) => &self.initial_testnet_peers,
         }
     }
 

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -392,7 +392,7 @@ lazy_static! {
         let mut hash_map = HashMap::new();
 
         hash_map.insert(Mainnet, Version::min_specified_for_upgrade(Mainnet, Nu5));
-        hash_map.insert(Testnet(None.into()), Version::min_specified_for_upgrade(Testnet(None.into()), Nu5));
+        hash_map.insert(Network::new_testnet(), Version::min_specified_for_upgrade(Network::new_testnet(), Nu5));
 
         hash_map
     };

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -392,7 +392,7 @@ lazy_static! {
         let mut hash_map = HashMap::new();
 
         hash_map.insert(Mainnet, Version::min_specified_for_upgrade(Mainnet, Nu5));
-        hash_map.insert(Testnet, Version::min_specified_for_upgrade(Testnet, Nu5));
+        hash_map.insert(Testnet(None.into()), Version::min_specified_for_upgrade(Testnet(None.into()), Nu5));
 
         hash_map
     };

--- a/zebra-network/src/isolated/tests/vectors.rs
+++ b/zebra-network/src/isolated/tests/vectors.rs
@@ -27,7 +27,7 @@ async fn connect_isolated_sends_anonymised_version_message_tcp() {
     }
 
     connect_isolated_sends_anonymised_version_message_tcp_net(Mainnet).await;
-    connect_isolated_sends_anonymised_version_message_tcp_net(Testnet(None.into())).await;
+    connect_isolated_sends_anonymised_version_message_tcp_net(Network::new_testnet()).await;
 }
 
 async fn connect_isolated_sends_anonymised_version_message_tcp_net(network: Network) {
@@ -82,7 +82,7 @@ async fn connect_isolated_sends_anonymised_version_message_mem() {
     let _init_guard = zebra_test::init();
 
     connect_isolated_sends_anonymised_version_message_mem_net(Mainnet).await;
-    connect_isolated_sends_anonymised_version_message_mem_net(Testnet(None.into())).await;
+    connect_isolated_sends_anonymised_version_message_mem_net(Network::new_testnet()).await;
 }
 
 async fn connect_isolated_sends_anonymised_version_message_mem_net(network: Network) {

--- a/zebra-network/src/isolated/tests/vectors.rs
+++ b/zebra-network/src/isolated/tests/vectors.rs
@@ -27,7 +27,7 @@ async fn connect_isolated_sends_anonymised_version_message_tcp() {
     }
 
     connect_isolated_sends_anonymised_version_message_tcp_net(Mainnet).await;
-    connect_isolated_sends_anonymised_version_message_tcp_net(Testnet).await;
+    connect_isolated_sends_anonymised_version_message_tcp_net(Testnet(None.into())).await;
 }
 
 async fn connect_isolated_sends_anonymised_version_message_tcp_net(network: Network) {
@@ -82,7 +82,7 @@ async fn connect_isolated_sends_anonymised_version_message_mem() {
     let _init_guard = zebra_test::init();
 
     connect_isolated_sends_anonymised_version_message_mem_net(Mainnet).await;
-    connect_isolated_sends_anonymised_version_message_mem_net(Testnet).await;
+    connect_isolated_sends_anonymised_version_message_mem_net(Testnet(None.into())).await;
 }
 
 async fn connect_isolated_sends_anonymised_version_message_mem_net(network: Network) {

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -82,7 +82,7 @@ async fn local_listener_unspecified_port_unspecified_addr_v4() {
     // these tests might fail on machines with no configured IPv4 addresses
     // (localhost should be enough)
     local_listener_port_with("0.0.0.0:0".parse().unwrap(), Mainnet).await;
-    local_listener_port_with("0.0.0.0:0".parse().unwrap(), Testnet(None.into())).await;
+    local_listener_port_with("0.0.0.0:0".parse().unwrap(), Network::new_testnet()).await;
 }
 
 /// Test that zebra-network discovers dynamic bind-to-all-interfaces listener ports,
@@ -103,7 +103,7 @@ async fn local_listener_unspecified_port_unspecified_addr_v6() {
 
     // these tests might fail on machines with no configured IPv6 addresses
     local_listener_port_with("[::]:0".parse().unwrap(), Mainnet).await;
-    local_listener_port_with("[::]:0".parse().unwrap(), Testnet(None.into())).await;
+    local_listener_port_with("[::]:0".parse().unwrap(), Network::new_testnet()).await;
 }
 
 /// Test that zebra-network discovers dynamic localhost listener ports,
@@ -118,7 +118,7 @@ async fn local_listener_unspecified_port_localhost_addr_v4() {
 
     // these tests might fail on machines with unusual IPv4 localhost configs
     local_listener_port_with("127.0.0.1:0".parse().unwrap(), Mainnet).await;
-    local_listener_port_with("127.0.0.1:0".parse().unwrap(), Testnet(None.into())).await;
+    local_listener_port_with("127.0.0.1:0".parse().unwrap(), Network::new_testnet()).await;
 }
 
 /// Test that zebra-network discovers dynamic localhost listener ports,
@@ -137,7 +137,7 @@ async fn local_listener_unspecified_port_localhost_addr_v6() {
 
     // these tests might fail on machines with no configured IPv6 addresses
     local_listener_port_with("[::1]:0".parse().unwrap(), Mainnet).await;
-    local_listener_port_with("[::1]:0".parse().unwrap(), Testnet(None.into())).await;
+    local_listener_port_with("[::1]:0".parse().unwrap(), Network::new_testnet()).await;
 }
 
 /// Test that zebra-network propagates fixed localhost listener ports to the `AddressBook`.
@@ -154,7 +154,7 @@ async fn local_listener_fixed_port_localhost_addr_v4() {
     local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), Mainnet).await;
     local_listener_port_with(
         SocketAddr::new(localhost_v4, random_known_port()),
-        Testnet(None.into()),
+        Network::new_testnet(),
     )
     .await;
 }
@@ -177,7 +177,7 @@ async fn local_listener_fixed_port_localhost_addr_v6() {
     local_listener_port_with(SocketAddr::new(localhost_v6, random_known_port()), Mainnet).await;
     local_listener_port_with(
         SocketAddr::new(localhost_v6, random_known_port()),
-        Testnet(None.into()),
+        Network::new_testnet(),
     )
     .await;
 }
@@ -219,7 +219,7 @@ async fn peer_limit_zero_testnet() {
     let address_book = init_with_peer_limit(
         0,
         unreachable_inbound_service,
-        Testnet(None.into()),
+        Network::new_testnet(),
         None,
         None,
     )
@@ -262,7 +262,7 @@ async fn peer_limit_one_testnet() {
 
     let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
 
-    let _ = init_with_peer_limit(1, nil_inbound_service, Testnet(None.into()), None, None).await;
+    let _ = init_with_peer_limit(1, nil_inbound_service, Network::new_testnet(), None, None).await;
 
     // Let the crawler run for a while.
     tokio::time::sleep(CRAWLER_TEST_DURATION).await;
@@ -300,7 +300,7 @@ async fn peer_limit_two_testnet() {
 
     let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
 
-    let _ = init_with_peer_limit(2, nil_inbound_service, Testnet(None.into()), None, None).await;
+    let _ = init_with_peer_limit(2, nil_inbound_service, Network::new_testnet(), None, None).await;
 
     // Let the crawler run for a while.
     tokio::time::sleep(CRAWLER_TEST_DURATION).await;

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -82,7 +82,7 @@ async fn local_listener_unspecified_port_unspecified_addr_v4() {
     // these tests might fail on machines with no configured IPv4 addresses
     // (localhost should be enough)
     local_listener_port_with("0.0.0.0:0".parse().unwrap(), Mainnet).await;
-    local_listener_port_with("0.0.0.0:0".parse().unwrap(), Testnet).await;
+    local_listener_port_with("0.0.0.0:0".parse().unwrap(), Testnet(None.into())).await;
 }
 
 /// Test that zebra-network discovers dynamic bind-to-all-interfaces listener ports,
@@ -103,7 +103,7 @@ async fn local_listener_unspecified_port_unspecified_addr_v6() {
 
     // these tests might fail on machines with no configured IPv6 addresses
     local_listener_port_with("[::]:0".parse().unwrap(), Mainnet).await;
-    local_listener_port_with("[::]:0".parse().unwrap(), Testnet).await;
+    local_listener_port_with("[::]:0".parse().unwrap(), Testnet(None.into())).await;
 }
 
 /// Test that zebra-network discovers dynamic localhost listener ports,
@@ -118,7 +118,7 @@ async fn local_listener_unspecified_port_localhost_addr_v4() {
 
     // these tests might fail on machines with unusual IPv4 localhost configs
     local_listener_port_with("127.0.0.1:0".parse().unwrap(), Mainnet).await;
-    local_listener_port_with("127.0.0.1:0".parse().unwrap(), Testnet).await;
+    local_listener_port_with("127.0.0.1:0".parse().unwrap(), Testnet(None.into())).await;
 }
 
 /// Test that zebra-network discovers dynamic localhost listener ports,
@@ -137,7 +137,7 @@ async fn local_listener_unspecified_port_localhost_addr_v6() {
 
     // these tests might fail on machines with no configured IPv6 addresses
     local_listener_port_with("[::1]:0".parse().unwrap(), Mainnet).await;
-    local_listener_port_with("[::1]:0".parse().unwrap(), Testnet).await;
+    local_listener_port_with("[::1]:0".parse().unwrap(), Testnet(None.into())).await;
 }
 
 /// Test that zebra-network propagates fixed localhost listener ports to the `AddressBook`.
@@ -152,7 +152,11 @@ async fn local_listener_fixed_port_localhost_addr_v4() {
     }
 
     local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), Mainnet).await;
-    local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), Testnet).await;
+    local_listener_port_with(
+        SocketAddr::new(localhost_v4, random_known_port()),
+        Testnet(None.into()),
+    )
+    .await;
 }
 
 /// Test that zebra-network propagates fixed localhost listener ports to the `AddressBook`.
@@ -171,7 +175,11 @@ async fn local_listener_fixed_port_localhost_addr_v6() {
     }
 
     local_listener_port_with(SocketAddr::new(localhost_v6, random_known_port()), Mainnet).await;
-    local_listener_port_with(SocketAddr::new(localhost_v6, random_known_port()), Testnet).await;
+    local_listener_port_with(
+        SocketAddr::new(localhost_v6, random_known_port()),
+        Testnet(None.into()),
+    )
+    .await;
 }
 
 /// Test zebra-network with a peer limit of zero peers on mainnet.
@@ -208,8 +216,14 @@ async fn peer_limit_zero_testnet() {
     let unreachable_inbound_service =
         service_fn(|_| async { unreachable!("inbound service should never be called") });
 
-    let address_book =
-        init_with_peer_limit(0, unreachable_inbound_service, Testnet, None, None).await;
+    let address_book = init_with_peer_limit(
+        0,
+        unreachable_inbound_service,
+        Testnet(None.into()),
+        None,
+        None,
+    )
+    .await;
     assert_eq!(
         address_book.lock().unwrap().peers().count(),
         0,
@@ -248,7 +262,7 @@ async fn peer_limit_one_testnet() {
 
     let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
 
-    let _ = init_with_peer_limit(1, nil_inbound_service, Testnet, None, None).await;
+    let _ = init_with_peer_limit(1, nil_inbound_service, Testnet(None.into()), None, None).await;
 
     // Let the crawler run for a while.
     tokio::time::sleep(CRAWLER_TEST_DURATION).await;
@@ -286,7 +300,7 @@ async fn peer_limit_two_testnet() {
 
     let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
 
-    let _ = init_with_peer_limit(2, nil_inbound_service, Testnet, None, None).await;
+    let _ = init_with_peer_limit(2, nil_inbound_service, Testnet(None.into()), None, None).await;
 
     // Let the crawler run for a while.
     tokio::time::sleep(CRAWLER_TEST_DURATION).await;

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -628,9 +628,6 @@ impl Codec {
     /// Currently, Zebra parses received `addrv2`s, ignoring some address types.
     /// Zebra never sends `addrv2` messages.
     pub(super) fn read_addrv2<R: Read>(&self, reader: R) -> Result<Message, Error> {
-        // TODO: Deserialize this field without `ZcashDeserialize`, check if there is some network id
-        //       in `self.with_testnet_parameters(NetworkParameters::network_id)`, and use that instead
-        //       of the default value. Check that serialization uses configured values too.
         let addrs: Vec<AddrV2> = reader.zcash_deserialize_into()?;
 
         if addrs.len() > constants::MAX_ADDRS_IN_MESSAGE {

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -628,6 +628,9 @@ impl Codec {
     /// Currently, Zebra parses received `addrv2`s, ignoring some address types.
     /// Zebra never sends `addrv2` messages.
     pub(super) fn read_addrv2<R: Read>(&self, reader: R) -> Result<Message, Error> {
+        // TODO: Deserialize this field without `ZcashDeserialize`, check if there is some network id
+        //       in `self.with_testnet_parameters(NetworkParameters::network_id)`, and use that instead
+        //       of the default value. Check that serialization uses configured values too.
         let addrs: Vec<AddrV2> = reader.zcash_deserialize_into()?;
 
         if addrs.len() > constants::MAX_ADDRS_IN_MESSAGE {

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -29,7 +29,7 @@ impl From<Network> for Magic {
     fn from(network: Network) -> Self {
         match network {
             Network::Mainnet => magics::MAINNET,
-            Network::Testnet(_) => magics::TESTNET,
+            Network::Testnet(params) => params.network_id().map_or(magics::TESTNET, Magic),
         }
     }
 }

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -199,7 +199,7 @@ mod test {
 
     #[test]
     fn version_extremes_testnet() {
-        version_extremes(Testnet(None.into()))
+        version_extremes(Network::new_testnet())
     }
 
     /// Test the min_specified_for_upgrade and min_specified_for_height functions for `network` with
@@ -227,7 +227,7 @@ mod test {
 
     #[test]
     fn version_consistent_testnet() {
-        version_consistent(Testnet(None.into()))
+        version_consistent(Network::new_testnet())
     }
 
     /// Check that the min_specified_for_upgrade and min_specified_for_height functions

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -29,7 +29,7 @@ impl From<Network> for Magic {
     fn from(network: Network) -> Self {
         match network {
             Network::Mainnet => magics::MAINNET,
-            Network::Testnet => magics::TESTNET,
+            Network::Testnet(_) => magics::TESTNET,
         }
     }
 }
@@ -101,16 +101,16 @@ impl Version {
         //       sync? zcashd accepts 170_002 or later during its initial sync.
         Version(match (network, network_upgrade) {
             (_, Genesis) | (_, BeforeOverwinter) => 170_002,
-            (Testnet, Overwinter) => 170_003,
+            (Testnet(_), Overwinter) => 170_003,
             (Mainnet, Overwinter) => 170_005,
             (_, Sapling) => 170_007,
-            (Testnet, Blossom) => 170_008,
+            (Testnet(_), Blossom) => 170_008,
             (Mainnet, Blossom) => 170_009,
-            (Testnet, Heartwood) => 170_010,
+            (Testnet(_), Heartwood) => 170_010,
             (Mainnet, Heartwood) => 170_011,
-            (Testnet, Canopy) => 170_012,
+            (Testnet(_), Canopy) => 170_012,
             (Mainnet, Canopy) => 170_013,
-            (Testnet, Nu5) => 170_050,
+            (Testnet(_), Nu5) => 170_050,
             (Mainnet, Nu5) => 170_100,
         })
     }
@@ -199,7 +199,7 @@ mod test {
 
     #[test]
     fn version_extremes_testnet() {
-        version_extremes(Testnet)
+        version_extremes(Testnet(None.into()))
     }
 
     /// Test the min_specified_for_upgrade and min_specified_for_height functions for `network` with
@@ -227,7 +227,7 @@ mod test {
 
     #[test]
     fn version_consistent_testnet() {
-        version_consistent(Testnet)
+        version_consistent(Testnet(None.into()))
     }
 
     /// Check that the min_specified_for_upgrade and min_specified_for_height functions

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
@@ -25,7 +25,7 @@ impl Response {
             networksolps,
             networkhashps: networksolps,
             chain: network.bip70_network_name(),
-            testnet: network.is_a_test_network(),
+            testnet: network.is_testnet(),
         }
     }
 }

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
@@ -25,7 +25,7 @@ impl Response {
             networksolps,
             networkhashps: networksolps,
             chain: network.bip70_network_name(),
-            testnet: network.is_testnet(),
+            testnet: network.is_a_test_network(),
         }
     }
 }

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -35,9 +35,9 @@ async fn test_rpc_response_data() {
 
     tokio::join!(
         test_rpc_response_data_for_network(Mainnet),
-        test_rpc_response_data_for_network(Testnet),
+        test_rpc_response_data_for_network(Testnet(None.into())),
         test_mocked_rpc_response_data_for_network(Mainnet),
-        test_mocked_rpc_response_data_for_network(Testnet),
+        test_mocked_rpc_response_data_for_network(Testnet(None.into())),
     );
 }
 
@@ -45,7 +45,7 @@ async fn test_rpc_response_data_for_network(network: Network) {
     // Create a continuous chain of mainnet and testnet blocks from genesis
     let block_data = match network {
         Mainnet => &*zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS,
-        Testnet => &*zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS,
+        Testnet(_) => &*zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS,
     };
 
     let blocks: Vec<Arc<Block>> = block_data

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -35,9 +35,9 @@ async fn test_rpc_response_data() {
 
     tokio::join!(
         test_rpc_response_data_for_network(Mainnet),
-        test_rpc_response_data_for_network(Testnet(None.into())),
+        test_rpc_response_data_for_network(Network::new_testnet()),
         test_mocked_rpc_response_data_for_network(Mainnet),
-        test_mocked_rpc_response_data_for_network(Testnet(None.into())),
+        test_mocked_rpc_response_data_for_network(Network::new_testnet()),
     );
 }
 

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -412,7 +412,7 @@ pub async fn test_responses<State, ReadState>(
     // `validateaddress`
     let founder_address = match network {
         Network::Mainnet => "t3fqvkzrrNaMcamkQMwAyHRjfDdM2xQvDTR",
-        Network::Testnet => "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
+        Network::Testnet(_) => "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
     };
 
     let validate_address = get_block_template_rpc
@@ -430,7 +430,7 @@ pub async fn test_responses<State, ReadState>(
     // `z_validateaddress`
     let founder_address = match network {
         Network::Mainnet => "t3fqvkzrrNaMcamkQMwAyHRjfDdM2xQvDTR",
-        Network::Testnet => "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
+        Network::Testnet(_) => "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi",
     };
 
     let z_validate_address = get_block_template_rpc

--- a/zebra-rpc/src/methods/tests/utils.rs
+++ b/zebra-rpc/src/methods/tests/utils.rs
@@ -18,7 +18,7 @@ pub fn fake_history_tree(network: Network) -> Arc<HistoryTree> {
             &vectors::BLOCK_MAINNET_1046400_BYTES[..],
             *vectors::SAPLING_FINAL_ROOT_MAINNET_1046400_BYTES,
         ),
-        Network::Testnet => (
+        Network::Testnet(_) => (
             &vectors::BLOCK_TESTNET_1116000_BYTES[..],
             *vectors::SAPLING_FINAL_ROOT_TESTNET_1116000_BYTES,
         ),

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -654,10 +654,10 @@ async fn rpc_getaddresstxids_invalid_arguments() {
 async fn rpc_getaddresstxids_response() {
     let _init_guard = zebra_test::init();
 
-    for network in [Mainnet, Testnet] {
+    for network in [Mainnet, Testnet(None.into())] {
         let blocks: Vec<Arc<Block>> = match network {
             Mainnet => &*zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS,
-            Testnet => &*zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS,
+            Testnet(_) => &*zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS,
         }
         .iter()
         .map(|(_height, block_bytes)| block_bytes.zcash_deserialize_into().unwrap())

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -654,7 +654,7 @@ async fn rpc_getaddresstxids_invalid_arguments() {
 async fn rpc_getaddresstxids_response() {
     let _init_guard = zebra_test::init();
 
-    for network in [Mainnet, Testnet(None.into())] {
+    for network in [Mainnet, Network::new_testnet()] {
         let blocks: Vec<Arc<Block>> = match network {
             Mainnet => &*zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS,
             Testnet(_) => &*zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS,

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -130,7 +130,7 @@ fn gen_temp_path(prefix: &str) -> PathBuf {
 impl Config {
     /// Returns the path for the finalized state database
     pub fn db_path(&self, network: Network) -> PathBuf {
-        let net_dir = network.lowercase_name();
+        let net_dir = network.cache_name();
 
         if self.ephemeral {
             gen_temp_path(&format!(

--- a/zebra-state/src/service/arbitrary.rs
+++ b/zebra-state/src/service/arbitrary.rs
@@ -93,7 +93,7 @@ impl PreparedChain {
             .activation_height(Network::Mainnet)
             .expect("must have height");
         let test_height = NetworkUpgrade::Heartwood
-            .activation_height(Network::Testnet)
+            .activation_height(Network::new_testnet())
             .expect("must have height");
         let height = std::cmp::max(main_height, test_height);
 

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -183,9 +183,8 @@ impl AdjustedDifficulty {
             self.candidate_time,
             self.relevant_times[0],
         ) {
-            assert_eq!(
-                self.network,
-                Network::Testnet,
+            assert!(
+                self.network.is_testnet(),
                 "invalid network: the minimum difficulty rule only applies on testnet"
             );
             ExpandedDifficulty::target_difficulty_limit(self.network).to_compact()

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -184,7 +184,7 @@ impl AdjustedDifficulty {
             self.relevant_times[0],
         ) {
             assert!(
-                self.network.is_testnet(),
+                self.network.is_a_test_network(),
                 "invalid network: the minimum difficulty rule only applies on testnet"
             );
             ExpandedDifficulty::target_difficulty_limit(self.network).to_compact()

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -428,7 +428,7 @@ impl FinalizedState {
 
             let mut blocks_size_to_dump = match self.network {
                 Network::Mainnet => MAINNET_AWAY_FROM_TIP_BULK_SIZE,
-                Network::Testnet => TESTNET_AWAY_FROM_TIP_BULK_SIZE,
+                Network::Testnet(_) => TESTNET_AWAY_FROM_TIP_BULK_SIZE,
             };
 
             // If we are close to the tip, index one block per bulk call.

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
@@ -52,7 +52,7 @@ fn test_raw_rocksdb_column_families() {
     let _init_guard = zebra_test::init();
 
     test_raw_rocksdb_column_families_with_network(Mainnet);
-    test_raw_rocksdb_column_families_with_network(Testnet(None.into()));
+    test_raw_rocksdb_column_families_with_network(Network::new_testnet());
 }
 
 /// Snapshot raw column families for `network`.

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
@@ -52,7 +52,7 @@ fn test_raw_rocksdb_column_families() {
     let _init_guard = zebra_test::init();
 
     test_raw_rocksdb_column_families_with_network(Mainnet);
-    test_raw_rocksdb_column_families_with_network(Testnet);
+    test_raw_rocksdb_column_families_with_network(Testnet(None.into()));
 }
 
 /// Snapshot raw column families for `network`.
@@ -91,7 +91,7 @@ fn test_raw_rocksdb_column_families_with_network(network: Network) {
     // - genesis, block 1, and block 2
     let blocks = match network {
         Mainnet => &*zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS,
-        Testnet => &*zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS,
+        Testnet(_) => &*zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS,
     };
 
     // We limit the number of blocks, because the serialized data is a few kilobytes per block.

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -504,8 +504,8 @@ fn address_variant(address: &transparent::Address) -> u8 {
     match (address.network(), address) {
         (Mainnet, PayToPublicKeyHash { .. }) => 0,
         (Mainnet, PayToScriptHash { .. }) => 1,
-        (Testnet, PayToPublicKeyHash { .. }) => 2,
-        (Testnet, PayToScriptHash { .. }) => 3,
+        (Testnet(_), PayToPublicKeyHash { .. }) => 2,
+        (Testnet(_), PayToScriptHash { .. }) => 3,
     }
 }
 
@@ -531,7 +531,7 @@ impl FromDisk for transparent::Address {
         let network = if address_variant < 2 {
             Mainnet
         } else {
-            Testnet
+            Testnet(None.into())
         };
 
         if address_variant % 2 == 0 {

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use zebra_chain::{
     amount::{self, Amount, NonNegative},
     block::Height,
-    parameters::Network::*,
+    parameters::Network::{self, *},
     serialization::{ZcashDeserializeInto, ZcashSerialize},
     transparent::{self, Address::*},
 };
@@ -531,7 +531,7 @@ impl FromDisk for transparent::Address {
         let network = if address_variant < 2 {
             Mainnet
         } else {
-            Testnet(None.into())
+            Network::new_testnet()
         };
 
         if address_variant % 2 == 0 {

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
@@ -155,7 +155,7 @@ fn test_block_and_transaction_data() {
     let _init_guard = zebra_test::init();
 
     test_block_and_transaction_data_with_network(Mainnet);
-    test_block_and_transaction_data_with_network(Testnet);
+    test_block_and_transaction_data_with_network(Testnet(None.into()));
 }
 
 /// Snapshot finalized block and transaction data for `network`.
@@ -183,7 +183,7 @@ fn test_block_and_transaction_data_with_network(network: Network) {
     // - genesis, block 1, and block 2
     let blocks = match network {
         Mainnet => &*zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS,
-        Testnet => &*zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS,
+        Testnet(_) => &*zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS,
     };
 
     // We limit the number of blocks, because the serialized data is a few kilobytes per block.

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
@@ -155,7 +155,7 @@ fn test_block_and_transaction_data() {
     let _init_guard = zebra_test::init();
 
     test_block_and_transaction_data_with_network(Mainnet);
-    test_block_and_transaction_data_with_network(Testnet(None.into()));
+    test_block_and_transaction_data_with_network(Network::new_testnet());
 }
 
 /// Snapshot finalized block and transaction data for `network`.

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -41,7 +41,7 @@ fn test_block_db_round_trip() {
         .map(|(_height, block)| block.zcash_deserialize_into().unwrap());
 
     test_block_db_round_trip_with(Mainnet, mainnet_test_cases);
-    test_block_db_round_trip_with(Testnet, testnet_test_cases);
+    test_block_db_round_trip_with(Testnet(None.into()), testnet_test_cases);
 
     // It doesn't matter if these blocks are mainnet or testnet,
     // because there is no validation at this level of the database.

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -41,7 +41,7 @@ fn test_block_db_round_trip() {
         .map(|(_height, block)| block.zcash_deserialize_into().unwrap());
 
     test_block_db_round_trip_with(Mainnet, mainnet_test_cases);
-    test_block_db_round_trip_with(Testnet(None.into()), testnet_test_cases);
+    test_block_db_round_trip_with(Network::new_testnet(), testnet_test_cases);
 
     // It doesn't matter if these blocks are mainnet or testnet,
     // because there is no validation at this level of the database.

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -135,7 +135,7 @@ fn best_chain_wins() -> Result<()> {
     let _init_guard = zebra_test::init();
 
     best_chain_wins_for_network(Network::Mainnet)?;
-    best_chain_wins_for_network(Network::Testnet)?;
+    best_chain_wins_for_network(Network::Testnet(None.into()))?;
 
     Ok(())
 }
@@ -148,7 +148,7 @@ fn best_chain_wins_for_network(network: Network) -> Result<()> {
         Network::Mainnet => {
             zebra_test::vectors::BLOCK_MAINNET_653599_BYTES.zcash_deserialize_into()?
         }
-        Network::Testnet => {
+        Network::Testnet(_) => {
             zebra_test::vectors::BLOCK_TESTNET_583999_BYTES.zcash_deserialize_into()?
         }
     };
@@ -180,7 +180,7 @@ fn finalize_pops_from_best_chain() -> Result<()> {
     let _init_guard = zebra_test::init();
 
     finalize_pops_from_best_chain_for_network(Network::Mainnet)?;
-    finalize_pops_from_best_chain_for_network(Network::Testnet)?;
+    finalize_pops_from_best_chain_for_network(Network::Testnet(None.into()))?;
 
     Ok(())
 }
@@ -193,7 +193,7 @@ fn finalize_pops_from_best_chain_for_network(network: Network) -> Result<()> {
         Network::Mainnet => {
             zebra_test::vectors::BLOCK_MAINNET_653599_BYTES.zcash_deserialize_into()?
         }
-        Network::Testnet => {
+        Network::Testnet(_) => {
             zebra_test::vectors::BLOCK_TESTNET_583999_BYTES.zcash_deserialize_into()?
         }
     };
@@ -234,7 +234,7 @@ fn commit_block_extending_best_chain_doesnt_drop_worst_chains() -> Result<()> {
     let _init_guard = zebra_test::init();
 
     commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(Network::Mainnet)?;
-    commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(Network::Testnet)?;
+    commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -249,7 +249,7 @@ fn commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(
         Network::Mainnet => {
             zebra_test::vectors::BLOCK_MAINNET_653599_BYTES.zcash_deserialize_into()?
         }
-        Network::Testnet => {
+        Network::Testnet(_) => {
             zebra_test::vectors::BLOCK_TESTNET_583999_BYTES.zcash_deserialize_into()?
         }
     };
@@ -287,7 +287,7 @@ fn shorter_chain_can_be_best_chain() -> Result<()> {
     let _init_guard = zebra_test::init();
 
     shorter_chain_can_be_best_chain_for_network(Network::Mainnet)?;
-    shorter_chain_can_be_best_chain_for_network(Network::Testnet)?;
+    shorter_chain_can_be_best_chain_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -300,7 +300,7 @@ fn shorter_chain_can_be_best_chain_for_network(network: Network) -> Result<()> {
         Network::Mainnet => {
             zebra_test::vectors::BLOCK_MAINNET_653599_BYTES.zcash_deserialize_into()?
         }
-        Network::Testnet => {
+        Network::Testnet(_) => {
             zebra_test::vectors::BLOCK_TESTNET_583999_BYTES.zcash_deserialize_into()?
         }
     };
@@ -337,7 +337,7 @@ fn longer_chain_with_more_work_wins() -> Result<()> {
     let _init_guard = zebra_test::init();
 
     longer_chain_with_more_work_wins_for_network(Network::Mainnet)?;
-    longer_chain_with_more_work_wins_for_network(Network::Testnet)?;
+    longer_chain_with_more_work_wins_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -350,7 +350,7 @@ fn longer_chain_with_more_work_wins_for_network(network: Network) -> Result<()> 
         Network::Mainnet => {
             zebra_test::vectors::BLOCK_MAINNET_653599_BYTES.zcash_deserialize_into()?
         }
-        Network::Testnet => {
+        Network::Testnet(_) => {
             zebra_test::vectors::BLOCK_TESTNET_583999_BYTES.zcash_deserialize_into()?
         }
     };
@@ -391,7 +391,7 @@ fn equal_length_goes_to_more_work() -> Result<()> {
     let _init_guard = zebra_test::init();
 
     equal_length_goes_to_more_work_for_network(Network::Mainnet)?;
-    equal_length_goes_to_more_work_for_network(Network::Testnet)?;
+    equal_length_goes_to_more_work_for_network(Network::Testnet(None.into()))?;
 
     Ok(())
 }
@@ -403,7 +403,7 @@ fn equal_length_goes_to_more_work_for_network(network: Network) -> Result<()> {
         Network::Mainnet => {
             zebra_test::vectors::BLOCK_MAINNET_653599_BYTES.zcash_deserialize_into()?
         }
-        Network::Testnet => {
+        Network::Testnet(_) => {
             zebra_test::vectors::BLOCK_TESTNET_583999_BYTES.zcash_deserialize_into()?
         }
     };
@@ -437,7 +437,10 @@ fn equal_length_goes_to_more_work_for_network(network: Network) -> Result<()> {
 #[test]
 fn history_tree_is_updated() -> Result<()> {
     history_tree_is_updated_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Heartwood)?;
-    history_tree_is_updated_for_network_upgrade(Network::Testnet, NetworkUpgrade::Heartwood)?;
+    history_tree_is_updated_for_network_upgrade(
+        Network::Testnet(None.into()),
+        NetworkUpgrade::Heartwood,
+    )?;
     // TODO: we can't test other upgrades until we have a method for creating a FinalizedState
     // with a HistoryTree.
     Ok(())
@@ -449,7 +452,7 @@ fn history_tree_is_updated_for_network_upgrade(
 ) -> Result<()> {
     let blocks = match network {
         Network::Mainnet => &*zebra_test::vectors::MAINNET_BLOCKS,
-        Network::Testnet => &*zebra_test::vectors::TESTNET_BLOCKS,
+        Network::Testnet(_) => &*zebra_test::vectors::TESTNET_BLOCKS,
     };
     let height = network_upgrade.activation_height(network).unwrap().0;
 
@@ -542,7 +545,7 @@ fn history_tree_is_updated_for_network_upgrade(
 #[test]
 fn commitment_is_validated() {
     commitment_is_validated_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Heartwood);
-    commitment_is_validated_for_network_upgrade(Network::Testnet, NetworkUpgrade::Heartwood);
+    commitment_is_validated_for_network_upgrade(Network::new_testnet(), NetworkUpgrade::Heartwood);
     // TODO: we can't test other upgrades until we have a method for creating a FinalizedState
     // with a HistoryTree.
 }
@@ -550,7 +553,7 @@ fn commitment_is_validated() {
 fn commitment_is_validated_for_network_upgrade(network: Network, network_upgrade: NetworkUpgrade) {
     let blocks = match network {
         Network::Mainnet => &*zebra_test::vectors::MAINNET_BLOCKS,
-        Network::Testnet => &*zebra_test::vectors::TESTNET_BLOCKS,
+        Network::Testnet(_) => &*zebra_test::vectors::TESTNET_BLOCKS,
     };
     let height = network_upgrade.activation_height(network).unwrap().0;
 

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -135,7 +135,7 @@ fn best_chain_wins() -> Result<()> {
     let _init_guard = zebra_test::init();
 
     best_chain_wins_for_network(Network::Mainnet)?;
-    best_chain_wins_for_network(Network::Testnet(None.into()))?;
+    best_chain_wins_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -180,7 +180,7 @@ fn finalize_pops_from_best_chain() -> Result<()> {
     let _init_guard = zebra_test::init();
 
     finalize_pops_from_best_chain_for_network(Network::Mainnet)?;
-    finalize_pops_from_best_chain_for_network(Network::Testnet(None.into()))?;
+    finalize_pops_from_best_chain_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -391,7 +391,7 @@ fn equal_length_goes_to_more_work() -> Result<()> {
     let _init_guard = zebra_test::init();
 
     equal_length_goes_to_more_work_for_network(Network::Mainnet)?;
-    equal_length_goes_to_more_work_for_network(Network::Testnet(None.into()))?;
+    equal_length_goes_to_more_work_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -437,10 +437,7 @@ fn equal_length_goes_to_more_work_for_network(network: Network) -> Result<()> {
 #[test]
 fn history_tree_is_updated() -> Result<()> {
     history_tree_is_updated_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Heartwood)?;
-    history_tree_is_updated_for_network_upgrade(
-        Network::Testnet(None.into()),
-        NetworkUpgrade::Heartwood,
-    )?;
+    history_tree_is_updated_for_network_upgrade(Network::new_testnet(), NetworkUpgrade::Heartwood)?;
     // TODO: we can't test other upgrades until we have a method for creating a FinalizedState
     // with a HistoryTree.
     Ok(())

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -564,7 +564,7 @@ fn continuous_empty_blocks_from_test_vectors() -> impl Strategy<
             // Select the test vector based on the network
             let raw_blocks = match network {
                 Network::Mainnet => &*zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS,
-                Network::Testnet => &*zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS,
+                Network::Testnet(_) => &*zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS,
             };
 
             // Transform the test vector's block bytes into a vector of `SemanticallyVerifiedBlock`s.

--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -63,7 +63,7 @@ async fn check_transcripts_mainnet() -> Result<(), Report> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn check_transcripts_testnet() -> Result<(), Report> {
-    check_transcripts(Network::Testnet).await
+    check_transcripts(Network::new_testnet()).await
 }
 
 #[spandoc::spandoc]
@@ -75,7 +75,7 @@ async fn check_transcripts(network: Network) -> Result<(), Report> {
 
     for transcript_data in match network {
         Network::Mainnet => mainnet_transcript,
-        Network::Testnet => testnet_transcript,
+        Network::Testnet(_) => testnet_transcript,
     } {
         // We're not verifying UTXOs here.
         let (service, _, _, _) = zebra_state::init(Config::ephemeral(), network, Height::MAX, 0);

--- a/zebrad/src/components/mempool/storage/tests.rs
+++ b/zebrad/src/components/mempool/storage/tests.rs
@@ -19,7 +19,7 @@ pub fn unmined_transactions_in_blocks(
 ) -> impl DoubleEndedIterator<Item = VerifiedUnminedTx> {
     let blocks = match network {
         Network::Mainnet => zebra_test::vectors::MAINNET_BLOCKS.iter(),
-        Network::Testnet => zebra_test::vectors::TESTNET_BLOCKS.iter(),
+        Network::Testnet(_) => zebra_test::vectors::TESTNET_BLOCKS.iter(),
     };
 
     // Deserialize the blocks that are selected based on the specified `block_height_range`.

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -62,7 +62,7 @@ fn mempool_storage_basic() -> Result<()> {
     // Test multiple times to catch intermittent bugs since eviction is randomized
     for _ in 0..10 {
         mempool_storage_basic_for_network(Network::Mainnet)?;
-        mempool_storage_basic_for_network(Network::Testnet)?;
+        mempool_storage_basic_for_network(Network::new_testnet())?;
     }
 
     Ok(())
@@ -239,7 +239,7 @@ fn mempool_expired_basic() -> Result<()> {
     let _init_guard = zebra_test::init();
 
     mempool_expired_basic_for_network(Network::Mainnet)?;
-    mempool_expired_basic_for_network(Network::Testnet)?;
+    mempool_expired_basic_for_network(Network::new_testnet())?;
 
     Ok(())
 }
@@ -256,7 +256,7 @@ fn mempool_expired_basic_for_network(network: Network) -> Result<()> {
         Network::Mainnet => {
             zebra_test::vectors::BLOCK_MAINNET_982681_BYTES.zcash_deserialize_into()?
         }
-        Network::Testnet => {
+        Network::Testnet(_) => {
             zebra_test::vectors::BLOCK_TESTNET_925483_BYTES.zcash_deserialize_into()?
         }
     };

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1028,7 +1028,7 @@ fn sync_one_checkpoint_mainnet() -> Result<()> {
 fn sync_one_checkpoint_testnet() -> Result<()> {
     sync_until(
         TINY_CHECKPOINT_TEST_HEIGHT,
-        Testnet(None.into()),
+        Network::new_testnet(),
         STOP_AT_HEIGHT_REGEX,
         TINY_CHECKPOINT_TIMEOUT,
         None,
@@ -1248,7 +1248,7 @@ fn sync_to_mandatory_checkpoint_mainnet() -> Result<()> {
 #[cfg_attr(feature = "test_sync_to_mandatory_checkpoint_testnet", test)]
 fn sync_to_mandatory_checkpoint_testnet() -> Result<()> {
     let _init_guard = zebra_test::init();
-    let network = Testnet(None.into());
+    let network = Network::new_testnet();
     create_cached_database(network)
 }
 
@@ -1299,7 +1299,7 @@ fn full_sync_mainnet() -> Result<()> {
 #[ignore]
 fn full_sync_testnet() -> Result<()> {
     // TODO: add "ZEBRA" at the start of this env var, to avoid clashes
-    full_sync_test(Testnet(None.into()), "FULL_SYNC_TESTNET_TIMEOUT_MINUTES")
+    full_sync_test(Network::new_testnet(), "FULL_SYNC_TESTNET_TIMEOUT_MINUTES")
 }
 
 #[cfg(feature = "prometheus")]
@@ -2505,14 +2505,14 @@ async fn generate_checkpoints_mainnet() -> Result<()> {
 #[ignore]
 #[cfg(feature = "zebra-checkpoints")]
 async fn generate_checkpoints_testnet() -> Result<()> {
-    common::checkpoints::run(Testnet(None.into())).await
+    common::checkpoints::run(Network::new_testnet()).await
 }
 
 /// Check that new states are created with the current state format version,
 /// and that restarting `zebrad` doesn't change the format version.
 #[tokio::test]
 async fn new_state_format() -> Result<()> {
-    for network in [Mainnet, Testnet(None.into())] {
+    for network in [Mainnet, Network::new_testnet()] {
         state_format_test("new_state_format_test", network, 2, None).await?;
     }
 
@@ -2530,7 +2530,7 @@ async fn update_state_format() -> Result<()> {
     fake_version.minor = 0;
     fake_version.patch = 0;
 
-    for network in [Mainnet, Testnet(None.into())] {
+    for network in [Mainnet, Network::new_testnet()] {
         state_format_test("update_state_format_test", network, 3, Some(&fake_version)).await?;
     }
 
@@ -2547,7 +2547,7 @@ async fn downgrade_state_format() -> Result<()> {
     fake_version.minor = u16::MAX.into();
     fake_version.patch = 0;
 
-    for network in [Mainnet, Testnet(None.into())] {
+    for network in [Mainnet, Network::new_testnet()] {
         state_format_test(
             "downgrade_state_format_test",
             network,

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1028,7 +1028,7 @@ fn sync_one_checkpoint_mainnet() -> Result<()> {
 fn sync_one_checkpoint_testnet() -> Result<()> {
     sync_until(
         TINY_CHECKPOINT_TEST_HEIGHT,
-        Testnet,
+        Testnet(None.into()),
         STOP_AT_HEIGHT_REGEX,
         TINY_CHECKPOINT_TIMEOUT,
         None,
@@ -1248,7 +1248,7 @@ fn sync_to_mandatory_checkpoint_mainnet() -> Result<()> {
 #[cfg_attr(feature = "test_sync_to_mandatory_checkpoint_testnet", test)]
 fn sync_to_mandatory_checkpoint_testnet() -> Result<()> {
     let _init_guard = zebra_test::init();
-    let network = Testnet;
+    let network = Testnet(None.into());
     create_cached_database(network)
 }
 
@@ -1274,7 +1274,7 @@ fn sync_past_mandatory_checkpoint_mainnet() -> Result<()> {
 #[cfg_attr(feature = "test_sync_past_mandatory_checkpoint_testnet", test)]
 fn sync_past_mandatory_checkpoint_testnet() -> Result<()> {
     let _init_guard = zebra_test::init();
-    let network = Testnet;
+    let network = Network::new_testnet();
     sync_past_mandatory_checkpoint(network)
 }
 
@@ -1299,7 +1299,7 @@ fn full_sync_mainnet() -> Result<()> {
 #[ignore]
 fn full_sync_testnet() -> Result<()> {
     // TODO: add "ZEBRA" at the start of this env var, to avoid clashes
-    full_sync_test(Testnet, "FULL_SYNC_TESTNET_TIMEOUT_MINUTES")
+    full_sync_test(Testnet(None.into()), "FULL_SYNC_TESTNET_TIMEOUT_MINUTES")
 }
 
 #[cfg(feature = "prometheus")]
@@ -2512,7 +2512,7 @@ async fn generate_checkpoints_testnet() -> Result<()> {
 /// and that restarting `zebrad` doesn't change the format version.
 #[tokio::test]
 async fn new_state_format() -> Result<()> {
-    for network in [Mainnet, Testnet] {
+    for network in [Mainnet, Testnet(None.into())] {
         state_format_test("new_state_format_test", network, 2, None).await?;
     }
 
@@ -2530,7 +2530,7 @@ async fn update_state_format() -> Result<()> {
     fake_version.minor = 0;
     fake_version.patch = 0;
 
-    for network in [Mainnet, Testnet] {
+    for network in [Mainnet, Testnet(None.into())] {
         state_format_test("update_state_format_test", network, 3, Some(&fake_version)).await?;
     }
 
@@ -2547,7 +2547,7 @@ async fn downgrade_state_format() -> Result<()> {
     fake_version.minor = u16::MAX.into();
     fake_version.patch = 0;
 
-    for network in [Mainnet, Testnet] {
+    for network in [Mainnet, Testnet(None.into())] {
         state_format_test(
             "downgrade_state_format_test",
             network,

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2505,7 +2505,7 @@ async fn generate_checkpoints_mainnet() -> Result<()> {
 #[ignore]
 #[cfg(feature = "zebra-checkpoints")]
 async fn generate_checkpoints_testnet() -> Result<()> {
-    common::checkpoints::run(Testnet).await
+    common::checkpoints::run(Testnet(None.into())).await
 }
 
 /// Check that new states are created with the current state format version,

--- a/zebrad/tests/common/checkpoints.rs
+++ b/zebrad/tests/common/checkpoints.rs
@@ -82,7 +82,7 @@ pub async fn run(network: Network) -> Result<()> {
     // Wait for the upgrade if needed.
     // Currently we only write an image for testnet, which is quick.
     // (Mainnet would need to wait at the end of this function, if the upgrade is long.)
-    if network == Testnet {
+    if network.is_testnet() {
         let state_version_message = wait_for_state_version_message(&mut zebrad)?;
 
         // Before we write a cached state image, wait for a database upgrade.

--- a/zebrad/tests/common/checkpoints.rs
+++ b/zebrad/tests/common/checkpoints.rs
@@ -82,7 +82,7 @@ pub async fn run(network: Network) -> Result<()> {
     // Wait for the upgrade if needed.
     // Currently we only write an image for testnet, which is quick.
     // (Mainnet would need to wait at the end of this function, if the upgrade is long.)
-    if network.is_testnet() {
+    if network.is_a_test_network() {
         let state_version_message = wait_for_state_version_message(&mut zebrad)?;
 
         // Before we write a cached state image, wait for a database upgrade.


### PR DESCRIPTION
## Motivation

This PR is a step towards adding the `Regtest` network to Zebra, adding optional `cache_name`, `genesis_hash`, `network_id`, `default_port`, and `activation_heights` fields to `Network::Testnet`.

For testing ZSAs, it's not yet clear what other fields will be needed or whether the scope of this approach will be viable.

Part of #7845.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [ ] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

## Solution

- Adds new fields to `TestnetParameters` in `Testnet`
- Uses values in `TestnetParameters`, if any, instead of hard-coded defaults
- Updates references

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
