### PR TITLE
fix(ci): revert script changes causing workflow failures

### DIFF
--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -199,6 +199,7 @@ jobs:
           echo "CACHED_DISK_NAME=${CACHED_DISK_NAME}" >> "${GITHUB_ENV}"
           echo "DISK_OPTION=image=${CACHED_DISK_NAME}" >> "${GITHUB_ENV}"
 
+
       # Create a Compute Engine virtual machine and attach a cached state disk using the
       # $CACHED_DISK_NAME variable as the source image to populate the disk cached state
       # if the test needs it.

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -272,7 +272,7 @@ jobs:
           --boot-disk-type pd-ssd \
           --image-project=cos-cloud \
           --image-family=cos-stable \
-          --create-disk=${DISK_OPTION},name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=400GB,type=pd-ssd \
+          --create-disk=${DISK_OPTION}name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=400GB,type=pd-ssd \
           --container-image=gcr.io/google-containers/busybox \
           --machine-type ${{ vars.GCP_LARGE_MACHINE }} \
           --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -193,73 +193,11 @@ jobs:
           DISK_SUFFIX: ${{ inputs.disk_suffix }}
           PREFER_MAIN_CACHED_STATE: ${{ inputs.prefer_main_cached_state }}
         run: |
-          # source ./.github/workflows/scripts/gcp-get-cached-disks.sh
-          # echo "cached_disk_name=${CACHED_DISK_NAME}" >> "${GITHUB_OUTPUT}"
-          # echo "STATE_VERSION=${LOCAL_STATE_VERSION}" >> "${GITHUB_ENV}"
-          # echo "CACHED_DISK_NAME=${CACHED_DISK_NAME}" >> "${GITHUB_ENV}"
-          # echo "DISK_OPTION=image=${CACHED_DISK_NAME}" >> "${GITHUB_ENV}"
-
-          # TODO: remove this script and use the one in ./.github/workflows/scripts/gcp-get-cached-disks.sh
-          set -x
-          LOCAL_STATE_VERSION=$(grep -oE "DATABASE_FORMAT_VERSION: .* [0-9]+" "$GITHUB_WORKSPACE/zebra-state/src/constants.rs" | grep -oE "[0-9]+" | tail -n1)
-          echo "STATE_VERSION: $LOCAL_STATE_VERSION"
-          if [[ "${{ inputs.needs_lwd_state }}" == "true" ]]; then
-              DISK_PREFIX=${{ inputs.lwd_state_dir }}
-          else
-              DISK_PREFIX=${{ inputs.zebra_state_dir || inputs.disk_prefix }}
-          fi
-          # Try to find an image generated from a previous step or run of this commit.
-          # Fields are listed in the "Create image from state disk" step.
-          #
-          # We don't want to match the full branch name here, because:
-          # - we want to ignore the different GITHUB_REFs across manually triggered jobs,
-          #   pushed branches, and PRs,
-          # - previous commits might have been buggy,
-          #   or they might have worked and hide bugs in this commit
-          #   (we can't avoid this issue entirely, but we don't want to make it more likely), and
-          # - the branch name might have been shortened for the image.
-          #
-          # The probability of two matching short commit hashes within the same month is very low.
-          COMMIT_DISK_PREFIX="${DISK_PREFIX}-.+-${{ env.GITHUB_SHA_SHORT }}-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}"
-          COMMIT_CACHED_DISK_NAME=$(gcloud compute images list --filter="status=READY AND name~${COMMIT_DISK_PREFIX}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
-          echo "${GITHUB_REF_SLUG_URL}-${{ env.GITHUB_SHA_SHORT }} Disk: $COMMIT_CACHED_DISK_NAME"
-          if [[ -n "$COMMIT_CACHED_DISK_NAME" ]]; then
-              echo "Description: $(gcloud compute images describe $COMMIT_CACHED_DISK_NAME --format='value(DESCRIPTION)')"
-          fi
-          # Try to find an image generated from the main branch
-          MAIN_CACHED_DISK_NAME=$(gcloud compute images list --filter="status=READY AND name~${DISK_PREFIX}-main-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
-          echo "main Disk: $MAIN_CACHED_DISK_NAME"
-          if [[ -n "$MAIN_CACHED_DISK_NAME" ]]; then
-              echo "Description: $(gcloud compute images describe $MAIN_CACHED_DISK_NAME --format='value(DESCRIPTION)')"
-          fi
-          # Try to find an image generated from any other branch
-          ANY_CACHED_DISK_NAME=$(gcloud compute images list --filter="status=READY AND name~${DISK_PREFIX}-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
-          echo "any branch Disk: $ANY_CACHED_DISK_NAME"
-          if [[ -n "$ANY_CACHED_DISK_NAME" ]]; then
-              echo "Description: $(gcloud compute images describe $ANY_CACHED_DISK_NAME --format='value(DESCRIPTION)')"
-          fi
-          # Select a cached disk based on the job settings
-          CACHED_DISK_NAME="$COMMIT_CACHED_DISK_NAME"
-          if [[ -z "$CACHED_DISK_NAME" ]] && [[ "${{ inputs.prefer_main_cached_state }}" == "true" ]]; then
-              echo "Preferring main branch cached state to other branches..."
-              CACHED_DISK_NAME="$MAIN_CACHED_DISK_NAME"
-          fi
-          if [[ -z "$CACHED_DISK_NAME" ]]; then
-              CACHED_DISK_NAME="$ANY_CACHED_DISK_NAME"
-          fi
-          if [[ -z "$CACHED_DISK_NAME" ]]; then
-              echo "No cached state disk available"
-              echo "Expected ${COMMIT_DISK_PREFIX}"
-              echo "Also searched for cached disks from other branches"
-              echo "Cached state test jobs must depend on the cached state rebuild job"
-              exit 1
-          fi
-          echo "Selected Disk: $CACHED_DISK_NAME"
-          echo "cached_disk_name=$CACHED_DISK_NAME" >> "$GITHUB_OUTPUT"
-          echo "STATE_VERSION=$LOCAL_STATE_VERSION" >> "$GITHUB_ENV"
-          echo "CACHED_DISK_NAME=$CACHED_DISK_NAME" >> "$GITHUB_ENV"
-          echo "DISK_OPTION=image=$CACHED_DISK_NAME" >> "$GITHUB_ENV"
-
+          source ./.github/workflows/scripts/gcp-get-cached-disks.sh
+          echo "cached_disk_name=${CACHED_DISK_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "STATE_VERSION=${LOCAL_STATE_VERSION}" >> "${GITHUB_ENV}"
+          echo "CACHED_DISK_NAME=${CACHED_DISK_NAME}" >> "${GITHUB_ENV}"
+          echo "DISK_OPTION=image=${CACHED_DISK_NAME}" >> "${GITHUB_ENV}"
 
       # Create a Compute Engine virtual machine and attach a cached state disk using the
       # $CACHED_DISK_NAME variable as the source image to populate the disk cached state

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -258,6 +258,7 @@ jobs:
           echo "cached_disk_name=$CACHED_DISK_NAME" >> "$GITHUB_OUTPUT"
           echo "STATE_VERSION=$LOCAL_STATE_VERSION" >> "$GITHUB_ENV"
           echo "CACHED_DISK_NAME=$CACHED_DISK_NAME" >> "$GITHUB_ENV"
+          echo "DISK_OPTION=image=$CACHED_DISK_NAME" >> "$GITHUB_ENV"
 
 
       # Create a Compute Engine virtual machine and attach a cached state disk using the
@@ -272,7 +273,7 @@ jobs:
           --boot-disk-type pd-ssd \
           --image-project=cos-cloud \
           --image-family=cos-stable \
-          --create-disk=${DISK_OPTION}name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=400GB,type=pd-ssd \
+          --create-disk=${DISK_OPTION},name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=400GB,type=pd-ssd \
           --container-image=gcr.io/google-containers/busybox \
           --machine-type ${{ vars.GCP_LARGE_MACHINE }} \
           --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -193,11 +193,71 @@ jobs:
           DISK_SUFFIX: ${{ inputs.disk_suffix }}
           PREFER_MAIN_CACHED_STATE: ${{ inputs.prefer_main_cached_state }}
         run: |
-          source ./.github/workflows/scripts/gcp-get-cached-disks.sh
-          echo "cached_disk_name=${CACHED_DISK_NAME}" >> "${GITHUB_OUTPUT}"
-          echo "STATE_VERSION=${LOCAL_STATE_VERSION}" >> "${GITHUB_ENV}"
-          echo "CACHED_DISK_NAME=${CACHED_DISK_NAME}" >> "${GITHUB_ENV}"
-          echo "DISK_OPTION=image=${CACHED_DISK_NAME}" >> "${GITHUB_ENV}"
+          # source ./.github/workflows/scripts/gcp-get-cached-disks.sh
+          # echo "cached_disk_name=${CACHED_DISK_NAME}" >> "${GITHUB_OUTPUT}"
+          # echo "STATE_VERSION=${LOCAL_STATE_VERSION}" >> "${GITHUB_ENV}"
+          # echo "CACHED_DISK_NAME=${CACHED_DISK_NAME}" >> "${GITHUB_ENV}"
+          # echo "DISK_OPTION=image=${CACHED_DISK_NAME}" >> "${GITHUB_ENV}"
+
+          # TODO: remove this script and use the one in ./.github/workflows/scripts/gcp-get-cached-disks.sh
+          set -x
+          LOCAL_STATE_VERSION=$(grep -oE "DATABASE_FORMAT_VERSION: .* [0-9]+" "$GITHUB_WORKSPACE/zebra-state/src/constants.rs" | grep -oE "[0-9]+" | tail -n1)
+          echo "STATE_VERSION: $LOCAL_STATE_VERSION"
+          if [[ "${{ inputs.needs_lwd_state }}" == "true" ]]; then
+              DISK_PREFIX=${{ inputs.lwd_state_dir }}
+          else
+              DISK_PREFIX=${{ inputs.zebra_state_dir || inputs.disk_prefix }}
+          fi
+          # Try to find an image generated from a previous step or run of this commit.
+          # Fields are listed in the "Create image from state disk" step.
+          #
+          # We don't want to match the full branch name here, because:
+          # - we want to ignore the different GITHUB_REFs across manually triggered jobs,
+          #   pushed branches, and PRs,
+          # - previous commits might have been buggy,
+          #   or they might have worked and hide bugs in this commit
+          #   (we can't avoid this issue entirely, but we don't want to make it more likely), and
+          # - the branch name might have been shortened for the image.
+          #
+          # The probability of two matching short commit hashes within the same month is very low.
+          COMMIT_DISK_PREFIX="${DISK_PREFIX}-.+-${{ env.GITHUB_SHA_SHORT }}-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}"
+          COMMIT_CACHED_DISK_NAME=$(gcloud compute images list --filter="status=READY AND name~${COMMIT_DISK_PREFIX}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          echo "${GITHUB_REF_SLUG_URL}-${{ env.GITHUB_SHA_SHORT }} Disk: $COMMIT_CACHED_DISK_NAME"
+          if [[ -n "$COMMIT_CACHED_DISK_NAME" ]]; then
+              echo "Description: $(gcloud compute images describe $COMMIT_CACHED_DISK_NAME --format='value(DESCRIPTION)')"
+          fi
+          # Try to find an image generated from the main branch
+          MAIN_CACHED_DISK_NAME=$(gcloud compute images list --filter="status=READY AND name~${DISK_PREFIX}-main-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          echo "main Disk: $MAIN_CACHED_DISK_NAME"
+          if [[ -n "$MAIN_CACHED_DISK_NAME" ]]; then
+              echo "Description: $(gcloud compute images describe $MAIN_CACHED_DISK_NAME --format='value(DESCRIPTION)')"
+          fi
+          # Try to find an image generated from any other branch
+          ANY_CACHED_DISK_NAME=$(gcloud compute images list --filter="status=READY AND name~${DISK_PREFIX}-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-${{ inputs.disk_suffix }}" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          echo "any branch Disk: $ANY_CACHED_DISK_NAME"
+          if [[ -n "$ANY_CACHED_DISK_NAME" ]]; then
+              echo "Description: $(gcloud compute images describe $ANY_CACHED_DISK_NAME --format='value(DESCRIPTION)')"
+          fi
+          # Select a cached disk based on the job settings
+          CACHED_DISK_NAME="$COMMIT_CACHED_DISK_NAME"
+          if [[ -z "$CACHED_DISK_NAME" ]] && [[ "${{ inputs.prefer_main_cached_state }}" == "true" ]]; then
+              echo "Preferring main branch cached state to other branches..."
+              CACHED_DISK_NAME="$MAIN_CACHED_DISK_NAME"
+          fi
+          if [[ -z "$CACHED_DISK_NAME" ]]; then
+              CACHED_DISK_NAME="$ANY_CACHED_DISK_NAME"
+          fi
+          if [[ -z "$CACHED_DISK_NAME" ]]; then
+              echo "No cached state disk available"
+              echo "Expected ${COMMIT_DISK_PREFIX}"
+              echo "Also searched for cached disks from other branches"
+              echo "Cached state test jobs must depend on the cached state rebuild job"
+              exit 1
+          fi
+          echo "Selected Disk: $CACHED_DISK_NAME"
+          echo "cached_disk_name=$CACHED_DISK_NAME" >> "$GITHUB_OUTPUT"
+          echo "STATE_VERSION=$LOCAL_STATE_VERSION" >> "$GITHUB_ENV"
+          echo "CACHED_DISK_NAME=$CACHED_DISK_NAME" >> "$GITHUB_ENV"
 
 
       # Create a Compute Engine virtual machine and attach a cached state disk using the

--- a/.github/workflows/sub-find-cached-disks.yml
+++ b/.github/workflows/sub-find-cached-disks.yml
@@ -69,6 +69,8 @@ jobs:
         env:
           GITHUB_WORKSPACE: ${{ env.GITHUB_WORKSPACE }}
           NETWORK: ${{ env.NETWORK }} # use lowercase version from env, not input
+        # TODO: Use the `gcp-get-available-disks.sh` script instead of the inline script,
+        # as this is crashing. And it might related to the returned JSON values.
         run: |
           # ./.github/workflows/scripts/gcp-get-available-disks.sh
           LOCAL_STATE_VERSION=$(grep -oE "DATABASE_FORMAT_VERSION: .* [0-9]+" "$GITHUB_WORKSPACE/zebra-state/src/constants.rs" | grep -oE "[0-9]+" | tail -n1)

--- a/.github/workflows/sub-find-cached-disks.yml
+++ b/.github/workflows/sub-find-cached-disks.yml
@@ -70,4 +70,30 @@ jobs:
           GITHUB_WORKSPACE: ${{ env.GITHUB_WORKSPACE }}
           NETWORK: ${{ env.NETWORK }} # use lowercase version from env, not input
         run: |
-          ./.github/workflows/scripts/gcp-get-available-disks.sh
+          # ./.github/workflows/scripts/gcp-get-available-disks.sh
+          LOCAL_STATE_VERSION=$(grep -oE "DATABASE_FORMAT_VERSION: .* [0-9]+" "$GITHUB_WORKSPACE/zebra-state/src/constants.rs" | grep -oE "[0-9]+" | tail -n1)
+          echo "STATE_VERSION: $LOCAL_STATE_VERSION"
+          LWD_TIP_DISK=$(gcloud compute images list --filter="status=READY AND name~lwd-cache-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-tip" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          if [[ -z "$LWD_TIP_DISK" ]]; then
+              echo "No TIP disk found for lightwalletd on network: ${NETWORK}"
+              echo "lwd_tip_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
+          else
+              echo "Disk: $LWD_TIP_DISK"
+              echo "lwd_tip_disk=${{ toJSON(true) }}" >> "$GITHUB_OUTPUT"
+          fi
+          ZEBRA_TIP_DISK=$(gcloud compute images list --filter="status=READY AND name~zebrad-cache-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-tip" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          if [[ -z "$ZEBRA_TIP_DISK" ]]; then
+              echo "No TIP disk found for Zebra on network: ${NETWORK}"
+              echo "zebra_tip_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
+          else
+              echo "Disk: $ZEBRA_TIP_DISK"
+              echo "zebra_tip_disk=${{ toJSON(true) }}" >> "$GITHUB_OUTPUT"
+          fi
+          ZEBRA_CHECKPOINT_DISK=$(gcloud compute images list --filter="status=READY AND name~zebrad-cache-.+-[0-9a-f]+-v${LOCAL_STATE_VERSION}-${NETWORK}-checkpoint" --format="value(NAME)" --sort-by=~creationTimestamp --limit=1)
+          if [[ -z "$ZEBRA_CHECKPOINT_DISK" ]]; then
+              echo "No CHECKPOINT disk found for Zebra on network: ${NETWORK}"
+              echo "zebra_checkpoint_disk=${{ toJSON(false) }}" >> "$GITHUB_OUTPUT"
+          else
+              echo "Disk: $ZEBRA_CHECKPOINT_DISK"
+              echo "zebra_checkpoint_disk=${{ toJSON(true) }}" >> "$GITHUB_OUTPUT"
+          fi


### PR DESCRIPTION
## Motivation

CI has been failing with an internal GitHub error since PR https://github.com/ZcashFoundation/zebra/pull/8005 merged

Closes https://github.com/ZcashFoundation/zebra/issues/8123
Closes https://github.com/ZcashFoundation/zebra/pull/8132

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [ ] Will the PR name make sense to users?
  - [ ] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [ ] Is the documentation up to date?

## Solution

Partially revert #8005 for the scripts which checks for the cached state existence. 


### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.
