### PR TITLE
change(scan): Store scanned TXIDs in "display order"

### DIFF
--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -187,7 +187,7 @@ pub async fn start(
 /// - Add prior block metadata once we have access to Zebra's state.
 pub fn scan_block<K: ScanningKey>(
     network: Network,
-    block: &Arc<Block>,
+    block: &Block,
     sapling_tree_size: u32,
     scanning_keys: &[K],
 ) -> Result<ScannedBlock<K::Nf>, ScanError> {
@@ -251,7 +251,7 @@ pub fn sapling_key_to_scan_block_keys(
 }
 
 /// Converts a zebra block and meta data into a compact block.
-pub fn block_to_compact(block: &Arc<Block>, chain_metadata: ChainMetadata) -> CompactBlock {
+pub fn block_to_compact(block: &Block, chain_metadata: ChainMetadata) -> CompactBlock {
     CompactBlock {
         height: block
             .coinbase_height()

--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -22,12 +22,8 @@ use zcash_primitives::{
 };
 
 use zebra_chain::{
-    block::Block,
-    chain_tip::ChainTip,
-    diagnostic::task::WaitForPanics,
-    parameters::Network,
-    serialization::ZcashSerialize,
-    transaction::{self, Transaction},
+    block::Block, chain_tip::ChainTip, diagnostic::task::WaitForPanics, parameters::Network,
+    serialization::ZcashSerialize, transaction::Transaction,
 };
 use zebra_state::{ChainTipChange, SaplingScannedResult};
 
@@ -344,6 +340,6 @@ fn scanned_block_to_db_result<Nf>(scanned_block: ScannedBlock<Nf>) -> Vec<Saplin
     scanned_block
         .transactions()
         .iter()
-        .map(|tx| transaction::Hash::from_bytes_in_display_order(tx.txid.as_ref()))
+        .map(|tx| SaplingScannedResult::from(tx.txid.as_ref()))
         .collect()
 }


### PR DESCRIPTION
## Motivation

Close #8056.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

## Solution

- [Store scanned TXIDs in "display order"](https://github.com/ZcashFoundation/zebra/commit/0a0e54352eaad6b0048862beb085b37fc70a4820)
- [Unrelated: Remove a redundant `Arc`](https://github.com/ZcashFoundation/zebra/commit/808245cce168d8953fe13636bf5afd497699aec2)

### Testing

I didn't add any new tests. I updated tests that this PR affects.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._