### PR TITLE
add(docs): Note default path to config in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ sections in the book for more details.
 
 #### Optional Configs & Features
 
+##### Initializing Configuration File
+
+```console
+zebrad generate -o ~/.config/zebrad.toml
+```
+
+The above command places the generated `zebrad.toml` config file in the default preferences directory of Linux. For other OSes default locations [see here](https://docs.rs/dirs/latest/dirs/fn.preference_dir.html).
+
 ##### Configuring Progress Bars
 
 Configure `tracing.progress_bar` in your `zebrad.toml` to

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -45,7 +45,7 @@ pub struct Config {
     /// | Linux   | `$XDG_CACHE_HOME/zebra` or `$HOME/.cache/zebra` | `/home/alice/.cache/zebra`           |
     /// | macOS   | `$HOME/Library/Caches/zebra`                    | `/Users/Alice/Library/Caches/zebra`  |
     /// | Windows | `{FOLDERID_LocalAppData}\zebra`                 | `C:\Users\Alice\AppData\Local\zebra` |
-    /// | Other   | `std::env::current_dir()/cache/zebra`           | `/cache/zebra`                       |
+    /// | Other   | `std::env::current_dir()/.cache/zebra`          | `/.cache/zebra`                      |
     ///
     /// # Security
     ///

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -45,7 +45,7 @@ pub struct Config {
     /// | Linux   | `$XDG_CACHE_HOME/zebra` or `$HOME/.cache/zebra` | `/home/alice/.cache/zebra`           |
     /// | macOS   | `$HOME/Library/Caches/zebra`                    | `/Users/Alice/Library/Caches/zebra`  |
     /// | Windows | `{FOLDERID_LocalAppData}\zebra`                 | `C:\Users\Alice\AppData\Local\zebra` |
-    /// | Other   | `std::env::current_dir()/.cache/zebra`          | `/.cache/zebra`                      |
+    /// | Other   | `std::env::current_dir()/cache/zebra`           | `/cache/zebra`                       |
     ///
     /// # Security
     ///

--- a/zebrad/src/commands/generate.rs
+++ b/zebrad/src/commands/generate.rs
@@ -44,6 +44,16 @@ impl Runnable for GenerateCmd {
 # 1. The -c flag on the command line, e.g., `zebrad -c myconfig.toml start`;
 # 2. The file `zebrad.toml` in the users's preference directory (platform-dependent);
 # 3. The default config.
+#
+# The user's preference directory and the default path to the `zebrad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html:
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zebrad.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zebrad.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zebrad.toml`     |
+# | Other    | `std::env::current_dir()/.config`     | `/.config/zebrad.toml`                         |
 
 "
         .to_owned();

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -22,7 +22,6 @@ use serde::{Deserialize, Serialize};
 /// | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zebrad.toml`              |
 /// | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zebrad.toml` |
 /// | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zebrad.toml`     |
-/// | Other    | `std::env::current_dir()/.config`     | `/.config/zebrad.toml`                         |
 #[derive(Clone, Default, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct ZebradConfig {

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -11,6 +11,18 @@ use serde::{Deserialize, Serialize};
 /// The `zebrad` config is a TOML-encoded version of this structure. The meaning
 /// of each field is described in the documentation, although it may be necessary
 /// to click through to the sub-structures for each section.
+///
+/// The path to the configuration file can also be specified with the `--config` flag when running Zebra.
+///
+/// The default path to the `zebrad` config is platform dependent, based on
+/// [`dirs::preference_dir`](https://docs.rs/dirs/latest/dirs/fn.preference_dir.html):
+///
+/// | Platform | Value                                 | Example                                        |
+/// | -------- | ------------------------------------- | ---------------------------------------------- |
+/// | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zebrad.toml`              |
+/// | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zebrad.toml` |
+/// | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zebrad.toml`     |
+/// | Other    | `std::env::current_dir()/.config`     | `/.config/zebrad.toml`                         |
 #[derive(Clone, Default, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct ZebradConfig {

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -54,6 +54,18 @@
 //! - Additional contexts: wider target deployments for people to use a consensus
 //!   node in more contexts e.g. mobile, wasm, etc.
 //!
+//! ## Configuration
+//!
+//! The command below places the generated `zebrad.toml` config file in the default preferences directory of Linux:
+//!
+//! ```console
+//! zebrad generate -o ~/.config/zebrad.toml
+//! ```
+//!
+//! For other OSes default locations [see here](https://docs.rs/dirs/latest/dirs/fn.preference_dir.html).
+//!
+//! See [`config::ZebradConfig`] for more information.
+//!
 //! ## Zebra Feature Flags
 //!
 //! The following `zebrad` feature flags are available at compile time:

--- a/zebrad/src/lib.rs
+++ b/zebrad/src/lib.rs
@@ -62,9 +62,7 @@
 //! zebrad generate -o ~/.config/zebrad.toml
 //! ```
 //!
-//! For other OSes default locations [see here](https://docs.rs/dirs/latest/dirs/fn.preference_dir.html).
-//!
-//! See [`config::ZebradConfig`] for more information.
+//! See [`config::ZebradConfig`] for other OSes default locations or more information about how to configure Zebra.
 //!
 //! ## Zebra Feature Flags
 //!

--- a/zebrad/tests/common/configs/shieldedscan-v1.6.0.toml
+++ b/zebrad/tests/common/configs/shieldedscan-v1.6.0.toml
@@ -1,0 +1,89 @@
+# Default configuration for zebrad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zebrad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
+#
+# zebrad attempts to load configs in the following order:
+#
+# 1. The -c flag on the command line, e.g., `zebrad -c myconfig.toml start`;
+# 2. The file `zebrad.toml` in the users's preference directory (platform-dependent);
+# 3. The default config.
+#
+# The user's preference directory and the default path to the `zebrad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zebrad.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zebrad.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zebrad.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[mempool]
+eviction_memory_time = "1h"
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+debug_like_zcashd = true
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+initial_mainnet_peers = [
+    "dnsseed.z.cash:8233",
+    "dnsseed.str4d.xyz:8233",
+    "mainnet.seeder.zfnd.org:8233",
+    "mainnet.is.yolo.money:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+    "testnet.is.yolo.money:18233",
+]
+listen_addr = "0.0.0.0:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+peerset_initial_target_size = 25
+
+[rpc]
+debug_force_finished_sync = false
+parallel_cpu_threads = 0
+
+[shielded_scan]
+cache_dir = "cache_dir"
+delete_old_database = true
+ephemeral = false
+
+[shielded_scan.sapling_keys_to_scan]
+
+[state]
+cache_dir = "cache_dir"
+delete_old_database = true
+ephemeral = false
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 50
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false

--- a/zebrad/tests/common/configs/v1.6.0.toml
+++ b/zebrad/tests/common/configs/v1.6.0.toml
@@ -1,29 +1,4 @@
-//! `generate` subcommand - generates a default `zebrad.toml` config.
-
-use crate::config::ZebradConfig;
-use abscissa_core::{Command, Runnable};
-use clap::Parser;
-
-/// Generate a default `zebrad.toml` configuration
-#[derive(Command, Debug, Default, Parser)]
-pub struct GenerateCmd {
-    /// The file to write the generated config to.
-    //
-    // TODO: use PathBuf here instead, to support non-UTF-8 paths
-    #[clap(
-        long,
-        short,
-        help = "The file to write the generated config to (stdout if unspecified)"
-    )]
-    output_file: Option<String>,
-}
-
-impl Runnable for GenerateCmd {
-    /// Start the application.
-    #[allow(clippy::print_stdout)]
-    fn run(&self) {
-        let default_config = ZebradConfig::default();
-        let mut output = r"# Default configuration for zebrad.
+# Default configuration for zebrad.
 #
 # This file can be used as a skeleton for custom configs.
 #
@@ -54,24 +29,54 @@ impl Runnable for GenerateCmd {
 # | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zebrad.toml` |
 # | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zebrad.toml`     |
 
-"
-        .to_owned();
+[consensus]
+checkpoint_sync = true
 
-        // this avoids a ValueAfterTable error
-        // https://github.com/alexcrichton/toml-rs/issues/145
-        let conf = toml::Value::try_from(default_config).unwrap();
-        output += &toml::to_string_pretty(&conf).expect("default config should be serializable");
-        match self.output_file {
-            Some(ref output_file) => {
-                use std::{fs::File, io::Write};
-                File::create(output_file)
-                    .expect("must be able to open output file")
-                    .write_all(output.as_bytes())
-                    .expect("must be able to write output");
-            }
-            None => {
-                println!("{output}");
-            }
-        }
-    }
-}
+[mempool]
+eviction_memory_time = "1h"
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+debug_like_zcashd = true
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+initial_mainnet_peers = [
+    "dnsseed.z.cash:8233",
+    "dnsseed.str4d.xyz:8233",
+    "mainnet.seeder.zfnd.org:8233",
+    "mainnet.is.yolo.money:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+    "testnet.is.yolo.money:18233",
+]
+listen_addr = "0.0.0.0:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+peerset_initial_target_size = 25
+
+[rpc]
+debug_force_finished_sync = false
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+delete_old_database = true
+ephemeral = false
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 50
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false


### PR DESCRIPTION
## Motivation

This PR makes it easier to find docs about the default config paths for macOS and Windows.

Closes #7964.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

Adds a note to the README, zebrad docs, `ZebradConfig` docs, and `generate` command output with a link to default path to preferences directory for macOS/Windows.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
