### PR TITLE
change(scan): Store one transaction ID per database row, to make queries easier

### DIFF
--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -1,6 +1,10 @@
 //! The scanner task and scanning APIs.
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+    time::Duration,
+};
 
 use color_eyre::{eyre::eyre, Report};
 use itertools::Itertools;
@@ -25,7 +29,7 @@ use zebra_chain::{
     block::Block, chain_tip::ChainTip, diagnostic::task::WaitForPanics, parameters::Network,
     serialization::ZcashSerialize, transaction::Transaction,
 };
-use zebra_state::{ChainTipChange, SaplingScannedResult};
+use zebra_state::{ChainTipChange, SaplingScannedResult, TransactionIndex};
 
 use crate::storage::{SaplingScanningKey, Storage};
 
@@ -158,8 +162,8 @@ pub async fn start(
                 let dfvk_res = scanned_block_to_db_result(dfvk_res);
                 let ivk_res = scanned_block_to_db_result(ivk_res);
 
-                storage.add_sapling_result(sapling_key.clone(), height, dfvk_res);
-                storage.add_sapling_result(sapling_key, height, ivk_res);
+                storage.add_sapling_results(sapling_key.clone(), height, dfvk_res);
+                storage.add_sapling_results(sapling_key, height, ivk_res);
 
                 Ok::<_, Report>(())
             })
@@ -336,10 +340,17 @@ fn transaction_to_compact((index, tx): (usize, Arc<Transaction>)) -> CompactTx {
 }
 
 /// Convert a scanned block to a list of scanner database results.
-fn scanned_block_to_db_result<Nf>(scanned_block: ScannedBlock<Nf>) -> Vec<SaplingScannedResult> {
+fn scanned_block_to_db_result<Nf>(
+    scanned_block: ScannedBlock<Nf>,
+) -> BTreeMap<TransactionIndex, SaplingScannedResult> {
     scanned_block
         .transactions()
         .iter()
-        .map(|tx| SaplingScannedResult::from(tx.txid.as_ref()))
+        .map(|tx| {
+            (
+                TransactionIndex::from_usize(tx.index),
+                SaplingScannedResult::from(tx.txid.as_ref()),
+            )
+        })
         .collect()
 }

--- a/zebra-scan/src/storage/db.rs
+++ b/zebra-scan/src/storage/db.rs
@@ -35,6 +35,10 @@ pub const SCANNER_COLUMN_FAMILIES_IN_CODE: &[&str] = &[
     // TODO: add Orchard support
 ];
 
+/// The major version number of the scanner database. This must be updated whenever the database
+/// format changes.
+const SCANNER_DATABASE_FORMAT_MAJOR_VERSION: u64 = 1;
+
 impl Storage {
     // Creation
 
@@ -96,8 +100,8 @@ impl Storage {
 
     /// The database format version in the running scanner code.
     pub fn database_format_version_in_code() -> Version {
-        // TODO: implement scanner database versioning
-        Version::new(0, 0, 0)
+        // TODO: implement in-place scanner database format upgrades
+        Version::new(SCANNER_DATABASE_FORMAT_MAJOR_VERSION, 0, 0)
     }
 
     /// Check for panics in code running in spawned threads.

--- a/zebra-scan/src/storage/db/sapling.rs
+++ b/zebra-scan/src/storage/db/sapling.rs
@@ -4,16 +4,19 @@
 //!
 //! | name             | key                           | value                    |
 //! |------------------|-------------------------------|--------------------------|
-//! | `sapling_tx_ids` | `SaplingScannedDatabaseIndex` | `transaction::Hash`      |
+//! | `sapling_tx_ids` | `SaplingScannedDatabaseIndex` | `Option<SaplingScannedResult>`      |
 //!
 //! And types:
+//! `SaplingScannedResult`: same as `transaction::Hash`, but with bytes in display order.
+//! `None` is stored as a zero-length array of bytes.
+//!
 //! `SaplingScannedDatabaseIndex` = `SaplingScanningKey` | `TransactionLocation`
 //! `TransactionLocation` = `Height` | `TransactionIndex`
 //!
 //! This format allows us to efficiently find all the results for each key, and the latest height
 //! for each key.
 //!
-//! If there are no results for a height, we store an empty list of results for the coinbase
+//! If there are no results for a height, we store `None` as the result for the coinbase
 //! transaction. This allows is to scan each key from the next height after we restart. We also use
 //! this mechanism to store key birthday heights, by storing the height before the birthday as the
 //! "last scanned" block.

--- a/zebra-scan/src/storage/db/sapling.rs
+++ b/zebra-scan/src/storage/db/sapling.rs
@@ -4,17 +4,19 @@
 //!
 //! | name             | key                           | value                    |
 //! |------------------|-------------------------------|--------------------------|
-//! | `sapling_tx_ids` | `SaplingScannedDatabaseIndex` | `Vec<transaction::Hash>` |
+//! | `sapling_tx_ids` | `SaplingScannedDatabaseIndex` | `transaction::Hash`      |
 //!
 //! And types:
-//! SaplingScannedDatabaseIndex = `SaplingScanningKey` | `Height`
+//! `SaplingScannedDatabaseIndex` = `SaplingScanningKey` | `TransactionLocation`
+//! `TransactionLocation` = `Height` | `TransactionIndex`
 //!
 //! This format allows us to efficiently find all the results for each key, and the latest height
 //! for each key.
 //!
-//! If there are no results for a height, we store an empty list of results. This allows is to scan
-//! each key from the next height after we restart. We also use this mechanism to store key
-//! birthday heights, by storing the height before the birthday as the "last scanned" block.
+//! If there are no results for a height, we store an empty list of results for the coinbase
+//! transaction. This allows is to scan each key from the next height after we restart. We also use
+//! this mechanism to store key birthday heights, by storing the height before the birthday as the
+//! "last scanned" block.
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/zebra-scan/src/storage/db/sapling.rs
+++ b/zebra-scan/src/storage/db/sapling.rs
@@ -24,7 +24,8 @@ use std::{
 };
 
 use itertools::Itertools;
-use zebra_chain::{block::Height, transaction};
+
+use zebra_chain::block::Height;
 use zebra_state::{
     AsColumnFamilyRef, ReadDisk, SaplingScannedDatabaseEntry, SaplingScannedDatabaseIndex,
     SaplingScannedResult, SaplingScanningKey, TransactionIndex, WriteDisk,
@@ -85,7 +86,7 @@ impl Storage {
         // But we want Vec<SaplingScannedResult>, with empty Vecs instead of [None, None, ...]
         results
             .into_iter()
-            .map(|(index, vector)| -> (Height, Vec<transaction::Hash>) {
+            .map(|(index, vector)| -> (Height, Vec<SaplingScannedResult>) {
                 (index, vector.into_iter().flatten().collect())
             })
             .collect()

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -37,7 +37,7 @@ use zebra_chain::{
     parameters::Network,
     serialization::ZcashDeserializeInto,
 };
-use zebra_state::SaplingScannedResult;
+use zebra_state::{SaplingScannedResult, TransactionIndex};
 
 use crate::{
     config::Config,
@@ -188,7 +188,7 @@ fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
     let mut s = crate::storage::Storage::new(&Config::ephemeral(), Network::Mainnet);
 
     // Insert the generated key to the database
-    s.add_sapling_key(key_to_be_stored.clone(), None);
+    s.add_sapling_key(&key_to_be_stored, None);
 
     // Check key was added
     assert_eq!(s.sapling_keys().len(), 1);
@@ -226,7 +226,11 @@ fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
     let result = SaplingScannedResult::from(result.transactions()[0].txid.as_ref());
 
     // Add result to database
-    s.add_sapling_result(key_to_be_stored.clone(), Height(1), vec![result]);
+    s.add_sapling_results(
+        key_to_be_stored.clone(),
+        Height(1),
+        [(TransactionIndex::from_usize(0), result)].into(),
+    );
 
     // Check the result was added
     assert_eq!(

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -56,7 +56,7 @@ pub use service::{
     chain_tip::{ChainTipChange, LatestChainTip, TipAction},
     check, init, spawn_init,
     watch_receiver::WatchReceiver,
-    OutputIndex, OutputLocation, TransactionLocation,
+    OutputIndex, OutputLocation, TransactionIndex, TransactionLocation,
 };
 
 #[cfg(feature = "shielded-scan")]

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -85,7 +85,7 @@ pub mod arbitrary;
 #[cfg(test)]
 mod tests;
 
-pub use finalized_state::{OutputIndex, OutputLocation, TransactionLocation};
+pub use finalized_state::{OutputIndex, OutputLocation, TransactionIndex, TransactionLocation};
 
 use self::queued_blocks::{QueuedCheckpointVerified, QueuedSemanticallyVerified, SentHashes};
 

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -42,7 +42,8 @@ mod tests;
 pub use disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk};
 #[allow(unused_imports)]
 pub use disk_format::{
-    FromDisk, IntoDisk, OutputIndex, OutputLocation, TransactionLocation, MAX_ON_DISK_HEIGHT,
+    FromDisk, IntoDisk, OutputIndex, OutputLocation, TransactionIndex, TransactionLocation,
+    MAX_ON_DISK_HEIGHT,
 };
 pub use zebra_db::ZebraDb;
 

--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -19,7 +19,7 @@ pub mod scan;
 #[cfg(test)]
 mod tests;
 
-pub use block::{TransactionLocation, MAX_ON_DISK_HEIGHT};
+pub use block::{TransactionIndex, TransactionLocation, MAX_ON_DISK_HEIGHT};
 pub use transparent::{OutputIndex, OutputLocation};
 
 #[cfg(feature = "shielded-scan")]

--- a/zebra-state/src/service/finalized_state/disk_format/block.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/block.rs
@@ -114,7 +114,7 @@ impl TransactionIndex {
     /// This value corresponds to the coinbase transaction.
     pub const MIN: Self = Self(u16::MIN);
 
-    /// The maximun value of a transaction index.
+    /// The maximum value of a transaction index.
     ///
     /// This value corresponds to the highest possible transaction index.
     pub const MAX: Self = Self(u16::MAX);
@@ -174,7 +174,7 @@ impl TransactionLocation {
         index: TransactionIndex::MIN,
     };
 
-    /// The maximun value of a transaction location.
+    /// The maximum value of a transaction location.
     ///
     /// This value corresponds to the last transaction in the highest possible block.
     pub const MAX: Self = Self {

--- a/zebra-state/src/service/finalized_state/disk_format/block.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/block.rs
@@ -89,7 +89,7 @@ impl TransactionIndex {
         )
     }
 
-    /// Returns this index as a `usize`
+    /// Returns this index as a `usize`.
     pub fn as_usize(&self) -> usize {
         self.0.into()
     }
@@ -103,11 +103,21 @@ impl TransactionIndex {
         )
     }
 
-    /// Returns this index as a `u64`
+    /// Returns this index as a `u64`.
     #[allow(dead_code)]
     pub fn as_u64(&self) -> u64 {
         self.0.into()
     }
+
+    /// The minimum value of a transaction index.
+    ///
+    /// This value corresponds to the coinbase transaction.
+    pub const MIN: Self = Self(u16::MIN);
+
+    /// The maximun value of a transaction index.
+    ///
+    /// This value corresponds to the highest possible transaction index.
+    pub const MAX: Self = Self(u16::MAX);
 }
 
 /// A transaction's location in the chain, by block height and transaction index.
@@ -127,6 +137,11 @@ pub struct TransactionLocation {
 }
 
 impl TransactionLocation {
+    /// Creates a transaction location from a block height and transaction index.
+    pub fn from_parts(height: Height, index: TransactionIndex) -> TransactionLocation {
+        TransactionLocation { height, index }
+    }
+
     /// Creates a transaction location from a block height and transaction index.
     pub fn from_index(height: Height, transaction_index: u16) -> TransactionLocation {
         TransactionLocation {
@@ -148,6 +163,42 @@ impl TransactionLocation {
         TransactionLocation {
             height,
             index: TransactionIndex::from_u64(transaction_index),
+        }
+    }
+
+    /// The minimum value of a transaction location.
+    ///
+    /// This value corresponds to the genesis coinbase transaction.
+    pub const MIN: Self = Self {
+        height: Height::MIN,
+        index: TransactionIndex::MIN,
+    };
+
+    /// The maximun value of a transaction location.
+    ///
+    /// This value corresponds to the last transaction in the highest possible block.
+    pub const MAX: Self = Self {
+        height: Height::MAX,
+        index: TransactionIndex::MAX,
+    };
+
+    /// The minimum value of a transaction location for `height`.
+    ///
+    /// This value is the coinbase transaction.
+    pub const fn min_for_height(height: Height) -> Self {
+        Self {
+            height,
+            index: TransactionIndex::MIN,
+        }
+    }
+
+    /// The maximum value of a transaction location for `height`.
+    ///
+    /// This value can be a valid entry, but it won't fit in a 2MB block.
+    pub const fn max_for_height(height: Height) -> Self {
+        Self {
+            height,
+            index: TransactionIndex::MAX,
         }
     }
 }

--- a/zebra-state/src/service/finalized_state/disk_format/scan.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/scan.rs
@@ -4,23 +4,14 @@
 //!
 //! # Correctness
 //!
-//! Once format versions are implemented for the scanner database,
 //! `zebra_scan::Storage::database_format_version_in_code()` must be incremented
 //! each time the database format (column, serialization, etc) changes.
 
 use zebra_chain::{block::Height, transaction};
 
-use crate::{FromDisk, IntoDisk};
+use crate::{FromDisk, IntoDisk, TransactionLocation};
 
-use super::block::HEIGHT_DISK_BYTES;
-
-/// The fixed length of the scanning result.
-///
-/// TODO: If the scanning result doesn't have a fixed length, either:
-/// - deserialize using internal length or end markers,
-/// - prefix it with a length, or
-/// - stop storing vectors of results on disk, instead store each result with a unique key.
-pub const SAPLING_SCANNING_RESULT_LENGTH: usize = 32;
+use super::block::TRANSACTION_LOCATION_DISK_BYTES;
 
 /// The type used in Zebra to store Sapling scanning keys.
 /// It can represent a full viewing key or an individual viewing key.
@@ -52,7 +43,7 @@ pub struct SaplingScannedDatabaseEntry {
     pub index: SaplingScannedDatabaseIndex,
 
     /// The database column family value.
-    pub value: Vec<SaplingScannedResult>,
+    pub value: Option<SaplingScannedResult>,
 }
 
 /// A database column family key for a block scanned with a Sapling vieweing key.
@@ -61,39 +52,62 @@ pub struct SaplingScannedDatabaseIndex {
     /// The Sapling viewing key used to scan the block.
     pub sapling_key: SaplingScanningKey,
 
-    /// The height of the block.
-    pub height: Height,
+    /// The transaction location: block height and transaction index.
+    pub tx_loc: TransactionLocation,
 }
 
 impl SaplingScannedDatabaseIndex {
     /// The minimum value of a sapling scanned database index.
+    ///
     /// This value is guarateed to be the minimum, and not correspond to a valid key.
+    //
+    // Note: to calculate the maximum value, we need a key length.
     pub const fn min() -> Self {
         Self {
             // The empty string is the minimum value in RocksDB lexicographic order.
             sapling_key: String::new(),
-            // Genesis is the minimum height, and never has valid shielded transfers.
-            height: Height(0),
+            tx_loc: TransactionLocation::MIN,
         }
     }
 
     /// The minimum value of a sapling scanned database index for `sapling_key`.
-    /// This value is guarateed to be the minimum, and not correspond to a valid entry.
+    ///
+    /// This value does not correspond to a valid entry.
+    /// (The genesis coinbase transaction does not have shielded transfers.)
     pub fn min_for_key(sapling_key: &SaplingScanningKey) -> Self {
         Self {
             sapling_key: sapling_key.clone(),
-            // Genesis is the minimum height, and never has valid shielded transfers.
-            height: Height(0),
+            tx_loc: TransactionLocation::MIN,
         }
     }
 
     /// The maximum value of a sapling scanned database index for `sapling_key`.
-    /// This value is guarateed to be the maximum, and not correspond to a valid entry.
+    ///
+    /// This value may correspond to a valid entry, but it won't be mined for many decades.
     pub fn max_for_key(sapling_key: &SaplingScanningKey) -> Self {
         Self {
             sapling_key: sapling_key.clone(),
-            // The maximum height will never be mined - we'll increase it before that happens.
-            height: Height::MAX,
+            tx_loc: TransactionLocation::MAX,
+        }
+    }
+
+    /// The minimum value of a sapling scanned database index for `sapling_key` and `height`.
+    ///
+    /// This value can be a valid entry for shielded coinbase.
+    pub fn min_for_key_and_height(sapling_key: &SaplingScanningKey, height: Height) -> Self {
+        Self {
+            sapling_key: sapling_key.clone(),
+            tx_loc: TransactionLocation::min_for_height(height),
+        }
+    }
+
+    /// The maximum value of a sapling scanned database index for `sapling_key` and `height`.
+    ///
+    /// This value can be a valid entry, but it won't fit in a 2MB block.
+    pub fn max_for_key_and_height(sapling_key: &SaplingScanningKey, height: Height) -> Self {
+        Self {
+            sapling_key: sapling_key.clone(),
+            tx_loc: TransactionLocation::max_for_height(height),
         }
     }
 }
@@ -120,7 +134,7 @@ impl IntoDisk for SaplingScannedDatabaseIndex {
         let mut bytes = Vec::new();
 
         bytes.extend(self.sapling_key.as_bytes());
-        bytes.extend(self.height.as_bytes());
+        bytes.extend(self.tx_loc.as_bytes());
 
         bytes
     }
@@ -130,11 +144,11 @@ impl FromDisk for SaplingScannedDatabaseIndex {
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
         let bytes = bytes.as_ref();
 
-        let (sapling_key, height) = bytes.split_at(bytes.len() - HEIGHT_DISK_BYTES);
+        let (sapling_key, tx_loc) = bytes.split_at(bytes.len() - TRANSACTION_LOCATION_DISK_BYTES);
 
         Self {
             sapling_key: SaplingScanningKey::from_bytes(sapling_key),
-            height: Height::from_bytes(height),
+            tx_loc: TransactionLocation::from_bytes(tx_loc),
         }
     }
 }
@@ -153,22 +167,28 @@ impl FromDisk for SaplingScannedResult {
     }
 }
 
-impl IntoDisk for Vec<SaplingScannedResult> {
+impl IntoDisk for Option<SaplingScannedResult> {
     type Bytes = Vec<u8>;
 
     fn as_bytes(&self) -> Self::Bytes {
-        self.iter()
-            .flat_map(SaplingScannedResult::as_bytes)
-            .collect()
+        let mut bytes = Vec::new();
+
+        if let Some(result) = self.as_ref() {
+            bytes.extend(result.as_bytes());
+        }
+
+        bytes
     }
 }
 
-impl FromDisk for Vec<SaplingScannedResult> {
+impl FromDisk for Option<SaplingScannedResult> {
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
-        bytes
-            .as_ref()
-            .chunks(SAPLING_SCANNING_RESULT_LENGTH)
-            .map(SaplingScannedResult::from_bytes)
-            .collect()
+        let bytes = bytes.as_ref();
+
+        if bytes.is_empty() {
+            None
+        } else {
+            Some(SaplingScannedResult::from_bytes(bytes))
+        }
     }
 }


### PR DESCRIPTION
## Motivation

We want technical users to be able to use `ldb` to query the scanner database. This means we need one transaction ID per row.

Close #8050.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

There is already a summary for this project in the changelog.

_If a checkbox isn't relevant to the PR, mark it as done._

### Complex Code or Requirements

This changes the format from:
`ScannerKey | Height -> Vec<transaction::Hash>` to:
`ScannerKey | Height | TransactionIndex -> Option<transaction::Hash>`.

`None` can be used to represent birthday heights and scanner progress in #8022.

This format isn't ideal, because handing `None` is harder to code and review. We can change it to use a custom enum later, or track keys, birthdays, and progress in a separate column family. But that's for after the MVP.

## Solution

- Change the scanner database format (see above)
- Change the serialization formats
- Update the major version to 1
- Update format docs

### Testing

I updated the existing tests where needed, and they pass.

## Review

This is blocking finishing off the scanner, so it seems like a high priority for review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

- #8022
- #8046
- re-do #7813
