### PR TITLE
fix(ci): Skip GCP CI jobs on PRs from external contributors, let mergify test them after approval

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
@@ -1,0 +1,37 @@
+# Workflow patches for skipping Google Cloud CD deployments on PRs from external repositories.
+name: Deploy Nodes to GCP
+
+# Run on PRs from external repositories, let them pass, and then Mergify will check them.
+# GitHub doesn't support filtering workflows by source branch names, so we have to do it for each
+# job.
+on:
+  pull_request:
+
+# IMPORTANT
+#
+# These job names must be kept in sync with the `.patch.yml` and `.yml` files.
+jobs:
+  # We don't patch the testnet job, because testnet isn't required to merge (it's too unstable)
+  build:
+    name: Build CD Docker / Build images
+    # Only run on PRs from external repositories, skipping ZF branches and tags.
+    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') && !contains(github.head_ref || github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  test-configuration-file:
+    name: Test CD default Docker config file / Test default-conf in Docker
+    # This dependency allows all these jobs to depend on a single condition, making it easier to
+    # change.
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  test-zebra-conf-path:
+    name: Test CD custom Docker config file / Test custom-conf in Docker
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/cd-deploy-nodes-gcp.patch.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch.yml
@@ -1,5 +1,8 @@
+# Workflow patches for skipping Google Cloud CD deployments, when Rust code or dependencies aren't
+# modified in a PR.
 name: Deploy Nodes to GCP
 
+# Run on PRs with unmodified code and dependency files.
 on:
   pull_request:
    paths-ignore:
@@ -19,7 +22,11 @@ on:
      - '.github/workflows/cd-deploy-nodes-gcp.yml'
      - '.github/workflows/sub-build-docker-image.yml'
 
+# IMPORTANT
+#
+# These job names must be kept in sync with the `.patch-external.yml` and `.yml` files.
 jobs:
+  # We don't patch the testnet job, because testnet isn't required to merge (it's too unstable)
   build:
     name: Build CD Docker / Build images
     runs-on: ubuntu-latest

--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -1,3 +1,6 @@
+# Google Cloud node deployments and tests that run when Rust code or dependencies are modified,
+# but only on PRs from the ZcashFoundation/zebra repository.
+# (External PRs are tested/deployed by mergify.)
 name: Deploy Nodes to GCP
 
 # Ensures that only one workflow task will run at a time. Previous deployments, if
@@ -31,6 +34,7 @@ on:
 
   # TODO: Temporarily disabled to reduce network load, see #6894.
   #push:
+  #  # Skip main branch updates where Rust code and dependencies aren't modified.
   #  branches:
   #    - main
   #  paths:
@@ -52,6 +56,7 @@ on:
 
   # Only runs the Docker image tests, doesn't deploy any instances
   pull_request:
+    # Skip PRs where Rust code and dependencies aren't modified.
     paths:
       # code and tests
       - '**/*.rs'
@@ -73,6 +78,9 @@ on:
     types:
       - published
 
+# IMPORTANT
+#
+# These job names must be kept in sync with the `.patch.yml` and `.patch-external.yml` files.
 jobs:
   # If a release was made we want to extract the first part of the semver from the
   # tag_name
@@ -107,6 +115,9 @@ jobs:
   # The image will be commonly named `zebrad:<short-hash | github-ref | semver>`
   build:
     name: Build CD Docker
+    # Skip PRs from external repositories, let them pass, and then Mergify will check them.
+    # Since this workflow also runs on release tags, we need to check for them as well.
+    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') || contains(github.head_ref || github.ref, 'refs/tags/') }}
     uses: ./.github/workflows/sub-build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile

--- a/.github/workflows/ci-integration-tests-gcp.patch-external.yml
+++ b/.github/workflows/ci-integration-tests-gcp.patch-external.yml
@@ -1,104 +1,101 @@
-# Workflow patches for skipping Google Cloud integration test CI when Rust code or dependencies
-# aren't modified in a PR.
+# Workflow patches for skipping Google Cloud unit test CI on PRs from external repositories.
 name: Integration Tests on GCP
 
-# Run on PRs with unmodified code and dependency files.
+# Run on PRs from external repositories, let them pass, and then Mergify will check them.
+# GitHub doesn't support filtering workflows by source branch names, so we have to do it for each
+# job.
 on:
   pull_request:
-    paths-ignore:
-      # code and tests
-      - '**/*.rs'
-      # hard-coded checkpoints and proptest regressions
-      - '**/*.txt'
-      # test data snapshots
-      - '**/*.snap'
-      # dependencies
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      # configuration files
-      - '.cargo/config.toml'
-      - '**/clippy.toml'
-      # workflow definitions
-      - 'docker/**'
-      - '.dockerignore'
-      - '.github/workflows/ci-unit-tests-docker.yml'
-      - '.github/workflows/sub-deploy-integration-tests-gcp.yml'
-      - '.github/workflows/sub-find-cached-disks.yml'
-      - '.github/workflows/sub-build-docker-image.yml'
 
 # IMPORTANT
 #
-# These job names must be kept in sync with the `.patch-external.yml` and `.yml` files.
+# These job names must be kept in sync with the `.patch.yml` and `.yml` files.
 jobs:
   # We don't patch the testnet job, because testnet isn't required to merge (it's too unstable)
   get-available-disks:
     name: Check if cached state disks exist for Mainnet / Check if cached state disks exist
+    # Only run on PRs from external repositories.
+    # (github.ref is always a local branch, so this check will skip non-PRs as well.)
+    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   build:
     name: Build CI Docker / Build images
+    # This dependency allows all these jobs to depend on a single condition, making it easier to
+    # change.
+    needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-stateful-sync:
     name: Zebra checkpoint update / Run sync-past-checkpoint test
+    needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-update-sync:
     name: Zebra tip update / Run update-to-tip test
+    needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   checkpoints-mainnet:
     name: Generate checkpoints mainnet / Run checkpoints-mainnet test
+    needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   lightwalletd-rpc-test:
     name: Zebra tip JSON-RPC / Run fully-synced-rpc test
+    needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   lightwalletd-transactions-test:
     name: lightwalletd tip send / Run lwd-send-transactions test
+    needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   get-block-template-test:
     name: get block template / Run get-block-template test
+    needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   submit-block-test:
     name: submit block / Run submit-block test
+    needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   lightwalletd-full-sync:
     name: lightwalletd tip / Run lwd-full-sync test
+    needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   lightwalletd-update-sync:
     name: lightwalletd tip update / Run lwd-update-sync test
+    needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   lightwalletd-grpc-test:
     name: lightwalletd GRPC tests / Run lwd-grpc-wallet test
+    needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/ci-integration-tests-gcp.yml
+++ b/.github/workflows/ci-integration-tests-gcp.yml
@@ -1,3 +1,5 @@
+# Google Cloud integration tests that run when Rust code or dependencies are modified,
+# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are tested by mergify.)
 name: Integration Tests on GCP
 
 # Ensures that only one workflow task will run at a time. Previous builds, if
@@ -47,6 +49,7 @@ on:
         default: false
 
   pull_request:
+    # Skip PRs where Rust code and dependencies aren't modified.
     paths:
       # code and tests
       - '**/*.rs'
@@ -68,6 +71,7 @@ on:
       - '.github/workflows/sub-find-cached-disks.yml'
 
   push:
+    # Skip main branch updates where Rust code and dependencies aren't modified.
     branches:
       - main
     paths:
@@ -91,6 +95,9 @@ on:
       - '.github/workflows/sub-find-cached-disks.yml'
       - '.github/workflows/sub-build-docker-image.yml'
 
+# IMPORTANT
+#
+# These job names must be kept in sync with the `.patch.yml` and `.patch-external.yml` files.
 jobs:
   # to also run a job on Mergify head branches,
   # add `|| (github.event_name == 'push' && startsWith(github.head_ref, 'mergify/merge-queue/'))`:
@@ -104,6 +111,8 @@ jobs:
   # The outputs for this job have the same names as the workflow outputs in sub-find-cached-disks.yml
   get-available-disks:
     name: Check if cached state disks exist for ${{ inputs.network || vars.ZCASH_NETWORK }}
+    # Skip PRs from external repositories, let them pass, and then Mergify will check them
+    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
     uses: ./.github/workflows/sub-find-cached-disks.yml
     with:
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
@@ -114,6 +123,7 @@ jobs:
   # Some outputs are ignored, because we don't run those jobs on testnet.
   get-available-disks-testnet:
     name: Check if cached state disks exist for testnet
+    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
     uses: ./.github/workflows/sub-find-cached-disks.yml
     with:
       network: 'Testnet'
@@ -125,6 +135,7 @@ jobs:
   # testnet when running the image.
   build:
     name: Build CI Docker
+    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
     uses: ./.github/workflows/sub-build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -148,7 +148,11 @@ jobs:
         with:
           level: warning
           fail_on_error: false
+      # This gives an error when run on PRs from external repositories, so we skip it.
       - name: validate-dependabot
+        # If this is a PR, check that the PR source is from a local branch.
+        # (github.ref is always a local branch, so this check always passes for non-PRs.)
+        if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
         uses: marocchino/validate-dependabot@v2.1.0
 
   codespell:

--- a/.github/workflows/ci-unit-tests-docker.patch-external.yml
+++ b/.github/workflows/ci-unit-tests-docker.patch-external.yml
@@ -21,42 +21,43 @@ jobs:
 
   test-all:
     name: Test all
-    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
+    # This dependency allows all these jobs to depend on a single condition, making it easier to change.
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-fake-activation-heights:
     name: Test with fake activation heights
-    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-empty-sync:
     name: Test checkpoint sync from empty state
-    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-lightwalletd-integration:
     name: Test integration with lightwalletd
-    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-configuration-file:
     name: Test CI default Docker config file / Test default-conf in Docker
-    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-zebra-conf-path:
     name: Test CI custom Docker config file / Test custom-conf in Docker
-    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/ci-unit-tests-docker.patch-external.yml
+++ b/.github/workflows/ci-unit-tests-docker.patch-external.yml
@@ -2,17 +2,9 @@
 name: Docker Unit Tests
 
 # Run on PRs from external repositories, let them pass, and then Mergify will check them.
+# GitHub doesn't support filtering workflows by source branch names, so we have to do it for each job.
 on:
   pull_request:
-    # IMPORTANT
-    #
-    # These patterns are the inverse of the ones in the non-patch file.
-    branches:
-      # Patch only external repositories
-      - '**/**'
-      # But don't patch mergify and dependabot
-      - '!mergify/**'
-      - '!dependabot/**'
 
 # IMPORTANT
 #
@@ -20,42 +12,51 @@ on:
 jobs:
   build:
     name: Build CI Docker / Build images
+    # If this is a PR, check that the PR source is from a local branch.
+    # (github.ref is always a local branch, so this check always passes for non-PRs.)
+    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-all:
     name: Test all
+    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-fake-activation-heights:
     name: Test with fake activation heights
+    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-empty-sync:
     name: Test checkpoint sync from empty state
+    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-lightwalletd-integration:
     name: Test integration with lightwalletd
+    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-configuration-file:
     name: Test CI default Docker config file / Test default-conf in Docker
+    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-zebra-conf-path:
     name: Test CI custom Docker config file / Test custom-conf in Docker
+    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/ci-unit-tests-docker.patch-external.yml
+++ b/.github/workflows/ci-unit-tests-docker.patch-external.yml
@@ -1,0 +1,61 @@
+# Workflow patches for skipping Google Cloud CI on PRs from external repositories.
+name: Docker Unit Tests
+
+# Run on PRs from external repositories, let them pass, and then Mergify will check them.
+on:
+  pull_request:
+    # IMPORTANT
+    #
+    # These patterns are the inverse of the ones in the non-patch file.
+    branches:
+      # Patch only external repositories
+      - '**/**'
+      # But don't patch mergify and dependabot
+      - '!mergify/**'
+      - '!dependabot/**'
+
+# IMPORTANT
+#
+# These job names must be kept in sync with the `.patch.yml` and `.yml` files.
+jobs:
+  build:
+    name: Build CI Docker / Build images
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  test-all:
+    name: Test all
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  test-fake-activation-heights:
+    name: Test with fake activation heights
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  test-empty-sync:
+    name: Test checkpoint sync from empty state
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  test-lightwalletd-integration:
+    name: Test integration with lightwalletd
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  test-configuration-file:
+    name: Test CI default Docker config file / Test default-conf in Docker
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  test-zebra-conf-path:
+    name: Test CI custom Docker config file / Test custom-conf in Docker
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/ci-unit-tests-docker.patch-external.yml
+++ b/.github/workflows/ci-unit-tests-docker.patch-external.yml
@@ -1,8 +1,9 @@
-# Workflow patches for skipping Google Cloud CI on PRs from external repositories.
+# Workflow patches for skipping Google Cloud unit test CI on PRs from external repositories.
 name: Docker Unit Tests
 
 # Run on PRs from external repositories, let them pass, and then Mergify will check them.
-# GitHub doesn't support filtering workflows by source branch names, so we have to do it for each job.
+# GitHub doesn't support filtering workflows by source branch names, so we have to do it for each
+# job.
 on:
   pull_request:
 
@@ -12,7 +13,7 @@ on:
 jobs:
   build:
     name: Build CI Docker / Build images
-    # Only run on PRs from external repositories. 
+    # Only run on PRs from external repositories.
     # (github.ref is always a local branch, so this check will skip non-PRs as well.)
     if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
@@ -21,7 +22,8 @@ jobs:
 
   test-all:
     name: Test all
-    # This dependency allows all these jobs to depend on a single condition, making it easier to change.
+    # This dependency allows all these jobs to depend on a single condition, making it easier to
+    # change.
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-unit-tests-docker.patch-external.yml
+++ b/.github/workflows/ci-unit-tests-docker.patch-external.yml
@@ -12,51 +12,51 @@ on:
 jobs:
   build:
     name: Build CI Docker / Build images
-    # If this is a PR, check that the PR source is from a local branch.
-    # (github.ref is always a local branch, so this check always passes for non-PRs.)
-    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
+    # Only run on PRs from external repositories. 
+    # (github.ref is always a local branch, so this check will skip non-PRs as well.)
+    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-all:
     name: Test all
-    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-fake-activation-heights:
     name: Test with fake activation heights
-    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-empty-sync:
     name: Test checkpoint sync from empty state
-    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-lightwalletd-integration:
     name: Test integration with lightwalletd
-    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-configuration-file:
     name: Test CI default Docker config file / Test default-conf in Docker
-    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
 
   test-zebra-conf-path:
     name: Test CI custom Docker config file / Test custom-conf in Docker
-    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/ci-unit-tests-docker.patch.yml
+++ b/.github/workflows/ci-unit-tests-docker.patch.yml
@@ -1,4 +1,4 @@
-# Workflow patches for skipping CI when Rust code and dependencies aren't modified in a PR.
+# Workflow patches for skipping unit test CI when Rust code or dependencies aren't modified in a PR.
 name: Docker Unit Tests
 
 # Run on PRs with unmodified code and dependency files.

--- a/.github/workflows/ci-unit-tests-docker.patch.yml
+++ b/.github/workflows/ci-unit-tests-docker.patch.yml
@@ -4,15 +4,6 @@ name: Docker Unit Tests
 # so they can be skipped when the modified files make the actual workflow run.
 on:
   pull_request:
-    # Only run on branches from external repositories, let them pass, and then Mergify will check them
-    #
-    # IMPORTANT: these patterns are the reverse of the ones in the non-patch file.
-    branches:
-      # Patch only external repositories
-      - '**/**'
-      # But don't patch mergify and dependabot
-      - '!mergify/**'
-      - '!dependabot/**'
     paths-ignore:
       # code and tests
       - '**/*.rs'

--- a/.github/workflows/ci-unit-tests-docker.patch.yml
+++ b/.github/workflows/ci-unit-tests-docker.patch.yml
@@ -1,7 +1,7 @@
+# Workflow patches for skipping CI when Rust code and dependencies aren't modified in a PR.
 name: Docker Unit Tests
 
-# These jobs *don't* depend on cached Google Cloud state disks,
-# so they can be skipped when the modified files make the actual workflow run.
+# Run on PRs with unmodified code and dependency files.
 on:
   pull_request:
     paths-ignore:
@@ -25,6 +25,9 @@ on:
       - '.github/workflows/sub-find-cached-disks.yml'
       - '.github/workflows/sub-build-docker-image.yml'
 
+# IMPORTANT
+#
+# These job names must be kept in sync with the `.patch-external.yml` and `.yml` files.
 jobs:
   build:
     name: Build CI Docker / Build images

--- a/.github/workflows/ci-unit-tests-docker.patch.yml
+++ b/.github/workflows/ci-unit-tests-docker.patch.yml
@@ -4,6 +4,15 @@ name: Docker Unit Tests
 # so they can be skipped when the modified files make the actual workflow run.
 on:
   pull_request:
+    # Only run on branches from external repositories, let them pass, and then Mergify will check them
+    #
+    # IMPORTANT: these patterns are the reverse of the ones in the non-patch file.
+    branches:
+      # Patch only external repositories
+      - '**/**'
+      # But don't patch mergify and dependabot
+      - '!mergify/**'
+      - '!dependabot/**'
     paths-ignore:
       # code and tests
       - '**/*.rs'

--- a/.github/workflows/ci-unit-tests-docker.yml
+++ b/.github/workflows/ci-unit-tests-docker.yml
@@ -1,4 +1,5 @@
-# Google Cloud CI that runs when Rust code and dependencies are modified in a PR from the ZcashFoundation/zebra repository.
+# Google Cloud unit tests that run when Rust code or dependencies are modified,
+# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are tested by mergify.)
 name: Docker Unit Tests
 
 # Ensures that only one workflow task will run at a time. Previous builds, if
@@ -46,7 +47,7 @@ on:
   push:
     branches:
       - main
-    # Skip main branch merges where Rust code and dependencies aren't modified.
+    # Skip main branch updates where Rust code and dependencies aren't modified.
     paths:
       # code and tests
       - '**/*.rs'

--- a/.github/workflows/ci-unit-tests-docker.yml
+++ b/.github/workflows/ci-unit-tests-docker.yml
@@ -21,6 +21,15 @@ on:
         default: false
 
   pull_request:
+    # Skip branches from external repositories, let them pass, and then Mergify will check them
+    branches:
+      # Include all branches
+      - '**'
+      # Exclude external repositories
+      - '!**/**'
+      # But include mergify and dependabot
+      - 'mergify/**'
+      - 'dependabot/**'
     paths:
       # code and tests
       - '**/*.rs'

--- a/.github/workflows/ci-unit-tests-docker.yml
+++ b/.github/workflows/ci-unit-tests-docker.yml
@@ -1,3 +1,4 @@
+# Google Cloud CI that runs when Rust code and dependencies are modified in a PR from the ZcashFoundation/zebra repository.
 name: Docker Unit Tests
 
 # Ensures that only one workflow task will run at a time. Previous builds, if
@@ -21,7 +22,7 @@ on:
         default: false
 
   pull_request:
-    # Skip branches from external repositories, let them pass, and then Mergify will check them
+    # Skip PRs from external repositories, let them pass, and then Mergify will check them
     branches:
       # Include all branches
       - '**'
@@ -30,6 +31,7 @@ on:
       # But include mergify and dependabot
       - 'mergify/**'
       - 'dependabot/**'
+    # Skip PRs where Rust code and dependencies aren't modified.
     paths:
       # code and tests
       - '**/*.rs'
@@ -53,6 +55,7 @@ on:
   push:
     branches:
       - main
+    # Skip main branch merges where Rust code and dependencies aren't modified.
     paths:
       # code and tests
       - '**/*.rs'
@@ -84,6 +87,9 @@ env:
   COLORBT_SHOW_HIDDEN: ${{ vars.COLORBT_SHOW_HIDDEN }}
   CARGO_INCREMENTAL: ${{ vars.CARGO_INCREMENTAL }}
 
+# IMPORTANT
+#
+# These job names must be kept in sync with the `.patch.yml` and `.patch-external.yml` files.
 jobs:
   # Build the docker image used by the tests.
   #

--- a/.github/workflows/ci-unit-tests-docker.yml
+++ b/.github/workflows/ci-unit-tests-docker.yml
@@ -22,15 +22,6 @@ on:
         default: false
 
   pull_request:
-    # Skip PRs from external repositories, let them pass, and then Mergify will check them
-    branches:
-      # Include all branches
-      - '**'
-      # Exclude external repositories
-      - '!**/**'
-      # But include mergify and dependabot
-      - 'mergify/**'
-      - 'dependabot/**'
     # Skip PRs where Rust code and dependencies aren't modified.
     paths:
       # code and tests
@@ -98,6 +89,8 @@ jobs:
   # testnet when running the image.
   build:
     name: Build CI Docker
+    # Skip PRs from external repositories, let them pass, and then Mergify will check them
+    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
     uses: ./.github/workflows/sub-build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile

--- a/.github/workflows/docs-deploy-firebase.patch-external.yml
+++ b/.github/workflows/docs-deploy-firebase.patch-external.yml
@@ -1,0 +1,30 @@
+# Workflow patches for skipping Google Cloud docs updates on PRs from external repositories.
+name: Docs
+
+# Run on PRs from external repositories, let them pass, and then Mergify will check them.
+# GitHub doesn't support filtering workflows by source branch names, so we have to do it for each
+# job.
+on:
+  pull_request:
+
+# IMPORTANT
+#
+# These job names must be kept in sync with the `.patch.yml` and `.yml` files.
+jobs:
+  build-docs-book:
+    name: Build and Deploy Zebra Book Docs
+    # Only run on PRs from external repositories.
+    # (github.ref is always a local branch, so this check will skip non-PRs as well.)
+    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+  build-docs-internal:
+    name: Build and Deploy Zebra Internal Docs
+    # This dependency allows all these jobs to depend on a single condition, making it easier to
+    # change.
+    needs: build-docs-book
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/docs-deploy-firebase.patch.yml
+++ b/.github/workflows/docs-deploy-firebase.patch.yml
@@ -1,9 +1,10 @@
+# Workflow patches for skipping Google Cloud docs updates when docs, Rust code, or dependencies
+# aren't modified in a PR.
 name: Docs
 
+# Run on PRs with unmodified docs, code, and dependency files.
 on:
   pull_request:
-    branches:
-      - main
     paths-ignore:
       # doc source files
       - 'book/**'
@@ -20,6 +21,9 @@ on:
       # workflow definitions
       - '.github/workflows/docs-deploy-firebase.yml'
 
+# IMPORTANT
+#
+# These job names must be kept in sync with the `.patch-external.yml` and `.yml` files.
 jobs:
   build-docs-book:
     name: Build and Deploy Zebra Book Docs
@@ -29,7 +33,6 @@ jobs:
 
   build-docs-internal:
     name: Build and Deploy Zebra Internal Docs
-    timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -1,3 +1,5 @@
+# Google Cloud docs updates that run when docs, Rust code, or dependencies are modified,
+# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are deployed by mergify.)
 name: Docs
 
 # Ensures that only one workflow task will run at a time. Previous deployments, if
@@ -9,7 +11,9 @@ concurrency:
 
 on:
   workflow_dispatch:
+
   push:
+    # Skip main branch updates where docs, Rust code, and dependencies aren't modified.
     branches:
       - main
     paths:
@@ -29,8 +33,7 @@ on:
       - '.github/workflows/docs-deploy-firebase.yml'
 
   pull_request:
-    branches:
-      - main
+    # Skip PRs where docs, Rust code, and dependencies aren't modified.
     paths:
       # doc source files
       - 'book/**'
@@ -60,9 +63,14 @@ env:
   # https://github.com/ZcashFoundation/zebra/blob/main/.cargo/config.toml#L87
   RUSTDOCFLAGS: --html-in-header katex-header.html -D warnings -A rustdoc::private_intra_doc_links
 
+# IMPORTANT
+#
+# These job names must be kept in sync with the `.patch.yml` and `.patch-external.yml` files.
 jobs:
   build-docs-book:
     name: Build and Deploy Zebra Book Docs
+    # Skip PRs from external repositories, let them pass, and then Mergify will check them
+    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
     permissions:
@@ -116,6 +124,7 @@ jobs:
 
   build-docs-internal:
     name: Build and Deploy Zebra Internal Docs
+    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
     timeout-minutes: 45
     runs-on: ubuntu-latest
     permissions:

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -1,4 +1,7 @@
 //! Zebrad Abscissa Application
+//!
+//! This is the code that starts `zebrad`, and launches its tasks and services.
+//! See [the crate docs](crate) and [the start docs](crate::commands::start) for more details.
 
 use std::{env, fmt::Write as _, io::Write as _, process, sync::Arc};
 

--- a/zebrad/src/commands.rs
+++ b/zebrad/src/commands.rs
@@ -10,10 +10,11 @@ pub use self::{entry_point::EntryPoint, start::StartCmd};
 
 use self::{copy_state::CopyStateCmd, generate::GenerateCmd, tip_height::TipHeightCmd};
 
+pub mod start;
+
 mod copy_state;
 mod entry_point;
 mod generate;
-mod start;
 mod tip_height;
 
 #[cfg(test)]


### PR DESCRIPTION
## Motivation

This is a quick fix for CI failures on PRs from external repositories.

We've asked the ZSA and ZSF teams to submit PRs, so let's make it a good experience for them.

Close #4529.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

This is a significant change for external developers, but we can add it to the changelog in another PR.

### Specifications

GitHub context and the difference between ref and head_ref:
https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

Skipping individual job steps:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif

### Example PRs and branch names

Internal PR: rate-limit-getaddr #7955
Recent external PR: rex4539/typos #7865
Dependabot: dependabot/github_actions/devops-599883908b #7948
Mergify: mergify/merge-queue/d948c06290 #7954

### Complex Code or Requirements

We need to skip external branches in the actual CI jobs, but only run on changed files.

Then we need to run on external branches in the patch jobs, or run on unchanged files. This requires two patch workflow files. (Conditions in the same workflow file are both required, but we want either condition.)

## Solution

- Skip GCP workflows on external PRs
- Add patch workflows for GCP workflows that run dummy jobs on external PRs
- Skip optional steps on external PRs because they are failing

Extra changes:
- Document some workflows
- Add a trivial Rust change so Rust GCP workflows run on this PR
- Cleanup some unnecessary workflow conditions and timeouts

### Testing

We can check this using this branch, which is from @teor2345's external repository. But it won't be fully tested until we merge it, and get a branch from someone who isn't a ZF GitHub org member.

## Review

I'd like to get this merged quickly so external developers have a good experience, and sort out any non-blocking changes later.

### Reviewer Checklist

Check before approving the PR:
  - [x] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [x] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

