### PR TITLE
refactor: remove obsolete clippy allows in non_finalized_state

### DIFF
--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -182,7 +182,6 @@ impl NonFinalizedState {
         // Chain::cmp uses the partial cumulative work, and the hash of the tip block.
         // Neither of these fields has interior mutability.
         // (And when the tip block is dropped for a chain, the chain is also dropped.)
-        #[allow(clippy::mutable_key_type)]
         let chains = mem::take(&mut self.chain_set);
         let mut chains = chains.into_iter();
 
@@ -582,7 +581,6 @@ impl NonFinalizedState {
     ///
     /// The chain can be an existing chain in the non-finalized state, or a freshly
     /// created fork.
-    #[allow(clippy::unwrap_in_result)]
     fn parent_chain(&self, parent_hash: block::Hash) -> Result<Arc<Chain>, ValidateContextError> {
         match self.find_chain(|chain| chain.non_finalized_tip_hash() == parent_hash) {
             // Clone the existing Arc<Chain> in the non-finalized state


### PR DESCRIPTION
## Motivation

I was reading the codebase and found these two `#[allow()]`s obsolete

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

Just remove the obsolete allows

### Testing

```
cargo +nightly clippy -p zebra-state
```

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
