### PR TITLE
fix(rpc): Make the `verbose` argument of the `getrawtransaction` RPC optional

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -226,7 +226,7 @@ pub trait Rpc {
     fn get_raw_transaction(
         &self,
         txid_hex: String,
-        verbose: u8,
+        verbose: Option<u8>,
     ) -> BoxFuture<Result<GetRawTransaction>>;
 
     /// Returns the transaction ids made by the provided transparent addresses.
@@ -945,10 +945,11 @@ where
     fn get_raw_transaction(
         &self,
         txid_hex: String,
-        verbose: u8,
+        verbose: Option<u8>,
     ) -> BoxFuture<Result<GetRawTransaction>> {
         let mut state = self.state.clone();
         let mut mempool = self.mempool.clone();
+        let verbose = verbose.unwrap_or(0);
         let verbose = verbose != 0;
 
         async move {

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -446,7 +446,7 @@ proptest! {
                 NoChainTip,
             );
 
-            let send_task = tokio::spawn(rpc.get_raw_transaction(non_hex_string, 0));
+            let send_task = tokio::spawn(rpc.get_raw_transaction(non_hex_string, Some(0)));
 
             mempool.expect_no_requests().await?;
             state.expect_no_requests().await?;
@@ -505,7 +505,7 @@ proptest! {
                 NoChainTip,
             );
 
-            let send_task = tokio::spawn(rpc.get_raw_transaction(hex::encode(random_bytes), 0));
+            let send_task = tokio::spawn(rpc.get_raw_transaction(hex::encode(random_bytes), Some(0)));
 
             mempool.expect_no_requests().await?;
             state.expect_no_requests().await?;

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -252,7 +252,7 @@ async fn test_rpc_response_data_for_network(network: Network) {
 
     // make the api call
     let get_raw_transaction =
-        rpc.get_raw_transaction(first_block_first_transaction.hash().encode_hex(), 0u8);
+        rpc.get_raw_transaction(first_block_first_transaction.hash().encode_hex(), Some(0u8));
     let (response, _) = futures::join!(get_raw_transaction, mempool_req);
     let get_raw_transaction = response.expect("We should have a GetRawTransaction struct");
 
@@ -269,7 +269,7 @@ async fn test_rpc_response_data_for_network(network: Network) {
 
     // make the api call
     let get_raw_transaction =
-        rpc.get_raw_transaction(first_block_first_transaction.hash().encode_hex(), 1u8);
+        rpc.get_raw_transaction(first_block_first_transaction.hash().encode_hex(), Some(1u8));
     let (response, _) = futures::join!(get_raw_transaction, mempool_req);
     let get_raw_transaction = response.expect("We should have a GetRawTransaction struct");
 

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -423,7 +423,7 @@ async fn rpc_getrawtransaction() {
                         conventional_fee: Amount::zero(),
                     }]));
                 });
-            let get_tx_req = rpc.get_raw_transaction(tx.hash().encode_hex(), 0u8);
+            let get_tx_req = rpc.get_raw_transaction(tx.hash().encode_hex(), Some(0u8));
             let (response, _) = futures::join!(get_tx_req, mempool_req);
             let get_tx = response.expect("We should have a GetRawTransaction struct");
             if let GetRawTransaction::Raw(raw_tx) = get_tx {
@@ -454,8 +454,8 @@ async fn rpc_getrawtransaction() {
     let run_state_test_case = |block_idx: usize, block: Arc<Block>, tx: Arc<Transaction>| {
         let read_state = read_state.clone();
         let tx_hash = tx.hash();
-        let get_tx_verbose_0_req = rpc.get_raw_transaction(tx_hash.encode_hex(), 0u8);
-        let get_tx_verbose_1_req = rpc.get_raw_transaction(tx_hash.encode_hex(), 1u8);
+        let get_tx_verbose_0_req = rpc.get_raw_transaction(tx_hash.encode_hex(), Some(0u8));
+        let get_tx_verbose_1_req = rpc.get_raw_transaction(tx_hash.encode_hex(), Some(1u8));
 
         async move {
             let (response, _) = futures::join!(get_tx_verbose_0_req, make_mempool_req(tx_hash));


### PR DESCRIPTION
## Motivation

The `verbose` argument of the `getrawtransaction` RPC is specified as optional in the documentation: https://zcash.github.io/rpc/getrawtransaction.html. It's also specified as optional in Zebra's docs: https://github.com/ZcashFoundation/zebra/blob/5dd33d7265b9a8afe7f6b84264cc4faa2a5bfada/zebra-rpc/src/methods.rs#L215, but not implemented as such.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

### Specifications

https://zcash.github.io/rpc/getrawtransaction.html

## Solution

- Use `Option<u8>` instead of `u8` for the `verbose` argument.

### Testing

- I adjusted existing tests and didn't add any new tests.
- I manually tested that the argument is optional with this PR and that its value defaults to 0.
- I also manually tested that Zebra required this argument without this PR, which didn't comply with the spec.

## Review

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._