### PR TITLE
change(scan): Use the on-disk database for keys and results

### DIFF
--- a/zebra-scan/src/lib.rs
+++ b/zebra-scan/src/lib.rs
@@ -13,4 +13,4 @@ pub mod storage;
 mod tests;
 
 pub use config::Config;
-pub use init::init;
+pub use init::{init, spawn_init};

--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -58,7 +58,7 @@ pub async fn start(mut state: State, storage: Storage) -> Result<(), Report> {
         };
 
         // Read keys from the storage
-        let available_keys = storage.get_sapling_keys();
+        let available_keys = storage.sapling_keys();
 
         for key in available_keys {
             info!(

--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -32,7 +32,7 @@ pub type State = Buffer<
 const INITIAL_WAIT: Duration = Duration::from_secs(10);
 
 /// The amount of time between checking and starting new scans.
-const CHECK_INTERVAL: Duration = Duration::from_secs(10);
+const CHECK_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Start the scan task given state and storage.
 ///

--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -16,7 +16,8 @@ use zcash_client_backend::{
 use zcash_primitives::zip32::AccountId;
 
 use zebra_chain::{
-    block::Block, parameters::Network, serialization::ZcashSerialize, transaction::Transaction,
+    block::Block, diagnostic::task::WaitForPanics, parameters::Network,
+    serialization::ZcashSerialize, transaction::Transaction,
 };
 
 use crate::storage::Storage;
@@ -57,13 +58,16 @@ pub async fn start(mut state: State, storage: Storage) -> Result<(), Report> {
             _ => unreachable!("unmatched response to a state::Tip request"),
         };
 
-        // Read keys from the storage
-        let available_keys = storage.sapling_keys();
+        // Read keys from the storage on disk, which can block.
+        let key_storage = storage.clone();
+        let available_keys = tokio::task::spawn_blocking(move || key_storage.sapling_keys())
+            .wait_for_panics()
+            .await;
 
         for key in available_keys {
             info!(
-                "Scanning the blockchain for key {} from block 1 to {:?}",
-                key.0, tip,
+                "Scanning the blockchain for key {} from block {:?} to {:?}",
+                key.0, key.1, tip,
             );
         }
 
@@ -72,6 +76,11 @@ pub async fn start(mut state: State, storage: Storage) -> Result<(), Report> {
 }
 
 /// Returns transactions belonging to the given `ScanningKey`.
+///
+/// # Performance / Hangs
+///
+/// This method can block while reading database files, so it must be inside spawn_blocking()
+/// in async code.
 ///
 /// TODO:
 /// - Remove the `sapling_tree_size` parameter or turn it into an `Option` once we have access to

--- a/zebra-scan/src/storage.rs
+++ b/zebra-scan/src/storage.rs
@@ -100,7 +100,10 @@ impl Storage {
     ///
     /// Birthdays are adjusted to sapling activation if they are too low or missing.
     ///
-    /// TODO: this method reads database files, so it should be in spawn_blocking() in async code.
+    /// # Performance / Hangs
+    ///
+    /// This method can block while reading database files, so it must be inside spawn_blocking()
+    /// in async code.
     pub fn sapling_keys(&self) -> HashMap<SaplingScanningKey, Height> {
         self.sapling_keys_and_birthday_heights()
     }

--- a/zebra-scan/src/storage.rs
+++ b/zebra-scan/src/storage.rs
@@ -10,7 +10,8 @@ use crate::config::Config;
 
 pub mod db;
 
-pub use db::{SaplingScanningKey, SaplingScannedResult};
+// Public types and APIs
+pub use db::{SaplingScannedResult, SaplingScanningKey};
 
 /// Store key info and results of the scan.
 ///

--- a/zebra-scan/src/storage.rs
+++ b/zebra-scan/src/storage.rs
@@ -4,15 +4,13 @@
 
 use std::collections::HashMap;
 
-use zebra_chain::{block::Height, parameters::Network, transaction::Hash};
+use zebra_chain::{block::Height, parameters::Network};
 
 use crate::config::Config;
 
 pub mod db;
 
-/// The type used in Zebra to store Sapling scanning keys.
-/// It can represent a full viewing key or an individual viewing key.
-pub type SaplingScanningKey = String;
+pub use db::{SaplingScanningKey, SaplingScannedResult};
 
 /// Store key info and results of the scan.
 ///
@@ -46,7 +44,7 @@ pub struct Storage {
     sapling_keys: HashMap<SaplingScanningKey, Option<Height>>,
 
     /// The sapling key and the related transaction id.
-    sapling_results: HashMap<SaplingScanningKey, Vec<Hash>>,
+    sapling_results: HashMap<SaplingScanningKey, Vec<SaplingScannedResult>>,
 }
 
 impl Storage {
@@ -74,7 +72,7 @@ impl Storage {
     }
 
     /// Add a sapling result to the storage.
-    pub fn add_sapling_result(&mut self, key: SaplingScanningKey, txid: Hash) {
+    pub fn add_sapling_result(&mut self, key: SaplingScanningKey, txid: SaplingScannedResult) {
         if let Some(results) = self.sapling_results.get_mut(&key) {
             results.push(txid);
         } else {
@@ -82,19 +80,19 @@ impl Storage {
         }
     }
 
-    /// Get the results of a sapling key.
+    /// Returns all the results for a sapling key, for every scanned block height.
     //
     // TODO: Rust style - remove "get_" from these names
-    pub fn get_sapling_results(&self, key: &str) -> Vec<Hash> {
+    pub fn get_sapling_results(&self, key: &str) -> Vec<SaplingScannedResult> {
         self.sapling_results.get(key).cloned().unwrap_or_default()
     }
 
-    /// Get all keys and their birthdays.
+    /// Returns all the keys and their birthdays.
     //
     // TODO: any value below sapling activation as the birthday height, or `None`, should default
     // to sapling activation. This requires the configured network.
     // Return Height not Option<Height>.
-    pub fn get_sapling_keys(&self) -> HashMap<String, Option<Height>> {
+    pub fn get_sapling_keys(&self) -> HashMap<SaplingScanningKey, Option<Height>> {
         self.sapling_keys.clone()
     }
 }

--- a/zebra-scan/src/storage/db.rs
+++ b/zebra-scan/src/storage/db.rs
@@ -5,13 +5,19 @@ use std::{collections::HashMap, path::Path};
 use semver::Version;
 
 use zebra_chain::parameters::Network;
+use zebra_state::ReadDisk;
 
 use crate::Config;
 
 use super::Storage;
 
 // Public types and APIs
-pub use zebra_state::{SaplingScanningKey, SaplingScannedResult, ZebraDb as ScannerDb};
+pub use zebra_state::{
+    SaplingScannedDatabaseEntry, SaplingScannedDatabaseIndex, SaplingScannedResult,
+    SaplingScanningKey, ZebraDb as ScannerDb,
+};
+
+pub mod sapling;
 
 /// The directory name used to distinguish the scanner database from Zebra's other databases or
 /// flat files.
@@ -24,12 +30,14 @@ pub const SCANNER_DATABASE_KIND: &str = "private-scan";
 /// Existing column families that aren't listed here are preserved when the database is opened.
 pub const SCANNER_COLUMN_FAMILIES_IN_CODE: &[&str] = &[
     // Sapling
-    "sapling_tx_ids",
+    sapling::SAPLING_TX_IDS,
     // Orchard
-    // TODO
+    // TODO: add Orchard support
 ];
 
 impl Storage {
+    // Creation
+
     /// Opens and returns an on-disk scanner results database instance for `config` and `network`.
     /// If there is no existing database, creates a new database on disk.
     ///
@@ -76,11 +84,7 @@ impl Storage {
         new_storage
     }
 
-    /// The database format version in the running scanner code.
-    pub fn database_format_version_in_code() -> Version {
-        // TODO: implement scanner database versioning
-        Version::new(0, 0, 0)
-    }
+    // Config
 
     /// Returns the configured network for this database.
     pub fn network(&self) -> Network {
@@ -92,6 +96,14 @@ impl Storage {
         self.db.path()
     }
 
+    // Versioning & Upgrades
+
+    /// The database format version in the running scanner code.
+    pub fn database_format_version_in_code() -> Version {
+        // TODO: implement scanner database versioning
+        Version::new(0, 0, 0)
+    }
+
     /// Check for panics in code running in spawned threads.
     /// If a thread exited with a panic, resume that panic.
     ///
@@ -100,5 +112,13 @@ impl Storage {
     // TODO: when we implement format changes, call this method regularly
     pub fn check_for_panics(&mut self) {
         self.db.check_for_panics()
+    }
+
+    // General database status
+
+    /// Returns true if the database is empty.
+    pub fn is_empty(&self) -> bool {
+        // Any column family that is populated at (or near) startup can be used here.
+        self.db.zs_is_empty(&self.sapling_tx_ids_cf())
     }
 }

--- a/zebra-scan/src/storage/db.rs
+++ b/zebra-scan/src/storage/db.rs
@@ -74,7 +74,6 @@ impl Storage {
 
         let new_storage = Self {
             db,
-            sapling_keys: HashMap::new(),
             sapling_results: HashMap::new(),
         };
 

--- a/zebra-scan/src/storage/db.rs
+++ b/zebra-scan/src/storage/db.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, path::Path};
 use semver::Version;
 
 use zebra_chain::parameters::Network;
-use zebra_state::ReadDisk;
+use zebra_state::{DiskWriteBatch, ReadDisk};
 
 use crate::Config;
 
@@ -120,5 +120,27 @@ impl Storage {
     pub fn is_empty(&self) -> bool {
         // Any column family that is populated at (or near) startup can be used here.
         self.db.zs_is_empty(&self.sapling_tx_ids_cf())
+    }
+}
+
+// General writing
+
+/// Wrapper type for scanner database writes.
+#[must_use = "batches must be written to the database"]
+#[derive(Default)]
+pub struct ScannerWriteBatch(pub DiskWriteBatch);
+
+// Redirect method calls to DiskWriteBatch for convenience.
+impl std::ops::Deref for ScannerWriteBatch {
+    type Target = DiskWriteBatch;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ScannerWriteBatch {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }

--- a/zebra-scan/src/storage/db.rs
+++ b/zebra-scan/src/storage/db.rs
@@ -1,6 +1,6 @@
 //! Persistent storage for scanner results.
 
-use std::{collections::HashMap, path::Path};
+use std::path::Path;
 
 use semver::Version;
 
@@ -72,10 +72,7 @@ impl Storage {
                 .map(ToString::to_string),
         );
 
-        let new_storage = Self {
-            db,
-            sapling_results: HashMap::new(),
-        };
+        let new_storage = Self { db };
 
         // TODO: report the last scanned height here?
         tracing::info!("loaded Zebra scanner cache");

--- a/zebra-scan/src/storage/db.rs
+++ b/zebra-scan/src/storage/db.rs
@@ -11,7 +11,7 @@ use crate::Config;
 use super::Storage;
 
 // Public types and APIs
-pub use zebra_state::ZebraDb as ScannerDb;
+pub use zebra_state::{SaplingScanningKey, SaplingScannedResult, ZebraDb as ScannerDb};
 
 /// The directory name used to distinguish the scanner database from Zebra's other databases or
 /// flat files.

--- a/zebra-scan/src/storage/db/sapling.rs
+++ b/zebra-scan/src/storage/db/sapling.rs
@@ -1,6 +1,18 @@
 //! Sapling-specific database reading and writing.
+//!
+//! The sapling scanner database has the following format:
+//!
+//! | name             | key                           | value                    |
+//! |------------------|-------------------------------|--------------------------|
+//! | `sapling_tx_ids` | `SaplingScannedDatabaseIndex` | `Vec<transaction::Hash>` |
+//!
+//! And types:
+//! SaplingScannedDatabaseIndex = `SaplingScanningKey` | `Height`
+//!
+//! This format allows us to efficiently find all the results for each key, and the latest height
+//! for each key.
 
-use zebra_state::AsColumnFamilyRef;
+use zebra_state::{AsColumnFamilyRef, ReadDisk, SaplingScannedDatabaseIndex, SaplingScannedResult};
 
 use crate::storage::Storage;
 
@@ -10,8 +22,19 @@ use crate::storage::Storage;
 pub const SAPLING_TX_IDS: &str = "sapling_tx_ids";
 
 impl Storage {
+    // Reading Sapling database entries
+
+    /// Returns the results for a specific key and block height.
+    pub fn sapling_tx_ids(&self, index: &SaplingScannedDatabaseIndex) -> Vec<SaplingScannedResult> {
+        self.db
+            .zs_get(&self.sapling_tx_ids_cf(), &index)
+            .unwrap_or_default()
+    }
+
+    // Column family convenience methods
+
     /// Returns a handle to the `sapling_tx_ids` column family.
-    pub fn sapling_tx_ids_cf(&self) -> impl AsColumnFamilyRef + '_ {
+    pub(crate) fn sapling_tx_ids_cf(&self) -> impl AsColumnFamilyRef + '_ {
         self.db.cf_handle(SAPLING_TX_IDS).unwrap()
     }
 }

--- a/zebra-scan/src/storage/db/sapling.rs
+++ b/zebra-scan/src/storage/db/sapling.rs
@@ -11,10 +11,15 @@
 //!
 //! This format allows us to efficiently find all the results for each key, and the latest height
 //! for each key.
+//!
+//! If there are no results for a height, we store an empty list of results. This allows is to scan
+//! each key from the next height after we restart. We also use this mechanism to store key
+//! birthday heights, by storing the height before the birthday as the "last scanned" block.
 
+use zebra_chain::block::Height;
 use zebra_state::{
     AsColumnFamilyRef, ReadDisk, SaplingScannedDatabaseEntry, SaplingScannedDatabaseIndex,
-    SaplingScannedResult, WriteDisk,
+    SaplingScannedResult, SaplingScanningKey, WriteDisk,
 };
 
 use crate::storage::Storage;
@@ -45,6 +50,16 @@ impl Storage {
     pub(crate) fn sapling_tx_ids_cf(&self) -> impl AsColumnFamilyRef + '_ {
         self.db.cf_handle(SAPLING_TX_IDS).unwrap()
     }
+
+    // Writing batches
+
+    /// Write `batch` to the database for this storage.
+    pub(crate) fn write_batch(&self, batch: ScannerWriteBatch) {
+        // Just panic on errors for now
+        self.db
+            .write_batch(batch.0)
+            .expect("unexpected database error")
+    }
 }
 
 // Writing database entries
@@ -60,5 +75,29 @@ impl ScannerWriteBatch {
         entry: SaplingScannedDatabaseEntry,
     ) {
         self.zs_insert(&storage.sapling_tx_ids_cf(), entry.index, entry.value);
+    }
+
+    /// Insert a sapling scanning `key`, and mark all heights before `birthday_height` so they
+    /// won't be scanned.
+    ///
+    /// If a result already exists for the height before the birthday, it is replaced with an empty
+    /// result.
+    pub(crate) fn insert_sapling_key(
+        &mut self,
+        storage: &Storage,
+        sapling_key: SaplingScanningKey,
+        birthday_height: Option<Height>,
+    ) {
+        let min_birthday_height = storage.min_sapling_birthday_height();
+        let birthday_height = birthday_height
+            .unwrap_or(min_birthday_height)
+            .max(min_birthday_height);
+
+        let index = SaplingScannedDatabaseIndex {
+            sapling_key,
+            height: birthday_height,
+        };
+
+        self.zs_insert(&storage.sapling_tx_ids_cf(), index, Vec::new());
     }
 }

--- a/zebra-scan/src/storage/db/sapling.rs
+++ b/zebra-scan/src/storage/db/sapling.rs
@@ -12,9 +12,14 @@
 //! This format allows us to efficiently find all the results for each key, and the latest height
 //! for each key.
 
-use zebra_state::{AsColumnFamilyRef, ReadDisk, SaplingScannedDatabaseIndex, SaplingScannedResult};
+use zebra_state::{
+    AsColumnFamilyRef, ReadDisk, SaplingScannedDatabaseEntry, SaplingScannedDatabaseIndex,
+    SaplingScannedResult, WriteDisk,
+};
 
 use crate::storage::Storage;
+
+use super::ScannerWriteBatch;
 
 /// The name of the sapling transaction IDs result column family.
 ///
@@ -36,5 +41,21 @@ impl Storage {
     /// Returns a handle to the `sapling_tx_ids` column family.
     pub(crate) fn sapling_tx_ids_cf(&self) -> impl AsColumnFamilyRef + '_ {
         self.db.cf_handle(SAPLING_TX_IDS).unwrap()
+    }
+}
+
+// Writing database entries
+//
+// TODO: split the write type into state and scanner, so we can't call state write methods on
+// scanner databases
+impl ScannerWriteBatch {
+    /// Inserts a scanned sapling result for a key and height.
+    /// If a result already exists for that key and height, it is replaced.
+    pub(crate) fn insert_sapling_result(
+        &mut self,
+        storage: &Storage,
+        entry: SaplingScannedDatabaseEntry,
+    ) {
+        self.zs_insert(&storage.sapling_tx_ids_cf(), entry.index, entry.value);
     }
 }

--- a/zebra-scan/src/storage/db/sapling.rs
+++ b/zebra-scan/src/storage/db/sapling.rs
@@ -37,6 +37,8 @@ impl Storage {
     // Reading Sapling database entries
 
     /// Returns the results for a specific key and block height.
+    //
+    // TODO: add tests for this method
     pub fn sapling_result_for_key_and_block(
         &self,
         index: &SaplingScannedDatabaseIndex,

--- a/zebra-scan/src/storage/db/sapling.rs
+++ b/zebra-scan/src/storage/db/sapling.rs
@@ -113,7 +113,9 @@ impl Storage {
 
     /// Returns a handle to the `sapling_tx_ids` column family.
     pub(crate) fn sapling_tx_ids_cf(&self) -> impl AsColumnFamilyRef + '_ {
-        self.db.cf_handle(SAPLING_TX_IDS).unwrap()
+        self.db
+            .cf_handle(SAPLING_TX_IDS)
+            .expect("column family was created when database was created")
     }
 
     // Writing batches

--- a/zebra-scan/src/storage/db/sapling.rs
+++ b/zebra-scan/src/storage/db/sapling.rs
@@ -30,7 +30,10 @@ impl Storage {
     // Reading Sapling database entries
 
     /// Returns the results for a specific key and block height.
-    pub fn sapling_tx_ids(&self, index: &SaplingScannedDatabaseIndex) -> Vec<SaplingScannedResult> {
+    pub fn sapling_result_for_key_and_block(
+        &self,
+        index: &SaplingScannedDatabaseIndex,
+    ) -> Vec<SaplingScannedResult> {
         self.db
             .zs_get(&self.sapling_tx_ids_cf(), &index)
             .unwrap_or_default()

--- a/zebra-scan/src/storage/db/sapling.rs
+++ b/zebra-scan/src/storage/db/sapling.rs
@@ -1,0 +1,17 @@
+//! Sapling-specific database reading and writing.
+
+use zebra_state::AsColumnFamilyRef;
+
+use crate::storage::Storage;
+
+/// The name of the sapling transaction IDs result column family.
+///
+/// This constant should be used so the compiler can detect typos.
+pub const SAPLING_TX_IDS: &str = "sapling_tx_ids";
+
+impl Storage {
+    /// Returns a handle to the `sapling_tx_ids` column family.
+    pub fn sapling_tx_ids_cf(&self) -> impl AsColumnFamilyRef + '_ {
+        self.db.cf_handle(SAPLING_TX_IDS).unwrap()
+    }
+}

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -32,7 +32,10 @@ use zcash_primitives::{
 };
 
 use zebra_chain::{
-    block::Block, chain_tip::ChainTip, parameters::Network, serialization::ZcashDeserializeInto,
+    block::{Block, Height},
+    chain_tip::ChainTip,
+    parameters::Network,
+    serialization::ZcashDeserializeInto,
     transaction::Hash,
 };
 
@@ -222,12 +225,16 @@ fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
     let found_transaction_hash = Hash::from_bytes_in_display_order(found_transaction);
 
     // Add result to database
-    s.add_sapling_result(key_to_be_stored.clone(), found_transaction_hash);
+    s.add_sapling_result(
+        key_to_be_stored.clone(),
+        Height(1),
+        vec![found_transaction_hash],
+    );
 
     // Check the result was added
     assert_eq!(
-        s.get_sapling_results(key_to_be_stored.as_str())[0],
-        found_transaction_hash
+        s.sapling_results(&key_to_be_stored).get(&Height(1)),
+        Some(&vec![found_transaction_hash])
     );
 
     Ok(())

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -187,8 +187,11 @@ fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
     s.add_sapling_key(key_to_be_stored.clone(), None);
 
     // Check key was added
-    assert_eq!(s.get_sapling_keys().len(), 1);
-    assert_eq!(s.get_sapling_keys().get(&key_to_be_stored), Some(&None));
+    assert_eq!(s.sapling_keys().len(), 1);
+    assert_eq!(
+        s.sapling_keys().get(&key_to_be_stored),
+        Some(&s.min_sapling_birthday_height())
+    );
 
     let vks: Vec<(&AccountId, &SaplingIvk)> = vec![];
     let nf = Nullifier([7; 32]);

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -60,7 +60,7 @@ pub use service::{
 };
 
 #[cfg(feature = "shielded-scan")]
-pub use service::finalized_state::{ReadDisk, ZebraDb};
+pub use service::finalized_state::{FromDisk, IntoDisk, ReadDisk, ZebraDb};
 
 #[cfg(any(test, feature = "proptest-impl", feature = "shielded-scan"))]
 pub use service::finalized_state::{DiskWriteBatch, WriteDisk};

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -60,6 +60,8 @@ pub use service::{
 };
 
 #[cfg(feature = "shielded-scan")]
+pub use rocksdb::AsColumnFamilyRef;
+#[cfg(feature = "shielded-scan")]
 pub use service::finalized_state::{
     FromDisk, IntoDisk, ReadDisk, SaplingScannedDatabaseEntry, SaplingScannedDatabaseIndex,
     SaplingScannedResult, SaplingScanningKey, ZebraDb,

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -61,7 +61,8 @@ pub use service::{
 
 #[cfg(feature = "shielded-scan")]
 pub use service::finalized_state::{
-    FromDisk, IntoDisk, ReadDisk, SaplingScanningKey, SaplingScannedResult, ZebraDb,
+    FromDisk, IntoDisk, ReadDisk, SaplingScannedDatabaseEntry, SaplingScannedDatabaseIndex,
+    SaplingScannedResult, SaplingScanningKey, ZebraDb,
 };
 
 #[cfg(any(test, feature = "proptest-impl", feature = "shielded-scan"))]

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -60,7 +60,9 @@ pub use service::{
 };
 
 #[cfg(feature = "shielded-scan")]
-pub use service::finalized_state::{FromDisk, IntoDisk, ReadDisk, ZebraDb};
+pub use service::finalized_state::{
+    FromDisk, IntoDisk, ReadDisk, SaplingScanningKey, SaplingScannedResult, ZebraDb,
+};
 
 #[cfg(any(test, feature = "proptest-impl", feature = "shielded-scan"))]
 pub use service::finalized_state::{DiskWriteBatch, WriteDisk};

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -47,7 +47,10 @@ pub use disk_format::{
 pub use zebra_db::ZebraDb;
 
 #[cfg(feature = "shielded-scan")]
-pub use disk_format::{SaplingScanningKey, SaplingScannedResult};
+pub use disk_format::{
+    SaplingScannedDatabaseEntry, SaplingScannedDatabaseIndex, SaplingScannedResult,
+    SaplingScanningKey,
+};
 
 /// The column families supported by the running `zebra-state` database code.
 ///

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -46,6 +46,9 @@ pub use disk_format::{
 };
 pub use zebra_db::ZebraDb;
 
+#[cfg(feature = "shielded-scan")]
+pub use disk_format::{SaplingScanningKey, SaplingScannedResult};
+
 /// The column families supported by the running `zebra-state` database code.
 ///
 /// Existing column families that aren't listed here are preserved when the database is opened.

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -39,15 +39,12 @@ mod arbitrary;
 mod tests;
 
 #[allow(unused_imports)]
-pub use disk_db::{DiskDb, DiskWriteBatch, WriteDisk};
-pub use disk_format::{OutputIndex, OutputLocation, TransactionLocation};
+pub use disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk};
+#[allow(unused_imports)]
+pub use disk_format::{
+    FromDisk, IntoDisk, OutputIndex, OutputLocation, TransactionLocation, MAX_ON_DISK_HEIGHT,
+};
 pub use zebra_db::ZebraDb;
-
-#[cfg(feature = "shielded-scan")]
-pub use disk_db::ReadDisk;
-
-#[cfg(any(test, feature = "proptest-impl"))]
-pub use disk_format::MAX_ON_DISK_HEIGHT;
 
 /// The column families supported by the running `zebra-state` database code.
 ///

--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -23,7 +23,10 @@ pub use block::{TransactionLocation, MAX_ON_DISK_HEIGHT};
 pub use transparent::{OutputIndex, OutputLocation};
 
 #[cfg(feature = "shielded-scan")]
-pub use scan::{SaplingScanningKey, SaplingScannedResult};
+pub use scan::{
+    SaplingScannedDatabaseEntry, SaplingScannedDatabaseIndex, SaplingScannedResult,
+    SaplingScanningKey,
+};
 
 /// Helper type for writing types to disk as raw bytes.
 /// Also used to convert key types to raw bytes for disk lookups.

--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -13,6 +13,9 @@ pub mod shielded;
 pub mod transparent;
 pub mod upgrade;
 
+#[cfg(feature = "shielded-scan")]
+pub mod scan;
+
 #[cfg(test)]
 mod tests;
 

--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -22,6 +22,9 @@ mod tests;
 pub use block::{TransactionLocation, MAX_ON_DISK_HEIGHT};
 pub use transparent::{OutputIndex, OutputLocation};
 
+#[cfg(feature = "shielded-scan")]
+pub use scan::{SaplingScanningKey, SaplingScannedResult};
+
 /// Helper type for writing types to disk as raw bytes.
 /// Also used to convert key types to raw bytes for disk lookups.
 pub trait IntoDisk {

--- a/zebra-state/src/service/finalized_state/disk_format/scan.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/scan.rs
@@ -36,11 +36,11 @@ pub struct SaplingScannedDatabaseEntry {
     pub index: SaplingScannedDatabaseIndex,
 
     /// The database column family value.
-    pub value: SaplingScannedResult,
+    pub value: Vec<SaplingScannedResult>,
 }
 
 /// A database column family key for a block scanned with a Sapling vieweing key.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SaplingScannedDatabaseIndex {
     /// The Sapling viewing key used to scan the block.
     pub sapling_key: SaplingScanningKey,
@@ -56,8 +56,28 @@ impl SaplingScannedDatabaseIndex {
         Self {
             // The empty string is the minimum value in RocksDB lexicographic order.
             sapling_key: String::new(),
-            // Genesis is the minimum height.
+            // Genesis is the minimum height, and never has valid shielded transfers.
             height: Height(0),
+        }
+    }
+
+    /// The minimum value of a sapling scanned database index for `sapling_key`.
+    /// This value is guarateed to be the minimum, and not correspond to a valid entry.
+    pub fn min_for_key(sapling_key: &SaplingScanningKey) -> Self {
+        Self {
+            sapling_key: sapling_key.clone(),
+            // Genesis is the minimum height, and never has valid shielded transfers.
+            height: Height(0),
+        }
+    }
+
+    /// The maximum value of a sapling scanned database index for `sapling_key`.
+    /// This value is guarateed to be the maximum, and not correspond to a valid entry.
+    pub fn max_for_key(sapling_key: &SaplingScanningKey) -> Self {
+        Self {
+            sapling_key: sapling_key.clone(),
+            // The maximum height will never be mined - we'll increase it before that happens.
+            height: Height::MAX,
         }
     }
 }

--- a/zebra-state/src/service/finalized_state/disk_format/scan.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/scan.rs
@@ -1,0 +1,32 @@
+//! Serialization formats for the shielded scanner results database.
+//!
+//! Due to Rust's orphan rule, these serializations must be implemented in this crate.
+//!
+//! # Correctness
+//!
+//! Once format versions are implemented for the scanner database,
+//! `zebra_scan::Storage::database_format_version_in_code()` must be incremented
+//! each time the database format (column, serialization, etc) changes.
+
+use crate::{FromDisk, IntoDisk};
+
+/// The type used in Zebra to store Sapling scanning keys.
+/// It can represent a full viewing key or an individual viewing key.
+///
+/// This must be the same type as `zebra_scan::storage::SaplingScanningKey`.
+pub type SaplingScanningKey = String;
+
+impl IntoDisk for SaplingScanningKey {
+    type Bytes = Vec<u8>;
+
+    fn as_bytes(&self) -> Self::Bytes {
+        self.as_bytes().to_vec()
+    }
+}
+
+impl FromDisk for SaplingScanningKey {
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
+        SaplingScanningKey::from_utf8(bytes.as_ref().to_vec())
+            .expect("only valid UTF-8 strings are committed to the database")
+    }
+}

--- a/zebra-state/src/service/finalized_state/disk_format/scan.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/scan.rs
@@ -14,6 +14,14 @@ use crate::{FromDisk, IntoDisk};
 
 use super::block::HEIGHT_DISK_BYTES;
 
+/// The fixed length of the scanning result.
+///
+/// TODO: If the scanning result doesn't have a fixed length, either:
+/// - deserialize using internal length or end markers,
+/// - prefix it with a length, or
+/// - stop storing vectors of results on disk, instead store each result with a unique key.
+pub const SAPLING_SCANNING_RESULT_LENGTH: usize = 32;
+
 /// The type used in Zebra to store Sapling scanning keys.
 /// It can represent a full viewing key or an individual viewing key.
 pub type SaplingScanningKey = String;
@@ -41,13 +49,18 @@ pub struct SaplingScannedDatabaseIndex {
     pub height: Height,
 }
 
-/// The fixed length of the scanning result.
-///
-/// TODO: If the scanning result doesn't have a fixed length, either:
-/// - deserialize using internal length or end markers,
-/// - prefix it with a length, or
-/// - stop storing vectors of results on disk, instead store each result with a unique key.
-pub const SAPLING_SCANNING_RESULT_LENGTH: usize = 32;
+impl SaplingScannedDatabaseIndex {
+    /// The minimum value of a sapling scanned database index.
+    /// This value is guarateed to be the minimum, and not correspond to a valid key.
+    pub const fn min() -> Self {
+        Self {
+            // The empty string is the minimum value in RocksDB lexicographic order.
+            sapling_key: String::new(),
+            // Genesis is the minimum height.
+            height: Height(0),
+        }
+    }
+}
 
 impl IntoDisk for SaplingScanningKey {
     type Bytes = Vec<u8>;

--- a/zebra-state/src/service/finalized_state/disk_format/scan.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/scan.rs
@@ -8,25 +8,56 @@
 //! `zebra_scan::Storage::database_format_version_in_code()` must be incremented
 //! each time the database format (column, serialization, etc) changes.
 
+use zebra_chain::transaction;
+
 use crate::{FromDisk, IntoDisk};
 
 /// The type used in Zebra to store Sapling scanning keys.
 /// It can represent a full viewing key or an individual viewing key.
-///
-/// This must be the same type as `zebra_scan::storage::SaplingScanningKey`.
 pub type SaplingScanningKey = String;
+
+/// The type used in Zebra to store Sapling scanning results.
+pub type SaplingScannedResult = transaction::Hash;
+
+/// The fixed length of the scanning result.
+///
+/// TODO: If the scanning result doesn't have a fixed length, either:
+/// - deserialize using internal length or end markers,
+/// - prefix it with a length, or
+/// - stop storing vectors of results on disk, instead store each result with a unique key.
+pub const SAPLING_SCANNING_RESULT_LENGTH: usize = 32;
 
 impl IntoDisk for SaplingScanningKey {
     type Bytes = Vec<u8>;
 
     fn as_bytes(&self) -> Self::Bytes {
-        self.as_bytes().to_vec()
+        SaplingScanningKey::as_bytes(self).to_vec()
     }
 }
 
 impl FromDisk for SaplingScanningKey {
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
         SaplingScanningKey::from_utf8(bytes.as_ref().to_vec())
-            .expect("only valid UTF-8 strings are committed to the database")
+            .expect("only valid UTF-8 strings are written to the database")
+    }
+}
+
+impl IntoDisk for Vec<SaplingScannedResult> {
+    type Bytes = Vec<u8>;
+
+    fn as_bytes(&self) -> Self::Bytes {
+        self.iter()
+            .flat_map(SaplingScannedResult::as_bytes)
+            .collect()
+    }
+}
+
+impl FromDisk for Vec<SaplingScannedResult> {
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
+        bytes
+            .as_ref()
+            .chunks(SAPLING_SCANNING_RESULT_LENGTH)
+            .map(SaplingScannedResult::from_bytes)
+            .collect()
     }
 }

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -35,7 +35,8 @@ pub mod metrics;
 pub mod shielded;
 pub mod transparent;
 
-#[cfg(any(test, feature = "proptest-impl"))]
+#[cfg(any(test, feature = "proptest-impl", feature = "shielded-scan"))]
+// TODO: when the database is split out of zebra-state, always expose these methods.
 pub mod arbitrary;
 
 /// Wrapper struct to ensure high-level `zebra-state` database access goes through the correct API.

--- a/zebra-state/src/service/finalized_state/zebra_db/arbitrary.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/arbitrary.rs
@@ -1,5 +1,7 @@
 //! Arbitrary value generation and test harnesses for high-level typed database access.
 
+#![allow(unused_imports)]
+
 use std::ops::Deref;
 
 use zebra_chain::{amount::NonNegative, block::Block, sprout, value_balance::ValueBalance};
@@ -21,13 +23,14 @@ impl Deref for ZebraDb {
 impl ZebraDb {
     /// Returns the inner database.
     ///
-    /// This is a test-only method, because it allows write access
+    /// This is a test-only and shielded-scan-only method, because it allows write access
     /// and raw read access to the RocksDB instance.
     pub fn db(&self) -> &DiskDb {
         &self.db
     }
 
     /// Allow to set up a fake value pool in the database for testing purposes.
+    #[cfg(any(test, feature = "proptest-impl"))]
     pub fn set_finalized_value_pool(&self, fake_value_pool: ValueBalance<NonNegative>) {
         let mut batch = DiskWriteBatch::new();
         let value_pool_cf = self.db().cf_handle("tip_chain_value_pool").unwrap();
@@ -38,6 +41,7 @@ impl ZebraDb {
 
     /// Artificially prime the note commitment tree anchor sets with anchors
     /// referenced in a block, for testing purposes _only_.
+    #[cfg(any(test, feature = "proptest-impl"))]
     pub fn populate_with_anchors(&self, block: &Block) {
         let mut batch = DiskWriteBatch::new();
 

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -402,7 +402,7 @@ impl ZebraDb {
     }
 
     /// Writes the given batch to the database.
-    pub(crate) fn write_batch(&self, batch: DiskWriteBatch) -> Result<(), rocksdb::Error> {
+    pub fn write_batch(&self, batch: DiskWriteBatch) -> Result<(), rocksdb::Error> {
         self.db.write(batch)
     }
 }

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -292,7 +292,7 @@ impl StartCmd {
         // Spawn never ending scan task.
         let scan_task_handle = {
             info!("spawning shielded scanner with configured viewing keys");
-            zebra_scan::init(&config.shielded_scan, config.network.network, state)
+            zebra_scan::spawn_init(&config.shielded_scan, config.network.network, state)
         };
 
         #[cfg(not(feature = "zebra-scan"))]

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2804,7 +2804,7 @@ async fn fully_synced_rpc_z_getsubtreesbyindex_snapshot_test() -> Result<()> {
     Ok(())
 }
 
-/// Test that the scanner gets started when the node starts.
+/// Test that the scanner task gets started when the node starts.
 #[cfg(feature = "zebra-scan")]
 #[test]
 fn scan_task_starts() -> Result<()> {

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2831,10 +2831,10 @@ fn scan_task_starts() -> Result<()> {
     // Check that scan task started and the first scanning is done.
     let output = child.wait_with_output()?;
 
-    output.stdout_line_contains("spawning zebra_scanner")?;
+    output.stdout_line_contains("spawning shielded scanner with configured viewing keys")?;
     output.stdout_line_contains(
         format!(
-            "Scanning the blockchain for key {} from block 1 to",
+            "Scanning the blockchain for key {} from block",
             ZECPAGES_VIEWING_KEY
         )
         .as_str(),


### PR DESCRIPTION
## Motivation

This PR replaces the in-memory database with a database on disk.

Depends-On: #8031 

Close #8019 
The remaining checklist items in that ticket actually belong in other tickets.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

### Specifications

The design is in ticket #8019.

### Complex Code or Requirements

The "get all keys" code is a bit messy, we can fix it up after the MVP when we have a column family just for keys.

## Solution

- Implement database serialization for keys and results
- Add key/birthday read and write methods
- Add scanning result read and write methods
- Spawn blocking database functions on a blocking async task

### Testing

I updated the existing tests, and marked the functions that need tests with a TODO. We can do those tests in the PRs where we actually use those functions, because we might change how those functions work when we start using them.

## Review

This is a routine scanner database change.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

- #8021

And then:
- #8022
- #7813