### PR TITLE
Scan blocks with sapling keys and write the results to the database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5802,6 +5802,7 @@ dependencies = [
  "ff",
  "group",
  "indexmap 2.1.0",
+ "itertools 0.12.0",
  "jubjub",
  "rand 0.8.5",
  "semver 1.0.20",

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -22,6 +22,7 @@ categories = ["cryptography::cryptocurrencies"]
 
 color-eyre = "0.6.2"
 indexmap = { version = "2.0.1", features = ["serde"] }
+itertools = "0.12.0"
 semver = "1.0.20"
 serde = { version = "1.0.193", features = ["serde_derive"] }
 tokio = { version = "1.34.0", features = ["time"] }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -24,7 +24,7 @@ color-eyre = "0.6.2"
 indexmap = { version = "2.0.1", features = ["serde"] }
 semver = "1.0.20"
 serde = { version = "1.0.193", features = ["serde_derive"] }
-tokio = "1.34.0"
+tokio = { version = "1.34.0", features = ["time"] }
 tower = "0.4.13"
 tracing = "0.1.39"
 

--- a/zebra-scan/src/config.rs
+++ b/zebra-scan/src/config.rs
@@ -12,13 +12,15 @@ use crate::storage::SaplingScanningKey;
 /// Configuration for scanning.
 pub struct Config {
     /// The sapling keys to scan for and the birthday height of each of them.
+    ///
+    /// Currently only supports Extended Full Viewing Keys in ZIP-32 format.
     //
     // TODO: allow keys without birthdays
     pub sapling_keys_to_scan: IndexMap<SaplingScanningKey, u32>,
 
     /// The scanner results database config.
     //
-    // TODO: Remove fields that are only used by the state to create a common database config.
+    // TODO: Remove fields that are only used by the state, and create a common database config.
     #[serde(flatten)]
     db_config: DbConfig,
 }

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -5,6 +5,7 @@ use tokio::task::JoinHandle;
 use tracing::Instrument;
 
 use zebra_chain::{diagnostic::task::WaitForPanics, parameters::Network};
+use zebra_state::ChainTipChange;
 
 use crate::{scan, storage::Storage, Config};
 
@@ -15,19 +16,27 @@ pub fn spawn_init(
     config: &Config,
     network: Network,
     state: scan::State,
+    chain_tip_change: ChainTipChange,
 ) -> JoinHandle<Result<(), Report>> {
     let config = config.clone();
-    tokio::spawn(init(config, network, state).in_current_span())
+
+    // TODO: spawn an entirely new executor here, to avoid timing attacks.
+    tokio::spawn(init(config, network, state, chain_tip_change).in_current_span())
 }
 
 /// Initialize the scanner based on its config.
 ///
 /// TODO: add a test for this function.
-pub async fn init(config: Config, network: Network, state: scan::State) -> Result<(), Report> {
+pub async fn init(
+    config: Config,
+    network: Network,
+    state: scan::State,
+    chain_tip_change: ChainTipChange,
+) -> Result<(), Report> {
     let storage = tokio::task::spawn_blocking(move || Storage::new(&config, network))
         .wait_for_panics()
         .await;
 
     // TODO: add more tasks here?
-    scan::start(state, storage).await
+    scan::start(state, chain_tip_change, storage).await
 }

--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -104,11 +104,18 @@ pub async fn start(
             _ => unreachable!("unmatched response to a state::Tip request"),
         };
 
+        // Only log at info level every 100,000 blocks
+        let is_info_log =
+            height == storage.min_sapling_birthday_height() || height.0 % INFO_LOG_INTERVAL == 0;
 
-        for key in available_keys {
+        // TODO: add debug logs?
+        if is_info_log {
             info!(
-                "Scanning the blockchain for key {} from block {:?} to {:?}",
-                key.0, key.1, tip,
+                "Scanning the blockchain: now at block {:?}, current tip {:?}",
+                height,
+                chain_tip_change
+                    .latest_chain_tip()
+                    .best_tip_height_and_hash(),
             );
         }
 

--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -39,10 +39,14 @@ pub type State = Buffer<
     zebra_state::Request,
 >;
 
-/// Wait a few seconds at startup so tip height is always `Some`.
-const INITIAL_WAIT: Duration = Duration::from_secs(10);
+/// Wait a few seconds at startup for some blocks to get verified.
+///
+/// But sometimes the state might be empty if the network is slow.
+const INITIAL_WAIT: Duration = Duration::from_secs(15);
 
-/// The amount of time between checking and starting new scans.
+/// The amount of time between checking for new blocks and starting new scans.
+///
+/// This is just under half the target block interval.
 const CHECK_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Start the scan task given state and storage.

--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -143,9 +143,16 @@ pub async fn start(
             let block = block.clone();
             let mut storage = storage.clone();
 
+            // We use a dummy size of the Sapling note commitment tree. We can't set the size to
+            // zero, because the underlying scanning function would return
+            // `zcash_client_backeng::scanning::ScanError::TreeSizeUnknown`.
+            let sapling_tree_size = 1;
+
             tokio::task::spawn_blocking(move || {
-                let dfvk_res = scan_block(network, &block, 0, &dfvks).map_err(|e| eyre!(e))?;
-                let ivk_res = scan_block(network, &block, 0, &ivks).map_err(|e| eyre!(e))?;
+                let dfvk_res =
+                    scan_block(network, &block, sapling_tree_size, &dfvks).map_err(|e| eyre!(e))?;
+                let ivk_res =
+                    scan_block(network, &block, sapling_tree_size, &ivks).map_err(|e| eyre!(e))?;
 
                 let dfvk_res = scanned_block_to_db_result(dfvk_res);
                 let ivk_res = scanned_block_to_db_result(ivk_res);

--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -143,10 +143,15 @@ pub async fn start(
             let block = block.clone();
             let mut storage = storage.clone();
 
-            // We use a dummy size of the Sapling note commitment tree. We can't set the size to
-            // zero, because the underlying scanning function would return
+            // We use a dummy size of the Sapling note commitment tree.
+            //
+            // We can't set the size to zero, because the underlying scanning function would return
             // `zcash_client_backeng::scanning::ScanError::TreeSizeUnknown`.
-            let sapling_tree_size = 1;
+            //
+            // And we can't set them close to 0, because the scanner subtracts the number of notes
+            // in the block, and panics with "attempt to subtract with overflow". The number of
+            // notes in a block must be less than this value, this is a consensus rule.
+            let sapling_tree_size = 1 << 16;
 
             tokio::task::spawn_blocking(move || {
                 let dfvk_res =

--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -243,3 +243,12 @@ fn transaction_to_compact((index, tx): (usize, Arc<Transaction>)) -> CompactTx {
         actions: vec![],
     }
 }
+
+/// Convert a scanned block to a list of scanner database results.
+fn scanned_block_to_db_result<Nf>(scanned_block: ScannedBlock<Nf>) -> Vec<SaplingScannedResult> {
+    scanned_block
+        .transactions()
+        .iter()
+        .map(|tx| transaction::Hash::from_bytes_in_display_order(tx.txid.as_ref()))
+        .collect()
+}

--- a/zebra-scan/src/storage.rs
+++ b/zebra-scan/src/storage.rs
@@ -101,7 +101,7 @@ impl Storage {
         &mut self,
         sapling_key: SaplingScanningKey,
         height: Height,
-        result: Vec<SaplingScannedResult>,
+        sapling_result: Vec<SaplingScannedResult>,
     ) {
         // It's ok to write some results and not others during shutdown, so each result can get its
         // own batch. (They will be re-scanned on startup anyway.)
@@ -114,7 +114,7 @@ impl Storage {
 
         let entry = SaplingScannedDatabaseEntry {
             index,
-            value: result,
+            value: sapling_result,
         };
 
         batch.insert_sapling_result(self, entry);

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -109,6 +109,7 @@ async fn scanning_zecpages_from_populated_zebra_state() -> Result<()> {
     // Build a vector of viewing keys `vks` to scan for.
     let fvk = efvk.fvk;
     let ivk = fvk.vk.ivk();
+    let ivks = vec![ivk];
 
     let network = zebra_chain::parameters::Network::Mainnet;
 
@@ -143,9 +144,9 @@ async fn scanning_zecpages_from_populated_zebra_state() -> Result<()> {
             orchard_commitment_tree_size,
         };
 
-        let compact_block = block_to_compact(block.clone(), chain_metadata);
+        let compact_block = block_to_compact(&block, chain_metadata);
 
-        let res = scan_block(network, block, sapling_commitment_tree_size, &ivk)
+        let res = scan_block(network, &block, sapling_commitment_tree_size, &ivks)
             .expect("scanning block for the ZECpages viewing key should work");
 
         transactions_found += res.transactions().len();

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -628,6 +628,11 @@ impl ChainTipChange {
             }
         }
     }
+
+    /// Returns the inner `LatestChainTip`.
+    pub fn latest_chain_tip(&self) -> LatestChainTip {
+        self.latest_chain_tip.clone()
+    }
 }
 
 impl Clone for ChainTipChange {

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -282,7 +282,7 @@ impl StartCmd {
             peer_set,
             mempool.clone(),
             sync_status,
-            chain_tip_change,
+            chain_tip_change.clone(),
         );
 
         info!("spawning syncer task");
@@ -292,7 +292,12 @@ impl StartCmd {
         // Spawn never ending scan task.
         let scan_task_handle = {
             info!("spawning shielded scanner with configured viewing keys");
-            zebra_scan::spawn_init(&config.shielded_scan, config.network.network, state)
+            zebra_scan::spawn_init(
+                &config.shielded_scan,
+                config.network.network,
+                state,
+                chain_tip_change,
+            )
         };
 
         #[cfg(not(feature = "shielded-scan"))]

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -291,6 +291,7 @@ impl StartCmd {
         #[cfg(feature = "shielded-scan")]
         // Spawn never ending scan task.
         let scan_task_handle = {
+            // TODO: log the number of keys and update the scan_task_starts() test
             info!("spawning shielded scanner with configured viewing keys");
             zebra_scan::spawn_init(
                 &config.shielded_scan,

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2805,8 +2805,8 @@ async fn fully_synced_rpc_z_getsubtreesbyindex_snapshot_test() -> Result<()> {
 }
 
 /// Test that the scanner task gets started when the node starts.
-#[cfg(feature = "shielded-scan")]
 #[test]
+#[cfg(feature = "shielded-scan")]
 fn scan_task_starts() -> Result<()> {
     use indexmap::IndexMap;
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2832,13 +2832,16 @@ fn scan_task_starts() -> Result<()> {
     let output = child.wait_with_output()?;
 
     output.stdout_line_contains("spawning shielded scanner with configured viewing keys")?;
+    /*
+    TODO: these lines only happen when we reach sapling activation height
+    output.stdout_line_contains("Scanning the blockchain: now at block")?;
     output.stdout_line_contains(
         format!(
-            "Scanning the blockchain for key {} from block",
-            ZECPAGES_VIEWING_KEY
+            "Scanning the blockchain for key 0, started at block",
         )
         .as_str(),
     )?;
+    */
 
     // Make sure the command was killed
     output.assert_was_killed()?;


### PR DESCRIPTION
## Motivation

This PR scans the blockchain and adds the scanner results to the scanner database.

Close #8021

I think it might also
close #7953
but @upbqdn feel free to replace that code with your PR, and re-open that ticket if it's not finished.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

The changelog summary for 1.5.0 already talks about scanning.

### Complex Code or Requirements

I tried scanning with all the keys to make sure it would work, but we only really need to scan with the full viewing key. I couldn't find the encoding for individual viewing keys, so I left that until later.

There's also a bunch of `spawn_blocking()` calls in here.

## Solution

Changes:
- Parse keys once at the start of the scan
  - Create a function that parses a key into a list of keys
  - Take a list of keys from the same key in the scanner for now
- Pass a ChainTipChange to the scanner function, this turned out to be mostly useless but it's good for progress
- Get a block from the state instead of the tip height
- Use a dummy sapling tree size
- Scan each block and add the results to storage
  - Convert a scanned block to a sapling result

Fixes:
- Fix availability of tokio::time in scanner
- Make it easier to pass keys and blocks to conversion functions
- Increase scanner wait times
- Don't log secret keys, only log every 100,000 blocks
- Move blocking tasks into spawn_blocking()

### Testing

- Update the acceptance test

I manually tested this, getting it in CI is ticket #8037

## Review

@oxarbitrage might want to review the scanner bits, and @upbqdn the block/state bits?

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

#8022 then lots of testing:
- #7813 
- #8037 
- Round-trip tests for the database formats