### PR TITLE
feat(scanner): Add a very basic RAM database to store keys and scan results

### DIFF
--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -19,6 +19,7 @@ categories = ["cryptography::cryptocurrencies"]
 # Production features that activate extra dependencies, or extra features in dependencies
 
 [dependencies]
+zebra-chain = { path = "../zebra-chain" }
 
 [dev-dependencies]
 
@@ -35,5 +36,4 @@ group = "0.13.0"
 tokio = { version = "1.33.0", features = ["test-util"] }
 
 zebra-state = { path = "../zebra-state" }
-zebra-chain = { path = "../zebra-chain" }
 zebra-test = { path = "../zebra-test" }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["cryptography::cryptocurrencies"]
 # Production features that activate extra dependencies, or extra features in dependencies
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.31" }
 
 [dev-dependencies]
 

--- a/zebra-scan/src/lib.rs
+++ b/zebra-scan/src/lib.rs
@@ -4,5 +4,7 @@
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
 #![doc(html_root_url = "https://docs.rs/zebra_scan")]
 
+mod storage;
+
 #[cfg(test)]
 mod tests;

--- a/zebra-scan/src/storage.rs
+++ b/zebra-scan/src/storage.rs
@@ -4,14 +4,18 @@ use std::collections::HashMap;
 
 use zebra_chain::{block::Height, transaction::Hash};
 
+/// The type used in Zebra to store Sapling scanning keys.
+/// It can represent a full viewing key or an individual viewing key.
+pub type SaplingScanningKey = String;
+
 /// Store key info and results of the scan.
 #[allow(dead_code)]
 pub struct Storage {
     /// The key and an optional birthday for it.
-    keys: HashMap<String, Option<Height>>,
+    keys: HashMap<SaplingScanningKey, Option<Height>>,
 
     /// The key and the related transaction id.
-    results: HashMap<String, Vec<Hash>>,
+    results: HashMap<SaplingScanningKey, Vec<Hash>>,
 }
 
 #[allow(dead_code)]
@@ -25,12 +29,12 @@ impl Storage {
     }
 
     /// Add a key to the storage.
-    pub fn add_key(&mut self, key: String, birthday: Option<Height>) {
+    pub fn add_key(&mut self, key: SaplingScanningKey, birthday: Option<Height>) {
         self.keys.insert(key, birthday);
     }
 
     /// Add a result to the storage.
-    pub fn add_result(&mut self, key: String, txid: Hash) {
+    pub fn add_result(&mut self, key: SaplingScanningKey, txid: Hash) {
         if let Some(results) = self.results.get_mut(&key) {
             results.push(txid);
         } else {
@@ -44,7 +48,7 @@ impl Storage {
     }
 
     /// Get all keys.
-    pub fn get_keys(&self) -> Vec<String> {
+    pub fn get_keys(&self) -> Vec<SaplingScanningKey> {
         self.keys.keys().cloned().collect()
     }
 }

--- a/zebra-scan/src/storage.rs
+++ b/zebra-scan/src/storage.rs
@@ -1,0 +1,50 @@
+//! Store viewing keys and results of the scan.
+
+use std::collections::HashMap;
+
+use zebra_chain::{block::Height, transaction::Hash};
+
+/// Store key info and results of the scan.
+#[allow(dead_code)]
+pub struct Storage {
+    /// The key and an optional birthday for it.
+    keys: HashMap<String, Option<Height>>,
+
+    /// The key and the related transaction id.
+    results: HashMap<String, Vec<Hash>>,
+}
+
+#[allow(dead_code)]
+impl Storage {
+    /// Create a new storage.
+    pub fn new() -> Self {
+        Self {
+            keys: HashMap::new(),
+            results: HashMap::new(),
+        }
+    }
+
+    /// Add a key to the storage.
+    pub fn add_key(&mut self, key: String, birthday: Option<Height>) {
+        self.keys.insert(key, birthday);
+    }
+
+    /// Add a result to the storage.
+    pub fn add_result(&mut self, key: String, txid: Hash) {
+        if let Some(results) = self.results.get_mut(&key) {
+            results.push(txid);
+        } else {
+            self.results.insert(key, vec![txid]);
+        }
+    }
+
+    /// Get the results of a key.
+    pub fn get_results(&self, key: &str) -> Option<&Vec<Hash>> {
+        self.results.get(key)
+    }
+
+    /// Get all keys.
+    pub fn get_keys(&self) -> Vec<String> {
+        self.keys.keys().cloned().collect()
+    }
+}

--- a/zebra-scan/src/storage.rs
+++ b/zebra-scan/src/storage.rs
@@ -43,12 +43,12 @@ impl Storage {
     }
 
     /// Get the results of a sapling key.
-    pub fn get_sapling_results(&self, key: &str) -> Option<&Vec<Hash>> {
-        self.sapling_results.get(key)
+    pub fn get_sapling_results(&self, key: &str) -> Vec<Hash> {
+        self.sapling_results.get(key).cloned().unwrap_or_default()
     }
 
-    /// Get all sapling keys.
-    pub fn get_sapling_keys(&self) -> Vec<SaplingScanningKey> {
-        self.sapling_keys.keys().cloned().collect()
+    /// Get all keys and their birthdays.
+    pub fn get_sapling_keys(&self) -> HashMap<String, Option<Height>> {
+        self.sapling_keys.clone()
     }
 }

--- a/zebra-scan/src/storage.rs
+++ b/zebra-scan/src/storage.rs
@@ -11,11 +11,11 @@ pub type SaplingScanningKey = String;
 /// Store key info and results of the scan.
 #[allow(dead_code)]
 pub struct Storage {
-    /// The key and an optional birthday for it.
-    keys: HashMap<SaplingScanningKey, Option<Height>>,
+    /// The sapling key and an optional birthday for it.
+    sapling_keys: HashMap<SaplingScanningKey, Option<Height>>,
 
-    /// The key and the related transaction id.
-    results: HashMap<SaplingScanningKey, Vec<Hash>>,
+    /// The sapling key and the related transaction id.
+    sapling_results: HashMap<SaplingScanningKey, Vec<Hash>>,
 }
 
 #[allow(dead_code)]
@@ -23,32 +23,32 @@ impl Storage {
     /// Create a new storage.
     pub fn new() -> Self {
         Self {
-            keys: HashMap::new(),
-            results: HashMap::new(),
+            sapling_keys: HashMap::new(),
+            sapling_results: HashMap::new(),
         }
     }
 
-    /// Add a key to the storage.
-    pub fn add_key(&mut self, key: SaplingScanningKey, birthday: Option<Height>) {
-        self.keys.insert(key, birthday);
+    /// Add a sapling key to the storage.
+    pub fn add_sapling_key(&mut self, key: SaplingScanningKey, birthday: Option<Height>) {
+        self.sapling_keys.insert(key, birthday);
     }
 
-    /// Add a result to the storage.
-    pub fn add_result(&mut self, key: SaplingScanningKey, txid: Hash) {
-        if let Some(results) = self.results.get_mut(&key) {
+    /// Add a sapling result to the storage.
+    pub fn add_sapling_result(&mut self, key: SaplingScanningKey, txid: Hash) {
+        if let Some(results) = self.sapling_results.get_mut(&key) {
             results.push(txid);
         } else {
-            self.results.insert(key, vec![txid]);
+            self.sapling_results.insert(key, vec![txid]);
         }
     }
 
-    /// Get the results of a key.
-    pub fn get_results(&self, key: &str) -> Option<&Vec<Hash>> {
-        self.results.get(key)
+    /// Get the results of a sapling key.
+    pub fn get_sapling_results(&self, key: &str) -> Option<&Vec<Hash>> {
+        self.sapling_results.get(key)
     }
 
-    /// Get all keys.
-    pub fn get_keys(&self) -> Vec<SaplingScanningKey> {
-        self.keys.keys().cloned().collect()
+    /// Get all sapling keys.
+    pub fn get_sapling_keys(&self) -> Vec<SaplingScanningKey> {
+        self.sapling_keys.keys().cloned().collect()
     }
 }

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -301,11 +301,11 @@ async fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
     let mut s = crate::storage::Storage::new();
 
     // Insert the generated key to the database
-    s.add_key(key_to_be_stored.clone(), None);
+    s.add_sapling_key(key_to_be_stored.clone(), None);
 
     // Check key was added
-    assert_eq!(s.get_keys().len(), 1);
-    assert_eq!(s.get_keys()[0], key_to_be_stored.clone());
+    assert_eq!(s.get_sapling_keys().len(), 1);
+    assert_eq!(s.get_sapling_keys()[0], key_to_be_stored.clone());
 
     let vks: Vec<(&AccountId, &SaplingIvk)> = vec![];
     let nf = Nullifier([7; 32]);
@@ -336,11 +336,11 @@ async fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
     let found_transaction_hash = Hash::from_bytes_in_display_order(found_transaction);
 
     // Add result to database
-    s.add_result(key_to_be_stored.clone(), found_transaction_hash);
+    s.add_sapling_result(key_to_be_stored.clone(), found_transaction_hash);
 
     // Check the result was added
     assert_eq!(
-        s.get_results(key_to_be_stored.as_str()).unwrap()[0],
+        s.get_sapling_results(key_to_be_stored.as_str()).unwrap()[0],
         found_transaction_hash
     );
 

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -305,7 +305,7 @@ async fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
 
     // Check key was added
     assert_eq!(s.get_sapling_keys().len(), 1);
-    assert_eq!(s.get_sapling_keys()[0], key_to_be_stored.clone());
+    assert_eq!(s.get_sapling_keys().get(&key_to_be_stored), Some(&None));
 
     let vks: Vec<(&AccountId, &SaplingIvk)> = vec![];
     let nf = Nullifier([7; 32]);
@@ -340,7 +340,7 @@ async fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
 
     // Check the result was added
     assert_eq!(
-        s.get_sapling_results(key_to_be_stored.as_str()).unwrap()[0],
+        s.get_sapling_results(key_to_be_stored.as_str())[0],
         found_transaction_hash
     );
 


### PR DESCRIPTION
## Motivation

We want to have a database with viewing keys and scanning results. The scanner task can get the keys to scan from this database and insert results of found transactions.

This is the most basic version i was able to do with a simple test. 

Should close https://github.com/ZcashFoundation/zebra/issues/7904, unblock https://github.com/ZcashFoundation/zebra/issues/7941 and partially unblock https://github.com/ZcashFoundation/zebra/issues/7928

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [ ] Will the PR name make sense to users?
  - [ ] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [ ] Is the documentation up to date?

## Solution

Add a basic storage for the blockchain scanner project.


### Testing

A new test that uses the new database was added.


## Review

I am open to suggestions if we keep the PR simple, i prefer to open new tickets for more complex tasks.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
