### PR TITLE
security: Limit how many addresses we use from each peer address message

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -84,6 +84,10 @@ pub const DEFAULT_MAX_CONNS_PER_IP: usize = 1;
 /// This will be used as `Config.peerset_initial_target_size` if no valid value is provided.
 pub const DEFAULT_PEERSET_INITIAL_TARGET_SIZE: usize = 25;
 
+/// The maximum number of peers we will add to the address book after each `getaddr` request.
+pub const PEER_ADDR_RESPONSE_LIMIT: usize =
+    DEFAULT_PEERSET_INITIAL_TARGET_SIZE * OUTBOUND_PEER_LIMIT_MULTIPLIER / 2;
+
 /// The buffer size for the peer set.
 ///
 /// This should be greater than 1 to avoid sender contention, but also reasonably

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -413,7 +413,7 @@ impl Handler {
         ignored_msg
     }
 
-    /// Adds `new_addrs` to the `cached_addrs` cache, then takes and returns a limited number of
+    /// Adds `new_addrs` to the `cached_addrs` cache, then takes and returns `response_size`
     /// addresses from that cache.
     ///
     /// `cached_addrs` can be empty if the cache is empty. `new_addrs` can be empty or `None` if
@@ -453,7 +453,8 @@ impl Handler {
         // It's ok to just partially shuffle the cache, because it doesn't actually matter which
         // peers we drop. Having excess peers is rare, because most peers only send one large
         // unsolicited peer message when they first connect.
-        *cached_addrs = remaining[0..MAX_ADDRS_IN_MESSAGE].to_vec();
+        *cached_addrs = remaining.to_vec();
+        cached_addrs.truncate(MAX_ADDRS_IN_MESSAGE);
 
         response.to_vec()
     }

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -251,6 +251,7 @@ impl Handler {
                     )))
                 }
             }
+
             // `zcashd` returns requested blocks in a single batch of messages.
             // Other blocks or non-blocks messages can come before or after the batch.
             // `zcashd` silently skips missing blocks, rather than sending a final `notfound` message.
@@ -365,6 +366,10 @@ impl Handler {
                     block_hashes(&items[..]).collect(),
                 )))
             }
+            (Handler::FindHeaders, Message::Headers(headers)) => {
+                Handler::Finished(Ok(Response::BlockHeaders(headers)))
+            }
+
             (Handler::MempoolTransactionIds, Message::Inv(items))
                 if items.iter().all(|item| item.unmined_tx_id().is_some()) =>
             {
@@ -372,9 +377,7 @@ impl Handler {
                     transaction_ids(&items).collect(),
                 )))
             }
-            (Handler::FindHeaders, Message::Headers(headers)) => {
-                Handler::Finished(Ok(Response::BlockHeaders(headers)))
-            }
+
             // By default, messages are not responses.
             (state, msg) => {
                 trace!(?msg, "did not interpret message as response");

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -975,16 +975,16 @@ where
             // respond to our getaddr requests.
             (AwaitingRequest, Peers) if !self.cached_addrs.is_empty() => {
                 let mut response_addrs = std::mem::take(&mut self.cached_addrs);
-                let remaining_addrs = response_addrs.split_off(PEER_ADDR_RESPONSE_LIMIT);
+                if response_addrs.len() > PEER_ADDR_RESPONSE_LIMIT {
+                    self.cached_addrs = response_addrs.split_off(PEER_ADDR_RESPONSE_LIMIT);
+                }
 
                 debug!(
                     response_addrs = response_addrs.len(),
-                    remaining_addrs = remaining_addrs.len(),
+                    remaining_addrs = self.cached_addrs.len(),
                     PEER_ADDR_RESPONSE_LIMIT,
                     "responding to Peers request using some cached addresses",
                 );
-
-                self.cached_addrs = remaining_addrs;
 
                 Ok(Handler::Finished(Ok(Response::Peers(response_addrs))))
             }

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -161,6 +161,8 @@ impl Handler {
             }
 
             (Handler::Peers, Message::Addr(new_addrs)) => {
+                // Security: This method performs security-sensitive operations, see its comments
+                // for details.
                 let response_addrs =
                     Handler::update_addr_cache(cached_addrs, &new_addrs, PEER_ADDR_RESPONSE_LIMIT);
 
@@ -1001,15 +1003,9 @@ where
 
             // Take some cached addresses from the peer connection. This address cache helps
             // work-around a `zcashd` addr response rate-limit.
-            //
-            // # Security
-            //
-            // We limit how many peer addresses we take from each peer, so that our address book
-            // and outbound connections aren't controlled by a single peer (#1869).
-            //
-            // Remaining peers are left in the cache, so that we can use them if the peer doesn't
-            // respond to our getaddr requests.
             (AwaitingRequest, Peers) if !self.cached_addrs.is_empty() => {
+                // Security: This method performs security-sensitive operations, see its comments
+                // for details.
                 let response_addrs = Handler::update_addr_cache(&mut self.cached_addrs, None, PEER_ADDR_RESPONSE_LIMIT);
 
                 debug!(

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -77,8 +77,8 @@ mod tests;
 /// ││        ▼                                                      ││
 /// ││        Λ                                                      ││
 /// ││       ╱ ╲              filter by                              ││
-/// ││      ▕   ▏        is_ready_for_connection_attempt             ││
-/// ││       ╲ ╱    to remove recent `Responded`,                    ││
+/// ││      ▕   ▏   is_ready_for_connection_attempt                  ││
+/// ││       ╲ ╱     to remove recent `Responded`,                   ││
 /// ││        V  `AttemptPending`, and `Failed` peers                ││
 /// ││        │                                                      ││
 /// ││        │    try outbound connection,                          ││
@@ -105,7 +105,8 @@ mod tests;
 /// │         │
 /// │         ▼
 /// │┌───────────────────────────────────────┐
-/// ││ every time we receive a peer message: │
+/// ││ when connection succeeds, and every   │
+/// ││  time we receive a peer heartbeat:    │
 /// └│  * update state to `Responded`        │
 ///  │  * update last_response to now()      │
 ///  └───────────────────────────────────────┘
@@ -120,11 +121,6 @@ mod tests;
 // TODO:
 //   * show all possible transitions between Attempt/Responded/Failed,
 //     except Failed -> Responded is invalid, must go through Attempt
-//   * for now, seed peers go straight to handshaking and responded,
-//     but we'll fix that once we add the Seed state
-// When we add the Seed state:
-//   * show that seed peers that transition to other never attempted
-//     states are already in the address book
 pub(crate) struct CandidateSet<S>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Send,
@@ -447,10 +443,8 @@ fn validate_addrs(
     // TODO:
     // We should eventually implement these checks in this function:
     // - Zebra should ignore peers that are older than 3 weeks (part of #1865)
-    //   - Zebra should count back 3 weeks from the newest peer timestamp sent
-    //     by the other peer, to compensate for clock skew
-    // - Zebra should limit the number of addresses it uses from a single Addrs
-    //   response (#1869)
+    // - Zebra should count back 3 weeks from the newest peer timestamp sent
+    //   by the other peer, to compensate for clock skew
 
     let mut addrs: Vec<_> = addrs.into_iter().collect();
 


### PR DESCRIPTION
## Motivation

We want to limit how many addresses we use from each peer, so that our outbound connections are based on peers shared by most of our peers.

Close #1869

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

We might want to have an overall changelog entry for the tracking issue, but it doesn't need to be added here.

### Complex Code or Requirements

We need to limit in two places: existing cached peers, and responses based on a request. These limits operate slightly differently, because only a new response can cause an overflow.

## Solution

- When we have cached peers, only take some of them to answer a request
- When we send a peer request, only take some of the response to answer a request, and put the rest in the cache
- In response to unsolicited address messages, add the latest addresses to the cache, and discard the oldest ones
- Choose response addresses at random
- Update outdated docs referring to this ticket

### Testing

Add a new proptest for the cache update method.

The remaining parts of the PR are simple and can be checked by manual review, or by existing tests (including integration tests).

## Review

This is a routine fix.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

