### PR TITLE
change(log): Silence verbose failed connection logs

### DIFF
--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -863,8 +863,9 @@ where
 
                 // Increment the connection count before we spawn the connection.
                 let outbound_connection_tracker = active_outbound_connections.track_connection();
+                let outbound_connections = active_outbound_connections.update_count();
                 debug!(
-                    outbound_connections = ?active_outbound_connections.update_count(),
+                    ?outbound_connections,
                     "opening an outbound peer connection"
                 );
 
@@ -892,6 +893,7 @@ where
                                 candidate,
                                 outbound_connector,
                                 outbound_connection_tracker,
+                                outbound_connections,
                                 peerset_tx,
                                 address_book_updater,
                                 demand_tx,
@@ -1026,6 +1028,7 @@ where
 #[instrument(skip(
     outbound_connector,
     outbound_connection_tracker,
+    outbound_connections,
     peerset_tx,
     address_book_updater,
     demand_tx
@@ -1034,6 +1037,7 @@ async fn dial<C>(
     candidate: MetaAddr,
     mut outbound_connector: C,
     outbound_connection_tracker: ConnectionTracker,
+    outbound_connections: usize,
     mut peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
     address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
@@ -1048,6 +1052,9 @@ where
         + 'static,
     C::Future: Send + 'static,
 {
+    // The maximum number of open or pending connections before we log an info-level message.
+    const MAX_CONNECTIONS_FOR_INFO_LOG: usize = 5;
+
     // # Correctness
     //
     // To avoid hangs, the dialer must only await:
@@ -1076,7 +1083,13 @@ where
         }
         // The connection was never opened, or it failed the handshake and was dropped.
         Err(error) => {
-            info!(?error, ?candidate.addr, "failed to make outbound connection to peer");
+            // Silence verbose info logs in production, but keep logs if the number of connections is low.
+            // Also silence them completely in tests.
+            if outbound_connections <= MAX_CONNECTIONS_FOR_INFO_LOG && !cfg!(test) {
+                info!(?error, ?candidate.addr, "failed to make outbound connection to peer");
+            } else {
+                debug!(?error, ?candidate.addr, "failed to make outbound connection to peer");
+            }
             report_failed(address_book_updater.clone(), candidate).await;
 
             // The demand signal that was taken out of the queue to attempt to connect to the

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -864,10 +864,7 @@ where
                 // Increment the connection count before we spawn the connection.
                 let outbound_connection_tracker = active_outbound_connections.track_connection();
                 let outbound_connections = active_outbound_connections.update_count();
-                debug!(
-                    ?outbound_connections,
-                    "opening an outbound peer connection"
-                );
+                debug!(?outbound_connections, "opening an outbound peer connection");
 
                 // Spawn each handshake or crawl into an independent task, so handshakes can make
                 // progress while crawls are running.
@@ -1052,7 +1049,8 @@ where
         + 'static,
     C::Future: Send + 'static,
 {
-    // The maximum number of open or pending connections before we log an info-level message.
+    // If Zebra only has a few connections, we log connection failures at info level,
+    // so users can diagnose and fix the problem. This defines the threshold for info logs.
     const MAX_CONNECTIONS_FOR_INFO_LOG: usize = 5;
 
     // # Correctness


### PR DESCRIPTION
## Motivation

1. Having lots of failed connection logs makes Zebra less usable, but when there are only a few connections users need to know why
2. It's also causing GitHub to be very slow showing logs in tests

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- In production, log failed connections at info level at startup, and when there are less than 5 connections
- In tests, always log failed connections at debug level (except maybe for startup)

## Review

This is a low priority logging fix.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

