### PR TITLE
change(ci): Build the crate target by itself in ci-build-crates.yml

### DIFF
--- a/.github/workflows/ci-build-crates.yml
+++ b/.github/workflows/ci-build-crates.yml
@@ -127,21 +127,32 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
 
-        # We could use `features: ['', '--all-features', '--no-default-features']` as a matrix argument,
-        # but it's faster to run these commands sequentially, so they can re-use the local cargo cache.
-        #
-        # Some Zebra crates do not have any features, and most don't have any default features.
+      # We could use `features: ['', '--all-features', '--no-default-features']` as a matrix argument,
+      # but it's faster to run these commands sequentially, so they can re-use the local cargo cache.
+      #
+      # Some Zebra crates do not have any features, and most don't have any default features.
+      # Some targets activate features, but we still need to be able to build without them.
       - name: Build ${{ matrix.crate }} crate with no default features
+        run: |
+          cargo clippy --package ${{ matrix.crate }} --no-default-features -- -D warnings
+          cargo build --package ${{ matrix.crate }} --no-default-features
+
+      - name: Build ${{ matrix.crate }} crate with no default features and all targets
         run: |
           cargo clippy --package ${{ matrix.crate }} --no-default-features --all-targets -- -D warnings
           cargo build --package ${{ matrix.crate }} --no-default-features --all-targets
 
       - name: Build ${{ matrix.crate }} crate with default features
         run: |
+          cargo clippy --package ${{ matrix.crate }} -- -D warnings
+          cargo build --package ${{ matrix.crate }}
+
+      - name: Build ${{ matrix.crate }} crate with default features and all targets
+        run: |
           cargo clippy --package ${{ matrix.crate }} --all-targets -- -D warnings
           cargo build --package ${{ matrix.crate }} --all-targets
 
-      - name: Build ${{ matrix.crate }} crate with all features
+      - name: Build ${{ matrix.crate }} crate with all features and all targets
         run: |
           cargo clippy --package ${{ matrix.crate }} --all-features --all-targets -- -D warnings
           cargo build --package ${{ matrix.crate }} --all-features --all-targets

--- a/.github/workflows/ci-build-crates.yml
+++ b/.github/workflows/ci-build-crates.yml
@@ -104,8 +104,9 @@ jobs:
     # Some of these builds take more than 14GB disk space
     runs-on: ubuntu-latest-m
     strategy:
-      # avoid rate-limit errors by only launching a few of these jobs at a time
-      max-parallel: 2
+      # avoid rate-limit errors by only launching a few of these jobs at a time,
+      # but still finish in a similar time to the longest tests
+      max-parallel: 3
       fail-fast: true
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
 

--- a/.github/workflows/ci-build-crates.yml
+++ b/.github/workflows/ci-build-crates.yml
@@ -61,17 +61,18 @@ jobs:
       # This step is meant to dynamically create a JSON containing the values of each crate
       # available in this repo in the root directory. We use `cargo tree` to accomplish this task.
       #
-      # The result from `cargo tree` is then transform to JSON values between double quotes,
-      # and separated by commas, then added to a `crates.txt` and assigned to a $JSON_CRATES variable.
+      # The result from `cargo tree` is then sorted so the longest job (zebrad) runs first,
+      # transformed to JSON values between double quotes, and separated by commas,
+      # then added to a `crates.txt`.
       #
-      # A JSON object is created and assigned to a $MATRIX variable, which is use to create an output
-      # named `matrix`, which is then used as the input in following steps,
+      # A JSON object is created and assigned to a $MATRIX variable, which is use to create an
+      # output named `matrix`, which is then used as the input in following steps,
       # using ` ${{ fromJson(needs.matrix.outputs.matrix) }}`
       - id: set-matrix
         name: Dynamically build crates JSON
         run: |
           TEMP_DIR=$(mktemp -d)
-          echo "$(cargo tree --depth 0 --edges no-normal,no-dev,no-build,no-proc-macro --prefix none | cut -d ' ' -f1 | sed '/^$/d' | awk '{ printf "\"%s\",\n", $0 }' | sed '$ s/.$//')" > $TEMP_DIR/crates.txt
+          cargo tree --depth 0 --edges no-normal,no-dev,no-build,no-proc-macro --prefix none | cut -d ' ' -f1 | sed '/^$/d' | LC_ALL=C sort --reverse | awk '{ printf "\"%s\",\n", $0 }' | sed '$ s/.$//' > $TEMP_DIR/crates.txt
           MATRIX=$( (
             echo '{ "crate" : ['
             echo "$(cat $TEMP_DIR/crates.txt)"


### PR DESCRIPTION
## Motivation

This test isn't catching some build failures due to missing features that are enabled only by tests.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

### Specifications

All targets builds tests, examples, and binaries as well as the crate itself.

### Complex Code or Requirements

All features enables these features anyway, so we usually don't need to test it with just the crate target.

## Solution

Run no default features and default features crate builds in CI
Run 3 jobs in parallel and run zebrad first

### Testing

These are extra tests

## Review

This is a routine testing change

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
