### PR TITLE
fix(elasticsearch): Make bulk size the same for testnet and mainnet

### DIFF
--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -458,15 +458,11 @@ impl FinalizedState {
             let block_time = block.header.time.timestamp();
             let local_time = chrono::Utc::now().timestamp();
 
-            // Mainnet bulk size is small enough to avoid the elasticsearch 100mb content
-            // length limitation. MAX_BLOCK_BYTES = 2MB but each block use around 4.1 MB of JSON.
+            // Bulk size is small enough to avoid the elasticsearch 100mb content length limitation.
+            // MAX_BLOCK_BYTES = 2MB but each block use around 4.1 MB of JSON.
             // Each block count as 2 as we send them with a operation/header line. A value of 48
             // is 24 blocks.
-            const MAINNET_AWAY_FROM_TIP_BULK_SIZE: usize = 48;
-
-            // Testnet bulk size is larger as blocks are generally smaller in the testnet.
-            // A value of 800 is 400 blocks as we are not counting the operation line.
-            const TESTNET_AWAY_FROM_TIP_BULK_SIZE: usize = 800;
+            const AWAY_FROM_TIP_BULK_SIZE: usize = 48;
 
             // The number of blocks the bulk will have when we are in sync.
             // A value of 2 means only 1 block as we want to insert them as soon as we get
@@ -477,10 +473,7 @@ impl FinalizedState {
             // less than this number of seconds.
             const CLOSE_TO_TIP_SECONDS: i64 = 14400; // 4 hours
 
-            let mut blocks_size_to_dump = match self.network() {
-                Network::Mainnet => MAINNET_AWAY_FROM_TIP_BULK_SIZE,
-                Network::Testnet => TESTNET_AWAY_FROM_TIP_BULK_SIZE,
-            };
+            let mut blocks_size_to_dump = AWAY_FROM_TIP_BULK_SIZE;
 
             // If we are close to the tip, index one block per bulk call.
             if local_time - block_time < CLOSE_TO_TIP_SECONDS {


### PR DESCRIPTION
## Motivation

The bulk size for testnet is greater than mainnet which should synchronize the chain faster, however Elasticsearch has a limit of 100M per bulk. A stream of big blocks in the testnet can crash the node. 

Close https://github.com/ZcashFoundation/zebra/issues/7270

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [ ] Is the documentation up to date?

## Solution

Make the testnet bulk size equal to the mainnet. This is 24 blocks per bulk.


### Testing

I manually tested running the testnet, it syncing and adding records to the database as expected.


## Review

Anyone can review.


### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

