### PR TITLE
change(scan): Create a scanner storage database, but don't use it yet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5804,6 +5804,7 @@ dependencies = [
  "indexmap 2.1.0",
  "jubjub",
  "rand 0.8.5",
+ "semver 1.0.20",
  "serde",
  "tokio",
  "tower",

--- a/zebra-consensus/src/config.rs
+++ b/zebra-consensus/src/config.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// Configuration for parallel semantic verification:
 /// <https://zebra.zfnd.org/dev/rfcs/0002-parallel-verification.html#definitions>
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(
     deny_unknown_fields,
     default,

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -46,7 +46,7 @@ pub use cache_dir::CacheDir;
 const MAX_SINGLE_SEED_PEER_DNS_RETRIES: usize = 0;
 
 /// Configuration for networking code.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
     /// The address on which this node should listen for connections.

--- a/zebra-rpc/src/config.rs
+++ b/zebra-rpc/src/config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub mod mining;
 
 /// RPC configuration section.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
     /// IP address and port for the RPC server.

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -22,6 +22,7 @@ categories = ["cryptography::cryptocurrencies"]
 
 color-eyre = "0.6.2"
 indexmap = { version = "2.0.1", features = ["serde"] }
+semver = "1.0.20"
 serde = { version = "1.0.193", features = ["serde_derive"] }
 tokio = "1.34.0"
 tower = "0.4.13"
@@ -31,7 +32,7 @@ zcash_client_backend = "0.10.0-rc.1"
 zcash_primitives = "0.13.0-rc.1"
 
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.31" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.31" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.31", features = ["shielded-scan"] }
 
 [dev-dependencies]
 

--- a/zebra-scan/src/config.rs
+++ b/zebra-scan/src/config.rs
@@ -12,6 +12,8 @@ use crate::storage::SaplingScanningKey;
 /// Configuration for scanning.
 pub struct Config {
     /// The sapling keys to scan for and the birthday height of each of them.
+    //
+    // TODO: allow keys without birthdays
     pub sapling_keys_to_scan: IndexMap<SaplingScanningKey, u32>,
 
     /// The scanner results database config.
@@ -37,5 +39,10 @@ impl Config {
             db_config: DbConfig::ephemeral(),
             ..Self::default()
         }
+    }
+
+    /// Returns the database-specific config.
+    pub fn db_config(&self) -> &DbConfig {
+        &self.db_config
     }
 }

--- a/zebra-scan/src/config.rs
+++ b/zebra-scan/src/config.rs
@@ -7,7 +7,7 @@ use zebra_state::Config as DbConfig;
 
 use crate::storage::SaplingScanningKey;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 /// Configuration for scanning.
 pub struct Config {

--- a/zebra-scan/src/config.rs
+++ b/zebra-scan/src/config.rs
@@ -3,21 +3,39 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
+use zebra_state::Config as DbConfig;
+
 use crate::storage::SaplingScanningKey;
 
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 /// Configuration for scanning.
 pub struct Config {
     /// The sapling keys to scan for and the birthday height of each of them.
-    // TODO: any value below sapling activation as the birthday height should default to sapling activation.
     pub sapling_keys_to_scan: IndexMap<SaplingScanningKey, u32>,
+
+    /// The scanner results database config.
+    //
+    // TODO: Remove fields that are only used by the state to create a common database config.
+    #[serde(flatten)]
+    db_config: DbConfig,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             sapling_keys_to_scan: IndexMap::new(),
+            db_config: DbConfig::default(),
+        }
+    }
+}
+
+impl Config {
+    /// Returns a config for a temporary database that is deleted when it is dropped.
+    pub fn ephemeral() -> Self {
+        Self {
+            db_config: DbConfig::ephemeral(),
+            ..Self::default()
         }
     }
 }

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -4,11 +4,17 @@ use color_eyre::Report;
 use tokio::task::JoinHandle;
 use tracing::Instrument;
 
+use zebra_chain::parameters::Network;
+
 use crate::{scan, storage::Storage, Config};
 
 /// Initialize the scanner based on its config.
-pub fn init(config: &Config, state: scan::State) -> JoinHandle<Result<(), Report>> {
-    let storage = Storage::new(config);
+pub fn init(
+    config: &Config,
+    network: Network,
+    state: scan::State,
+) -> JoinHandle<Result<(), Report>> {
+    let storage = Storage::new(config, network);
 
     // TODO: add more tasks here?
     tokio::spawn(scan::start(state, storage).in_current_span())

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -1,0 +1,15 @@
+//! Initializing the scanner.
+
+use color_eyre::Report;
+use tokio::task::JoinHandle;
+use tracing::Instrument;
+
+use crate::{scan, storage::Storage, Config};
+
+/// Initialize the scanner based on its config.
+pub fn init(config: &Config, state: scan::State) -> JoinHandle<Result<(), Report>> {
+    let storage = Storage::new(config);
+
+    // TODO: add more tasks here?
+    tokio::spawn(scan::start(state, storage).in_current_span())
+}

--- a/zebra-scan/src/lib.rs
+++ b/zebra-scan/src/lib.rs
@@ -5,8 +5,12 @@
 #![doc(html_root_url = "https://docs.rs/zebra_scan")]
 
 pub mod config;
+pub mod init;
 pub mod scan;
 pub mod storage;
 
 #[cfg(test)]
 mod tests;
+
+pub use config::Config;
+pub use init::init;

--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -21,7 +21,8 @@ use zebra_chain::{
 
 use crate::storage::Storage;
 
-type State = Buffer<
+/// The generic state type used by the scanner.
+pub type State = Buffer<
     BoxService<zebra_state::Request, zebra_state::Response, zebra_state::BoxError>,
     zebra_state::Request,
 >;
@@ -35,7 +36,7 @@ const CHECK_INTERVAL: Duration = Duration::from_secs(10);
 /// Start the scan task given state and storage.
 ///
 /// - This function is dummy at the moment. It just makes sure we can read the storage and the state.
-/// - Modificatiuons here might have an impact in the `scan_task_starts` test.
+/// - Modifications here might have an impact in the `scan_task_starts` test.
 /// - Real scanning code functionality will be added in the future here.
 pub async fn start(mut state: State, storage: Storage) -> Result<(), Report> {
     // We want to make sure the state has a tip height available before we start scanning.

--- a/zebra-scan/src/storage.rs
+++ b/zebra-scan/src/storage.rs
@@ -1,15 +1,18 @@
 //! Store viewing keys and results of the scan.
 
+#![allow(dead_code)]
+
 use std::collections::HashMap;
 
 use zebra_chain::{block::Height, transaction::Hash};
+
+pub mod db;
 
 /// The type used in Zebra to store Sapling scanning keys.
 /// It can represent a full viewing key or an individual viewing key.
 pub type SaplingScanningKey = String;
 
 /// Store key info and results of the scan.
-#[allow(dead_code)]
 pub struct Storage {
     /// The sapling key and an optional birthday for it.
     sapling_keys: HashMap<SaplingScanningKey, Option<Height>>,
@@ -18,7 +21,6 @@ pub struct Storage {
     sapling_results: HashMap<SaplingScanningKey, Vec<Hash>>,
 }
 
-#[allow(dead_code)]
 impl Storage {
     /// Create a new storage.
     pub fn new() -> Self {

--- a/zebra-scan/src/storage.rs
+++ b/zebra-scan/src/storage.rs
@@ -29,11 +29,17 @@ impl Storage {
     /// Create a new storage based on `config`.
     //
     // TODO: replace this with `new_db()`.
-    pub fn new(_config: Config) -> Self {
-        Self {
+    pub fn new(config: &Config) -> Self {
+        let mut storage = Self {
             sapling_keys: HashMap::new(),
             sapling_results: HashMap::new(),
+        };
+
+        for (key, birthday) in config.sapling_keys_to_scan.iter() {
+            storage.add_sapling_key(key.clone(), Some(zebra_chain::block::Height(*birthday)));
         }
+
+        storage
     }
 
     /// Add a sapling key to the storage.

--- a/zebra-scan/src/storage.rs
+++ b/zebra-scan/src/storage.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use zebra_chain::{block::Height, transaction::Hash};
+use zebra_chain::{block::Height, parameters::Network, transaction::Hash};
 
 use crate::config::Config;
 
@@ -29,7 +29,7 @@ impl Storage {
     /// Create a new storage based on `config`.
     //
     // TODO: replace this with `new_db()`.
-    pub fn new(config: &Config) -> Self {
+    pub fn new(config: &Config, _network: Network) -> Self {
         let mut storage = Self {
             sapling_keys: HashMap::new(),
             sapling_results: HashMap::new(),

--- a/zebra-scan/src/storage.rs
+++ b/zebra-scan/src/storage.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 
 use zebra_chain::{block::Height, transaction::Hash};
 
+use crate::config::Config;
+
 pub mod db;
 
 /// The type used in Zebra to store Sapling scanning keys.
@@ -14,6 +16,8 @@ pub type SaplingScanningKey = String;
 
 /// Store key info and results of the scan.
 pub struct Storage {
+    // TODO: replace these fields with a database instance.
+    //
     /// The sapling key and an optional birthday for it.
     sapling_keys: HashMap<SaplingScanningKey, Option<Height>>,
 
@@ -22,8 +26,10 @@ pub struct Storage {
 }
 
 impl Storage {
-    /// Create a new storage.
-    pub fn new() -> Self {
+    /// Create a new storage based on `config`.
+    //
+    // TODO: replace this with `new_db()`.
+    pub fn new(_config: Config) -> Self {
         Self {
             sapling_keys: HashMap::new(),
             sapling_results: HashMap::new(),
@@ -50,13 +56,11 @@ impl Storage {
     }
 
     /// Get all keys and their birthdays.
+    //
+    // TODO: any value below sapling activation as the birthday height, or `None`, should default
+    // to sapling activation. This requires the configured network.
+    // Return Height not Option<Height>.
     pub fn get_sapling_keys(&self) -> HashMap<String, Option<Height>> {
         self.sapling_keys.clone()
-    }
-}
-
-impl Default for Storage {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/zebra-scan/src/storage.rs
+++ b/zebra-scan/src/storage.rs
@@ -19,6 +19,7 @@ pub type SaplingScanningKey = String;
 /// `rocksdb` allows concurrent writes through a shared reference,
 /// so clones of the scanner storage represent the same database instance.
 /// When the final clone is dropped, the database is closed.
+#[derive(Clone, Debug)]
 pub struct Storage {
     // Configuration
     //

--- a/zebra-scan/src/storage/db.rs
+++ b/zebra-scan/src/storage/db.rs
@@ -1,1 +1,102 @@
 //! Persistent storage for scanner results.
+
+use std::{collections::HashMap, path::Path};
+
+use semver::Version;
+
+use zebra_chain::parameters::Network;
+
+use crate::Config;
+
+use super::Storage;
+
+// Public types and APIs
+pub use zebra_state::ZebraDb as ScannerDb;
+
+/// The directory name used to distinguish the scanner database from Zebra's other databases or
+/// flat files.
+///
+/// We use "private" in the name to warn users not to share this data.
+pub const SCANNER_DATABASE_KIND: &str = "private-scan";
+
+/// The column families supported by the running `zebra-scan` database code.
+///
+/// Existing column families that aren't listed here are preserved when the database is opened.
+pub const SCANNER_COLUMN_FAMILIES_IN_CODE: &[&str] = &[
+    // Sapling
+    "sapling_tx_ids",
+    // Orchard
+    // TODO
+];
+
+impl Storage {
+    /// Opens and returns an on-disk scanner results database instance for `config` and `network`.
+    /// If there is no existing database, creates a new database on disk.
+    ///
+    /// New keys in `config` are not inserted into the database.
+    pub(crate) fn new_db(config: &Config, network: Network) -> Self {
+        Self::new_with_debug(
+            config, network,
+            // TODO: make format upgrades work with any database, then change this to `false`
+            true,
+        )
+    }
+
+    /// Returns an on-disk database instance with the supplied production and debug settings.
+    /// If there is no existing database, creates a new database on disk.
+    ///
+    /// New keys in `config` are not inserted into the database.
+    ///
+    /// This method is intended for use in tests.
+    pub(crate) fn new_with_debug(
+        config: &Config,
+        network: Network,
+        debug_skip_format_upgrades: bool,
+    ) -> Self {
+        let db = ScannerDb::new(
+            config.db_config(),
+            SCANNER_DATABASE_KIND,
+            &Self::database_format_version_in_code(),
+            network,
+            debug_skip_format_upgrades,
+            SCANNER_COLUMN_FAMILIES_IN_CODE
+                .iter()
+                .map(ToString::to_string),
+        );
+
+        let new_storage = Self {
+            db,
+            sapling_keys: HashMap::new(),
+            sapling_results: HashMap::new(),
+        };
+
+        // TODO: report the last scanned height here?
+        tracing::info!("loaded Zebra scanner cache");
+
+        new_storage
+    }
+
+    /// The database format version in the running scanner code.
+    pub fn database_format_version_in_code() -> Version {
+        // TODO: implement scanner database versioning
+        Version::new(0, 0, 0)
+    }
+
+    /// Returns the configured network for this database.
+    pub fn network(&self) -> Network {
+        self.db.network()
+    }
+
+    /// Returns the `Path` where the files used by this database are located.
+    pub fn path(&self) -> &Path {
+        self.db.path()
+    }
+
+    /// Check for panics in code running in spawned threads.
+    /// If a thread exited with a panic, resume that panic.
+    ///
+    /// This method should be called regularly, so that panics are detected as soon as possible.
+    pub fn check_for_panics(&mut self) {
+        self.db.check_for_panics()
+    }
+}

--- a/zebra-scan/src/storage/db.rs
+++ b/zebra-scan/src/storage/db.rs
@@ -96,6 +96,8 @@ impl Storage {
     /// If a thread exited with a panic, resume that panic.
     ///
     /// This method should be called regularly, so that panics are detected as soon as possible.
+    //
+    // TODO: when we implement format changes, call this method regularly
     pub fn check_for_panics(&mut self) {
         self.db.check_for_panics()
     }

--- a/zebra-scan/src/storage/db.rs
+++ b/zebra-scan/src/storage/db.rs
@@ -1,0 +1,1 @@
+//! Persistent storage for scanner results.

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -180,7 +180,7 @@ fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
         zcash_client_backend::encoding::encode_extended_full_viewing_key("zxviews", &extfvk);
 
     // Create a database
-    let mut s = crate::storage::Storage::new(Config::ephemeral());
+    let mut s = crate::storage::Storage::new(&Config::ephemeral());
 
     // Insert the generated key to the database
     s.add_sapling_key(key_to_be_stored.clone(), None);

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -35,7 +35,10 @@ use zebra_chain::{
     block::Block, chain_tip::ChainTip, serialization::ZcashDeserializeInto, transaction::Hash,
 };
 
-use crate::scan::{block_to_compact, scan_block};
+use crate::{
+    config::Config,
+    scan::{block_to_compact, scan_block},
+};
 
 /// Prove that we can create fake blocks with fake notes and scan them using the
 /// `zcash_client_backend::scanning::scan_block` function:
@@ -177,7 +180,7 @@ fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
         zcash_client_backend::encoding::encode_extended_full_viewing_key("zxviews", &extfvk);
 
     // Create a database
-    let mut s = crate::storage::Storage::new();
+    let mut s = crate::storage::Storage::new(Config::ephemeral());
 
     // Insert the generated key to the database
     s.add_sapling_key(key_to_be_stored.clone(), None);

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -32,7 +32,8 @@ use zcash_primitives::{
 };
 
 use zebra_chain::{
-    block::Block, chain_tip::ChainTip, serialization::ZcashDeserializeInto, transaction::Hash,
+    block::Block, chain_tip::ChainTip, parameters::Network, serialization::ZcashDeserializeInto,
+    transaction::Hash,
 };
 
 use crate::{

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -180,7 +180,7 @@ fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
         zcash_client_backend::encoding::encode_extended_full_viewing_key("zxviews", &extfvk);
 
     // Create a database
-    let mut s = crate::storage::Storage::new(&Config::ephemeral());
+    let mut s = crate::storage::Storage::new(&Config::ephemeral(), Network::Mainnet);
 
     // Insert the generated key to the database
     s.add_sapling_key(key_to_be_stored.clone(), None);

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -162,7 +162,7 @@ impl Config {
         version_path
     }
 
-    /// Construct a config for an ephemeral database
+    /// Returns a config for a temporary database that is deleted when it is dropped.
     pub fn ephemeral() -> Config {
         Config {
             ephemeral: true,

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// Configuration for the state service.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
     /// The root directory for storing cached block data.

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -132,8 +132,12 @@ impl ZebraDb {
 
     /// Launch any required format changes or format checks, and store their thread handle.
     pub fn spawn_format_change(&mut self, format_change: DbFormatChange) {
-        // Always do format upgrades & checks in production code.
-        if cfg!(test) && self.debug_skip_format_upgrades {
+        // Always do format upgrades in production, but allow them to be skipped by the scanner
+        // (because it doesn't support them yet).
+        //
+        // TODO: Make scanner support format upgrades, then remove `shielded-scan` here.
+        let can_skip_format_upgrades = cfg!(test) || cfg!(feature = "shielded-scan");
+        if can_skip_format_upgrades && self.debug_skip_format_upgrades {
             return;
         }
 

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -292,7 +292,7 @@ impl StartCmd {
         // Spawn never ending scan task.
         let scan_task_handle = {
             info!("spawning shielded scanner with configured viewing keys");
-            zebra_scan::init(&config.shielded_scan, state)
+            zebra_scan::init(&config.shielded_scan, config.network.network, state)
         };
 
         #[cfg(not(feature = "zebra-scan"))]

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -291,12 +291,9 @@ impl StartCmd {
         #[cfg(feature = "zebra-scan")]
         // Spawn never ending scan task.
         let scan_task_handle = {
+            // TODO: move this into a zebra_scan::init() method
             info!("spawning zebra_scanner");
-            let mut storage = zebra_scan::storage::Storage::new();
-            for (key, birthday) in config.shielded_scan.sapling_keys_to_scan.iter() {
-                storage.add_sapling_key(key.clone(), Some(zebra_chain::block::Height(*birthday)));
-            }
-
+            let storage = zebra_scan::storage::Storage::new(&config.shielded_scan);
             tokio::spawn(zebra_scan::scan::start(state, storage).in_current_span())
         };
         #[cfg(not(feature = "zebra-scan"))]

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -291,11 +291,10 @@ impl StartCmd {
         #[cfg(feature = "zebra-scan")]
         // Spawn never ending scan task.
         let scan_task_handle = {
-            // TODO: move this into a zebra_scan::init() method
-            info!("spawning zebra_scanner");
-            let storage = zebra_scan::storage::Storage::new(&config.shielded_scan);
-            tokio::spawn(zebra_scan::scan::start(state, storage).in_current_span())
+            info!("spawning shielded scanner with configured viewing keys");
+            zebra_scan::init(&config.shielded_scan, state)
         };
+
         #[cfg(not(feature = "zebra-scan"))]
         // Spawn a dummy scan task which doesn't do anything and never finishes.
         let scan_task_handle: tokio::task::JoinHandle<Result<(), Report>> =

--- a/zebrad/src/components/mempool/config.rs
+++ b/zebrad/src/components/mempool/config.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 /// Mempool configuration section.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
     /// The mempool transaction cost limit.

--- a/zebrad/src/components/metrics.rs
+++ b/zebrad/src/components/metrics.rs
@@ -59,7 +59,7 @@ impl MetricsEndpoint {
 }
 
 /// Metrics configuration section.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
     /// The address used for the Prometheus metrics endpoint.

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -220,7 +220,7 @@ const SYNC_RESTART_DELAY: Duration = Duration::from_secs(67);
 const GENESIS_TIMEOUT_RETRY: Duration = Duration::from_secs(10);
 
 /// Sync configuration section.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
     /// The number of parallel block download requests.

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 /// The `zebrad` config is a TOML-encoded version of this structure. The meaning
 /// of each field is described in the documentation, although it may be necessary
 /// to click through to the sub-structures for each section.
-#[derive(Clone, Default, Debug, Deserialize, Serialize)]
+#[derive(Clone, Default, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct ZebradConfig {
     /// Consensus configuration


### PR DESCRIPTION
## Motivation

This does the database creation and column family parts of #8019, but doesn't actually use the database.

There's still the actual data part of that ticket left for the next PR, and testing.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

### Complex Code or Requirements

This seems to just work as expected.

## Solution

- Create an on-disk database in the scanner storage (but don't use it yet)
- Create a column family
- Use ephemeral storage in tests

Related changes:
- Move populating storage into the `new()` method
- Add a `zebra_scan::init()` method

Related fixes:
- Fix a bug in the state where format tests weren't being skipped on shutdown even if the database was configured to skip them

### Testing

The existing tests found one bug already, we'll add more in the next few PRs.

## Review

This seemed like enough code to review for now. It's not urgent but it is on the critical path to completing the scanner MVP.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

The rest of #8019:
- Define key and result serialization
- Put the keys in the database
- Put the results in the database
- Document the database format