### PR TITLE
cleanup(clippy): Remove unnecessary `try_into()` with `cargo clippy --fix`

### DIFF
--- a/zebra-chain/src/orchard/keys.rs
+++ b/zebra-chain/src/orchard/keys.rs
@@ -87,17 +87,12 @@ impl PartialEq<[u8; 11]> for Diversifier {
     }
 }
 
-impl TryFrom<Diversifier> for pallas::Affine {
-    type Error = &'static str;
-
+impl From<Diversifier> for pallas::Affine {
     /// Get a diversified base point from a diversifier value in affine
     /// representation.
-    fn try_from(d: Diversifier) -> Result<Self, Self::Error> {
-        if let Ok(projective_point) = pallas::Point::try_from(d) {
-            Ok(projective_point.into())
-        } else {
-            Err("Invalid Diversifier -> pallas::Affine")
-        }
+    fn from(d: Diversifier) -> Self {
+        let projective_point = pallas::Point::from(d);
+        projective_point.into()
     }
 }
 

--- a/zebra-chain/src/sapling/arbitrary.rs
+++ b/zebra-chain/src/sapling/arbitrary.rs
@@ -85,7 +85,7 @@ impl Arbitrary for Output {
                 cv: ExtendedPoint::generator().try_into().unwrap(),
                 cm_u: NoteCommitment(AffinePoint::identity()).extract_u(),
                 ephemeral_key: keys::EphemeralPublicKey(
-                    ExtendedPoint::generator().try_into().unwrap(),
+                    ExtendedPoint::generator().into(),
                 ),
                 enc_ciphertext,
                 out_ciphertext,

--- a/zebra-chain/src/sapling/arbitrary.rs
+++ b/zebra-chain/src/sapling/arbitrary.rs
@@ -84,9 +84,7 @@ impl Arbitrary for Output {
             .prop_map(|(enc_ciphertext, out_ciphertext, zkproof)| Self {
                 cv: ExtendedPoint::generator().try_into().unwrap(),
                 cm_u: NoteCommitment(AffinePoint::identity()).extract_u(),
-                ephemeral_key: keys::EphemeralPublicKey(
-                    ExtendedPoint::generator().into(),
-                ),
+                ephemeral_key: keys::EphemeralPublicKey(ExtendedPoint::generator().into()),
                 enc_ciphertext,
                 out_ciphertext,
                 zkproof,

--- a/zebra-consensus/src/block/subsidy/general.rs
+++ b/zebra-consensus/src/block/subsidy/general.rs
@@ -44,8 +44,8 @@ pub fn halving_divisor(height: Height, network: Network) -> Option<u64> {
         Some(halving_div)
     } else {
         let pre_blossom_height = blossom_height - SLOW_START_SHIFT;
-        let scaled_pre_blossom_height = pre_blossom_height
-            * HeightDiff::try_from(BLOSSOM_POW_TARGET_SPACING_RATIO).expect("constant is positive");
+        let scaled_pre_blossom_height =
+            pre_blossom_height * HeightDiff::from(BLOSSOM_POW_TARGET_SPACING_RATIO);
 
         let post_blossom_height = height - blossom_height;
 

--- a/zebra-consensus/src/primitives/halo2/tests.rs
+++ b/zebra-consensus/src/primitives/halo2/tests.rs
@@ -75,7 +75,7 @@ fn generate_test_vectors() {
                         let action = zebra_chain::orchard::Action {
                             cv: a.cv_net().to_bytes().try_into().unwrap(),
                             nullifier: a.nullifier().to_bytes().try_into().unwrap(),
-                            rk: <[u8; 32]>::from(a.rk()).try_into().unwrap(),
+                            rk: <[u8; 32]>::from(a.rk()).into(),
                             cm_x: pallas::Base::from_repr(a.cmx().into()).unwrap(),
                             ephemeral_key: a.encrypted_note().epk_bytes.try_into().unwrap(),
                             enc_ciphertext: a.encrypted_note().enc_ciphertext.into(),
@@ -90,8 +90,7 @@ fn generate_test_vectors() {
                     .try_into()
                     .unwrap(),
                 binding_sig: <[u8; 64]>::from(bundle.authorization().binding_signature())
-                    .try_into()
-                    .unwrap(),
+                    .into(),
             }
         })
         .collect();

--- a/zebra-consensus/src/primitives/halo2/tests.rs
+++ b/zebra-consensus/src/primitives/halo2/tests.rs
@@ -89,8 +89,7 @@ fn generate_test_vectors() {
                     .collect::<Vec<_>>()
                     .try_into()
                     .unwrap(),
-                binding_sig: <[u8; 64]>::from(bundle.authorization().binding_signature())
-                    .into(),
+                binding_sig: <[u8; 64]>::from(bundle.authorization().binding_signature()).into(),
             }
         })
         .collect();

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -525,8 +525,7 @@ mod tests {
             INVENTORY_ROTATION_INTERVAL
                 < Duration::from_secs(
                     POST_BLOSSOM_POW_TARGET_SPACING
-                        .try_into()
-                        .expect("non-negative"),
+                        .into(),
                 ),
             "we should expire inventory every time 1-2 new blocks get generated"
         );

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -523,7 +523,7 @@ mod tests {
 
         assert!(
             INVENTORY_ROTATION_INTERVAL
-                < Duration::from_secs(POST_BLOSSOM_POW_TARGET_SPACING.into(),),
+                < Duration::from_secs(POST_BLOSSOM_POW_TARGET_SPACING.into()),
             "we should expire inventory every time 1-2 new blocks get generated"
         );
     }

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -523,10 +523,7 @@ mod tests {
 
         assert!(
             INVENTORY_ROTATION_INTERVAL
-                < Duration::from_secs(
-                    POST_BLOSSOM_POW_TARGET_SPACING
-                        .into(),
-                ),
+                < Duration::from_secs(POST_BLOSSOM_POW_TARGET_SPACING.into(),),
             "we should expire inventory every time 1-2 new blocks get generated"
         );
     }

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -221,7 +221,7 @@ impl CachedFfiTransaction {
         };
 
         if err == zcash_script_error_t_zcash_script_ERR_OK {
-            let ret = ret.try_into().expect("c_uint fits in a u64");
+            let ret = ret.into();
             Ok(ret)
         } else {
             Err(Error::from(err))

--- a/zebra-state/src/service/check/utxo.rs
+++ b/zebra-state/src/service/check/utxo.rs
@@ -196,8 +196,7 @@ pub fn transparent_coinbase_spend(
 
     match spend_restriction {
         OnlyShieldedOutputs { spend_height } => {
-            let min_spend_height =
-                utxo.height + MIN_TRANSPARENT_COINBASE_MATURITY.into();
+            let min_spend_height = utxo.height + MIN_TRANSPARENT_COINBASE_MATURITY.into();
             let min_spend_height =
                 min_spend_height.expect("valid UTXOs have coinbase heights far below Height::MAX");
             if spend_height >= min_spend_height {

--- a/zebra-state/src/service/check/utxo.rs
+++ b/zebra-state/src/service/check/utxo.rs
@@ -197,7 +197,7 @@ pub fn transparent_coinbase_spend(
     match spend_restriction {
         OnlyShieldedOutputs { spend_height } => {
             let min_spend_height =
-                utxo.height + MIN_TRANSPARENT_COINBASE_MATURITY.try_into().unwrap();
+                utxo.height + MIN_TRANSPARENT_COINBASE_MATURITY.into();
             let min_spend_height =
                 min_spend_height.expect("valid UTXOs have coinbase heights far below Height::MAX");
             if spend_height >= min_spend_height {

--- a/zebra-state/src/service/finalized_state/disk_format/block.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/block.rs
@@ -92,8 +92,7 @@ impl TransactionIndex {
     /// Returns this index as a `usize`
     pub fn as_usize(&self) -> usize {
         self.0
-            .try_into()
-            .expect("the maximum valid index fits in usize")
+            .into()
     }
 
     /// Creates a transaction index from a `u64`.
@@ -109,8 +108,7 @@ impl TransactionIndex {
     #[allow(dead_code)]
     pub fn as_u64(&self) -> u64 {
         self.0
-            .try_into()
-            .expect("the maximum valid index fits in u64")
+            .into()
     }
 }
 

--- a/zebra-state/src/service/finalized_state/disk_format/block.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/block.rs
@@ -91,8 +91,7 @@ impl TransactionIndex {
 
     /// Returns this index as a `usize`
     pub fn as_usize(&self) -> usize {
-        self.0
-            .into()
+        self.0.into()
     }
 
     /// Creates a transaction index from a `u64`.
@@ -107,8 +106,7 @@ impl TransactionIndex {
     /// Returns this index as a `u64`
     #[allow(dead_code)]
     pub fn as_u64(&self) -> u64 {
-        self.0
-            .into()
+        self.0.into()
     }
 }
 

--- a/zebra-utils/src/bin/zebra-checkpoints/main.rs
+++ b/zebra-utils/src/bin/zebra-checkpoints/main.rs
@@ -164,8 +164,7 @@ async fn main() -> Result<()> {
 
     // Checkpoints must be on the main chain, so we skip blocks that are within the
     // Zcash reorg limit.
-    let height_limit = height_limit
-        - HeightDiff::try_from(MIN_TRANSPARENT_COINBASE_MATURITY).expect("constant fits in i32");
+    let height_limit = height_limit - HeightDiff::from(MIN_TRANSPARENT_COINBASE_MATURITY);
     let height_limit = height_limit
         .ok_or_else(|| {
             eyre!(

--- a/zebrad/src/components/mempool/crawler/tests/timing.rs
+++ b/zebrad/src/components/mempool/crawler/tests/timing.rs
@@ -12,8 +12,7 @@ fn ensure_timing_consistent() {
     assert!(
         RATE_LIMIT_DELAY.as_secs()
             < POST_BLOSSOM_POW_TARGET_SPACING
-                .try_into()
-                .expect("not negative"),
+                .into(),
         "a mempool crawl should complete before most new blocks"
     );
 

--- a/zebrad/src/components/mempool/crawler/tests/timing.rs
+++ b/zebrad/src/components/mempool/crawler/tests/timing.rs
@@ -1,6 +1,6 @@
 //! Timing tests for the mempool crawler.
 
-use std::convert::TryInto;
+
 
 use zebra_chain::parameters::POST_BLOSSOM_POW_TARGET_SPACING;
 use zebra_network::constants::{DEFAULT_CRAWL_NEW_PEER_INTERVAL, HANDSHAKE_TIMEOUT};

--- a/zebrad/src/components/mempool/crawler/tests/timing.rs
+++ b/zebrad/src/components/mempool/crawler/tests/timing.rs
@@ -1,7 +1,5 @@
 //! Timing tests for the mempool crawler.
 
-
-
 use zebra_chain::parameters::POST_BLOSSOM_POW_TARGET_SPACING;
 use zebra_network::constants::{DEFAULT_CRAWL_NEW_PEER_INTERVAL, HANDSHAKE_TIMEOUT};
 
@@ -10,9 +8,7 @@ use crate::components::mempool::crawler::RATE_LIMIT_DELAY;
 #[test]
 fn ensure_timing_consistent() {
     assert!(
-        RATE_LIMIT_DELAY.as_secs()
-            < POST_BLOSSOM_POW_TARGET_SPACING
-                .into(),
+        RATE_LIMIT_DELAY.as_secs() < POST_BLOSSOM_POW_TARGET_SPACING.into(),
         "a mempool crawl should complete before most new blocks"
     );
 

--- a/zebrad/src/components/sync/tests/timing.rs
+++ b/zebrad/src/components/sync/tests/timing.rs
@@ -1,10 +1,8 @@
 //! Check the relationship between various sync timeouts and delays.
 
-use std::{
-    sync::{
-        atomic::{AtomicU8, Ordering},
-        Arc,
-    },
+use std::sync::{
+    atomic::{AtomicU8, Ordering},
+    Arc,
 };
 
 use futures::future;
@@ -78,9 +76,7 @@ fn ensure_timeouts_consistent() {
     );
 
     assert!(
-        SYNC_RESTART_DELAY.as_secs()
-            < POST_BLOSSOM_POW_TARGET_SPACING
-                .into(),
+        SYNC_RESTART_DELAY.as_secs() < POST_BLOSSOM_POW_TARGET_SPACING.into(),
         "a syncer tip crawl should complete before most new blocks"
     );
 

--- a/zebrad/src/components/sync/tests/timing.rs
+++ b/zebrad/src/components/sync/tests/timing.rs
@@ -1,7 +1,6 @@
 //! Check the relationship between various sync timeouts and delays.
 
 use std::{
-    convert::TryInto,
     sync::{
         atomic::{AtomicU8, Ordering},
         Arc,

--- a/zebrad/src/components/sync/tests/timing.rs
+++ b/zebrad/src/components/sync/tests/timing.rs
@@ -81,8 +81,7 @@ fn ensure_timeouts_consistent() {
     assert!(
         SYNC_RESTART_DELAY.as_secs()
             < POST_BLOSSOM_POW_TARGET_SPACING
-                .try_into()
-                .expect("not negative"),
+                .into(),
         "a syncer tip crawl should complete before most new blocks"
     );
 

--- a/zebrad/tests/common/checkpoints.rs
+++ b/zebrad/tests/common/checkpoints.rs
@@ -396,8 +396,7 @@ pub fn wait_for_zebra_checkpoints_generation<
     test_type: TestType,
     show_zebrad_logs: bool,
 ) -> Result<(TestChild<TempDir>, TestChild<P>)> {
-    let last_checkpoint_gap = HeightDiff::try_from(MIN_TRANSPARENT_COINBASE_MATURITY)
-        .expect("constant fits in HeightDiff")
+    let last_checkpoint_gap = HeightDiff::from(MIN_TRANSPARENT_COINBASE_MATURITY)
         + HeightDiff::try_from(MAX_CHECKPOINT_HEIGHT_GAP).expect("constant fits in HeightDiff");
     let expected_final_checkpoint_height =
         (zebra_tip_height - last_checkpoint_gap).expect("network tip is high enough");


### PR DESCRIPTION
## Motivation

This is a routine cleanup of nightly clippy warnings.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - ~~Will the PR name make sense to users?~~
  - [x] Does the PR have a priority label?
  - ~~Have you added or updated tests?~~
  - ~~Is the documentation up to date?~~

Not a significant or user change, no test or doc changes needed.

_If a checkbox isn't relevant to the PR, mark it as done._

### Complex Code or Requirements

Is the code change in Orchard correct? Is every diversifier value a valid point?

## Solution

Remove unnecessary `try_from()` using Clippy.

### Testing

This already has test coverage.

## Review

This is a low priority cleanup.


### Reviewer Checklist

Check before approving the PR:
  - [x] Does the PR scope match the ticket?
  - [x] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [x] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

