### PR TITLE
fix(scan): Start scanning task only if there are keys to scan

### DIFF
--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -289,10 +289,12 @@ impl StartCmd {
         let syncer_task_handle = tokio::spawn(syncer.sync().in_current_span());
 
         #[cfg(feature = "shielded-scan")]
-        // Spawn never ending scan task.
-        let scan_task_handle = {
+        // Spawn never ending scan task only if we have keys to scan for.
+        let scan_task_handle = if !config.shielded_scan.sapling_keys_to_scan.is_empty() {
             info!("spawning shielded scanner with configured viewing keys");
             zebra_scan::spawn_init(&config.shielded_scan, config.network.network, state)
+        } else {
+            tokio::spawn(std::future::pending().in_current_span())
         };
 
         #[cfg(not(feature = "shielded-scan"))]

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -204,6 +204,9 @@ pub const MAX_ASYNC_BLOCKING_TIME: Duration = zebra_test::mock_service::DEFAULT_
 /// The test config file prefix for `--feature getblocktemplate-rpcs` configs.
 pub const GET_BLOCK_TEMPLATE_CONFIG_PREFIX: &str = "getblocktemplate-";
 
+/// The test config file prefix for `--feature shielded-scan` configs.
+pub const SHIELDED_SCAN_CONFIG_PREFIX: &str = "shieldedscan-";
+
 #[test]
 fn generate_no_args() -> Result<()> {
     let _init_guard = zebra_test::init();
@@ -806,18 +809,18 @@ fn last_config_is_stored() -> Result<()> {
          zebrad generate | \n\
          sed 's/cache_dir = \".*\"/cache_dir = \"cache_dir\"/' > \n\
          zebrad/tests/common/configs/{}<next-release-tag>.toml",
-        if cfg!(feature = "getblocktemplate-rpcs") {
-            GET_BLOCK_TEMPLATE_CONFIG_PREFIX
+        if cfg!(feature = "shielded-scan") {
+            SHIELDED_SCAN_CONFIG_PREFIX
         } else {
             ""
         },
-        if cfg!(feature = "getblocktemplate-rpcs") {
-            "--features=getblocktemplate-rpcs "
+        if cfg!(feature = "shielded-scan") {
+            "--features=shielded-scan "
         } else {
             ""
         },
-        if cfg!(feature = "getblocktemplate-rpcs") {
-            GET_BLOCK_TEMPLATE_CONFIG_PREFIX
+        if cfg!(feature = "shielded-scan") {
+            SHIELDED_SCAN_CONFIG_PREFIX
         } else {
             ""
         },
@@ -943,6 +946,14 @@ fn stored_configs_work() -> Result<()> {
                 ?config_file_path,
                 "skipping getblocktemplate-rpcs config file path"
             );
+            continue;
+        }
+
+        // ignore files starting with shieldedscan prefix
+        // if we were not built with the shielded-scan feature.
+        #[cfg(not(feature = "shielded-scan"))]
+        if config_file_name.starts_with(SHIELDED_SCAN_CONFIG_PREFIX) {
+            tracing::info!(?config_file_path, "skipping shielded-scan config file path");
             continue;
         }
 

--- a/zebrad/tests/common/config.rs
+++ b/zebrad/tests/common/config.rs
@@ -80,6 +80,26 @@ pub fn default_test_config(net: Network) -> Result<ZebradConfig> {
         mining.miner_address = Some(miner_address.parse().expect("hard-coded address is valid"));
     }
 
+    #[cfg(feature = "shielded_scan")]
+    {
+        let mut shielded_scan = zebra_scan::Config::default();
+        shielded_scan.ephemeral = true;
+
+        let config = ZebradConfig {
+            network,
+            state,
+            sync,
+            mempool,
+            consensus,
+            tracing,
+            mining,
+            shielded_scan,
+            ..ZebradConfig::default()
+        };
+
+        return Ok(config);
+    }
+
     let config = ZebradConfig {
         network,
         state,

--- a/zebrad/tests/common/configs/shieldedscan-v1.5.0.toml
+++ b/zebrad/tests/common/configs/shieldedscan-v1.5.0.toml
@@ -1,0 +1,80 @@
+# Default configuration for zebrad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zebrad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
+#
+# zebrad attempts to load configs in the following order:
+#
+# 1. The -c flag on the command line, e.g., `zebrad -c myconfig.toml start`;
+# 2. The file `zebrad.toml` in the users's preference directory (platform-dependent);
+# 3. The default config.
+
+[consensus]
+checkpoint_sync = true
+
+[mempool]
+eviction_memory_time = "1h"
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+debug_like_zcashd = true
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+initial_mainnet_peers = [
+    "dnsseed.z.cash:8233",
+    "dnsseed.str4d.xyz:8233",
+    "mainnet.seeder.zfnd.org:8233",
+    "mainnet.is.yolo.money:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+    "testnet.is.yolo.money:18233",
+]
+listen_addr = "0.0.0.0:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+peerset_initial_target_size = 25
+
+[rpc]
+debug_force_finished_sync = false
+parallel_cpu_threads = 0
+
+[shielded_scan]
+cache_dir = "cache_dir"
+delete_old_database = true
+ephemeral = false
+
+[shielded_scan.sapling_keys_to_scan]
+
+[state]
+cache_dir = "cache_dir"
+delete_old_database = true
+ephemeral = false
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 50
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false


### PR DESCRIPTION
## Motivation

Part of https://github.com/ZcashFoundation/zebra/issues/7892

When we run the Zebra test suite some tests will fail with database already in use. It seems a bug in shutdown. We want to run the scan tests and config tests so we can lock that functionality and keep making progress.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

## Solution

- Start scan only if there are keys.
- Fix config test for new config file that is generated when `shielded-scan` feature is enabled.
- Add ephemeral database in tests by default.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

- Re enable feature in CI: https://github.com/ZcashFoundation/zebra/issues/7892
- Create a new ticket top test scan database conflict. Deal with the bug there. 
