### PR TITLE
docs(fix): update the node version in debian install details

### DIFF
--- a/book/src/user/mining-testnet-s-nomp.md
+++ b/book/src/user/mining-testnet-s-nomp.md
@@ -110,18 +110,18 @@ These fixes disable mining pool operator payments and miner payments: they just 
 1. `git clone https://github.com/ZcashFoundation/s-nomp`
 2. `cd s-nomp`
 3. Use the Zebra fixes: `git checkout zebra-mining`
-4. Use node 8.11.0:
+4. Use node 10:
 
     ```sh
-    nodenv install 8.11.0
-    nodenv local 8.11.0
+    nodenv install 10
+    nodenv local 10
     ```
 
     or
 
     ```sh
-    nvm install 8.11.0
-    nvm use 8.11.0
+    nvm install 10
+    nvm use 10
     ```
 
 5. Update dependencies and install:


### PR DESCRIPTION
## Motivation

The https://zebra.zfnd.org/user/mining-testnet-s-nomp.html tutorial is failing in the Debian/Ubuntu installation details.

It needs node 10 to work now, arch instructions were already updated (thanks @upbqdn for pointing that out to me).

The rest seems to be fine.