### PR TITLE
change(scan): Standardise on the `shielded-scan` feature name

### DIFF
--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -288,14 +288,14 @@ impl StartCmd {
         info!("spawning syncer task");
         let syncer_task_handle = tokio::spawn(syncer.sync().in_current_span());
 
-        #[cfg(feature = "zebra-scan")]
+        #[cfg(feature = "shielded-scan")]
         // Spawn never ending scan task.
         let scan_task_handle = {
             info!("spawning shielded scanner with configured viewing keys");
             zebra_scan::spawn_init(&config.shielded_scan, config.network.network, state)
         };
 
-        #[cfg(not(feature = "zebra-scan"))]
+        #[cfg(not(feature = "shielded-scan"))]
         // Spawn a dummy scan task which doesn't do anything and never finishes.
         let scan_task_handle: tokio::task::JoinHandle<Result<(), Report>> =
             tokio::spawn(std::future::pending().in_current_span());

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -44,7 +44,7 @@ pub struct ZebradConfig {
     /// Mining configuration
     pub mining: zebra_rpc::config::mining::Config,
 
-    #[cfg(feature = "zebra-scan")]
+    #[cfg(feature = "shielded-scan")]
     /// Scanner configuration
     pub shielded_scan: zebra_scan::config::Config,
 }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2805,7 +2805,7 @@ async fn fully_synced_rpc_z_getsubtreesbyindex_snapshot_test() -> Result<()> {
 }
 
 /// Test that the scanner task gets started when the node starts.
-#[cfg(feature = "zebra-scan")]
+#[cfg(feature = "shielded-scan")]
 #[test]
 fn scan_task_starts() -> Result<()> {
     use indexmap::IndexMap;


### PR DESCRIPTION
## Motivation

We're using both the `shielded-scan` and `zebra-scan` feature names. Due to some `cargo` automatic feature changes in 2024, we should avoid using feature names that are the same as crates. (They might work differently soon.)

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

### Specifications

https://github.com/rust-lang/cargo/issues/12173

## Solution

Just use the `shielded-scan` feature

### Testing

The existing tests cover this, and using this feature name might activate more tests.

## Review

This is a routine cleanup.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

