### PR TITLE
add(scan): Create a tower Service in zebra-scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5862,6 +5862,7 @@ dependencies = [
  "chrono",
  "color-eyre",
  "ff",
+ "futures",
  "group",
  "indexmap 2.1.0",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5879,6 +5879,7 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_primitives",
  "zebra-chain",
+ "zebra-node-services",
  "zebra-state",
  "zebra-test",
 ]

--- a/zebra-node-services/src/lib.rs
+++ b/zebra-node-services/src/lib.rs
@@ -12,3 +12,5 @@ pub mod rpc_client;
 /// non-'static lifetimes, (e.g., when a type contains a borrow and is
 /// parameterized by 'a), *not* that the object itself has 'static lifetime.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+pub mod scan_service;

--- a/zebra-node-services/src/scan_service.rs
+++ b/zebra-node-services/src/scan_service.rs
@@ -1,0 +1,4 @@
+//! Request and response types for zebra-scan tower service.
+
+pub mod request;
+pub mod response;

--- a/zebra-node-services/src/scan_service/request.rs
+++ b/zebra-node-services/src/scan_service/request.rs
@@ -1,0 +1,23 @@
+//! Scan [`tower::Service`] request types.
+
+#[derive(Debug)]
+/// Request types for [`ScanService`](crate::service::ScanService)
+pub enum Request {
+    /// TODO: Accept `KeyHash`es and return key hashes that are registered
+    CheckKeyHashes(Vec<()>),
+
+    /// TODO: Accept `ViewingKeyWithHash`es and return Ok(()) if successful or an error
+    RegisterKeys(Vec<()>),
+
+    /// TODO: Accept `KeyHash`es and return Ok(Vec<KeyHash>) with hashes of deleted keys
+    DeleteKeys(Vec<()>),
+
+    /// TODO: Accept `KeyHash`es and return `Transaction`s
+    Results(Vec<()>),
+
+    /// TODO: Accept `KeyHash`es and return a channel receiver
+    SubscribeResults(Vec<()>),
+
+    /// TODO: Accept `KeyHash`es and return transaction ids
+    ClearResults(Vec<()>),
+}

--- a/zebra-node-services/src/scan_service/request.rs
+++ b/zebra-node-services/src/scan_service/request.rs
@@ -1,7 +1,7 @@
-//! Scan [`tower::Service`] request types.
+//! `zebra_scan::service::ScanService` request types.
 
 #[derive(Debug)]
-/// Request types for [`ScanService`](crate::service::ScanService)
+/// Request types for `zebra_scan::service::ScanService`
 pub enum Request {
     /// TODO: Accept `KeyHash`es and return key hashes that are registered
     CheckKeyHashes(Vec<()>),
@@ -9,7 +9,7 @@ pub enum Request {
     /// TODO: Accept `ViewingKeyWithHash`es and return Ok(()) if successful or an error
     RegisterKeys(Vec<()>),
 
-    /// TODO: Accept `KeyHash`es and return Ok(Vec<KeyHash>) with hashes of deleted keys
+    /// TODO: Accept `KeyHash`es and return Ok(`Vec<KeyHash>`) with hashes of deleted keys
     DeleteKeys(Vec<()>),
 
     /// TODO: Accept `KeyHash`es and return `Transaction`s

--- a/zebra-node-services/src/scan_service/response.rs
+++ b/zebra-node-services/src/scan_service/response.rs
@@ -1,11 +1,11 @@
-//! Scan [`tower::Service`] response types.
+//! `zebra_scan::service::ScanService` response types.
 
 use std::sync::{mpsc, Arc};
 
 use zebra_chain::transaction::Transaction;
 
 #[derive(Debug)]
-/// Response types for [`ScanService`](crate::service::ScanService)
+/// Response types for `zebra_scan::service::ScanService`
 pub enum Response {
     /// Response to SubscribeResults
     ResultsReceiver(mpsc::Receiver<Arc<Transaction>>),

--- a/zebra-node-services/src/scan_service/response.rs
+++ b/zebra-node-services/src/scan_service/response.rs
@@ -1,0 +1,12 @@
+//! Scan [`tower::Service`] response types.
+
+use std::sync::{mpsc, Arc};
+
+use zebra_chain::transaction::Transaction;
+
+#[derive(Debug)]
+/// Response types for [`ScanService`](crate::service::ScanService)
+pub enum Response {
+    /// Response to SubscribeResults
+    ResultsReceiver(mpsc::Receiver<Arc<Transaction>>),
+}

--- a/zebra-node-services/src/scan_service/response.rs
+++ b/zebra-node-services/src/scan_service/response.rs
@@ -7,6 +7,9 @@ use zebra_chain::transaction::Transaction;
 #[derive(Debug)]
 /// Response types for `zebra_scan::service::ScanService`
 pub enum Response {
-    /// Response to SubscribeResults
-    ResultsReceiver(mpsc::Receiver<Arc<Transaction>>),
+    /// Response to Results request
+    Results(Vec<Transaction>),
+
+    /// Response to SubscribeResults request
+    SubscribeResults(mpsc::Receiver<Arc<Transaction>>),
 }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -50,6 +50,7 @@ zcash_primitives = "0.13.0-rc.1"
 
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
 zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34", features = ["shielded-scan"] }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.33" }
 
 chrono = { version = "0.4.31", default-features = false, features = ["clock", "std", "serde"] }
 

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -44,6 +44,7 @@ serde = { version = "1.0.193", features = ["serde_derive"] }
 tokio = { version = "1.35.1", features = ["time"] }
 tower = "0.4.13"
 tracing = "0.1.39"
+futures = "0.3.30"
 
 zcash_client_backend = "0.10.0-rc.1"
 zcash_primitives = "0.13.0-rc.1"

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -13,7 +13,7 @@ use crate::{scan, storage::Storage, Config};
 
 #[derive(Debug)]
 /// Commands that can be sent to [`ScanTask`]
-pub enum ScannerCommand {
+pub enum ScanTaskCommand {
     /// Start scanning for new viewing keys
     RegisterKeys(Vec<()>), // TODO: send `ViewingKeyWithHash`es
 
@@ -43,7 +43,7 @@ pub struct ScanTask {
     _handle: JoinHandle<Result<(), Report>>,
 
     /// Task command channel sender
-    cmd_sender: mpsc::Sender<ScannerCommand>,
+    cmd_sender: mpsc::Sender<ScanTaskCommand>,
 }
 
 impl ScanTask {
@@ -64,7 +64,10 @@ impl ScanTask {
     }
 
     /// Sends a command to the scan task
-    pub fn send(&mut self, command: ScannerCommand) -> Result<(), mpsc::SendError<ScannerCommand>> {
+    pub fn send(
+        &mut self,
+        command: ScanTaskCommand,
+    ) -> Result<(), mpsc::SendError<ScanTaskCommand>> {
         self.cmd_sender.send(command)
     }
 }

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -40,7 +40,7 @@ pub enum ScanTaskCommand {
 /// Scan task handle and command channel sender
 pub struct ScanTask {
     /// [`JoinHandle`] of scan task
-    _handle: JoinHandle<Result<(), Report>>,
+    pub handle: JoinHandle<Result<(), Report>>,
 
     /// Task command channel sender
     cmd_sender: mpsc::Sender<ScanTaskCommand>,
@@ -58,7 +58,7 @@ impl ScanTask {
         let (cmd_sender, _cmd_receiver) = mpsc::channel();
 
         Self {
-            _handle: spawn_init(config, network, state, chain_tip_change),
+            handle: spawn_init(config, network, state, chain_tip_change),
             cmd_sender,
         }
     }

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -1,13 +1,73 @@
 //! Initializing the scanner.
 
+use std::sync::{mpsc, Arc};
+
 use color_eyre::Report;
-use tokio::task::JoinHandle;
+use tokio::{sync::oneshot, task::JoinHandle};
 use tracing::Instrument;
 
-use zebra_chain::{diagnostic::task::WaitForPanics, parameters::Network};
+use zebra_chain::{diagnostic::task::WaitForPanics, parameters::Network, transaction::Transaction};
 use zebra_state::ChainTipChange;
 
 use crate::{scan, storage::Storage, Config};
+
+#[derive(Debug)]
+/// Commands that can be sent to [`ScanTask`]
+pub enum ScannerCommand {
+    /// Start scanning for new viewing keys
+    RegisterKeys(Vec<()>), // TODO: send `ViewingKeyWithHash`es
+
+    /// Stop scanning for deleted viewing keys
+    RemoveKeys {
+        /// Notify the caller once the key is removed (so the caller can wait before clearing results)
+        done_tx: oneshot::Sender<()>,
+
+        /// Key hashes that are to be removed
+        key_hashes: Vec<()>,
+    },
+
+    /// Start sending results for key hashes to `result_sender`
+    SubscribeResults {
+        /// Sender for results
+        result_sender: mpsc::Sender<Arc<Transaction>>,
+
+        /// Key hashes to send the results of to result channel
+        key_hashes: Vec<()>,
+    },
+}
+
+#[derive(Debug)]
+/// Scan task handle and command channel sender
+pub struct ScanTask {
+    /// [`JoinHandle`] of scan task
+    _handle: JoinHandle<Result<(), Report>>,
+
+    /// Task command channel sender
+    cmd_sender: mpsc::Sender<ScannerCommand>,
+}
+
+impl ScanTask {
+    /// Spawns a new [`ScanTask`].
+    pub fn spawn(
+        config: &Config,
+        network: Network,
+        state: scan::State,
+        chain_tip_change: ChainTipChange,
+    ) -> Self {
+        // TODO: Pass `_cmd_receiver` to `scan::start()` to pass it new keys after it's been spawned
+        let (cmd_sender, _cmd_receiver) = mpsc::channel();
+
+        Self {
+            _handle: spawn_init(config, network, state, chain_tip_change),
+            cmd_sender,
+        }
+    }
+
+    /// Sends a command to the scan task
+    pub fn send(&mut self, command: ScannerCommand) -> Result<(), mpsc::SendError<ScannerCommand>> {
+        self.cmd_sender.send(command)
+    }
+}
 
 /// Initialize the scanner based on its config, and spawn a task for it.
 ///

--- a/zebra-scan/src/lib.rs
+++ b/zebra-scan/src/lib.rs
@@ -12,6 +12,9 @@ pub mod init;
 pub mod scan;
 pub mod storage;
 
+use zebra_node_services::scan_service::{request::Request, response::Response};
+
+mod service;
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod tests;
 

--- a/zebra-scan/src/service.rs
+++ b/zebra-scan/src/service.rs
@@ -17,7 +17,7 @@ pub struct ScanService {
     db: Storage,
 
     /// Handle to scan task that's responsible for writing results
-    _scan_task: ScanTask,
+    scan_task: ScanTask,
 }
 
 impl ScanService {
@@ -30,7 +30,7 @@ impl ScanService {
     ) -> Self {
         Self {
             db: Storage::new(config, network, false),
-            _scan_task: ScanTask::spawn(config, network, state, chain_tip_change),
+            scan_task: ScanTask::spawn(config, network, state, chain_tip_change),
         }
     }
 }
@@ -42,7 +42,11 @@ impl Service<Request> for ScanService {
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // TODO: Check for panics in scan task
+        // TODO: If scan task returns an error, add error to the panic message
+        assert!(
+            !self.scan_task.handle.is_finished(),
+            "scan task finished unexpectedly"
+        );
 
         self.db.check_for_panics();
 

--- a/zebra-scan/src/service.rs
+++ b/zebra-scan/src/service.rs
@@ -2,7 +2,9 @@
 
 use std::{future::Future, pin::Pin, task::Poll};
 
+use futures::future::FutureExt;
 use tower::Service;
+
 use zebra_chain::parameters::Network;
 use zebra_state::ChainTipChange;
 
@@ -15,12 +17,12 @@ pub struct ScanService {
     db: Storage,
 
     /// Handle to scan task that's responsible for writing results
-    scan_task: ScanTask,
+    _scan_task: ScanTask,
 }
 
 impl ScanService {
     /// Create a new [`ScanService`].
-    pub fn new(
+    pub fn _new(
         config: &Config,
         network: Network,
         state: scan::State,
@@ -28,7 +30,7 @@ impl ScanService {
     ) -> Self {
         Self {
             db: Storage::new(config, network, false),
-            scan_task: ScanTask::spawn(config, network, state, chain_tip_change),
+            _scan_task: ScanTask::spawn(config, network, state, chain_tip_change),
         }
     }
 }
@@ -39,7 +41,7 @@ impl Service<Request> for ScanService {
     type Future =
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
-    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
         // TODO: Check for panics in scan task
 
         self.db.check_for_panics();
@@ -49,37 +51,33 @@ impl Service<Request> for ScanService {
 
     fn call(&mut self, req: Request) -> Self::Future {
         match req {
-            Request::CheckKeyHashes(key_hashes) => {
+            Request::CheckKeyHashes(_key_hashes) => {
                 // TODO: check that these entries exist in db
-                todo!()
             }
 
-            Request::RegisterKeys(viewing_key_with_hashes) => {
+            Request::RegisterKeys(_viewing_key_with_hashes) => {
                 // TODO:
                 //  - add these keys as entries in db
                 //  - send keys to scanner task
-                todo!()
             }
 
-            Request::DeleteKeys(key_hashes) => {
+            Request::DeleteKeys(_key_hashes) => {
                 // TODO: delete these entries from db
-                todo!()
             }
 
-            Request::Results(key_hashes) => {
+            Request::Results(_key_hashes) => {
                 // TODO: read results from db
-                todo!()
             }
 
-            Request::SubscribeResults(key_hashes) => {
+            Request::SubscribeResults(_key_hashes) => {
                 // TODO: send key_hashes and mpsc::Sender to scanner task, return mpsc::Receiver to caller
-                todo!()
             }
 
-            Request::ClearResults(key_hashes) => {
+            Request::ClearResults(_key_hashes) => {
                 // TODO: clear results from db
-                todo!()
             }
         }
+
+        async move { Ok(Response::Results(vec![])) }.boxed()
     }
 }

--- a/zebra-scan/src/service.rs
+++ b/zebra-scan/src/service.rs
@@ -1,0 +1,85 @@
+//! [`tower::Service`] for zebra-scan.
+
+use std::{future::Future, pin::Pin, task::Poll};
+
+use tower::Service;
+use zebra_chain::parameters::Network;
+use zebra_state::ChainTipChange;
+
+use crate::{init::ScanTask, scan, storage::Storage, Config, Request, Response};
+
+/// Zebra-scan [`tower::Service`]
+#[derive(Debug)]
+pub struct ScanService {
+    /// On-disk storage
+    db: Storage,
+
+    /// Handle to scan task that's responsible for writing results
+    scan_task: ScanTask,
+}
+
+impl ScanService {
+    /// Create a new [`ScanService`].
+    pub fn new(
+        config: &Config,
+        network: Network,
+        state: scan::State,
+        chain_tip_change: ChainTipChange,
+    ) -> Self {
+        Self {
+            db: Storage::new(config, network, false),
+            scan_task: ScanTask::spawn(config, network, state, chain_tip_change),
+        }
+    }
+}
+
+impl Service<Request> for ScanService {
+    type Response = Response;
+    type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // TODO: Check for panics in scan task
+
+        self.db.check_for_panics();
+
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        match req {
+            Request::CheckKeyHashes(key_hashes) => {
+                // TODO: check that these entries exist in db
+                todo!()
+            }
+
+            Request::RegisterKeys(viewing_key_with_hashes) => {
+                // TODO:
+                //  - add these keys as entries in db
+                //  - send keys to scanner task
+                todo!()
+            }
+
+            Request::DeleteKeys(key_hashes) => {
+                // TODO: delete these entries from db
+                todo!()
+            }
+
+            Request::Results(key_hashes) => {
+                // TODO: read results from db
+                todo!()
+            }
+
+            Request::SubscribeResults(key_hashes) => {
+                // TODO: send key_hashes and mpsc::Sender to scanner task, return mpsc::Receiver to caller
+                todo!()
+            }
+
+            Request::ClearResults(key_hashes) => {
+                // TODO: clear results from db
+                todo!()
+            }
+        }
+    }
+}

--- a/zebra-scan/src/service.rs
+++ b/zebra-scan/src/service.rs
@@ -62,11 +62,13 @@ impl Service<Request> for ScanService {
             Request::RegisterKeys(_viewing_key_with_hashes) => {
                 // TODO:
                 //  - add these keys as entries in db
-                //  - send keys to scanner task
+                //  - send new keys to scan task
             }
 
             Request::DeleteKeys(_key_hashes) => {
-                // TODO: delete these entries from db
+                // TODO:
+                //  - delete these keys and their results from db
+                //  - send deleted keys to scan task
             }
 
             Request::Results(_key_hashes) => {
@@ -78,7 +80,7 @@ impl Service<Request> for ScanService {
             }
 
             Request::ClearResults(_key_hashes) => {
-                // TODO: clear results from db
+                // TODO: clear results for these keys from db
             }
         }
 


### PR DESCRIPTION
## Motivation

This PR adds a `ScanService` struct to `zebra-scan` to be used by RPC methods in `zebra-grpc`.

Closes #8182.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Defines `ScanService`/`ScanTask` structs and `ScanTaskCommand` enum
- Defines `Request` and `Response` enums in `zebra-node-services`
- Implements `tower::Service` for `ScanService`
- Adds an instance of `Storage` and `ScanTask` to fields on `ScanService`
- Checks for panics in `poll_ready()` method
- Adds some possible `Request` variants and match arms in `call()` method

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [x] Does the PR scope match the ticket?
  - [x] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [x] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

Implement match arms for `Request` variants