### PR TITLE
change(docs): Point to a manually created list of Zebra crates in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,11 +191,12 @@ The Zcash Foundation maintains the following resources documenting Zebra:
   - [User Documentation](https://zebra.zfnd.org/user.html),
   - [Developer Documentation](https://zebra.zfnd.org/dev.html).
 
-- The public APIs for the latest releases of the individual `zebra-*` crates are documented at
-[docs.rs](https://docs.rs/releases/search?query=zebrad).
+- The [documentation of the public
+  APIs](https://docs.rs/zebrad/latest/zebrad/#zebra-crates) for the latest
+  releases of the individual Zebra crates.
 
-- The internal APIs for the `main` branch are documented at
-<https://doc-internal.zebra.zfnd.org>.
+- The [documentation of the internal APIs](https://doc-internal.zebra.zfnd.org)
+  for the `main` branch of the whole Zebra monorepo.
 
 ## User support
 

--- a/book/src/api.md
+++ b/book/src/api.md
@@ -1,8 +1,10 @@
 # API Reference
 
-Zebra's API documentation is generated using Rustdoc:
+The Zcash Foundation maintains the following API documentation for Zebra:
 
-- [`docs.rs`](https://docs.rs/releases/search?query=zebrad) renders documentation for the public API
-  of the latest crate releases;
-- [`doc-internal.zebra.zfnd.org`](https://doc-internal.zebra.zfnd.org/) renders documentation for
-  the internal API on the `main` branch.
+- The [documentation of the public
+  APIs](https://docs.rs/zebrad/latest/zebrad/#zebra-crates) for the latest
+  releases of the individual Zebra crates.
+
+- The [documentation of the internal APIs](https://doc-internal.zebra.zfnd.org)
+  for the `main` branch of the whole Zebra monorepo.

--- a/book/src/dev.md
+++ b/book/src/dev.md
@@ -1,9 +1,11 @@
 # Developer Documentation
 
-This section contains the contribution guide and design documentation. It
-does not contain API documentation, which is generated using Rustdoc:
+This section contains the contribution guide and design documentation. It does
+not contain:
 
-- [`docs.rs`](https://docs.rs/releases/search?query=zebrad) renders documentation for the public API
-  of the latest crate releases;
-- [`doc-internal.zebra.zfnd.org`](https://doc-internal.zebra.zfnd.org/) renders documentation for
-  the internal API on the `main` branch.
+- The [documentation of the public
+  APIs](https://docs.rs/zebrad/latest/zebrad/#zebra-crates) for the latest
+  releases of the individual Zebra crates.
+
+- The [documentation of the internal APIs](https://doc-internal.zebra.zfnd.org)
+  for the `main` branch of the whole Zebra monorepo.


### PR DESCRIPTION
## Motivation

PR #7886 introduced this link to docs.rs for the docs of the public APIs: https://docs.rs/releases/search?query=zebra. However, the query in the link returns crates that are not part of the Zebra's public API and doesn't return the two tower-* crates that are part of Zebra.

This is a regular clean-up.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

This PR refers to a manually created list of links pointing to the docs of the public APIs of all current Zebra crates.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._