### PR TITLE
change(scan): Refactor scanning tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5798,6 +5798,7 @@ name = "zebra-scan"
 version = "0.1.0-alpha.0"
 dependencies = [
  "bls12_381",
+ "chrono",
  "color-eyre",
  "ff",
  "group",

--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -491,7 +491,7 @@ impl Error {
 ///     -MAX_MONEY..=MAX_MONEY,
 /// );
 /// ```
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
 pub struct NegativeAllowed;
 
 impl Constraint for NegativeAllowed {

--- a/zebra-chain/src/block/hash.rs
+++ b/zebra-chain/src/block/hash.rs
@@ -20,8 +20,8 @@ use proptest_derive::Arbitrary;
 ///
 /// Note: Zebra displays transaction and block hashes in big-endian byte-order,
 /// following the u256 convention set by Bitcoin and zcashd.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Default)]
-#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary, Default))]
 pub struct Hash(pub [u8; 32]);
 
 impl Hash {

--- a/zebra-chain/src/block/hash.rs
+++ b/zebra-chain/src/block/hash.rs
@@ -20,7 +20,7 @@ use proptest_derive::Arbitrary;
 ///
 /// Note: Zebra displays transaction and block hashes in big-endian byte-order,
 /// following the u256 convention set by Bitcoin and zcashd.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Default)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct Hash(pub [u8; 32]);
 

--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -22,7 +22,7 @@ use proptest_derive::Arbitrary;
 /// backwards reference (previous header hash) present in the block
 /// header. Each block points backwards to its parent, all the way
 /// back to the genesis block (the first block in the blockchain).
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Header {
     /// The block's version field. This is supposed to be `4`:
     ///

--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -22,7 +22,7 @@ use proptest_derive::Arbitrary;
 /// backwards reference (previous header hash) present in the block
 /// header. Each block points backwards to its parent, all the way
 /// back to the genesis block (the first block in the blockchain).
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 pub struct Header {
     /// The block's version field. This is supposed to be `4`:
     ///

--- a/zebra-chain/src/block/merkle.rs
+++ b/zebra-chain/src/block/merkle.rs
@@ -69,8 +69,8 @@ use proptest_derive::Arbitrary;
 /// aggressive anti-DoS mechanism.
 ///
 /// [ZIP-244]: https://zips.z.cash/zip-0244
-#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
-#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary, Default))]
 pub struct Root(pub [u8; 32]);
 
 impl fmt::Debug for Root {

--- a/zebra-chain/src/block/merkle.rs
+++ b/zebra-chain/src/block/merkle.rs
@@ -69,7 +69,7 @@ use proptest_derive::Arbitrary;
 /// aggressive anti-DoS mechanism.
 ///
 /// [ZIP-244]: https://zips.z.cash/zip-0244
-#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct Root(pub [u8; 32]);
 

--- a/zebra-chain/src/fmt.rs
+++ b/zebra-chain/src/fmt.rs
@@ -163,7 +163,7 @@ where
 
 /// Wrapper to override `Debug`, redirecting it to hex-encode the type.
 /// The type must implement `AsRef<[u8]>`.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 #[serde(transparent)]
 pub struct HexDebug<T: AsRef<[u8]>>(pub T);

--- a/zebra-chain/src/sapling.rs
+++ b/zebra-chain/src/sapling.rs
@@ -24,7 +24,9 @@ pub mod shielded_data;
 pub mod spend;
 pub mod tree;
 
-pub use commitment::{CommitmentRandomness, NoteCommitment, ValueCommitment};
+pub use commitment::{
+    CommitmentRandomness, NotSmallOrderValueCommitment, NoteCommitment, ValueCommitment,
+};
 pub use keys::Diversifier;
 pub use note::{EncryptedNote, Note, Nullifier, WrappedNoteKey};
 pub use output::{Output, OutputInTransactionV4, OutputPrefixInTransactionV5};

--- a/zebra-chain/src/sapling/commitment.rs
+++ b/zebra-chain/src/sapling/commitment.rs
@@ -157,7 +157,7 @@ impl NoteCommitment {
 /// [`NotSmallOrderValueCommitment`].
 ///
 /// <https://zips.z.cash/protocol/protocol.pdf#concretehomomorphiccommit>
-#[derive(Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Deserialize, PartialEq, Eq, Serialize, Default)]
 pub struct ValueCommitment(#[serde(with = "serde_helpers::AffinePoint")] jubjub::AffinePoint);
 
 impl<'a> std::ops::Add<&'a ValueCommitment> for ValueCommitment {
@@ -301,7 +301,7 @@ lazy_static! {
 ///
 /// <https://zips.z.cash/protocol/protocol.pdf#spenddesc>
 /// <https://zips.z.cash/protocol/protocol.pdf#outputdesc>
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize, Default)]
 pub struct NotSmallOrderValueCommitment(ValueCommitment);
 
 impl TryFrom<ValueCommitment> for NotSmallOrderValueCommitment {

--- a/zebra-chain/src/sapling/commitment.rs
+++ b/zebra-chain/src/sapling/commitment.rs
@@ -157,7 +157,8 @@ impl NoteCommitment {
 /// [`NotSmallOrderValueCommitment`].
 ///
 /// <https://zips.z.cash/protocol/protocol.pdf#concretehomomorphiccommit>
-#[derive(Clone, Copy, Deserialize, PartialEq, Eq, Serialize, Default)]
+#[derive(Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Default))]
 pub struct ValueCommitment(#[serde(with = "serde_helpers::AffinePoint")] jubjub::AffinePoint);
 
 impl<'a> std::ops::Add<&'a ValueCommitment> for ValueCommitment {
@@ -301,7 +302,8 @@ lazy_static! {
 ///
 /// <https://zips.z.cash/protocol/protocol.pdf#spenddesc>
 /// <https://zips.z.cash/protocol/protocol.pdf#outputdesc>
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize, Default)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Default))]
 pub struct NotSmallOrderValueCommitment(ValueCommitment);
 
 impl TryFrom<ValueCommitment> for NotSmallOrderValueCommitment {

--- a/zebra-chain/src/sapling/note/ciphertexts.rs
+++ b/zebra-chain/src/sapling/note/ciphertexts.rs
@@ -12,6 +12,12 @@ use crate::serialization::{SerializationError, ZcashDeserialize, ZcashSerialize}
 #[derive(Deserialize, Serialize)]
 pub struct EncryptedNote(#[serde(with = "BigArray")] pub(crate) [u8; 580]);
 
+impl From<[u8; 580]> for EncryptedNote {
+    fn from(byte_array: [u8; 580]) -> Self {
+        Self(byte_array)
+    }
+}
+
 impl fmt::Debug for EncryptedNote {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("EncryptedNote")
@@ -58,6 +64,12 @@ impl ZcashDeserialize for EncryptedNote {
 /// Corresponds to Sapling's 'outCiphertext'
 #[derive(Deserialize, Serialize)]
 pub struct WrappedNoteKey(#[serde(with = "BigArray")] pub(crate) [u8; 80]);
+
+impl From<[u8; 80]> for WrappedNoteKey {
+    fn from(byte_array: [u8; 80]) -> Self {
+        Self(byte_array)
+    }
+}
 
 impl fmt::Debug for WrappedNoteKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -62,7 +62,7 @@ mod tests;
 /// > (see equations in the Zcash Specification [section 7.7.4])
 ///
 /// [section 7.7.4]: https://zips.z.cash/protocol/protocol.pdf#nbits
-#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
 pub struct CompactDifficulty(pub(crate) u32);
 
 /// An invalid CompactDifficulty value, for testing.

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -62,7 +62,8 @@ mod tests;
 /// > (see equations in the Zcash Specification [section 7.7.4])
 ///
 /// [section 7.7.4]: https://zips.z.cash/protocol/protocol.pdf#nbits
-#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Default))]
 pub struct CompactDifficulty(pub(crate) u32);
 
 /// An invalid CompactDifficulty value, for testing.

--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -93,6 +93,7 @@ impl Clone for Solution {
 
 impl Eq for Solution {}
 
+#[cfg(any(test, feature = "proptest-impl"))]
 impl Default for Solution {
     fn default() -> Self {
         Self([0; SOLUTION_SIZE])

--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -93,6 +93,12 @@ impl Clone for Solution {
 
 impl Eq for Solution {}
 
+impl Default for Solution {
+    fn default() -> Self {
+        Self([0; SOLUTION_SIZE])
+    }
+}
+
 impl ZcashSerialize for Solution {
     fn zcash_serialize<W: io::Write>(&self, writer: W) -> Result<(), io::Error> {
         zcash_serialize_bytes(&self.0.to_vec(), writer)

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -35,6 +35,8 @@ zcash_primitives = "0.13.0-rc.1"
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.31" }
 zebra-state = { path = "../zebra-state", version = "1.0.0-beta.31", features = ["shielded-scan"] }
 
+chrono = { version = "0.4.31", default-features = false, features = ["clock", "std", "serde"] }
+
 [dev-dependencies]
 
 bls12_381 = "0.8.0"

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -55,7 +55,7 @@ use crate::{
 /// This test:
 /// - Creates a viewing key and a fake block containing a Sapling output decryptable by the key.
 /// - Scans the block.
-/// - Checks that the result contains the txid of the tx containin the Sapling output.
+/// - Checks that the result contains the txid of the tx containing the Sapling output.
 #[tokio::test]
 async fn scanning_from_fake_generated_blocks() -> Result<()> {
     let extsk = ExtendedSpendingKey::master(&[]);
@@ -121,7 +121,7 @@ async fn scanning_zecpages_from_populated_zebra_state() -> Result<()> {
     let ivk = fvk.vk.ivk();
     let ivks = vec![ivk];
 
-    let network = zebra_chain::parameters::Network::Mainnet;
+    let network = Network::Mainnet;
 
     // Create a continuous chain of mainnet blocks from genesis
     let blocks: Vec<Arc<Block>> = zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -64,11 +64,6 @@ async fn scanning_from_fake_generated_blocks() -> Result<()> {
 
     let (block, sapling_tree_size) = fake_block(1u32.into(), nf, &dfvk, 1, true, Some(0));
 
-    // The fake block has the following transactions in this order:
-    // 1. a transparent coinbase tx,
-    // 2. a V4 tx containing a random Sapling output,
-    // 3. a V4 tx containing a Sapling output decryptable by `dfvk`,
-    // 4. another V4 tx containing a random Sapling output.
     assert_eq!(block.transactions.len(), 4);
 
     let res = scan_block(
@@ -210,11 +205,6 @@ fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
 
     let nf = Nullifier([7; 32]);
 
-    // The fake block has the following transactions in this order:
-    // 1. a transparent coinbase tx,
-    // 2. a V4 tx containing a random Sapling output,
-    // 3. a V4 tx containing a Sapling output decryptable by `dfvk`,
-    // 4. another V4 tx containing a random Sapling output.
     let (block, sapling_tree_size) = fake_block(1u32.into(), nf, &dfvk, 1, true, Some(0));
 
     let res = scan_block(
@@ -249,6 +239,12 @@ fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
 }
 
 /// Generates a fake block containing a Sapling output decryptable by `dfvk`.
+///
+/// The fake block has the following transactions in this order:
+/// 1. a transparent coinbase tx,
+/// 2. a V4 tx containing a random Sapling output,
+/// 3. a V4 tx containing a Sapling output decryptable by `dfvk`,
+/// 4. depending on the value of `tx_after`, another V4 tx containing a random Sapling output.
 fn fake_block(
     height: BlockHeight,
     nf: Nullifier,


### PR DESCRIPTION
## Motivation

Address https://github.com/ZcashFoundation/zebra/pull/7994#discussion_r1405426798.

This PR creates fake blocks in Zebra's format that are worth scanning and adjusts existing tests. We can also leverage this functionality in further tests. I expect we'll need to refine the API for fake blocks later on when we need more complicated tests.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

## Solution

- Create fake Zebra blocks:
  - Use the already existing `fake_compact_block` function to create fake compact blocks.
  - Convert transactions from the compact format to Zebra's V4.
  - Create fake Zebra blocks using the converted transactions.
- Refactor existing tests to use the fake Zebra's blocks.
- Fix some nits in the existing tests.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._