### PR TITLE
cleanup(zebra-network): Avoid address book lock contention in some rare cases

### DIFF
--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -868,18 +868,18 @@ where
                     "opening an outbound peer connection"
                 );
 
+                // Try to get the next available peer for a handshake.
+                //
+                // candidates.next() has a short timeout, and briefly holds the address
+                // book lock, so it shouldn't hang.
+                //
+                // Hold the lock for as short a time as possible.
+                let candidate = { candidates.lock().await.next().await };
+
                 // Spawn each handshake or crawl into an independent task, so handshakes can make
                 // progress while crawls are running.
                 let handshake_or_crawl_handle = tokio::spawn(
                     async move {
-                        // Try to get the next available peer for a handshake.
-                        //
-                        // candidates.next() has a short timeout, and briefly holds the address
-                        // book lock, so it shouldn't hang.
-                        //
-                        // Hold the lock for as short a time as possible.
-                        let candidate = { candidates.lock().await.next().await };
-
                         if let Some(candidate) = candidate {
                             // we don't need to spawn here, because there's nothing running concurrently
                             dial(


### PR DESCRIPTION
## Motivation

This PR limits how often Zebra's outbound connector can try to get a lock on the address book.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

### Complex Code or Requirements

The outbound connector will wait for a lock on the candidate set and address book with a short timeout before continuing with the next `crawler_action`.

## Solution

- Try to find a candidate address in the outbound connector task instead of a spawned task

## Review

Anyone can review, this PR is optional-priority and should be reviewed last.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
