### PR TITLE
fix(miner): Avoid some duplicate block errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?branch=equihash-solver-tromp#97a1e0adb57a83acd02e6eea5bb06fbb3b04ec21"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?branch=equihash-solver-tromp#aff6fac6cb9c7390565313733f0ba7d679166504"
 dependencies = [
  "blake2b_simd",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/ZcashFoundation/librustzcash.git?branch=equihash-solver-tromp#251098313920466958fcd05b25e151d4edd3a1b1"
+source = "git+https://github.com/ZcashFoundation/librustzcash.git?branch=equihash-solver-tromp#97a1e0adb57a83acd02e6eea5bb06fbb3b04ec21"
 dependencies = [
  "blake2b_simd",
  "byteorder",

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -30,7 +30,6 @@ use zebra_rpc::{
     config::mining::Config,
     methods::{
         get_block_template_rpcs::{
-            constants::GET_BLOCK_TEMPLATE_MEMPOOL_LONG_POLL_INTERVAL,
             get_block_template::{
                 self, proposal::TimeSource, proposal_block_from_template,
                 GetBlockTemplateCapability::*, GetBlockTemplateRequestMode::*,

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -45,6 +45,15 @@ use zebra_state::WatchReceiver;
 /// The amount of time we wait between block template retries.
 pub const BLOCK_TEMPLATE_WAIT_TIME: Duration = Duration::from_secs(20);
 
+/// A rate-limit for block template refreshes.
+pub const BLOCK_TEMPLATE_REFRESH_LIMIT: Duration = Duration::from_secs(2);
+
+/// How long we wait after mining a block, before expecting a new template.
+///
+/// This should be slightly longer than `BLOCK_TEMPLATE_REFRESH_LIMIT` to allow for template
+/// generation.
+pub const BLOCK_MINING_WAIT_TIME: Duration = Duration::from_secs(3);
+
 /// Initialize the miner based on its config, and spawn a task for it.
 ///
 /// This method is CPU and memory-intensive. It uses 144 MB of RAM and one CPU core per configured
@@ -295,10 +304,7 @@ where
         // If the blockchain is changing rapidly, limit how often we'll update the template.
         // But if we're shutting down, do that immediately.
         if !template_sender.is_closed() && !is_shutting_down() {
-            sleep(Duration::from_secs(
-                GET_BLOCK_TEMPLATE_MEMPOOL_LONG_POLL_INTERVAL,
-            ))
-            .await;
+            sleep(BLOCK_TEMPLATE_REFRESH_LIMIT).await;
         }
     }
 
@@ -426,7 +432,7 @@ where
             // If the blockchain is changing rapidly, limit how often we'll update the template.
             // But if we're shutting down, do that immediately.
             if template_receiver.has_changed().is_ok() && !is_shutting_down() {
-                sleep(Duration::from_secs(1)).await;
+                sleep(BLOCK_TEMPLATE_REFRESH_LIMIT).await;
             }
 
             continue;
@@ -437,19 +443,23 @@ where
         // TODO: if there is a new template (`cancel_fn().is_err()`), and
         //       GetBlockTemplate.submit_old is false, return immediately, and skip submitting the
         //       blocks.
+        let mut any_success = false;
         for block in blocks {
             let data = block
                 .zcash_serialize_to_vec()
                 .expect("serializing to Vec never fails");
 
             match rpc.submit_block(HexData(data), None).await {
-                Ok(success) => info!(
-                    ?height,
-                    hash = ?block.hash(),
-                    ?solver_id,
-                    ?success,
-                    "successfully mined a new block",
-                ),
+                Ok(success) => {
+                    info!(
+                        ?height,
+                        hash = ?block.hash(),
+                        ?solver_id,
+                        ?success,
+                        "successfully mined a new block",
+                    );
+                    any_success = true;
+                }
                 Err(error) => info!(
                     ?height,
                     hash = ?block.hash(),
@@ -458,6 +468,25 @@ where
                     "validating a newly mined block failed, trying again",
                 ),
             }
+        }
+
+        // Start re-mining quickly after a failed solution.
+        // If there's a new template, we'll use it, otherwise the existing one is ok.
+        if !any_success {
+            // If the blockchain is changing rapidly, limit how often we'll update the template.
+            // But if we're shutting down, do that immediately.
+            if template_receiver.has_changed().is_ok() && !is_shutting_down() {
+                sleep(BLOCK_TEMPLATE_REFRESH_LIMIT).await;
+            }
+            continue;
+        }
+
+        // Wait for the new block to verify, and the RPC task to pick up a new template.
+        // But don't wait too long, we could have mined on a fork.
+        tokio::select! {
+            shutdown_result = template_receiver.changed() => shutdown_result?,
+            _ = sleep(BLOCK_MINING_WAIT_TIME) => {}
+
         }
     }
 


### PR DESCRIPTION
## Motivation

Sometimes one of Zebra's miners will:
- submit a valid block
- restart mining on the same template
- submit a duplicate of that block

This happens when a valid solution is mined quickly, before the block has time to validate, and the template has time to refresh.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

### Complex Code or Requirements

This is a pretty standard concurrency bug.

## Solution

- Decrease the time that the template generator waits between RPC calls to 2 seconds
- When a miner is successful, make it wait for 3 seconds before restarting mining, for block verification and RPC template generation (this time can be increased if the bug still happens)
- When a block fails, start re-mining after the standard 2 second rate-limit
- Define a constant for the standard RPC and miner rate-limit, and another constant for the wait time after mining a block

### Testing

I've tested this manually and it's no worse that the current code.

## Review

This is a routine fix.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

Adjust the constants as needed.