### PR TITLE
fix(db): Fix a sprout/history tree read panic in Zebra 1.4.0, which only happens before the 25.3.0 state upgrade completes

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/fix_tree_key_type.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/fix_tree_key_type.rs
@@ -28,11 +28,6 @@ pub fn run(
     // Writing the trees back to the database automatically updates their format.
     let mut batch = DiskWriteBatch::new();
 
-    // Delete the previous `Height` tip key format, which is now a duplicate.
-    // It's ok to do a full delete, because the trees are restored before the batch is written.
-    batch.delete_range_sprout_tree(upgrade_db, &Height(0), &MAX_ON_DISK_HEIGHT);
-    batch.delete_range_history_tree(upgrade_db, &Height(0), &MAX_ON_DISK_HEIGHT);
-
     // Update the sprout tip key format in the database.
     batch.update_sprout_tree(upgrade_db, &sprout_tip_tree);
     batch.update_history_tree(upgrade_db, &history_tip_tree);
@@ -45,6 +40,24 @@ pub fn run(
     upgrade_db
         .write_batch(batch)
         .expect("updating tree key formats should always succeed");
+
+    // These deletes can be slow due to tombstones for previously deleted keys,
+    // so we do it in a separate batch to avoid data races with syncing (#7961).
+    let mut batch = DiskWriteBatch::new();
+
+    // Delete the previous `Height` tip key format, which is now a duplicate.
+    // This doesn't delete the new `()` key format, because it serializes to an empty array.
+    batch.delete_range_sprout_tree(upgrade_db, &Height(0), &MAX_ON_DISK_HEIGHT);
+    batch.delete_range_history_tree(upgrade_db, &Height(0), &MAX_ON_DISK_HEIGHT);
+
+    // Return before we write if the upgrade is cancelled.
+    if !matches!(cancel_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)) {
+        return Err(CancelFormatChange);
+    }
+
+    upgrade_db
+        .write_batch(batch)
+        .expect("cleaning up old tree key formats should always succeed");
 
     Ok(())
 }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/fix_tree_key_type.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/fix_tree_key_type.rs
@@ -41,7 +41,7 @@ pub fn run(
         .write_batch(batch)
         .expect("updating tree key formats should always succeed");
 
-    // These deletes can be slow due to tombstones for previously deleted keys,
+    // The deletes below can be slow due to tombstones for previously deleted keys,
     // so we do it in a separate batch to avoid data races with syncing (#7961).
     let mut batch = DiskWriteBatch::new();
 

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -62,7 +62,7 @@ impl ZebraDb {
             // In Zebra 1.4.0 and later, we only update the history tip tree when it has changed (for every block after heartwood).
             // But we write with a `()` key, not a height key.
             // So we need to look for the most recent update height if the `()` key has never been written.
-            history_tree = self.db.zs_last_key_value(&history_tree_cf);
+            history_tree = self.db.zs_last_key_value(&history_tree_cf).map(|(_height_key, tree_value)| tree_value);
         }
 
         history_tree.unwrap_or_default()

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -62,7 +62,10 @@ impl ZebraDb {
             // In Zebra 1.4.0 and later, we only update the history tip tree when it has changed (for every block after heartwood).
             // But we write with a `()` key, not a height key.
             // So we need to look for the most recent update height if the `()` key has never been written.
-            history_tree = self.db.zs_last_key_value(&history_tree_cf).map(|(_height_key, tree_value)| tree_value);
+            history_tree = self
+                .db
+                .zs_last_key_value(&history_tree_cf)
+                .map(|(_key: Height, tree_value)| tree_value);
         }
 
         history_tree.unwrap_or_default()

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -65,7 +65,7 @@ impl ZebraDb {
             history_tree = self
                 .db
                 .zs_last_key_value(&history_tree_cf)
-                .map(|(_key: Height, tree_value)| tree_value);
+                .map(|(_key, tree_value): (Height, _)| tree_value);
         }
 
         history_tree.unwrap_or_default()

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -59,11 +59,10 @@ impl ZebraDb {
         let mut history_tree: Option<Arc<HistoryTree>> = self.db.zs_get(&history_tree_cf, &());
 
         if history_tree.is_none() {
-            let tip_height = self
-                .finalized_tip_height()
-                .expect("just checked for an empty database");
-
-            history_tree = self.db.zs_get(&history_tree_cf, &tip_height);
+            // In Zebra 1.4.0 and later, we only update the history tip tree when it has changed (for every block after heartwood).
+            // But we write with a `()` key, not a height key.
+            // So we need to look for the most recent update height if the `()` key has never been written.
+            history_tree = self.db.zs_last_key_value(&history_tree_cf);
         }
 
         history_tree.unwrap_or_default()

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -112,7 +112,10 @@ impl ZebraDb {
             // In Zebra 1.4.0 and later, we don't update the sprout tip tree unless it is changed.
             // And we write with a `()` key, not a height key.
             // So we need to look for the most recent update height if the `()` key has never been written.
-            sprout_tree = self.db.zs_last_key_value(&sprout_tree_cf).map(|(_height_key, tree_value)| tree_value);
+            sprout_tree = self
+                .db
+                .zs_last_key_value(&sprout_tree_cf)
+                .map(|(_key: Height, tree_value)| tree_value);
         }
 
         sprout_tree.expect("Sprout note commitment tree must exist if there is a finalized tip")

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -112,7 +112,7 @@ impl ZebraDb {
             // In Zebra 1.4.0 and later, we don't update the sprout tip tree unless it is changed.
             // And we write with a `()` key, not a height key.
             // So we need to look for the most recent update height if the `()` key has never been written.
-            sprout_tree = self.db.zs_last_key_value(&sprout_tree_cf).map(|(_height_key, tree_value)| tree_value);;
+            sprout_tree = self.db.zs_last_key_value(&sprout_tree_cf).map(|(_height_key, tree_value)| tree_value);
         }
 
         sprout_tree.expect("Sprout note commitment tree must exist if there is a finalized tip")

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -112,7 +112,7 @@ impl ZebraDb {
             // In Zebra 1.4.0 and later, we don't update the sprout tip tree unless it is changed.
             // And we write with a `()` key, not a height key.
             // So we need to look for the most recent update height if the `()` key has never been written.
-            sprout_tree = self.db.zs_last_key_value(&sprout_tree_cf);
+            sprout_tree = self.db.zs_last_key_value(&sprout_tree_cf).map(|(_height_key, tree_value)| tree_value);;
         }
 
         sprout_tree.expect("Sprout note commitment tree must exist if there is a finalized tip")

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -109,11 +109,10 @@ impl ZebraDb {
             self.db.zs_get(&sprout_tree_cf, &());
 
         if sprout_tree.is_none() {
-            let tip_height = self
-                .finalized_tip_height()
-                .expect("just checked for an empty database");
-
-            sprout_tree = self.db.zs_get(&sprout_tree_cf, &tip_height);
+            // In Zebra 1.4.0 and later, we don't update the sprout tip tree unless it is changed.
+            // And we write with a `()` key, not a height key.
+            // So we need to look for the most recent update height if the `()` key has never been written.
+            sprout_tree = self.db.zs_last_key_value(&sprout_tree_cf);
         }
 
         sprout_tree.expect("Sprout note commitment tree must exist if there is a finalized tip")

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -115,7 +115,7 @@ impl ZebraDb {
             sprout_tree = self
                 .db
                 .zs_last_key_value(&sprout_tree_cf)
-                .map(|(_key: Height, tree_value)| tree_value);
+                .map(|(_key, tree_value): (Height, _)| tree_value);
         }
 
         sprout_tree.expect("Sprout note commitment tree must exist if there is a finalized tip")


### PR DESCRIPTION
## Motivation

Zebra 1.4.0 only writes the sprout and history trees when they have changed, but it expects to find them at the empty key `()` or tip height. If there aren't any sprout transactions, or we're before heartwood, the trees can actually be below the tip height.

See this detailed explanation:
https://github.com/ZcashFoundation/zebra/issues/7961#issuecomment-1820451884

There is also a race condition that can happen when upgrading from 1.1.0 to 1.4.0, which we support on a best effort basis.

See this detailed explanation for this possible race condition:
https://github.com/ZcashFoundation/zebra/issues/7961#issuecomment-1820395206

Close #7961.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

We might want a changelog entry, I'm not sure.

### Complex Code or Requirements

This is concurrent code involving a data race.

## Solution

- Look for the sprout tree at the greatest available height before and during the 25.3.0 upgrade, rather than just checking the tip height
- Minimise the risk of a potential data race before and during the 25.3.0 state upgrade, by moving slow code to another database batch

### Testing

Marek and the ticket reporter have both manually tested this code and confirmed it is correct.

I don't think we can test for the race condition that's fixed in this PR.

## Review

This is a high priority fix.

### Reviewer Checklist

Check before approving the PR:
  - [x] Does the PR scope match the ticket?
  - [x] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [x] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

Document how to avoid this happening again in the state upgrade docs.

In particular, don't concurrently read and write the same keys in the same column family:
- in an upgrade, and
- in the sync.

And make sure the read and write methods have compatible conditions.