### PR TITLE
dependabot(change): Exclude hyper from production dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,8 @@ updates:
         prod:
           dependency-type: "production"
           exclude-patterns:
-            - "zcash_*|orchard|halo2*|incrementalmerkletree|bridgetree|equihash"
+            # TODO: remove hyper from pattern after jsonrpc-http-server upgrades to v1
+            - "zcash_*|orchard|halo2*|incrementalmerkletree|bridgetree|equihash|hyper"
         dev:
           dependency-type: "development"
   # Devops section


### PR DESCRIPTION
## Motivation

We want to exclude hyper from future dependabot PRs until `jsonrpc-http-server` starts using v1 so that they can be merged without changes.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Add `|hyper` to the exclude pattern for production dependencies.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

- Revert this PR when `jsonrpc-http-server` starts using hyper v1.x.x