### PR TITLE
change(scan): Impl `From<SaplingScannedResult>` for `[u8; 32]`

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_format/scan.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/scan.rs
@@ -43,6 +43,12 @@ impl From<&[u8; 32]> for SaplingScannedResult {
     }
 }
 
+impl From<SaplingScannedResult> for [u8; 32] {
+    fn from(scanned_result: SaplingScannedResult) -> Self {
+        scanned_result.0
+    }
+}
+
 /// A database column family entry for a block scanned with a Sapling vieweing key.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary, Default))]


### PR DESCRIPTION
## Motivation

This is a trivial PR that adds `From<SaplingScannedResult>` for `[u8; 32]`.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Impl `From<SaplingScannedResult>` for `[u8; 32]`.

## Review

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._