### PR TITLE
fix(ci): Temporarily disable validating dependabot

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -148,11 +148,12 @@ jobs:
         with:
           level: warning
           fail_on_error: false
-      # This gives an error when run on PRs from external repositories, so we skip it.
-      - name: validate-dependabot
-        # If this is a PR, check that the PR source is a local branch. Always runs on non-PRs.
-        if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
-        uses: marocchino/validate-dependabot@v2.1.0
+      # This is failing with a JSON schema error, see #8028 for details.        
+      #- name: validate-dependabot
+      #  # This gives an error when run on PRs from external repositories, so we skip it.
+      #  # If this is a PR, check that the PR source is a local branch. Always runs on non-PRs.
+      #  if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
+      #  uses: marocchino/validate-dependabot@v2.1.0
 
   codespell:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

The validate-dependabot action is always failing, see #8028 for details.

Until it's fixed let's disable that step.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

## Review

This is urgent because red crosses on all PRs are distracting for developers and reviewers.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

Fix #8028 and revert this PR.