### PR TITLE
cleanup(db): Give forward and reverse database iterators explicit names

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -56,6 +56,9 @@ rustflags = [
     "-Wmissing_docs",
 
     # TODOs:
+    # Fix this lint eventually.
+    "-Aclippy::result_large_err",
+
     # `cargo fix` might help do these fixes,
     # or add a config.toml to sub-directories which should allow these lints,
     # or try allowing the lint in the specific module (lib.rs doesn't seem to work in some cases)

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -420,13 +420,13 @@ impl AddressTransaction {
     /// address. Starts at the first UTXO, or at the `query` start height, whichever is greater.
     /// Ends at the maximum possible transaction index for the end height.
     ///
-    /// Used to look up transactions with [`DiskDb::zs_range_iter`][1].
+    /// Used to look up transactions with [`DiskDb::zs_forward_range_iter`][1].
     ///
     /// The transaction locations in the:
     /// - start bound might be invalid, if it is based on the `query` start height.
     /// - end bound will always be invalid.
     ///
-    /// But this is not an issue, since [`DiskDb::zs_range_iter`][1] will fetch all existing
+    /// But this is not an issue, since [`DiskDb::zs_forward_range_iter`][1] will fetch all existing
     /// (valid) values in the range.
     ///
     /// [1]: super::super::disk_db::DiskDb

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -78,7 +78,7 @@ impl ZebraDb {
     ) -> impl Iterator<Item = (RawBytes, Arc<HistoryTree>)> + '_ {
         let history_tree_cf = self.db.cf_handle("history_tree").unwrap();
 
-        self.db.zs_range_iter(&history_tree_cf, .., false)
+        self.db.zs_forward_range_iter(&history_tree_cf, ..)
     }
 
     // Value pool methods

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -155,7 +155,7 @@ impl ZebraDb {
         &self,
     ) -> impl Iterator<Item = (RawBytes, Arc<sprout::tree::NoteCommitmentTree>)> + '_ {
         let sprout_trees = self.db.cf_handle("sprout_note_commitment_tree").unwrap();
-        self.db.zs_range_iter(&sprout_trees, .., false)
+        self.db.zs_forward_range_iter(&sprout_trees, ..)
     }
 
     // # Sapling trees
@@ -209,7 +209,7 @@ impl ZebraDb {
         R: std::ops::RangeBounds<Height>,
     {
         let sapling_trees = self.db.cf_handle("sapling_note_commitment_tree").unwrap();
-        self.db.zs_range_iter(&sapling_trees, range, false)
+        self.db.zs_forward_range_iter(&sapling_trees, range)
     }
 
     /// Returns the Sapling note commitment trees in the reversed range, in decreasing height order.
@@ -259,7 +259,7 @@ impl ZebraDb {
             .unwrap();
 
         self.db
-            .zs_range_iter(&sapling_subtrees, range, false)
+            .zs_forward_range_iter(&sapling_subtrees, range)
             .collect()
     }
 
@@ -335,7 +335,7 @@ impl ZebraDb {
         R: std::ops::RangeBounds<Height>,
     {
         let orchard_trees = self.db.cf_handle("orchard_note_commitment_tree").unwrap();
-        self.db.zs_range_iter(&orchard_trees, range, false)
+        self.db.zs_forward_range_iter(&orchard_trees, range)
     }
 
     /// Returns the Orchard note commitment trees in the reversed range, in decreasing height order.
@@ -385,7 +385,7 @@ impl ZebraDb {
             .unwrap();
 
         self.db
-            .zs_range_iter(&orchard_subtrees, range, false)
+            .zs_forward_range_iter(&orchard_subtrees, range)
             .collect()
     }
 

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -242,11 +242,7 @@ impl ZebraDb {
             AddressTransaction::address_iterator_range(address_location, query_height_range);
 
         self.db
-            .zs_range_iter(
-                &tx_loc_by_transparent_addr_loc,
-                transaction_location_range,
-                false,
-            )
+            .zs_forward_range_iter(&tx_loc_by_transparent_addr_loc, transaction_location_range)
             .map(|(tx_loc, ())| tx_loc)
             .collect()
     }


### PR DESCRIPTION
## Motivation

It was really tricky to use our database API in #8050, so I wanted to make iterator directions clearer.

This is different from the Rust `Iterator` trait, but that's probably ok as long as it's more explicit.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

### Specifications

RocksDB has forward and reverse iterators, we use our own generic wrappers for them.

## Solution

- Rename iterators to forward, and remove extra boolean arguments
- Ignore a clippy lint

### Testing

This is covered by existing tests.

## Review

This is a low priority cleanup, but it might be useful for some of the scanner work.

Please double-check that:
- false is forward
- true is reverse

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

