### PR TITLE
build(deps): bump `jsonrpc` from 0.16.0 to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efde8d2422fb79ed56db1d3aea8fa5b583351d15a26770cdee2f88813dd702"
+checksum = "a26d9104d516092f092d97448787505881fdb6518293b2d6500bf9c180c839dd"
 dependencies = [
  "base64 0.13.1",
  "serde",

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -105,7 +105,7 @@ reqwest = { version = "0.11.23", default-features = false, features = ["rustls-t
 # These crates are needed for the zebra-checkpoints and search-issue-refs binaries
 tokio = { version = "1.35.1", features = ["full"], optional = true }
 
-jsonrpc = { version = "0.16.0", optional = true }
+jsonrpc = { version = "0.17.0", optional = true }
 
 zcash_primitives = { version = "0.13.0-rc.1", optional = true }
 zcash_client_backend = {version = "0.10.0-rc.1", optional = true}

--- a/zebra-utils/src/bin/scanning-results-reader/main.rs
+++ b/zebra-utils/src/bin/scanning-results-reader/main.rs
@@ -106,8 +106,8 @@ fn get_tx_via_rpc(txid: String) -> String {
         .expect("URL should be valid")
         .build();
     let client = Client::with_transport(transport);
-    let params = [RawValue::from_string(txid).expect("Provided TXID should be a valid JSON")];
-    let request = client.build_request("getrawtransaction", &params);
+    let params = RawValue::from_string(txid).expect("Provided TXID should be a valid JSON");
+    let request = client.build_request("getrawtransaction", Some(&params));
     let response = client
         .send_request(request)
         .expect("Sending the `getrawtransaction` request should succeed");


### PR DESCRIPTION
## Motivation

This is needed to upgrade to the latest version of `jsonrpc`.

The version bump was originally part of #8137.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Bump `jsonrpc` version
- Pass an `Option` as the second argument to `build_request` instead of an array

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._