### PR TITLE
fix(scan): Stop logging viewing keys in the config

### DIFF
--- a/zebra-scan/src/config.rs
+++ b/zebra-scan/src/config.rs
@@ -1,5 +1,7 @@
 //! Configuration for blockchain scanning tasks.
 
+use std::fmt::Debug;
+
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +9,7 @@ use zebra_state::Config as DbConfig;
 
 use crate::storage::SaplingScanningKey;
 
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 /// Configuration for scanning.
 pub struct Config {
@@ -23,6 +25,16 @@ pub struct Config {
     // TODO: Remove fields that are only used by the state, and create a common database config.
     #[serde(flatten)]
     db_config: DbConfig,
+}
+
+impl Debug for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Config")
+            // Security: don't log private keys, birthday heights might also be private
+            .field("sapling_keys_to_scan", &self.sapling_keys_to_scan.len())
+            .field("db_config", &self.db_config)
+            .finish()
+    }
 }
 
 impl Default for Config {


### PR DESCRIPTION
## Motivation

The default Debug impl will log viewing keys when Zebra starts up, but we don't want private keys in the log.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

Just log the number of keys instead.

### Testing

I tested this manually by running `zebrad` with the `shielded-scan` feature and the zecpages key in the config.

## Review

This is a lower priority security fix, but it should still be done before the release.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

