### PR TITLE
Make sure scanner database is accessed using the correct types

### DIFF
--- a/zebra-chain/src/block/height.rs
+++ b/zebra-chain/src/block/height.rs
@@ -112,6 +112,15 @@ impl From<Height> for BlockHeight {
     }
 }
 
+impl TryFrom<BlockHeight> for Height {
+    type Error = &'static str;
+
+    /// Checks that the `height` is within the valid [`Height`] range.
+    fn try_from(height: BlockHeight) -> Result<Self, Self::Error> {
+        Self::try_from(u32::from(height))
+    }
+}
+
 /// A difference between two [`Height`]s, possibly negative.
 ///
 /// This can represent the difference between any height values,

--- a/zebra-scan/src/lib.rs
+++ b/zebra-scan/src/lib.rs
@@ -4,6 +4,9 @@
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]
 #![doc(html_root_url = "https://docs.rs/zebra_scan")]
 
+#[macro_use]
+extern crate tracing;
+
 pub mod config;
 pub mod init;
 pub mod scan;

--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -9,7 +9,6 @@ use std::{
 use color_eyre::{eyre::eyre, Report};
 use itertools::Itertools;
 use tower::{buffer::Buffer, util::BoxService, Service, ServiceExt};
-use tracing::info;
 
 use zcash_client_backend::{
     data_api::ScannedBlock,

--- a/zebra-scan/src/storage/db.rs
+++ b/zebra-scan/src/storage/db.rs
@@ -85,7 +85,7 @@ impl Storage {
         // Report where we are for each key in the database.
         let keys = new_storage.sapling_keys_last_heights();
         for (key_num, (_key, height)) in keys.iter().enumerate() {
-            tracing::info!(
+            info!(
                 "Last scanned height for key number {} is {}, resuming at {}",
                 key_num,
                 height.as_usize(),
@@ -93,7 +93,7 @@ impl Storage {
             );
         }
 
-        tracing::info!("loaded Zebra scanner cache");
+        info!("loaded Zebra scanner cache");
 
         new_storage
     }

--- a/zebra-scan/src/storage/db.rs
+++ b/zebra-scan/src/storage/db.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 use semver::Version;
 
 use zebra_chain::parameters::Network;
-use zebra_state::{DiskWriteBatch, ReadDisk};
 
 use crate::Config;
 
@@ -134,28 +133,6 @@ impl Storage {
     /// Returns true if the database is empty.
     pub fn is_empty(&self) -> bool {
         // Any column family that is populated at (or near) startup can be used here.
-        self.db.zs_is_empty(&self.sapling_tx_ids_cf())
-    }
-}
-
-// General writing
-
-/// Wrapper type for scanner database writes.
-#[must_use = "batches must be written to the database"]
-#[derive(Default)]
-pub struct ScannerWriteBatch(pub DiskWriteBatch);
-
-// Redirect method calls to DiskWriteBatch for convenience.
-impl std::ops::Deref for ScannerWriteBatch {
-    type Target = DiskWriteBatch;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ScannerWriteBatch {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        self.sapling_tx_ids_cf().zs_is_empty()
     }
 }

--- a/zebra-scan/src/storage/db/sapling.rs
+++ b/zebra-scan/src/storage/db/sapling.rs
@@ -2,9 +2,9 @@
 //!
 //! The sapling scanner database has the following format:
 //!
-//! | name             | key                           | value                    |
-//! |------------------|-------------------------------|--------------------------|
-//! | `sapling_tx_ids` | `SaplingScannedDatabaseIndex` | `Option<SaplingScannedResult>`      |
+//! | name               | Reading & Writing Key/Values                    |
+//! |--------------------|-------------------------------------------------|
+//! | [`SAPLING_TX_IDS`] | [`SaplingTxIdsCf`] & [`WriteSaplingTxIdsBatch`] |
 //!
 //! And types:
 //! `SaplingScannedResult`: same as `transaction::Hash`, but with bytes in display order.
@@ -30,18 +30,30 @@ use itertools::Itertools;
 
 use zebra_chain::block::Height;
 use zebra_state::{
-    AsColumnFamilyRef, ReadDisk, SaplingScannedDatabaseEntry, SaplingScannedDatabaseIndex,
-    SaplingScannedResult, SaplingScanningKey, TransactionIndex, WriteDisk,
+    SaplingScannedDatabaseEntry, SaplingScannedDatabaseIndex, SaplingScannedResult,
+    SaplingScanningKey, TransactionIndex, TransactionLocation, TypedColumnFamily, WriteTypedBatch,
 };
 
-use crate::storage::Storage;
-
-use super::ScannerWriteBatch;
+use crate::storage::{Storage, INSERT_CONTROL_INTERVAL};
 
 /// The name of the sapling transaction IDs result column family.
 ///
 /// This constant should be used so the compiler can detect typos.
 pub const SAPLING_TX_IDS: &str = "sapling_tx_ids";
+
+/// The type for reading sapling transaction IDs results from the database.
+///
+/// This constant should be used so the compiler can detect incorrectly typed accesses to the
+/// column family.
+pub type SaplingTxIdsCf<'cf> =
+    TypedColumnFamily<'cf, SaplingScannedDatabaseIndex, Option<SaplingScannedResult>>;
+
+/// The type for writing sapling transaction IDs results from the database.
+///
+/// This constant should be used so the compiler can detect incorrectly typed accesses to the
+/// column family.
+pub type WriteSaplingTxIdsBatch<'cf> =
+    WriteTypedBatch<'cf, SaplingScannedDatabaseIndex, Option<SaplingScannedResult>>;
 
 impl Storage {
     // Reading Sapling database entries
@@ -49,13 +61,11 @@ impl Storage {
     /// Returns the result for a specific database index (key, block height, transaction index).
     /// Returns `None` if the result is missing or an empty marker for a birthday or progress
     /// height.
-    //
-    // TODO: add tests for this method
     pub fn sapling_result_for_index(
         &self,
         index: &SaplingScannedDatabaseIndex,
     ) -> Option<SaplingScannedResult> {
-        self.db.zs_get(&self.sapling_tx_ids_cf(), &index).flatten()
+        self.sapling_tx_ids_cf().zs_get(index).flatten()
     }
 
     /// Returns the results for a specific key and block height.
@@ -102,10 +112,7 @@ impl Storage {
         let sapling_tx_ids = self.sapling_tx_ids_cf();
         let mut keys = HashMap::new();
 
-        let mut last_stored_record: Option<(
-            SaplingScannedDatabaseIndex,
-            Option<SaplingScannedResult>,
-        )> = self.db.zs_last_key_value(&sapling_tx_ids);
+        let mut last_stored_record = sapling_tx_ids.zs_last_key_value();
 
         while let Some((last_stored_record_index, _result)) = last_stored_record {
             let sapling_key = last_stored_record_index.sapling_key.clone();
@@ -119,8 +126,7 @@ impl Storage {
             );
 
             // Skip all the results until the next key.
-            last_stored_record = self.db.zs_prev_key_value_strictly_before(
-                &sapling_tx_ids,
+            last_stored_record = sapling_tx_ids.zs_prev_key_value_strictly_before(
                 &SaplingScannedDatabaseIndex::min_for_key(&sapling_key),
             );
         }
@@ -135,43 +141,60 @@ impl Storage {
         &self,
         range: impl RangeBounds<SaplingScannedDatabaseIndex>,
     ) -> BTreeMap<SaplingScannedDatabaseIndex, Option<SaplingScannedResult>> {
-        self.db
-            .zs_items_in_range_ordered(&self.sapling_tx_ids_cf(), range)
+        self.sapling_tx_ids_cf().zs_items_in_range_ordered(range)
     }
 
     // Column family convenience methods
 
-    /// Returns a handle to the `sapling_tx_ids` column family.
-    pub(crate) fn sapling_tx_ids_cf(&self) -> impl AsColumnFamilyRef + '_ {
-        self.db
-            .cf_handle(SAPLING_TX_IDS)
+    /// Returns a typed handle to the `sapling_tx_ids` column family.
+    pub(crate) fn sapling_tx_ids_cf(&self) -> SaplingTxIdsCf {
+        SaplingTxIdsCf::new(&self.db, SAPLING_TX_IDS)
             .expect("column family was created when database was created")
     }
 
-    // Writing batches
+    // Writing database entries
 
-    /// Write `batch` to the database for this storage.
-    pub(crate) fn write_batch(&self, batch: ScannerWriteBatch) {
-        // Just panic on errors for now.
-        self.db
-            .write_batch(batch.0)
-            .expect("unexpected database error")
-    }
-}
-
-// Writing database entries
-//
-// TODO: split the write type into state and scanner, so we can't call state write methods on
-// scanner databases
-impl ScannerWriteBatch {
-    /// Inserts a scanned sapling result for a key and height.
-    /// If a result already exists for that key and height, it is replaced.
-    pub(crate) fn insert_sapling_result(
+    /// Inserts a batch of scanned sapling result for a key and height.
+    /// If a result already exists for that key, height, and index, it is replaced.
+    pub(crate) fn insert_sapling_results(
         &mut self,
-        storage: &Storage,
-        entry: SaplingScannedDatabaseEntry,
+        sapling_key: &SaplingScanningKey,
+        height: Height,
+        sapling_results: BTreeMap<TransactionIndex, SaplingScannedResult>,
     ) {
-        self.zs_insert(&storage.sapling_tx_ids_cf(), entry.index, entry.value);
+        // We skip key heights that have one or more results, so the results for each key height
+        // must be in a single batch.
+        let mut batch = self.sapling_tx_ids_cf().for_writing();
+
+        // Every `INSERT_CONTROL_INTERVAL` we add a new entry to the scanner database for each key
+        // so we can track progress made in the last interval even if no transaction was yet found.
+        let needs_control_entry =
+            height.0 % INSERT_CONTROL_INTERVAL == 0 && sapling_results.is_empty();
+
+        // Add scanner progress tracking entry for key.
+        // Defensive programming: add the tracking entry first, so that we don't accidentally
+        // overwrite real results with it. (This is currently prevented by the empty check.)
+        if needs_control_entry {
+            batch = Self::insert_sapling_height(batch, sapling_key, height);
+        }
+
+        for (index, sapling_result) in sapling_results {
+            let index = SaplingScannedDatabaseIndex {
+                sapling_key: sapling_key.clone(),
+                tx_loc: TransactionLocation::from_parts(height, index),
+            };
+
+            let entry = SaplingScannedDatabaseEntry {
+                index,
+                value: Some(sapling_result),
+            };
+
+            batch = batch.zs_insert(entry.index, entry.value);
+        }
+
+        batch
+            .write_batch()
+            .expect("unexpected database write failure");
     }
 
     /// Insert a sapling scanning `key`, and mark all heights before `birthday_height` so they
@@ -184,11 +207,10 @@ impl ScannerWriteBatch {
     /// TODO: ignore incorrect changes to birthday heights
     pub(crate) fn insert_sapling_key(
         &mut self,
-        storage: &Storage,
         sapling_key: &SaplingScanningKey,
         birthday_height: Option<Height>,
     ) {
-        let min_birthday_height = storage.min_sapling_birthday_height();
+        let min_birthday_height = self.min_sapling_birthday_height();
 
         // The birthday height must be at least the minimum height for that pool.
         let birthday_height = birthday_height
@@ -197,19 +219,35 @@ impl ScannerWriteBatch {
         // And we want to skip up to the height before it.
         let skip_up_to_height = birthday_height.previous().unwrap_or(Height::MIN);
 
-        let index =
-            SaplingScannedDatabaseIndex::min_for_key_and_height(sapling_key, skip_up_to_height);
-        self.zs_insert(&storage.sapling_tx_ids_cf(), index, None);
+        // It's ok to write some keys and not others during shutdown, so each key can get its own
+        // batch. (They will be re-written on startup anyway.)
+        //
+        // TODO: ignore incorrect changes to birthday heights, and redundant
+        //       birthday heights
+        Self::insert_sapling_height(
+            self.sapling_tx_ids_cf().for_writing(),
+            sapling_key,
+            skip_up_to_height,
+        )
+        .write_batch()
+        .expect("unexpected database write failure");
     }
 
-    /// Insert sapling height with no results
-    pub(crate) fn insert_sapling_height(
-        &mut self,
-        storage: &Storage,
+    /// Insert sapling height with no results.
+    ///
+    /// If a result already exists for the coinbase transaction at that height,
+    /// it is replaced with an empty result. This should never happen.
+    //
+    // TODO: turn this into a method on a wrapper type for WriteSaplingTxIdsBatch
+    //       and impl Deref and DerefMut<WriteTypedBatch> on the wrapper
+    fn insert_sapling_height<'cf>(
+        write_sapling_tx_ids_batch: WriteSaplingTxIdsBatch<'cf>,
         sapling_key: &SaplingScanningKey,
         height: Height,
-    ) {
+    ) -> WriteSaplingTxIdsBatch<'cf> {
         let index = SaplingScannedDatabaseIndex::min_for_key_and_height(sapling_key, height);
-        self.zs_insert(&storage.sapling_tx_ids_cf(), index, None);
+
+        // TODO: assert that we don't overwrite any entries here.
+        write_sapling_tx_ids_batch.zs_insert(index, None)
     }
 }

--- a/zebra-scan/src/storage/db/sapling.rs
+++ b/zebra-scan/src/storage/db/sapling.rs
@@ -153,6 +153,9 @@ impl Storage {
     }
 
     // Writing database entries
+    //
+    // To avoid exposing internal types, and accidentally forgetting to write a batch,
+    // each pub(crate) write method should write an entire batch.
 
     /// Inserts a batch of scanned sapling result for a key and height.
     /// If a result already exists for that key, height, and index, it is replaced.

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -60,15 +60,19 @@ pub use service::{
 };
 
 #[cfg(feature = "shielded-scan")]
-pub use rocksdb::AsColumnFamilyRef;
-#[cfg(feature = "shielded-scan")]
 pub use service::finalized_state::{
-    FromDisk, IntoDisk, SaplingScannedDatabaseEntry, SaplingScannedDatabaseIndex,
-    SaplingScannedResult, SaplingScanningKey, TypedColumnFamily, WriteTypedBatch, ZebraDb,
+    SaplingScannedDatabaseEntry, SaplingScannedDatabaseIndex, SaplingScannedResult,
+    SaplingScanningKey,
 };
 
 #[cfg(any(test, feature = "proptest-impl", feature = "shielded-scan"))]
-pub use service::finalized_state::{DiskWriteBatch, ReadDisk, WriteDisk};
+pub use service::{
+    finalized_state::{
+        DiskWriteBatch, FromDisk, IntoDisk, ReadDisk, TypedColumnFamily, WriteDisk,
+        WriteTypedBatch, ZebraDb,
+    },
+    ReadStateService,
+};
 
 #[cfg(feature = "getblocktemplate-rpcs")]
 pub use response::GetBlockTemplateChainInfo;
@@ -78,8 +82,11 @@ pub use service::{
     arbitrary::{populated_state, CHAIN_TIP_UPDATE_WAIT_LIMIT},
     chain_tip::{ChainTipBlock, ChainTipSender},
     finalized_state::{RawBytes, KV, MAX_ON_DISK_HEIGHT},
-    init_test, init_test_services, ReadStateService,
+    init_test, init_test_services,
 };
+
+#[cfg(any(test, feature = "proptest-impl"))]
+pub use constants::latest_version_for_adding_subtrees;
 
 #[cfg(not(any(test, feature = "proptest-impl")))]
 #[allow(unused_imports)]
@@ -91,8 +98,5 @@ pub(crate) use config::hidden::{
 pub use config::hidden::{
     write_database_format_version_to_disk, write_state_database_format_version_to_disk,
 };
-
-#[cfg(any(test, feature = "proptest-impl"))]
-pub use constants::latest_version_for_adding_subtrees;
 
 pub(crate) use request::ContextuallyVerifiedBlock;

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -64,7 +64,7 @@ pub use rocksdb::AsColumnFamilyRef;
 #[cfg(feature = "shielded-scan")]
 pub use service::finalized_state::{
     FromDisk, IntoDisk, SaplingScannedDatabaseEntry, SaplingScannedDatabaseIndex,
-    SaplingScannedResult, SaplingScanningKey, ZebraDb,
+    SaplingScannedResult, SaplingScanningKey, TypedColumnFamily, WriteTypedBatch, ZebraDb,
 };
 
 #[cfg(any(test, feature = "proptest-impl", feature = "shielded-scan"))]

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -28,6 +28,8 @@ use crate::{
     BoxError, CheckpointVerifiedBlock, CloneError, Config,
 };
 
+pub mod column_family;
+
 mod disk_db;
 mod disk_format;
 mod zebra_db;
@@ -38,6 +40,8 @@ mod arbitrary;
 #[cfg(test)]
 mod tests;
 
+#[allow(unused_imports)]
+pub use column_family::{TypedColumnFamily, WriteTypedBatch};
 #[allow(unused_imports)]
 pub use disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk};
 #[allow(unused_imports)]

--- a/zebra-state/src/service/finalized_state/column_family.rs
+++ b/zebra-state/src/service/finalized_state/column_family.rs
@@ -9,7 +9,7 @@ use std::{
     ops::RangeBounds,
 };
 
-use crate::{DiskWriteBatch, FromDisk, IntoDisk, ReadDisk, WriteDisk};
+use crate::service::finalized_state::{DiskWriteBatch, FromDisk, IntoDisk, ReadDisk, WriteDisk};
 
 use super::DiskDb;
 

--- a/zebra-state/src/service/finalized_state/column_family.rs
+++ b/zebra-state/src/service/finalized_state/column_family.rs
@@ -1,5 +1,11 @@
 //! Type-safe column family access.
 
+// When these types aren't exported, they become dead code.
+#![cfg_attr(
+    not(any(test, feature = "proptest-impl", feature = "shielded-scan")),
+    allow(dead_code)
+)]
+
 use std::{
     any::type_name,
     collections::{BTreeMap, HashMap},

--- a/zebra-state/src/service/finalized_state/column_family.rs
+++ b/zebra-state/src/service/finalized_state/column_family.rs
@@ -1,0 +1,287 @@
+//! Type-safe column family access.
+
+use std::{
+    any::type_name,
+    collections::{BTreeMap, HashMap},
+    fmt::Debug,
+    hash::Hash,
+    marker::PhantomData,
+    ops::RangeBounds,
+};
+
+use crate::{DiskWriteBatch, FromDisk, IntoDisk, ReadDisk, WriteDisk};
+
+use super::DiskDb;
+
+/// A type-safe read-only column family reference.
+///
+/// Use this struct instead of raw [`ReadDisk`] access, because it is type-safe.
+/// So you only have to define the types once, and you can't accidentally use different types for
+/// reading and writing. (Which is a source of subtle database bugs.)
+#[derive(Clone)]
+pub struct TypedColumnFamily<'cf, Key, Value>
+where
+    Key: IntoDisk + FromDisk + Debug,
+    Value: IntoDisk + FromDisk,
+{
+    /// The database.
+    db: DiskDb,
+
+    /// The column family reference in the database.
+    cf: rocksdb::ColumnFamilyRef<'cf>,
+
+    /// The column family name, only used for debugging and equality checking.
+    _cf_name: String,
+
+    /// A marker type used to bind the key and value types to the struct.
+    _marker: PhantomData<(Key, Value)>,
+}
+
+/// A type-safe and drop-safe batch write to a column family.
+///
+/// Use this struct instead of raw [`WriteDisk`] access, because it is type-safe.
+/// So you only have to define the types once, and you can't accidentally use different types for
+/// reading and writing. (Which is a source of subtle database bugs.)
+///
+/// This type is also drop-safe: unwritten batches have to be specifically ignored.
+#[must_use = "batches must be written to the database"]
+#[derive(Debug, Eq, PartialEq)]
+pub struct WriteTypedBatch<'cf, Key, Value>
+where
+    Key: IntoDisk + FromDisk + Debug,
+    Value: IntoDisk + FromDisk,
+{
+    inner: TypedColumnFamily<'cf, Key, Value>,
+
+    batch: DiskWriteBatch,
+}
+
+impl<'cf, Key, Value> Debug for TypedColumnFamily<'cf, Key, Value>
+where
+    Key: IntoDisk + FromDisk + Debug,
+    Value: IntoDisk + FromDisk,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(&format!(
+            "TypedColumnFamily<{}, {}>",
+            type_name::<Key>(),
+            type_name::<Value>()
+        ))
+        .field("db", &self.db)
+        .field("cf", &self._cf_name)
+        .finish()
+    }
+}
+
+impl<'cf, Key, Value> PartialEq for TypedColumnFamily<'cf, Key, Value>
+where
+    Key: IntoDisk + FromDisk + Debug,
+    Value: IntoDisk + FromDisk,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.db == other.db && self._cf_name == other._cf_name
+    }
+}
+
+impl<'cf, Key, Value> Eq for TypedColumnFamily<'cf, Key, Value>
+where
+    Key: IntoDisk + FromDisk + Debug,
+    Value: IntoDisk + FromDisk,
+{
+}
+
+impl<'cf, Key, Value> TypedColumnFamily<'cf, Key, Value>
+where
+    Key: IntoDisk + FromDisk + Debug,
+    Value: IntoDisk + FromDisk,
+{
+    // Creation
+
+    /// Returns a new typed column family, if it exists in the database.
+    pub fn new(db: &'cf DiskDb, cf_name: &str) -> Option<Self> {
+        let cf = db.cf_handle(cf_name)?;
+
+        Some(Self {
+            db: db.clone(),
+            cf,
+            _cf_name: cf_name.to_string(),
+            _marker: PhantomData,
+        })
+    }
+
+    /// Returns a new writeable typed column family for this column family.
+    ///
+    /// This is the only way to get a writeable column family, which ensures
+    /// that the read and write types are consistent.
+    pub fn for_writing(self) -> WriteTypedBatch<'cf, Key, Value> {
+        WriteTypedBatch {
+            inner: self,
+            batch: DiskWriteBatch::new(),
+        }
+    }
+
+    // Reading
+
+    /// Returns true if this rocksdb column family does not contain any entries.
+    pub fn zs_is_empty(&self) -> bool {
+        self.db.zs_is_empty(&self.cf)
+    }
+
+    /// Returns the value for `key` in this rocksdb column family, if present.
+    pub fn zs_get(&self, key: &Key) -> Option<Value> {
+        self.db.zs_get(&self.cf, key)
+    }
+
+    /// Check if this rocksdb column family contains the serialized form of `key`.
+    pub fn zs_contains(&self, key: &Key) -> bool {
+        self.db.zs_contains(&self.cf, key)
+    }
+
+    /// Returns the lowest key in this column family, and the corresponding value.
+    ///
+    /// Returns `None` if this column family is empty.
+    pub fn zs_first_key_value(&self) -> Option<(Key, Value)> {
+        self.db.zs_first_key_value(&self.cf)
+    }
+
+    /// Returns the highest key in this column family, and the corresponding value.
+    ///
+    /// Returns `None` if this column family is empty.
+    pub fn zs_last_key_value(&self) -> Option<(Key, Value)> {
+        self.db.zs_last_key_value(&self.cf)
+    }
+
+    /// Returns the first key greater than or equal to `lower_bound` in this column family,
+    /// and the corresponding value.
+    ///
+    /// Returns `None` if there are no keys greater than or equal to `lower_bound`.
+    pub fn zs_next_key_value_from(&self, lower_bound: &Key) -> Option<(Key, Value)> {
+        self.db.zs_next_key_value_from(&self.cf, lower_bound)
+    }
+
+    /// Returns the first key strictly greater than `lower_bound` in this column family,
+    /// and the corresponding value.
+    ///
+    /// Returns `None` if there are no keys greater than `lower_bound`.
+    pub fn zs_next_key_value_strictly_after(&self, lower_bound: &Key) -> Option<(Key, Value)> {
+        self.db
+            .zs_next_key_value_strictly_after(&self.cf, lower_bound)
+    }
+
+    /// Returns the first key less than or equal to `upper_bound` in this column family,
+    /// and the corresponding value.
+    ///
+    /// Returns `None` if there are no keys less than or equal to `upper_bound`.
+    pub fn zs_prev_key_value_back_from(&self, upper_bound: &Key) -> Option<(Key, Value)> {
+        self.db.zs_prev_key_value_back_from(&self.cf, upper_bound)
+    }
+
+    /// Returns the first key strictly less than `upper_bound` in this column family,
+    /// and the corresponding value.
+    ///
+    /// Returns `None` if there are no keys less than `upper_bound`.
+    pub fn zs_prev_key_value_strictly_before(&self, upper_bound: &Key) -> Option<(Key, Value)> {
+        self.db
+            .zs_prev_key_value_strictly_before(&self.cf, upper_bound)
+    }
+
+    /// Returns a forward iterator over the items in this column family in `range`.
+    ///
+    /// Holding this iterator open might delay block commit transactions.
+    pub fn zs_forward_range_iter<Range>(
+        &self,
+        range: Range,
+    ) -> impl Iterator<Item = (Key, Value)> + '_
+    where
+        Range: RangeBounds<Key>,
+    {
+        self.db.zs_forward_range_iter(&self.cf, range)
+    }
+
+    /// Returns a reverse iterator over the items in this column family in `range`.
+    ///
+    /// Holding this iterator open might delay block commit transactions.
+    pub fn zs_reverse_range_iter<Range>(
+        &self,
+        range: Range,
+    ) -> impl Iterator<Item = (Key, Value)> + '_
+    where
+        Range: RangeBounds<Key>,
+    {
+        self.db.zs_reverse_range_iter(&self.cf, range)
+    }
+}
+
+impl<'cf, Key, Value> TypedColumnFamily<'cf, Key, Value>
+where
+    Key: IntoDisk + FromDisk + Debug + Ord,
+    Value: IntoDisk + FromDisk,
+{
+    /// Returns the keys and values in this column family in `range`, in an ordered `BTreeMap`.
+    ///
+    /// Holding this iterator open might delay block commit transactions.
+    pub fn zs_items_in_range_ordered<Range>(&self, range: Range) -> BTreeMap<Key, Value>
+    where
+        Range: RangeBounds<Key>,
+    {
+        self.db.zs_items_in_range_ordered(&self.cf, range)
+    }
+}
+
+impl<'cf, Key, Value> TypedColumnFamily<'cf, Key, Value>
+where
+    Key: IntoDisk + FromDisk + Debug + Hash + Eq,
+    Value: IntoDisk + FromDisk,
+{
+    /// Returns the keys and values in this column family in `range`, in an unordered `HashMap`.
+    ///
+    /// Holding this iterator open might delay block commit transactions.
+    pub fn zs_items_in_range_unordered<Range>(&self, range: Range) -> HashMap<Key, Value>
+    where
+        Range: RangeBounds<Key>,
+    {
+        self.db.zs_items_in_range_unordered(&self.cf, range)
+    }
+}
+
+impl<'cf, Key, Value> WriteTypedBatch<'cf, Key, Value>
+where
+    Key: IntoDisk + FromDisk + Debug,
+    Value: IntoDisk + FromDisk,
+{
+    // Writing batches
+
+    /// Writes this batch to this column family in the database.
+    pub fn write(self) -> Result<(), rocksdb::Error> {
+        self.inner.db.write(self.batch)
+    }
+
+    // Batching before writing
+
+    /// Serialize and insert the given key and value into this column family,
+    /// overwriting any existing `value` for `key`.
+    pub fn zs_insert(mut self, key: Key, value: Value) -> Self {
+        self.batch.zs_insert(&self.inner.cf, key, value);
+
+        self
+    }
+
+    /// Remove the given key from this column family, if it exists.
+    pub fn zs_delete(mut self, key: Key) -> Self {
+        self.batch.zs_delete(&self.inner.cf, key);
+
+        self
+    }
+
+    /// Delete the given key range from this rocksdb column family, if it exists, including `from`
+    /// and excluding `until_strictly_before`.
+    //.
+    // TODO: convert zs_delete_range() to take std::ops::RangeBounds
+    //       see zs_range_iter() for an example of the edge cases
+    pub fn zs_delete_range(mut self, from: Key, until_strictly_before: Key) -> Self {
+        self.batch
+            .zs_delete_range(&self.inner.cf, from, until_strictly_before);
+
+        self
+    }
+}

--- a/zebra-state/src/service/finalized_state/column_family.rs
+++ b/zebra-state/src/service/finalized_state/column_family.rs
@@ -252,7 +252,7 @@ where
     // Writing batches
 
     /// Writes this batch to this column family in the database.
-    pub fn write(self) -> Result<(), rocksdb::Error> {
+    pub fn write_batch(self) -> Result<(), rocksdb::Error> {
         self.inner.db.write(self.batch)
     }
 


### PR DESCRIPTION
## Motivation

During the scanner MVP, it was easy to change the column family's types, but forget to update the code everywhere. There were at least two bugs like this, from two different developers.

Instead, we can make each column family strongly typed, so it can only be accessed using the correct types.

Preparation for #7833, let's document the easier way this PR implements.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

### API & Rust Reference

https://docs.rs/rocksdb/latest/rocksdb/struct.WriteBatchWithTransaction.html

https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html
https://doc.rust-lang.org/std/marker/struct.PhantomData.html

### Complex Code or Requirements

<!--
Does this PR change concurrency, unsafe code, or complex consensus rules?
If it does, label this PR with `extra-reviews`.
-->


## Solution

Production:
- Define types for reading and writing sapling transaction ID results
- Simplify implementations using typed column families
- Make sure each method writes its own batch
- Implement common methods as a trivial trait

Docs & debugging:
- impl Debug and PartialEq on some database types to improve debugging
- Update docs & parameter names
- Deprecate some traits that we shouldn't use for new column families

Unrelated cleanups:
- impl TryFrom<zcash_primitives::BlockHeight> for Height
- Simplify logging macros in the scanner

We can't make the column family name string constant part of the type, because Rust doesn't support String const generics yet.

### Testing

This PR is well covered by existing tests, which pass.

## Review

This is a routine cleanup/internal enhancement.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

Use the new `TypedColumnFamily` and `WriteTypedBatch` for existing state column families. We might discover some bugs this way.

Document how to set up a new column family using these types - #7833


