### PR TITLE
Add `ldb` RocksDB query tool to the Dockerfile

### DIFF
--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -6,7 +6,6 @@ Follow the [Docker or compilation instructions](https://zebra.zfnd.org/index.htm
 
 To compile Zebra from source, you will need to [install some dependencies.](https://zebra.zfnd.org/index.html#building-zebra).
 
-
 ## Alternative Compilation Methods
 
 ### Compiling Manually from git
@@ -58,7 +57,12 @@ If you're having trouble with:
 
 - use `cargo install` without `--locked` to build with the latest versions of each dependency
 
-#### Optional Tor feature
+## Experimental Shielded Scanning feature
+
+- install the `rocksdb-tools` or `rocksdb` packages to get the `ldb` binary, which allows expert users to
+  [query the scanner database](https://zebra.zfnd.org/user/shielded-scan.html). This binary is sometimes called `rocksdb_ldb`.
+
+## Optional Tor feature
 
 - **sqlite linker errors:** libsqlite3 is an optional dependency of the `zebra-network/tor` feature.
   If you don't have it installed, you might see errors like `note: /usr/bin/ld: cannot find -lsqlite3`.

--- a/book/src/user/run.md
+++ b/book/src/user/run.md
@@ -13,8 +13,9 @@ structure, and documentation for all of the config options can be found
 
 You can run Zebra as a:
 
-- [`lightwalletd` backend](https://zebra.zfnd.org/user/lightwalletd.html), and
-- experimental [mining backend](https://zebra.zfnd.org/user/mining.html).
+- [`lightwalletd` backend](https://zebra.zfnd.org/user/lightwalletd.html),
+- [mining backend](https://zebra.zfnd.org/user/mining.html), or
+- experimental [Sapling shielded transaction scanner](https://zebra.zfnd.org/user/shielded-scan.html).
 
 ## Supported versions
 

--- a/book/src/user/shielded-scan.md
+++ b/book/src/user/shielded-scan.md
@@ -1,0 +1,24 @@
+# Zebra Shielded Scanning
+
+## Build & Install
+
+Using the `shielded-scan` feature. TODO: add examples, document the feature in zebrad/src/lib.rs.
+
+## Configuration
+
+In `zebrad.toml`, use:
+- the `[shielded_scan]` table for database settings, and
+- the `[shielded_scan.sapling_keys_to_scan]` table for diversifiable full viewing keys.
+
+TODO: add a definition for DFVK, link to its format, and add examples and links to keys and database settings.
+
+## Running Sapling Scanning
+
+Launch Zebra and wait for 12-24 hours.
+
+## Expert: Querying Raw Sapling Scanning Results
+
+TODO: Copy these instructions and examples here:
+- https://github.com/ZcashFoundation/zebra/issues/8046#issuecomment-1844772654
+
+Database paths are different on Linux, macOS, and Windows.

--- a/book/src/user/shielded-scan.md
+++ b/book/src/user/shielded-scan.md
@@ -1,5 +1,17 @@
 # Zebra Shielded Scanning
 
+This document describes how expert users can try Zebra's shielded scanning feature.
+
+For now, we only support Sapling, and only store transaction IDs in the scanner results database.
+Ongoing development is tracked in issue [#7728](https://github.com/ZcashFoundation/zebra/issues/7728).
+
+## Important Security Warning
+
+Zebra's shielded scanning feature has known security issues. It is for experimental use only.
+
+Do not use regular or sensitive viewing keys with Zebra's experimental scanning feature. Do not use this
+feature on a shared machine. We suggest generating new keys for experimental use.
+
 ## Build & Install
 
 Using the `shielded-scan` feature. TODO: add examples, document the feature in zebrad/src/lib.rs.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get -qq update && \
     ca-certificates \
     protobuf-compiler \
     rsync \
+    rocksdb-tools \
     ; \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
@@ -181,7 +182,8 @@ COPY --from=release /entrypoint.sh /
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    ca-certificates
+    ca-certificates \
+    rocksdb-tools
 
 # Config settings for zebrad
 ARG FEATURES


### PR DESCRIPTION
## Motivation

This adds the `ldb` RocksDB tool to support expert users querying scanner databases in Docker images. It's also useful for diagnosing chain state database issues in Docker images.

Close #8051.
Initial framework for #8046.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

I expect we'll deal with the changelog in the docs ticket #8046.

### Debian Package File List

https://packages.debian.org/bullseye/amd64/rocksdb-tools/filelist

### Complex Code or Requirements

This adds around 30 MB to the size of the Docker image. But it's already around 1 GB, so that doesn't matter much.

## Solution

- Add the RocksDB tools to the test, experimental, and non-experimental production Docker images
- Add a rough framework for a scanner doc, and link to it from other docs
- Add an install doc for the `ldb` tool

### Testing

This image is built in every Rust PR.

## Review

This is a routine change.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

- #8046
