### PR TITLE
feat(mine): Add an internal Zcash miner to Zebra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,20 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Zebra 1.6.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.6.0) - TODO: 2024-01-??
+
+This release:
+- TODO: summary of other important changes
+- adds an experimental `internal-miner` feature, which mines blocks within `zebrad`. This feature
+  is only supported on testnet. Use a more efficient GPU or ASIC for mainnet mining.
+
+TODO: the rest of the changelog
+
+
 ## [Zebra 1.5.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.5.0) - 2023-11-28
 
 This release:
-- fixes a panic that was introduced in Zebra v1.4.0, which happens in rare circumstances when reading cached sprout or history trees. 
+- fixes a panic that was introduced in Zebra v1.4.0, which happens in rare circumstances when reading cached sprout or history trees.
 - further improves how Zebra recovers from network interruptions and prevents potential network hangs.
 - limits the ability of synthetic nodes to spread throughout the network through Zebra to address some of the Ziggurat red team report.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5898,7 +5898,6 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-derive",
  "jsonrpc-http-server",
- "num_cpus",
  "proptest",
  "rand 0.8.5",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?branch=equihash-solver-tromp#838d1e937e8a6f23e99fa4ea4e1984013d423a6f"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?branch=equihash-solver-tromp#ee069c1a7afe29d301f83cbeebf88b075164589e"
 dependencies = [
  "blake2b_simd",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,8 +1339,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab579d7cf78477773b03e80bc2f89702ef02d7112c711d54ca93dcdce68533d5"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?branch=equihash-solver-tromp#da26c34772f4922eb13b4a1e7d88a969bbcf6a91"
 dependencies = [
  "blake2b_simd",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4354,6 +4354,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-priority"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72cb4958060ee2d9540cef68bb3871fd1e547037772c7fe7650d5d1cbec53b3"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6072,6 +6086,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "thread-priority",
  "tinyvec",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,6 +1343,7 @@ source = "git+https://github.com/ZcashFoundation/librustzcash.git?branch=equihas
 dependencies = [
  "blake2b_simd",
  "byteorder",
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?branch=equihash-solver-tromp#ee069c1a7afe29d301f83cbeebf88b075164589e"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?branch=equihash-solver-tromp#251098313920466958fcd05b25e151d4edd3a1b1"
 dependencies = [
  "blake2b_simd",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?branch=equihash-solver-tromp#da26c34772f4922eb13b4a1e7d88a969bbcf6a91"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?branch=equihash-solver-tromp#838d1e937e8a6f23e99fa4ea4e1984013d423a6f"
 dependencies = [
  "blake2b_simd",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,6 +1339,16 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab579d7cf78477773b03e80bc2f89702ef02d7112c711d54ca93dcdce68533d5"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+]
+
+[[package]]
+name = "equihash"
+version = "0.2.0"
 source = "git+https://github.com/ZcashFoundation/librustzcash.git?branch=equihash-solver-tromp#da26c34772f4922eb13b4a1e7d88a969bbcf6a91"
 dependencies = [
  "blake2b_simd",
@@ -5633,7 +5643,7 @@ dependencies = [
  "blake2s_simd",
  "bls12_381",
  "byteorder",
- "equihash",
+ "equihash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "fpe",
  "group",
@@ -5731,7 +5741,8 @@ dependencies = [
  "criterion",
  "displaydoc",
  "ed25519-zebra",
- "equihash",
+ "equihash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash 0.2.0 (git+https://github.com/ZcashFoundation/librustzcash.git?branch=equihash-solver-tromp)",
  "futures",
  "group",
  "halo2_proofs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,12 @@ opt-level = 3
 [profile.dev.package.bls12_381]
 opt-level = 3
 
+[profile.dev.package.byteorder]
+opt-level = 3
+
+[profile.dev.package.equihash]
+opt-level = 3
+
 [profile.dev.package.zcash_proofs]
 opt-level = 3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,9 @@ panic = "abort"
 #     - add "-flto=thin" to all C/C++ code builds
 #     - see https://doc.rust-lang.org/rustc/linker-plugin-lto.html#cc-code-as-a-dependency-in-rust
 lto = "thin"
+
+[patch.crates-io]
+# Use the the working solver branch:
+equihash = { git = 'https://github.com/ZcashFoundation/librustzcash.git', branch = 'equihash-solver-tromp' }
+# or during development, use the locally checked out and modified version of equihash:
+#equihash = { path = '../librustzcash/components/equihash' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,9 +88,3 @@ panic = "abort"
 #     - add "-flto=thin" to all C/C++ code builds
 #     - see https://doc.rust-lang.org/rustc/linker-plugin-lto.html#cc-code-as-a-dependency-in-rust
 lto = "thin"
-
-[patch.crates-io]
-# Use the the working solver branch:
-equihash = { git = 'https://github.com/ZcashFoundation/librustzcash.git', branch = 'equihash-solver-tromp' }
-# or during development, use the locally checked out and modified version of equihash:
-#equihash = { path = '../librustzcash/components/equihash' }

--- a/deny.toml
+++ b/deny.toml
@@ -137,6 +137,8 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
+    # TODO: remove this after the equihash solver branch is merged and released
+    "https://github.com/ZcashFoundation/librustzcash.git"
 ]
 
 [sources.allow-org]

--- a/deny.toml
+++ b/deny.toml
@@ -86,6 +86,11 @@ skip-tree = [
     # wait for hdwallet to upgrade
     { name = "ring", version = "=0.16.20" },
 
+    # wait for the equihash/solver feature to merge
+    # https://github.com/zcash/librustzcash/pull/1083
+    # https://github.com/zcash/librustzcash/pull/1088
+    { name = "equihash", version = "=0.2.0" },
+
     # zebra-utils dependencies
 
     # wait for structopt upgrade (or upgrade to clap 4)
@@ -137,7 +142,9 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    # TODO: remove this after the equihash solver branch is merged and released
+    # TODO: remove this after the equihash solver branch is merged and released.
+    #
+    # "cargo deny" will log a warning in builds without the internal-miner feature. That's ok.
     "https://github.com/ZcashFoundation/librustzcash.git"
 ]
 

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -36,7 +36,10 @@ getblocktemplate-rpcs = [
 
 # Experimental internal miner support
 internal-miner = [
-    "equihash/solver",
+    # TODO: replace with "equihash/solver" when that feature is merged and released:
+    # https://github.com/zcash/librustzcash/pull/1083
+    # https://github.com/zcash/librustzcash/pull/1088
+    "equihash-solver",
 ]
 
 # Experimental elasticsearch support
@@ -66,7 +69,19 @@ blake2s_simd = "1.0.2"
 bridgetree = "0.4.0"
 bs58 = { version = "0.5.0", features = ["check"] }
 byteorder = "1.5.0"
+
 equihash = "0.2.0"
+# Experimental internal miner support
+#
+# TODO: remove "equihash-solver" when the "equihash/solver" feature is merged and released:
+# https://github.com/zcash/librustzcash/pull/1083
+# https://github.com/zcash/librustzcash/pull/1088
+#
+# Use the the working solver branch:
+equihash-solver = { version = "0.2.0", git = "https://github.com/ZcashFoundation/librustzcash.git", branch = "equihash-solver-tromp", features = ["solver"], package = "equihash", optional = true }
+# or during development, use the locally checked out and modified version of equihash:
+#equihash-solver = { path = "../librustzcash/components/equihash", package = "equihash" }
+
 group = "0.13.0"
 incrementalmerkletree = "0.5.0"
 jubjub = "0.10.0"

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -34,6 +34,14 @@ getblocktemplate-rpcs = [
     "zcash_address",
 ]
 
+# Experimental internal miner support
+internal-miner = [
+    "equihash/solver",
+    # TODO: enable common code using either "internal-miner" or "getblocktemplate-rpcs",
+    # and remove this feature dependency
+    "getblocktemplate-rpcs",
+]
+
 # Experimental elasticsearch support
 elasticsearch = []
 

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -80,7 +80,7 @@ equihash = "0.2.0"
 # Use the the working solver branch:
 equihash-solver = { version = "0.2.0", git = "https://github.com/ZcashFoundation/librustzcash.git", branch = "equihash-solver-tromp", features = ["solver"], package = "equihash", optional = true }
 # or during development, use the locally checked out and modified version of equihash:
-#equihash-solver = { path = "../librustzcash/components/equihash", package = "equihash" }
+#equihash-solver = { version = "0.2.0", path = "../../librustzcash/components/equihash", features = ["solver"], package = "equihash", optional = true }
 
 group = "0.13.0"
 incrementalmerkletree = "0.5.0"

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -77,7 +77,9 @@ equihash = "0.2.0"
 # https://github.com/zcash/librustzcash/pull/1083
 # https://github.com/zcash/librustzcash/pull/1088
 #
-# Use the the working solver branch:
+# Use the solver PR:
+# - latest: branch = "equihash-solver-tromp",
+# - crashing with double-frees: rev = "da26c34772f4922eb13b4a1e7d88a969bbcf6a91",
 equihash-solver = { version = "0.2.0", git = "https://github.com/ZcashFoundation/librustzcash.git", branch = "equihash-solver-tromp", features = ["solver"], package = "equihash", optional = true }
 # or during development, use the locally checked out and modified version of equihash:
 #equihash-solver = { version = "0.2.0", path = "../../librustzcash/components/equihash", features = ["solver"], package = "equihash", optional = true }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -37,9 +37,6 @@ getblocktemplate-rpcs = [
 # Experimental internal miner support
 internal-miner = [
     "equihash/solver",
-    # TODO: enable common code using either "internal-miner" or "getblocktemplate-rpcs",
-    # and remove this feature dependency
-    "getblocktemplate-rpcs",
 ]
 
 # Experimental elasticsearch support

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -29,7 +29,7 @@ async-error = [
     "tokio",
 ]
 
-# Experimental mining RPC support
+# Mining RPC support
 getblocktemplate-rpcs = [
     "zcash_address",
 ]

--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -123,6 +123,11 @@ impl Header {
             ))?
         }
     }
+
+    /// Compute the hash of this header.
+    pub fn hash(&self) -> Hash {
+        Hash::from(self)
+    }
 }
 
 /// A header with a count of the number of transactions in its block.

--- a/zebra-chain/src/primitives.rs
+++ b/zebra-chain/src/primitives.rs
@@ -12,6 +12,8 @@ mod address;
 #[cfg(feature = "getblocktemplate-rpcs")]
 pub use address::Address;
 
+pub mod byte_array;
+
 pub use ed25519_zebra as ed25519;
 pub use reddsa;
 pub use redjubjub;

--- a/zebra-chain/src/primitives/byte_array.rs
+++ b/zebra-chain/src/primitives/byte_array.rs
@@ -1,0 +1,14 @@
+//! Functions for modifying byte arrays.
+
+/// Increments `byte_array` by 1, interpreting it as a big-endian integer.
+/// If the big-endian integer overflowed, sets all the bytes to zero, and returns `true`.
+pub fn increment_big_endian(byte_array: &mut [u8]) -> bool {
+    // Increment the last byte in the array that is less than u8::MAX, and clear any bytes after it
+    // to increment the next value in big-endian (lexicographic) order.
+    let is_wrapped_overflow = byte_array.iter_mut().rev().all(|v| {
+        *v = v.wrapping_add(1);
+        v == &0
+    });
+
+    is_wrapped_overflow
+}

--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -61,6 +61,8 @@ impl Solution {
             .zcash_serialize(&mut input)
             .expect("serialization into a vec can't fail");
 
+        // The part of the header before the nonce and solution.
+        // This data is kept constant during solver runs, so the verifier API takes it separately.
         let input = &input[0..Solution::INPUT_LENGTH];
 
         equihash::is_valid_solution(n, k, input, nonce.as_ref(), solution)?;
@@ -116,6 +118,8 @@ impl Solution {
         header
             .zcash_serialize(&mut input)
             .expect("serialization into a vec can't fail");
+        // Take the part of the header before the nonce and solution.
+        // This data is kept constant for this solver run.
         let input = &input[0..Solution::INPUT_LENGTH];
 
         while !is_shutting_down() {

--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -109,6 +109,12 @@ impl Solution {
             for solution in solutions {
                 header.solution = Self::from_bytes(solution)
                     .expect("unexpected invalid solution: incorrect length");
+                // TODO: only run this redundant check in tests
+                header
+                    .solution
+                    .check(&header)
+                    .expect("unexpected invalid solution: invalid solution for header");
+
                 if Self::difficulty_is_valid(&header) {
                     return header;
                 }

--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -109,7 +109,7 @@ impl Solution {
         let input = &input[0..Solution::INPUT_LENGTH];
 
         while !is_shutting_down() {
-            let solutions = equihash::tromp::solve_200_9_compressed(input, || {
+            let solutions = equihash_solver::tromp::solve_200_9_compressed(input, || {
                 // This skips the first nonce, which doesn't matter in practice.
                 Self::next_nonce(&mut header.nonce);
                 Some(*header.nonce)

--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -145,7 +145,7 @@ impl Solution {
                 }
             }
 
-            info!(
+            debug!(
                 solutions = ?solutions.len(),
                 "found valid solutions which did not pass the validity or difficulty checks"
             );

--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -118,11 +118,12 @@ impl Solution {
             for solution in &solutions {
                 header.solution = Self::from_bytes(solution)
                     .expect("unexpected invalid solution: incorrect length");
-                // TODO: only run this redundant check in tests
-                header
-                    .solution
-                    .check(&header)
-                    .expect("unexpected invalid solution: invalid solution for header");
+
+                // TODO: work out why we sometimes get invalid solutions here
+                if let Err(error) = header.solution.check(&header) {
+                    info!(?error, "found invalid solution for header");
+                    continue;
+                }
 
                 if Self::difficulty_is_valid(&header) {
                     info!("found valid solution and difficulty");
@@ -132,7 +133,7 @@ impl Solution {
 
             info!(
                 solutions = ?solutions.len(),
-                "found valid solutions which did not pass the difficulty check"
+                "found valid solutions which did not pass the validity or difficulty checks"
             );
         }
 

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -24,7 +24,7 @@ progress-bar = [
     "zebra-state/progress-bar",
 ]
 
-# Experimental mining RPC support
+# Mining RPC support
 getblocktemplate-rpcs = [
      "zebra-state/getblocktemplate-rpcs",
      "zebra-node-services/getblocktemplate-rpcs",

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 
 # Production features that activate extra dependencies, or extra features in dependencies
 
-# Experimental mining RPC support
+# Mining RPC support
 getblocktemplate-rpcs = [
     "zebra-chain/getblocktemplate-rpcs",
 ]

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -48,7 +48,6 @@ hyper = { version = "0.14.28", features = ["http1", "server"] }
 jsonrpc-core = "18.0.0"
 jsonrpc-derive = "18.0.0"
 jsonrpc-http-server = "18.0.0"
-num_cpus = "1.16.0"
 
 # zebra-rpc needs the preserve_order feature in serde_json, which is a dependency of jsonrpc-core
 serde_json = { version = "1.0.108", features = ["preserve_order"] }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 
 # Production features that activate extra dependencies, or extra features in dependencies
 
-# Experimental mining RPC support
+# Mining RPC support
 getblocktemplate-rpcs = [
     "rand",
     "zcash_address",

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -29,6 +29,9 @@ getblocktemplate-rpcs = [
     "zebra-chain/getblocktemplate-rpcs",
 ]
 
+# Experimental internal miner support
+internal-miner = []
+
 # Test-only features
 proptest-impl = [
     "proptest",

--- a/zebra-rpc/src/config.rs
+++ b/zebra-rpc/src/config.rs
@@ -36,17 +36,17 @@ pub struct Config {
     /// State queries are run concurrently using the shared thread pool controlled by
     /// the [`SyncSection.parallel_cpu_threads`](https://docs.rs/zebrad/latest/zebrad/components/sync/struct.Config.html#structfield.parallel_cpu_threads) config.
     ///
-    /// We recommend setting both configs to `0` (automatic scaling) for the best performance.
-    /// This uses one thread per available CPU core.
+    /// If the number of threads is not configured or zero, Zebra uses the number of logical cores.
+    /// If the number of logical cores can't be detected, Zebra uses one thread.
     ///
-    /// Set to `1` by default, which runs all RPC queries on a single thread, and detects RPC
-    /// port conflicts from multiple Zebra or `zcashd` instances.
+    /// Set to `1` to run all RPC queries on a single thread, and detect RPC port conflicts from
+    /// multiple Zebra or `zcashd` instances.
     ///
     /// For details, see [the `jsonrpc_http_server` documentation](https://docs.rs/jsonrpc-http-server/latest/jsonrpc_http_server/struct.ServerBuilder.html#method.threads).
     ///
     /// ## Warning
     ///
-    /// Changing this config disables RPC port conflict detection.
+    /// The default config uses multiple threads, which disables RPC port conflict detection.
     /// This can allow multiple Zebra instances to share the same RPC port.
     ///
     /// If some of those instances are outdated or failed, RPC queries can be slow or inconsistent.

--- a/zebra-rpc/src/config/mining.rs
+++ b/zebra-rpc/src/config/mining.rs
@@ -15,6 +15,28 @@ pub struct Config {
     /// `getblocktemplate` RPC coinbase transaction.
     pub miner_address: Option<transparent::Address>,
 
+    /// Mine blocks using Zebra's internal miner, without an external mining pool or equihash solver.
+    ///
+    /// This experimental feature is only supported on testnet.
+    /// Mainnet miners should use a mining pool with GPUs or ASICs designed for efficient mining.
+    ///
+    /// The internal miner is off by default.
+    #[cfg(feature = "internal-miner")]
+    pub internal_miner: bool,
+
+    /// The number of internal miner threads used by Zebra.
+    /// These threads are scheduled at low priority.
+    ///
+    /// The number of threads is limited by the available parallelism reported by the OS.
+    /// If the number of threads isn't configured, or can't be detected, Zebra uses one thread.
+    /// This is different from Zebra's other parallelism configs, because mining runs constantly and
+    /// uses a large amount of memory. (144 MB of RAM and 100% of a core per thread.)
+    ///
+    /// If the number of threads is set to zero, Zebra disables mining.
+    /// This matches `zcashd`'s behaviour, but is different from Zebra's other parallelism configs.
+    #[cfg(feature = "internal-miner")]
+    pub internal_miner_threads: usize,
+
     /// Extra data to include in coinbase transaction inputs.
     /// Limited to around 95 bytes by the consensus rules.
     ///
@@ -36,6 +58,12 @@ impl Default for Config {
             // TODO: do we want to default to v5 transactions and Zebra coinbase data?
             extra_coinbase_data: None,
             debug_like_zcashd: true,
+            // TODO: ignore and warn rather than panicking if these fields are in the config,
+            //       but the feature isn't enabled.
+            #[cfg(feature = "internal-miner")]
+            internal_miner: false,
+            #[cfg(feature = "internal-miner")]
+            internal_miner_threads: 1,
         }
     }
 }
@@ -47,5 +75,11 @@ impl Config {
     /// enabled, allowing us to log a warning when the config found is different from the default.
     pub fn skip_getblocktemplate(&self) -> bool {
         !cfg!(feature = "getblocktemplate-rpcs")
+    }
+
+    /// Is the internal miner enabled using at least one thread?
+    #[cfg(feature = "internal-miner")]
+    pub fn is_internal_miner_enabled(&self) -> bool {
+        self.internal_miner && self.internal_miner_threads > 0
     }
 }

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -498,6 +498,10 @@ where
                 // - add `async changed()` method to ChainSyncStatus (like `ChainTip`)
                 check_synced_to_tip(network, latest_chain_tip.clone(), sync_status.clone())?;
 
+                // TODO: return an error if we have no peers, like `zcashd` does,
+                //       and add a developer config that mines regardless of how many peers we have.
+                // https://github.com/zcash/zcash/blob/6fdd9f1b81d3b228326c9826fa10696fc516444b/src/miner.cpp#L865-L880
+
                 // We're just about to fetch state data, then maybe wait for any changes.
                 // Mark all the changes before the fetch as seen.
                 // Changes are also ignored in any clones made after the mark.

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -329,6 +329,17 @@ where
         sync_status: SyncStatus,
         address_book: AddressBook,
     ) -> Self {
+        // Prevent loss of miner funds due to an unsupported or incorrect address type.
+        if let Some(miner_address) = mining_config.miner_address {
+            assert_eq!(
+                miner_address.network(),
+                network,
+                "incorrect miner address config: {miner_address} \
+                         network.network {network} and miner address network {} must match",
+                miner_address.network(),
+            );
+        }
+
         // A limit on the configured extra coinbase data, regardless of the current block height.
         // This is different from the consensus rule, which limits the total height + data.
         const EXTRA_COINBASE_DATA_LIMIT: usize =

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -689,7 +689,6 @@ where
                 // But the coinbase value depends on the selected transactions, so this needs
                 // further analysis to check if it actually saves us any time.
 
-                // TODO: change logging to debug after testing
                 tokio::select! {
                     // Poll the futures in the listed order, for efficiency.
                     // We put the most frequent conditions first.
@@ -697,7 +696,7 @@ where
 
                     // This timer elapses every few seconds
                     _elapsed = wait_for_mempool_request => {
-                        tracing::info!(
+                        tracing::debug!(
                             ?max_time,
                             ?cur_time,
                             ?server_long_poll_id,
@@ -736,7 +735,7 @@ where
                                     continue;
                                 }
 
-                                tracing::info!(
+                                tracing::debug!(
                                     ?max_time,
                                     ?cur_time,
                                     ?server_long_poll_id,
@@ -746,8 +745,7 @@ where
                             }
 
                             Err(recv_error) => {
-                                // This log should stay at info when the others go to debug,
-                                // it will help with debugging.
+                                // This log is rare and helps with debugging, so it's ok to be info.
                                 tracing::info!(
                                     ?recv_error,
                                     ?max_time,
@@ -770,8 +768,7 @@ where
                     // The max time does not elapse during normal operation on mainnet,
                     // and it rarely elapses on testnet.
                     Some(_elapsed) = wait_for_max_time => {
-                        // This log should stay at info when the others go to debug,
-                        // it's very rare.
+                        // This log is very rare so it's ok to be info.
                         tracing::info!(
                             ?max_time,
                             ?cur_time,

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -546,9 +546,7 @@ where
         async move {
             get_block_template::check_parameters(&parameters)?;
 
-            let client_long_poll_id = parameters
-                .as_ref()
-                .and_then(|params| params.long_poll_id.clone());
+            let client_long_poll_id = parameters.as_ref().and_then(|params| params.long_poll_id);
 
             // - One-off checks
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -713,7 +713,8 @@ where
                                 // Despite the documentation, this future sometimes returns
                                 // spuriously, even when the tip hasn't changed. This could be a
                                 // bug where the state does spurious updates, or where the change
-                                // detection or its future is implemented incorrectly.
+                                // detection or its future is implemented incorrectly. Since it's a
+                                // bug in both the RPC and miner, it could be a tokio bug.
                                 let new_tip_hash = latest_chain_tip.best_tip_hash();
                                 if new_tip_hash == Some(tip_hash) {
                                     tracing::debug!(

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -232,22 +232,29 @@ pub struct GetBlockTemplateRpcImpl<
     AddressBook,
 > where
     Mempool: Service<
-        mempool::Request,
-        Response = mempool::Response,
-        Error = zebra_node_services::BoxError,
-    >,
+            mempool::Request,
+            Response = mempool::Response,
+            Error = zebra_node_services::BoxError,
+        > + 'static,
+    Mempool::Future: Send,
     State: Service<
-        zebra_state::ReadRequest,
-        Response = zebra_state::ReadResponse,
-        Error = zebra_state::BoxError,
-    >,
+            zebra_state::ReadRequest,
+            Response = zebra_state::ReadResponse,
+            Error = zebra_state::BoxError,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
+    <State as Service<zebra_state::ReadRequest>>::Future: Send,
+    Tip: ChainTip + Clone + Send + Sync + 'static,
     BlockVerifierRouter: Service<zebra_consensus::Request, Response = block::Hash, Error = zebra_consensus::BoxError>
         + Clone
         + Send
         + Sync
         + 'static,
+    <BlockVerifierRouter as Service<zebra_consensus::Request>>::Future: Send,
     SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
-    AddressBook: AddressBookPeers,
+    AddressBook: AddressBookPeers + Clone + Send + Sync + 'static,
 {
     // Configuration
     //
@@ -296,6 +303,7 @@ where
             Response = mempool::Response,
             Error = zebra_node_services::BoxError,
         > + 'static,
+    Mempool::Future: Send,
     State: Service<
             zebra_state::ReadRequest,
             Response = zebra_state::ReadResponse,
@@ -304,12 +312,14 @@ where
         + Send
         + Sync
         + 'static,
+    <State as Service<zebra_state::ReadRequest>>::Future: Send,
     Tip: ChainTip + Clone + Send + Sync + 'static,
     BlockVerifierRouter: Service<zebra_consensus::Request, Response = block::Hash, Error = zebra_consensus::BoxError>
         + Clone
         + Send
         + Sync
         + 'static,
+    <BlockVerifierRouter as Service<zebra_consensus::Request>>::Future: Send,
     SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
     AddressBook: AddressBookPeers + Clone + Send + Sync + 'static,
 {

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
@@ -346,3 +346,21 @@ pub enum Response {
     /// `getblocktemplate` RPC request in proposal mode.
     ProposalMode(ProposalResponse),
 }
+
+impl Response {
+    /// Returns the inner template, if the response is in template mode.
+    pub fn try_into_template(self) -> Option<GetBlockTemplate> {
+        match self {
+            Response::TemplateMode(template) => Some(*template),
+            Response::ProposalMode(_) => None,
+        }
+    }
+
+    /// Returns the inner proposal, if the response is in proposal mode.
+    pub fn try_into_proposal(self) -> Option<ProposalResponse> {
+        match self {
+            Response::TemplateMode(_) => None,
+            Response::ProposalMode(proposal) => Some(proposal),
+        }
+    }
+}

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/long_poll.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/long_poll.rs
@@ -113,7 +113,7 @@ impl LongPollInput {
 ///
 /// `zcashd` IDs are currently 69 hex/decimal digits long.
 /// Since Zebra's IDs are only 46 hex/decimal digits, mining pools should be able to handle them.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct LongPollId {
     // Fields that invalidate old work:

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -45,7 +45,7 @@ proptest! {
                 Mainnet,
                 false,
                 true,
-                Buffer::new(mempool.clone(), 1),
+                mempool.clone(),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
             );
@@ -100,7 +100,7 @@ proptest! {
                 Mainnet,
                 false,
                 true,
-                Buffer::new(mempool.clone(), 1),
+                mempool.clone(),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
             );
@@ -160,7 +160,7 @@ proptest! {
                 Mainnet,
                 false,
                 true,
-                Buffer::new(mempool.clone(), 1),
+                mempool.clone(),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
             );
@@ -228,7 +228,7 @@ proptest! {
                 Mainnet,
                 false,
                 true,
-                Buffer::new(mempool.clone(), 1),
+                mempool.clone(),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
             );
@@ -285,7 +285,7 @@ proptest! {
                 Mainnet,
                 false,
                 true,
-                Buffer::new(mempool.clone(), 1),
+                mempool.clone(),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
             );
@@ -340,7 +340,7 @@ proptest! {
                 Mainnet,
                 false,
                 true,
-                Buffer::new(mempool.clone(), 1),
+                mempool.clone(),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
             );
@@ -441,7 +441,7 @@ proptest! {
                 Mainnet,
                 false,
                 true,
-                Buffer::new(mempool.clone(), 1),
+                mempool.clone(),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
             );
@@ -500,7 +500,7 @@ proptest! {
                 Mainnet,
                 false,
                 true,
-                Buffer::new(mempool.clone(), 1),
+                mempool.clone(),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
             );
@@ -548,7 +548,7 @@ proptest! {
             network,
             false,
             true,
-            Buffer::new(mempool.clone(), 1),
+            mempool.clone(),
             Buffer::new(state.clone(), 1),
             NoChainTip,
         );
@@ -599,7 +599,7 @@ proptest! {
             network,
             false,
             true,
-            Buffer::new(mempool.clone(), 1),
+            mempool.clone(),
             Buffer::new(state.clone(), 1),
             chain_tip,
         );
@@ -686,7 +686,7 @@ proptest! {
                 network,
                 false,
                 true,
-                Buffer::new(mempool.clone(), 1),
+                mempool.clone(),
                 Buffer::new(state.clone(), 1),
                 chain_tip,
             );
@@ -750,7 +750,7 @@ proptest! {
                 network,
                 false,
                 true,
-                Buffer::new(mempool.clone(), 1),
+                mempool.clone(),
                 Buffer::new(state.clone(), 1),
                 chain_tip,
             );
@@ -802,7 +802,7 @@ proptest! {
                 Mainnet,
                 false,
                 true,
-                Buffer::new(mempool.clone(), 1),
+                mempool.clone(),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
             );
@@ -892,7 +892,7 @@ proptest! {
                 Mainnet,
                 false,
                 true,
-                Buffer::new(mempool.clone(), 1),
+                mempool.clone(),
                 Buffer::new(state.clone(), 1),
                 NoChainTip,
             );

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -8,6 +8,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use insta::dynamic_redaction;
+use tower::buffer::Buffer;
 
 use zebra_chain::{
     block::Block,
@@ -338,7 +339,7 @@ async fn test_mocked_rpc_response_data_for_network(network: Network) {
         network,
         false,
         true,
-        Buffer::new(mempool, 1),
+        mempool,
         state.clone(),
         latest_chain_tip,
     );

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -92,10 +92,13 @@ pub async fn test_responses<State, ReadState>(
     let mut mock_sync_status = MockSyncStatus::default();
     mock_sync_status.set_is_close_to_tip(true);
 
+    #[allow(clippy::unnecessary_struct_initialization)]
     let mining_config = crate::config::mining::Config {
         miner_address: Some(transparent::Address::from_script_hash(network, [0xad; 20])),
         extra_coinbase_data: None,
         debug_like_zcashd: true,
+        // Use default field values when optional features are enabled in tests
+        ..Default::default()
     };
 
     // nu5 block height

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1099,7 +1099,7 @@ async fn rpc_getmininginfo() {
     let get_block_template_rpc = get_block_template_rpcs::GetBlockTemplateRpcImpl::new(
         Mainnet,
         Default::default(),
-        Buffer::new(MockService::build().for_unit_tests(), 1),
+        MockService::build().for_unit_tests(),
         read_state,
         latest_chain_tip.clone(),
         MockService::build().for_unit_tests(),
@@ -1135,7 +1135,7 @@ async fn rpc_getnetworksolps() {
     let get_block_template_rpc = get_block_template_rpcs::GetBlockTemplateRpcImpl::new(
         Mainnet,
         Default::default(),
-        Buffer::new(MockService::build().for_unit_tests(), 1),
+        MockService::build().for_unit_tests(),
         read_state,
         latest_chain_tip.clone(),
         MockService::build().for_unit_tests(),
@@ -1575,7 +1575,7 @@ async fn rpc_validateaddress() {
     let get_block_template_rpc = get_block_template_rpcs::GetBlockTemplateRpcImpl::new(
         Mainnet,
         Default::default(),
-        Buffer::new(MockService::build().for_unit_tests(), 1),
+        MockService::build().for_unit_tests(),
         MockService::build().for_unit_tests(),
         mock_chain_tip,
         MockService::build().for_unit_tests(),
@@ -1620,7 +1620,7 @@ async fn rpc_z_validateaddress() {
     let get_block_template_rpc = get_block_template_rpcs::GetBlockTemplateRpcImpl::new(
         Mainnet,
         Default::default(),
-        Buffer::new(MockService::build().for_unit_tests(), 1),
+        MockService::build().for_unit_tests(),
         MockService::build().for_unit_tests(),
         mock_chain_tip,
         MockService::build().for_unit_tests(),
@@ -1825,7 +1825,7 @@ async fn rpc_z_listunifiedreceivers() {
     let get_block_template_rpc = get_block_template_rpcs::GetBlockTemplateRpcImpl::new(
         Mainnet,
         Default::default(),
-        Buffer::new(MockService::build().for_unit_tests(), 1),
+        MockService::build().for_unit_tests(),
         MockService::build().for_unit_tests(),
         mock_chain_tip,
         MockService::build().for_unit_tests(),

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1231,10 +1231,13 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
         true => Some(transparent::Address::from_pub_key_hash(Mainnet, [0x7e; 20])),
     };
 
+    #[allow(clippy::unnecessary_struct_initialization)]
     let mining_config = crate::config::mining::Config {
         miner_address,
         extra_coinbase_data: None,
         debug_like_zcashd: true,
+        // Use default field values when optional features are enabled in tests
+        ..Default::default()
     };
 
     // nu5 block height
@@ -1677,10 +1680,13 @@ async fn rpc_getdifficulty() {
     let mut mock_sync_status = MockSyncStatus::default();
     mock_sync_status.set_is_close_to_tip(true);
 
+    #[allow(clippy::unnecessary_struct_initialization)]
     let mining_config = Config {
         miner_address: None,
         extra_coinbase_data: None,
         debug_like_zcashd: true,
+        // Use default field values when optional features are enabled in tests
+        ..Default::default()
     };
 
     // nu5 block height

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -152,17 +152,6 @@ impl RpcServer {
 
             #[cfg(feature = "getblocktemplate-rpcs")]
             {
-                // Prevent loss of miner funds due to an unsupported or incorrect address type.
-                if let Some(miner_address) = mining_config.miner_address {
-                    assert_eq!(
-                        miner_address.network(),
-                        network,
-                        "incorrect miner address config: {miner_address} \
-                         network.network {network} and miner address network {} must match",
-                        miner_address.network(),
-                    );
-                }
-
                 // Initialize the getblocktemplate rpc method handler
                 let get_block_template_rpc_impl = GetBlockTemplateRpcImpl::new(
                     network,

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -7,7 +7,7 @@
 //! See the full list of
 //! [Differences between JSON-RPC 1.0 and 2.0.](https://www.simple-is-better.org/rpc/#differences-between-1-0-and-2-0)
 
-use std::{fmt, panic};
+use std::{fmt, panic, thread::available_parallelism};
 
 use jsonrpc_core::{Compatibility, MetaIoHandler};
 use jsonrpc_http_server::{CloseHandle, ServerBuilder};
@@ -187,7 +187,7 @@ impl RpcServer {
             // If zero, automatically scale threads to the number of CPU cores
             let mut parallel_cpu_threads = config.parallel_cpu_threads;
             if parallel_cpu_threads == 0 {
-                parallel_cpu_threads = num_cpus::get();
+                parallel_cpu_threads = available_parallelism().map(usize::from).unwrap_or(1);
             }
 
             // The server is a blocking task, which blocks on executor shutdown.

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -12,8 +12,7 @@ use std::{fmt, panic};
 use jsonrpc_core::{Compatibility, MetaIoHandler};
 use jsonrpc_http_server::{CloseHandle, ServerBuilder};
 use tokio::task::JoinHandle;
-use tower::{buffer::Buffer, Service};
-
+use tower::Service;
 use tracing::{Instrument, *};
 
 use zebra_chain::{
@@ -99,7 +98,7 @@ impl RpcServer {
         mining_config: crate::config::mining::Config,
         build_version: VersionString,
         user_agent: UserAgentString,
-        mempool: Buffer<Mempool, mempool::Request>,
+        mempool: Mempool,
         state: State,
         #[cfg_attr(not(feature = "getblocktemplate-rpcs"), allow(unused_variables))]
         block_verifier_router: BlockVerifierRouter,
@@ -117,7 +116,10 @@ impl RpcServer {
                 mempool::Request,
                 Response = mempool::Response,
                 Error = zebra_node_services::BoxError,
-            > + 'static,
+            > + Clone
+            + Send
+            + Sync
+            + 'static,
         Mempool::Future: Send,
         State: Service<
                 zebra_state::ReadRequest,

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -22,7 +22,7 @@ progress-bar = [
     "howudoin",
 ]
 
-# Experimental mining RPC support
+# Mining RPC support
 getblocktemplate-rpcs = [
     "zebra-chain/getblocktemplate-rpcs",
 ]

--- a/zebra-state/src/service/watch_receiver.rs
+++ b/zebra-state/src/service/watch_receiver.rs
@@ -99,11 +99,20 @@ where
         self.receiver.borrow().clone()
     }
 
-    /// Calls [`watch::Receiver::changed`] and returns the result.
+    /// Calls [`watch::Receiver::changed()`] and returns the result.
+    /// Returns when the inner value has been updated, even if the old and new values are equal.
     ///
     /// Marks the watched data as seen.
     pub async fn changed(&mut self) -> Result<(), watch::error::RecvError> {
         self.receiver.changed().await
+    }
+
+    /// Calls [`watch::Receiver::has_changed()`] and returns the result.
+    /// Returns `true` when the inner value has been updated, even if the old and new values are equal.
+    ///
+    /// Does not mark the watched data as seen.
+    pub fn has_changed(&self) -> Result<bool, watch::error::RecvError> {
+        self.receiver.has_changed()
     }
 
     /// Marks the watched data as seen.

--- a/zebra-state/src/service/watch_receiver.rs
+++ b/zebra-state/src/service/watch_receiver.rs
@@ -116,8 +116,13 @@ where
     }
 
     /// Marks the watched data as seen.
-    /// Calls [`watch::Receiver::mark_changed()`].
     pub fn mark_as_seen(&mut self) {
+        self.receiver.borrow_and_update();
+    }
+
+    /// Marks the watched data as unseen.
+    /// Calls [`watch::Receiver::mark_changed()`].
+    pub fn mark_changed(&mut self) {
         self.receiver.mark_changed();
     }
 }

--- a/zebra-state/src/service/watch_receiver.rs
+++ b/zebra-state/src/service/watch_receiver.rs
@@ -116,7 +116,8 @@ where
     }
 
     /// Marks the watched data as seen.
+    /// Calls [`watch::Receiver::mark_changed()`].
     pub fn mark_as_seen(&mut self) {
-        self.receiver.borrow_and_update();
+        self.receiver.mark_changed();
     }
 }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -68,6 +68,13 @@ getblocktemplate-rpcs = [
     "zebra-chain/getblocktemplate-rpcs",
 ]
 
+# Experimental internal miner support
+internal-miner = [
+    "zebra-chain/internal-miner",
+    # TODO: move common code into zebra-chain or zebra-node-services and remove the RPC dependency
+    "getblocktemplate-rpcs",
+]
+
 # Experimental shielded blockchain scanning
 shielded-scan = ["zebra-scan"]
 

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -70,6 +70,7 @@ getblocktemplate-rpcs = [
 
 # Experimental internal miner support
 internal-miner = [
+    "thread-priority",
     "zebra-chain/internal-miner",
     # TODO: move common code into zebra-chain or zebra-node-services and remove the RPC dependency
     "zebra-rpc/getblocktemplate-rpcs",
@@ -206,6 +207,9 @@ atty = "0.2.14"
 
 num-integer = "0.1.45"
 rand = "0.8.5"
+
+# prod feature internal-miner
+thread-priority = { version = "0.15.1", optional = true }
 
 # prod feature sentry
 sentry = { version = "0.32.1", default-features = false, features = ["backtrace", "contexts", "reqwest", "rustls", "tracing"], optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -72,7 +72,7 @@ getblocktemplate-rpcs = [
 internal-miner = [
     "zebra-chain/internal-miner",
     # TODO: move common code into zebra-chain or zebra-node-services and remove the RPC dependency
-    "getblocktemplate-rpcs",
+    "zebra-rpc/getblocktemplate-rpcs",
 ]
 
 # Experimental shielded blockchain scanning

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -73,6 +73,7 @@ internal-miner = [
     "thread-priority",
     "zebra-chain/internal-miner",
     # TODO: move common code into zebra-chain or zebra-node-services and remove the RPC dependency
+    "zebra-rpc/internal-miner",
     "zebra-rpc/getblocktemplate-rpcs",
 ]
 

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -78,9 +78,7 @@ fn vergen_build_version() -> Option<Version> {
     // - optional pre-release: `-`tag[`.`tag ...]
     // - optional build: `+`tag[`.`tag ...]
     // change the git describe format to the semver 2.0 format
-    let Some(vergen_git_describe) = VERGEN_GIT_DESCRIBE else {
-        return None;
-    };
+    let vergen_git_describe = VERGEN_GIT_DESCRIBE?;
 
     // `git describe` uses "dirty" for uncommitted changes,
     // but users won't understand what that means.
@@ -90,10 +88,7 @@ fn vergen_build_version() -> Option<Version> {
     let mut vergen_git_describe = vergen_git_describe.split('-').peekable();
 
     // Check the "version core" part.
-    let version = vergen_git_describe.next();
-    let Some(mut version) = version else {
-        return None;
-    };
+    let mut version = vergen_git_describe.next()?;
 
     // strip the leading "v", if present.
     version = version.strip_prefix('v').unwrap_or(version);

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -313,7 +313,7 @@ impl StartCmd {
         //
         // TODO: add a config to enable the miner rather than a feature.
         #[cfg(feature = "internal-miner")]
-        let miner_task_handle = {
+        let miner_task_handle = if config.mining.is_internal_miner_enabled() {
             info!("spawning Zcash miner");
             let rpc = zebra_rpc::methods::get_block_template_rpcs::GetBlockTemplateRpcImpl::new(
                 config.network.network,
@@ -327,6 +327,8 @@ impl StartCmd {
             );
 
             crate::components::miner::spawn_init(&config.mining, rpc)
+        } else {
+            tokio::spawn(std::future::pending().in_current_span())
         };
 
         #[cfg(not(feature = "internal-miner"))]

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -45,6 +45,16 @@
 //!  * Progress Task
 //!    * logs progress towards the chain tip
 //!
+//! Shielded Scanning:
+//!  * Shielded Scanner Task
+//!    * if the user has configured Zebra with their shielded viewing keys, scans new and existing
+//!      blocks for transactions that use those keys
+//!
+//! Block Mining:
+//!  * Internal Miner Task
+//!    * if the user has configured Zebra to mine blocks, spawns tasks to generate new blocks,
+//!      and submits them for verification. This automatically shares these new blocks with peers.
+//!
 //! Mempool Transactions:
 //!  * Mempool Service
 //!    * activates when the syncer is near the chain tip

--- a/zebrad/src/components.rs
+++ b/zebrad/src/components.rs
@@ -16,5 +16,8 @@ pub mod tokio;
 #[allow(missing_docs)]
 pub mod tracing;
 
+#[cfg(feature = "internal-miner")]
+pub mod miner;
+
 pub use inbound::Inbound;
 pub use sync::ChainSync;

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -180,7 +180,7 @@ where
         result = template_generator => { first_result = result; }
         result = mining_solvers.next() => {
             first_result = result
-                .expect("stream never teminates because there is at least one solver task");
+                .expect("stream never terminates because there is at least one solver task");
         }
     }
 

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -205,7 +205,7 @@ where
 
         // Wait for the chain to sync so we get a valid template.
         let Ok(template) = template else {
-            info!(
+            debug!(
                 ?BLOCK_TEMPLATE_WAIT_TIME,
                 "waiting for a valid block template",
             );

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -51,7 +51,6 @@ pub const BLOCK_TEMPLATE_WAIT_TIME: Duration = Duration::from_secs(20);
 /// mining thread.
 ///
 /// See [`run_mining_solver()`] for more details.
-#[instrument(skip(config, rpc))]
 pub fn spawn_init<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>(
     config: &Config,
     rpc: GetBlockTemplateRpcImpl<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>,

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -48,8 +48,8 @@ pub const BLOCK_TEMPLATE_WAIT_TIME: Duration = Duration::from_secs(20);
 /// This method is CPU and memory-intensive. It uses 144 MB of RAM and one CPU core per configured
 /// mining thread.
 ///
-/// TODO: add a test for this function.
-#[instrument(skip(rpc))]
+/// See [`run_mining_solver()`] for more details.
+#[instrument(skip(config, rpc))]
 pub fn spawn_init<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>(
     config: &Config,
     rpc: GetBlockTemplateRpcImpl<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>,
@@ -94,7 +94,7 @@ where
 /// This method is CPU and memory-intensive. It uses 144 MB of RAM and one CPU core per configured
 /// mining thread.
 ///
-/// TODO: add a test for this function.
+/// See [`run_mining_solver()`] for more details.
 pub async fn init<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>(
     _config: Config,
     rpc: GetBlockTemplateRpcImpl<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>,

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -10,7 +10,7 @@ use std::{sync::Arc, time::Duration};
 
 use color_eyre::Report;
 use thread_priority::{ThreadBuilder, ThreadPriority};
-use tokio::{task::JoinHandle, time::sleep};
+use tokio::{sync::watch, task::JoinHandle, time::sleep};
 use tower::Service;
 use tracing::{Instrument, Span};
 
@@ -30,7 +30,7 @@ use zebra_rpc::{
     methods::{
         get_block_template_rpcs::{
             get_block_template::{
-                self, proposal::TimeSource, proposal_block_from_template, GetBlockTemplate,
+                self, proposal::TimeSource, proposal_block_from_template,
                 GetBlockTemplateCapability::*, GetBlockTemplateRequestMode::*,
             },
             types::hex_data::HexData,
@@ -38,6 +38,7 @@ use zebra_rpc::{
         GetBlockTemplateRpc, GetBlockTemplateRpcImpl,
     },
 };
+use zebra_state::WatchReceiver;
 
 /// The amount of time we wait between block template retries.
 pub const BLOCK_TEMPLATE_WAIT_TIME: Duration = Duration::from_secs(20);
@@ -127,16 +128,30 @@ where
     SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
     AddressBook: AddressBookPeers + Clone + Send + Sync + 'static,
 {
-    run_mining_solver(rpc).await
+    let (template_sender, template_receiver) = watch::channel(None);
+    let template_receiver = WatchReceiver::new(template_receiver);
+
+    // TODO: select!{} on the block generator and all the mining solver threads
+    //       add a config & launch the configured number of solvers, using available_parallelism()
+    //       by default
+    generate_block_templates(rpc.clone(), template_sender).await?;
+    run_mining_solver(0, template_receiver, rpc).await?;
+
+    Ok(())
 }
 
-/// Runs a single mining thread to generate blocks, calculate equihash solutions, and submit valid
-/// blocks to Zebra's block validator.
-///
-/// This method is CPU and memory-intensive. It uses 144 MB of RAM and one CPU core while running.
-/// It can run for minutes or hours if the network difficulty is high.
-pub async fn run_mining_solver<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>(
+/// Generates block templates using `rpc`, and sends them to mining threads using `template_sender`.
+#[instrument(skip(rpc, template_sender))]
+pub async fn generate_block_templates<
+    Mempool,
+    State,
+    Tip,
+    BlockVerifierRouter,
+    SyncStatus,
+    AddressBook,
+>(
     rpc: GetBlockTemplateRpcImpl<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>,
+    template_sender: watch::Sender<Option<Arc<Block>>>,
 ) -> Result<(), Report>
 where
     Mempool: Service<
@@ -168,12 +183,11 @@ where
     AddressBook: AddressBookPeers + Clone + Send + Sync + 'static,
 {
     // Pass the correct arguments, even if Zebra currently ignores them.
-    let mut long_poll_id = None;
     let mut parameters = get_block_template::JsonParameters {
         mode: Template,
         data: None,
         capabilities: vec![LongPoll, CoinbaseTxn],
-        long_poll_id,
+        long_poll_id: None,
         _work_id: None,
     };
 
@@ -186,7 +200,12 @@ where
                 ?BLOCK_TEMPLATE_WAIT_TIME,
                 "waiting for a valid block template",
             );
-            sleep(BLOCK_TEMPLATE_WAIT_TIME).await;
+
+            // Skip the wait if we got an error because we are shutting down.
+            if !is_shutting_down() {
+                sleep(BLOCK_TEMPLATE_WAIT_TIME).await;
+            }
+
             continue;
         };
 
@@ -194,11 +213,89 @@ where
             .try_into_template()
             .expect("invalid RPC response: proposal in response to a template request");
 
-        // TODO: select!{} on either a solved header or a new block template using long_poll_id
-        //       cancel the solver if there's a new template
-        //       add a config & launch the configured number of solvers, using available_parallelism()
-        //       by default
-        let solver_id = 0;
+        info!(
+            height = ?template.height,
+            transactions = ?template.transactions.len(),
+            "mining with an updated block template",
+        );
+
+        // Tell the next loop iteration to wait until the template has changed before returning.
+        parameters.long_poll_id = Some(template.long_poll_id);
+
+        let block = proposal_block_from_template(&template, TimeSource::CurTime)
+            .expect("unexpected invalid block template");
+
+        // Always send, even if all the receivers have been dropped.
+        let _prev_template = template_sender.send_replace(Some(Arc::new(block)));
+    }
+
+    Ok(())
+}
+
+/// Runs a single mining thread that gets blocks from the `template_receiver`, calculates equihash
+/// solutions with nonces based on `solver_id`, and submits valid blocks to Zebra's block validator.
+///
+/// This method is CPU and memory-intensive. It uses 144 MB of RAM and one CPU core while running.
+/// It can run for minutes or hours if the network difficulty is high. Mining uses a thread with
+/// low CPU priority.
+#[instrument(skip(template_receiver, rpc))]
+pub async fn run_mining_solver<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>(
+    solver_id: u8,
+    template_receiver: WatchReceiver<Option<Arc<Block>>>,
+    rpc: GetBlockTemplateRpcImpl<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>,
+) -> Result<(), Report>
+where
+    Mempool: Service<
+            mempool::Request,
+            Response = mempool::Response,
+            Error = zebra_node_services::BoxError,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
+    Mempool::Future: Send,
+    State: Service<
+            zebra_state::ReadRequest,
+            Response = zebra_state::ReadResponse,
+            Error = zebra_state::BoxError,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
+    <State as Service<zebra_state::ReadRequest>>::Future: Send,
+    Tip: ChainTip + Clone + Send + Sync + 'static,
+    BlockVerifierRouter: Service<zebra_consensus::Request, Response = block::Hash, Error = zebra_consensus::BoxError>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    <BlockVerifierRouter as Service<zebra_consensus::Request>>::Future: Send,
+    SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
+    AddressBook: AddressBookPeers + Clone + Send + Sync + 'static,
+{
+    while !is_shutting_down() {
+        // Get the latest block template.
+        let template = template_receiver.cloned_watch_data();
+
+        let Some(template) = template else {
+            if solver_id == 0 {
+                info!(
+                    ?solver_id,
+                    ?BLOCK_TEMPLATE_WAIT_TIME,
+                    "solver waiting for initial block template"
+                );
+            } else {
+                debug!(
+                    ?solver_id,
+                    ?BLOCK_TEMPLATE_WAIT_TIME,
+                    "solver waiting for initial block template"
+                );
+            }
+
+            // Skip the wait if we didn't get a template because we are shutting down.
+            if !is_shutting_down() {
+                sleep(BLOCK_TEMPLATE_WAIT_TIME).await;
+            }
 
             continue;
         };
@@ -224,12 +321,16 @@ where
                 info!(
                     ?height,
                     ?solver_id,
+                    new_template = ?template_receiver.has_changed(),
+                    shutting_down = ?is_shutting_down(),
                     "solver cancelled: getting a new block template or shutting down"
                 );
             } else {
                 debug!(
                     ?height,
                     ?solver_id,
+                    new_template = ?template_receiver.has_changed(),
+                    shutting_down = ?is_shutting_down(),
                     "solver cancelled: getting a new block template or shutting down"
                 );
             }

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -1,0 +1,67 @@
+//! Internal mining in Zebra.
+//!
+//! # TODO
+//! - pause mining if we have no peers, like `zcashd` does,
+//!   and add a developer config that mines regardless of how many peers we have.
+//!   <https://github.com/zcash/zcash/blob/6fdd9f1b81d3b228326c9826fa10696fc516444b/src/miner.cpp#L865-L880>
+//! - move common code into zebra-chain or zebra-node-services and remove the RPC dependency.
+
+use color_eyre::Report;
+use tower::Service;
+
+use zebra_chain::{block, chain_sync_status::ChainSyncStatus, chain_tip::ChainTip};
+use zebra_network::AddressBookPeers;
+use zebra_node_services::mempool;
+use zebra_rpc::methods::{
+    get_block_template_rpcs::get_block_template::{
+        self, GetBlockTemplateCapability::*, GetBlockTemplateRequestMode::*,
+    },
+    GetBlockTemplateRpc, GetBlockTemplateRpcImpl,
+};
+
+/// Runs a single mining thread to generate blocks, calculate equihash solutions, and submit valid
+/// blocks to Zebra's block validator.
+#[instrument(skip(rpc))]
+pub async fn run_mining_solver<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>(
+    rpc: GetBlockTemplateRpcImpl<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>,
+) -> Result<(), Report>
+where
+    Mempool: Service<
+            mempool::Request,
+            Response = mempool::Response,
+            Error = zebra_node_services::BoxError,
+        > + 'static,
+    Mempool::Future: Send,
+    State: Service<
+            zebra_state::ReadRequest,
+            Response = zebra_state::ReadResponse,
+            Error = zebra_state::BoxError,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
+    <State as Service<zebra_state::ReadRequest>>::Future: Send,
+    Tip: ChainTip + Clone + Send + Sync + 'static,
+    BlockVerifierRouter: Service<zebra_consensus::Request, Response = block::Hash, Error = zebra_consensus::BoxError>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    <BlockVerifierRouter as Service<zebra_consensus::Request>>::Future: Send,
+    SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
+    AddressBook: AddressBookPeers + Clone + Send + Sync + 'static,
+{
+    // Pass the correct arguments, even if Zebra currently ignores them.
+    let mut long_poll_id = None;
+    let mut parameters = get_block_template::JsonParameters {
+        mode: Template,
+        data: None,
+        capabilities: vec![LongPoll, CoinbaseTxn],
+        long_poll_id,
+        _work_id: None,
+    };
+
+    let template = rpc.get_block_template(Some(parameters)).await;
+
+    Ok(())
+}

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -186,8 +186,9 @@ where
             .expect("invalid RPC response: proposal in response to a template request");
 
         // TODO: select!{} on either a solved header or a new block template using long_poll_id
-        //       cancel the solver if there's a new template or if Zebra is shutting down
-        //       launch the configured number of solvers
+        //       cancel the solver if there's a new template
+        //       add a config & launch the configured number of solvers, using available_parallelism()
+        //       by default
         let solver_id = 0;
 
         let height = template.height;

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -9,7 +9,7 @@
 use std::{cmp::min, sync::Arc, thread::available_parallelism, time::Duration};
 
 use color_eyre::Report;
-use futures::{stream::FuturesUnordered, TryStreamExt};
+use futures::{stream::FuturesUnordered, StreamExt};
 use thread_priority::{ThreadBuilder, ThreadPriority};
 use tokio::{select, sync::watch, task::JoinHandle, time::sleep};
 use tower::Service;
@@ -178,9 +178,8 @@ where
     let first_result;
     select! {
         result = template_generator => { first_result = result; }
-        result = mining_solvers.try_next() => {
+        result = mining_solvers.next() => {
             first_result = result
-                .transpose()
                 .expect("stream never teminates because there is at least one solver task");
         }
     }

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -58,7 +58,10 @@ where
             mempool::Request,
             Response = mempool::Response,
             Error = zebra_node_services::BoxError,
-        > + 'static,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
     Mempool::Future: Send,
     State: Service<
             zebra_state::ReadRequest,
@@ -100,7 +103,10 @@ where
             mempool::Request,
             Response = mempool::Response,
             Error = zebra_node_services::BoxError,
-        > + 'static,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
     Mempool::Future: Send,
     State: Service<
             zebra_state::ReadRequest,
@@ -137,7 +143,10 @@ where
             mempool::Request,
             Response = mempool::Response,
             Error = zebra_node_services::BoxError,
-        > + 'static,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
     Mempool::Future: Send,
     State: Service<
             zebra_state::ReadRequest,

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -7,17 +7,101 @@
 //! - move common code into zebra-chain or zebra-node-services and remove the RPC dependency.
 
 use color_eyre::Report;
+use tokio::task::JoinHandle;
 use tower::Service;
+use tracing::Instrument;
 
 use zebra_chain::{block, chain_sync_status::ChainSyncStatus, chain_tip::ChainTip};
 use zebra_network::AddressBookPeers;
 use zebra_node_services::mempool;
-use zebra_rpc::methods::{
-    get_block_template_rpcs::get_block_template::{
-        self, GetBlockTemplateCapability::*, GetBlockTemplateRequestMode::*,
+use zebra_rpc::{
+    config::mining::Config,
+    methods::{
+        get_block_template_rpcs::get_block_template::{
+            self, GetBlockTemplateCapability::*, GetBlockTemplateRequestMode::*,
+        },
+        GetBlockTemplateRpc, GetBlockTemplateRpcImpl,
     },
-    GetBlockTemplateRpc, GetBlockTemplateRpcImpl,
 };
+
+/// Initialize the miner based on its config, and spawn a task for it.
+///
+/// TODO:
+/// - add a miner config for the number of solver threads.
+/// - add a test for this function.
+pub fn spawn_init<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>(
+    config: &Config,
+    rpc: GetBlockTemplateRpcImpl<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>,
+) -> JoinHandle<Result<(), Report>>
+where
+    Mempool: Service<
+            mempool::Request,
+            Response = mempool::Response,
+            Error = zebra_node_services::BoxError,
+        > + 'static,
+    Mempool::Future: Send,
+    State: Service<
+            zebra_state::ReadRequest,
+            Response = zebra_state::ReadResponse,
+            Error = zebra_state::BoxError,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
+    <State as Service<zebra_state::ReadRequest>>::Future: Send,
+    Tip: ChainTip + Clone + Send + Sync + 'static,
+    BlockVerifierRouter: Service<zebra_consensus::Request, Response = block::Hash, Error = zebra_consensus::BoxError>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    <BlockVerifierRouter as Service<zebra_consensus::Request>>::Future: Send,
+    SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
+    AddressBook: AddressBookPeers + Clone + Send + Sync + 'static,
+{
+    let config = config.clone();
+
+    // TODO: spawn an entirely new executor here, so mining is isolated from higher priority tasks.
+    tokio::spawn(init(config, rpc).in_current_span())
+}
+
+/// Initialize the miner based on its config.
+///
+/// TODO: add a test for this function.
+pub async fn init<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>(
+    _config: Config,
+    rpc: GetBlockTemplateRpcImpl<Mempool, State, Tip, BlockVerifierRouter, SyncStatus, AddressBook>,
+) -> Result<(), Report>
+where
+    Mempool: Service<
+            mempool::Request,
+            Response = mempool::Response,
+            Error = zebra_node_services::BoxError,
+        > + 'static,
+    Mempool::Future: Send,
+    State: Service<
+            zebra_state::ReadRequest,
+            Response = zebra_state::ReadResponse,
+            Error = zebra_state::BoxError,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
+    <State as Service<zebra_state::ReadRequest>>::Future: Send,
+    Tip: ChainTip + Clone + Send + Sync + 'static,
+    BlockVerifierRouter: Service<zebra_consensus::Request, Response = block::Hash, Error = zebra_consensus::BoxError>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    <BlockVerifierRouter as Service<zebra_consensus::Request>>::Future: Send,
+    SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
+    AddressBook: AddressBookPeers + Clone + Send + Sync + 'static,
+{
+    // TODO: launch the configured number of solvers
+    //       make mining threads lower priority than other threads
+    run_mining_solver(rpc).await
+}
 
 /// Runs a single mining thread to generate blocks, calculate equihash solutions, and submit valid
 /// blocks to Zebra's block validator.

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -375,6 +375,13 @@ where
                     "solver cancelled: getting a new block template or shutting down"
                 );
             }
+
+            // If the blockchain is changing rapidly, limit how often we'll update the template.
+            // But if we're shutting down, do that immediately.
+            if template_receiver.has_changed().is_ok() && !is_shutting_down() {
+                sleep(Duration::from_secs(1)).await;
+            }
+
             continue;
         };
 

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -261,7 +261,8 @@ pub struct Config {
 
     /// The number of threads used to verify signatures, proofs, and other CPU-intensive code.
     ///
-    /// Set to `0` by default, which uses one thread per available CPU core.
+    /// If the number of threads is not configured or zero, Zebra uses the number of logical cores.
+    /// If the number of logical cores can't be detected, Zebra uses one thread.
     /// For details, see [the `rayon` documentation](https://docs.rs/rayon/latest/rayon/struct.ThreadPoolBuilder.html#method.num_threads).
     pub parallel_cpu_threads: usize,
 }

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -111,9 +111,12 @@
 //! ### Experimental
 //!
 //! * `elasticsearch`: save block data into elasticsearch database. Read the [elasticsearch](https://zebra.zfnd.org/user/elasticsearch.html)
-//! section of the book for more details.
+//!   section of the book for more details.
 //! * `shielded-scan`: enable experimental support for scanning shielded transactions. Read the [shielded-scan](https://zebra.zfnd.org/user/shielded-scan.html)
-//! section of the book for more details.
+//!   section of the book for more details.
+//! * `internal-miner`: enable experimental support for mining inside Zebra, without an external
+//!   mining pool. This feature is only supported on testnet. Use a GPU or ASIC on mainnet for
+//!   efficient mining.
 
 #![doc(html_favicon_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-favicon-128.png")]
 #![doc(html_logo_url = "https://zfnd.org/wp-content/uploads/2022/03/zebra-icon.png")]

--- a/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
@@ -169,7 +169,7 @@ async fn try_validate_block_template(client: &RpcRequestClient) -> Result<()> {
 
     {
         let client = client.clone();
-        let mut long_poll_id = response_json_result.long_poll_id.clone();
+        let mut long_poll_id = response_json_result.long_poll_id;
 
         tokio::spawn(async move {
             loop {
@@ -196,7 +196,7 @@ async fn try_validate_block_template(client: &RpcRequestClient) -> Result<()> {
                     }
 
                     long_poll_result = long_poll_request => {
-                        long_poll_id = long_poll_result.long_poll_id.clone();
+                        long_poll_id = long_poll_result.long_poll_id;
 
                         if let Some(false) = long_poll_result.submit_old {
                             let _ = long_poll_result_tx.send(long_poll_result);


### PR DESCRIPTION
## Motivation

It would be easier to test Zebra if we could mine blocks without external mining software.

This PR depends on changes to `equihash`:
https://github.com/zcash/librustzcash/pull/1088
https://github.com/zcash/librustzcash/pull/1083

This is an experimental "free sprint" project.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?
    - [x] List of features in `zebrad/src/lib.rs` 
    - [x] List of tasks in `zebrad/src/commands/start.rs` 

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

### Specifications

This code obeys the consensus rules by generating valid blocks, but it uses the existing verifiers. So there are no consensus-critical changes here.

### Complex Code or Requirements

This code launches concurrent async tasks and OS threads. We should check that panics and shutdowns are handled correctly. In particular, miner threads should restart mining with each new block template.

We should check that any common or expected errors are handled by retrying rather than panicking.

We should check that the threads are actually doing *different* work, they should have nonces with large gaps between them.

## Solution

Rust Features:
- add an `internal-miner` feature and dependencies

Solver:
- depend on the new solver code in `equihash`
- add an `equihash::Solution::solve()` method with difficulty checks

Miner:
- add a miner task to the start command
- wait until a valid template is available
- spawn to a blocking async executor thread 
- spawn to a low-priority OS thread
- handle shutdowns by cancelling the miner

Parallel Mining:
- use a different nonce for each thread
- spawn multiple miner threads based on a new config, use `available_parallelism()` by default
- `select! {}` on solutions or new block templates using `long_poll_id`
- cancel and restart the solver if there's a new template
- rate-limit template changes

Related Changes:
- Fix a bug in the `get_block_template` RPC change detection
- make RPC instances cloneable and LongPollId copyable
- use the same generic constraints for the RPC struct and impls
- move some code around so it's easier to re-use
- add utility and convenience methods to existing types

### Testing

I manually verified that:
- the mining threads are running, and there are approximately the configured number of threads
- they are using 100% CPU
- they are low priority (blue in `htop`)
- they produce valid blocks (according to Zebra's verifier)
- the miner runs overnight successfully
- the blocks are mined off the tip
- the blocks are accepted by other nodes
- the [block nonces](https://testnet.zcashblockexplorer.com/blocks/000365cd36db8fcee91bbe4de75eac1a191ee5ede9a915f6f41fb636d7aec9f3) match [the pattern used by Zebra](https://github.com/ZcashFoundation/zebra/pull/8136/files#diff-d73b289b9e87396ee873d64e4bdd5f1d9e57f820adf73df42be03040a3341e89R487-R491), and it's not just the first thread successfully mining 

## Review

This PR is ready for review.

I'd like to focus on bugs and overall code structure in this review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

- Get the `equihash` changes merged and released, and update that dependency
- Check we have at least one peer before starting mining (the existing sync to tip check partly covers this)
- Optional: Add a cached state test that mines a block on testnet?
