### PR TITLE
chore: Hotfix v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Zebra 1.5.2](https://github.com/ZcashFoundation/zebra/releases/tag/v1.5.2) - 2024-01-23
+
+This release serves as a hotfix for version 1.5.1, addressing issues encountered after its initial release. For more information about version 1.5.1, refer to [this link](https://github.com/ZcashFoundation/zebra/releases/tag/v1.5.2).
+
+Following the release on GitHub, we identified difficulties in publishing the `zebra-chain` crate to crates.io. Detailed information is available in [issue #8180](https://github.com/ZcashFoundation/zebra/issues/8180) and its references.
+
+Unfortunately, to resolve this challenge, which involves an unpublished dependency, we had to temporarily remove the internal miner support introduced in version 1.5.1.
+
+In our efforts to reinstate this feature, we've opened a tracking ticket to monitor the progress of the required code that must be merged into the `equihash` dependency. You can follow the developments in [issue #8183](https://github.com/ZcashFoundation/zebra/issues/8183), which will only be closed once the feature is successfully restored.
+
+### Breaking Changes
+
+- Temporally remove the internal miner functionality ([#8184](https://github.com/ZcashFoundation/zebra/pull/8184))
+
+### Contributors
+
+Thank you to everyone who contributed to this release, we couldn't make Zebra without you:
+@oxarbitrage
+
+
 ## [Zebra 1.5.1](https://github.com/ZcashFoundation/zebra/releases/tag/v1.5.1) - 2024-01-18
 
 This release:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "tower-batch-control"
-version = "0.2.41-beta.9"
+version = "0.2.41-beta.10"
 dependencies = [
  "color-eyre",
  "ed25519-zebra",
@@ -4682,7 +4682,7 @@ dependencies = [
 
 [[package]]
 name = "tower-fallback"
-version = "0.2.41-beta.9"
+version = "0.2.41-beta.10"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5657,7 +5657,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 dependencies = [
  "bitflags 2.4.1",
  "bitflags-serde-legacy",
@@ -5718,7 +5718,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 dependencies = [
  "bitflags 2.4.1",
  "byteorder",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 dependencies = [
  "color-eyre",
  "jsonrpc-core",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 dependencies = [
  "chrono",
  "futures",
@@ -5848,7 +5848,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-scan"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "bls12_381",
  "chrono",
@@ -5877,7 +5877,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 dependencies = [
  "displaydoc",
  "hex",
@@ -5890,7 +5890,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 dependencies = [
  "bincode",
  "chrono",
@@ -5934,7 +5934,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-test"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 dependencies = [
  "color-eyre",
  "futures",
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 dependencies = [
  "color-eyre",
  "hex",
@@ -5987,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -17,7 +17,7 @@ docker run --detach zfnd/zebra:latest
 ### Build it locally
 
 ```shell
-git clone --depth 1 --branch v1.5.1 https://github.com/ZcashFoundation/zebra.git
+git clone --depth 1 --branch v1.5.2 https://github.com/ZcashFoundation/zebra.git
 docker build --file docker/Dockerfile --target runtime --tag zebra:local .
 docker run --detach zebra:local
 ```

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -19,7 +19,7 @@ To compile Zebra directly from GitHub, or from a GitHub release source archive:
 ```sh
 git clone https://github.com/ZcashFoundation/zebra.git
 cd zebra
-git checkout v1.5.1
+git checkout v1.5.2
 ```
 
 3. Build and Run `zebrad`
@@ -32,7 +32,7 @@ target/release/zebrad start
 ### Compiling from git using cargo install
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.5.1 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.5.2 zebrad
 ```
 
 ### Compiling on ARM

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-batch-control"
-version = "0.2.41-beta.9"
+version = "0.2.41-beta.10"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Tower middleware for batch request processing"
 # # Legal

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-fallback"
-version = "0.2.41-beta.9"
+version = "0.2.41-beta.10"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Tower service combinator that sends requests to a first service, then retries processing on a second fallback service if the first service errors."
 license = "MIT OR Apache-2.0"

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Core Zcash data structures"
 license = "MIT OR Apache-2.0"
@@ -137,7 +137,7 @@ proptest-derive = { version = "0.4.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand_chacha = { version = "0.3.1", optional = true }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.33", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.34", optional = true }
 
 [dev-dependencies]
 # Benchmarks

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Implementation of Zcash consensus checks"
 license = "MIT OR Apache-2.0"
@@ -63,13 +63,13 @@ orchard = "0.6.0"
 zcash_proofs = { version = "0.13.0-rc.1", features = ["multicore" ] }
 wagyu-zcash-parameters = "0.2.0"
 
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.9" }
-tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.9" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.10" }
+tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.10" }
 
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.33" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.33" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.33" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.33" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.34" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal
@@ -83,7 +83,7 @@ howudoin = { version = "0.1.2", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.4.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.33", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["async-error"] }
 
 [dev-dependencies]
 proptest = "1.4.0"

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-node-services"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The interfaces of some Zebra node services"
 license = "MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.33" }
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.34" }
 
 # Optional dependencies
 

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license = "MIT OR Apache-2.0"
@@ -72,12 +72,12 @@ zcash_address = { version = "0.3.1", optional = true }
 # Test-only feature proptest-impl
 proptest = { version = "1.4.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.33", features = ["json-conversion"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.33" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.33" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.33" }
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.33" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.33" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["json-conversion"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.34" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.34" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.34" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34" }
 
 [dev-dependencies]
 insta = { version = "1.33.0", features = ["redactions", "json", "ron"] }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-scan"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Shielded transaction scanner for the Zcash blockchain"
 license = "MIT OR Apache-2.0"
@@ -48,8 +48,8 @@ tracing = "0.1.39"
 zcash_client_backend = "0.10.0-rc.1"
 zcash_primitives = "0.13.0-rc.1"
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.33" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.33", features = ["shielded-scan"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34", features = ["shielded-scan"] }
 
 chrono = { version = "0.4.31", default-features = false, features = ["clock", "std", "serde"] }
 
@@ -64,7 +64,7 @@ jubjub = { version = "0.10.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 zcash_note_encryption = { version = "0.4.0", optional = true }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.33", optional = true }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.34", optional = true }
 
 [dev-dependencies]
 
@@ -80,5 +80,5 @@ jubjub = "0.10.0"
 rand = "0.8.5"
 zcash_note_encryption = "0.4.0"
 
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.33", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.33" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.34" }

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license = "MIT OR Apache-2.0"
@@ -17,7 +17,7 @@ categories = ["api-bindings", "cryptography::cryptocurrencies"]
 [dependencies]
 zcash_script = "0.1.14"
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.33" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
 
 thiserror = "1.0.56"
 displaydoc = "0.2.4"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "State contextual verification and storage code for Zebra"
 license = "MIT OR Apache-2.0"
@@ -76,13 +76,13 @@ tracing = "0.1.39"
 elasticsearch = { version = "8.5.0-alpha.1", default-features = false, features = ["rustls-tls"], optional = true }
 serde_json = { version = "1.0.111", package = "serde_json", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.33", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
 
 # test feature proptest-impl
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.33", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.34", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.4.0", optional = true }
 

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-test"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Test harnesses and test vectors for Zebra"
 license = "MIT OR Apache-2.0"

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Developer tools for Zebra maintenance and testing"
 license = "MIT OR Apache-2.0"
@@ -87,12 +87,12 @@ tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
 thiserror = "1.0.56"
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.33" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.33" }
-zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.2", optional = true }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
+zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.3", optional = true }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.33", optional = true }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.34", optional = true }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { version = "0.12.0", optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "1.5.1"
+version = "1.5.2"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license = "MIT OR Apache-2.0"
@@ -158,18 +158,18 @@ test_sync_past_mandatory_checkpoint_mainnet = []
 test_sync_past_mandatory_checkpoint_testnet = []
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.33" }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.33" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.33" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.33" }
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.33" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.33" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.34" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.34" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.34" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34" }
 
 # Experimental shielded-scan feature
-zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.2", optional = true }
+zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.3", optional = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.33", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.34", optional = true }
 
 abscissa_core = "0.7.0"
 clap = { version = "4.4.16", features = ["cargo"] }


### PR DESCRIPTION
## Motivation

This is a hotfix release. We had problems with the crates.io publishing (https://github.com/ZcashFoundation/zebra/issues/8180).

Close https://github.com/ZcashFoundation/zebra/issues/8181

It bumps everything to a new version instead of just some dependencies. This might not be needed but i think it can avoid future confusion.

## Follow up work

- [ ] Publish the new crate versions to crates.io after this get merged into main.
- [ ] Create the hotfix release in github.
