### PR TITLE
Create a `scan_block` function to use across scanning tasks

### DIFF
--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -336,3 +336,12 @@ pub(crate) fn transparent_output_address(
         None => None,
     }
 }
+
+impl From<Network> for zcash_primitives::consensus::Network {
+    fn from(network: Network) -> Self {
+        match network {
+            Network::Mainnet => zcash_primitives::consensus::Network::MainNetwork,
+            Network::Testnet => zcash_primitives::consensus::Network::TestNetwork,
+        }
+    }
+}

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -22,6 +22,9 @@ categories = ["cryptography::cryptocurrencies"]
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.31" }
 zebra-state = { path = "../zebra-state", version = "1.0.0-beta.31" }
 
+zcash_primitives = "0.13.0-rc.1"
+zcash_client_backend = "0.10.0-rc.1"
+
 color-eyre = "0.6.2"
 indexmap = { version = "2.0.1", features = ["serde"] }
 serde = { version = "1.0.193", features = ["serde_derive"] }
@@ -30,9 +33,6 @@ tower = "0.4.13"
 tracing = "0.1.39"
 
 [dev-dependencies]
-
-zcash_client_backend = "0.10.0-rc.1"
-zcash_primitives = "0.13.0-rc.1"
 zcash_note_encryption = "0.4.0"
 
 rand = "0.8.5"

--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -1,10 +1,21 @@
 //! The scan task.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use color_eyre::{eyre::eyre, Report};
 use tower::{buffer::Buffer, util::BoxService, Service, ServiceExt};
 use tracing::info;
+use zcash_client_backend::{
+    data_api::ScannedBlock,
+    proto::compact_formats::{
+        ChainMetadata, CompactBlock, CompactSaplingOutput, CompactSaplingSpend, CompactTx,
+    },
+    scanning::{ScanError, ScanningKey},
+};
+use zcash_primitives::zip32::AccountId;
+use zebra_chain::{
+    block::Block, parameters::Network, serialization::ZcashSerialize, transaction::Transaction,
+};
 
 use crate::storage::Storage;
 
@@ -54,5 +65,130 @@ pub async fn start(mut state: State, storage: Storage) -> Result<(), Report> {
         }
 
         tokio::time::sleep(CHECK_INTERVAL).await;
+    }
+}
+
+/// Returns transactions belonging to any of the given [`ScanningKey`]s.
+///
+/// TODO:
+/// - Remove the `sapling_tree_size` parameter or turn it into an `Option` once we have access to
+/// Zebra's state, and we can retrieve the tree size ourselves.
+/// - Add prior block metadata once we have access to Zebra's state.
+pub fn scan_block<K: ScanningKey>(
+    network: Network,
+    block: Arc<Block>,
+    sapling_tree_size: u32,
+    scanning_keys: &[&K],
+) -> Result<ScannedBlock<K::Nf>, ScanError> {
+    // TODO: Implement a check that returns early when the block height is below the Sapling
+    // activation height.
+
+    let network: zcash_primitives::consensus::Network = network.into();
+
+    let chain_metadata = ChainMetadata {
+        sapling_commitment_tree_size: sapling_tree_size,
+        // Orchard is not supported at the moment so the tree size can be 0.
+        orchard_commitment_tree_size: 0,
+    };
+
+    // Use a dummy `AccountId` as we don't use accounts yet.
+    let dummy_account = AccountId::from(0);
+
+    let scanning_keys: Vec<_> = scanning_keys
+        .iter()
+        .map(|key| (&dummy_account, key))
+        .collect();
+
+    zcash_client_backend::scanning::scan_block(
+        &network,
+        block_to_compact(block, chain_metadata),
+        &scanning_keys,
+        // Ignore whether notes are change from a viewer's own spends for now.
+        &[],
+        // Ignore previous blocks for now.
+        None,
+    )
+}
+
+/// Converts a zebra block and meta data into a compact block.
+pub fn block_to_compact(block: Arc<Block>, chain_metadata: ChainMetadata) -> CompactBlock {
+    CompactBlock {
+        height: block
+            .coinbase_height()
+            .expect("verified block should have a valid height")
+            .0
+            .into(),
+        hash: block.hash().bytes_in_display_order().to_vec(),
+        prev_hash: block
+            .header
+            .previous_block_hash
+            .bytes_in_display_order()
+            .to_vec(),
+        time: block
+            .header
+            .time
+            .timestamp()
+            .try_into()
+            .expect("unsigned 32-bit times should work until 2105"),
+        header: block
+            .header
+            .zcash_serialize_to_vec()
+            .expect("verified block should serialize"),
+        vtx: block
+            .transactions
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(transaction_to_compact)
+            .collect(),
+        chain_metadata: Some(chain_metadata),
+
+        // The protocol version is used for the gRPC wire format, so it isn't needed here.
+        proto_version: 0,
+    }
+}
+
+/// Converts a zebra transaction into a compact transaction.
+fn transaction_to_compact((index, tx): (usize, Arc<Transaction>)) -> CompactTx {
+    CompactTx {
+        index: index
+            .try_into()
+            .expect("tx index in block should fit in u64"),
+        hash: tx.hash().bytes_in_display_order().to_vec(),
+
+        // `fee` is not checked by the `scan_block` function. It is allowed to be unset.
+        // <https://docs.rs/zcash_client_backend/latest/zcash_client_backend/proto/compact_formats/struct.CompactTx.html#structfield.fee>
+        fee: 0,
+
+        spends: tx
+            .sapling_nullifiers()
+            .map(|nf| CompactSaplingSpend {
+                nf: <[u8; 32]>::from(*nf).to_vec(),
+            })
+            .collect(),
+
+        // > output encodes the cmu field, ephemeralKey field, and a 52-byte prefix of the encCiphertext field of a Sapling Output
+        //
+        // <https://docs.rs/zcash_client_backend/latest/zcash_client_backend/proto/compact_formats/struct.CompactSaplingOutput.html>
+        outputs: tx
+            .sapling_outputs()
+            .map(|output| CompactSaplingOutput {
+                cmu: output.cm_u.to_bytes().to_vec(),
+                ephemeral_key: output
+                    .ephemeral_key
+                    .zcash_serialize_to_vec()
+                    .expect("verified output should serialize successfully"),
+                ciphertext: output
+                    .enc_ciphertext
+                    .zcash_serialize_to_vec()
+                    .expect("verified output should serialize successfully")
+                    .into_iter()
+                    .take(52)
+                    .collect(),
+            })
+            .collect(),
+
+        // `actions` is not checked by the `scan_block` function.
+        actions: vec![],
     }
 }

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -510,6 +510,12 @@ fn random_compact_tx(mut rng: impl RngCore) -> CompactTx {
     ctx
 }
 
+/// Returns transactions belonging to any of the given [`ScanningKey`]s.
+///
+/// TODO:
+/// - Remove the `sapling_tree_size` parameter or turn it into an `Option` once we have access to
+/// Zebra's state, and we can retrieve the tree size ourselves.
+/// - Add prior block metadata once we have access to Zebra's state.
 fn scan_block<K: ScanningKey>(
     network: Network,
     block: Arc<Block>,

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -522,13 +522,10 @@ fn scan_block<K: ScanningKey>(
     sapling_tree_size: u32,
     scanning_keys: &[&K],
 ) -> Result<ScannedBlock<K::Nf>, ScanError> {
-    let network: zcash_primitives::consensus::Network = match network {
-        Network::Mainnet => zcash_primitives::consensus::Network::MainNetwork,
-        Network::Testnet => zcash_primitives::consensus::Network::TestNetwork,
-    };
-
     // TODO: Implement a check that returns early when the block height is below the Sapling
     // activation height.
+
+    let network: zcash_primitives::consensus::Network = network.into();
 
     let chain_metadata = ChainMetadata {
         sapling_commitment_tree_size: sapling_tree_size,

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -402,18 +402,23 @@ fn fake_compact_block(
 
     // Create a fake Note for the account
     let mut rng = OsRng;
-    let rseed = generate_random_rseed(&Network::TestNetwork, height, &mut rng);
+    let rseed = generate_random_rseed(
+        &zcash_primitives::consensus::Network::TestNetwork,
+        height,
+        &mut rng,
+    );
     let note = Note::from_parts(to, NoteValue::from_raw(value), rseed);
-    let encryptor = sapling_note_encryption::<_, Network>(
+    let encryptor = sapling_note_encryption::<_, zcash_primitives::consensus::Network>(
         Some(dfvk.fvk().ovk),
         note.clone(),
         MemoBytes::empty(),
         &mut rng,
     );
     let cmu = note.cmu().to_bytes().to_vec();
-    let ephemeral_key = SaplingDomain::<Network>::epk_bytes(encryptor.epk())
-        .0
-        .to_vec();
+    let ephemeral_key =
+        SaplingDomain::<zcash_primitives::consensus::Network>::epk_bytes(encryptor.epk())
+            .0
+            .to_vec();
     let enc_ciphertext = encryptor.encrypt_note_plaintext();
 
     // Create a fake CompactBlock containing the note

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -529,6 +529,7 @@ fn scan_block<K: ScanningKey>(
 
     let chain_metadata = ChainMetadata {
         sapling_commitment_tree_size: sapling_tree_size,
+        // Orchard is not supported at the moment so the tree size can be 0.
         orchard_commitment_tree_size: 0,
     };
 


### PR DESCRIPTION
## Motivation

Close #7947.

### PR Author Checklist

  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

I wrapped the original scanning function so it:

- takes:
	- Zebra's blocks;
	- Zebra's network type;
	- keys without accounts;
- doesn't take:
	- Sapling nullifiers;
	- prior block metadata.

### Testing

I updated two existing tests. Two more use the original scanning function, but they're better off with that one.

## Review

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._