### PR TITLE
change(state): Expose ZebraDb methods that can create different kinds of databases

### DIFF
--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -35,6 +35,9 @@ proptest-impl = [
     "zebra-chain/proptest-impl"
 ]
 
+# Experimental shielded blockchain scanning
+shielded-scan = []
+
 # Experimental elasticsearch support
 elasticsearch = [
     "dep:elasticsearch",

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -463,6 +463,7 @@ pub(crate) use hidden::{
 };
 
 pub(crate) mod hidden {
+    #![allow(dead_code)]
 
     use super::*;
 

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -458,11 +458,25 @@ pub(crate) fn database_format_version_at_path(
 
 // Hide this destructive method from the public API, except in tests.
 #[allow(unused_imports)]
-pub(crate) use hidden::write_database_format_version_to_disk;
+pub(crate) use hidden::{
+    write_database_format_version_to_disk, write_state_database_format_version_to_disk,
+};
 
 pub(crate) mod hidden {
 
     use super::*;
+
+    /// Writes `changed_version` to the on-disk state database after the format is changed.
+    /// (Or a new database is created.)
+    ///
+    /// See `write_database_format_version_to_disk()` for details.
+    pub fn write_state_database_format_version_to_disk(
+        config: &Config,
+        changed_version: &Version,
+        network: Network,
+    ) -> Result<(), BoxError> {
+        write_database_format_version_to_disk(config, STATE_DATABASE_KIND, changed_version, network)
+    }
 
     /// Writes `changed_version` to the on-disk database after the format is changed.
     /// (Or a new database is created.)

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -14,7 +14,10 @@ use tracing::Span;
 
 use zebra_chain::parameters::Network;
 
-use crate::{constants::DATABASE_FORMAT_VERSION_FILE_NAME, BoxError};
+use crate::{
+    constants::{DATABASE_FORMAT_VERSION_FILE_NAME, STATE_DATABASE_KIND},
+    state_database_format_version_in_code, BoxError,
+};
 
 /// Configuration for the state service.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -356,7 +359,20 @@ fn parse_major_version(dir_name: &str) -> Option<u64> {
 
 // TODO: move these to the format upgrade module
 
-/// Returns the full semantic version of the on-disk database, based on its kind, major version,
+/// Returns the full semantic version of the on-disk state database, based on its config and network.
+pub fn state_database_format_version_on_disk(
+    config: &Config,
+    network: Network,
+) -> Result<Option<Version>, BoxError> {
+    database_format_version_on_disk(
+        config,
+        STATE_DATABASE_KIND,
+        state_database_format_version_in_code().major,
+        network,
+    )
+}
+
+/// Returns the full semantic version of the on-disk database, based on its config, kind, major version,
 /// and network.
 ///
 /// Typically, the version is read from a version text file.

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -283,9 +283,8 @@ fn delete_old_databases(config: Config, db_kind: String, major_version: u64, net
 
             if let Some(deleted_db_version) = deleted_db_version {
                 info!(
-                    ?deleted_db_version,
-                    ?db_kind,
-                    "deleted outdated database directory"
+                    ?deleted_db,
+                    "deleted outdated {db_kind} database directory"
                 );
             }
         }

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -196,6 +196,19 @@ impl Default for Config {
 // Cleaning up old database versions
 // TODO: put this in a different module?
 
+/// Spawns a task that checks if there are old state database folders,
+/// and deletes them from the filesystem.
+///
+/// See `check_and_delete_old_databases()` for details.
+pub fn check_and_delete_old_state_databases(config: &Config, network: Network) -> JoinHandle<()> {
+    check_and_delete_old_databases(
+        config,
+        STATE_DATABASE_KIND,
+        state_database_format_version_in_code().major,
+        network,
+    )
+}
+
 /// Spawns a task that checks if there are old database folders,
 /// and deletes them from the filesystem.
 ///

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -279,13 +279,10 @@ fn delete_old_databases(config: Config, db_kind: String, major_version: u64, net
 
     if let Some(db_kind_dir) = read_dir(&db_path) {
         for entry in db_kind_dir.flatten() {
-            let deleted_db_version = check_and_delete_database(&config, major_version, &entry);
+            let deleted_db = check_and_delete_database(&config, major_version, &entry);
 
-            if let Some(deleted_db_version) = deleted_db_version {
-                info!(
-                    ?deleted_db,
-                    "deleted outdated {db_kind} database directory"
-                );
+            if let Some(deleted_db) = deleted_db {
+                info!(?deleted_db, "deleted outdated {db_kind} database directory");
             }
         }
     }

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -6,7 +6,10 @@ use semver::Version;
 
 // For doc comment links
 #[allow(unused_imports)]
-use crate::config::{self, Config};
+use crate::{
+    config::{self, Config},
+    constants,
+};
 
 pub use zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
 
@@ -41,8 +44,8 @@ pub const STATE_DATABASE_KIND: &str = "state";
 /// - we previously added compatibility code, and
 /// - it's available in all supported Zebra versions.
 ///
-/// Use [`config::database_format_version_in_code()`] or
-/// [`config::database_format_version_on_disk()`] to get the full semantic format version.
+/// Instead of using this constant directly, use [`constants::state_database_format_version_in_code()`]
+/// or [`config::database_format_version_on_disk()`] to get the full semantic format version.
 const DATABASE_FORMAT_VERSION: u64 = 25;
 
 /// The database format minor version, incremented each time the on-disk database format has a

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -27,6 +27,9 @@ pub use zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
 // TODO: change to HeightDiff
 pub const MAX_BLOCK_REORG_HEIGHT: u32 = MIN_TRANSPARENT_COINBASE_MATURITY - 1;
 
+/// The directory name used to distinguish the state database from Zebra's other databases or flat files.
+pub const STATE_DATABASE_KIND: &str = "state";
+
 /// The database format major version, incremented each time the on-disk database format has a
 /// breaking data format change.
 ///
@@ -40,7 +43,7 @@ pub const MAX_BLOCK_REORG_HEIGHT: u32 = MIN_TRANSPARENT_COINBASE_MATURITY - 1;
 ///
 /// Use [`config::database_format_version_in_code()`] or
 /// [`config::database_format_version_on_disk()`] to get the full semantic format version.
-pub(crate) const DATABASE_FORMAT_VERSION: u64 = 25;
+const DATABASE_FORMAT_VERSION: u64 = 25;
 
 /// The database format minor version, incremented each time the on-disk database format has a
 /// significant data format change.
@@ -49,11 +52,23 @@ pub(crate) const DATABASE_FORMAT_VERSION: u64 = 25;
 /// - adding new column families,
 /// - changing the format of a column family in a compatible way, or
 /// - breaking changes with compatibility code in all supported Zebra versions.
-pub(crate) const DATABASE_FORMAT_MINOR_VERSION: u64 = 3;
+const DATABASE_FORMAT_MINOR_VERSION: u64 = 3;
 
 /// The database format patch version, incremented each time the on-disk database format has a
 /// significant format compatibility fix.
-pub(crate) const DATABASE_FORMAT_PATCH_VERSION: u64 = 0;
+const DATABASE_FORMAT_PATCH_VERSION: u64 = 0;
+
+/// Returns the full semantic version of the currently running state database format code.
+///
+/// This is the version implemented by the Zebra code that's currently running,
+/// the minor and patch versions on disk can be different.
+pub fn state_database_format_version_in_code() -> Version {
+    Version::new(
+        DATABASE_FORMAT_VERSION,
+        DATABASE_FORMAT_MINOR_VERSION,
+        DATABASE_FORMAT_PATCH_VERSION,
+    )
+}
 
 /// Returns the highest database version that modifies the subtree index format.
 ///

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -60,7 +60,7 @@ pub use service::{
 };
 
 #[cfg(feature = "shielded-scan")]
-pub use service::finalized_state::{DiskDb, ReadDisk};
+pub use service::finalized_state::{ReadDisk, ZebraDb};
 
 #[cfg(any(test, feature = "proptest-impl", feature = "shielded-scan"))]
 pub use service::finalized_state::{DiskWriteBatch, WriteDisk};

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -39,8 +39,11 @@ mod service;
 #[cfg(test)]
 mod tests;
 
-pub use config::{check_and_delete_old_databases, database_format_version_on_disk, Config};
-pub use constants::MAX_BLOCK_REORG_HEIGHT;
+pub use config::{
+    check_and_delete_old_databases, database_format_version_on_disk,
+    state_database_format_version_on_disk, Config,
+};
+pub use constants::{state_database_format_version_in_code, MAX_BLOCK_REORG_HEIGHT};
 pub use error::{
     BoxError, CloneError, CommitSemanticallyVerifiedError, DuplicateNullifierError,
     ValidateContextError,

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -73,6 +73,9 @@ pub use service::{
     init_test, init_test_services, ReadStateService,
 };
 
+#[cfg(not(any(test, feature = "proptest-impl")))]
+pub(crate) use config::hidden::write_database_format_version_to_disk;
+
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use config::hidden::write_database_format_version_to_disk;
 

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -77,6 +77,7 @@ pub use service::{
 };
 
 #[cfg(not(any(test, feature = "proptest-impl")))]
+#[allow(unused_imports)]
 pub(crate) use config::hidden::{
     write_database_format_version_to_disk, write_state_database_format_version_to_disk,
 };

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -40,8 +40,8 @@ mod service;
 mod tests;
 
 pub use config::{
-    check_and_delete_old_databases, database_format_version_on_disk,
-    state_database_format_version_on_disk, Config,
+    check_and_delete_old_databases, check_and_delete_old_state_databases,
+    database_format_version_on_disk, state_database_format_version_on_disk, Config,
 };
 pub use constants::{state_database_format_version_in_code, MAX_BLOCK_REORG_HEIGHT};
 pub use error::{

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -39,10 +39,7 @@ mod service;
 #[cfg(test)]
 mod tests;
 
-pub use config::{
-    check_and_delete_old_databases, database_format_version_in_code,
-    database_format_version_on_disk, Config,
-};
+pub use config::{check_and_delete_old_databases, database_format_version_on_disk, Config};
 pub use constants::MAX_BLOCK_REORG_HEIGHT;
 pub use error::{
     BoxError, CloneError, CommitSemanticallyVerifiedError, DuplicateNullifierError,

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -77,10 +77,14 @@ pub use service::{
 };
 
 #[cfg(not(any(test, feature = "proptest-impl")))]
-pub(crate) use config::hidden::write_database_format_version_to_disk;
+pub(crate) use config::hidden::{
+    write_database_format_version_to_disk, write_state_database_format_version_to_disk,
+};
 
 #[cfg(any(test, feature = "proptest-impl"))]
-pub use config::hidden::write_database_format_version_to_disk;
+pub use config::hidden::{
+    write_database_format_version_to_disk, write_state_database_format_version_to_disk,
+};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use constants::latest_version_for_adding_subtrees;

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -59,6 +59,12 @@ pub use service::{
     OutputIndex, OutputLocation, TransactionLocation,
 };
 
+#[cfg(feature = "shielded-scan")]
+pub use service::finalized_state::{DiskDb, ReadDisk};
+
+#[cfg(any(test, feature = "proptest-impl", feature = "shielded-scan"))]
+pub use service::finalized_state::{DiskWriteBatch, WriteDisk};
+
 #[cfg(feature = "getblocktemplate-rpcs")]
 pub use response::GetBlockTemplateChainInfo;
 
@@ -66,7 +72,7 @@ pub use response::GetBlockTemplateChainInfo;
 pub use service::{
     arbitrary::{populated_state, CHAIN_TIP_UPDATE_WAIT_LIMIT},
     chain_tip::{ChainTipBlock, ChainTipSender},
-    finalized_state::{DiskWriteBatch, MAX_ON_DISK_HEIGHT},
+    finalized_state::MAX_ON_DISK_HEIGHT,
     init_test, init_test_services, ReadStateService,
 };
 

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -3,7 +3,7 @@
 //! Zebra's database is implemented in 4 layers:
 //! - [`FinalizedState`]: queues, validates, and commits blocks, using...
 //! - [`ZebraDb`]: reads and writes [`zebra_chain`] types to the database, using...
-//! - [`DiskDb`](disk_db::DiskDb): reads and writes format-specific types
+//! - [`DiskDb`]: reads and writes format-specific types
 //!   to the database, using...
 //! - [`disk_format`]: converts types to raw database bytes.
 //!
@@ -38,17 +38,17 @@ mod arbitrary;
 #[cfg(test)]
 mod tests;
 
+#[allow(unused_imports)]
+pub use disk_db::{DiskWriteBatch, WriteDisk};
 pub use disk_format::{OutputIndex, OutputLocation, TransactionLocation};
+
+#[cfg(feature = "shielded-scan")]
+pub use disk_db::{DiskDb, ReadDisk};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use disk_format::MAX_ON_DISK_HEIGHT;
 
 pub(super) use zebra_db::ZebraDb;
-
-#[cfg(any(test, feature = "proptest-impl"))]
-pub use disk_db::DiskWriteBatch;
-#[cfg(not(any(test, feature = "proptest-impl")))]
-use disk_db::DiskWriteBatch;
 
 /// The finalized part of the chain state, stored in the db.
 ///

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -50,6 +50,8 @@ pub use disk_db::ReadDisk;
 pub use disk_format::MAX_ON_DISK_HEIGHT;
 
 /// The column families supported by the running `zebra-state` database code.
+///
+/// Existing column families that aren't listed here are preserved when the database is opened.
 pub const STATE_COLUMN_FAMILIES_IN_CODE: &[&str] = &[
     // Blocks
     "hash_by_height",

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -39,16 +39,16 @@ mod arbitrary;
 mod tests;
 
 #[allow(unused_imports)]
-pub use disk_db::{DiskWriteBatch, WriteDisk};
+pub use disk_db::{DiskDb, DiskWriteBatch, WriteDisk};
 pub use disk_format::{OutputIndex, OutputLocation, TransactionLocation};
+pub use zebra_db::ZebraDb;
 
 #[cfg(feature = "shielded-scan")]
-pub use disk_db::{DiskDb, ReadDisk};
+pub use disk_db::ReadDisk;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use disk_format::MAX_ON_DISK_HEIGHT;
 
-pub(super) use zebra_db::ZebraDb;
 
 /// The finalized part of the chain state, stored in the db.
 ///

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -49,6 +49,39 @@ pub use disk_db::ReadDisk;
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use disk_format::MAX_ON_DISK_HEIGHT;
 
+/// The column families supported by the running `zebra-state` database code.
+pub const STATE_COLUMN_FAMILIES_IN_CODE: &[&str] = &[
+    // Blocks
+    "hash_by_height",
+    "height_by_hash",
+    "block_header_by_height",
+    // Transactions
+    "tx_by_loc",
+    "hash_by_tx_loc",
+    "tx_loc_by_hash",
+    // Transparent
+    "balance_by_transparent_addr",
+    "tx_loc_by_transparent_addr_loc",
+    "utxo_by_out_loc",
+    "utxo_loc_by_transparent_addr_loc",
+    // Sprout
+    "sprout_nullifiers",
+    "sprout_anchors",
+    "sprout_note_commitment_tree",
+    // Sapling
+    "sapling_nullifiers",
+    "sapling_anchors",
+    "sapling_note_commitment_tree",
+    "sapling_note_commitment_subtree",
+    // Orchard
+    "orchard_nullifiers",
+    "orchard_anchors",
+    "orchard_note_commitment_tree",
+    "orchard_note_commitment_subtree",
+    // Chain
+    "history_tree",
+    "tip_chain_value_pool",
+];
 
 /// The finalized part of the chain state, stored in the db.
 ///
@@ -120,7 +153,14 @@ impl FinalizedState {
         debug_skip_format_upgrades: bool,
         #[cfg(feature = "elasticsearch")] elastic_db: Option<elasticsearch::Elasticsearch>,
     ) -> Self {
-        let db = ZebraDb::new(config, network, debug_skip_format_upgrades);
+        let db = ZebraDb::new(
+            config,
+            network,
+            debug_skip_format_upgrades,
+            STATE_COLUMN_FAMILIES_IN_CODE
+                .iter()
+                .map(ToString::to_string),
+        );
 
         #[cfg(feature = "elasticsearch")]
         let new_state = Self {

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -617,43 +617,13 @@ impl DiskDb {
     /// <https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ#configuration-and-tuning>
     const MEMTABLE_RAM_CACHE_MEGABYTES: usize = 128;
 
-    /// The column families supported by the running database code.
-    const COLUMN_FAMILIES_IN_CODE: &'static [&'static str] = &[
-        // Blocks
-        "hash_by_height",
-        "height_by_hash",
-        "block_header_by_height",
-        // Transactions
-        "tx_by_loc",
-        "hash_by_tx_loc",
-        "tx_loc_by_hash",
-        // Transparent
-        "balance_by_transparent_addr",
-        "tx_loc_by_transparent_addr_loc",
-        "utxo_by_out_loc",
-        "utxo_loc_by_transparent_addr_loc",
-        // Sprout
-        "sprout_nullifiers",
-        "sprout_anchors",
-        "sprout_note_commitment_tree",
-        // Sapling
-        "sapling_nullifiers",
-        "sapling_anchors",
-        "sapling_note_commitment_tree",
-        "sapling_note_commitment_subtree",
-        // Orchard
-        "orchard_nullifiers",
-        "orchard_anchors",
-        "orchard_note_commitment_tree",
-        "orchard_note_commitment_subtree",
-        // Chain
-        "history_tree",
-        "tip_chain_value_pool",
-    ];
-
     /// Opens or creates the database at `config.path` for `network`,
     /// and returns a shared low-level database wrapper.
-    pub fn new(config: &Config, network: Network) -> DiskDb {
+    pub fn new(
+        config: &Config,
+        network: Network,
+        column_families_in_code: impl IntoIterator<Item = String>,
+    ) -> DiskDb {
         let path = config.db_path(network);
 
         let db_options = DiskDb::options();
@@ -666,9 +636,7 @@ impl DiskDb {
         //
         // <https://github.com/facebook/rocksdb/wiki/Column-Families#reference>
         let column_families_on_disk = DB::list_cf(&db_options, &path).unwrap_or_default();
-        let column_families_in_code = Self::COLUMN_FAMILIES_IN_CODE
-            .iter()
-            .map(ToString::to_string);
+        let column_families_in_code = column_families_in_code.into_iter();
 
         let column_families = column_families_on_disk
             .into_iter()

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -7,8 +7,8 @@
 //!
 //! # Correctness
 //!
-//! The [`crate::constants::DATABASE_FORMAT_VERSION`] constants must
-//! be incremented each time the database format (column, serialization, etc) changes.
+//! [`crate::constants::state_database_format_version_in_code()`] must be incremented
+//! each time the database format (column, serialization, etc) changes.
 
 use std::{
     collections::{BTreeMap, HashMap},

--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -2,8 +2,8 @@
 //!
 //! # Correctness
 //!
-//! The [`crate::constants::DATABASE_FORMAT_VERSION`] constant must
-//! be incremented each time the database format (column, serialization, etc) changes.
+//! [`crate::constants::state_database_format_version_in_code()`] must be incremented
+//! each time the database format (column, serialization, etc) changes.
 
 use std::sync::Arc;
 

--- a/zebra-state/src/service/finalized_state/disk_format/block.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/block.rs
@@ -2,8 +2,8 @@
 //!
 //! # Correctness
 //!
-//! The [`crate::constants::DATABASE_FORMAT_VERSION`] constant must
-//! be incremented each time the database format (column, serialization, etc) changes.
+//! [`crate::constants::state_database_format_version_in_code()`] must be incremented
+//! each time the database format (column, serialization, etc) changes.
 
 use zebra_chain::{
     block::{self, Height},

--- a/zebra-state/src/service/finalized_state/disk_format/chain.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/chain.rs
@@ -2,8 +2,8 @@
 //!
 //! # Correctness
 //!
-//! The [`crate::constants::DATABASE_FORMAT_VERSION`] constant must
-//! be incremented each time the database format (column, serialization, etc) changes.
+//! [`crate::constants::state_database_format_version_in_code()`] must be incremented
+//! each time the database format (column, serialization, etc) changes.
 
 use std::collections::BTreeMap;
 

--- a/zebra-state/src/service/finalized_state/disk_format/shielded.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/shielded.rs
@@ -2,8 +2,8 @@
 //!
 //! # Correctness
 //!
-//! The [`crate::constants::DATABASE_FORMAT_VERSION`] constant must
-//! be incremented each time the database format (column, serialization, etc) changes.
+//! [`crate::constants::state_database_format_version_in_code()`] must be incremented
+//! each time the database format (column, serialization, etc) changes.
 
 use bincode::Options;
 

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -2,8 +2,8 @@
 //!
 //! # Correctness
 //!
-//! The [`crate::constants::DATABASE_FORMAT_VERSION`] constant must
-//! be incremented each time the database format (column, serialization, etc) changes.
+//! [`crate::constants::state_database_format_version_in_code()`] must be incremented
+//! each time the database format (column, serialization, etc) changes.
 
 use std::{cmp::max, fmt::Debug};
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -392,6 +392,8 @@ impl DbFormatChange {
         Ok(())
     }
 
+    // TODO: Move state-specific upgrade code to a finalized_state/* module.
+
     /// Apply any required format updates to the database.
     /// Format changes should be launched in an independent `std::thread`.
     ///

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -15,17 +15,13 @@ use zebra_chain::{
         task::{CheckForPanics, WaitForPanics},
         CodeTimer,
     },
-    parameters::Network,
 };
 
 use DbFormatChange::*;
 
 use crate::{
-    config::write_database_format_version_to_disk,
-    constants::{latest_version_for_adding_subtrees, DATABASE_FORMAT_VERSION},
-    database_format_version_in_code, database_format_version_on_disk,
+    constants::latest_version_for_adding_subtrees,
     service::finalized_state::{DiskWriteBatch, ZebraDb},
-    Config,
 };
 
 pub(crate) mod add_subtrees;
@@ -113,7 +109,9 @@ impl DbFormatChange {
     /// Also logs that change at info level.
     ///
     /// If `disk_version` is `None`, Zebra is creating a new database.
-    pub fn open_database(running_version: Version, disk_version: Option<Version>) -> Self {
+    pub fn open_database(running_version: &Version, disk_version: Option<Version>) -> Self {
+        let running_version = running_version.clone();
+
         let Some(disk_version) = disk_version else {
             info!(
                 %running_version,
@@ -160,8 +158,8 @@ impl DbFormatChange {
     /// This check makes sure the upgrade and new block code produce the same data.
     ///
     /// Also logs the check at info level.
-    pub fn check_new_blocks() -> Self {
-        let running_version = database_format_version_in_code();
+    pub fn check_new_blocks(db: &ZebraDb) -> Self {
+        let running_version = db.format_version_in_code();
 
         info!(%running_version, "checking new blocks were written in current database format");
         CheckNewBlocksCurrent { running_version }
@@ -219,14 +217,12 @@ impl DbFormatChange {
     /// Launch a `std::thread` that applies this format change to the database,
     /// then continues running to perform periodic format checks.
     ///
-    /// `initial_tip_height` is the database height when it was opened, and `upgrade_db` is the
+    /// `initial_tip_height` is the database height when it was opened, and `db` is the
     /// database instance to upgrade or check.
     pub fn spawn_format_change(
         self,
-        config: Config,
-        network: Network,
+        db: ZebraDb,
         initial_tip_height: Option<Height>,
-        upgrade_db: ZebraDb,
     ) -> DbFormatChangeThreadHandle {
         // # Correctness
         //
@@ -237,13 +233,7 @@ impl DbFormatChange {
         let span = Span::current();
         let update_task = thread::spawn(move || {
             span.in_scope(move || {
-                self.format_change_run_loop(
-                    config,
-                    network,
-                    initial_tip_height,
-                    upgrade_db,
-                    cancel_receiver,
-                )
+                self.format_change_run_loop(db, initial_tip_height, cancel_receiver)
             })
         });
 
@@ -264,21 +254,13 @@ impl DbFormatChange {
     /// newly added blocks matches the current format. It will run until it is cancelled or panics.
     fn format_change_run_loop(
         self,
-        config: Config,
-        network: Network,
+        db: ZebraDb,
         initial_tip_height: Option<Height>,
-        upgrade_db: ZebraDb,
         cancel_receiver: mpsc::Receiver<CancelFormatChange>,
     ) -> Result<(), CancelFormatChange> {
-        self.run_format_change_or_check(
-            &config,
-            network,
-            initial_tip_height,
-            &upgrade_db,
-            &cancel_receiver,
-        )?;
+        self.run_format_change_or_check(&db, initial_tip_height, &cancel_receiver)?;
 
-        let Some(debug_validity_check_interval) = config.debug_validity_check_interval else {
+        let Some(debug_validity_check_interval) = db.config().debug_validity_check_interval else {
             return Ok(());
         };
 
@@ -292,11 +274,9 @@ impl DbFormatChange {
                 return Err(CancelFormatChange);
             }
 
-            Self::check_new_blocks().run_format_change_or_check(
-                &config,
-                network,
+            Self::check_new_blocks(&db).run_format_change_or_check(
+                &db,
                 initial_tip_height,
-                &upgrade_db,
                 &cancel_receiver,
             )?;
         }
@@ -306,24 +286,16 @@ impl DbFormatChange {
     #[allow(clippy::unwrap_in_result)]
     pub(crate) fn run_format_change_or_check(
         &self,
-        config: &Config,
-        network: Network,
+        db: &ZebraDb,
         initial_tip_height: Option<Height>,
-        upgrade_db: &ZebraDb,
         cancel_receiver: &mpsc::Receiver<CancelFormatChange>,
     ) -> Result<(), CancelFormatChange> {
         match self {
             // Perform any required upgrades, then mark the state as upgraded.
-            Upgrade { .. } => self.apply_format_upgrade(
-                config,
-                network,
-                initial_tip_height,
-                upgrade_db,
-                cancel_receiver,
-            )?,
+            Upgrade { .. } => self.apply_format_upgrade(db, initial_tip_height, cancel_receiver)?,
 
             NewlyCreated { .. } => {
-                Self::mark_as_newly_created(config, network);
+                Self::mark_as_newly_created(db);
             }
 
             Downgrade { .. } => {
@@ -332,7 +304,7 @@ impl DbFormatChange {
                 // At the start of a format downgrade, the database must be marked as partially or
                 // fully downgraded. This lets newer Zebra versions know that some blocks with older
                 // formats have been added to the database.
-                Self::mark_as_downgraded(config, network);
+                Self::mark_as_downgraded(db);
 
                 // Older supported versions just assume they can read newer formats,
                 // because they can't predict all changes a newer Zebra version could make.
@@ -373,10 +345,10 @@ impl DbFormatChange {
         //   (unless a future upgrade breaks these format checks)
         // - re-opening the current version should be valid, regardless of whether the upgrade
         //   or new block code created the format (or any combination).
-        Self::format_validity_checks_detailed(upgrade_db, cancel_receiver)?.unwrap_or_else(|_| {
+        Self::format_validity_checks_detailed(db, cancel_receiver)?.unwrap_or_else(|_| {
             panic!(
                 "unexpected invalid database format: delete and re-sync the database at '{:?}'",
-                upgrade_db.path()
+                db.path()
             )
         });
 
@@ -407,10 +379,8 @@ impl DbFormatChange {
     #[allow(clippy::unwrap_in_result)]
     fn apply_format_upgrade(
         &self,
-        config: &Config,
-        network: Network,
-        initial_tip_height: Option<Height>,
         db: &ZebraDb,
+        initial_tip_height: Option<Height>,
         cancel_receiver: &mpsc::Receiver<CancelFormatChange>,
     ) -> Result<(), CancelFormatChange> {
         let Upgrade {
@@ -432,7 +402,7 @@ impl DbFormatChange {
                 "marking empty database as upgraded"
             );
 
-            Self::mark_as_upgraded_to(&database_format_version_in_code(), config, network);
+            Self::mark_as_upgraded_to(db, newer_running_version);
 
             info!(
                 %newer_running_version,
@@ -512,7 +482,7 @@ impl DbFormatChange {
 
             // Mark the database as upgraded. Zebra won't repeat the upgrade anymore once the
             // database is marked, so the upgrade MUST be complete at this point.
-            Self::mark_as_upgraded_to(&version_for_pruning_trees, config, network);
+            Self::mark_as_upgraded_to(db, &version_for_pruning_trees);
 
             timer.finish(module_path!(), line!(), "deduplicate trees upgrade");
         }
@@ -540,7 +510,7 @@ impl DbFormatChange {
 
             // Mark the database as upgraded. Zebra won't repeat the upgrade anymore once the
             // database is marked, so the upgrade MUST be complete at this point.
-            Self::mark_as_upgraded_to(&latest_version_for_adding_subtrees, config, network);
+            Self::mark_as_upgraded_to(db, &latest_version_for_adding_subtrees);
 
             timer.finish(module_path!(), line!(), "add subtrees upgrade");
         }
@@ -566,7 +536,7 @@ impl DbFormatChange {
 
             // Mark the database as upgraded. Zebra won't repeat the upgrade anymore once the
             // database is marked, so the upgrade MUST be complete at this point.
-            Self::mark_as_upgraded_to(&version_for_tree_keys_and_caches, config, network);
+            Self::mark_as_upgraded_to(db, &version_for_tree_keys_and_caches);
 
             timer.finish(module_path!(), line!(), "tree keys and caches upgrade");
         }
@@ -723,12 +693,13 @@ impl DbFormatChange {
     /// # Panics
     ///
     /// If the format should not have been upgraded, because the database is not newly created.
-    fn mark_as_newly_created(config: &Config, network: Network) {
-        let disk_version = database_format_version_on_disk(config, network)
+    fn mark_as_newly_created(db: &ZebraDb) {
+        let running_version = db.format_version_in_code();
+        let disk_version = db
+            .format_version_on_disk()
             .expect("unable to read database format version file path");
-        let running_version = database_format_version_in_code();
 
-        let default_new_version = Some(Version::new(DATABASE_FORMAT_VERSION, 0, 0));
+        let default_new_version = Some(Version::new(running_version.major, 0, 0));
 
         // The database version isn't empty any more, because we've created the RocksDB database
         // and acquired its lock. (If it is empty, we have a database locking bug.)
@@ -739,7 +710,7 @@ impl DbFormatChange {
              running: {running_version}"
         );
 
-        write_database_format_version_to_disk(&running_version, config, network)
+        db.update_format_version_on_disk(&running_version)
             .expect("unable to write database format version file to disk");
 
         info!(
@@ -770,11 +741,12 @@ impl DbFormatChange {
     /// - older or the same as the disk version
     ///   (multiple upgrades to the same version are not allowed)
     /// - greater than the running version (that's a logic bug)
-    fn mark_as_upgraded_to(format_upgrade_version: &Version, config: &Config, network: Network) {
-        let disk_version = database_format_version_on_disk(config, network)
+    fn mark_as_upgraded_to(db: &ZebraDb, format_upgrade_version: &Version) {
+        let running_version = db.format_version_in_code();
+        let disk_version = db
+            .format_version_on_disk()
             .expect("unable to read database format version file")
             .expect("tried to upgrade a newly created database");
-        let running_version = database_format_version_in_code();
 
         assert!(
             running_version > disk_version,
@@ -800,7 +772,7 @@ impl DbFormatChange {
              running: {running_version}"
         );
 
-        write_database_format_version_to_disk(format_upgrade_version, config, network)
+        db.update_format_version_on_disk(format_upgrade_version)
             .expect("unable to write database format version file to disk");
 
         info!(
@@ -828,11 +800,12 @@ impl DbFormatChange {
     /// If the state is newly created, because the running version should be the same.
     ///
     /// Multiple downgrades are allowed, because they all downgrade to the same running version.
-    fn mark_as_downgraded(config: &Config, network: Network) {
-        let disk_version = database_format_version_on_disk(config, network)
+    fn mark_as_downgraded(db: &ZebraDb) {
+        let running_version = db.format_version_in_code();
+        let disk_version = db
+            .format_version_on_disk()
             .expect("unable to read database format version file")
             .expect("can't downgrade a newly created database");
-        let running_version = database_format_version_in_code();
 
         assert!(
             disk_version >= running_version,
@@ -841,7 +814,7 @@ impl DbFormatChange {
              running: {running_version}"
         );
 
-        write_database_format_version_to_disk(&running_version, config, network)
+        db.update_format_version_on_disk(&running_version)
             .expect("unable to write database format version file to disk");
 
         info!(

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -80,7 +80,12 @@ impl ZebraDb {
     ///
     /// If `debug_skip_format_upgrades` is true, don't do any format upgrades or format checks.
     /// This argument is only used when running tests, it is ignored in production code.
-    pub fn new(config: &Config, network: Network, debug_skip_format_upgrades: bool) -> ZebraDb {
+    pub fn new(
+        config: &Config,
+        network: Network,
+        debug_skip_format_upgrades: bool,
+        column_families_in_code: impl IntoIterator<Item = String>,
+    ) -> ZebraDb {
         let running_version = database_format_version_in_code();
         let disk_version = database_format_version_on_disk(config, network)
             .expect("unable to read database format version file");
@@ -97,7 +102,7 @@ impl ZebraDb {
             // changes to the default database version. Then we set the correct version in the
             // upgrade thread. We need to do the version change in this order, because the version
             // file can only be changed while we hold the RocksDB database lock.
-            db: DiskDb::new(config, network),
+            db: DiskDb::new(config, network, column_families_in_code),
         };
 
         db.spawn_format_change(config, network, format_change);

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -171,7 +171,7 @@ impl ZebraDb {
 
     /// Returns the fixed major version for this database.
     pub fn major_version(&self) -> u64 {
-        self.format_version_in_code().major
+        self.db.major_version()
     }
 
     /// Returns the format version of this database on disk.

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -14,10 +14,11 @@ use std::{
     sync::{mpsc, Arc},
 };
 
+use semver::Version;
 use zebra_chain::parameters::Network;
 
 use crate::{
-    config::{database_format_version_in_code, database_format_version_on_disk},
+    config::database_format_version_on_disk,
     service::finalized_state::{
         disk_db::DiskDb,
         disk_format::{
@@ -25,7 +26,7 @@ use crate::{
             upgrade::{DbFormatChange, DbFormatChangeThreadHandle},
         },
     },
-    Config,
+    write_database_format_version_to_disk, BoxError, Config,
 };
 
 pub mod block;
@@ -37,7 +38,7 @@ pub mod transparent;
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod arbitrary;
 
-/// Wrapper struct to ensure high-level typed database access goes through the correct API.
+/// Wrapper struct to ensure high-level `zebra-state` database access goes through the correct API.
 ///
 /// `rocksdb` allows concurrent writes through a shared reference,
 /// so database instances are cloneable. When the final clone is dropped,
@@ -51,11 +52,13 @@ pub struct ZebraDb {
     //
     /// The configuration for the database.
     //
-    // TODO: use the database and version paths instead, and refactor the upgrade code to use paths
+    // TODO: move the config to DiskDb
     config: Arc<Config>,
 
     /// Should format upgrades and format checks be skipped for this instance?
     /// Only used in test code.
+    //
+    // TODO: move this to DiskDb
     debug_skip_format_upgrades: bool,
 
     // Owned State
@@ -68,6 +71,8 @@ pub struct ZebraDb {
     ///
     /// This field should be dropped before the database field, so the format upgrade task is
     /// cancelled before the database is dropped. This helps avoid some kinds of deadlocks.
+    //
+    // TODO: move the generic upgrade code and fields to DiskDb
     format_change_handle: Option<DbFormatChangeThreadHandle>,
 
     /// The inner low-level database wrapper for the RocksDB database.
@@ -75,23 +80,32 @@ pub struct ZebraDb {
 }
 
 impl ZebraDb {
-    /// Opens or creates the database at `config.path` for `network`,
+    /// Opens or creates the database at a path based on the kind, major version and network,
+    /// with the supplied column families, preserving any existing column families,
     /// and returns a shared high-level typed database wrapper.
     ///
     /// If `debug_skip_format_upgrades` is true, don't do any format upgrades or format checks.
     /// This argument is only used when running tests, it is ignored in production code.
+    //
+    // TODO: rename to StateDb and remove the db_kind and column_families_in_code arguments
     pub fn new(
         config: &Config,
+        db_kind: impl AsRef<str>,
+        format_version_in_code: &Version,
         network: Network,
         debug_skip_format_upgrades: bool,
         column_families_in_code: impl IntoIterator<Item = String>,
     ) -> ZebraDb {
-        let running_version = database_format_version_in_code();
-        let disk_version = database_format_version_on_disk(config, network)
-            .expect("unable to read database format version file");
+        let disk_version = database_format_version_on_disk(
+            config,
+            &db_kind,
+            format_version_in_code.major,
+            network,
+        )
+        .expect("unable to read database format version file");
 
         // Log any format changes before opening the database, in case opening fails.
-        let format_change = DbFormatChange::open_database(running_version, disk_version);
+        let format_change = DbFormatChange::open_database(format_version_in_code, disk_version);
 
         // Open the database and do initial checks.
         let mut db = ZebraDb {
@@ -102,21 +116,22 @@ impl ZebraDb {
             // changes to the default database version. Then we set the correct version in the
             // upgrade thread. We need to do the version change in this order, because the version
             // file can only be changed while we hold the RocksDB database lock.
-            db: DiskDb::new(config, network, column_families_in_code),
+            db: DiskDb::new(
+                config,
+                db_kind,
+                format_version_in_code,
+                network,
+                column_families_in_code,
+            ),
         };
 
-        db.spawn_format_change(config, network, format_change);
+        db.spawn_format_change(format_change);
 
         db
     }
 
     /// Launch any required format changes or format checks, and store their thread handle.
-    pub fn spawn_format_change(
-        &mut self,
-        config: &Config,
-        network: Network,
-        format_change: DbFormatChange,
-    ) {
+    pub fn spawn_format_change(&mut self, format_change: DbFormatChange) {
         // Always do format upgrades & checks in production code.
         if cfg!(test) && self.debug_skip_format_upgrades {
             return;
@@ -133,16 +148,57 @@ impl ZebraDb {
 
         // TODO:
         // - should debug_stop_at_height wait for the upgrade task to finish?
-        // - if needed, make upgrade_db into a FinalizedState,
-        //   or move the FinalizedState methods needed for upgrades to ZebraDb.
-        let format_change_handle = format_change.spawn_format_change(
-            config.clone(),
-            network,
-            initial_tip_height,
-            upgrade_db,
-        );
+        let format_change_handle =
+            format_change.spawn_format_change(upgrade_db, initial_tip_height);
 
         self.format_change_handle = Some(format_change_handle);
+    }
+
+    /// Returns config for this database.
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    /// Returns the configured database kind for this database.
+    pub fn db_kind(&self) -> String {
+        self.db.db_kind()
+    }
+
+    /// Returns the format version of the running code that created this `ZebraDb` instance in memory.
+    pub fn format_version_in_code(&self) -> Version {
+        self.db.format_version_in_code()
+    }
+
+    /// Returns the fixed major version for this database.
+    pub fn major_version(&self) -> u64 {
+        self.format_version_in_code().major
+    }
+
+    /// Returns the format version of this database on disk.
+    ///
+    /// See `database_format_version_on_disk()` for details.
+    pub fn format_version_on_disk(&self) -> Result<Option<Version>, BoxError> {
+        database_format_version_on_disk(
+            self.config(),
+            self.db_kind(),
+            self.major_version(),
+            self.network(),
+        )
+    }
+
+    /// Updates the format of this database on disk to the suppled version.
+    ///
+    /// See `write_database_format_version_to_disk()` for details.
+    pub(crate) fn update_format_version_on_disk(
+        &self,
+        new_version: &Version,
+    ) -> Result<(), BoxError> {
+        write_database_format_version_to_disk(
+            self.config(),
+            self.db_kind(),
+            new_version,
+            self.network(),
+        )
     }
 
     /// Returns the configured network for this database.
@@ -196,8 +252,13 @@ impl ZebraDb {
             // which would then make unrelated PRs fail when Zebra starts up.
 
             // If the upgrade has completed, or we've done a downgrade, check the state is valid.
-            let disk_version = database_format_version_on_disk(&self.config, self.network())
-                .expect("unexpected invalid or unreadable database version file");
+            let disk_version = database_format_version_on_disk(
+                &self.config,
+                self.db_kind(),
+                self.major_version(),
+                self.network(),
+            )
+            .expect("unexpected invalid or unreadable database version file");
 
             if let Some(disk_version) = disk_version {
                 // We need to keep the cancel handle until the format check has finished,
@@ -206,14 +267,12 @@ impl ZebraDb {
 
                 // We block here because the checks are quick and database validity is
                 // consensus-critical.
-                if disk_version >= database_format_version_in_code() {
-                    DbFormatChange::check_new_blocks()
+                if disk_version >= self.db.format_version_in_code() {
+                    DbFormatChange::check_new_blocks(self)
                         .run_format_change_or_check(
-                            &self.config,
-                            self.network(),
-                            // This argument is not used by the format check.
-                            None,
                             self,
+                            // The initial tip height is not used by the new blocks format check.
+                            None,
                             &never_cancel_receiver,
                         )
                         .expect("cancel handle is never used");

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -6,8 +6,8 @@
 //!
 //! # Correctness
 //!
-//! The [`crate::constants::DATABASE_FORMAT_VERSION`] constant must
-//! be incremented each time the database format (column, serialization, etc) changes.
+//! [`crate::constants::state_database_format_version_in_code()`] must be incremented
+//! each time the database format (column, serialization, etc) changes.
 
 use std::{
     path::Path,

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -6,8 +6,8 @@
 //!
 //! # Correctness
 //!
-//! The [`crate::constants::DATABASE_FORMAT_VERSION`] constant must
-//! be incremented each time the database format (column, serialization, etc) changes.
+//! [`crate::constants::state_database_format_version_in_code()`] must be incremented
+//! each time the database format (column, serialization, etc) changes.
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -26,6 +26,7 @@ use zebra_chain::{
 use zebra_test::vectors::{MAINNET_BLOCKS, TESTNET_BLOCKS};
 
 use crate::{
+    constants::{state_database_format_version_in_code, STATE_DATABASE_KIND},
     request::{FinalizedBlock, Treestate},
     service::finalized_state::{disk_db::DiskWriteBatch, ZebraDb, STATE_COLUMN_FAMILIES_IN_CODE},
     CheckpointVerifiedBlock, Config,
@@ -80,6 +81,8 @@ fn test_block_db_round_trip_with(
 
     let state = ZebraDb::new(
         &Config::ephemeral(),
+        STATE_DATABASE_KIND,
+        &state_database_format_version_in_code(),
         network,
         // The raw database accesses in this test create invalid database formats.
         true,

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -27,7 +27,7 @@ use zebra_test::vectors::{MAINNET_BLOCKS, TESTNET_BLOCKS};
 
 use crate::{
     request::{FinalizedBlock, Treestate},
-    service::finalized_state::{disk_db::DiskWriteBatch, ZebraDb},
+    service::finalized_state::{disk_db::DiskWriteBatch, ZebraDb, STATE_COLUMN_FAMILIES_IN_CODE},
     CheckpointVerifiedBlock, Config,
 };
 
@@ -83,6 +83,9 @@ fn test_block_db_round_trip_with(
         network,
         // The raw database accesses in this test create invalid database formats.
         true,
+        STATE_COLUMN_FAMILIES_IN_CODE
+            .iter()
+            .map(ToString::to_string),
     );
 
     // Check that each block round-trips to the database

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -8,8 +8,8 @@
 //!
 //! # Correctness
 //!
-//! The [`crate::constants::DATABASE_FORMAT_VERSION`] constant must
-//! be incremented each time the database format (column, serialization, etc) changes.
+//! [`crate::constants::state_database_format_version_in_code()`] must be incremented
+//! each time the database format (column, serialization, etc) changes.
 
 use std::{borrow::Borrow, collections::HashMap, sync::Arc};
 

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -9,8 +9,8 @@
 //!
 //! # Correctness
 //!
-//! The [`crate::constants::DATABASE_FORMAT_VERSION`] constant must
-//! be incremented each time the database format (column, serialization, etc) changes.
+//! [`crate::constants::state_database_format_version_in_code()`] must be incremented
+//! each time the database format (column, serialization, etc) changes.
 
 use std::{
     collections::{BTreeMap, HashMap},

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -8,8 +8,8 @@
 //!
 //! # Correctness
 //!
-//! The [`crate::constants::DATABASE_FORMAT_VERSION`] constant must
-//! be incremented each time the database format (column, serialization, etc) changes.
+//! [`crate::constants::state_database_format_version_in_code()`] must be incremented
+//! each time the database format (column, serialization, etc) changes.
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},

--- a/zebra-state/src/service/read/tests/vectors.rs
+++ b/zebra-state/src/service/read/tests/vectors.rs
@@ -18,6 +18,7 @@ use zebra_test::{
 };
 
 use crate::{
+    constants::{state_database_format_version_in_code, STATE_DATABASE_KIND},
     init_test_services, populated_state,
     response::MinedTx,
     service::{
@@ -369,6 +370,8 @@ where
 fn new_ephemeral_db() -> ZebraDb {
     ZebraDb::new(
         &Config::ephemeral(),
+        STATE_DATABASE_KIND,
+        &state_database_format_version_in_code(),
         Mainnet,
         true,
         STATE_COLUMN_FAMILIES_IN_CODE

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -16,7 +16,8 @@ use semver::{BuildMetadata, Version};
 
 use zebra_network::constants::PORT_IN_USE_ERROR;
 use zebra_state::{
-    constants::LOCK_FILE_ERROR, database_format_version_in_code, database_format_version_on_disk,
+    constants::LOCK_FILE_ERROR, state_database_format_version_in_code,
+    state_database_format_version_on_disk,
 };
 
 use crate::{
@@ -267,7 +268,7 @@ impl Application for ZebradApp {
 
         // reads state disk version file, doesn't open RocksDB database
         let disk_db_version =
-            match database_format_version_on_disk(&config.state, config.network.network) {
+            match state_database_format_version_on_disk(&config.state, config.network.network) {
                 Ok(Some(version)) => version.to_string(),
                 // This "version" is specially formatted to match a relaxed version regex in CI
                 Ok(None) => "creating.new.database".to_string(),
@@ -286,7 +287,7 @@ impl Application for ZebradApp {
             // code constant
             (
                 "running state version",
-                database_format_version_in_code().to_string(),
+                state_database_format_version_in_code().to_string(),
             ),
             // state disk file, doesn't open database
             ("initial disk state version", disk_db_version),

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -249,8 +249,10 @@ impl StartCmd {
         );
 
         info!("spawning delete old databases task");
-        let mut old_databases_task_handle =
-            zebra_state::check_and_delete_old_databases(config.state.clone());
+        let mut old_databases_task_handle = zebra_state::check_and_delete_old_state_databases(
+            config.state.clone(),
+            config.network.network,
+        );
 
         info!("spawning progress logging task");
         let progress_task_handle = tokio::spawn(

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -250,7 +250,7 @@ impl StartCmd {
 
         info!("spawning delete old databases task");
         let mut old_databases_task_handle = zebra_state::check_and_delete_old_state_databases(
-            config.state.clone(),
+            &config.state,
             config.network.network,
         );
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -159,7 +159,7 @@ use zebra_chain::{
 };
 use zebra_network::constants::PORT_IN_USE_ERROR;
 use zebra_node_services::rpc_client::RpcRequestClient;
-use zebra_state::{constants::LOCK_FILE_ERROR, database_format_version_in_code};
+use zebra_state::{constants::LOCK_FILE_ERROR, state_database_format_version_in_code};
 
 use zebra_test::{
     args,
@@ -1856,7 +1856,7 @@ fn lightwalletd_integration_test(test_type: TestType) -> Result<()> {
         wait_for_state_version_upgrade(
             &mut zebrad,
             &state_version_message,
-            database_format_version_in_code(),
+            state_database_format_version_in_code(),
             [format!(
                 "Opened RPC endpoint at {}",
                 zebra_rpc_address.expect("lightwalletd test must have RPC port")
@@ -1866,7 +1866,7 @@ fn lightwalletd_integration_test(test_type: TestType) -> Result<()> {
         wait_for_state_version_upgrade(
             &mut zebrad,
             &state_version_message,
-            database_format_version_in_code(),
+            state_database_format_version_in_code(),
             None,
         )?;
     }
@@ -1978,7 +1978,7 @@ fn lightwalletd_integration_test(test_type: TestType) -> Result<()> {
                     wait_for_state_version_upgrade(
                         &mut zebrad,
                         &state_version_message,
-                        database_format_version_in_code(),
+                        state_database_format_version_in_code(),
                         None,
                     )?;
                 }
@@ -2004,7 +2004,7 @@ fn lightwalletd_integration_test(test_type: TestType) -> Result<()> {
                 wait_for_state_version_upgrade(
                     &mut zebrad,
                     &state_version_message,
-                    database_format_version_in_code(),
+                    state_database_format_version_in_code(),
                     None,
                 )?;
             }
@@ -2192,7 +2192,7 @@ fn zebra_state_conflict() -> Result<()> {
         dir_conflict_full.push("state");
         dir_conflict_full.push(format!(
             "v{}",
-            zebra_state::database_format_version_in_code().major,
+            zebra_state::state_database_format_version_in_code().major,
         ));
         dir_conflict_full.push(config.network.network.to_string().to_lowercase());
         format!(
@@ -2526,7 +2526,7 @@ async fn new_state_format() -> Result<()> {
 ///       (or just add a delay during tests)
 #[tokio::test]
 async fn update_state_format() -> Result<()> {
-    let mut fake_version = database_format_version_in_code();
+    let mut fake_version = state_database_format_version_in_code();
     fake_version.minor = 0;
     fake_version.patch = 0;
 
@@ -2543,7 +2543,7 @@ async fn update_state_format() -> Result<()> {
 /// Future version compatibility is a best-effort attempt, this test can be disabled if it fails.
 #[tokio::test]
 async fn downgrade_state_format() -> Result<()> {
-    let mut fake_version = database_format_version_in_code();
+    let mut fake_version = state_database_format_version_in_code();
     fake_version.minor = u16::MAX.into();
     fake_version.patch = 0;
 
@@ -2631,7 +2631,7 @@ async fn state_format_test(
         // Give zebra_state enough time to actually write the database version to disk.
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        let running_version = database_format_version_in_code();
+        let running_version = state_database_format_version_in_code();
 
         match fake_version.cmp(&running_version) {
             Ordering::Less => expect_older_version = true,
@@ -2737,7 +2737,7 @@ async fn fully_synced_rpc_z_getsubtreesbyindex_snapshot_test() -> Result<()> {
     wait_for_state_version_upgrade(
         &mut zebrad,
         &state_version_message,
-        database_format_version_in_code(),
+        state_database_format_version_in_code(),
         None,
     )?;
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2625,8 +2625,12 @@ async fn state_format_test(
             .zebrad_config(test_name, false, Some(dir.path()), network)
             .expect("already checked config")?;
 
-        zebra_state::write_database_format_version_to_disk(fake_version, &config.state, network)
-            .expect("can't write fake database version to disk");
+        zebra_state::write_state_database_format_version_to_disk(
+            &config.state,
+            fake_version,
+            network,
+        )
+        .expect("can't write fake database version to disk");
 
         // Give zebra_state enough time to actually write the database version to disk.
         tokio::time::sleep(Duration::from_secs(1)).await;

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2379,7 +2379,7 @@ fn delete_old_databases() -> Result<()> {
 
     // inside dir was deleted
     child.expect_stdout_line_matches(format!(
-        "deleted outdated state directory deleted_db={canonicalized_inside_dir:?}"
+        "deleted outdated state database directory.*deleted_db.*=.*{canonicalized_inside_dir:?}"
     ))?;
     assert!(!inside_dir.as_path().exists());
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2331,8 +2331,8 @@ async fn fully_synced_rpc_test() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn delete_old_databases() -> Result<()> {
+#[test]
+fn delete_old_databases() -> Result<()> {
     use std::fs::{canonicalize, create_dir};
 
     let _init_guard = zebra_test::init();
@@ -2804,10 +2804,10 @@ async fn fully_synced_rpc_z_getsubtreesbyindex_snapshot_test() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "zebra-scan")]
 /// Test that the scanner gets started when the node starts.
-#[tokio::test]
-async fn scan_task_starts() -> Result<()> {
+#[cfg(feature = "zebra-scan")]
+#[test]
+fn scan_task_starts() -> Result<()> {
     use indexmap::IndexMap;
 
     const ZECPAGES_VIEWING_KEY: &str = "zxviews1q0duytgcqqqqpqre26wkl45gvwwwd706xw608hucmvfalr759ejwf7qshjf5r9aa7323zulvz6plhttp5mltqcgs9t039cx2d09mgq05ts63n8u35hyv6h9nc9ctqqtue2u7cer2mqegunuulq2luhq3ywjcz35yyljewa4mgkgjzyfwh6fr6jd0dzd44ghk0nxdv2hnv4j5nxfwv24rwdmgllhe0p8568sgqt9ckt02v2kxf5ahtql6s0ltjpkckw8gtymxtxuu9gcr0swvz";

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2379,7 +2379,7 @@ fn delete_old_databases() -> Result<()> {
 
     // inside dir was deleted
     child.expect_stdout_line_matches(format!(
-        "deleted outdated state directory deleted_state={canonicalized_inside_dir:?}"
+        "deleted outdated state directory deleted_db={canonicalized_inside_dir:?}"
     ))?;
     assert!(!inside_dir.as_path().exists());
 

--- a/zebrad/tests/common/checkpoints.rs
+++ b/zebrad/tests/common/checkpoints.rs
@@ -20,7 +20,7 @@ use zebra_chain::{
 };
 use zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP;
 use zebra_node_services::rpc_client::RpcRequestClient;
-use zebra_state::database_format_version_in_code;
+use zebra_state::state_database_format_version_in_code;
 use zebra_test::{
     args,
     command::{Arguments, TestDirExt, NO_MATCHES_REGEX_ITER},
@@ -98,7 +98,7 @@ pub async fn run(network: Network) -> Result<()> {
         wait_for_state_version_upgrade(
             &mut zebrad,
             &state_version_message,
-            database_format_version_in_code(),
+            state_database_format_version_in_code(),
             None,
         )?;
     }

--- a/zebrad/tests/common/lightwalletd/wallet_grpc_test.rs
+++ b/zebrad/tests/common/lightwalletd/wallet_grpc_test.rs
@@ -43,7 +43,7 @@ use zebra_chain::{
     parameters::NetworkUpgrade::{Nu5, Sapling},
     serialization::ZcashDeserializeInto,
 };
-use zebra_state::database_format_version_in_code;
+use zebra_state::state_database_format_version_in_code;
 
 use crate::common::{
     cached_state::{
@@ -122,7 +122,7 @@ pub async fn run() -> Result<()> {
         wait_for_state_version_upgrade(
             &mut zebrad,
             &state_version_message,
-            database_format_version_in_code(),
+            state_database_format_version_in_code(),
             [format!("Opened RPC endpoint at {zebra_rpc_address}")],
         )?;
     }
@@ -159,7 +159,7 @@ pub async fn run() -> Result<()> {
         wait_for_state_version_upgrade(
             &mut zebrad,
             &state_version_message,
-            database_format_version_in_code(),
+            state_database_format_version_in_code(),
             None,
         )?;
     }


### PR DESCRIPTION
## Motivation

We want to be able to create a blockchain scanner results database as a completely separate database directory and instance. This is a rough draft of a first step, which allows different kinds of databases to be created using `ZebraDb::new()`.

Close #8001

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

### Specifications

See the ticket for a rough design.

### Complex Code or Requirements

There are a lot of code changes in this PR already, so I'd like to do the scanner database and its tests in another ticket.

## Solution

- Provide access to ZebraDb and WriteBatch outside the state
- Pass column families to ZebradDb::new()
- Allow the database kind and current version to be changed in:
  - config.rs
  - finalized_state.rs
  - ZebraDb
  - DiskDb
  - upgrade.rs
- Make some upgrade.rs methods easier to use, simplify their arguments

### Testing

Tests for new kinds of databases will be added when we add this database to the scanner.

The current state tests were updated and give good coverage.

## Review

This PR blocks "Persistent storage of scanner results" in the MVP in #7728.

I'm looking for a review for a correct refactor. Missing functionality or additional refactors should go in the follow-up tickets #7926 and #7937.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

- #7926:
    - Split the state upgrade code so it doesn't try to run on the scanner format
    - Move all generic database methods to DiskDb, and use it to create the scanner database, so other databases don't have access to state-specific methods
    - move the old versions cleanup task into DiskDb

- #7937