### PR TITLE
change(ci): Delete least used ci-build-crates.yml step and increase concurrency

### DIFF
--- a/.github/workflows/ci-build-crates.yml
+++ b/.github/workflows/ci-build-crates.yml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       # avoid rate-limit errors by only launching a few of these jobs at a time,
       # but still finish in a similar time to the longest tests
-      max-parallel: 3
+      max-parallel: 4
       fail-fast: true
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
 
@@ -134,20 +134,15 @@ jobs:
       #
       # Some Zebra crates do not have any features, and most don't have any default features.
       # Some targets activate features, but we still need to be able to build without them.
-      - name: Build ${{ matrix.crate }} crate with no default features
+      - name: Build ${{ matrix.crate }} crate with default features
         run: |
-          cargo clippy --package ${{ matrix.crate }} --no-default-features -- -D warnings
-          cargo build --package ${{ matrix.crate }} --no-default-features
+          cargo clippy --package ${{ matrix.crate }} -- -D warnings
+          cargo build --package ${{ matrix.crate }}
 
       - name: Build ${{ matrix.crate }} crate with no default features and all targets
         run: |
           cargo clippy --package ${{ matrix.crate }} --no-default-features --all-targets -- -D warnings
           cargo build --package ${{ matrix.crate }} --no-default-features --all-targets
-
-      - name: Build ${{ matrix.crate }} crate with default features
-        run: |
-          cargo clippy --package ${{ matrix.crate }} -- -D warnings
-          cargo build --package ${{ matrix.crate }}
 
       - name: Build ${{ matrix.crate }} crate with default features and all targets
         run: |


### PR DESCRIPTION
## Motivation

Currently building crates individually is the longest workflow, so let's reduce the time it takes.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

## Solution

- Remove the step that tests the least common configuration
- Increase concurrency from 3 to 4

### Testing

This slightly reduces build coverage, but the removed settings are unusual.

## Review

This is a low priority change/cleanup.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

