### PR TITLE
scan(test): Implement scanner format round-trip tests

### DIFF
--- a/zebra-chain/src/block/height.rs
+++ b/zebra-chain/src/block/height.rs
@@ -23,6 +23,7 @@ pub mod json_conversion;
 /// There are multiple formats for serializing a height, so we don't implement
 /// `ZcashSerialize` or `ZcashDeserialize` for `Height`.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Default))]
 pub struct Height(pub u32);
 
 #[derive(Error, Debug)]

--- a/zebra-state/src/service/finalized_state/disk_format/block.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/block.rs
@@ -65,7 +65,7 @@ pub const TRANSACTION_LOCATION_DISK_BYTES: usize = HEIGHT_DISK_BYTES + TX_INDEX_
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(
     any(test, feature = "proptest-impl"),
-    derive(Arbitrary, Serialize, Deserialize)
+    derive(Arbitrary, Default, Serialize, Deserialize)
 )]
 pub struct TransactionIndex(pub(super) u16);
 
@@ -126,7 +126,7 @@ impl TransactionIndex {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(
     any(test, feature = "proptest-impl"),
-    derive(Arbitrary, Serialize, Deserialize)
+    derive(Arbitrary, Default, Serialize, Deserialize)
 )]
 pub struct TransactionLocation {
     /// The block height of the transaction.

--- a/zebra-state/src/service/finalized_state/disk_format/scan.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/scan.rs
@@ -13,6 +13,12 @@ use crate::{FromDisk, IntoDisk, TransactionLocation};
 
 use super::block::TRANSACTION_LOCATION_DISK_BYTES;
 
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
+#[cfg(test)]
+mod tests;
+
 /// The type used in Zebra to store Sapling scanning keys.
 /// It can represent a full viewing key or an individual viewing key.
 pub type SaplingScanningKey = String;
@@ -22,6 +28,7 @@ pub type SaplingScanningKey = String;
 /// Currently contains a TXID in "display order", which is big-endian byte order following the u256
 /// convention set by Bitcoin and zcashd.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary, Default))]
 pub struct SaplingScannedResult([u8; 32]);
 
 impl From<SaplingScannedResult> for transaction::Hash {
@@ -38,6 +45,7 @@ impl From<&[u8; 32]> for SaplingScannedResult {
 
 /// A database column family entry for a block scanned with a Sapling vieweing key.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary, Default))]
 pub struct SaplingScannedDatabaseEntry {
     /// The database column family key. Must be unique for each scanning key and scanned block.
     pub index: SaplingScannedDatabaseIndex,
@@ -48,6 +56,7 @@ pub struct SaplingScannedDatabaseEntry {
 
 /// A database column family key for a block scanned with a Sapling vieweing key.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary, Default))]
 pub struct SaplingScannedDatabaseIndex {
     /// The Sapling viewing key used to scan the block.
     pub sapling_key: SaplingScanningKey,

--- a/zebra-state/src/service/finalized_state/disk_format/scan/tests.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/scan/tests.rs
@@ -1,0 +1,3 @@
+//! Tests for scanner database serialization.
+
+mod prop;

--- a/zebra-state/src/service/finalized_state/disk_format/scan/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/scan/tests/prop.rs
@@ -1,0 +1,36 @@
+//! Randomised proptests for scanner database formats.
+
+use proptest::{arbitrary::any, prelude::*};
+
+use crate::{
+    service::finalized_state::arbitrary::assert_value_properties, SaplingScannedDatabaseIndex,
+    SaplingScannedResult, SaplingScanningKey,
+};
+
+#[test]
+fn roundtrip_sapling_scanning_key() {
+    let _init_guard = zebra_test::init();
+
+    proptest!(|(val in any::<SaplingScanningKey>())| assert_value_properties(val));
+}
+
+#[test]
+fn roundtrip_sapling_db_index() {
+    let _init_guard = zebra_test::init();
+
+    proptest!(|(val in any::<SaplingScannedDatabaseIndex>())| assert_value_properties(val));
+}
+
+#[test]
+fn roundtrip_sapling_result() {
+    let _init_guard = zebra_test::init();
+
+    proptest!(|(val in any::<SaplingScannedResult>())| assert_value_properties(val));
+}
+
+#[test]
+fn roundtrip_option_sapling_result() {
+    let _init_guard = zebra_test::init();
+
+    proptest!(|(val in any::<Option<SaplingScannedResult>>())| assert_value_properties(val));
+}

--- a/zebra-state/src/service/finalized_state/disk_format/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/prop.rs
@@ -49,7 +49,7 @@ fn roundtrip_block_height() {
             // Limit the random height to the valid on-disk range.
             // Blocks outside this range are rejected before they reach the state.
             // (It would take decades to generate a valid chain this high.)
-            val = val.clamp(Height(0), MAX_ON_DISK_HEIGHT);
+            val.0 %= MAX_ON_DISK_HEIGHT.0 + 1;
             assert_value_properties(val)
         }
     );
@@ -77,7 +77,7 @@ fn roundtrip_transaction_location() {
 
     proptest!(
         |(mut val in any::<TransactionLocation>())| {
-            val.height = val.height.clamp(Height(0), MAX_ON_DISK_HEIGHT);
+            val.height.0 %= MAX_ON_DISK_HEIGHT.0 + 1;
             assert_value_properties(val)
         }
     );
@@ -145,7 +145,7 @@ fn roundtrip_output_location() {
 
     proptest!(
         |(mut val in any::<OutputLocation>())| {
-            *val.height_mut() = val.height().clamp(Height(0), MAX_ON_DISK_HEIGHT);
+            val.height_mut().0 %= MAX_ON_DISK_HEIGHT.0 + 1;
             assert_value_properties(val)
         }
     );
@@ -157,7 +157,7 @@ fn roundtrip_address_location() {
 
     proptest!(
         |(mut val in any::<AddressLocation>())| {
-            *val.height_mut() = val.height().clamp(Height(0), MAX_ON_DISK_HEIGHT);
+            val.height_mut().0 %= MAX_ON_DISK_HEIGHT.0 + 1;
             assert_value_properties(val)
         }
     );
@@ -169,7 +169,7 @@ fn roundtrip_address_balance_location() {
 
     proptest!(
         |(mut val in any::<AddressBalanceLocation>())| {
-            *val.height_mut() = val.address_location().height().clamp(Height(0), MAX_ON_DISK_HEIGHT);
+            val.height_mut().0 %= MAX_ON_DISK_HEIGHT.0 + 1;
             assert_value_properties(val)
         }
     );
@@ -188,8 +188,8 @@ fn roundtrip_address_unspent_output() {
 
     proptest!(
         |(mut val in any::<AddressUnspentOutput>())| {
-            *val.address_location_mut().height_mut() = val.address_location().height().clamp(Height(0), MAX_ON_DISK_HEIGHT);
-            *val.unspent_output_location_mut().height_mut() = val.unspent_output_location().height().clamp(Height(0), MAX_ON_DISK_HEIGHT);
+            val.address_location_mut().height_mut().0 %= MAX_ON_DISK_HEIGHT.0 + 1;
+            val.unspent_output_location_mut().height_mut().0 %= MAX_ON_DISK_HEIGHT.0 + 1;
 
             assert_value_properties(val)
         }
@@ -202,8 +202,8 @@ fn roundtrip_address_transaction() {
 
     proptest!(
         |(mut val in any::<AddressTransaction>())| {
-            *val.address_location_mut().height_mut() = val.address_location().height().clamp(Height(0), MAX_ON_DISK_HEIGHT);
-            val.transaction_location_mut().height = val.transaction_location().height.clamp(Height(0), MAX_ON_DISK_HEIGHT);
+            val.address_location_mut().height_mut().0 %= MAX_ON_DISK_HEIGHT.0 + 1;
+            val.transaction_location_mut().height.0 %= MAX_ON_DISK_HEIGHT.0 + 1;
 
             assert_value_properties(val)
         }
@@ -464,7 +464,6 @@ fn roundtrip_orchard_subtree_data() {
     let _init_guard = zebra_test::init();
 
     proptest!(|(mut val in any::<NoteCommitmentSubtreeData<orchard::tree::Node>>())| {
-        val.end_height = val.end_height.clamp(Height(0), MAX_ON_DISK_HEIGHT);
         val.end_height.0 %= MAX_ON_DISK_HEIGHT.0 + 1;
         assert_value_properties(val)
     });

--- a/zebra-state/src/service/finalized_state/disk_format/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/prop.rs
@@ -26,12 +26,15 @@ use crate::service::finalized_state::{
 
 // Common
 
-// TODO: turn this into a unit test, it has a fixed value
+/// This test has a fixed value, so testing it once is sufficient.
 #[test]
 fn roundtrip_unit_type() {
     let _init_guard = zebra_test::init();
 
-    proptest!(|(val in any::<()>())| assert_value_properties(val));
+    // The unit type `()` is serialized to the empty (zero-length) array `[]`.
+    #[allow(clippy::let_unit_value)]
+    let value = ();
+    assert_value_properties(value);
 }
 
 // Block


### PR DESCRIPTION
## Motivation

We skipped these tests in tickets #8019 and #8050. Now the format has settled it's a good time to do them.


### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

### Test APIs

Proptests generate random typed data, then run it through a test closure or function. In this case, our `assert_value_properties()` makes sure that the round-trip format is correct.

We can't use `clamp()` with proptests because it sets the value to the end of the range, but we want it distributed over the range.

## Solution / Testing

- Add round-trip format tests for all the scanner formats
- Add `Arbitrary` implementations for all the scanner formats

Related changes:
- Derive `Default` in test-only code to make testing easier
- Clean up an existing round-trip test

Related fixes:
- Increase proptest coverage of height serialization

(The fix for ticket #7443 in PR #7628 was incomplete.)

## Review

This is a lower priority routine testing change.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

