### PR TITLE
security: Rate limit GetAddr responses

### DIFF
--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -281,7 +281,7 @@ impl AddressBook {
 
     /// Get the active addresses in `self` in random order with sanitized timestamps,
     /// including our local listener address.
-    pub fn sanitized(&self, now: chrono::DateTime<Utc>) -> Vec<MetaAddr> {
+    pub(crate) fn sanitized(&self, now: chrono::DateTime<Utc>) -> Vec<MetaAddr> {
         use rand::seq::SliceRandom;
         let _guard = self.span.enter();
 

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -270,7 +270,7 @@ impl AddressBook {
     /// including our local listener address.
     ///
     /// Limited to a the number of peer addresses Zebra should give out per `GetAddr` request.
-    pub fn sanitized_window(&self) -> Vec<MetaAddr> {
+    pub fn fresh_get_addr_response(&self) -> Vec<MetaAddr> {
         let now = Utc::now();
         let mut peers = self.sanitized(now);
         let address_limit = peers.len().div_ceil(ADDR_RESPONSE_LIMIT_DENOMINATOR);

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -268,12 +268,13 @@ impl AddressBook {
 
     /// Get the active addresses in `self` in random order with sanitized timestamps,
     /// including our local listener address.
+    ///
+    /// Limited to a the number of peer addresses Zebra should give out per `GetAddr` request.
     pub fn sanitized_window(&self) -> Vec<MetaAddr> {
         let now = Utc::now();
         let mut peers = self.sanitized(now);
         let address_limit = peers.len().div_ceil(ADDR_RESPONSE_LIMIT_DENOMINATOR);
-        let address_limit = MAX_ADDRS_IN_MESSAGE.min(address_limit);
-        peers.truncate(address_limit);
+        peers.truncate(MAX_ADDRS_IN_MESSAGE.min(address_limit));
 
         peers
     }

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -515,7 +515,7 @@ mod tests {
         );
 
         assert!(
-            MAX_ADDRS_IN_ADDRESS_BOOK < TYPICAL_MAINNET_ADDRESS_BOOK_SIZE,
+            MAX_ADDRS_IN_ADDRESS_BOOK < TYPICAL_MAINNET_ADDRESS_BOOK_SIZE * 2,
             "the address book limit should actually be used"
         );
     }

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -309,7 +309,7 @@ pub const MAX_ADDRS_IN_MESSAGE: usize = 1000;
 ///
 /// This limit makes sure that Zebra does not reveal its entire address book
 /// in a single `Peers` response.
-pub const ADDR_RESPONSE_LIMIT_DENOMINATOR: usize = 3;
+pub const ADDR_RESPONSE_LIMIT_DENOMINATOR: usize = 4;
 
 /// The maximum number of addresses Zebra will keep in its address book.
 ///

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -501,6 +501,10 @@ mod tests {
     fn ensure_address_limits_consistent() {
         // Zebra 1.0.0-beta.2 address book metrics in December 2021.
         const TYPICAL_MAINNET_ADDRESS_BOOK_SIZE: usize = 4_500;
+        // Minimum address book size that allows Zebra to fill the max_addrs_in_message
+        // without giving out more than `1 / ADDR_RESPONSE_LIMIT_DENOMINATOR` of its peers
+        const MINIMUM_MAINNET_ADDRESS_BOOK_SIZE: usize =
+            MAX_ADDRS_IN_MESSAGE * (ADDR_RESPONSE_LIMIT_DENOMINATOR + 1);
 
         let _init_guard = zebra_test::init();
 
@@ -515,7 +519,8 @@ mod tests {
         );
 
         assert!(
-            MAX_ADDRS_IN_ADDRESS_BOOK < TYPICAL_MAINNET_ADDRESS_BOOK_SIZE * 2,
+            MAX_ADDRS_IN_ADDRESS_BOOK
+                <= TYPICAL_MAINNET_ADDRESS_BOOK_SIZE.max(MINIMUM_MAINNET_ADDRESS_BOOK_SIZE),
             "the address book limit should actually be used"
         );
     }

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -499,12 +499,9 @@ mod tests {
     #[test]
     #[allow(clippy::assertions_on_constants)]
     fn ensure_address_limits_consistent() {
-        // Zebra 1.0.0-beta.2 address book metrics in December 2021.
-        const TYPICAL_MAINNET_ADDRESS_BOOK_SIZE: usize = 4_500;
-        // Minimum address book size that allows Zebra to fill the max_addrs_in_message
-        // without giving out more than `1 / ADDR_RESPONSE_LIMIT_DENOMINATOR` of its peers
-        const MINIMUM_MAINNET_ADDRESS_BOOK_SIZE: usize =
-            MAX_ADDRS_IN_MESSAGE * (ADDR_RESPONSE_LIMIT_DENOMINATOR + 1);
+        // Estimated network address book size in November 2023, after the address book limit was increased.
+        // Zebra 1.0.0-beta.2 address book metrics in December 2021 showed 4500 peers.
+        const TYPICAL_MAINNET_ADDRESS_BOOK_SIZE: usize = 5_500;
 
         let _init_guard = zebra_test::init();
 
@@ -519,8 +516,7 @@ mod tests {
         );
 
         assert!(
-            MAX_ADDRS_IN_ADDRESS_BOOK
-                <= TYPICAL_MAINNET_ADDRESS_BOOK_SIZE.max(MINIMUM_MAINNET_ADDRESS_BOOK_SIZE),
+            MAX_ADDRS_IN_ADDRESS_BOOK <= TYPICAL_MAINNET_ADDRESS_BOOK_SIZE,
             "the address book limit should actually be used"
         );
     }

--- a/zebra-network/src/protocol/internal/response.rs
+++ b/zebra-network/src/protocol/internal/response.rs
@@ -142,4 +142,9 @@ impl Response {
     pub fn is_inventory_download(&self) -> bool {
         matches!(self, Response::Blocks(_) | Response::Transactions(_))
     }
+
+    /// Returns true if self is the [`Response::Nil`] variant.
+    pub fn is_nil(&self) -> bool {
+        matches!(self, Self::Nil)
+    }
 }

--- a/zebra-network/src/protocol/internal/response.rs
+++ b/zebra-network/src/protocol/internal/response.rs
@@ -144,6 +144,7 @@ impl Response {
     }
 
     /// Returns true if self is the [`Response::Nil`] variant.
+    #[allow(dead_code)]
     pub fn is_nil(&self) -> bool {
         matches!(self, Self::Nil)
     }

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -145,7 +145,7 @@ impl CachedPeerAddrs {
         // try getting a lock on the address book if it's time to refresh the cached addresses
         match self.address_book.try_lock() {
             Ok(address_book) => {
-                self.cached_addrs = address_book.sanitized_window();
+                self.cached_addrs = address_book.fresh_get_addr_response();
                 self.refresh_time = now + INBOUND_CACHED_ADDRS_REFRESH_INTERVAL;
             }
 

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -73,6 +73,10 @@ pub const GETDATA_SENT_BYTES_LIMIT: usize = 1_000_000;
 /// many peers instead of just a few peers.)
 pub const GETDATA_MAX_BLOCK_COUNT: usize = 16;
 
+/// The maximum duration that a `CachedPeerAddrs` is considered fresh before the inbound service
+/// should get new peer addresses from the address book to send as a `GetAddr` response.
+const INBOUND_CACHED_ADDRS_REFRESH_INTERVAL: Duration = Duration::from_secs(10 * 60);
+
 type BlockDownloadPeerSet =
     Buffer<BoxService<zn::Request, zn::Response, zn::BoxError>, zn::Request>;
 type State = Buffer<BoxService<zs::Request, zs::Response, zs::BoxError>, zs::Request>;
@@ -106,8 +110,6 @@ pub struct InboundSetupData {
     /// Allows efficient access to the best tip of the blockchain.
     pub latest_chain_tip: zs::LatestChainTip,
 }
-
-const INBOUND_CACHED_ADDRS_REFRESH_INTERVAL: Duration = Duration::from_secs(10 * 60);
 
 /// Caches and refreshes a partial list of peer addresses to be returned as a `GetAddr` response.
 pub struct CachedPeerAddrs {

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -379,7 +379,7 @@ impl Service<zn::Request> for Inbound {
             }
             // Clean up completed download tasks, ignoring their results
             Setup::Initialized {
-                mut cached_peer_addr_response,
+                cached_peer_addr_response,
                 mut block_downloads,
                 mempool,
                 state,
@@ -390,7 +390,6 @@ impl Service<zn::Request> for Inbound {
                 // If we returned Pending here, and there were no waiting block downloads,
                 // then inbound requests would wait for the next block download, and hang forever.
                 while let Poll::Ready(Some(_)) = block_downloads.as_mut().poll_next(cx) {}
-                cached_peer_addr_response.try_refresh();
 
                 result = Ok(());
 
@@ -451,6 +450,7 @@ impl Service<zn::Request> for Inbound {
                 //
                 // If the address book is busy, try again inside the future. If it can't be locked
                 // twice, ignore the request.
+                cached_peer_addr_response.try_refresh();
                 let response = cached_peer_addr_response.value();
 
                 async move {

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -137,7 +137,7 @@ pub enum Setup {
         /// a shared list of peer addresses used to periodically refresh the partial list.
         ///
         /// Refreshed from the address book in `poll_ready` method
-        /// after [`INBOUND_CACHED_ADDRS_REFRESH_INTERVAL`](cached_peer_addr_response::INBOUND_CACHED_ADDRS_REFRESH_INTERVAL).
+        /// after [`CACHED_ADDRS_REFRESH_INTERVAL`](cached_peer_addr_response::CACHED_ADDRS_REFRESH_INTERVAL).
         cached_peer_addr_response: CachedPeerAddrResponse,
 
         /// A `futures::Stream` that downloads and verifies gossiped blocks.

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -75,10 +75,6 @@ pub const GETDATA_SENT_BYTES_LIMIT: usize = 1_000_000;
 /// many peers instead of just a few peers.)
 pub const GETDATA_MAX_BLOCK_COUNT: usize = 16;
 
-/// The maximum duration that a `CachedPeerAddrResponse` is considered fresh before the inbound service
-/// should get new peer addresses from the address book to send as a `GetAddr` response.
-const INBOUND_CACHED_ADDRS_REFRESH_INTERVAL: Duration = Duration::from_secs(10 * 60);
-
 type BlockDownloadPeerSet =
     Buffer<BoxService<zn::Request, zn::Response, zn::BoxError>, zn::Request>;
 type State = Buffer<BoxService<zs::Request, zs::Response, zs::BoxError>, zs::Request>;

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -9,9 +9,9 @@ use std::{
     collections::HashSet,
     future::Future,
     pin::Pin,
-    sync::{Arc, Mutex, TryLockError},
+    sync::Arc,
     task::{Context, Poll},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use futures::{
@@ -40,7 +40,10 @@ use super::sync::{BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT};
 
 use InventoryResponse::*;
 
+mod cached_peer_addr_response;
 pub(crate) mod downloads;
+
+use cached_peer_addr_response::CachedPeerAddrResponse;
 
 #[cfg(test)]
 mod tests;
@@ -108,74 +111,6 @@ pub struct InboundSetupData {
 
     /// Allows efficient access to the best tip of the blockchain.
     pub latest_chain_tip: zs::LatestChainTip,
-}
-
-/// Caches and refreshes a partial list of peer addresses to be returned as a `GetAddr` response.
-pub struct CachedPeerAddrResponse {
-    /// A shared list of peer addresses.
-    address_book: Arc<Mutex<zn::AddressBook>>,
-
-    /// An owned list of peer addresses used as a `GetAddr` response.
-    value: zn::Response,
-
-    /// Instant after which `cached_addrs` should be refreshed.
-    refresh_time: Instant,
-}
-
-impl CachedPeerAddrResponse {
-    /// Creates a new empty [`CachedPeerAddrResponse`].
-    fn new(address_book: Arc<Mutex<AddressBook>>) -> Self {
-        Self {
-            address_book,
-            value: zn::Response::Nil,
-            refresh_time: Instant::now(),
-        }
-    }
-
-    fn value(&self) -> zn::Response {
-        self.value.clone()
-    }
-
-    /// Refreshes the `cached_addrs` if the time has past `refresh_time` or the cache is empty
-    fn try_refresh(&mut self) {
-        let now = Instant::now();
-
-        // return early if there are some cached addresses, and they are still fresh
-        if now < self.refresh_time && !self.value.is_nil() {
-            return;
-        }
-
-        // try getting a lock on the address book if it's time to refresh the cached addresses
-        match self
-            .address_book
-            .try_lock()
-            .map(|book| book.fresh_get_addr_response())
-        {
-            // update cached value and refresh_time if there _are_ peers in the address books.
-            Ok(peers) if !peers.is_empty() => {
-                self.refresh_time = now + INBOUND_CACHED_ADDRS_REFRESH_INTERVAL;
-                self.value = zn::Response::Peers(peers);
-            }
-
-            Ok(_) => {
-                debug!(
-                    "could not refresh cached response because our address \
-                     book has no available peers"
-                );
-            }
-
-            Err(TryLockError::WouldBlock) => {
-                let next_refresh_time = self.refresh_time + INBOUND_CACHED_ADDRS_REFRESH_INTERVAL;
-
-                if now > next_refresh_time {
-                    warn!("getaddrs response hasn't been refreshed in some time");
-                };
-            }
-            Err(TryLockError::Poisoned(_)) => {
-                panic!("previous thread panicked while holding the address book lock")
-            }
-        };
-    }
 }
 
 /// Tracks the internal state of the [`Inbound`] service during setup.

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -137,7 +137,7 @@ pub enum Setup {
         /// a shared list of peer addresses used to periodically refresh the partial list.
         ///
         /// Refreshed from the address book in `poll_ready` method
-        /// after [`INBOUND_CACHED_ADDRS_REFRESH_INTERVAL`].
+        /// after [`INBOUND_CACHED_ADDRS_REFRESH_INTERVAL`](cached_peer_addr_response::INBOUND_CACHED_ADDRS_REFRESH_INTERVAL).
         cached_peer_addr_response: CachedPeerAddrResponse,
 
         /// A `futures::Stream` that downloads and verifies gossiped blocks.

--- a/zebrad/src/components/inbound/cached_peer_addr_response.rs
+++ b/zebrad/src/components/inbound/cached_peer_addr_response.rs
@@ -40,7 +40,7 @@ impl CachedPeerAddrResponse {
         let now = Instant::now();
 
         // return early if there are some cached addresses, and they are still fresh
-        if now < self.refresh_time && !self.value.is_nil() {
+        if now < self.refresh_time {
             return;
         }
 

--- a/zebrad/src/components/inbound/cached_peer_addr_response.rs
+++ b/zebrad/src/components/inbound/cached_peer_addr_response.rs
@@ -60,7 +60,11 @@ impl CachedPeerAddrResponse {
             .try_lock()
             .map(|book| book.fresh_get_addr_response())
         {
-            // update cached value and refresh_time if there _are_ peers in the address books.
+            // Update cached value and refresh_time, even if the address book is empty.
+            //
+            // Security: this avoids outdated gossiped peers. Outdated Zebra binaries will gradually lose all their peers,
+            // because those peers refuse to connect to outdated versions. So we don't want those outdated Zebra
+            // versions to keep gossiping old peer information either.
             Ok(peers) if !peers.is_empty() => {
                 self.refresh_time = now + INBOUND_CACHED_ADDRS_REFRESH_INTERVAL;
                 self.value = zn::Response::Peers(peers);

--- a/zebrad/src/components/inbound/cached_peer_addr_response.rs
+++ b/zebrad/src/components/inbound/cached_peer_addr_response.rs
@@ -60,7 +60,7 @@ impl CachedPeerAddrResponse {
             .try_lock()
             .map(|book| book.fresh_get_addr_response())
         {
-            // Update cached value and refresh_time, even if the address book is empty.
+            // Update cached value and refresh_time if there are some gossipable peers in the address book.
             //
             // Security: this avoids outdated gossiped peers. Outdated Zebra binaries will gradually lose all their peers,
             // because those peers refuse to connect to outdated versions. So we don't want those outdated Zebra

--- a/zebrad/src/components/inbound/cached_peer_addr_response.rs
+++ b/zebrad/src/components/inbound/cached_peer_addr_response.rs
@@ -1,0 +1,78 @@
+//! Periodically-refreshed GetAddr response for the inbound service.
+//!
+//! Used to avoid giving out Zebra's entire address book over a short duration.
+
+use std::{
+    sync::{Mutex, TryLockError},
+    time::Instant,
+};
+
+use super::*;
+
+/// Caches and refreshes a partial list of peer addresses to be returned as a `GetAddr` response.
+pub struct CachedPeerAddrResponse {
+    /// A shared list of peer addresses.
+    address_book: Arc<Mutex<zn::AddressBook>>,
+
+    /// An owned list of peer addresses used as a `GetAddr` response.
+    value: zn::Response,
+
+    /// Instant after which `cached_addrs` should be refreshed.
+    refresh_time: Instant,
+}
+
+impl CachedPeerAddrResponse {
+    /// Creates a new empty [`CachedPeerAddrResponse`].
+    pub(super) fn new(address_book: Arc<Mutex<AddressBook>>) -> Self {
+        Self {
+            address_book,
+            value: zn::Response::Nil,
+            refresh_time: Instant::now(),
+        }
+    }
+
+    pub(super) fn value(&self) -> zn::Response {
+        self.value.clone()
+    }
+
+    /// Refreshes the `cached_addrs` if the time has past `refresh_time` or the cache is empty
+    pub(super) fn try_refresh(&mut self) {
+        let now = Instant::now();
+
+        // return early if there are some cached addresses, and they are still fresh
+        if now < self.refresh_time && !self.value.is_nil() {
+            return;
+        }
+
+        // try getting a lock on the address book if it's time to refresh the cached addresses
+        match self
+            .address_book
+            .try_lock()
+            .map(|book| book.fresh_get_addr_response())
+        {
+            // update cached value and refresh_time if there _are_ peers in the address books.
+            Ok(peers) if !peers.is_empty() => {
+                self.refresh_time = now + INBOUND_CACHED_ADDRS_REFRESH_INTERVAL;
+                self.value = zn::Response::Peers(peers);
+            }
+
+            Ok(_) => {
+                debug!(
+                    "could not refresh cached response because our address \
+                     book has no available peers"
+                );
+            }
+
+            Err(TryLockError::WouldBlock) => {
+                let next_refresh_time = self.refresh_time + INBOUND_CACHED_ADDRS_REFRESH_INTERVAL;
+
+                if now > next_refresh_time {
+                    warn!("getaddrs response hasn't been refreshed in some time");
+                };
+            }
+            Err(TryLockError::Poisoned(_)) => {
+                panic!("previous thread panicked while holding the address book lock")
+            }
+        };
+    }
+}

--- a/zebrad/src/components/inbound/cached_peer_addr_response.rs
+++ b/zebrad/src/components/inbound/cached_peer_addr_response.rs
@@ -11,7 +11,7 @@ use super::*;
 
 /// The maximum duration that a `CachedPeerAddrResponse` is considered fresh before the inbound service
 /// should get new peer addresses from the address book to send as a `GetAddr` response.
-pub const INBOUND_CACHED_ADDRS_REFRESH_INTERVAL: Duration = Duration::from_secs(10 * 60);
+pub const CACHED_ADDRS_REFRESH_INTERVAL: Duration = Duration::from_secs(10 * 60);
 
 /// The maximum duration that a `CachedPeerAddrResponse` is considered fresh before the inbound service
 /// should get new peer addresses from the address book to send as a `GetAddr` response.
@@ -66,7 +66,7 @@ impl CachedPeerAddrResponse {
             // because those peers refuse to connect to outdated versions. So we don't want those outdated Zebra
             // versions to keep gossiping old peer information either.
             Ok(peers) if !peers.is_empty() => {
-                self.refresh_time = now + INBOUND_CACHED_ADDRS_REFRESH_INTERVAL;
+                self.refresh_time = now + CACHED_ADDRS_REFRESH_INTERVAL;
                 self.value = zn::Response::Peers(peers);
             }
 

--- a/zebrad/src/components/inbound/cached_peer_addr_response.rs
+++ b/zebrad/src/components/inbound/cached_peer_addr_response.rs
@@ -13,8 +13,8 @@ use super::*;
 /// should get new peer addresses from the address book to send as a `GetAddr` response.
 pub const CACHED_ADDRS_REFRESH_INTERVAL: Duration = Duration::from_secs(10 * 60);
 
-/// The maximum duration that a `CachedPeerAddrResponse` is considered fresh before the inbound service
-/// should get new peer addresses from the address book to send as a `GetAddr` response.
+/// The maximum duration that a `CachedPeerAddrResponse` is considered fresh after the normal refresh time
+/// before it should return `Response::Nil` until it can get new peer addresses from the address book.
 const INBOUND_CACHED_ADDRS_MAX_FRESH_DURATION: Duration = Duration::from_secs(60);
 
 /// Caches and refreshes a partial list of peer addresses to be returned as a `GetAddr` response.

--- a/zebrad/src/components/inbound/cached_peer_addr_response.rs
+++ b/zebrad/src/components/inbound/cached_peer_addr_response.rs
@@ -11,7 +11,7 @@ use super::*;
 
 /// The maximum duration that a `CachedPeerAddrResponse` is considered fresh before the inbound service
 /// should get new peer addresses from the address book to send as a `GetAddr` response.
-const INBOUND_CACHED_ADDRS_REFRESH_INTERVAL: Duration = Duration::from_secs(10 * 60);
+pub const INBOUND_CACHED_ADDRS_REFRESH_INTERVAL: Duration = Duration::from_secs(10 * 60);
 
 /// The maximum duration that a `CachedPeerAddrResponse` is considered fresh before the inbound service
 /// should get new peer addresses from the address book to send as a `GetAddr` response.

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -19,12 +19,16 @@ use zebra_chain::{
     block::{Block, Height},
     fmt::humantime_seconds,
     parameters::Network::{self, *},
-    serialization::ZcashDeserializeInto,
+    serialization::{DateTime32, ZcashDeserializeInto},
     transaction::{UnminedTx, UnminedTxId, VerifiedUnminedTx},
 };
 use zebra_consensus::{error::TransactionError, transaction, Config as ConsensusConfig};
 use zebra_network::{
-    constants::DEFAULT_MAX_CONNS_PER_IP, AddressBook, InventoryResponse, Request, Response,
+    constants::{
+        ADDR_RESPONSE_LIMIT_DENOMINATOR, DEFAULT_MAX_CONNS_PER_IP, MAX_ADDRS_IN_ADDRESS_BOOK,
+    },
+    types::{MetaAddr, PeerServices},
+    AddressBook, InventoryResponse, Request, Response,
 };
 use zebra_node_services::mempool;
 use zebra_state::{ChainTipChange, Config as StateConfig, CHAIN_TIP_UPDATE_WAIT_LIMIT};
@@ -740,6 +744,112 @@ async fn inbound_block_height_lookahead_limit() -> Result<(), crate::BoxError> {
     );
 
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+/// Checks that Zebra won't give out its entire address book over a short duration.
+async fn caches_getaddr_response() {
+    const NUM_ADDRESSES: usize = 20;
+    const NUM_REQUESTS: usize = 10;
+    const EXPECTED_NUM_RESULTS: usize = NUM_ADDRESSES / ADDR_RESPONSE_LIMIT_DENOMINATOR;
+
+    let _init_guard = zebra_test::init();
+
+    let addrs = (0..NUM_ADDRESSES)
+        .map(|idx| format!("127.0.0.{idx}:{idx}"))
+        .map(|addr| {
+            MetaAddr::new_gossiped_meta_addr(
+                addr.parse().unwrap(),
+                PeerServices::NODE_NETWORK,
+                DateTime32::now(),
+            )
+        });
+
+    let inbound = {
+        let network = Mainnet;
+        let consensus_config = ConsensusConfig::default();
+        let state_config = StateConfig::ephemeral();
+        let address_book = AddressBook::new_with_addrs(
+            SocketAddr::from_str("0.0.0.0:0").unwrap(),
+            Mainnet,
+            DEFAULT_MAX_CONNS_PER_IP,
+            MAX_ADDRS_IN_ADDRESS_BOOK,
+            Span::none(),
+            addrs,
+        );
+
+        let address_book = Arc::new(std::sync::Mutex::new(address_book));
+
+        // UTXO verification doesn't matter for these tests.
+        let (state, _read_only_state_service, latest_chain_tip, _chain_tip_change) =
+            zebra_state::init(state_config.clone(), network, Height::MAX, 0);
+
+        let state_service = ServiceBuilder::new().buffer(1).service(state);
+
+        // Download task panics and timeouts are propagated to the tests that use Groth16 verifiers.
+        let (
+            block_verifier,
+            _transaction_verifier,
+            _groth16_download_handle,
+            _max_checkpoint_height,
+        ) = zebra_consensus::router::init(consensus_config.clone(), network, state_service.clone())
+            .await;
+
+        let peer_set = MockService::build()
+            .with_max_request_delay(MAX_PEER_SET_REQUEST_DELAY)
+            .for_unit_tests();
+        let buffered_peer_set = Buffer::new(BoxService::new(peer_set.clone()), 10);
+
+        let buffered_mempool_service =
+            Buffer::new(BoxService::new(MockService::build().for_unit_tests()), 10);
+        let (setup_tx, setup_rx) = oneshot::channel();
+
+        let inbound_service = ServiceBuilder::new()
+            .load_shed()
+            .service(Inbound::new(MAX_INBOUND_CONCURRENCY, setup_rx));
+        let inbound_service = BoxService::new(inbound_service);
+        let inbound_service = ServiceBuilder::new().buffer(1).service(inbound_service);
+
+        let setup_data = InboundSetupData {
+            address_book: address_book.clone(),
+            block_download_peer_set: buffered_peer_set,
+            block_verifier,
+            mempool: buffered_mempool_service.clone(),
+            state: state_service.clone(),
+            latest_chain_tip,
+        };
+        let r = setup_tx.send(setup_data);
+        // We can't expect or unwrap because the returned Result does not implement Debug
+        assert!(r.is_ok(), "unexpected setup channel send failure");
+
+        inbound_service
+    };
+
+    let Ok(zebra_network::Response::Peers(first_result)) =
+        inbound.clone().oneshot(zebra_network::Request::Peers).await
+    else {
+        panic!("result should match Ok(Peers(_))")
+    };
+
+    assert_eq!(
+        first_result.len(),
+        EXPECTED_NUM_RESULTS,
+        "inbound service should respond with expected number of peer addresses",
+    );
+
+    for _ in 0..NUM_REQUESTS {
+        let Ok(zebra_network::Response::Peers(peers)) =
+            inbound.clone().oneshot(zebra_network::Request::Peers).await
+        else {
+            panic!("result should match Ok(Peers(_))")
+        };
+
+        assert_eq!(
+            peers,
+            first_result,
+            "inbound service should return the same result for every Peers request until the refresh time",
+        );
+    }
 }
 
 /// Setup a fake Zebra network stack, with fake peer set.

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -59,6 +59,9 @@ async fn inbound_peers_empty_address_book() -> Result<(), crate::BoxError> {
         listen_addr,
     ) = setup(None).await;
 
+    // yield and sleep until the address book lock is released.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
     // Send a request to inbound directly
     let request = inbound_service.clone().oneshot(Request::Peers);
     let response = request.await;


### PR DESCRIPTION
## Motivation

We want to avoid giving out Zebra's entire address book over a short duration.

Closes #7823.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Updates `ADDR_RESPONSE_LIMIT_DENOMINATOR` to 4
- Adds a 10 minute `INBOUND_CACHED_ADDRS_REFRESH_INTERVAL` constant
- Adds a `CachedPeerAddrs` struct with a reference to the address book
- Replaces the `address_book` field in `Setup::Initialized` with an instance of `CachedPeerAddrs`
- Refreshes the cached addresses in the inbound service's `poll_ready()` method if they are stale
- Returns `cached_addrs` in response to `inbound::Peers` requests instead of reading from the address book
- Logs a warning if it hasn't been able to get a lock on the address book to update the cached_addrs in an unexpectedly long time

Related cleanups:

- Moves logic for truncating list of peers for `GetAddr` response to a `sanitized_window()` method on `AddressBook`.

### Testing

TODO: This PR still needs tests.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._