### PR TITLE
change(systemd): Send all zebrad logs to the journal under systemd

### DIFF
--- a/zebrad/systemd/zebrad.service
+++ b/zebrad/systemd/zebrad.service
@@ -22,6 +22,8 @@ ExecStart=/usr/bin/zebrad start
 Restart=always
 PrivateTmp=true
 NoNewPrivileges=true
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 Alias=zebrad


### PR DESCRIPTION
## Motivation

In bug #7961 a user reported that they only get panic messages in the systemd journal. But we'd like all Zebra logs to go there.

This does not close that ticket, but it will be useful to help diagnose future issues like it.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [ ] Is the documentation up to date?

##### For significant changes:
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

### Specifications

https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#StandardOutput=

### Complex Code or Requirements

The `journald` feature should also do something similar, but it will provide structured logs, rather than just log lines.

## Solution

Send all zebrad output to the journal under systemd

### Testing

This is difficult to test unless someone is already running Zebra with systemd.

## Review

This is a routine fix.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
