### PR TITLE
Revert "dependabot(change): Exclude hyper from production dependabot upgrades"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,7 @@ updates:
         prod:
           dependency-type: "production"
           exclude-patterns:
-            # TODO: remove hyper from pattern after jsonrpc-http-server upgrades to v1
-            - "zcash_*|orchard|halo2*|incrementalmerkletree|bridgetree|equihash|hyper"
+            - "zcash_*|orchard|halo2*|incrementalmerkletree|bridgetree|equihash"
         dev:
           dependency-type: "development"
   # Devops section


### PR DESCRIPTION
Reverts ZcashFoundation/zebra#8010

## Motivation

We want to stop `hyper` dependabot PRs until we manually upgrade it.

`groups.exclude-patterns` from PR #8010 doesn't seem to do what we want:
> exclude-patterns | Use to exclude certain dependencies from the group. If a dependency is excluded from a group, Dependabot will continue to raise single pull requests to update the dependency to its latest version.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

For example, see https://github.com/ZcashFoundation/zebra/pull/8015.

`ignore` would be closer, but it requires another PR to undo, so let's avoid that:
> By default all dependencies that are explicitly defined in a manifest are kept up to date by Dependabot version updates. In addition, Dependabot security updates also update vulnerable dependencies that are defined in lock files. You can use allow and ignore to customize which dependencies to maintain. 

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore

Instead, we can just manually tell dependabot to ignore `hyper` 1.x.x:
> @dependabot ignore <dependency name> major version will close this group update PR and stop Dependabot creating any more for the specific dependency's major version (unless you unignore this specific dependency's major version or upgrade to it yourself)

And it will automatically do upgrades after our first manual `hyper` upgrade.