### PR TITLE
fix(CI): Pin `cargo-deny-action` to v1.5.10

### DIFF
--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -255,7 +255,7 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.4.0
 
       - name: Check ${{ matrix.checks }} with features ${{ matrix.features }}
-        uses: EmbarkStudios/cargo-deny-action@v1
+        uses: EmbarkStudios/cargo-deny-action@v1.5.10
         with:
           # --all-features spuriously activates openssl, but we want to ban that dependency in
           # all of zebrad's production features for security reasons. But the --all-features job is


### PR DESCRIPTION
## Motivation

We use `cargo-deny-action@v1` in CI, which currently defaults to v1.5.11. This version of the action fails with this error: https://github.com/ZcashFoundation/zebra/actions/runs/7639791083/job/20814504342?pr=8185#step:5:14.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Is the documentation up to date?

## Solution

- Pin `cargo-deny-action` to v1.5.10.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

Revert this PR by addressing #8193.