### PR TITLE
fix(ci): Use correct check for external repositories

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     name: Build CD Docker / Build images
     # Only run on PRs from external repositories, skipping ZF branches and tags.
-    if: ${{ startsWith(github.event_name, 'pull') && github.event.head.repo.fork }}
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
@@ -16,10 +16,10 @@ jobs:
   build:
     name: Build CD Docker / Build images
     # Only run on PRs from external repositories, skipping ZF branches and tags.
-    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') && !contains(github.head_ref || github.ref, 'refs/tags/') }}
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   test-configuration-file:
     name: Test CD default Docker config file / Test default-conf in Docker
@@ -28,11 +28,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   test-zebra-conf-path:
     name: Test CD custom Docker config file / Test custom-conf in Docker
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -117,8 +117,8 @@ jobs:
   build:
     name: Build CD Docker
     # Skip PRs from external repositories, let them pass, and then Mergify will check them.
-    # Since this workflow also runs on release tags, we need to check for them as well.
-    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') || contains(github.head_ref || github.ref, 'refs/tags/') }}
+    # This workflow also runs on release tags, the event name check will run it on releases.
+    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
     uses: ./.github/workflows/sub-build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile

--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -118,7 +118,7 @@ jobs:
     name: Build CD Docker
     # Skip PRs from external repositories, let them pass, and then Mergify will check them.
     # This workflow also runs on release tags, the event name check will run it on releases.
-    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
+    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/sub-build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile

--- a/.github/workflows/ci-integration-tests-gcp.patch-external.yml
+++ b/.github/workflows/ci-integration-tests-gcp.patch-external.yml
@@ -16,11 +16,10 @@ jobs:
   get-available-disks:
     name: Check if cached state disks exist for Mainnet / Check if cached state disks exist
     # Only run on PRs from external repositories.
-    # (github.ref is always a local branch, so this check will skip non-PRs as well.)
-    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   build:
     name: Build CI Docker / Build images
@@ -29,74 +28,74 @@ jobs:
     needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   test-stateful-sync:
     name: Zebra checkpoint update / Run sync-past-checkpoint test
     needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   test-update-sync:
     name: Zebra tip update / Run update-to-tip test
     needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   checkpoints-mainnet:
     name: Generate checkpoints mainnet / Run checkpoints-mainnet test
     needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   lightwalletd-rpc-test:
     name: Zebra tip JSON-RPC / Run fully-synced-rpc test
     needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   lightwalletd-transactions-test:
     name: lightwalletd tip send / Run lwd-send-transactions test
     needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   get-block-template-test:
     name: get block template / Run get-block-template test
     needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   submit-block-test:
     name: submit block / Run submit-block test
     needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   lightwalletd-full-sync:
     name: lightwalletd tip / Run lwd-full-sync test
     needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   lightwalletd-update-sync:
     name: lightwalletd tip update / Run lwd-update-sync test
     needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   lightwalletd-grpc-test:
     name: lightwalletd GRPC tests / Run lwd-grpc-wallet test
     needs: get-available-disks
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/ci-integration-tests-gcp.patch-external.yml
+++ b/.github/workflows/ci-integration-tests-gcp.patch-external.yml
@@ -16,7 +16,7 @@ jobs:
   get-available-disks:
     name: Check if cached state disks exist for Mainnet / Check if cached state disks exist
     # Only run on PRs from external repositories.
-    if: ${{ startsWith(github.event_name, 'pull') && github.event.head.repo.fork }}
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/ci-integration-tests-gcp.yml
+++ b/.github/workflows/ci-integration-tests-gcp.yml
@@ -113,7 +113,7 @@ jobs:
   get-available-disks:
     name: Check if cached state disks exist for ${{ inputs.network || vars.ZCASH_NETWORK }}
     # Skip PRs from external repositories, let them pass, and then Mergify will check them
-    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
     uses: ./.github/workflows/sub-find-cached-disks.yml
     with:
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
@@ -124,7 +124,7 @@ jobs:
   # Some outputs are ignored, because we don't run those jobs on testnet.
   get-available-disks-testnet:
     name: Check if cached state disks exist for testnet
-    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
     uses: ./.github/workflows/sub-find-cached-disks.yml
     with:
       network: 'Testnet'
@@ -136,7 +136,7 @@ jobs:
   # testnet when running the image.
   build:
     name: Build CI Docker
-    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
     uses: ./.github/workflows/sub-build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile

--- a/.github/workflows/ci-integration-tests-gcp.yml
+++ b/.github/workflows/ci-integration-tests-gcp.yml
@@ -113,7 +113,7 @@ jobs:
   get-available-disks:
     name: Check if cached state disks exist for ${{ inputs.network || vars.ZCASH_NETWORK }}
     # Skip PRs from external repositories, let them pass, and then Mergify will check them
-    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
+    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/sub-find-cached-disks.yml
     with:
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
@@ -124,7 +124,7 @@ jobs:
   # Some outputs are ignored, because we don't run those jobs on testnet.
   get-available-disks-testnet:
     name: Check if cached state disks exist for testnet
-    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
+    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/sub-find-cached-disks.yml
     with:
       network: 'Testnet'
@@ -136,7 +136,7 @@ jobs:
   # testnet when running the image.
   build:
     name: Build CI Docker
-    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
+    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/sub-build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -150,9 +150,8 @@ jobs:
           fail_on_error: false
       # This gives an error when run on PRs from external repositories, so we skip it.
       - name: validate-dependabot
-        # If this is a PR, check that the PR source is from a local branch.
-        # (github.ref is always a local branch, so this check always passes for non-PRs.)
-        if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
+        # If this is a PR, check that the PR source is a local branch. Always runs on non-PRs.
+        if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
         uses: marocchino/validate-dependabot@v2.1.0
 
   codespell:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -151,7 +151,7 @@ jobs:
       # This gives an error when run on PRs from external repositories, so we skip it.
       - name: validate-dependabot
         # If this is a PR, check that the PR source is a local branch. Always runs on non-PRs.
-        if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
+        if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
         uses: marocchino/validate-dependabot@v2.1.0
 
   codespell:

--- a/.github/workflows/ci-unit-tests-docker.patch-external.yml
+++ b/.github/workflows/ci-unit-tests-docker.patch-external.yml
@@ -15,11 +15,10 @@ jobs:
   build:
     name: Build CI Docker / Build images
     # Only run on PRs from external repositories.
-    # (github.ref is always a local branch, so this check will skip non-PRs as well.)
-    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   test-all:
     name: Test all
@@ -28,39 +27,39 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   test-fake-activation-heights:
     name: Test with fake activation heights
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   test-empty-sync:
     name: Test checkpoint sync from empty state
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   test-lightwalletd-integration:
     name: Test integration with lightwalletd
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   test-configuration-file:
     name: Test CI default Docker config file / Test default-conf in Docker
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   test-zebra-conf-path:
     name: Test CI custom Docker config file / Test custom-conf in Docker
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/ci-unit-tests-docker.patch-external.yml
+++ b/.github/workflows/ci-unit-tests-docker.patch-external.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Build CI Docker / Build images
     # Only run on PRs from external repositories.
-    if: ${{ startsWith(github.event_name, 'pull') && github.event.head.repo.fork }}
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/ci-unit-tests-docker.yml
+++ b/.github/workflows/ci-unit-tests-docker.yml
@@ -92,7 +92,7 @@ jobs:
   build:
     name: Build CI Docker
     # Skip PRs from external repositories, let them pass, and then Mergify will check them
-    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
     uses: ./.github/workflows/sub-build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile

--- a/.github/workflows/ci-unit-tests-docker.yml
+++ b/.github/workflows/ci-unit-tests-docker.yml
@@ -92,7 +92,7 @@ jobs:
   build:
     name: Build CI Docker
     # Skip PRs from external repositories, let them pass, and then Mergify will check them
-    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
+    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/sub-build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile

--- a/.github/workflows/docs-deploy-firebase.patch-external.yml
+++ b/.github/workflows/docs-deploy-firebase.patch-external.yml
@@ -15,11 +15,10 @@ jobs:
   build-docs-book:
     name: Build and Deploy Zebra Book Docs
     # Only run on PRs from external repositories.
-    # (github.ref is always a local branch, so this check will skip non-PRs as well.)
-    if: ${{ !contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'
 
   build-docs-internal:
     name: Build and Deploy Zebra Internal Docs
@@ -28,4 +27,4 @@ jobs:
     needs: build-docs-book
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required"'
+      - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/docs-deploy-firebase.patch-external.yml
+++ b/.github/workflows/docs-deploy-firebase.patch-external.yml
@@ -15,7 +15,7 @@ jobs:
   build-docs-book:
     name: Build and Deploy Zebra Book Docs
     # Only run on PRs from external repositories.
-    if: ${{ startsWith(github.event_name, 'pull') && github.event.head.repo.fork }}
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -71,7 +71,7 @@ jobs:
   build-docs-book:
     name: Build and Deploy Zebra Book Docs
     # Skip PRs from external repositories, let them pass, and then Mergify will check them
-    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
+    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
     permissions:
@@ -125,7 +125,7 @@ jobs:
 
   build-docs-internal:
     name: Build and Deploy Zebra Internal Docs
-    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
+    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
     timeout-minutes: 45
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -71,7 +71,7 @@ jobs:
   build-docs-book:
     name: Build and Deploy Zebra Book Docs
     # Skip PRs from external repositories, let them pass, and then Mergify will check them
-    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
     permissions:
@@ -125,7 +125,7 @@ jobs:
 
   build-docs-internal:
     name: Build and Deploy Zebra Internal Docs
-    if: ${{ contains(github.head_ref || github.ref, 'refs/heads/') }}
+    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.head.repo.fork }}
     timeout-minutes: 45
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Motivation

There's a mistake in PR #7956 where it is skipping important jobs on all PRs in CI, rather than just external PRs.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

### Specifications

https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

You can see the full `github.event` object for an external PR here:
https://github.com/ZcashFoundation/zebra/actions/runs/6997671169/job/19034900585?pr=7999#step:2:995

## Solution

Use the `fork` field rather than trying to guess from the PR branch name

### Testing

I manually checked this worked:
- real workflow runs: https://github.com/ZcashFoundation/zebra/actions/runs/6997949380/job/19035477953?pr=8000
- patch-external skipped: https://github.com/ZcashFoundation/zebra/actions/runs/6997949377/job/19035476464?pr=8000

Since the logic is inverted for an external PR, that should also work.

## Review

This is urgent because some PRs and Mergify are skipping some CI jobs.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

