### PR TITLE
test(scan): Add typed database format snapshots to the scanner

### DIFF
--- a/zebra-chain/src/block/hash.rs
+++ b/zebra-chain/src/block/hash.rs
@@ -85,10 +85,9 @@ impl FromHex for Hash {
     type Error = <[u8; 32] as FromHex>::Error;
 
     fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
-        let mut hash = <[u8; 32]>::from_hex(hex)?;
-        hash.reverse();
+        let hash = <[u8; 32]>::from_hex(hex)?;
 
-        Ok(hash.into())
+        Ok(Self::from_bytes_in_display_order(&hash))
     }
 }
 
@@ -148,12 +147,6 @@ impl ZcashDeserialize for Hash {
 impl std::str::FromStr for Hash {
     type Err = SerializationError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut bytes = [0; 32];
-        if hex::decode_to_slice(s, &mut bytes[..]).is_err() {
-            Err(SerializationError::Parse("hex decoding error"))
-        } else {
-            bytes.reverse();
-            Ok(Hash(bytes))
-        }
+        Ok(Self::from_hex(s)?)
     }
 }

--- a/zebra-chain/src/serialization/error.rs
+++ b/zebra-chain/src/serialization/error.rs
@@ -2,6 +2,7 @@
 
 use std::{array::TryFromSliceError, io, num::TryFromIntError, str::Utf8Error};
 
+use hex::FromHexError;
 use thiserror::Error;
 
 /// A serialization error.
@@ -30,6 +31,10 @@ pub enum SerializationError {
     /// The length of a vec is too large to convert to a usize (and thus, too large to allocate on this platform)
     #[error("CompactSize too large: {0}")]
     TryFromIntError(#[from] TryFromIntError),
+
+    /// A string was not valid hexadecimal.
+    #[error("string was not hex: {0}")]
+    FromHexError(#[from] FromHexError),
 
     /// An error caused when validating a zatoshi `Amount`
     #[error("input couldn't be parsed as a zatoshi `Amount`: {source}")]

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -25,6 +25,7 @@ proptest-impl = [
     "proptest-derive",
     "zebra-state/proptest-impl",
     "zebra-chain/proptest-impl",
+    "zebra-test",
     "bls12_381",
     "ff",
     "group",
@@ -63,6 +64,8 @@ jubjub = { version = "0.10.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 zcash_note_encryption = { version = "0.4.0", optional = true }
 
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.31", optional = true }
+
 [dev-dependencies]
 
 insta = { version = "1.33.0", features = ["ron", "redactions"] }
@@ -78,4 +81,4 @@ rand = "0.8.5"
 zcash_note_encryption = "0.4.0"
 
 zebra-state = { path = "../zebra-state", version = "1.0.0-beta.31", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.31" }

--- a/zebra-scan/src/storage/db.rs
+++ b/zebra-scan/src/storage/db.rs
@@ -19,8 +19,8 @@ pub use zebra_state::{
 
 pub mod sapling;
 
-#[cfg(test)]
-mod tests;
+#[cfg(any(test, feature = "proptest-impl"))]
+pub mod tests;
 
 /// The directory name used to distinguish the scanner database from Zebra's other databases or
 /// flat files.

--- a/zebra-scan/src/storage/db/tests.rs
+++ b/zebra-scan/src/storage/db/tests.rs
@@ -1,3 +1,58 @@
 //! General scanner database tests.
 
+use std::sync::Arc;
+
+use zebra_chain::{
+    block::{Block, Height},
+    parameters::Network::{self, *},
+    serialization::ZcashDeserializeInto,
+};
+use zebra_state::TransactionIndex;
+
+use crate::{
+    storage::Storage,
+    tests::{FAKE_SAPLING_VIEWING_KEY, ZECPAGES_SAPLING_VIEWING_KEY},
+    Config,
+};
+
+#[cfg(test)]
 mod snapshot;
+
+/// Returns an empty `Storage` suitable for testing.
+pub fn new_test_storage(network: Network) -> Storage {
+    Storage::new(&Config::ephemeral(), network)
+}
+
+/// Add fake keys to `storage` for testing purposes.
+pub fn add_fake_keys(storage: &mut Storage) {
+    // Snapshot a birthday that is automatically set to activation height
+    storage.add_sapling_key(&ZECPAGES_SAPLING_VIEWING_KEY.to_string(), None);
+    // Snapshot a birthday above activation height
+    storage.add_sapling_key(&FAKE_SAPLING_VIEWING_KEY.to_string(), Height(1_000_000));
+}
+
+/// Add fake results to `storage` for testing purposes.
+pub fn add_fake_results(storage: &mut Storage, network: Network, height: Height) {
+    let blocks = match network {
+        Mainnet => &*zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS,
+        Testnet => &*zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS,
+    };
+
+    let block: Arc<Block> = blocks
+        .get(&height.0)
+        .expect("block height has test data")
+        .zcash_deserialize_into()
+        .expect("test data deserializes");
+
+    // Fake results from the first few blocks
+    storage.add_sapling_results(
+        &ZECPAGES_SAPLING_VIEWING_KEY.to_string(),
+        height,
+        block
+            .transactions
+            .iter()
+            .enumerate()
+            .map(|(index, tx)| (TransactionIndex::from_usize(index), tx.hash().into()))
+            .collect(),
+    );
+}

--- a/zebra-scan/src/storage/db/tests/snapshot.rs
+++ b/zebra-scan/src/storage/db/tests/snapshot.rs
@@ -154,9 +154,16 @@ fn snapshot_typed_result_data(storage: &Storage) {
     //
     // TODO: update this after PR #8080
     let sapling_keys_and_birthday_heights = storage.sapling_keys();
-    insta::assert_ron_snapshot!("sapling_keys", sapling_keys_and_birthday_heights);
-
     // HashMap has an unstable order across Rust releases, so we need to sort it here.
+    insta::assert_ron_snapshot!(
+        "sapling_keys",
+        sapling_keys_and_birthday_heights,
+        {
+                "." => insta::sorted_redaction()
+        }
+    );
+
+    // HashMap has an unstable order across Rust releases, so we need to sort it here as well.
     for (key_index, (sapling_key, _birthday_height)) in sapling_keys_and_birthday_heights
         .iter()
         .sorted()

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@mainnet_0.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@mainnet_0.snap
@@ -1,0 +1,10 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(0): [
+    SaplingScannedResult("c4eaa58879081de3c24a7b117ed2b28300e7ec4c4c1dff1d3f1268b7857a4ddb"),
+  ],
+  Height(419199): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@mainnet_1.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@mainnet_1.snap
@@ -1,0 +1,13 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(0): [
+    SaplingScannedResult("c4eaa58879081de3c24a7b117ed2b28300e7ec4c4c1dff1d3f1268b7857a4ddb"),
+  ],
+  Height(1): [
+    SaplingScannedResult("851bf6fbf7a976327817c738c489d7fa657752445430922d94c983c0b9ed4609"),
+  ],
+  Height(419199): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@mainnet_2.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@mainnet_2.snap
@@ -1,0 +1,16 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(0): [
+    SaplingScannedResult("c4eaa58879081de3c24a7b117ed2b28300e7ec4c4c1dff1d3f1268b7857a4ddb"),
+  ],
+  Height(1): [
+    SaplingScannedResult("851bf6fbf7a976327817c738c489d7fa657752445430922d94c983c0b9ed4609"),
+  ],
+  Height(2): [
+    SaplingScannedResult("8974d08d1c5f9c860d8b629d582a56659a4a1dcb2b5f98a25a5afcc2a784b0f4"),
+  ],
+  Height(419199): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@mainnet_keys.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@mainnet_keys.snap
@@ -1,0 +1,7 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(419199): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@testnet_0.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@testnet_0.snap
@@ -1,0 +1,10 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(0): [
+    SaplingScannedResult("c4eaa58879081de3c24a7b117ed2b28300e7ec4c4c1dff1d3f1268b7857a4ddb"),
+  ],
+  Height(279999): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@testnet_1.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@testnet_1.snap
@@ -1,0 +1,13 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(0): [
+    SaplingScannedResult("c4eaa58879081de3c24a7b117ed2b28300e7ec4c4c1dff1d3f1268b7857a4ddb"),
+  ],
+  Height(1): [
+    SaplingScannedResult("f37e9f691fffb635de0999491d906ee85ba40cd36dae9f6e5911a8277d7c5f75"),
+  ],
+  Height(279999): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@testnet_2.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@testnet_2.snap
@@ -1,0 +1,16 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(0): [
+    SaplingScannedResult("c4eaa58879081de3c24a7b117ed2b28300e7ec4c4c1dff1d3f1268b7857a4ddb"),
+  ],
+  Height(1): [
+    SaplingScannedResult("f37e9f691fffb635de0999491d906ee85ba40cd36dae9f6e5911a8277d7c5f75"),
+  ],
+  Height(2): [
+    SaplingScannedResult("5822c0532da8a008259ac39933d3210e508c17e3ba21d2b2c428785efdccb3d5"),
+  ],
+  Height(279999): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@testnet_keys.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_0_results@testnet_keys.snap
@@ -1,0 +1,7 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(279999): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@mainnet_0.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@mainnet_0.snap
@@ -1,0 +1,7 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(999999): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@mainnet_1.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@mainnet_1.snap
@@ -1,0 +1,7 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(999999): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@mainnet_2.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@mainnet_2.snap
@@ -1,0 +1,7 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(999999): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@mainnet_keys.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@mainnet_keys.snap
@@ -1,0 +1,7 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(999999): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@testnet_0.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@testnet_0.snap
@@ -1,0 +1,7 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(999999): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@testnet_1.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@testnet_1.snap
@@ -1,0 +1,7 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(999999): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@testnet_2.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@testnet_2.snap
@@ -1,0 +1,7 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(999999): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@testnet_keys.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_key_1_results@testnet_keys.snap
@@ -1,0 +1,7 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_results
+---
+{
+  Height(999999): [],
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@empty.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@empty.snap
@@ -1,0 +1,5 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_keys_and_birthday_heights
+---
+{}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@mainnet_0.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@mainnet_0.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_keys_and_birthday_heights
+---
+{
+  "zxviews1q0duytgcqqqqpqre26wkl45gvwwwd706xw608hucmvfalr759ejwf7qshjf5r9aa7323zulvz6plhttp5mltqcgs9t039cx2d09mgq05ts63n8u35hyv6h9nc9ctqqtue2u7cer2mqegunuulq2luhq3ywjcz35yyljewa4mgkgjzyfwh6fr6jd0dzd44ghk0nxdv2hnv4j5nxfwv24rwdmgllhe0p8568sgqt9ckt02v2kxf5ahtql6s0ltjpkckw8gtymxtxuu9gcr0swvz": Height(0),
+  "zxviewsfake": Height(1000000),
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@mainnet_1.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@mainnet_1.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_keys_and_birthday_heights
+---
+{
+  "zxviews1q0duytgcqqqqpqre26wkl45gvwwwd706xw608hucmvfalr759ejwf7qshjf5r9aa7323zulvz6plhttp5mltqcgs9t039cx2d09mgq05ts63n8u35hyv6h9nc9ctqqtue2u7cer2mqegunuulq2luhq3ywjcz35yyljewa4mgkgjzyfwh6fr6jd0dzd44ghk0nxdv2hnv4j5nxfwv24rwdmgllhe0p8568sgqt9ckt02v2kxf5ahtql6s0ltjpkckw8gtymxtxuu9gcr0swvz": Height(0),
+  "zxviewsfake": Height(1000000),
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@mainnet_2.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@mainnet_2.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_keys_and_birthday_heights
+---
+{
+  "zxviews1q0duytgcqqqqpqre26wkl45gvwwwd706xw608hucmvfalr759ejwf7qshjf5r9aa7323zulvz6plhttp5mltqcgs9t039cx2d09mgq05ts63n8u35hyv6h9nc9ctqqtue2u7cer2mqegunuulq2luhq3ywjcz35yyljewa4mgkgjzyfwh6fr6jd0dzd44ghk0nxdv2hnv4j5nxfwv24rwdmgllhe0p8568sgqt9ckt02v2kxf5ahtql6s0ltjpkckw8gtymxtxuu9gcr0swvz": Height(0),
+  "zxviewsfake": Height(1000000),
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@mainnet_keys.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@mainnet_keys.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_keys_and_birthday_heights
+---
+{
+  "zxviews1q0duytgcqqqqpqre26wkl45gvwwwd706xw608hucmvfalr759ejwf7qshjf5r9aa7323zulvz6plhttp5mltqcgs9t039cx2d09mgq05ts63n8u35hyv6h9nc9ctqqtue2u7cer2mqegunuulq2luhq3ywjcz35yyljewa4mgkgjzyfwh6fr6jd0dzd44ghk0nxdv2hnv4j5nxfwv24rwdmgllhe0p8568sgqt9ckt02v2kxf5ahtql6s0ltjpkckw8gtymxtxuu9gcr0swvz": Height(419200),
+  "zxviewsfake": Height(1000000),
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@testnet_0.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@testnet_0.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_keys_and_birthday_heights
+---
+{
+  "zxviews1q0duytgcqqqqpqre26wkl45gvwwwd706xw608hucmvfalr759ejwf7qshjf5r9aa7323zulvz6plhttp5mltqcgs9t039cx2d09mgq05ts63n8u35hyv6h9nc9ctqqtue2u7cer2mqegunuulq2luhq3ywjcz35yyljewa4mgkgjzyfwh6fr6jd0dzd44ghk0nxdv2hnv4j5nxfwv24rwdmgllhe0p8568sgqt9ckt02v2kxf5ahtql6s0ltjpkckw8gtymxtxuu9gcr0swvz": Height(0),
+  "zxviewsfake": Height(1000000),
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@testnet_1.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@testnet_1.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_keys_and_birthday_heights
+---
+{
+  "zxviews1q0duytgcqqqqpqre26wkl45gvwwwd706xw608hucmvfalr759ejwf7qshjf5r9aa7323zulvz6plhttp5mltqcgs9t039cx2d09mgq05ts63n8u35hyv6h9nc9ctqqtue2u7cer2mqegunuulq2luhq3ywjcz35yyljewa4mgkgjzyfwh6fr6jd0dzd44ghk0nxdv2hnv4j5nxfwv24rwdmgllhe0p8568sgqt9ckt02v2kxf5ahtql6s0ltjpkckw8gtymxtxuu9gcr0swvz": Height(0),
+  "zxviewsfake": Height(1000000),
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@testnet_2.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@testnet_2.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_keys_and_birthday_heights
+---
+{
+  "zxviews1q0duytgcqqqqpqre26wkl45gvwwwd706xw608hucmvfalr759ejwf7qshjf5r9aa7323zulvz6plhttp5mltqcgs9t039cx2d09mgq05ts63n8u35hyv6h9nc9ctqqtue2u7cer2mqegunuulq2luhq3ywjcz35yyljewa4mgkgjzyfwh6fr6jd0dzd44ghk0nxdv2hnv4j5nxfwv24rwdmgllhe0p8568sgqt9ckt02v2kxf5ahtql6s0ltjpkckw8gtymxtxuu9gcr0swvz": Height(0),
+  "zxviewsfake": Height(1000000),
+}

--- a/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@testnet_keys.snap
+++ b/zebra-scan/src/storage/db/tests/snapshots/sapling_keys@testnet_keys.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-scan/src/storage/db/tests/snapshot.rs
+expression: sapling_keys_and_birthday_heights
+---
+{
+  "zxviews1q0duytgcqqqqpqre26wkl45gvwwwd706xw608hucmvfalr759ejwf7qshjf5r9aa7323zulvz6plhttp5mltqcgs9t039cx2d09mgq05ts63n8u35hyv6h9nc9ctqqtue2u7cer2mqegunuulq2luhq3ywjcz35yyljewa4mgkgjzyfwh6fr6jd0dzd44ghk0nxdv2hnv4j5nxfwv24rwdmgllhe0p8568sgqt9ckt02v2kxf5ahtql6s0ltjpkckw8gtymxtxuu9gcr0swvz": Height(280000),
+  "zxviewsfake": Height(1000000),
+}

--- a/zebra-state/src/service/finalized_state/disk_format/scan.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/scan.rs
@@ -28,7 +28,10 @@ pub type SaplingScanningKey = String;
 /// Currently contains a TXID in "display order", which is big-endian byte order following the u256
 /// convention set by Bitcoin and zcashd.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary, Default))]
+#[cfg_attr(
+    any(test, feature = "proptest-impl"),
+    derive(Arbitrary, Default, serde::Serialize, serde::Deserialize)
+)]
 pub struct SaplingScannedResult([u8; 32]);
 
 impl From<SaplingScannedResult> for transaction::Hash {


### PR DESCRIPTION
## Motivation

These are part of the standard database tests in #8069.

Depends-On: #8075

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

### Complex Code or Requirements

It's actually much simpler than the existing state tests.

## Solution

- Add snapshot tests for every scanner database method, using the typed format
- Expose more test support code in zebra-scan

Related changes:
- Clean up `hex` implementation in `transaction::Hash`

### Testing

These are extra tests.

I have manually checked the data formats in the snapshots and they appear correct.

## Review

This would be helpful to merge soon, because it tests other PRs.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

Database conflict and ephemeral tests in #8069, or whatever acceptance tests we decide are useful.