### PR TITLE
security(net): Stop sending peer addresses from handshakes directly to the address book

### DIFF
--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -609,6 +609,7 @@ where
             .field("error_slot", &self.error_slot)
             .field("metrics_label", &self.metrics_label)
             .field("last_metrics_state", &self.last_metrics_state)
+            .field("last_overload_time", &self.last_overload_time)
             .finish()
     }
 }

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -541,13 +541,15 @@ where
     /// other state handling.
     pub(super) request_timer: Option<Pin<Box<Sleep>>>,
 
-    /// A cached copy of the last unsolicited `addr` or `addrv2` message from this peer.
+    /// Unused peers from recent `addr` or `addrv2` messages from this peer.
+    /// Also holds the initial addresses sent in `version` messages, or guessed from the remote IP.
     ///
-    /// When Zebra requests peers, the cache is consumed and returned as a synthetic response.
-    /// This works around `zcashd`'s address response rate-limit.
+    /// When peers send solicited or unsolicited peer advertisements, Zebra puts them in this cache.
     ///
-    /// Multi-peer `addr` or `addrv2` messages replace single-peer messages in the cache.
-    /// (`zcashd` also gossips its own address at regular intervals.)
+    /// When Zebra's components request peers, some cached peers are consumed and returned as a
+    /// synthetic response. This works around `zcashd`'s address response rate-limit.
+    ///
+    /// The cache is limited to avoid denial of service attacks.
     pub(super) cached_addrs: Vec<MetaAddr>,
 
     /// The `inbound` service, used to answer requests from this connection's peer.
@@ -618,7 +620,7 @@ impl<S, Tx> Connection<S, Tx>
 where
     Tx: Sink<Message, Error = SerializationError> + Unpin,
 {
-    /// Return a new connection from its channels, services, and shared state.
+    /// Return a new connection from its channels, services, shared state, and metadata.
     pub(crate) fn new(
         inbound_service: S,
         client_rx: futures::channel::mpsc::Receiver<ClientRequest>,
@@ -626,6 +628,7 @@ where
         peer_tx: Tx,
         connection_tracker: ConnectionTracker,
         connection_info: Arc<ConnectionInfo>,
+        initial_cached_addrs: Vec<MetaAddr>,
     ) -> Self {
         let metrics_label = connection_info.connected_addr.get_transient_addr_label();
 
@@ -633,7 +636,7 @@ where
             connection_info,
             state: State::AwaitingRequest,
             request_timer: None,
-            cached_addrs: Vec::new(),
+            cached_addrs: initial_cached_addrs,
             svc: inbound_service,
             client_rx: client_rx.into(),
             error_slot,

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -546,10 +546,11 @@ where
     ///
     /// When peers send solicited or unsolicited peer advertisements, Zebra puts them in this cache.
     ///
-    /// When Zebra's components request peers, some cached peers are consumed and returned as a
-    /// synthetic response. This works around `zcashd`'s address response rate-limit.
+    /// When Zebra's components request peers, some cached peers are randomly selected,
+    /// consumed, and returned as a modified response. This works around `zcashd`'s address
+    /// response rate-limit.
     ///
-    /// The cache is limited to avoid denial of service attacks.
+    /// The cache size is limited to avoid denial of service attacks.
     pub(super) cached_addrs: Vec<MetaAddr>,
 
     /// The `inbound` service, used to answer requests from this connection's peer.

--- a/zebra-network/src/peer/connection/tests.rs
+++ b/zebra-network/src/peer/connection/tests.rs
@@ -83,6 +83,7 @@ fn new_test_connection<A>() -> (
         peer_tx,
         ActiveConnectionCounter::new_counter().track_connection(),
         Arc::new(connection_info),
+        Vec::new(),
     );
 
     (


### PR DESCRIPTION
## Motivation

We want to stop sending connection addresses directly to the address book, because that's insecure.

Close #7951

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

### Complex Code or Requirements

This is actually simpler than the previous code, because it doesn't have concurrency issues with other updates for the same address.

Using gossiped addresses changes the outbound connection priority slightly.

## Solution

- Send handshake peer addresses to the per-connection address cache
- Update documentation

### Testing

@arya2 what tests should we write here?
Is inspection enough, or should we have a "not sent to the address book" or "sent to the cache" test?

## Review

This is a routine fix.

### Reviewer Checklist

Check before approving the PR:
  - [x] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [x] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

There are some cleanups in #7824 that depend on this.