### PR TITLE
cleanup(miner): Simplify concurrency in experimental internal miner

### DIFF
--- a/zebra-state/src/service/watch_receiver.rs
+++ b/zebra-state/src/service/watch_receiver.rs
@@ -125,4 +125,9 @@ where
     pub fn mark_changed(&mut self) {
         self.receiver.mark_changed();
     }
+
+    /// Returns true if the sender has dropped and the watch channel is closed.
+    pub fn is_closed(&mut self) -> bool {
+        self.receiver.has_changed().is_err()
+    }
 }

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -352,7 +352,7 @@ where
     AddressBook: AddressBookPeers + Clone + Send + Sync + 'static,
 {
     // Shut down the task when the template sender is dropped, or Zebra shuts down.
-    while template_receiver.has_changed().is_ok() && !is_shutting_down() {
+    while !template_receiver.is_closed() && !is_shutting_down() {
         // Get the latest block template, and mark the current value as seen.
         // We mark the value first to avoid missed updates.
         template_receiver.mark_as_seen();

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -249,10 +249,9 @@ where
     // Pass the correct arguments, even if Zebra currently ignores them.
     let mut parameters = get_block_template::JsonParameters {
         mode: Template,
-        data: None,
         capabilities: vec![LongPoll, CoinbaseTxn],
         long_poll_id: None,
-        _work_id: None,
+        ..Default::default()
     };
 
     // Shut down the task when all the template receivers are dropped, or Zebra shuts down.


### PR DESCRIPTION
## Motivation

This PR is not yet ready for review.

It should resolve the follow up work in https://github.com/ZcashFoundation/zebra/pull/8136, resolve some TODOs, and simplify the concurrent logic once completed.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [ ] Will the PR name make sense to users?
  - [ ] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [ ] Is the documentation up to date?

##### For significant changes:
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Adds an `is_closed()` method to `WatchReceiver`
- Adds `awaits` in mining solver tasks so only `generate_block_template` is responsible for waiting when the chain is changing rapidly or blocks have been submitted successfully

### Testing

This will require manual testing like that in https://github.com/ZcashFoundation/zebra/pull/8136

## Review

This PR is not yet ready for review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

