### PR TITLE
fix(ci): use a bigger machine for config file tests

### DIFF
--- a/.github/workflows/ci-unit-tests-docker.yml
+++ b/.github/workflows/ci-unit-tests-docker.yml
@@ -43,6 +43,7 @@ on:
       - '.github/workflows/sub-deploy-integration-tests-gcp.yml'
       - '.github/workflows/sub-build-docker-image.yml'
       - '.github/workflows/sub-find-cached-disks.yml'
+      - '.github/workflows/sub-test-zebra-config.yml'
 
   push:
     branches:

--- a/.github/workflows/sub-test-zebra-config.yml
+++ b/.github/workflows/sub-test-zebra-config.yml
@@ -32,7 +32,7 @@ jobs:
   test-docker-config:
     name: Test ${{ inputs.test_id }} in Docker
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
       - uses: actions/checkout@v4.1.1
         with:


### PR DESCRIPTION
## Motivation

We've been having this issue from time to time, but  as there's nothing in the Zebra config or on the Rust side that could cause this issue,  and all the other similar tests are passing, the most probable cause is we're using more memory than the default runners from GitHub are giving us when using this configuration. 

**Note:** Removing the `exec` command should be our last resort if this does not work by any means.

Closes: #7898


### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [ ] Will the PR name make sense to users?
  - [ ] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [ ] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._
## Solution

- Use a bigger runner with more memory. In this case `ubuntu-latest-m`

### Testing

Run this test at least 5 times. It should be really fast to do.


## Review

Nothing specific. 


### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
