### PR TITLE
fix(ci): use official `codespell` action

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -160,7 +160,7 @@ jobs:
     needs: changed-files
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: plettich/action-codespell@master
+      - uses: codespell-project/actions-codespell@v2.0
         with:
-          github_token: ${{ secrets.github_token }}
-          level: warning
+          only_warn: 1
+


### PR DESCRIPTION
## Motivation

Codespell has been failing based on an upstream error in the GitHub Action repo. We're taking this opportunity to use the new official version.

Fixes #8081

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [ ] Will the PR name make sense to users?
  - [ ] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [ ] Is the documentation up to date?

### Complex Code or Requirements

None

## Solution

- Change `plettich/action-codespell@master` with `codespell-project/actions-codespell@v2.0`
- Keep the same options

### Testing

Confirm this is running as expected.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
